### PR TITLE
fix: persist context bar settings across restarts

### DIFF
--- a/src/renderer/App.test.tsx
+++ b/src/renderer/App.test.tsx
@@ -2,6 +2,17 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { render, waitFor } from '@testing-library/react'
 import App from './App'
 import { useUpdaterStore } from '@/stores/updater-store'
+import { CONTEXT_BAR_SETTINGS_KEY } from '@/types/settings'
+
+const { mockContextBarSettingsRead } = vi.hoisted(() => ({
+  mockContextBarSettingsRead: vi.fn()
+}))
+
+vi.mock('./hooks/use-context-bar-settings', () => ({
+  useContextBarSettings: () => {
+    void mockContextBarSettingsRead(CONTEXT_BAR_SETTINGS_KEY)
+  }
+}))
 
 const mockCheckForUpdates = vi.fn(async () => {})
 const mockInitializeUpdater = vi.fn(async () => {})
@@ -32,7 +43,8 @@ const mockApi = {
     saveProjects: vi.fn(),
     getHomeDirectory: vi.fn(() => Promise.resolve({ success: true, data: '/home/user' })),
     read: vi.fn(() => Promise.resolve({ success: true, data: null })),
-    writeDebounced: vi.fn(() => Promise.resolve({ success: true, data: undefined }))
+    writeDebounced: vi.fn(() => Promise.resolve({ success: true, data: undefined })),
+    flushPendingWrites: vi.fn(() => Promise.resolve({ success: true, data: undefined }))
   },
   updater: {
     checkForUpdates: vi.fn(() => Promise.resolve({ success: true, data: null })),
@@ -106,6 +118,14 @@ describe('App Routes', () => {
     // WorkspaceDashboard should be rendered by default
     // Check for presence of rendered content (indicates route matched)
     expect(document.body.innerHTML).toBeTruthy()
+  })
+
+  it('loads context bar settings on mount', async () => {
+    render(<App />)
+
+    await waitFor(() => {
+      expect(mockContextBarSettingsRead).toHaveBeenCalledWith(CONTEXT_BAR_SETTINGS_KEY)
+    })
   })
 })
 

--- a/src/renderer/TauriApp.test.tsx
+++ b/src/renderer/TauriApp.test.tsx
@@ -1,0 +1,118 @@
+import { beforeEach, describe, expect, it, vi, afterEach } from 'vitest'
+import { render, waitFor } from '@testing-library/react'
+import TauriApp from './TauriApp'
+import { CONTEXT_BAR_SETTINGS_KEY } from '@/types/settings'
+
+const { mockPersistenceRead } = vi.hoisted(() => ({
+  mockPersistenceRead: vi.fn()
+}))
+
+vi.mock('@/lib/api', () => ({
+  persistenceApi: {
+    read: mockPersistenceRead
+  }
+}))
+
+vi.mock('@/hooks/use-window-state', () => ({
+  useWindowState: () => false
+}))
+
+vi.mock('./layouts/WorkspaceLayout', () => ({
+  default: () => <div>Workspace Layout</div>
+}))
+
+vi.mock('./pages/WorkspaceDashboard', () => ({
+  default: () => null
+}))
+
+vi.mock('./pages/ProjectSettings', () => ({
+  default: () => null
+}))
+
+vi.mock('./pages/AppPreferences', () => ({
+  default: () => null
+}))
+
+vi.mock('./pages/WorkspaceSnapshots', () => ({
+  default: () => null
+}))
+
+vi.mock('./pages/NotFound', () => ({
+  default: () => null
+}))
+
+vi.mock('./hooks/useTerminalAutoSave', () => ({
+  useTerminalAutoSave: () => undefined
+}))
+
+vi.mock('./hooks/use-terminal-restore', () => ({
+  useTerminalRestore: () => undefined
+}))
+
+vi.mock('./hooks/use-cwd', () => ({
+  useCwd: () => undefined
+}))
+
+vi.mock('./hooks/use-git-branch', () => ({
+  useGitBranch: () => undefined
+}))
+
+vi.mock('./hooks/use-git-status', () => ({
+  useGitStatus: () => undefined
+}))
+
+vi.mock('./hooks/use-exit-code', () => ({
+  useExitCode: () => undefined
+}))
+
+vi.mock('./hooks/use-app-settings', () => ({
+  useAppSettingsLoader: () => undefined
+}))
+
+vi.mock('./hooks/use-keyboard-shortcuts', () => ({
+  useKeyboardShortcutsLoader: () => undefined
+}))
+
+vi.mock('./hooks/use-projects-persistence', () => ({
+  useProjectsLoader: () => undefined,
+  useProjectsAutoSave: () => undefined
+}))
+
+vi.mock('./hooks/use-menu-updater-listener', () => ({
+  useMenuUpdaterListener: () => undefined
+}))
+
+vi.mock('./hooks/use-updater', () => ({
+  useUpdateCheck: () => undefined
+}))
+
+vi.mock('./components/UpdateAvailableToast', () => ({
+  useUpdateToast: () => undefined
+}))
+
+vi.mock('./hooks/use-visibility-state', () => ({
+  useVisibilityState: () => undefined
+}))
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mockPersistenceRead.mockResolvedValue({
+    success: false,
+    error: 'Key not found',
+    code: 'KEY_NOT_FOUND'
+  })
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe('TauriApp', () => {
+  it('loads context bar settings on mount', async () => {
+    render(<TauriApp />)
+
+    await waitFor(() => {
+      expect(mockPersistenceRead).toHaveBeenCalledWith(CONTEXT_BAR_SETTINGS_KEY)
+    })
+  })
+})

