### PR TITLE
fix: resolve terminal ID mismatch causing stale git status bar data

### DIFF
--- a/src/renderer/hooks/use-exit-code.ts
+++ b/src/renderer/hooks/use-exit-code.ts
@@ -3,12 +3,17 @@ import { useTerminalStore } from '@/stores/terminal-store'
 
 export function useExitCode(): void {
   const updateTerminalExitCode = useTerminalStore((state) => state.updateTerminalExitCode)
+  const findTerminalByPtyId = useTerminalStore((state) => state.findTerminalByPtyId)
 
   useEffect(() => {
-    const cleanup = window.api.terminal.onExitCodeChanged((terminalId: string, exitCode: number) => {
-      updateTerminalExitCode(terminalId, exitCode)
+    const cleanup = window.api.terminal.onExitCodeChanged((ptyId: string, exitCode: number) => {
+      // Look up terminal by ptyId and update using store id
+      const terminal = findTerminalByPtyId(ptyId)
+      if (terminal) {
+        updateTerminalExitCode(terminal.id, exitCode)
+      }
     })
 
     return cleanup
-  }, [updateTerminalExitCode])
+  }, [updateTerminalExitCode, findTerminalByPtyId])
 }

--- a/src/renderer/hooks/use-git-branch.ts
+++ b/src/renderer/hooks/use-git-branch.ts
@@ -7,13 +7,18 @@ import { useTerminalStore } from '@/stores/terminal-store'
  */
 export function useGitBranch(): void {
   const updateTerminalGitBranch = useTerminalStore((state) => state.updateTerminalGitBranch)
+  const findTerminalByPtyId = useTerminalStore((state) => state.findTerminalByPtyId)
   const cleanupRef = useRef<(() => void) | null>(null)
 
   useEffect(() => {
     // Subscribe to git branch changed events from main process
     const cleanup = window.api.terminal.onGitBranchChanged(
-      (terminalId: string, branch: string | null) => {
-        updateTerminalGitBranch(terminalId, branch)
+      (ptyId: string, branch: string | null) => {
+        // Look up terminal by ptyId and update using store id
+        const terminal = findTerminalByPtyId(ptyId)
+        if (terminal) {
+          updateTerminalGitBranch(terminal.id, branch)
+        }
       }
     )
 
@@ -25,5 +30,5 @@ export function useGitBranch(): void {
         cleanupRef.current = null
       }
     }
-  }, [updateTerminalGitBranch])
+  }, [updateTerminalGitBranch, findTerminalByPtyId])
 }

--- a/src/renderer/hooks/use-git-status.ts
+++ b/src/renderer/hooks/use-git-status.ts
@@ -8,13 +8,18 @@ import type { GitStatus } from '@/types/project'
  */
 export function useGitStatus(): void {
   const updateTerminalGitStatus = useTerminalStore((state) => state.updateTerminalGitStatus)
+  const findTerminalByPtyId = useTerminalStore((state) => state.findTerminalByPtyId)
   const cleanupRef = useRef<(() => void) | null>(null)
 
   useEffect(() => {
     // Subscribe to git status changed events from main process
     const cleanup = window.api.terminal.onGitStatusChanged(
-      (terminalId: string, status: GitStatus | null) => {
-        updateTerminalGitStatus(terminalId, status)
+      (ptyId: string, status: GitStatus | null) => {
+        // Look up terminal by ptyId and update using store id
+        const terminal = findTerminalByPtyId(ptyId)
+        if (terminal) {
+          updateTerminalGitStatus(terminal.id, status)
+        }
       }
     )
 
@@ -26,5 +31,5 @@ export function useGitStatus(): void {
         cleanupRef.current = null
       }
     }
-  }, [updateTerminalGitStatus])
+  }, [updateTerminalGitStatus, findTerminalByPtyId])
 }

--- a/src/renderer/pages/WorkspaceDashboard.test.tsx
+++ b/src/renderer/pages/WorkspaceDashboard.test.tsx
@@ -62,7 +62,8 @@ vi.mock('@/stores/terminal-store', () => ({
     addTerminal: mockAddTerminal,
     closeTerminal: mockCloseTerminal,
     renameTerminal: mockRenameTerminal,
-    reorderTerminals: vi.fn()
+    reorderTerminals: vi.fn(),
+    setTerminalPtyId: vi.fn()
   })
 }))
 

--- a/src/renderer/stores/terminal-store.test.ts
+++ b/src/renderer/stores/terminal-store.test.ts
@@ -203,6 +203,71 @@ describe('terminal-store', () => {
     })
   })
 
