### PR TITLE
fix: hide terminal tabs on non-workspace pages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,7 @@ nul
 /_bmad-output
 /_bmad
 /.github/agents
+
+# Auto Claude data directory
+.auto-claude/
+/.opencode

--- a/src/renderer/layouts/WorkspaceLayout.tsx
+++ b/src/renderer/layouts/WorkspaceLayout.tsx
@@ -421,17 +421,19 @@ export default function WorkspaceLayout(): React.JSX.Element {
         ) : (
           <>
             {/* Tab Bar */}
-            <TerminalTabBar
-              terminals={terminals}
-              activeTerminalId={activeTerminalId}
-              onSelectTerminal={selectTerminal}
-              onCloseTerminal={handleCloseTerminal}
-              onNewTerminal={handleNewTerminal}
-              onNewTerminalWithShell={handleNewTerminalWithShell}
-              onRenameTerminal={renameTerminal}
-              onReorderTerminals={(orderedIds) => reorderTerminals(activeProjectId, orderedIds)}
-              defaultShell={activeProject?.defaultShell}
-            />
+            {isWorkspaceRoute && (
+              <TerminalTabBar
+                terminals={terminals}
+                activeTerminalId={activeTerminalId}
+                onSelectTerminal={selectTerminal}
+                onCloseTerminal={handleCloseTerminal}
+                onNewTerminal={handleNewTerminal}
+                onNewTerminalWithShell={handleNewTerminalWithShell}
+                onRenameTerminal={renameTerminal}
+                onReorderTerminals={(orderedIds) => reorderTerminals(activeProjectId, orderedIds)}
+                defaultShell={activeProject?.defaultShell}
+              />
+            )}
 
             {/* Terminal Area / Route Content */}
             <div className="flex-1 overflow-hidden bg-terminal-bg relative">


### PR DESCRIPTION
## Summary
- Conditionally hide the `TerminalTabBar` component when not on the workspace dashboard route (`/`)
- Improves UI clarity by removing irrelevant tabs on Settings, Preferences, and Snapshots pages
- Settings content now expands to full height when tabs are hidden

## Changes
- `src/renderer/layouts/WorkspaceLayout.tsx`: Wrapped `TerminalTabBar` with `{isWorkspaceRoute && ...}` conditional
- `.gitignore`: Added `.auto-claude/` and `/.opencode` exclusions

## Test plan
- [x] TypeScript type check passes
- [ ] Manual testing: Navigate between workspace, settings, preferences, and snapshots pages
- [ ] Verify tabs show on `/`, hide on `/settings`, `/preferences`, `/snapshots`
- [ ] Verify settings content expands to full height
- [ ] Verify tabs reappear when navigating back to workspace
- [ ] Verify terminal processes remain active during navigation

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Terminal tab bar now displays only on the workspace route instead of appearing across all pages.

* **Chores**
  * Updated configuration to exclude data directories.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->