--- a/src/renderer/components/ContextBarSettingsPopover.test.tsx
+++ b/src/renderer/components/ContextBarSettingsPopover.test.tsx
@@ -1,0 +1,58 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { fireEvent, render, screen, within } from '@testing-library/react'
+import { ContextBarSettingsPopover } from './ContextBarSettingsPopover'
+import { useContextBarSettingsStore } from '@/stores/context-bar-settings-store'
+import { DEFAULT_CONTEXT_BAR_SETTINGS } from '@/types/settings'
+
+const { mockUpdateContextBarSetting } = vi.hoisted(() => ({
+  mockUpdateContextBarSetting: vi.fn()
+}))
+
+vi.mock('@/hooks/use-context-bar-settings', () => ({
+  useUpdateContextBarSetting: () => mockUpdateContextBarSetting
+}))
+
+describe('ContextBarSettingsPopover', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    useContextBarSettingsStore.setState({
+      settings: { ...DEFAULT_CONTEXT_BAR_SETTINGS },
+      isLoaded: true
+    })
+  })
+
+  it('renders the context bar settings popover trigger', () => {
+    render(<ContextBarSettingsPopover />)
+
+    expect(
+      screen.getByRole('button', { name: 'Context bar settings' })
+    ).toBeInTheDocument()
+  })
+
+  it('opens the popover and dispatches updates for each switch', () => {
+    render(<ContextBarSettingsPopover />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Context bar settings' }))
+
+    expect(screen.getByText('Show in Context Bar')).toBeInTheDocument()
+
+    const toggleCases: Array<[string, string]> = [
+      ['Git Branch', 'showGitBranch'],
+      ['Git Status', 'showGitStatus'],
+      ['Working Directory', 'showWorkingDirectory'],
+      ['Exit Code', 'showExitCode']
+    ]
+
+    toggleCases.forEach(([label, key]) => {
+      const row = screen.getByText(label).closest('div')
+      expect(row).not.toBeNull()
+
+      const toggle = within(row as HTMLElement).getByRole('switch')
+      fireEvent.click(toggle)
+
+      expect(mockUpdateContextBarSetting).toHaveBeenCalledWith(key)
+    })
+
+    expect(mockUpdateContextBarSetting).toHaveBeenCalledTimes(toggleCases.length)
+  })
+})

--- a/src/renderer/components/ContextBarSettingsPopover.tsx
+++ b/src/renderer/components/ContextBarSettingsPopover.tsx
@@ -2,9 +2,8 @@ import { Settings } from 'lucide-react'
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
 import { Switch } from '@/components/ui/switch'
 import { useContextBarSettingsStore } from '@/stores/context-bar-settings-store'
-import { CONTEXT_BAR_SETTINGS_KEY } from '@/types/settings'
+import { useUpdateContextBarSetting } from '@/hooks/use-context-bar-settings'
 import type { ContextBarSettings } from '@/types/settings'
