### PR TITLE
feat: add macOS build to release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -117,9 +117,46 @@ jobs:
           retention-days: 1
           if-no-files-found: error
 
+  build-macos:
+    name: Build macOS
+    needs: changelog
+    runs-on: macos-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Set version from tag
+        run: npm version ${{ github.ref_name }} --no-git-tag-version --allow-same-version
+
+      - name: Build macOS
+        run: bun run build:mac
+
+      - name: Upload macOS artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: macos-builds
+          path: |
+            dist/*.dmg
+          retention-days: 1
+          if-no-files-found: error
+
   publish:
     name: Publish Release
-    needs: [changelog, build-windows, build-linux]
+    needs: [changelog, build-windows, build-linux, build-macos]
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -133,6 +170,12 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: linux-builds
+          path: dist/
+
+      - name: Download macOS artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: macos-builds
           path: dist/
 
       - name: Create GitHub Release


### PR DESCRIPTION
## Summary
- Add `build-macos` job to release workflow that runs on `macos-latest`
- Produces DMG artifact for macOS distribution
- Runs in parallel with Windows and Linux builds
- Includes Mac artifacts in GitHub release

## Changes
- `.github/workflows/release.yml`: Add new `build-macos` job
- `tech-specs/mac-release-cd.md`: Add tech specification document

## Test plan
- [ ] Merge and push a beta tag (e.g., `v0.1.8-beta`) to verify build succeeds
- [ ] Confirm DMG artifact appears in GitHub release

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * macOS builds are now included in release artifacts for download.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->