### PR TITLE
feat: add markdown table of contents panel

### DIFF
--- a/src/renderer/components/editor/CodeEditor.tsx
+++ b/src/renderer/components/editor/CodeEditor.tsx
@@ -1,5 +1,10 @@
-import { useRef, useEffect } from 'react'
-import { useCodeMirror } from '@/hooks/use-codemirror'
+import { useRef, useEffect, useMemo, useState, useCallback } from 'react'
+import type { ImperativePanelGroupHandle, PanelOnResize } from 'react-resizable-panels'
+import { useCodeMirror, type VisibleLineRange } from '@/hooks/use-codemirror'
+import { TocPanel } from './TocPanel'
+import { ResizablePanelGroup, ResizablePanel, ResizableHandle } from '@/components/ui/resizable'
+import { useTocIsVisible, useTocWidth, useTocSettingsStore } from '@/stores/toc-settings-store'
+import { TOC_MAX_WIDTH, TOC_MIN_WIDTH } from '@/types/settings'
 
 interface CodeEditorProps {
   filePath: string
@@ -12,6 +17,7 @@ interface CodeEditorProps {
   onScrollChange: (scrollTop: number) => void
 }
 
+
 export function CodeEditor({
   content,
   language,
@@ -22,14 +28,43 @@ export function CodeEditor({
   onScrollChange
 }: CodeEditorProps): React.JSX.Element {
   const containerRef = useRef<HTMLDivElement>(null)
-  const { view, setContent } = useCodeMirror(containerRef, {
+  const layoutRef = useRef<HTMLDivElement>(null)
+  const panelGroupRef = useRef<ImperativePanelGroupHandle>(null)
+  const [visibleRange, setVisibleRange] = useState<VisibleLineRange | undefined>()
+  const [layoutWidth, setLayoutWidth] = useState(0)
+  const isTocVisible = useTocIsVisible()
+  const tocWidth = useTocWidth()
+  const setTocWidth = useTocSettingsStore((state) => state.setWidth)
+
+  const { view, setContent, scrollToLine } = useCodeMirror(containerRef, {
     content,
     language,
     readOnly,
     onChange,
     onCursorChange,
-    onScrollChange
+    onScrollChange,
+    onVisibleRangeChange: setVisibleRange
   })
+
+  const getTocPanelSizePercent = useCallback((): number => {
+    const panelWidth = layoutWidth || layoutRef.current?.clientWidth || 1000
+    const widthRatio = panelWidth > 0 ? tocWidth / panelWidth : 0
+    return Math.min(40, Math.max(10, widthRatio * 100))
+  }, [layoutWidth, tocWidth])
+
+  const tocPanelDefaultSize = useMemo(() => getTocPanelSizePercent(), [getTocPanelSizePercent])
+
+  const handleTocResize = useCallback<PanelOnResize>(
+    (size, prevSize): void => {
+      const layoutWidth = layoutRef.current?.clientWidth ?? 1000
+      const nextPixels = Math.round((size / 100) * layoutWidth)
+
+      if (prevSize !== size) {
+        setTocWidth(nextPixels)
+      }
+    },
+    [setTocWidth]
+  )
 
   // Update content when it changes from external source (file reload)
   const prevContentRef = useRef(content)
@@ -40,6 +75,27 @@ export function CodeEditor({
     }
   }, [content, setContent])
 
+  useEffect(() => {
+    const element = layoutRef.current
+    if (!element) {
+      return
+    }
+
+    const updateLayoutWidth = (): void => {
+      setLayoutWidth(element.clientWidth)
+    }
+
+    updateLayoutWidth()
+
+    const observer = new ResizeObserver(() => {
+      updateLayoutWidth()
+    })
+
+    observer.observe(element)
+
+    return () => observer.disconnect()
+  }, [])
+
   // Focus when becoming visible
   useEffect(() => {
     if (isVisible && view) {
@@ -47,7 +103,64 @@ export function CodeEditor({
     }
   }, [isVisible, view])
 
+  useEffect(() => {
+    if (!isTocVisible || language !== 'markdown') {
+      return
+    }
+
+    const group = panelGroupRef.current
+    if (!group) {
+      return
+    }
+
+    const tocSize = getTocPanelSizePercent()
+    const currentTocSize = group.getLayout()[1]
+
+    if (currentTocSize !== undefined && Math.abs(currentTocSize - tocSize) < 0.5) {
+      return
+    }
+
+    group.setLayout([100 - tocSize, tocSize])
+  }, [getTocPanelSizePercent, isTocVisible, language])
+
   return (
-    <div ref={containerRef} className="w-full h-full overflow-hidden" />
+    <div className="h-full w-full" style={{ display: isVisible ? 'block' : 'none' }}>
+      <div ref={layoutRef} className="h-full w-full">
+        <ResizablePanelGroup ref={panelGroupRef} direction="horizontal">
+          <ResizablePanel
+            defaultSize={isTocVisible && language === 'markdown' ? 100 - tocPanelDefaultSize : 100}
+            minSize={60}
+          >
+            <div ref={containerRef} className="w-full h-full overflow-hidden" />
+          </ResizablePanel>
+
+          {isTocVisible && language === 'markdown' && (
+            <>
+              <ResizableHandle />
+              <ResizablePanel
+                defaultSize={tocPanelDefaultSize}
+                minSize={10}
+                maxSize={40}
+                onResize={handleTocResize}
+              >
+                <div
+                  className="h-full"
+                  style={{ minWidth: TOC_MIN_WIDTH, maxWidth: TOC_MAX_WIDTH, width: '100%' }}
+                >
+                  <TocPanel
+                    editorMode="codemirror"
+                    codemirror={{
+                      content,
+                      scrollToLine,
+                      visibleRange
+                    }}
+                  />
+                </div>
+              </ResizablePanel>
+            </>
+          )}
+        </ResizablePanelGroup>
+      </div>
+    </div>
   )
 }

--- a/src/renderer/components/editor/CodeEditor.tsx
+++ b/src/renderer/components/editor/CodeEditor.tsx
@@ -3,7 +3,7 @@ import type { ImperativePanelGroupHandle, PanelOnResize } from 'react-resizable-
 import { useCodeMirror, type VisibleLineRange } from '@/hooks/use-codemirror'
 import { TocPanel } from './TocPanel'
 import { ResizablePanelGroup, ResizablePanel, ResizableHandle } from '@/components/ui/resizable'
-import { useTocIsVisible, useTocWidth, useTocSettingsStore } from '@/stores/toc-settings-store'
+import { useTocSettingsStore } from '@/stores/toc-settings-store'
 import { TOC_MAX_WIDTH, TOC_MIN_WIDTH } from '@/types/settings'
 
 interface CodeEditorProps {
@@ -17,6 +17,15 @@ interface CodeEditorProps {
   onScrollChange: (scrollTop: number) => void
 }
 
+function getTocPercentBounds(panelWidth: number): { minPercent: number; maxPercent: number } {
+  const minPercent = (TOC_MIN_WIDTH / panelWidth) * 100
+  const maxPercent = (TOC_MAX_WIDTH / panelWidth) * 100
+
+  return {
+    minPercent,
+    maxPercent: Math.max(minPercent, maxPercent)
+  }
+}
 
 export function CodeEditor({
   content,
@@ -32,9 +41,12 @@ export function CodeEditor({
   const panelGroupRef = useRef<ImperativePanelGroupHandle>(null)
   const [visibleRange, setVisibleRange] = useState<VisibleLineRange | undefined>()
   const [layoutWidth, setLayoutWidth] = useState(0)
-  const isTocVisible = useTocIsVisible()
-  const tocWidth = useTocWidth()
-  const setTocWidth = useTocSettingsStore((state) => state.setWidth)
+  const { isTocHydrated, isTocVisible, tocWidth, setTocWidth } = useTocSettingsStore((state) => ({
+    isTocHydrated: state.isLoaded || state.loadFailed,
+    isTocVisible: state.settings.isVisible,
+    tocWidth: state.settings.width,
+    setTocWidth: state.setWidth
+  }))
 
   const { view, setContent, scrollToLine } = useCodeMirror(containerRef, {
     content,
@@ -46,24 +58,34 @@ export function CodeEditor({
     onVisibleRangeChange: setVisibleRange
   })
 
-  const getTocPanelSizePercent = useCallback((): number => {
-    const panelWidth = layoutWidth || layoutRef.current?.clientWidth || 1000
-    const widthRatio = panelWidth > 0 ? tocWidth / panelWidth : 0
-    return Math.min(40, Math.max(10, widthRatio * 100))
-  }, [layoutWidth, tocWidth])
+  const getPanelWidth = useCallback((): number => {
+    return layoutWidth || layoutRef.current?.clientWidth || 1000
+  }, [layoutWidth])
 
+  const getTocPanelSizePercent = useCallback((): number => {
+    const panelWidth = getPanelWidth()
+    const { minPercent, maxPercent } = getTocPercentBounds(panelWidth)
+    const widthRatio = panelWidth > 0 ? tocWidth / panelWidth : 0
+
+    return Math.min(maxPercent, Math.max(minPercent, widthRatio * 100))
+  }, [getPanelWidth, tocWidth])
+
+  const tocPanelBounds = useMemo(() => getTocPercentBounds(getPanelWidth()), [getPanelWidth])
   const tocPanelDefaultSize = useMemo(() => getTocPanelSizePercent(), [getTocPanelSizePercent])
+  const canRenderToc = isTocHydrated && isTocVisible && language === 'markdown'
 
   const handleTocResize = useCallback<PanelOnResize>(
     (size, prevSize): void => {
-      const layoutWidth = layoutRef.current?.clientWidth ?? 1000
-      const nextPixels = Math.round((size / 100) * layoutWidth)
+      const panelWidth = getPanelWidth()
+      const { minPercent, maxPercent } = getTocPercentBounds(panelWidth)
+      const clampedSize = Math.min(maxPercent, Math.max(minPercent, size))
+      const nextPixels = Math.round((clampedSize / 100) * panelWidth)
 
       if (prevSize !== size) {
         setTocWidth(nextPixels)
       }
     },
-    [setTocWidth]
+    [getPanelWidth, setTocWidth]
   )
 
   // Update content when it changes from external source (file reload)
@@ -104,7 +126,7 @@ export function CodeEditor({
   }, [isVisible, view])
 
   useEffect(() => {
-    if (!isTocVisible || language !== 'markdown') {
+    if (!canRenderToc) {
       return
     }
 
@@ -121,26 +143,26 @@ export function CodeEditor({
     }
 
     group.setLayout([100 - tocSize, tocSize])
-  }, [getTocPanelSizePercent, isTocVisible, language])
+  }, [canRenderToc, getTocPanelSizePercent])
 
   return (
     <div className="h-full w-full" style={{ display: isVisible ? 'block' : 'none' }}>
       <div ref={layoutRef} className="h-full w-full">
         <ResizablePanelGroup ref={panelGroupRef} direction="horizontal">
           <ResizablePanel
-            defaultSize={isTocVisible && language === 'markdown' ? 100 - tocPanelDefaultSize : 100}
+            defaultSize={canRenderToc ? 100 - tocPanelDefaultSize : 100}
             minSize={60}
           >
             <div ref={containerRef} className="w-full h-full overflow-hidden" />
           </ResizablePanel>
 
-          {isTocVisible && language === 'markdown' && (
+          {canRenderToc && (
             <>
               <ResizableHandle />
               <ResizablePanel
                 defaultSize={tocPanelDefaultSize}
-                minSize={10}
-                maxSize={40}
+                minSize={tocPanelBounds.minPercent}
+                maxSize={tocPanelBounds.maxPercent}
                 onResize={handleTocResize}
               >
                 <div

--- a/src/renderer/components/editor/EditorPanel.tsx
+++ b/src/renderer/components/editor/EditorPanel.tsx
@@ -15,6 +15,7 @@ export function EditorPanel({
   filePath,
   isVisible
 }: EditorPanelProps): React.JSX.Element {
+  // Intentionally invoked for side effects: loads and persists shared TOC settings.
   useTocSettings()
 
   const fileState = useEditorStore(

--- a/src/renderer/components/editor/EditorPanel.tsx
+++ b/src/renderer/components/editor/EditorPanel.tsx
@@ -4,6 +4,7 @@ import { MarkdownEditor } from './MarkdownEditor'
 import { EditorToolbar } from './EditorToolbar'
 import { useEditorStore } from '@/stores/editor-store'
 import type { EditorFileState } from '@/stores/editor-store'
+import { useTocSettings } from '@/hooks/use-toc-settings'
 
 interface EditorPanelProps {
   filePath: string
@@ -14,6 +15,8 @@ export function EditorPanel({
   filePath,
   isVisible
 }: EditorPanelProps): React.JSX.Element {
+  useTocSettings()
+
   const fileState = useEditorStore(
     (state) => state.openFiles.get(filePath)
   ) as EditorFileState | undefined
@@ -25,28 +28,28 @@ export function EditorPanel({
     (content: string) => {
       updateContent(filePath, content)
     },
-    [filePath]
+    [filePath, updateContent]
   )
 
   const handleCursorChange = useCallback(
     (line: number, col: number) => {
       updateCursorPosition(filePath, line, col)
     },
-    [filePath]
+    [filePath, updateCursorPosition]
   )
 
   const handleScrollChange = useCallback(
     (scrollTop: number) => {
       updateScrollTop(filePath, scrollTop)
     },
-    [filePath]
+    [filePath, updateScrollTop]
   )
 
   const handleToggleViewMode = useCallback(() => {
     if (!fileState) return
     const newMode = fileState.viewMode === 'markdown' ? 'code' : 'markdown'
     setViewMode(filePath, newMode)
-  }, [filePath, fileState?.viewMode])
+  }, [filePath, fileState, setViewMode])
 
   if (!fileState) {
     return (

--- a/src/renderer/components/editor/EditorToolbar.tsx
+++ b/src/renderer/components/editor/EditorToolbar.tsx
@@ -37,11 +37,12 @@ export function EditorToolbar({
           <span>TOC</span>
         </Button>
 
-        <button
+        <Button
+          variant="ghost"
+          size="sm"
           onClick={onToggleViewMode}
           className={cn(
-            'flex items-center gap-1 px-2 py-0.5 text-xs rounded transition-colors',
-            'text-muted-foreground hover:text-foreground hover:bg-secondary'
+            'h-6 gap-1 px-2 text-xs text-muted-foreground hover:text-foreground hover:bg-secondary'
           )}
           title={viewMode === 'markdown' ? 'Switch to source mode' : 'Switch to WYSIWYG mode'}
         >
@@ -56,7 +57,7 @@ export function EditorToolbar({
               <span>Preview</span>
             </>
           )}
-        </button>
+        </Button>
       </div>
     </div>
   )

--- a/src/renderer/components/editor/EditorToolbar.tsx
+++ b/src/renderer/components/editor/EditorToolbar.tsx
@@ -1,5 +1,7 @@
-import { Code2, Eye } from 'lucide-react'
+import { Code2, Eye, List } from 'lucide-react'
 import { cn } from '@/lib/utils'
+import { Button } from '@/components/ui/button'
+import { useTocIsVisible, useTocSettingsStore } from '@/stores/toc-settings-store'
 
 interface EditorToolbarProps {
   viewMode: 'code' | 'markdown'
@@ -12,31 +14,50 @@ export function EditorToolbar({
   onToggleViewMode,
   filePath
 }: EditorToolbarProps): React.JSX.Element {
-  const fileName = filePath.split('/').pop() || filePath
+  const fileName = filePath.split(/[\\/]/).pop() || filePath
+  const isTocVisible = useTocIsVisible()
+  const toggleTocVisibility = useTocSettingsStore((state) => state.toggleVisibility)
 
   return (
     <div className="flex items-center justify-between px-3 h-8 border-b border-border bg-card flex-shrink-0">
       <span className="text-xs text-muted-foreground truncate">{fileName}</span>
-      <button
-        onClick={onToggleViewMode}
-        className={cn(
-          'flex items-center gap-1 px-2 py-0.5 text-xs rounded transition-colors',
-          'text-muted-foreground hover:text-foreground hover:bg-secondary'
-        )}
-        title={viewMode === 'markdown' ? 'Switch to source mode' : 'Switch to WYSIWYG mode'}
-      >
-        {viewMode === 'markdown' ? (
-          <>
-            <Code2 size={12} />
-            <span>Source</span>
-          </>
-        ) : (
-          <>
-            <Eye size={12} />
-            <span>Preview</span>
-          </>
-        )}
-      </button>
+      <div className="flex items-center gap-1">
+        <Button
+          variant="ghost"
+          size="sm"
+          className={cn(
+            'h-6 gap-1 px-2 text-xs text-muted-foreground hover:text-foreground',
+            isTocVisible && 'bg-accent text-accent-foreground'
+          )}
+          onClick={toggleTocVisibility}
+          title="Toggle Table of Contents"
+          aria-pressed={isTocVisible}
+        >
+          <List size={12} />
+          <span>TOC</span>
+        </Button>
+
+        <button
+          onClick={onToggleViewMode}
+          className={cn(
+            'flex items-center gap-1 px-2 py-0.5 text-xs rounded transition-colors',
+            'text-muted-foreground hover:text-foreground hover:bg-secondary'
+          )}
+          title={viewMode === 'markdown' ? 'Switch to source mode' : 'Switch to WYSIWYG mode'}
+        >
+          {viewMode === 'markdown' ? (
+            <>
+              <Code2 size={12} />
+              <span>Source</span>
+            </>
+          ) : (
+            <>
+              <Eye size={12} />
+              <span>Preview</span>
+            </>
+          )}
+        </button>
+      </div>
     </div>
   )
 }

--- a/src/renderer/components/editor/MarkdownEditor.tsx
+++ b/src/renderer/components/editor/MarkdownEditor.tsx
@@ -1,6 +1,11 @@
-import { useState, useEffect, useRef, useCallback } from 'react'
+import { useState, useEffect, useRef, useCallback, useMemo } from 'react'
+import type { ImperativePanelGroupHandle, PanelOnResize } from 'react-resizable-panels'
 import { useBlockNote } from '@/hooks/use-blocknote'
 import { BlockNoteViewRaw } from '@blocknote/react'
+import { TocPanel } from './TocPanel'
+import { ResizablePanelGroup, ResizablePanel, ResizableHandle } from '@/components/ui/resizable'
+import { useTocIsVisible, useTocWidth, useTocSettingsStore } from '@/stores/toc-settings-store'
+import { TOC_MAX_WIDTH, TOC_MIN_WIDTH } from '@/types/settings'
 import '@blocknote/react/style.css'
 
 interface MarkdownEditorProps {
@@ -49,11 +54,39 @@ export function MarkdownEditor({
     [onChange]
   )
 
-  const { editor, replaceContent } = useBlockNote({
+  const { editor, replaceContent, getHeadings, scrollToBlock } = useBlockNote({
     initialMarkdown: content,
     onChange: wrappedOnChange
   })
   const isDark = useIsDark()
+  const layoutRef = useRef<HTMLDivElement>(null)
+  const blockNoteScrollRootRef = useRef<HTMLDivElement>(null)
+  const panelGroupRef = useRef<ImperativePanelGroupHandle>(null)
+  const [blockNoteContainer, setBlockNoteContainer] = useState<HTMLDivElement | null>(null)
+  const [layoutWidth, setLayoutWidth] = useState(0)
+  const isTocVisible = useTocIsVisible()
+  const tocWidth = useTocWidth()
+  const setTocWidth = useTocSettingsStore((state) => state.setWidth)
+
+  const getTocPanelSizePercent = useCallback((): number => {
+    const panelWidth = layoutWidth || layoutRef.current?.clientWidth || 1000
+    const widthRatio = panelWidth > 0 ? tocWidth / panelWidth : 0
+    return Math.min(40, Math.max(10, widthRatio * 100))
+  }, [layoutWidth, tocWidth])
+
+  const tocPanelDefaultSize = useMemo(() => getTocPanelSizePercent(), [getTocPanelSizePercent])
+
+  const handleTocResize = useCallback<PanelOnResize>(
+    (size, prevSize): void => {
+      const layoutWidth = layoutRef.current?.clientWidth ?? 1000
+      const nextPixels = Math.round((size / 100) * layoutWidth)
+
+      if (prevSize !== size) {
+        setTocWidth(nextPixels)
+      }
+    },
+    [setTocWidth]
+  )
 
   // Sync content only for external changes (e.g., file reload from disk)
   useEffect(() => {
@@ -69,22 +102,96 @@ export function MarkdownEditor({
     }
   }, [content, replaceContent])
 
+  useEffect(() => {
+    setBlockNoteContainer(blockNoteScrollRootRef.current)
+  }, [])
+
+  useEffect(() => {
+    const element = layoutRef.current
+    if (!element) {
+      return
+    }
+
+    const updateLayoutWidth = (): void => {
+      setLayoutWidth(element.clientWidth)
+      setBlockNoteContainer(blockNoteScrollRootRef.current)
+    }
+
+    updateLayoutWidth()
+
+    const observer = new ResizeObserver(() => {
+      updateLayoutWidth()
+    })
+
+    observer.observe(element)
+
+    return () => observer.disconnect()
+  }, [])
+
+  useEffect(() => {
+    if (!isTocVisible) {
+      return
+    }
+
+    const group = panelGroupRef.current
+    if (!group) {
+      return
+    }
+
+    const tocSize = getTocPanelSizePercent()
+    const currentTocSize = group.getLayout()[1]
+
+    if (currentTocSize !== undefined && Math.abs(currentTocSize - tocSize) < 0.5) {
+      return
+    }
+
+    group.setLayout([100 - tocSize, tocSize])
+  }, [getTocPanelSizePercent, isTocVisible])
+
   return (
-    <div
-      className="w-full h-full overflow-auto"
-      style={{ display: isVisible ? 'block' : 'none' }}
-    >
-      <BlockNoteViewRaw
-        editor={editor}
-        theme={isDark ? 'dark' : 'light'}
-        formattingToolbar={false}
-        linkToolbar={false}
-        slashMenu={false}
-        emojiPicker={false}
-        sideMenu={false}
-        filePanel={false}
-        tableHandles={false}
-      />
+    <div className="w-full h-full" style={{ display: isVisible ? 'block' : 'none' }}>
+      <div ref={layoutRef} className="h-full w-full">
+        <ResizablePanelGroup ref={panelGroupRef} direction="horizontal">
+          <ResizablePanel defaultSize={isTocVisible ? 100 - tocPanelDefaultSize : 100} minSize={60}>
+            <div ref={blockNoteScrollRootRef} className="h-full overflow-auto">
+              <BlockNoteViewRaw
+                editor={editor}
+                theme={isDark ? 'dark' : 'light'}
+                formattingToolbar={false}
+                linkToolbar={false}
+                slashMenu={false}
+                emojiPicker={false}
+                sideMenu={false}
+                filePanel={false}
+                tableHandles={false}
+              />
+            </div>
+          </ResizablePanel>
+
+          {isTocVisible && (
+            <>
+              <ResizableHandle />
+              <ResizablePanel
+                defaultSize={tocPanelDefaultSize}
+                minSize={10}
+                maxSize={40}
+                onResize={handleTocResize}
+              >
+                <div
+                  className="h-full"
+                  style={{ minWidth: TOC_MIN_WIDTH, maxWidth: TOC_MAX_WIDTH, width: '100%' }}
+                >
+                  <TocPanel
+                    editorMode="blocknote"
+                    blocknote={{ getHeadings, scrollToBlock }}
+                    container={blockNoteContainer}
+                  />
+                </div>
+              </ResizablePanel>
+            </>
+          )}
+        </ResizablePanelGroup>
+      </div>
     </div>
   )
 }

--- a/src/renderer/components/editor/MarkdownEditor.tsx
+++ b/src/renderer/components/editor/MarkdownEditor.tsx
@@ -4,7 +4,7 @@ import { useBlockNote } from '@/hooks/use-blocknote'
 import { BlockNoteViewRaw } from '@blocknote/react'
 import { TocPanel } from './TocPanel'
 import { ResizablePanelGroup, ResizablePanel, ResizableHandle } from '@/components/ui/resizable'
-import { useTocIsVisible, useTocWidth, useTocSettingsStore } from '@/stores/toc-settings-store'
+import { useTocSettingsStore } from '@/stores/toc-settings-store'
 import { TOC_MAX_WIDTH, TOC_MIN_WIDTH } from '@/types/settings'
 import '@blocknote/react/style.css'
 
@@ -13,6 +13,16 @@ interface MarkdownEditorProps {
   content: string
   isVisible: boolean
   onChange: (content: string) => void
+}
+
+function getTocPercentBounds(panelWidth: number): { minPercent: number; maxPercent: number } {
+  const minPercent = (TOC_MIN_WIDTH / panelWidth) * 100
+  const maxPercent = (TOC_MAX_WIDTH / panelWidth) * 100
+
+  return {
+    minPercent,
+    maxPercent: Math.max(minPercent, maxPercent)
+  }
 }
 
 function useIsDark(): boolean {
@@ -37,6 +47,7 @@ function useIsDark(): boolean {
 }
 
 export function MarkdownEditor({
+  filePath,
   content,
   isVisible,
   onChange
@@ -44,6 +55,7 @@ export function MarkdownEditor({
   // Track whether the last content change came from this editor's onChange
   const isLocalChangeRef = useRef(false)
   const prevContentRef = useRef(content)
+  const prevFilePathRef = useRef(filePath)
 
   const wrappedOnChange = useCallback(
     (newContent: string) => {
@@ -64,43 +76,64 @@ export function MarkdownEditor({
   const panelGroupRef = useRef<ImperativePanelGroupHandle>(null)
   const [blockNoteContainer, setBlockNoteContainer] = useState<HTMLDivElement | null>(null)
   const [layoutWidth, setLayoutWidth] = useState(0)
-  const isTocVisible = useTocIsVisible()
-  const tocWidth = useTocWidth()
-  const setTocWidth = useTocSettingsStore((state) => state.setWidth)
+  const { isTocHydrated, isTocVisible, tocWidth, setTocWidth } = useTocSettingsStore((state) => ({
+    isTocHydrated: state.isLoaded || state.loadFailed,
+    isTocVisible: state.settings.isVisible,
+    tocWidth: state.settings.width,
+    setTocWidth: state.setWidth
+  }))
+
+  const getPanelWidth = useCallback((): number => {
+    return layoutWidth || layoutRef.current?.clientWidth || 1000
+  }, [layoutWidth])
 
   const getTocPanelSizePercent = useCallback((): number => {
-    const panelWidth = layoutWidth || layoutRef.current?.clientWidth || 1000
+    const panelWidth = getPanelWidth()
+    const { minPercent, maxPercent } = getTocPercentBounds(panelWidth)
     const widthRatio = panelWidth > 0 ? tocWidth / panelWidth : 0
-    return Math.min(40, Math.max(10, widthRatio * 100))
-  }, [layoutWidth, tocWidth])
 
+    return Math.min(maxPercent, Math.max(minPercent, widthRatio * 100))
+  }, [getPanelWidth, tocWidth])
+
+  const tocPanelBounds = useMemo(() => getTocPercentBounds(getPanelWidth()), [getPanelWidth])
   const tocPanelDefaultSize = useMemo(() => getTocPanelSizePercent(), [getTocPanelSizePercent])
+  const canRenderToc = isTocHydrated && isTocVisible
 
   const handleTocResize = useCallback<PanelOnResize>(
     (size, prevSize): void => {
-      const layoutWidth = layoutRef.current?.clientWidth ?? 1000
-      const nextPixels = Math.round((size / 100) * layoutWidth)
+      const panelWidth = getPanelWidth()
+      const { minPercent, maxPercent } = getTocPercentBounds(panelWidth)
+      const clampedSize = Math.min(maxPercent, Math.max(minPercent, size))
+      const nextPixels = Math.round((clampedSize / 100) * panelWidth)
 
       if (prevSize !== size) {
         setTocWidth(nextPixels)
       }
     },
-    [setTocWidth]
+    [getPanelWidth, setTocWidth]
   )
 
   // Sync content only for external changes (e.g., file reload from disk)
   useEffect(() => {
+    if (filePath !== prevFilePathRef.current) {
+      isLocalChangeRef.current = false
+      prevFilePathRef.current = filePath
+      prevContentRef.current = content
+      void replaceContent(content)
+      return
+    }
+
     if (content !== prevContentRef.current) {
       if (isLocalChangeRef.current) {
         // This change came from the editor itself, don't push it back
         isLocalChangeRef.current = false
       } else {
         // External change - replace editor content
-        replaceContent(content)
+        void replaceContent(content)
       }
       prevContentRef.current = content
     }
-  }, [content, replaceContent])
+  }, [content, filePath, replaceContent])
 
   useEffect(() => {
     setBlockNoteContainer(blockNoteScrollRootRef.current)
@@ -129,7 +162,7 @@ export function MarkdownEditor({
   }, [])
 
   useEffect(() => {
-    if (!isTocVisible) {
+    if (!canRenderToc) {
       return
     }
 
@@ -146,13 +179,13 @@ export function MarkdownEditor({
     }
 
     group.setLayout([100 - tocSize, tocSize])
-  }, [getTocPanelSizePercent, isTocVisible])
+  }, [canRenderToc, getTocPanelSizePercent])
 
   return (
     <div className="w-full h-full" style={{ display: isVisible ? 'block' : 'none' }}>
       <div ref={layoutRef} className="h-full w-full">
         <ResizablePanelGroup ref={panelGroupRef} direction="horizontal">
-          <ResizablePanel defaultSize={isTocVisible ? 100 - tocPanelDefaultSize : 100} minSize={60}>
+          <ResizablePanel defaultSize={canRenderToc ? 100 - tocPanelDefaultSize : 100} minSize={60}>
             <div ref={blockNoteScrollRootRef} className="h-full overflow-auto">
               <BlockNoteViewRaw
                 editor={editor}
@@ -168,13 +201,13 @@ export function MarkdownEditor({
             </div>
           </ResizablePanel>
 
-          {isTocVisible && (
+          {canRenderToc && (
             <>
               <ResizableHandle />
               <ResizablePanel
                 defaultSize={tocPanelDefaultSize}
-                minSize={10}
-                maxSize={40}
+                minSize={tocPanelBounds.minPercent}
+                maxSize={tocPanelBounds.maxPercent}
                 onResize={handleTocResize}
               >
                 <div

--- a/src/renderer/components/editor/TableOfContents.test.tsx
+++ b/src/renderer/components/editor/TableOfContents.test.tsx
@@ -4,25 +4,48 @@ import { fireEvent, render, screen } from '@testing-library/react'
 import { TableOfContents } from './TableOfContents'
 import type { TocHeading } from '@/hooks/use-toc-headings'
 
-vi.mock('@/components/ui/dropdown-menu', () => ({
-  DropdownMenu: ({ children }: { children: React.ReactNode }) => <>{children}</>,
-  DropdownMenuTrigger: ({ children }: { children: React.ReactNode }) => <>{children}</>,
-  DropdownMenuContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
-  DropdownMenuRadioGroup: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
-  DropdownMenuRadioItem: ({
-    children,
-    value,
-    onSelect
-  }: {
-    children: React.ReactNode
-    value: string
-    onSelect?: () => void
-  }) => (
-    <button type="button" data-value={value} onClick={onSelect}>
-      {children}
-    </button>
-  )
-}))
+vi.mock('@/components/ui/dropdown-menu', async () => {
+  const React = await import('react')
+
+  const RadioGroupContext = React.createContext<((value: string) => void) | undefined>(undefined)
+
+  return {
+    DropdownMenu: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+    DropdownMenuTrigger: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+    DropdownMenuContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+    DropdownMenuRadioGroup: ({
+      children,
+      onValueChange
+    }: {
+      children: React.ReactNode
+      onValueChange?: (value: string) => void
+    }) => <RadioGroupContext.Provider value={onValueChange}><div>{children}</div></RadioGroupContext.Provider>,
+    DropdownMenuRadioItem: ({
+      children,
+      value,
+      onSelect
+    }: {
+      children: React.ReactNode
+      value: string
+      onSelect?: () => void
+    }) => {
+      const onValueChange = React.useContext(RadioGroupContext)
+
+      return (
+        <button
+          type="button"
+          data-value={value}
+          onClick={() => {
+            onSelect?.()
+            onValueChange?.(value)
+          }}
+        >
+          {children}
+        </button>
+      )
+    }
+  }
+})
 
 const headings: TocHeading[] = [
   { id: 'heading-line-1', level: 1, text: 'Title', line: 1 },
@@ -93,5 +116,22 @@ describe('TableOfContents', () => {
     expect(screen.getByText('H1-H1')).toBeInTheDocument()
     expect(screen.getByText('H1-H2')).toBeInTheDocument()
     expect(screen.getByText('H1-H6')).toBeInTheDocument()
+  })
+
+  it('calls onMaxHeadingLevelChange when a heading range is selected', () => {
+    const onMaxHeadingLevelChange = vi.fn()
+
+    render(
+      <TableOfContents
+        headings={headings}
+        maxHeadingLevel={3}
+        onHeadingClick={vi.fn()}
+        onMaxHeadingLevelChange={onMaxHeadingLevelChange}
+      />
+    )
+
+    fireEvent.click(screen.getByText('H1-H5'))
+
+    expect(onMaxHeadingLevelChange).toHaveBeenCalledWith(5)
   })
 })

--- a/src/renderer/components/editor/TableOfContents.test.tsx
+++ b/src/renderer/components/editor/TableOfContents.test.tsx
@@ -1,0 +1,97 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import type React from 'react'
+import { fireEvent, render, screen } from '@testing-library/react'
+import { TableOfContents } from './TableOfContents'
+import type { TocHeading } from '@/hooks/use-toc-headings'
+
+vi.mock('@/components/ui/dropdown-menu', () => ({
+  DropdownMenu: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  DropdownMenuTrigger: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  DropdownMenuContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DropdownMenuRadioGroup: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DropdownMenuRadioItem: ({
+    children,
+    value,
+    onSelect
+  }: {
+    children: React.ReactNode
+    value: string
+    onSelect?: () => void
+  }) => (
+    <button type="button" data-value={value} onClick={onSelect}>
+      {children}
+    </button>
+  )
+}))
+
+const headings: TocHeading[] = [
+  { id: 'heading-line-1', level: 1, text: 'Title', line: 1 },
+  { id: 'heading-line-3', level: 2, text: 'Section', line: 3 }
+]
+
+describe('TableOfContents', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+  it('renders an empty state when there are no headings', () => {
+    render(
+      <TableOfContents
+        headings={[]}
+        maxHeadingLevel={3}
+        onHeadingClick={vi.fn()}
+        onMaxHeadingLevelChange={vi.fn()}
+      />
+    )
+
+    expect(screen.getByText('No headings found')).toBeInTheDocument()
+  })
+
+  it('renders heading items and highlights the active heading', () => {
+    render(
+      <TableOfContents
+        headings={headings}
+        activeHeadingId="heading-line-3"
+        maxHeadingLevel={3}
+        onHeadingClick={vi.fn()}
+        onMaxHeadingLevelChange={vi.fn()}
+      />
+    )
+
+    expect(screen.getByText('Title')).toBeInTheDocument()
+    expect(screen.getByText('Section').closest('button')).toHaveClass('bg-accent')
+  })
+
+  it('calls onHeadingClick when a heading is selected', () => {
+    const onHeadingClick = vi.fn()
+
+    render(
+      <TableOfContents
+        headings={headings}
+        maxHeadingLevel={3}
+        onHeadingClick={onHeadingClick}
+        onMaxHeadingLevelChange={vi.fn()}
+      />
+    )
+
+    fireEvent.click(screen.getByText('Section'))
+
+    expect(onHeadingClick).toHaveBeenCalledWith(headings[1])
+  })
+
+  it('exposes full heading level range in settings', () => {
+    render(
+      <TableOfContents
+        headings={headings}
+        maxHeadingLevel={3}
+        onHeadingClick={vi.fn()}
+        onMaxHeadingLevelChange={vi.fn()}
+      />
+    )
+
+    fireEvent.click(screen.getByLabelText('TOC settings'))
+
+    expect(screen.getByText('H1-H1')).toBeInTheDocument()
+    expect(screen.getByText('H1-H2')).toBeInTheDocument()
+    expect(screen.getByText('H1-H6')).toBeInTheDocument()
+  })
+})

--- a/src/renderer/components/editor/TableOfContents.tsx
+++ b/src/renderer/components/editor/TableOfContents.tsx
@@ -1,0 +1,98 @@
+import { Settings2, List } from 'lucide-react'
+import type { TocHeading } from '@/hooks/use-toc-headings'
+import { cn } from '@/lib/utils'
+import { Button } from '@/components/ui/button'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuTrigger
+} from '@/components/ui/dropdown-menu'
+
+const HEADING_LEVEL_OPTIONS = [1, 2, 3, 4, 5, 6]
+
+interface TableOfContentsProps {
+  headings: TocHeading[]
+  activeHeadingId?: string
+  maxHeadingLevel: number
+  onHeadingClick: (heading: TocHeading) => void
+  onMaxHeadingLevelChange: (level: number) => void
+}
+
+export function TableOfContents({
+  headings,
+  activeHeadingId,
+  maxHeadingLevel,
+  onHeadingClick,
+  onMaxHeadingLevelChange
+}: TableOfContentsProps): React.JSX.Element {
+  return (
+    <div className="flex h-full min-h-0 flex-col border-l border-border bg-card">
+      <div className="flex items-center justify-between gap-2 border-b border-border px-3 py-2">
+        <div className="flex items-center gap-2 text-sm font-medium text-foreground">
+          <List className="h-4 w-4" />
+          <span>Contents</span>
+        </div>
+
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button
+              variant="ghost"
+              size="icon"
+              className="h-7 w-7"
+              title="TOC settings"
+              aria-label="TOC settings"
+            >
+              <Settings2 className="h-4 w-4" />
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end">
+            <DropdownMenuRadioGroup
+              value={String(maxHeadingLevel)}
+              onValueChange={(value) => onMaxHeadingLevelChange(Number(value))}
+            >
+              {HEADING_LEVEL_OPTIONS.map((level) => (
+                <DropdownMenuRadioItem key={level} value={String(level)}>
+                  {`H1-H${level}`}
+                </DropdownMenuRadioItem>
+              ))}
+            </DropdownMenuRadioGroup>
+          </DropdownMenuContent>
+        </DropdownMenu>
+      </div>
+
+      {headings.length === 0 ? (
+        <div className="flex flex-1 items-center justify-center px-4 text-center text-sm text-muted-foreground">
+          No headings found
+        </div>
+      ) : (
+        <nav className="flex-1 overflow-auto py-2" aria-label="Table of contents">
+          <ul className="space-y-1 px-2">
+            {headings.map((heading) => {
+              const isActive = heading.id === activeHeadingId
+
+              return (
+                <li key={heading.id}>
+                  <button
+                    type="button"
+                    className={cn(
+                      'w-full rounded-md px-2 py-1.5 text-left text-sm transition-colors hover:bg-accent hover:text-accent-foreground',
+                      isActive && 'bg-accent text-accent-foreground'
+                    )}
+                    style={{ paddingLeft: (heading.level - 1) * 12 + 8 }}
+                    onClick={() => onHeadingClick(heading)}
+                    title={heading.text}
+                    aria-current={isActive ? 'location' : undefined}
+                  >
+                    <span className="block truncate">{heading.text}</span>
+                  </button>
+                </li>
+              )
+            })}
+          </ul>
+        </nav>
+      )}
+    </div>
+  )
+}

--- a/src/renderer/components/editor/TocPanel.tsx
+++ b/src/renderer/components/editor/TocPanel.tsx
@@ -1,0 +1,84 @@
+import { useMemo } from 'react'
+import { TableOfContents } from './TableOfContents'
+import { useTocHeadings, filterTocHeadings, type TocHeading } from '@/hooks/use-toc-headings'
+import { useBlockNoteActiveHeading, useCodeMirrorActiveHeading } from '@/hooks/use-active-heading'
+import { useTocSettingsStore } from '@/stores/toc-settings-store'
+import type { VisibleLineRange } from '@/hooks/use-codemirror'
+
+interface BlockNoteTocApi {
+  getHeadings: () => TocHeading[]
+  scrollToBlock: (blockId: string) => void
+}
+
+interface CodeMirrorTocApi {
+  content: string
+  scrollToLine: (lineNumber: number) => void
+  visibleRange?: VisibleLineRange
+}
+
+type TocPanelProps =
+  | {
+      editorMode: 'blocknote'
+      blocknote: BlockNoteTocApi
+      container: HTMLElement | null
+    }
+  | {
+      editorMode: 'codemirror'
+      codemirror: CodeMirrorTocApi
+    }
+
+export function TocPanel(props: TocPanelProps): React.JSX.Element {
+  const maxHeadingLevel = useTocSettingsStore((state) => state.settings.maxHeadingLevel)
+  const setMaxHeadingLevel = useTocSettingsStore((state) => state.setMaxHeadingLevel)
+
+  const blockNoteHeadings = useMemo(() => {
+    if (props.editorMode !== 'blocknote') {
+      return []
+    }
+
+    return filterTocHeadings(props.blocknote.getHeadings(), maxHeadingLevel)
+  }, [maxHeadingLevel, props])
+
+  const codeMirrorHeadingsResult = useTocHeadings({
+    content: props.editorMode === 'codemirror' ? props.codemirror.content : '',
+    maxLevel: maxHeadingLevel
+  })
+
+  const headings = props.editorMode === 'blocknote' ? blockNoteHeadings : codeMirrorHeadingsResult.headings
+
+  const blockNoteActiveHeadingId = useBlockNoteActiveHeading({
+    headings: props.editorMode === 'blocknote' ? blockNoteHeadings : [],
+    container: props.editorMode === 'blocknote' ? props.container : null,
+    isEnabled: props.editorMode === 'blocknote'
+  })
+
+  const codeMirrorActiveHeadingId = useCodeMirrorActiveHeading({
+    headings: props.editorMode === 'codemirror' ? codeMirrorHeadingsResult.headings : [],
+    visibleRange: props.editorMode === 'codemirror' ? props.codemirror.visibleRange : undefined
+  })
+
+  const activeHeadingId = props.editorMode === 'blocknote' ? blockNoteActiveHeadingId : codeMirrorActiveHeadingId
+
+  const handleHeadingClick = (heading: TocHeading): void => {
+    if (props.editorMode === 'blocknote') {
+      if (heading.blockId) {
+        props.blocknote.scrollToBlock(heading.blockId)
+      }
+      return
+    }
+
+    if (heading.line) {
+      props.codemirror.scrollToLine(heading.line)
+    }
+  }
+
+  return (
+    <TableOfContents
+      headings={headings}
+      activeHeadingId={activeHeadingId}
+      maxHeadingLevel={maxHeadingLevel}
+      onHeadingClick={handleHeadingClick}
+      onMaxHeadingLevelChange={setMaxHeadingLevel}
+    />
+  )
+}

--- a/src/renderer/components/ui/resizable.tsx
+++ b/src/renderer/components/ui/resizable.tsx
@@ -1,17 +1,21 @@
+import { forwardRef } from 'react'
 import { GripVertical } from 'lucide-react'
 import * as ResizablePrimitive from 'react-resizable-panels'
 
 import { cn } from '@/lib/utils'
 
-const ResizablePanelGroup = ({
-  className,
-  ...props
-}: React.ComponentProps<typeof ResizablePrimitive.PanelGroup>) => (
+const ResizablePanelGroup = forwardRef<
+  React.ElementRef<typeof ResizablePrimitive.PanelGroup>,
+  React.ComponentProps<typeof ResizablePrimitive.PanelGroup>
+>(({ className, ...props }, ref) => (
   <ResizablePrimitive.PanelGroup
+    ref={ref}
     className={cn('flex h-full w-full data-[panel-group-direction=vertical]:flex-col', className)}
     {...props}
   />
-)
+))
+
+ResizablePanelGroup.displayName = ResizablePrimitive.PanelGroup.displayName
 
 const ResizablePanel = ResizablePrimitive.Panel
 

--- a/src/renderer/hooks/use-active-heading.test.ts
+++ b/src/renderer/hooks/use-active-heading.test.ts
@@ -1,6 +1,6 @@
-import { describe, expect, it } from 'vitest'
-import { renderHook } from '@testing-library/react'
-import { getActiveHeadingFromVisibleRange, useCodeMirrorActiveHeading } from './use-active-heading'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { act, renderHook } from '@testing-library/react'
+import { getActiveHeadingFromVisibleRange, useBlockNoteActiveHeading, useCodeMirrorActiveHeading } from './use-active-heading'
 import type { TocHeading } from './use-toc-headings'
 
 const headings: TocHeading[] = [
@@ -8,6 +8,10 @@ const headings: TocHeading[] = [
   { id: 'heading-line-4', level: 2, text: 'Section', line: 4 },
   { id: 'heading-line-8', level: 3, text: 'Details', line: 8 }
 ]
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
 
 describe('use-active-heading', () => {
   it('returns the first heading when no visible range is available', () => {
@@ -39,5 +43,61 @@ describe('use-active-heading', () => {
     rerender({ visibleRange: { startLine: 8, endLine: 12 } })
 
     expect(result.current).toBe('heading-line-8')
+  })
+
+  it('maps visible BlockNote block ids back to TOC ids', () => {
+    const container = document.createElement('div')
+    const headingElement = document.createElement('div')
+    const headingContent = document.createElement('div')
+    headingElement.setAttribute('data-node-type', 'blockContainer')
+    headingElement.setAttribute('data-id', 'block-1')
+    headingContent.setAttribute('data-content-type', 'heading')
+    headingElement.appendChild(headingContent)
+    container.appendChild(headingElement)
+
+    const blockHeadings: TocHeading[] = [
+      { id: 'toc-heading-1', blockId: 'block-1', level: 1, text: 'Title' }
+    ]
+
+    let observerCallback: IntersectionObserverCallback | undefined
+
+    class MockIntersectionObserver {
+      constructor(callback: IntersectionObserverCallback) {
+        observerCallback = callback
+      }
+
+      observe = vi.fn()
+      disconnect = vi.fn()
+      unobserve = vi.fn()
+      root = null
+      rootMargin = '0px'
+      thresholds = [0]
+      takeRecords = () => []
+    }
+
+    vi.stubGlobal('IntersectionObserver', MockIntersectionObserver)
+
+    const { result } = renderHook(() =>
+      useBlockNoteActiveHeading({
+        headings: blockHeadings,
+        container,
+        isEnabled: true
+      })
+    )
+
+    act(() => {
+      observerCallback?.(
+        [
+          {
+            target: headingElement,
+            isIntersecting: true,
+            boundingClientRect: { top: 24 }
+          } as unknown as IntersectionObserverEntry
+        ],
+        {} as IntersectionObserver
+      )
+    })
+
+    expect(result.current).toBe('toc-heading-1')
   })
 })

--- a/src/renderer/hooks/use-active-heading.test.ts
+++ b/src/renderer/hooks/use-active-heading.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest'
+import { renderHook } from '@testing-library/react'
+import { getActiveHeadingFromVisibleRange, useCodeMirrorActiveHeading } from './use-active-heading'
+import type { TocHeading } from './use-toc-headings'
+
+const headings: TocHeading[] = [
+  { id: 'heading-line-1', level: 1, text: 'Title', line: 1 },
+  { id: 'heading-line-4', level: 2, text: 'Section', line: 4 },
+  { id: 'heading-line-8', level: 3, text: 'Details', line: 8 }
+]
+
+describe('use-active-heading', () => {
+  it('returns the first heading when no visible range is available', () => {
+    expect(getActiveHeadingFromVisibleRange(headings, undefined)).toBe('heading-line-1')
+  })
+
+  it('returns the nearest heading at or above the visible line', () => {
+    expect(getActiveHeadingFromVisibleRange(headings, { startLine: 1, endLine: 5 })).toBe('heading-line-1')
+    expect(getActiveHeadingFromVisibleRange(headings, { startLine: 6, endLine: 10 })).toBe('heading-line-4')
+    expect(getActiveHeadingFromVisibleRange(headings, { startLine: 10, endLine: 12 })).toBe('heading-line-8')
+  })
+
+  it('returns undefined when there are no headings', () => {
+    expect(getActiveHeadingFromVisibleRange([], { startLine: 1, endLine: 2 })).toBeUndefined()
+  })
+
+  it('computes active heading in the CodeMirror hook', () => {
+    const { result, rerender } = renderHook(
+      ({ visibleRange }) => useCodeMirrorActiveHeading({ headings, visibleRange }),
+      {
+        initialProps: {
+          visibleRange: { startLine: 2, endLine: 5 }
+        }
+      }
+    )
+
+    expect(result.current).toBe('heading-line-1')
+
+    rerender({ visibleRange: { startLine: 8, endLine: 12 } })
+
+    expect(result.current).toBe('heading-line-8')
+  })
+})

--- a/src/renderer/hooks/use-active-heading.ts
+++ b/src/renderer/hooks/use-active-heading.ts
@@ -1,0 +1,131 @@
+import { useEffect, useMemo, useState } from 'react'
+import type { TocHeading } from '@/hooks/use-toc-headings'
+
+function getActiveHeadingForLine(headings: TocHeading[], lineNumber: number): string | undefined {
+  let activeHeadingId: string | undefined
+
+  for (const heading of headings) {
+    if (heading.line === undefined) {
+      continue
+    }
+
+    if (heading.line <= lineNumber) {
+      activeHeadingId = heading.id
+      continue
+    }
+
+    break
+  }
+
+  return activeHeadingId ?? headings[0]?.id
+}
+
+export function getActiveHeadingFromVisibleRange(
+  headings: TocHeading[],
+  visibleRange?: { startLine: number; endLine: number }
+): string | undefined {
+  if (!headings.length) {
+    return undefined
+  }
+
+  if (!visibleRange) {
+    return headings[0]?.id
+  }
+
+  return getActiveHeadingForLine(headings, visibleRange.startLine)
+}
+
+interface UseCodeMirrorActiveHeadingOptions {
+  headings: TocHeading[]
+  visibleRange?: { startLine: number; endLine: number }
+}
+
+export function useCodeMirrorActiveHeading({
+  headings,
+  visibleRange
+}: UseCodeMirrorActiveHeadingOptions): string | undefined {
+  return useMemo(
+    () => getActiveHeadingFromVisibleRange(headings, visibleRange),
+    [headings, visibleRange]
+  )
+}
+
+interface UseBlockNoteActiveHeadingOptions {
+  headings: TocHeading[]
+  container: HTMLElement | null
+  isEnabled?: boolean
+}
+
+export function useBlockNoteActiveHeading({
+  headings,
+  container,
+  isEnabled = true
+}: UseBlockNoteActiveHeadingOptions): string | undefined {
+  const [activeHeadingId, setActiveHeadingId] = useState<string | undefined>(headings[0]?.id)
+
+  useEffect(() => {
+    setActiveHeadingId(headings[0]?.id)
+  }, [headings])
+
+  useEffect(() => {
+    if (!isEnabled || !container || !headings.length) {
+      return
+    }
+
+    const headingIds = new Set(headings.map((heading) => heading.blockId ?? heading.id))
+    const visibleHeadings = new Map<string, number>()
+
+    const updateActiveHeading = (): void => {
+      const next = Array.from(visibleHeadings.entries())
+        .sort((a, b) => a[1] - b[1])
+        .map(([headingId]) => headingId)[0]
+
+      if (next) {
+        setActiveHeadingId(next)
+      }
+    }
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        entries.forEach((entry) => {
+          const element = entry.target as HTMLElement
+          const headingId = element.dataset.id
+
+          if (!headingId) {
+            return
+          }
+
+          if (entry.isIntersecting) {
+            visibleHeadings.set(headingId, entry.boundingClientRect.top)
+          } else {
+            visibleHeadings.delete(headingId)
+          }
+        })
+
+        updateActiveHeading()
+      },
+      {
+        root: container,
+        threshold: [0, 0.1, 0.25],
+        rootMargin: '0px 0px -65% 0px'
+      }
+    )
+
+    const elements = Array.from(
+      container.querySelectorAll<HTMLElement>('[data-node-type="blockContainer"][data-id]')
+    ).filter((element) => {
+      const elementId = element.dataset.id
+      const isHeadingBlock = !!element.querySelector('[data-content-type="heading"]')
+      return !!elementId && isHeadingBlock && headingIds.has(elementId)
+    })
+
+    elements.forEach((element) => observer.observe(element))
+
+    return () => {
+      observer.disconnect()
+      visibleHeadings.clear()
+    }
+  }, [container, headings, isEnabled])
+
+  return activeHeadingId
+}

--- a/src/renderer/hooks/use-active-heading.ts
+++ b/src/renderer/hooks/use-active-heading.ts
@@ -121,7 +121,9 @@ export function useBlockNoteActiveHeading({
       return !!elementId && isHeadingBlock && headingIds.has(elementId)
     })
 
-    elements.forEach((element) => observer.observe(element))
+    elements.forEach((element) => {
+      observer.observe(element)
+    })
 
     return () => {
       observer.disconnect()

--- a/src/renderer/hooks/use-active-heading.ts
+++ b/src/renderer/hooks/use-active-heading.ts
@@ -73,6 +73,7 @@ export function useBlockNoteActiveHeading({
     }
 
     const headingIds = new Set(headings.map((heading) => heading.blockId ?? heading.id))
+    const blockIdToTocId = new Map(headings.map((heading) => [heading.blockId ?? heading.id, heading.id]))
     const visibleHeadings = new Map<string, number>()
 
     const updateActiveHeading = (): void => {
@@ -89,7 +90,8 @@ export function useBlockNoteActiveHeading({
       (entries) => {
         entries.forEach((entry) => {
           const element = entry.target as HTMLElement
-          const headingId = element.dataset.id
+          const blockId = element.dataset.id
+          const headingId = blockId ? blockIdToTocId.get(blockId) : undefined
 
           if (!headingId) {
             return

--- a/src/renderer/hooks/use-blocknote.ts
+++ b/src/renderer/hooks/use-blocknote.ts
@@ -138,16 +138,28 @@ export function useBlockNote(options: UseBlockNoteOptions): UseBlockNoteResult {
 
   const scrollToBlock = useCallback(
     (blockId: string): void => {
-      editor.setTextCursorPosition(blockId, 'start')
-      editor.focus()
+      const targetElement = editor.domElement?.querySelector<HTMLElement>(
+        `[data-node-type="blockContainer"][data-id="${CSS.escape(blockId)}"]`
+      )
 
-      requestAnimationFrame(() => {
-        const targetElement = Array.from(
-          editor.domElement?.querySelectorAll<HTMLElement>('[data-node-type="blockContainer"][data-id]') ?? []
-        ).find((element) => element.dataset.id === blockId)
+      if (!targetElement) {
+        return
+      }
 
-        targetElement?.scrollIntoView({ block: 'center' })
-      })
+      try {
+        editor.setTextCursorPosition(blockId, 'start')
+        editor.focus()
+
+        requestAnimationFrame(() => {
+          try {
+            targetElement.scrollIntoView({ block: 'center' })
+          } catch {
+            console.error('Failed to scroll TOC heading into view')
+          }
+        })
+      } catch {
+        console.error('Failed to focus TOC heading block')
+      }
     },
     [editor]
   )

--- a/src/renderer/hooks/use-blocknote.ts
+++ b/src/renderer/hooks/use-blocknote.ts
@@ -6,6 +6,7 @@ import {
   createCodeBlockSpec
 } from '@blocknote/core'
 import { codeBlockOptions } from '@blocknote/code-block'
+import type { TocHeading } from '@/hooks/use-toc-headings'
 
 interface UseBlockNoteOptions {
   initialMarkdown: string
@@ -15,10 +16,13 @@ interface UseBlockNoteOptions {
 interface UseBlockNoteResult {
   editor: BlockNoteEditor
   replaceContent: (markdown: string) => void
+  getHeadings: () => TocHeading[]
+  scrollToBlock: (blockId: string) => void
 }
 
 export function useBlockNote(options: UseBlockNoteOptions): UseBlockNoteResult {
   const onChangeRef = useRef(options.onChange)
+  const initialMarkdownRef = useRef(options.initialMarkdown)
   const debounceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   // Guard to suppress onChange during programmatic replaceBlocks calls
   const isReplacingRef = useRef(false)
@@ -40,7 +44,7 @@ export function useBlockNote(options: UseBlockNoteOptions): UseBlockNoteResult {
     const loadContent = async (): Promise<void> => {
       try {
         isReplacingRef.current = true
-        const blocks = await editor.tryParseMarkdownToBlocks(options.initialMarkdown)
+        const blocks = await editor.tryParseMarkdownToBlocks(initialMarkdownRef.current)
         editor.replaceBlocks(editor.document, blocks)
       } catch {
         // Failed to parse markdown
@@ -51,8 +55,9 @@ export function useBlockNote(options: UseBlockNoteOptions): UseBlockNoteResult {
         })
       }
     }
-    loadContent()
-  }, [])
+
+    void loadContent()
+  }, [editor])
 
   // Set up change listener
   useEffect(() => {
@@ -98,5 +103,54 @@ export function useBlockNote(options: UseBlockNoteOptions): UseBlockNoteResult {
     }
   }, [editor])
 
-  return { editor, replaceContent }
+  const getHeadings = useCallback((): TocHeading[] => {
+    return editor.document.flatMap((block) => {
+      if (block.type !== 'heading') {
+        return []
+      }
+
+      const level = typeof block.props.level === 'number' ? block.props.level : 1
+      const text = block.content
+        .flatMap((inlineContent) => {
+          if (inlineContent.type === 'text') {
+            return [inlineContent.text]
+          }
+
+          return []
+        })
+        .join('')
+        .trim()
+
+      if (!text) {
+        return []
+      }
+
+      return [
+        {
+          id: block.id,
+          blockId: block.id,
+          level,
+          text
+        }
+      ]
+    })
+  }, [editor])
+
+  const scrollToBlock = useCallback(
+    (blockId: string): void => {
+      editor.setTextCursorPosition(blockId, 'start')
+      editor.focus()
+
+      requestAnimationFrame(() => {
+        const targetElement = Array.from(
+          editor.domElement?.querySelectorAll<HTMLElement>('[data-node-type="blockContainer"][data-id]') ?? []
+        ).find((element) => element.dataset.id === blockId)
+
+        targetElement?.scrollIntoView({ block: 'center' })
+      })
+    },
+    [editor]
+  )
+
+  return { editor, replaceContent, getHeadings, scrollToBlock }
 }

--- a/src/renderer/hooks/use-codemirror.ts
+++ b/src/renderer/hooks/use-codemirror.ts
@@ -76,6 +76,11 @@ async function loadLanguage(lang: string): Promise<Extension | null> {
   return extension
 }
 
+export interface VisibleLineRange {
+  startLine: number
+  endLine: number
+}
+
 interface UseCodeMirrorOptions {
   content: string
   language: string
@@ -83,11 +88,23 @@ interface UseCodeMirrorOptions {
   onChange: (content: string) => void
   onCursorChange: (line: number, col: number) => void
   onScrollChange: (scrollTop: number) => void
+  onVisibleRangeChange?: (range: VisibleLineRange) => void
 }
 
 interface UseCodeMirrorResult {
   view: EditorView | null
   setContent: (content: string) => void
+  scrollToLine: (lineNumber: number) => void
+  getVisibleLineRange: () => VisibleLineRange | null
+}
+
+function getVisibleLineRangeForView(view: EditorView): VisibleLineRange {
+  const { from, to } = view.viewport
+
+  return {
+    startLine: view.state.doc.lineAt(from).number,
+    endLine: view.state.doc.lineAt(to).number
+  }
 }
 
 export function useCodeMirror(
@@ -99,15 +116,20 @@ export function useCodeMirror(
   const onChangeRef = useRef(options.onChange)
   const onCursorChangeRef = useRef(options.onCursorChange)
   const onScrollChangeRef = useRef(options.onScrollChange)
+  const onVisibleRangeChangeRef = useRef(options.onVisibleRangeChange)
+  const contentRef = useRef(options.content)
   const isExternalUpdate = useRef(false)
   const debounceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const scrollDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const visibleRangeDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const themeCompartment = useRef(new Compartment())
 
   // Keep refs up to date
   onChangeRef.current = options.onChange
   onCursorChangeRef.current = options.onCursorChange
   onScrollChangeRef.current = options.onScrollChange
+  onVisibleRangeChangeRef.current = options.onVisibleRangeChange
+  contentRef.current = options.content
 
   // Create editor
   useEffect(() => {
@@ -141,6 +163,13 @@ export function useCodeMirror(
         scrollDebounceRef.current = setTimeout(() => {
           onScrollChangeRef.current(view.scrollDOM.scrollTop)
         }, 300)
+
+        if (visibleRangeDebounceRef.current) {
+          clearTimeout(visibleRangeDebounceRef.current)
+        }
+        visibleRangeDebounceRef.current = setTimeout(() => {
+          onVisibleRangeChangeRef.current?.(getVisibleLineRangeForView(view))
+        }, 100)
         return false
       }
     })
@@ -180,7 +209,7 @@ export function useCodeMirror(
       if (!containerRef.current) return
 
       const state = EditorState.create({
-        doc: options.content,
+        doc: contentRef.current,
         extensions
       })
 
@@ -197,6 +226,7 @@ export function useCodeMirror(
       }
 
       viewRef.current = view
+      onVisibleRangeChangeRef.current?.(getVisibleLineRangeForView(view))
       setViewReady(true)
     }
 
@@ -215,13 +245,16 @@ export function useCodeMirror(
       if (scrollDebounceRef.current) {
         clearTimeout(scrollDebounceRef.current)
       }
+      if (visibleRangeDebounceRef.current) {
+        clearTimeout(visibleRangeDebounceRef.current)
+      }
       if (viewRef.current) {
         viewRef.current.destroy()
         viewRef.current = null
       }
       setViewReady(false)
     }
-  }, [options.language, options.readOnly])
+  }, [containerRef, options.language, options.readOnly])
 
   // Watch for dark/light theme changes via MutationObserver
   useEffect(() => {
@@ -256,5 +289,45 @@ export function useCodeMirror(
     isExternalUpdate.current = false
   }, [])
 
-  return { view: viewReady ? viewRef.current : null, setContent }
+  const scrollToLine = useCallback((lineNumber: number) => {
+    const view = viewRef.current
+    if (!view) return
+
+    const safeLineNumber = Math.min(Math.max(1, lineNumber), view.state.doc.lines)
+    const line = view.state.doc.line(safeLineNumber)
+    const lineBlock = view.lineBlockAt(line.from)
+    const targetScrollTop = Math.max(
+      0,
+      lineBlock.top - view.scrollDOM.clientHeight / 2 + lineBlock.height / 2
+    )
+
+    view.dispatch({
+      selection: { anchor: line.from }
+    })
+
+    view.scrollDOM.scrollTo({
+      top: targetScrollTop,
+      behavior: 'smooth'
+    })
+
+    onScrollChangeRef.current(targetScrollTop)
+    onVisibleRangeChangeRef.current?.(getVisibleLineRangeForView(view))
+    view.focus()
+  }, [])
+
+  const getVisibleLineRange = useCallback((): VisibleLineRange | null => {
+    const view = viewRef.current
+    if (!view) {
+      return null
+    }
+
+    return getVisibleLineRangeForView(view)
+  }, [])
+
+  return {
+    view: viewReady ? viewRef.current : null,
+    setContent,
+    scrollToLine,
+    getVisibleLineRange
+  }
 }

--- a/src/renderer/hooks/use-toc-headings.test.ts
+++ b/src/renderer/hooks/use-toc-headings.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest'
+import { renderHook } from '@testing-library/react'
+import { filterTocHeadings, parseMarkdownHeadings, useTocHeadings } from './use-toc-headings'
+
+describe('use-toc-headings', () => {
+  it('parses markdown headings with levels and line numbers', () => {
+    const headings = parseMarkdownHeadings(['# Title', 'text', '## Section', '### Subsection'].join('\n'))
+
+    expect(headings).toEqual([
+      { id: 'heading-line-1', level: 1, text: 'Title', line: 1 },
+      { id: 'heading-line-3', level: 2, text: 'Section', line: 3 },
+      { id: 'heading-line-4', level: 3, text: 'Subsection', line: 4 }
+    ])
+  })
+
+  it('supports indented atx headings, trailing closing hashes, and setext headings', () => {
+    const headings = parseMarkdownHeadings(
+      ['  ## Section ##', 'Title', '====', 'Subtitle', '----'].join('\n')
+    )
+
+    expect(headings).toEqual([
+      { id: 'heading-line-1', level: 2, text: 'Section', line: 1 },
+      { id: 'heading-line-2', level: 1, text: 'Title', line: 2 },
+      { id: 'heading-line-4', level: 2, text: 'Subtitle', line: 4 }
+    ])
+  })
+
+  it('does not duplicate atx headings when followed by setext markers', () => {
+    expect(parseMarkdownHeadings(['# Title', '---', '## Section', '==='].join('\n'))).toEqual([
+      { id: 'heading-line-1', level: 1, text: 'Title', line: 1 },
+      { id: 'heading-line-3', level: 2, text: 'Section', line: 3 }
+    ])
+  })
+
+  it('ignores non-heading lines and headings inside fenced code blocks', () => {
+    expect(parseMarkdownHeadings('plain text\n- list item\n```md\n# Hidden\n```\n# Visible')).toEqual([
+      { id: 'heading-line-6', level: 1, text: 'Visible', line: 6 }
+    ])
+  })
+
+  it('filters headings by max level', () => {
+    const headings = parseMarkdownHeadings('# Title\n## Section\n### Deep')
+
+    expect(filterTocHeadings(headings, 2)).toEqual([
+      { id: 'heading-line-1', level: 1, text: 'Title', line: 1 },
+      { id: 'heading-line-2', level: 2, text: 'Section', line: 2 }
+    ])
+  })
+
+  it('memoizes filtered headings in the hook', () => {
+    const { result, rerender } = renderHook(
+      ({ content, maxLevel }) => useTocHeadings({ content, maxLevel }),
+      {
+        initialProps: {
+          content: '# Title\n## Section\n### Deep',
+          maxLevel: 2
+        }
+      }
+    )
+
+    expect(result.current.headings).toHaveLength(2)
+
+    rerender({
+      content: '# Title\n## Section\n### Deep',
+      maxLevel: 3
+    })
+
+    expect(result.current.headings).toHaveLength(3)
+  })
+})

--- a/src/renderer/hooks/use-toc-headings.ts
+++ b/src/renderer/hooks/use-toc-headings.ts
@@ -1,0 +1,134 @@
+import { useMemo } from 'react'
+
+export interface TocHeading {
+  id: string
+  level: number
+  text: string
+  line?: number
+  blockId?: string
+}
+
+const ATX_HEADING_PATTERN = /^ {0,3}(#{1,6})[ \t]+(.+)$/
+const SETEXT_HEADING_PATTERN = /^ {0,3}(=+|-+)[ \t]*$/
+const FENCE_PATTERN = /^ {0,3}(`{3,}|~{3,})(.*)$/
+
+function normalizeAtxHeadingText(text: string): string {
+  return text.replace(/[ \t]+#+[ \t]*$/, '').trim()
+}
+
+function getFenceInfo(line: string): { marker: '`' | '~'; length: number } | null {
+  const match = FENCE_PATTERN.exec(line)
+  if (!match) {
+    return null
+  }
+
+  const marker = match[1][0] as '`' | '~'
+
+  return {
+    marker,
+    length: match[1].length
+  }
+}
+
+function isFenceClosingLine(
+  line: string,
+  activeFence: { marker: '`' | '~'; length: number }
+): boolean {
+  const trimmedLine = line.trim()
+  if (!trimmedLine) {
+    return false
+  }
+
+  if (!trimmedLine.startsWith(activeFence.marker)) {
+    return false
+  }
+
+  const markerCount = trimmedLine.match(new RegExp(`^\\${activeFence.marker}+`))?.[0].length ?? 0
+  if (markerCount < activeFence.length) {
+    return false
+  }
+
+  return trimmedLine.slice(markerCount).trim().length === 0
+}
+
+export function parseMarkdownHeadings(content: string): TocHeading[] {
+  const lines = content.split('\n')
+  const headings: TocHeading[] = []
+  let activeFence: { marker: '`' | '~'; length: number } | null = null
+
+  for (let index = 0; index < lines.length; index += 1) {
+    const lineContent = lines[index]
+
+    if (activeFence) {
+      if (isFenceClosingLine(lineContent, activeFence)) {
+        activeFence = null
+      }
+      continue
+    }
+
+    const fenceInfo = getFenceInfo(lineContent)
+    if (fenceInfo) {
+      activeFence = fenceInfo
+      continue
+    }
+
+    const atxMatch = ATX_HEADING_PATTERN.exec(lineContent)
+    if (atxMatch) {
+      const text = normalizeAtxHeadingText(atxMatch[2])
+      const line = index + 1
+
+      if (text) {
+        headings.push({
+          id: `heading-line-${line}`,
+          level: atxMatch[1].length,
+          text,
+          line
+        })
+      }
+
+      continue
+    }
+
+    const setextMatch = SETEXT_HEADING_PATTERN.exec(lineContent)
+    if (!setextMatch || index === 0) {
+      continue
+    }
+
+    const previousRawLine = lines[index - 1] ?? ''
+    const previousLine = previousRawLine.trim()
+    if (!previousLine || ATX_HEADING_PATTERN.test(previousRawLine) || previousRawLine.startsWith('    ')) {
+      continue
+    }
+
+    const line = index
+    headings.push({
+      id: `heading-line-${line}`,
+      level: setextMatch[1][0] === '=' ? 1 : 2,
+      text: previousLine,
+      line
+    })
+  }
+
+  return headings
+}
+
+export function filterTocHeadings(headings: TocHeading[], maxLevel: number): TocHeading[] {
+  return headings.filter((heading) => heading.level <= maxLevel)
+}
+
+interface UseTocHeadingsOptions {
+  content: string
+  maxLevel: number
+}
+
+interface UseTocHeadingsResult {
+  headings: TocHeading[]
+}
+
+export function useTocHeadings({ content, maxLevel }: UseTocHeadingsOptions): UseTocHeadingsResult {
+  const headings = useMemo(() => {
+    return filterTocHeadings(parseMarkdownHeadings(content), maxLevel)
+  }, [content, maxLevel])
+
+  return { headings }
+}

--- a/src/renderer/hooks/use-toc-settings.ts
+++ b/src/renderer/hooks/use-toc-settings.ts
@@ -1,0 +1,51 @@
+import { useEffect } from 'react'
+import { persistenceApi } from '@/lib/api'
+import type { TocSettings } from '@/types/settings'
+import { DEFAULT_TOC_SETTINGS, TOC_SETTINGS_KEY } from '@/types/settings'
+import { useTocSettingsStore } from '@/stores/toc-settings-store'
+
+let loadPromise: Promise<void> | null = null
+let hasSubscribedToPersistence = false
+
+async function initializeTocSettings(
+  setSettings: (settings: TocSettings) => void,
+  setLoaded: (loaded: boolean) => void
+): Promise<void> {
+  try {
+    const result = await persistenceApi.read<TocSettings>(TOC_SETTINGS_KEY)
+
+    if (result.success && result.data) {
+      setSettings({
+        ...DEFAULT_TOC_SETTINGS,
+        ...result.data
+      })
+    }
+  } catch {
+    console.error('Failed to load TOC settings')
+  } finally {
+    setLoaded(true)
+  }
+}
+
+export function useTocSettings(): void {
+  const setSettings = useTocSettingsStore((state) => state.setSettings)
+  const setLoaded = useTocSettingsStore((state) => state.setLoaded)
+
+  useEffect(() => {
+    if (!hasSubscribedToPersistence) {
+      useTocSettingsStore.subscribe((state) => {
+        if (!state.isLoaded) {
+          return
+        }
+
+        void persistenceApi.writeDebounced(TOC_SETTINGS_KEY, state.settings)
+      })
+
+      hasSubscribedToPersistence = true
+    }
+
+    if (!loadPromise && !useTocSettingsStore.getState().isLoaded) {
+      loadPromise = initializeTocSettings(setSettings, setLoaded)
+    }
+  }, [setLoaded, setSettings])
+}

--- a/src/renderer/hooks/use-toc-settings.ts
+++ b/src/renderer/hooks/use-toc-settings.ts
@@ -9,7 +9,8 @@ let hasSubscribedToPersistence = false
 
 async function initializeTocSettings(
   setSettings: (settings: TocSettings) => void,
-  setLoaded: (loaded: boolean) => void
+  setLoaded: (loaded: boolean) => void,
+  setLoadFailed: (failed: boolean) => void
 ): Promise<void> {
   try {
     const result = await persistenceApi.read<TocSettings>(TOC_SETTINGS_KEY)
@@ -19,22 +20,35 @@ async function initializeTocSettings(
         ...DEFAULT_TOC_SETTINGS,
         ...result.data
       })
+      setLoadFailed(false)
+      setLoaded(true)
+      return
     }
-  } catch {
+
+    if (!result.success && result.code === 'KEY_NOT_FOUND') {
+      setSettings(DEFAULT_TOC_SETTINGS)
+      setLoadFailed(false)
+      setLoaded(true)
+      return
+    }
+
+    setLoadFailed(true)
     console.error('Failed to load TOC settings')
-  } finally {
-    setLoaded(true)
+  } catch {
+    setLoadFailed(true)
+    console.error('Failed to load TOC settings')
   }
 }
 
 export function useTocSettings(): void {
   const setSettings = useTocSettingsStore((state) => state.setSettings)
   const setLoaded = useTocSettingsStore((state) => state.setLoaded)
+  const setLoadFailed = useTocSettingsStore((state) => state.setLoadFailed)
 
   useEffect(() => {
     if (!hasSubscribedToPersistence) {
       useTocSettingsStore.subscribe((state) => {
-        if (!state.isLoaded) {
+        if (!state.isLoaded || state.loadFailed) {
           return
         }
 
@@ -44,8 +58,9 @@ export function useTocSettings(): void {
       hasSubscribedToPersistence = true
     }
 
-    if (!loadPromise && !useTocSettingsStore.getState().isLoaded) {
-      loadPromise = initializeTocSettings(setSettings, setLoaded)
+    const storeState = useTocSettingsStore.getState()
+    if (!loadPromise && !storeState.isLoaded && !storeState.loadFailed) {
+      loadPromise = initializeTocSettings(setSettings, setLoaded, setLoadFailed)
     }
-  }, [setLoaded, setSettings])
+  }, [setLoadFailed, setLoaded, setSettings])
 }

--- a/src/renderer/stores/toc-settings-store.test.ts
+++ b/src/renderer/stores/toc-settings-store.test.ts
@@ -1,0 +1,60 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import { act, renderHook } from '@testing-library/react'
+import { useTocSettingsStore } from './toc-settings-store'
+import { DEFAULT_TOC_SETTINGS } from '@/types/settings'
+
+describe('toc-settings-store', () => {
+  beforeEach(() => {
+    useTocSettingsStore.setState({
+      settings: { ...DEFAULT_TOC_SETTINGS },
+      isLoaded: false
+    })
+  })
+
+  it('initializes with default settings', () => {
+    const { result } = renderHook(() => useTocSettingsStore())
+
+    expect(result.current.settings).toEqual(DEFAULT_TOC_SETTINGS)
+    expect(result.current.isLoaded).toBe(false)
+  })
+
+  it('toggles visibility', () => {
+    const { result } = renderHook(() => useTocSettingsStore())
+
+    act(() => {
+      result.current.toggleVisibility()
+    })
+
+    expect(result.current.settings.isVisible).toBe(!DEFAULT_TOC_SETTINGS.isVisible)
+  })
+
+  it('clamps width and max heading level', () => {
+    const { result } = renderHook(() => useTocSettingsStore())
+
+    act(() => {
+      result.current.setWidth(999)
+      result.current.setMaxHeadingLevel(9)
+    })
+
+    expect(result.current.settings.width).toBe(350)
+    expect(result.current.settings.maxHeadingLevel).toBe(6)
+
+    act(() => {
+      result.current.setWidth(10)
+      result.current.setMaxHeadingLevel(0)
+    })
+
+    expect(result.current.settings.width).toBe(150)
+    expect(result.current.settings.maxHeadingLevel).toBe(1)
+  })
+
+  it('marks settings as loaded', () => {
+    const { result } = renderHook(() => useTocSettingsStore())
+
+    act(() => {
+      result.current.setLoaded(true)
+    })
+
+    expect(result.current.isLoaded).toBe(true)
+  })
+})

--- a/src/renderer/stores/toc-settings-store.test.ts
+++ b/src/renderer/stores/toc-settings-store.test.ts
@@ -7,7 +7,8 @@ describe('toc-settings-store', () => {
   beforeEach(() => {
     useTocSettingsStore.setState({
       settings: { ...DEFAULT_TOC_SETTINGS },
-      isLoaded: false
+      isLoaded: false,
+      loadFailed: false
     })
   })
 
@@ -46,6 +47,20 @@ describe('toc-settings-store', () => {
 
     expect(result.current.settings.width).toBe(150)
     expect(result.current.settings.maxHeadingLevel).toBe(1)
+  })
+
+  it('sanitizes malformed persisted settings', () => {
+    const { result } = renderHook(() => useTocSettingsStore())
+
+    act(() => {
+      result.current.setSettings({
+        isVisible: 'yes' as unknown as boolean,
+        maxHeadingLevel: Number.NaN,
+        width: Number.POSITIVE_INFINITY
+      })
+    })
+
+    expect(result.current.settings).toEqual(DEFAULT_TOC_SETTINGS)
   })
 
   it('marks settings as loaded', () => {

--- a/src/renderer/stores/toc-settings-store.ts
+++ b/src/renderer/stores/toc-settings-store.ts
@@ -1,0 +1,76 @@
+import { create } from 'zustand'
+import type { TocSettings } from '@/types/settings'
+import { DEFAULT_TOC_SETTINGS, TOC_MAX_WIDTH, TOC_MIN_WIDTH } from '@/types/settings'
+
+interface TocSettingsState {
+  settings: TocSettings
+  isLoaded: boolean
+  setSettings: (settings: TocSettings) => void
+  toggleVisibility: () => void
+  setMaxHeadingLevel: (level: number) => void
+  setWidth: (width: number) => void
+  setLoaded: (loaded: boolean) => void
+}
+
+function clampHeadingLevel(level: number): number {
+  return Math.min(6, Math.max(1, Math.round(level)))
+}
+
+function clampWidth(width: number): number {
+  return Math.min(TOC_MAX_WIDTH, Math.max(TOC_MIN_WIDTH, Math.round(width)))
+}
+
+export const useTocSettingsStore = create<TocSettingsState>((set) => ({
+  settings: { ...DEFAULT_TOC_SETTINGS },
+  isLoaded: false,
+
+  setSettings: (settings) =>
+    set({
+      settings: {
+        isVisible: settings.isVisible,
+        maxHeadingLevel: clampHeadingLevel(settings.maxHeadingLevel),
+        width: clampWidth(settings.width)
+      }
+    }),
+
+  toggleVisibility: () =>
+    set((state) => ({
+      settings: {
+        ...state.settings,
+        isVisible: !state.settings.isVisible
+      }
+    })),
+
+  setMaxHeadingLevel: (level) =>
+    set((state) => ({
+      settings: {
+        ...state.settings,
+        maxHeadingLevel: clampHeadingLevel(level)
+      }
+    })),
+
+  setWidth: (width) =>
+    set((state) => ({
+      settings: {
+        ...state.settings,
+        width: clampWidth(width)
+      }
+    })),
+
+  setLoaded: (loaded) => set({ isLoaded: loaded })
+}))
+
+export const useTocIsVisible = (): boolean =>
+  useTocSettingsStore((state) => state.settings.isVisible)
+
+export const useTocMaxHeadingLevel = (): number =>
+  useTocSettingsStore((state) => state.settings.maxHeadingLevel)
+
+export const useTocWidth = (): number =>
+  useTocSettingsStore((state) => state.settings.width)
+
+export const useTocSettings = (): TocSettings =>
+  useTocSettingsStore((state) => state.settings)
+
+export const useTocSettingsLoaded = (): boolean =>
+  useTocSettingsStore((state) => state.isLoaded)

--- a/src/renderer/stores/toc-settings-store.ts
+++ b/src/renderer/stores/toc-settings-store.ts
@@ -5,29 +5,43 @@ import { DEFAULT_TOC_SETTINGS, TOC_MAX_WIDTH, TOC_MIN_WIDTH } from '@/types/sett
 interface TocSettingsState {
   settings: TocSettings
   isLoaded: boolean
+  loadFailed: boolean
   setSettings: (settings: TocSettings) => void
   toggleVisibility: () => void
   setMaxHeadingLevel: (level: number) => void
   setWidth: (width: number) => void
   setLoaded: (loaded: boolean) => void
+  setLoadFailed: (failed: boolean) => void
+}
+
+function getFiniteNumber(value: number, fallback: number): number {
+  const numericValue = Number(value)
+  return Number.isFinite(numericValue) ? numericValue : fallback
 }
 
 function clampHeadingLevel(level: number): number {
-  return Math.min(6, Math.max(1, Math.round(level)))
+  const safeLevel = getFiniteNumber(level, DEFAULT_TOC_SETTINGS.maxHeadingLevel)
+  return Math.min(6, Math.max(1, Math.round(safeLevel)))
 }
 
 function clampWidth(width: number): number {
-  return Math.min(TOC_MAX_WIDTH, Math.max(TOC_MIN_WIDTH, Math.round(width)))
+  const safeWidth = getFiniteNumber(width, DEFAULT_TOC_SETTINGS.width)
+  return Math.min(TOC_MAX_WIDTH, Math.max(TOC_MIN_WIDTH, Math.round(safeWidth)))
+}
+
+function normalizeVisibility(isVisible: boolean): boolean {
+  return typeof isVisible === 'boolean' ? isVisible : DEFAULT_TOC_SETTINGS.isVisible
 }
 
 export const useTocSettingsStore = create<TocSettingsState>((set) => ({
   settings: { ...DEFAULT_TOC_SETTINGS },
   isLoaded: false,
+  loadFailed: false,
 
   setSettings: (settings) =>
     set({
       settings: {
-        isVisible: settings.isVisible,
+        isVisible: normalizeVisibility(settings.isVisible),
         maxHeadingLevel: clampHeadingLevel(settings.maxHeadingLevel),
         width: clampWidth(settings.width)
       }
@@ -57,7 +71,8 @@ export const useTocSettingsStore = create<TocSettingsState>((set) => ({
       }
     })),
 
-  setLoaded: (loaded) => set({ isLoaded: loaded })
+  setLoaded: (loaded) => set({ isLoaded: loaded }),
+  setLoadFailed: (failed) => set({ loadFailed: failed })
 }))
 
 export const useTocIsVisible = (): boolean =>
@@ -74,3 +89,6 @@ export const useTocSettings = (): TocSettings =>
 
 export const useTocSettingsLoaded = (): boolean =>
   useTocSettingsStore((state) => state.isLoaded)
+
+export const useTocSettingsHydrated = (): boolean =>
+  useTocSettingsStore((state) => state.isLoaded || state.loadFailed)

--- a/src/renderer/types/settings.ts
+++ b/src/renderer/types/settings.ts
@@ -17,6 +17,24 @@ export const DEFAULT_CONTEXT_BAR_SETTINGS: ContextBarSettings = {
 // Persistence key for context bar settings
 export const CONTEXT_BAR_SETTINGS_KEY = 'settings/context-bar'
 
+// Table of contents panel settings
+export interface TocSettings {
+  isVisible: boolean
+  maxHeadingLevel: number
+  width: number
+}
+
+export const TOC_MIN_WIDTH = 150
+export const TOC_MAX_WIDTH = 350
+
+export const DEFAULT_TOC_SETTINGS: TocSettings = {
+  isVisible: true,
+  maxHeadingLevel: 3,
+  width: 220
+}
+
+export const TOC_SETTINGS_KEY = 'settings/toc'
+
 // Application-wide settings
 export interface AppSettings {
   terminalFontFamily: string


### PR DESCRIPTION
Closes #61

## Summary
- add a markdown-only table of contents panel for both BlockNote and CodeMirror editor modes
- persist TOC visibility, width, and max heading level, and add toolbar controls for markdown files
- support heading parsing, active heading highlighting, click-to-jump navigation, and focused tests for TOC behavior

## Test plan
- [x] npm run lint
- [x] npm run typecheck
- [x] npm test
- [x] npm run build:frontend:tauri

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a resizable TOC panel to code and markdown editors with persistent width and toggle in the toolbar.
  * TOC highlights the active section, supports clicking to jump to content, and integrates with both editor modes.
  * Configurable heading-level filter (H1–H6) via TOC settings; visible range syncs with editor for accurate active heading.

* **Tests**
  * Added comprehensive tests for TOC component, parsing, heading-active logic, and related hooks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->