-import { persistenceApi } from '@/lib/api'
 
 interface SettingToggleProps {
   label: string
@@ -23,13 +22,10 @@ function SettingToggle({ label, checked, onCheckedChange }: SettingToggleProps):
 
 export function ContextBarSettingsPopover(): React.JSX.Element {
   const settings = useContextBarSettingsStore((state) => state.settings)
-  const toggleElement = useContextBarSettingsStore((state) => state.toggleElement)
+  const updateContextBarSetting = useUpdateContextBarSetting()
 
   const handleToggle = (element: keyof ContextBarSettings): void => {
-    toggleElement(element)
-    // Persist to disk with debounce
-    const newSettings = { ...settings, [element]: !settings[element] }
-    void persistenceApi.writeDebounced(CONTEXT_BAR_SETTINGS_KEY, newSettings)
+    void updateContextBarSetting(element)
   }
 
   return (

--- a/src/renderer/hooks/use-context-bar-settings.test.ts
+++ b/src/renderer/hooks/use-context-bar-settings.test.ts
@@ -1,0 +1,141 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { act, renderHook, waitFor } from '@testing-library/react'
+import {
+  useContextBarSettings,
+  useUpdateContextBarSetting
+} from './use-context-bar-settings'
+import { useContextBarSettingsStore } from '@/stores/context-bar-settings-store'
+import {
+  CONTEXT_BAR_SETTINGS_KEY,
+  DEFAULT_CONTEXT_BAR_SETTINGS,
+  type ContextBarSettings
+} from '@/types/settings'
+
+const { mockPersistenceRead, mockPersistenceWriteDebounced } = vi.hoisted(() => ({
+  mockPersistenceRead: vi.fn(),
+  mockPersistenceWriteDebounced: vi.fn()
+}))
+
+vi.mock('@/lib/api', () => ({
+  persistenceApi: {
+    read: mockPersistenceRead,
+    writeDebounced: mockPersistenceWriteDebounced
+  }
+}))
+
+describe('useContextBarSettings', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    useContextBarSettingsStore.setState({
+      settings: { ...DEFAULT_CONTEXT_BAR_SETTINGS },
+      isLoaded: false
+    })
+
+    mockPersistenceRead.mockResolvedValue({
+      success: false,
+      error: 'Key not found',
+      code: 'KEY_NOT_FOUND'
+    })
+    mockPersistenceWriteDebounced.mockResolvedValue({ success: true, data: undefined })
+  })
+
+  it('restores persisted settings on startup', async () => {
+    const persistedSettings: ContextBarSettings = {
+      showGitBranch: false,
+      showGitStatus: false,
+      showWorkingDirectory: true,
+      showExitCode: false
+    }
+
+    mockPersistenceRead.mockResolvedValue({ success: true, data: persistedSettings })
+
+    renderHook(() => useContextBarSettings())
+
+    await waitFor(() => {
+      expect(useContextBarSettingsStore.getState().settings).toEqual(persistedSettings)
+      expect(useContextBarSettingsStore.getState().isLoaded).toBe(true)
+    })
+
+    expect(mockPersistenceRead).toHaveBeenCalledWith(CONTEXT_BAR_SETTINGS_KEY)
+  })
+
+  it('keeps defaults when no persisted key exists', async () => {
+    renderHook(() => useContextBarSettings())
+
+    await waitFor(() => {
+      expect(useContextBarSettingsStore.getState().settings).toEqual(
+        DEFAULT_CONTEXT_BAR_SETTINGS
+      )
+      expect(useContextBarSettingsStore.getState().isLoaded).toBe(true)
+    })
+  })
+
+  it('keeps defaults when loading settings throws', async () => {
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+    mockPersistenceRead.mockRejectedValue(new Error('read failed'))
+
+    renderHook(() => useContextBarSettings())
+
+    await waitFor(() => {
+      expect(useContextBarSettingsStore.getState().settings).toEqual(
+        DEFAULT_CONTEXT_BAR_SETTINGS
+      )
+      expect(useContextBarSettingsStore.getState().isLoaded).toBe(true)
+    })
+
+    expect(consoleErrorSpy).toHaveBeenCalledWith('Failed to load context bar settings')
+    consoleErrorSpy.mockRestore()
+  })
+
+  it('merges partial persisted settings with defaults', async () => {
+    mockPersistenceRead.mockResolvedValue({
+      success: true,
+      data: {
+        showGitBranch: false,
+        showExitCode: false
+      } as ContextBarSettings
+    })
+
+    renderHook(() => useContextBarSettings())
+
+    await waitFor(() => {
+      expect(useContextBarSettingsStore.getState().settings).toEqual({
+        ...DEFAULT_CONTEXT_BAR_SETTINGS,
+        showGitBranch: false,
+        showExitCode: false
+      })
+    })
+  })
+})
+
+describe('useUpdateContextBarSetting', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    useContextBarSettingsStore.setState({
+      settings: { ...DEFAULT_CONTEXT_BAR_SETTINGS },
+      isLoaded: true
+    })
+
+    mockPersistenceWriteDebounced.mockResolvedValue({ success: true, data: undefined })
+  })
+
+  it('updates the selected setting and persists the latest full snapshot', async () => {
+    const { result } = renderHook(() => useUpdateContextBarSetting())
+
+    await act(async () => {
+      await result.current('showGitStatus')
+    })
+
+    expect(useContextBarSettingsStore.getState().settings).toEqual({
+      ...DEFAULT_CONTEXT_BAR_SETTINGS,
+      showGitStatus: false
+    })
+    expect(mockPersistenceWriteDebounced).toHaveBeenCalledWith(
+      CONTEXT_BAR_SETTINGS_KEY,
+      {
+        ...DEFAULT_CONTEXT_BAR_SETTINGS,
+        showGitStatus: false
+      }
+    )
+  })
+})

--- a/src/renderer/hooks/use-context-bar-settings.ts
+++ b/src/renderer/hooks/use-context-bar-settings.ts
@@ -1,4 +1,4 @@
-import { useEffect } from 'react'
+import { useCallback, useEffect } from 'react'
 import { useContextBarSettingsStore } from '@/stores/context-bar-settings-store'
 import { persistenceApi } from '@/lib/api'
 import { CONTEXT_BAR_SETTINGS_KEY, DEFAULT_CONTEXT_BAR_SETTINGS } from '@/types/settings'
@@ -38,4 +38,19 @@ export function useContextBarSettings(): void {
 
     loadSettings()
   }, [setSettings, setLoaded])
+}
+
+export function useUpdateContextBarSetting(): (
+  element: keyof ContextBarSettings
+) => Promise<void> {
+  const toggleElement = useContextBarSettingsStore((state) => state.toggleElement)
+
+  return useCallback(
+    async (element: keyof ContextBarSettings) => {
+      toggleElement(element)
+      const updatedSettings = useContextBarSettingsStore.getState().settings
+      await persistenceApi.writeDebounced(CONTEXT_BAR_SETTINGS_KEY, updatedSettings)
+    },
+    [toggleElement]
+  )
 }

