### PR TITLE
fix: use dashes in artifact names for auto-updater compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -150,9 +150,21 @@
     ],
     "win": {
       "target": [
-        "nsis",
-        "portable"
+        {
+          "target": "nsis",
+          "arch": ["x64"]
+        },
+        {
+          "target": "portable",
+          "arch": ["x64"]
+        }
       ]
+    },
+    "nsis": {
+      "artifactName": "Termul-Manager-Setup-${version}.${ext}"
+    },
+    "portable": {
+      "artifactName": "Termul-Manager-${version}.${ext}"
     },
     "mac": {
       "target": [


### PR DESCRIPTION
## Summary
- Change artifact naming from dots (`Termul.Manager.Setup.0.2.2.exe`) to dashes (`Termul-Manager-Setup-0.2.2.exe`)
- This matches what existing v0.2.2 clients expect in `latest.yml` for auto-updates

## Problem
The current release v0.2.2 has a mismatch between:
- What the app expects (dashes): `Termul-Manager-Setup-0.2.2.exe`
- What GitHub releases have (dots): `Termul.Manager.Setup.0.2.2.exe`

This prevents existing users from auto-updating.

## Solution
Configure `artifactName` in electron-builder to explicitly use dashes, ensuring future releases produce files that match what the auto-updater expects.

## Test plan
- [ ] Build the app locally with `npm run build:win`
- [ ] Verify artifact names use dashes: `Termul-Manager-Setup-x.x.x.exe`
- [ ] Release v0.2.3 and verify existing v0.2.2 users can auto-update

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Windows build configuration to explicitly target 64-bit architecture
  * Refined installer and portable package naming conventions for Windows releases

<!-- end of auto-generated comment: release notes by coderabbit.ai -->