+  describe('setTerminalPtyId', () => {
+    it('should set ptyId on existing terminal', () => {
+      const { setTerminalPtyId } = useTerminalStore.getState()
+
+      setTerminalPtyId('t1', 'terminal-123-1')
+
+      const { terminals } = useTerminalStore.getState()
+      const terminal = terminals.find((t) => t.id === 't1')
+      expect(terminal?.ptyId).toBe('terminal-123-1')
+    })
+
+    it('should not affect other terminals', () => {
+      const { setTerminalPtyId } = useTerminalStore.getState()
+
+      setTerminalPtyId('t1', 'terminal-123-1')
+
+      const { terminals } = useTerminalStore.getState()
+      const terminal2 = terminals.find((t) => t.id === 't2')
+      expect(terminal2?.ptyId).toBeUndefined()
+    })
+
+    it('should update ptyId on terminal that already has one', () => {
+      const { setTerminalPtyId } = useTerminalStore.getState()
+
+      setTerminalPtyId('t1', 'terminal-old')
+      setTerminalPtyId('t1', 'terminal-new')
+
+      const { terminals } = useTerminalStore.getState()
+      const terminal = terminals.find((t) => t.id === 't1')
+      expect(terminal?.ptyId).toBe('terminal-new')
+    })
+  })
+
+  describe('findTerminalByPtyId', () => {
+    it('should find terminal by ptyId', () => {
+      const { setTerminalPtyId, findTerminalByPtyId } = useTerminalStore.getState()
+
+      setTerminalPtyId('t1', 'terminal-123-1')
+      const terminal = findTerminalByPtyId('terminal-123-1')
+
+      expect(terminal).toBeDefined()
+      expect(terminal?.id).toBe('t1')
+    })
+
+    it('should return undefined when ptyId not found', () => {
+      const { findTerminalByPtyId } = useTerminalStore.getState()
+
+      const terminal = findTerminalByPtyId('non-existent')
+      expect(terminal).toBeUndefined()
+    })
+
+    it('should find correct terminal when multiple have ptyIds', () => {
+      const { setTerminalPtyId, findTerminalByPtyId } = useTerminalStore.getState()
+
+      setTerminalPtyId('t1', 'terminal-123-1')
+      setTerminalPtyId('t2', 'terminal-123-2')
+
+      const terminal1 = findTerminalByPtyId('terminal-123-1')
+      const terminal2 = findTerminalByPtyId('terminal-123-2')
+
+      expect(terminal1?.id).toBe('t1')
+      expect(terminal2?.id).toBe('t2')
+    })
+  })
+
   describe('updateTerminalExitCode', () => {
     it('should update exit code for existing terminal', () => {
       const { updateTerminalExitCode } = useTerminalStore.getState()

--- a/src/renderer/stores/terminal-store.ts
+++ b/src/renderer/stores/terminal-store.ts
@@ -21,6 +21,8 @@ export interface TerminalState {
   renameTerminal: (id: string, name: string) => void
   reorderTerminals: (projectId: string, orderedIds: string[]) => void
   setTerminals: (terminals: Terminal[]) => void
+  setTerminalPtyId: (id: string, ptyId: string) => void
+  findTerminalByPtyId: (ptyId: string) => Terminal | undefined
   updateTerminalCwd: (id: string, cwd: string) => void
   updateTerminalGitBranch: (id: string, gitBranch: string | null) => void
   updateTerminalGitStatus: (id: string, gitStatus: GitStatus | null) => void
@@ -100,6 +102,16 @@ export const useTerminalStore = create<TerminalState>((set, get) => ({
     set({ terminals })
   },
 
+  setTerminalPtyId: (id: string, ptyId: string): void => {
+    set((state) => ({
+      terminals: state.terminals.map((t) => (t.id === id ? { ...t, ptyId } : t))
+    }))
+  },
+
+  findTerminalByPtyId: (ptyId: string): Terminal | undefined => {
+    return get().terminals.find((t) => t.ptyId === ptyId)
+  },
+
   updateTerminalCwd: (id: string, cwd: string): void => {
     set((state) => ({
       terminals: state.terminals.map((t) => (t.id === id ? { ...t, cwd } : t))
@@ -155,7 +167,7 @@ export function useActiveTerminalId(): string {
 
 export function useTerminalActions(): Pick<
   TerminalState,
-  'selectTerminal' | 'addTerminal' | 'closeTerminal' | 'renameTerminal' | 'reorderTerminals' | 'updateTerminalCwd'
+  'selectTerminal' | 'addTerminal' | 'closeTerminal' | 'renameTerminal' | 'reorderTerminals' | 'updateTerminalCwd' | 'setTerminalPtyId'
 > {
   return useTerminalStore(
     useShallow((state) => ({
@@ -164,7 +176,8 @@ export function useTerminalActions(): Pick<
       closeTerminal: state.closeTerminal,
       renameTerminal: state.renameTerminal,
       reorderTerminals: state.reorderTerminals,
-      updateTerminalCwd: state.updateTerminalCwd
+      updateTerminalCwd: state.updateTerminalCwd,
+      setTerminalPtyId: state.setTerminalPtyId
     }))
   )
 }

--- a/src/renderer/types/project.ts
+++ b/src/renderer/types/project.ts
@@ -31,6 +31,7 @@ export interface GitStatus {
 
 export interface Terminal {
   id: string
+  ptyId?: string
   name: string
   projectId: string
   shell: string


### PR DESCRIPTION
The status bar was showing stale data (wrong git branch, initial CWD) because IPC events from main process used PTY IDs while the renderer store used different IDs generated at terminal creation time.

Changes:
- Add ptyId field to Terminal interface for PTY ID sync
- Add setTerminalPtyId action and findTerminalByPtyId selector to store
- Update IPC hooks (use-cwd, use-git-branch, use-git-status, use-exit-code) to lookup terminals by ptyId before updating
- Wire up onSpawned callback in WorkspaceDashboard to sync PTY ID
- Re-fetch git state after sync to eliminate race condition
- Use ref-based stable handlers to prevent render loop

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced terminal session management with improved synchronization during terminal spawn events.

* **Bug Fixes**
  * Resolved race conditions when switching between projects with multiple active terminals.
  * Improved git status and branch information reliability during terminal lifecycle events.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->