--- a/src/renderer/layouts/WorkspaceLayout.close-persistence.test.tsx
+++ b/src/renderer/layouts/WorkspaceLayout.close-persistence.test.tsx
@@ -1,0 +1,378 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { TooltipProvider } from '@/components/ui/tooltip'
+import WorkspaceLayout from './WorkspaceLayout'
+
+const {
+  activeProject,
+  mockProjectActions,
+  mockTerminalActions,
+  mockEditorStoreState,
+  mockTerminalStoreState,
+  mockWorkspaceStoreState,
+  mockFileExplorerStoreState,
+  mockCloseRequested,
+  mockRespondToClose,
+  mockFlushPendingWrites,
+  mockWatchDirectory,
+  mockUnwatchDirectory,
+  mockKeyboardOnShortcut,
+  mockToastError
+} = vi.hoisted(() => ({
+  activeProject: {
+    id: 'project-1',
+    name: 'Project 1',
+    color: 'blue',
+    path: '/test/project',
+    gitBranch: 'main',
+    isActive: true
+  },
+  mockProjectActions: {
+    selectProject: vi.fn(),
+    addProject: vi.fn(),
+    updateProject: vi.fn(),
+    deleteProject: vi.fn(),
+    archiveProject: vi.fn(),
+    restoreProject: vi.fn(),
+    reorderProjects: vi.fn()
+  },
+  mockTerminalActions: {
+    addTerminal: vi.fn(),
+    closeTerminal: vi.fn(),
+    renameTerminal: vi.fn()
+  },
+  mockEditorStoreState: {
+    activeFilePath: null,
+    openFiles: new Map(),
+    getDirtyFileCount: vi.fn(() => 0),
+    saveAllDirty: vi.fn(async () => undefined),
+    saveFile: vi.fn(async () => true),
+    closeFile: vi.fn(),
+    setActiveFilePath: vi.fn()
+  },
+  mockTerminalStoreState: {
+    activeTerminalId: '',
+    selectTerminal: vi.fn(),
+    setTerminalPtyId: vi.fn()
+  },
+  mockWorkspaceStoreState: {
+    activePaneId: 'pane-root',
+    root: { type: 'leaf', id: 'pane-root', tabs: [], activeTabId: null },
+    syncTerminalTabs: vi.fn(),
+    getNextTabId: vi.fn(() => null),
+    addTabToPane: vi.fn(),
+    closeTab: vi.fn(),
+    removeTab: vi.fn()
+  },
+  mockFileExplorerStoreState: {
+    setRootPath: vi.fn(),
+    setRootLoadError: vi.fn(),
+    toggleVisibility: vi.fn()
+  },
+  mockCloseRequested: vi.fn(() => vi.fn()),
+  mockRespondToClose: vi.fn(),
+  mockFlushPendingWrites: vi.fn(async () => ({ success: true, data: undefined })),
+  mockWatchDirectory: vi.fn(async () => ({ success: true })),
+  mockUnwatchDirectory: vi.fn(async () => ({ success: true })),
+  mockKeyboardOnShortcut: vi.fn(() => vi.fn()),
+  mockToastError: vi.fn()
+}))
+
+vi.mock('@/stores/project-store', () => ({
+  useProjectsLoaded: () => true,
+  useProjects: () => [activeProject],
+  useActiveProject: () => activeProject,
+  useActiveProjectId: () => activeProject.id,
+  useProjectActions: () => mockProjectActions
+}))
+
+vi.mock('@/stores/terminal-store', () => ({
+  useTerminalStore: {
+    getState: () => mockTerminalStoreState
+  },
+  useTerminals: () => [],
+  useActiveTerminal: () => null,
+  useActiveTerminalId: () => '',
+  useTerminalActions: () => mockTerminalActions
+}))
+
+vi.mock('@/stores/file-explorer-store', () => ({
+  useFileExplorerVisible: () => false,
+  useFileExplorerStore: {
+    getState: () => mockFileExplorerStoreState
+  }
+}))
+
+vi.mock('@/stores/sidebar-store', () => ({
+  useSidebarVisible: () => false
+}))
+
+vi.mock('@/stores/editor-store', () => ({
+  useEditorStore: {
+    getState: () => mockEditorStoreState
+  }
+}))
+
+vi.mock('@/stores/workspace-store', () => ({
+  useWorkspaceStore: {
+    getState: () => mockWorkspaceStoreState,
+    subscribe: () => vi.fn()
+  },
+  useActiveTab: () => undefined,
+  usePaneRoot: () => ({ type: 'leaf', id: 'pane-root', tabs: [], activeTabId: null }),
+  editorTabId: (filePath: string) => `editor:${filePath}`,
+  getActiveTerminalIdFromTree: () => null,
+  getActiveFilePathFromTree: () => null,
+  findPaneContainingTab: () => null
+}))
+
+vi.mock('@/stores/keyboard-shortcuts-store', () => ({
+  useKeyboardShortcutsStore: () => ({
+    shortcuts: {
+      commandPalette: { customKey: 'Ctrl+K', defaultKey: 'Ctrl+K' },
+      commandPaletteAlt: { customKey: 'Ctrl+Shift+P', defaultKey: 'Ctrl+Shift+P' },
+      terminalSearch: { customKey: 'Ctrl+F', defaultKey: 'Ctrl+F' },
+      commandHistory: { customKey: 'Ctrl+R', defaultKey: 'Ctrl+R' },
+      newProject: { customKey: 'Ctrl+N', defaultKey: 'Ctrl+N' },
+      newTerminal: { customKey: 'Ctrl+T', defaultKey: 'Ctrl+T' },
+      nextTerminal: { customKey: 'Ctrl+PageDown', defaultKey: 'Ctrl+PageDown' },
+      prevTerminal: { customKey: 'Ctrl+PageUp', defaultKey: 'Ctrl+PageUp' },
+      zoomIn: { customKey: 'Ctrl+=', defaultKey: 'Ctrl+=' },
+      zoomOut: { customKey: 'Ctrl+-', defaultKey: 'Ctrl+-' },
+      zoomReset: { customKey: 'Ctrl+0', defaultKey: 'Ctrl+0' }
+    }
+  }),
+  matchesShortcut: () => false
+}))
+
+vi.mock('@/stores/app-settings-store', () => ({
+  useTerminalFontSize: () => 14,
+  useDefaultShell: () => 'bash',
+  useMaxTerminalsPerProject: () => 10
+}))
+
+vi.mock('@/hooks/use-snapshots', () => ({
+  useCreateSnapshot: () => vi.fn(),
+  useSnapshotLoader: () => undefined
+}))
+
+vi.mock('@/hooks/use-recent-commands', () => ({
+  useRecentCommandsLoader: () => undefined
+}))
+
+vi.mock('@/hooks/use-command-history', () => ({
+  useCommandHistoryLoader: () => undefined,
+  useAddCommand: () => vi.fn(),
+  useCommandHistory: () => []
+}))
+
+vi.mock('@/hooks/use-app-settings', () => ({
+  useUpdateAppSetting: () => vi.fn()
+}))
+
+vi.mock('@/hooks/use-file-watcher', () => ({
+  useFileWatcher: () => undefined
+}))
+
+vi.mock('@/hooks/use-editor-persistence', () => ({
+  useEditorPersistence: () => undefined
+}))
+
+vi.mock('@/components/ProjectSidebar', () => ({
+  ProjectSidebar: () => <div data-testid="project-sidebar" />
+}))
+
+vi.mock('@/components/workspace/PaneRenderer', () => ({
+  PaneRenderer: () => <div data-testid="pane-renderer" />
+}))
+
+vi.mock('@/components/file-explorer/FileExplorer', () => ({
+  FileExplorer: () => <div data-testid="file-explorer" />
+}))
+
+vi.mock('@/components/StatusBar', () => ({
+  StatusBar: () => <div data-testid="status-bar" />
+}))
+
+vi.mock('@/components/TitleBar', () => ({
+  TitleBar: () => <div data-testid="title-bar" />
+}))
+
+vi.mock('@/components/NewProjectModal', () => ({
+  NewProjectModal: () => null
+}))
+
+vi.mock('@/components/CreateSnapshotModal', () => ({
+  CreateSnapshotModal: () => null
+}))
+
+vi.mock('@/components/CommandPalette', () => ({
+  CommandPalette: () => null
+}))
+
+vi.mock('@/components/CommandHistoryModal', () => ({
+  CommandHistoryModal: () => null
+}))
+
+vi.mock('@/components/ConfirmDialog', () => ({
+  ConfirmDialog: ({
+    isOpen,
+    title,
+    confirmLabel = 'Confirm',
+    cancelLabel = 'Cancel',
+    secondaryAction,
+    onConfirm,
+    onCancel
+  }: {
+    isOpen: boolean
+    title: string
+    confirmLabel?: string
+    cancelLabel?: string
+    secondaryAction?: { label: string; onClick: () => void }
+    onConfirm: () => void
+    onCancel: () => void
+  }) =>
+    isOpen ? (
+      <div>
+        <div>{title}</div>
+        <button onClick={onCancel}>{cancelLabel}</button>
+        {secondaryAction ? (
+          <button onClick={secondaryAction.onClick}>{secondaryAction.label}</button>
+        ) : null}
+        <button onClick={onConfirm}>{confirmLabel}</button>
+      </div>
+    ) : null
+}))
+
+vi.mock('@/lib/api', () => ({
+  filesystemApi: {
+    watchDirectory: mockWatchDirectory,
+    unwatchDirectory: mockUnwatchDirectory
+  },
+  windowApi: {
+    onCloseRequested: mockCloseRequested,
+    respondToClose: mockRespondToClose
+  },
+  keyboardApi: {
+    onShortcut: mockKeyboardOnShortcut
+  },
+  terminalApi: {
+    spawn: vi.fn(),
+    kill: vi.fn()
+  },
+  persistenceApi: {
+    flushPendingWrites: mockFlushPendingWrites
+  }
+}))
+
+vi.mock('sonner', () => ({
+  toast: {
+    error: mockToastError
+  }
+}))
+
+function renderLayout() {
+  return render(
+    <TooltipProvider>
+      <MemoryRouter>
+        <WorkspaceLayout />
+      </MemoryRouter>
+    </TooltipProvider>
+  )
+}
+
+describe('WorkspaceLayout close persistence', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockEditorStoreState.activeFilePath = null
+    mockEditorStoreState.openFiles = new Map()
+    mockEditorStoreState.getDirtyFileCount.mockReturnValue(0)
+    mockEditorStoreState.saveAllDirty.mockResolvedValue(undefined)
+    mockFlushPendingWrites.mockResolvedValue({ success: true, data: undefined })
+    mockCloseRequested.mockImplementation(() => vi.fn())
+  })
+
+  it('flushes pending persistence writes before closing when there are no dirty files', async () => {
+    renderLayout()
+
+    const closeHandler = (mockCloseRequested.mock.calls as unknown as Array<[() => void]>)[0]?.[0]
+
+    await act(async () => {
+      closeHandler?.()
+    })
+
+    await waitFor(() => {
+      expect(mockFlushPendingWrites).toHaveBeenCalledTimes(1)
+      expect(mockRespondToClose).toHaveBeenCalledWith('close')
+    })
+  })
+
+  it('flushes pending persistence writes after saving all dirty files', async () => {
+    mockEditorStoreState.getDirtyFileCount.mockReset()
+    mockEditorStoreState.getDirtyFileCount
+      .mockReturnValueOnce(2)
+      .mockReturnValueOnce(0)
+
+    renderLayout()
+
+    const closeHandler = (mockCloseRequested.mock.calls as unknown as Array<[() => void]>)[0]?.[0]
+
+    await act(async () => {
+      closeHandler?.()
+    })
+
+    expect(await screen.findByText('Unsaved Changes')).toBeInTheDocument()
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Save All' }))
+    })
+
+    await waitFor(() => {
+      expect(mockEditorStoreState.saveAllDirty).toHaveBeenCalledTimes(1)
+      expect(mockFlushPendingWrites).toHaveBeenCalledTimes(1)
+      expect(mockRespondToClose).toHaveBeenCalledWith('close')
+    })
+  })
+
+  it('flushes pending persistence writes when the user discards dirty files', async () => {
+    mockEditorStoreState.getDirtyFileCount.mockReset()
+    mockEditorStoreState.getDirtyFileCount.mockReturnValue(2)
+
+    renderLayout()
+
+    const closeHandler = (mockCloseRequested.mock.calls as unknown as Array<[() => void]>)[0]?.[0]
+
+    await act(async () => {
+      closeHandler?.()
+    })
+
+    expect(await screen.findByText('Unsaved Changes')).toBeInTheDocument()
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: "Don't Save" }))
+    })
+
+    await waitFor(() => {
+      expect(mockFlushPendingWrites).toHaveBeenCalledTimes(1)
+      expect(mockRespondToClose).toHaveBeenCalledWith('close')
+    })
+  })
+
+  it('still closes the app when flushing pending persistence writes fails', async () => {
+    mockFlushPendingWrites.mockResolvedValue({ success: false, data: undefined })
+
+    renderLayout()
+
+    const closeHandler = (mockCloseRequested.mock.calls as unknown as Array<[() => void]>)[0]?.[0]
+
+    await act(async () => {
+      closeHandler?.()
+    })
+
+    await waitFor(() => {
+      expect(mockFlushPendingWrites).toHaveBeenCalledTimes(1)
+      expect(mockRespondToClose).toHaveBeenCalledWith('close')
+    })
+  })
+})

