### PR TITLE
fix: inject version from git tag into package.json during CD build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,6 +63,9 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
+      - name: Set version from tag
+        run: npm version ${{ github.ref_name }} --no-git-tag-version --allow-same-version
+
       - name: Build Windows
         run: bun run build:win
 
@@ -97,6 +100,9 @@ jobs:
 
       - name: Install dependencies
         run: bun install --frozen-lockfile
+
+      - name: Set version from tag
+        run: npm version ${{ github.ref_name }} --no-git-tag-version --allow-same-version
 
       - name: Build Linux
         run: bun run build:linux


### PR DESCRIPTION
## Summary

- Add "Set version from tag" step to Windows build job in release workflow
- Add "Set version from tag" step to Linux build job in release workflow
- Uses `npm version` to inject git tag version into `package.json` before electron-builder runs

This ensures artifact names (e.g., `Termul Manager-0.1.2.exe`) match the release version instead of the hardcoded `package.json` version (`0.1.0`).

## Test plan

- [ ] Merge this PR
- [ ] Delete and re-push `v0.1.2` tag to trigger release workflow
- [ ] Verify artifact names in GitHub Release match the tag version

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release automation workflow to improve versioning consistency during the build process.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->