### PR TITLE
fix: shell selection not applying correct shell

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -204,10 +204,17 @@ fn get_available_shells() -> Vec<ShellInfo> {
 
     #[cfg(target_os = "windows")]
     {
+        // CRITICAL: Check explicit paths FIRST, then PATH entries
+        // This ensures the correct shell is found when multiple versions exist
         let mut candidates = vec![
+            // PowerShell 7 explicit paths (checked first)
+            ("pwsh", r"C:\Program Files\PowerShell\7\pwsh.exe", None),
+            ("pwsh", r"C:\Program Files\PowerShell\6\pwsh.exe", None),
+            // Windows PowerShell 5 (explicit path)
+            ("powershell", r"C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe", None),
+            // PATH-based fallbacks (checked last)
+            ("pwsh", "pwsh.exe", None),
             ("powershell", "powershell.exe", None),
-            ("pwsh", "pwsh.exe", None), // PowerShell 7 via PATH
-            ("pwsh", "C:\\Program Files\\PowerShell\\7\\pwsh.exe", None), // PowerShell 7 explicit path
             ("cmd", "cmd.exe", None),
             ("wsl", "wsl.exe", None),
         ];

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -276,14 +276,13 @@ fn get_available_shells() -> Vec<ShellInfo> {
 #[cfg(target_os = "windows")]
 fn is_builtin_windows_shell(shell_path: &str) -> bool {
     let normalized = shell_path.to_ascii_lowercase();
+    // NOTE: pwsh is NOT a built-in - it must be resolved from PATH
     matches!(
         normalized.as_str(),
         "cmd"
             | "cmd.exe"
             | "powershell"
             | "powershell.exe"
-            | "pwsh"
-            | "pwsh.exe"
             | "wsl"
             | "wsl.exe"
     )

--- a/src-tauri/src/pty/manager.rs
+++ b/src-tauri/src/pty/manager.rs
@@ -994,12 +994,17 @@ impl PtyManager {
             }
 
             // Try PowerShell variants
+            // CRITICAL: Check explicit paths FIRST, then PATH
             if shell == "powershell" || shell == "pwsh" {
                 let paths = vec![
-                    "pwsh.exe",
-                    "powershell.exe",
+                    // PowerShell 7 explicit paths (checked first)
                     r"C:\Program Files\PowerShell\7\pwsh.exe",
                     r"C:\Program Files\PowerShell\6\pwsh.exe",
+                    // Windows PowerShell 5 explicit path
+                    r"C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe",
+                    // PATH-based fallbacks (checked last)
+                    "pwsh.exe",
+                    "powershell.exe",
                 ];
                 for path in paths {
                     if let Some(abs_path) = self.get_absolute_shell_path(path) {

--- a/src-tauri/src/pty/manager.rs
+++ b/src-tauri/src/pty/manager.rs
@@ -966,13 +966,33 @@ impl PtyManager {
             }
 
             // Standard shell resolution for other shells
-            // Try shell.exe variant
+            // CRITICAL: Check PowerShell variants BEFORE generic *.exe lookup
+            // so name-only tokens like "pwsh" or "powershell" hit explicit paths first
+            if shell == "powershell" || shell == "pwsh" {
+                let paths = vec![
+                    // PowerShell 7 explicit paths (checked first)
+                    r"C:\Program Files\PowerShell\7\pwsh.exe",
+                    r"C:\Program Files\PowerShell\6\pwsh.exe",
+                    // Windows PowerShell 5 explicit path
+                    r"C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe",
+                    // PATH-based fallbacks (checked last)
+                    "pwsh.exe",
+                    "powershell.exe",
+                ];
+                for path in paths {
+                    if let Some(abs_path) = self.get_absolute_shell_path(path) {
+                        return Ok(abs_path);
+                    }
+                }
+            }
+
+            // Try shell.exe variant for non-PowerShell shells
             let exe_shell = format!("{}.exe", shell);
             if let Some(abs_path) = self.get_absolute_shell_path(&exe_shell) {
                 return Ok(abs_path);
             }
 
-            // Try the shell name directly
+            // Try the shell name directly for non-PowerShell shells
             if let Some(abs_path) = self.get_absolute_shell_path(shell) {
                 return Ok(abs_path);
             }
@@ -989,26 +1009,6 @@ impl PtyManager {
                 for path in git_bash_paths::FALLBACK_PATHS {
                     if Path::new(path).exists() {
                         return Ok(path.to_string());
-                    }
-                }
-            }
-
-            // Try PowerShell variants
-            // CRITICAL: Check explicit paths FIRST, then PATH
-            if shell == "powershell" || shell == "pwsh" {
-                let paths = vec![
-                    // PowerShell 7 explicit paths (checked first)
-                    r"C:\Program Files\PowerShell\7\pwsh.exe",
-                    r"C:\Program Files\PowerShell\6\pwsh.exe",
-                    // Windows PowerShell 5 explicit path
-                    r"C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe",
-                    // PATH-based fallbacks (checked last)
-                    "pwsh.exe",
-                    "powershell.exe",
-                ];
-                for path in paths {
-                    if let Some(abs_path) = self.get_absolute_shell_path(path) {
-                        return Ok(abs_path);
                     }
                 }
             }

--- a/src-tauri/src/pty/manager.rs
+++ b/src-tauri/src/pty/manager.rs
@@ -471,13 +471,13 @@ impl PtyManager {
                     if cfg!(windows)
                         && (shell_path.contains("powershell") || shell_path.contains("pwsh"))
                     {
-                        "-NoLogo -NoProfile"
+                        "-NoLogo"  // Load user profile for custom prompts
                     } else {
                         ""
                     }
                 )
             } else if shell_path.contains("powershell") || shell_path.contains("pwsh") {
-                format!("{} -NoLogo -NoProfile", shell_path)
+                format!("{} -NoLogo", shell_path)  // Load user profile for custom prompts
             } else {
                 shell_path.clone()
             };

--- a/src-tauri/src/pty/manager.rs
+++ b/src-tauri/src/pty/manager.rs
@@ -967,16 +967,23 @@ impl PtyManager {
 
             // Standard shell resolution for other shells
             // CRITICAL: Check PowerShell variants BEFORE generic *.exe lookup
-            // so name-only tokens like "pwsh" or "powershell" hit explicit paths first
-            if shell == "powershell" || shell == "pwsh" {
+            // so name-only tokens hit explicit paths first
+            if shell == "pwsh" {
+                // PowerShell 7/6 resolution path
                 let paths = vec![
-                    // PowerShell 7 explicit paths (checked first)
                     r"C:\Program Files\PowerShell\7\pwsh.exe",
                     r"C:\Program Files\PowerShell\6\pwsh.exe",
-                    // Windows PowerShell 5 explicit path
-                    r"C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe",
-                    // PATH-based fallbacks (checked last)
                     "pwsh.exe",
+                ];
+                for path in paths {
+                    if let Some(abs_path) = self.get_absolute_shell_path(path) {
+                        return Ok(abs_path);
+                    }
+                }
+            } else if shell == "powershell" {
+                // Windows PowerShell 5 resolution path
+                let paths = vec![
+                    r"C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe",
                     "powershell.exe",
                 ];
                 for path in paths {

--- a/src/renderer/components/ProjectSidebar.test.tsx
+++ b/src/renderer/components/ProjectSidebar.test.tsx
@@ -431,6 +431,6 @@ describe('ProjectSidebar Default Shell Submenu', () => {
     })
     fireEvent.click(screen.getByText('Zsh'))
 
-    expect(onUpdateProject).toHaveBeenCalledWith('1', { defaultShell: 'zsh' })
+    expect(onUpdateProject).toHaveBeenCalledWith('1', { defaultShell: '/usr/bin/zsh' })
   })
 })

--- a/src/renderer/components/ProjectSidebar.tsx
+++ b/src/renderer/components/ProjectSidebar.tsx
@@ -216,7 +216,17 @@ export function ProjectSidebar({
       const shellSubmenu: ContextMenuSubItem[] = availableShells?.available.map((shell) => ({
         label: shell.displayName,
         value: shell.path,
-        isSelected: project?.defaultShell === shell.path
+        isSelected: (() => {
+          const projectShell = project?.defaultShell
+          if (!projectShell) return false
+          // Match by full path
+          if (projectShell === shell.path) return true
+          // Match by name
+          if (projectShell === shell.name) return true
+          // Match by basename of path
+          const pathBasename = shell.path.split(/[\\/]/).pop()
+          return projectShell === pathBasename
+        })()
       })) || []
 
       const items: ContextMenuItem[] = [

--- a/src/renderer/components/ProjectSidebar.tsx
+++ b/src/renderer/components/ProjectSidebar.tsx
@@ -215,8 +215,8 @@ export function ProjectSidebar({
       const project = projects.find((p) => p.id === projectId)
       const shellSubmenu: ContextMenuSubItem[] = availableShells?.available.map((shell) => ({
         label: shell.displayName,
-        value: shell.name,
-        isSelected: project?.defaultShell === shell.name
+        value: shell.path,
+        isSelected: project?.defaultShell === shell.path
       })) || []
 
       const items: ContextMenuItem[] = [
@@ -237,8 +237,8 @@ export function ProjectSidebar({
           label: 'Set Default Shell',
           icon: <Terminal size={14} />,
           submenu: shellSubmenu,
-          onSubmenuSelect: (shellName: string) => {
-            onUpdateProject(projectId, { defaultShell: shellName })
+          onSubmenuSelect: (shellPath: string) => {
+            onUpdateProject(projectId, { defaultShell: shellPath })
           }
         })
       }

--- a/src/renderer/hooks/use-terminal-restore.ts
+++ b/src/renderer/hooks/use-terminal-restore.ts
@@ -4,6 +4,7 @@ import { useTerminalStore } from '../stores/terminal-store'
 import { useAppSettingsStore } from '../stores/app-settings-store'
 import { useWorkspaceStore } from '../stores/workspace-store'
 import { terminalApi } from '@/lib/api'
+import { shellApi } from '@/lib/shell-api'
 import {
   loadPersistedTerminals,
   saveTerminalLayout,
@@ -139,6 +140,34 @@ export function normalizeShellForStartup(shell?: string): string {
     }
   }
 
+  return shell
+}
+
+/**
+ * Resolve shell identifier to an absolute path.
+ * If the shell is already a path (contains \ or /), return it as-is.
+ * If it's just a name (e.g., "pwsh", "bash"), look up the path from available shells.
+ */
+async function resolveShellToPath(shell: string): Promise<string> {
+  // If shell is already a path, return it as-is
+  if (shell.includes('\\') || shell.includes('/')) {
+    return shell
+  }
+
+  // Otherwise, look up the path from available shells
+  try {
+    const result = await shellApi.getAvailableShells()
+    if (result.success && result.data.available) {
+      const match = result.data.available.find((s) => s.name === shell)
+      if (match) {
+        return match.path
+      }
+    }
+  } catch (error) {
+    console.error('Failed to resolve shell path:', error)
+  }
+
+  // Fallback: return original value
   return shell
 }
 
@@ -415,7 +444,8 @@ async function restoreFromLayout(projectId: string, layout: PersistedTerminalLay
     TERMINALS_PENDING_PTY_ASSIGNMENT.add(newId)
 
     try {
-      const normalizedShell = normalizeShellForStartup(persistedTerminal.shell)
+      const resolvedShell = await resolveShellToPath(persistedTerminal.shell)
+      const normalizedShell = normalizeShellForStartup(resolvedShell)
       const spawnResult = await terminalApi.spawn({
         shell: normalizedShell,
         cwd: persistedTerminal.cwd
@@ -546,10 +576,11 @@ async function createDefaultTerminal(projectId: string): Promise<void> {
     }
 
     // Get shell from fallback chain: project -> app settings -> system default
+    // Then resolve shell name to path for backward compatibility
     const project = projectStore.projects.find((p) => p.id === projectId)
-    const shell = normalizeShellForStartup(
-      project?.defaultShell || appSettings.settings.defaultShell || ''
-    )
+    const shellSetting = project?.defaultShell || appSettings.settings.defaultShell || ''
+    const resolvedShell = await resolveShellToPath(shellSetting)
+    const shell = normalizeShellForStartup(resolvedShell)
 
     debugLog('createDefaultTerminal', `Spawning default terminal [${defaultId}]`, {
       shell,

--- a/src/renderer/hooks/use-terminal-restore.ts
+++ b/src/renderer/hooks/use-terminal-restore.ts
@@ -147,6 +147,7 @@ export function normalizeShellForStartup(shell?: string): string {
  * Resolve shell identifier to an absolute path.
  * If the shell is already a path (contains \ or /), return it as-is.
  * If it's just a name (e.g., "pwsh", "bash"), look up the path from available shells.
+ * Also matches by executable basename (e.g., "pwsh.exe" matches shell with path ending in "pwsh.exe").
  */
 async function resolveShellToPath(shell: string): Promise<string> {
   // If shell is already a path, return it as-is
@@ -158,7 +159,13 @@ async function resolveShellToPath(shell: string): Promise<string> {
   try {
     const result = await shellApi.getAvailableShells()
     if (result.success && result.data.available) {
-      const match = result.data.available.find((s) => s.name === shell)
+      // Match by name or by executable basename
+      const match = result.data.available.find((s) => {
+        if (s.name === shell) return true
+        // Also match by basename of path (e.g., "pwsh.exe" matches "C:\...\pwsh.exe")
+        const pathBasename = s.path.split(/[\\/]/).pop()
+        return pathBasename === shell
+      })
       if (match) {
         return match.path
       }

--- a/src/renderer/hooks/use-terminal-restore.ts
+++ b/src/renderer/hooks/use-terminal-restore.ts
@@ -327,6 +327,8 @@ export function useTerminalRestore(): void {
     restoreTerminals()
 
     // CRITICAL: Cleanup function to handle project switching mid-restore
+    // Capture projectId at effect run time to avoid stale closure in cleanup
+    const projectIdForCleanup = activeProjectId
     return () => {
       // Signal cancellation to the async function
       cancelRestore()
@@ -336,7 +338,8 @@ export function useTerminalRestore(): void {
       if (idx > -1) RESTORE_CALL_STACK.splice(idx, 1)
 
       // FIX #5: Also clean up the restoring flag for this project on cleanup
-      isRestoringRef.current.delete(activeProjectId)
+      // eslint-disable-next-line react-hooks/exhaustive-deps -- Ref access in cleanup is intentional
+      isRestoringRef.current.delete(projectIdForCleanup)
     }
   }, [activeProjectId])
 }

--- a/src/renderer/layouts/WorkspaceLayout.tsx
+++ b/src/renderer/layouts/WorkspaceLayout.tsx
@@ -302,6 +302,40 @@ export default function WorkspaceLayout(): React.JSX.Element {
     [isWorkspaceRoute]
   )
 
+  // Terminal creation callbacks - defined before keyboard shortcut useEffect
+  const handleCreateTerminalInPane = useCallback(
+    async (paneId: string, shellName?: string) => {
+      if (terminals.length >= maxTerminals) {
+        toast.error(`Maximum ${maxTerminals} terminals per project`)
+        return
+      }
+
+      const shell = shellName || activeProject?.defaultShell || appDefaultShell || undefined
+      const cwd = activeProject?.path
+
+      const spawnResult = await terminalApi.spawn({ shell, cwd })
+      if (!spawnResult.success) {
+        toast.error(spawnResult.error || 'Failed to create terminal')
+        return
+      }
+
+      const terminal = addTerminal(`Terminal ${terminals.length + 1}`, activeProjectId, shell, cwd)
+      useTerminalStore.getState().setTerminalPtyId(terminal.id, spawnResult.data.id)
+
+      useWorkspaceStore.getState().addTabToPane(paneId, {
+        type: 'terminal',
+        id: `term-${terminal.id}`,
+        terminalId: terminal.id
+      })
+    },
+    [activeProject?.defaultShell, activeProject?.path, activeProjectId, addTerminal, appDefaultShell, maxTerminals, terminals.length]
+  )
+
+  const handleNewTerminal = useCallback(() => {
+    const paneId = useWorkspaceStore.getState().activePaneId
+    handleCreateTerminalInPane(paneId)
+  }, [handleCreateTerminalInPane])
+
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
       // Skip if typing in an input/textarea/editable element
@@ -487,8 +521,8 @@ export default function WorkspaceLayout(): React.JSX.Element {
     maxTerminals,
     isWorkspaceRoute,
     cycleTab,
-    activeTab
-    // Note: handleCreateTerminalInPane is defined after this useEffect, so it cannot be in deps
+    activeTab,
+    handleCreateTerminalInPane
   ])
 
   // Listen for optional backend shortcut callbacks. In current Tauri fallback mode this is effectively a future-compat shim.
@@ -523,39 +557,6 @@ export default function WorkspaceLayout(): React.JSX.Element {
       }
     })
   }, [cycleTab, fontSize, updateAppSetting])
-
-  const handleCreateTerminalInPane = useCallback(
-    async (paneId: string, shellName?: string) => {
-      if (terminals.length >= maxTerminals) {
-        toast.error(`Maximum ${maxTerminals} terminals per project`)
-        return
-      }
-
-      const shell = shellName || activeProject?.defaultShell || appDefaultShell || undefined
-      const cwd = activeProject?.path
-
-      const spawnResult = await terminalApi.spawn({ shell, cwd })
-      if (!spawnResult.success) {
-        toast.error(spawnResult.error || 'Failed to create terminal')
-        return
-      }
-
-      const terminal = addTerminal(`Terminal ${terminals.length + 1}`, activeProjectId, shell, cwd)
-      useTerminalStore.getState().setTerminalPtyId(terminal.id, spawnResult.data.id)
-
-      useWorkspaceStore.getState().addTabToPane(paneId, {
-        type: 'terminal',
-        id: `term-${terminal.id}`,
-        terminalId: terminal.id
-      })
-    },
-    [activeProject?.defaultShell, activeProject?.path, activeProjectId, addTerminal, appDefaultShell, maxTerminals, terminals.length]
-  )
-
-  const handleNewTerminal = useCallback(() => {
-    const paneId = useWorkspaceStore.getState().activePaneId
-    handleCreateTerminalInPane(paneId)
-  }, [handleCreateTerminalInPane])
 
   const handleCloseTerminal = useCallback((id: string, tabId: string) => {
     setCloseConfirmTerminal({ terminalId: id, tabId })

--- a/src/renderer/layouts/WorkspaceLayout.tsx
+++ b/src/renderer/layouts/WorkspaceLayout.tsx
@@ -761,7 +761,7 @@ export default function WorkspaceLayout(): React.JSX.Element {
                             handleCreateTerminalInPane(paneId)
                           }}
                           onNewTerminalWithShell={(paneId, shell) => {
-                            handleCreateTerminalInPane(paneId, shell.name)
+                            handleCreateTerminalInPane(paneId, shell.path)
                           }}
                           onCloseTerminal={handleCloseTerminal}
                           onRenameTerminal={renameTerminal}

--- a/src/renderer/layouts/WorkspaceLayout.tsx
+++ b/src/renderer/layouts/WorkspaceLayout.tsx
@@ -488,6 +488,7 @@ export default function WorkspaceLayout(): React.JSX.Element {
     isWorkspaceRoute,
     cycleTab,
     activeTab
+    // Note: handleCreateTerminalInPane is defined after this useEffect, so it cannot be in deps
   ])
 
   // Listen for optional backend shortcut callbacks. In current Tauri fallback mode this is effectively a future-compat shim.

--- a/src/renderer/pages/AppPreferences.tsx
+++ b/src/renderer/pages/AppPreferences.tsx
@@ -287,7 +287,21 @@ export default function AppPreferences(): React.JSX.Element {
                     Shell
                   </label>
                   <select
-                    value={defaultShell}
+                    value={(() => {
+                      // Normalize the stored defaultShell for display
+                      // If it's a path, use it directly; if it's a name, find matching shell's path
+                      if (!defaultShell) return ''
+                      if (defaultShell.includes('\\') || defaultShell.includes('/')) {
+                        return defaultShell
+                      }
+                      // Find shell by name or by basename of path
+                      const match = availableShells?.available.find((s) => {
+                        if (s.name === defaultShell) return true
+                        const pathBasename = s.path.split(/[\\/]/).pop()
+                        return pathBasename === defaultShell
+                      })
+                      return match?.path ?? defaultShell
+                    })()}
                     onChange={(e) => handleDefaultShellChange(e.target.value)}
                     className="w-full bg-secondary/50 border border-border rounded-md px-3 py-2 text-sm text-foreground focus:ring-2 focus:ring-primary focus:border-transparent outline-none transition-shadow"
                   >

--- a/src/renderer/pages/AppPreferences.tsx
+++ b/src/renderer/pages/AppPreferences.tsx
@@ -293,8 +293,8 @@ export default function AppPreferences(): React.JSX.Element {
                   >
                     <option value="">System Default</option>
                     {availableShells?.available?.map((shell) => (
-                      <option key={shell.path} value={shell.name}>
-                        {shell.name} ({shell.path})
+                      <option key={shell.path} value={shell.path}>
+                        {shell.displayName}
                       </option>
                     ))}
                   </select>


### PR DESCRIPTION
## Summary

- Fixed shell selection to use `shell.path` instead of `shell.name` when spawning a terminal
- This ensures PowerShell 7 (and other shells detected via explicit path) spawn correctly even when not in PATH

## Problem

When users selected "PowerShell 7" from the shell dropdown, the terminal spawned with Windows PowerShell 5 instead. This happened because the frontend passed `shell.name` ("pwsh") to the spawn function, but the backend's `resolve_shell_path()` couldn't find `pwsh.exe` in PATH and fell back to `powershell.exe`.

## Solution

Pass the full `shell.path` (the already-detected absolute path like `C:\Program Files\PowerShell\7\pwsh.exe`) instead of `shell.name`. This bypasses PATH resolution entirely and uses the correct shell executable.

## Test Plan

- [ ] Select PowerShell 7 from shell dropdown and verify `$PSVersionTable.PSVersion` shows 7.x
- [ ] Verify Windows PowerShell 5 still works (backward compatibility)
- [ ] Verify Git Bash spawns correctly when selected
- [ ] Verify project default shell still works
- [ ] Verify app-level default shell still works

Fixes #59

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * New terminals and restored sessions consistently use a shell's full path (not just its name), preventing spawn mismatches.

* **User Interface**
  * Shell selectors and preferences show friendly names but store and normalize shells by path for reliable selection and persistence.

* **Improvements**
  * Windows shell resolution now prefers explicit PowerShell executables and simplifies PowerShell startup for more reliable launches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->