--- a/src/renderer/layouts/WorkspaceLayout.tsx
+++ b/src/renderer/layouts/WorkspaceLayout.tsx
@@ -51,7 +51,7 @@ import {
   useCommandHistory
 } from '@/hooks/use-command-history'
 import type { KeyboardShortcutCallback } from '@shared/types/ipc.types'
-import { filesystemApi, windowApi, keyboardApi, terminalApi } from '@/lib/api'
+import { filesystemApi, windowApi, keyboardApi, terminalApi, persistenceApi } from '@/lib/api'
 import { useKeyboardShortcutsStore, matchesShortcut } from '@/stores/keyboard-shortcuts-store'
 import {
   useTerminalFontSize,
@@ -235,6 +235,20 @@ export default function WorkspaceLayout(): React.JSX.Element {
     })
   }, [])
 
+  const closeAppWithPersistenceFlush = useCallback(async () => {
+    try {
+      const result = await persistenceApi.flushPendingWrites()
+      if (!result.success) {
+        console.error('Failed to flush pending persistence writes before close:', result.error)
+      }
+    } catch (error) {
+      console.error('Failed to flush pending persistence writes before close:', error)
+    } finally {
+      windowApi.respondToClose('close')
+      setIsAppCloseDialogOpen(false)
+    }
+  }, [])
+
   // Intercept app close to check for unsaved files
   useEffect(() => {
     return windowApi.onCloseRequested(() => {
@@ -243,10 +257,10 @@ export default function WorkspaceLayout(): React.JSX.Element {
         setAppCloseDirtyCount(dirtyCount)
         setIsAppCloseDialogOpen(true)
       } else {
-        windowApi.respondToClose('close')
+        void closeAppWithPersistenceFlush()
       }
     })
-  }, [])
+  }, [closeAppWithPersistenceFlush])
 
   // Load snapshots when project changes
   useSnapshotLoader()
