### PR TITLE
fix(changelog): prevent duplicate PR references in release notes

### DIFF
--- a/cliff.toml
+++ b/cliff.toml
@@ -17,9 +17,11 @@ body = """
 {% for group, commits in commits | group_by(attribute="group") %}
     ### {{ group | striptags | trim | upper_first }}
     {% for commit in commits %}
+        {%- set msg = commit.message | upper_first -%}
+        {%- set pr_in_msg = msg is containing("(#" ) -%}
         - {% if commit.scope %}**{{ commit.scope }}:** {% endif %}\
-            {{ commit.message | upper_first }}\
-            {% if commit.github.pr_number %} ([#{{ commit.github.pr_number }}](https://github.com/{{ get_env(name="GITHUB_REPO", default="OWNER/REPO") }}/pull/{{ commit.github.pr_number }})){% endif %}\
+            {{ msg }}\
+            {% if commit.remote.pr_number and not pr_in_msg %} ([#{{ commit.remote.pr_number }}](https://github.com/{{ get_env(name="GITHUB_REPO", default="OWNER/REPO") }}/pull/{{ commit.remote.pr_number }})){% endif %}\
     {% endfor %}
 {% endfor %}
 """


### PR DESCRIPTION
## Summary
- Fixed duplicate PR number references appearing in git-cliff generated changelogs
- Updated from deprecated `commit.github.pr_number` to `commit.remote.pr_number`

## Problem
When squash merging PRs, GitHub includes the PR number in commit titles (e.g., `feat: something (#25)`). Git-cliff was also adding another PR link, resulting in duplicate references like:
```
- Some feature (#25) ([#25](https://github.com/...))
```

## Solution
Modified `cliff.toml` to detect existing `(#XX)` patterns in commit messages and skip adding the duplicate link.

## Test plan
- [ ] Verify changelog generation with existing PR numbers in commits shows single reference
- [ ] Verify commits without PR numbers still get proper links added

🤖 Generated with [Claude Code](https://claude.com/claude-code)