@@ -665,14 +679,12 @@ export default function WorkspaceLayout(): React.JSX.Element {
       toast.error('Some files failed to save. Please try again or discard changes.')
       return
     }
-    windowApi.respondToClose('close')
-    setIsAppCloseDialogOpen(false)
-  }, [])
+    await closeAppWithPersistenceFlush()
+  }, [closeAppWithPersistenceFlush])
 
   const handleDiscardAllAndClose = useCallback(() => {
-    windowApi.respondToClose('close')
-    setIsAppCloseDialogOpen(false)
-  }, [])
+    void closeAppWithPersistenceFlush()
+  }, [closeAppWithPersistenceFlush])
 
   const handleCancelAppClose = useCallback(() => {
     windowApi.respondToClose('cancel')

--- a/src/renderer/lib/__tests__/api-bridge.test.ts
+++ b/src/renderer/lib/__tests__/api-bridge.test.ts
@@ -126,6 +126,7 @@ describe('API Bridge (api.ts)', () => {
       expect(typeof persistenceApi.read).toBe('function')
       expect(typeof persistenceApi.write).toBe('function')
       expect(typeof persistenceApi.writeDebounced).toBe('function')
+      expect(typeof persistenceApi.flushPendingWrites).toBe('function')
       expect(typeof persistenceApi.delete).toBe('function')
     })
 

--- a/src/renderer/lib/__tests__/tauri-persistence-api.test.ts
+++ b/src/renderer/lib/__tests__/tauri-persistence-api.test.ts
@@ -212,18 +212,17 @@ describe('tauriPersistenceApi', () => {
       expect(currentMockStore.set).toHaveBeenCalledTimes(2)
     })
 
-    it('should cancel previous debounce for same key', async () => {
+    it('should persist only the latest value for the same key and resolve all promises', async () => {
       const data1 = { value: 'test1' }
       const data2 = { value: 'test2' }
 
-      tauriPersistenceApi.writeDebounced('same-key', data1)
-
-      // Call again before debounce completes
-      tauriPersistenceApi.writeDebounced('same-key', data2)
+      const firstWrite = tauriPersistenceApi.writeDebounced('same-key', data1)
+      const secondWrite = tauriPersistenceApi.writeDebounced('same-key', data2)
 
       await vi.advanceTimersByTimeAsync(500)
 
-      // Should only call once with latest data
+      await expect(firstWrite).resolves.toEqual({ success: true, data: undefined })
+      await expect(secondWrite).resolves.toEqual({ success: true, data: undefined })
       expect(currentMockStore.set).toHaveBeenCalledTimes(1)
       expect(currentMockStore.set).toHaveBeenCalledWith('same-key', {
         _version: 1,
@@ -273,13 +272,16 @@ describe('tauriPersistenceApi', () => {
     it('should flush all pending debounced writes', async () => {
       const testData = { value: 'test' }
 
-      // Start a debounced write
-      tauriPersistenceApi.writeDebounced('flush-key', testData)
+      const pendingWrite = tauriPersistenceApi.writeDebounced('flush-key', testData)
 
-      // Flush before debounce completes
-      await tauriPersistenceApi.flushPendingWrites()
+      const result = await tauriPersistenceApi.flushPendingWrites()
 
-      // Should clear pending writes and call save
+      await expect(pendingWrite).resolves.toEqual({ success: true, data: undefined })
+      expect(result).toEqual({ success: true, data: undefined })
+      expect(currentMockStore.set).toHaveBeenCalledWith('flush-key', {
+        _version: 1,
+        data: testData
+      })
       expect(currentMockStore.save).toHaveBeenCalled()
     })
   })

--- a/src/renderer/lib/tauri-persistence-api.ts
+++ b/src/renderer/lib/tauri-persistence-api.ts
@@ -1,110 +1,216 @@
-import { Store } from '@tauri-apps/plugin-store';
-import type { IpcResult } from '@shared/types/ipc.types';
+import { Store } from '@tauri-apps/plugin-store'
+import type { IpcResult } from '@shared/types/ipc.types'
 
-const STORE_FILE = 'termul-data.json';
-const DEBOUNCE_MS = 500;
-const CURRENT_VERSION = 1;
+const STORE_FILE = 'termul-data.json'
+const DEBOUNCE_MS = 500
+const CURRENT_VERSION = 1
 
 interface PersistedStore<T> {
-  _version: number;
-  data: T;
+  _version: number
+  data: T
 }
 
-let storeInstance: Store | null = null;
-const pendingDebounce = new Map<string, ReturnType<typeof setTimeout>>();
+type PendingWriteResolver = (result: IpcResult<void>) => void
+
+interface PendingDebounceEntry<T = unknown> {
+  timer: ReturnType<typeof setTimeout> | null
+  data: T
+  resolvers: PendingWriteResolver[]
+  activeWrite: Promise<IpcResult<void>> | null
+}
+
+let storeInstance: Store | null = null
+const pendingDebounce = new Map<string, PendingDebounceEntry>()
+
+function createSuccessResult(): IpcResult<void> {
+  return { success: true, data: undefined }
+}
+
+function resolvePendingResolvers(
+  resolvers: PendingWriteResolver[],
+  result: IpcResult<void>
+): void {
+  resolvers.forEach((resolve) => resolve(result))
+}
 
 async function getStore(): Promise<Store> {
   if (!storeInstance) {
-    storeInstance = await Store.load(STORE_FILE, { autoSave: false, defaults: {} });
+    storeInstance = await Store.load(STORE_FILE, { autoSave: false, defaults: {} })
   }
-  return storeInstance;
+  return storeInstance
+}
+
+async function persistVersionedData<T>(key: string, data: T): Promise<IpcResult<void>> {
+  try {
+    const store = await getStore()
+    const versioned: PersistedStore<T> = { _version: CURRENT_VERSION, data }
+    await store.set(key, versioned)
+    await store.save()
+    return createSuccessResult()
+  } catch (err) {
+    return { success: false, error: String(err), code: 'WRITE_ERROR' }
+  }
+}
+
+function schedulePendingWrite(key: string, entry: PendingDebounceEntry): void {
+  if (entry.timer) {
+    clearTimeout(entry.timer)
+  }
+
+  entry.timer = setTimeout(() => {
+    entry.timer = null
+    void flushPendingEntry(key, entry)
+  }, DEBOUNCE_MS)
+}
+
+async function flushPendingEntry(
+  key: string,
+  entry: PendingDebounceEntry
+): Promise<IpcResult<void>> {
+  if (entry.activeWrite) {
+    const activeWriteResult = await entry.activeWrite
+
+    if (entry.resolvers.length === 0) {
+      if (entry.timer === null) {
+        pendingDebounce.delete(key)
+      }
+
+      return activeWriteResult
+    }
+  }
+
+  if (entry.resolvers.length === 0) {
+    if (entry.timer === null && entry.activeWrite === null) {
+      pendingDebounce.delete(key)
+    }
+
+    return createSuccessResult()
+  }
+
+  const dataToWrite = entry.data
+  const resolvers = [...entry.resolvers]
+  entry.resolvers = []
+
+  const writePromise = persistVersionedData(key, dataToWrite)
+    .then((result) => {
+      resolvePendingResolvers(resolvers, result)
+      return result
+    })
+    .finally(() => {
+      entry.activeWrite = null
+
+      if (entry.resolvers.length === 0 && entry.timer === null) {
+        pendingDebounce.delete(key)
+      }
+    })
+
+  entry.activeWrite = writePromise
+  return writePromise
 }
 
 export const tauriPersistenceApi = {
   async read<T>(key: string): Promise<IpcResult<T>> {
     try {
-      const store = await getStore();
-      const raw = await store.get<PersistedStore<T> | T>(key);
+      const store = await getStore()
+      const raw = await store.get<PersistedStore<T> | T>(key)
 
       if (raw === null || raw === undefined) {
-        return { success: false, error: `Key not found: ${key}`, code: 'KEY_NOT_FOUND' };
+        return { success: false, error: `Key not found: ${key}`, code: 'KEY_NOT_FOUND' }
       }
 
       // Handle versioned data
       if (typeof raw === 'object' && raw !== null && '_version' in raw) {
-        const versioned = raw as PersistedStore<T>;
-        return { success: true, data: versioned.data };
+        const versioned = raw as PersistedStore<T>
+        return { success: true, data: versioned.data }
       }
 
       // Legacy data without version
-      return { success: true, data: raw as T };
+      return { success: true, data: raw as T }
     } catch (err) {
-      return { success: false, error: String(err), code: 'READ_ERROR' };
+      return { success: false, error: String(err), code: 'READ_ERROR' }
     }
   },
 
   async write<T>(key: string, data: T): Promise<IpcResult<void>> {
-    try {
-      const store = await getStore();
-      const versioned: PersistedStore<T> = { _version: CURRENT_VERSION, data };
-      await store.set(key, versioned);
-      await store.save();
-      return { success: true, data: undefined };
-    } catch (err) {
-      return { success: false, error: String(err), code: 'WRITE_ERROR' };
-    }
+    return persistVersionedData(key, data)
   },
 
   async writeDebounced<T>(key: string, data: T): Promise<IpcResult<void>> {
-    const existing = pendingDebounce.get(key);
-    if (existing) clearTimeout(existing);
-
     return new Promise((resolve) => {
-      pendingDebounce.set(key, setTimeout(async () => {
-        const result = await tauriPersistenceApi.write(key, data);
-        pendingDebounce.delete(key);
-        resolve(result);
-      }, DEBOUNCE_MS));
-    });
+      const existing = pendingDebounce.get(key)
+
+      if (existing) {
+        existing.data = data
+        existing.resolvers.push(resolve)
+        schedulePendingWrite(key, existing)
+        return
+      }
+
+      const entry: PendingDebounceEntry<T> = {
+        timer: null,
+        data,
+        resolvers: [resolve],
+        activeWrite: null
+      }
+
+      pendingDebounce.set(key, entry)
+      schedulePendingWrite(key, entry)
+    })
   },
 
   async remove(key: string): Promise<IpcResult<void>> {
     try {
-      const store = await getStore();
-      await store.delete(key);
-      await store.save();
-      return { success: true, data: undefined };
+      const store = await getStore()
+      await store.delete(key)
+      await store.save()
+      return createSuccessResult()
     } catch (err) {
-      return { success: false, error: String(err), code: 'DELETE_ERROR' };
+      return { success: false, error: String(err), code: 'DELETE_ERROR' }
     }
   },
 
   // Alias for remove - matches PersistenceApi interface
   async delete(key: string): Promise<IpcResult<void>> {
-    return this.remove(key);
+    return this.remove(key)
   },
 
-  async flushPendingWrites(): Promise<void> {
-    for (const timer of pendingDebounce.values()) {
-      clearTimeout(timer);
+  async flushPendingWrites(): Promise<IpcResult<void>> {
+    let firstFailure: IpcResult<void> | null = null
+
+    for (const [key, entry] of Array.from(pendingDebounce.entries())) {
+      if (entry.timer) {
+        clearTimeout(entry.timer)
+        entry.timer = null
+      }
+
+      const result = await flushPendingEntry(key, entry)
+      if (!result.success && firstFailure === null) {
+        firstFailure = result
+      }
     }
-    pendingDebounce.clear();
-    const store = await getStore();
-    await store.save();
-  },
-};
+
+    return firstFailure ?? createSuccessResult()
+  }
+}
 
 /**
  * Factory function for consistency with other APIs
  */
 export function createTauriPersistenceApi() {
-  return tauriPersistenceApi;
+  return tauriPersistenceApi
 }
 
 /**
  * @internal Testing only - reset the singleton store instance
  */
 export function _resetStoreInstanceForTesting() {
-  storeInstance = null;
-  pendingDebounce.clear();
+  storeInstance = null
+
+  for (const entry of pendingDebounce.values()) {
+    if (entry.timer) {
+      clearTimeout(entry.timer)
+    }
+  }
+
+  pendingDebounce.clear()
 }

--- a/src/shared/types/ipc.types.ts
+++ b/src/shared/types/ipc.types.ts
@@ -125,6 +125,7 @@ export interface PersistenceApi {
   read: <T>(key: string) => Promise<IpcResult<T>>
   write: <T>(key: string, data: T) => Promise<IpcResult<void>>
   writeDebounced: <T>(key: string, data: T) => Promise<IpcResult<void>>
+  flushPendingWrites: () => Promise<IpcResult<void>>
   delete: (key: string) => Promise<IpcResult<void>>
 }
 


### PR DESCRIPTION
## Summary
- flush pending debounced persistence writes before app close so context bar settings are not lost on shutdown
- move context bar setting updates into a dedicated hook and expose `flushPendingWrites` on the shared persistence API contract
- add regression coverage for debounce flushing, startup loading, popover updates, and close-flow persistence behavior

## Test plan
- [x] `npm --prefix \"E:/open-source/PecutAPP/termul-fix-context-bar-settings-persistence\" test -- src/renderer/lib/__tests__/tauri-persistence-api.test.ts src/renderer/hooks/use-context-bar-settings.test.ts src/renderer/lib/__tests__/api-bridge.test.ts src/renderer/components/ContextBarSettingsPopover.test.tsx src/renderer/TauriApp.test.tsx src/renderer/layouts/WorkspaceLayout.close-persistence.test.tsx src/renderer/App.test.tsx`
- [x] `npm --prefix \"E:/open-source/PecutAPP/termul-fix-context-bar-settings-persistence\" run typecheck`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Improved context bar settings persistence with debounced write system for better performance
  * Added pending write flushing mechanism to ensure data is saved before app closes

* **Bug Fixes**
  * Fixed potential data loss by ensuring all pending persistence operations complete before closing the application

* **Tests**
  * Added comprehensive test coverage for context bar settings management and app close persistence behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->