### PR TITLE
feat: project env runtime support

### DIFF
--- a/src/renderer/components/terminal/ConnectedTerminal.tsx
+++ b/src/renderer/components/terminal/ConnectedTerminal.tsx
@@ -651,6 +651,12 @@ function ConnectedTerminalComponent({
         if (initialScrollback && initialScrollback.length > 0) {
           restoreScrollback(terminal, initialScrollback)
         }
+        // Write one-time info line if project env vars were applied
+        // (env should be passed via spawnOptions by the caller if this terminal was spawned with env vars)
+        if (memoizedSpawnOptions?.env && Object.keys(memoizedSpawnOptions.env).length > 0) {
+          const envCount = Object.keys(memoizedSpawnOptions.env).length
+          terminal.write(`\x1b[36m\r\n[Project env: ${envCount} variable${envCount !== 1 ? 's' : ''} applied]\x1b[0m\r\n`)
+        }
         // Restore scroll position if cached from previous pane
         restoreScrollPosition(externalTerminalId, terminal)
         if (onBoundToStoreTerminalRef.current) {

--- a/src/renderer/components/terminal/ConnectedTerminal.tsx
+++ b/src/renderer/components/terminal/ConnectedTerminal.tsx
@@ -614,6 +614,11 @@ function ConnectedTerminalComponent({
             if (initialScrollback && initialScrollback.length > 0) {
               restoreScrollback(terminal, initialScrollback)
             }
+            // Write one-time info line if project env vars were applied
+            if (memoizedSpawnOptions?.env && Object.keys(memoizedSpawnOptions.env).length > 0) {
+              const envCount = Object.keys(memoizedSpawnOptions.env).length
+              terminal.write(`\x1b[36m\r\n[Project env: ${envCount} variable${envCount !== 1 ? 's' : ''} applied]\x1b[0m\r\n`)
+            }
             // Restore scroll position if cached from previous pane
             restoreScrollPosition(result.data.id, terminal)
             if (onSpawned) {
@@ -667,7 +672,7 @@ function ConnectedTerminalComponent({
       const terminalId = ptyIdRef.current || externalTerminalId
       if (terminalId && terminalRef.current) {
         captureScrollPosition(terminalId)
-        void removeRendererRef(terminalId, instanceIdRef.current)
+        void removeRendererRef(terminalId, instanceId)
       }
 
       // Unregister terminal from registry

--- a/src/renderer/hooks/use-projects-persistence.ts
+++ b/src/renderer/hooks/use-projects-persistence.ts
@@ -13,7 +13,12 @@ function toPersistedProject(project: Project): PersistedProject {
     path: project.path,
     isArchived: project.isArchived,
     gitBranch: project.gitBranch,
-    defaultShell: project.defaultShell
+    defaultShell: project.defaultShell,
+    envVars: project.envVars?.map((envVar) => ({
+      key: envVar.key,
+      value: envVar.value,
+      isSecret: envVar.isSecret
+    }))
   }
 }
 
@@ -25,7 +30,12 @@ function fromPersistedProject(persisted: PersistedProject): Project {
     path: persisted.path,
     isArchived: persisted.isArchived,
     gitBranch: persisted.gitBranch,
-    defaultShell: persisted.defaultShell
+    defaultShell: persisted.defaultShell,
+    envVars: persisted.envVars?.map((envVar) => ({
+      key: envVar.key,
+      value: envVar.value,
+      isSecret: envVar.isSecret
+    }))
   }
 }
 

--- a/src/renderer/hooks/use-projects-persistence.ts
+++ b/src/renderer/hooks/use-projects-persistence.ts
@@ -14,6 +14,9 @@ function toPersistedProject(project: Project): PersistedProject {
     isArchived: project.isArchived,
     gitBranch: project.gitBranch,
     defaultShell: project.defaultShell,
+    // TODO: Secret values (isSecret===true) should be stored in secure OS storage (keyring/secureStore)
+    // instead of plaintext. For now, we persist all values but this is a security concern.
+    // A future PR should implement secure storage for secrets.
     envVars: project.envVars?.map((envVar) => ({
       key: envVar.key,
       value: envVar.value,

--- a/src/renderer/hooks/use-snapshots.ts
+++ b/src/renderer/hooks/use-snapshots.ts
@@ -4,6 +4,7 @@ import { persistenceApi, terminalApi } from '@/lib/api'
 import { useTerminalStore } from '@/stores/terminal-store'
 import { useProjectStore } from '@/stores/project-store'
 import { getTerminal } from '@/utils/terminal-registry'
+import { resolveEnvForSpawn } from '@/lib/env-parser'
 import type { PersistedTerminal, PersistedSnapshot } from '../../shared/types/persistence.types'
 import { DEFAULT_SCROLLBACK_LIMIT } from '../../shared/types/persistence.types'
 import type { Snapshot } from '@/types/project'
@@ -109,6 +110,11 @@ export function useRestoreSnapshot(): (snapshotId: string) => Promise<void> {
  */
 async function restoreFromSnapshot(projectId: string, snapshot: PersistedSnapshot): Promise<void> {
   const terminalStore = useTerminalStore.getState()
+  const projectStore = useProjectStore.getState()
+  const project = projectStore.projects.find((p) => p.id === projectId)
+
+  // Resolve project env vars for spawn
+  const { env } = resolveEnvForSpawn(project?.envVars)
 
   // Close all existing terminals for this project
   // CRITICAL: Kill PTYs before removing from store to prevent orphaned processes
@@ -131,7 +137,8 @@ async function restoreFromSnapshot(projectId: string, snapshot: PersistedSnapsho
   for (const persistedTerminal of snapshot.terminals) {
     const spawnResult = await terminalApi.spawn({
       shell: persistedTerminal.shell as 'powershell' | 'cmd' | 'bash' | 'zsh' | 'fish' | undefined,
-      cwd: persistedTerminal.cwd
+      cwd: persistedTerminal.cwd,
+      env
     })
 
     if (!spawnResult.success) {

--- a/src/renderer/hooks/use-snapshots.ts
+++ b/src/renderer/hooks/use-snapshots.ts
@@ -114,7 +114,8 @@ async function restoreFromSnapshot(projectId: string, snapshot: PersistedSnapsho
   const project = projectStore.projects.find((p) => p.id === projectId)
 
   // Resolve project env vars for spawn
-  const { env } = resolveEnvForSpawn(project?.envVars)
+  // TODO: Pass actual system env from backend for variable expansion
+  const { env, hasProjectEnv } = resolveEnvForSpawn(project?.envVars, {})
 
   // Close all existing terminals for this project
   // CRITICAL: Kill PTYs before removing from store to prevent orphaned processes
@@ -138,7 +139,7 @@ async function restoreFromSnapshot(projectId: string, snapshot: PersistedSnapsho
     const spawnResult = await terminalApi.spawn({
       shell: persistedTerminal.shell as 'powershell' | 'cmd' | 'bash' | 'zsh' | 'fish' | undefined,
       cwd: persistedTerminal.cwd,
-      env
+      ...(hasProjectEnv ? { env } : {})
     })
 
     if (!spawnResult.success) {

--- a/src/renderer/hooks/use-terminal-restore.ts
+++ b/src/renderer/hooks/use-terminal-restore.ts
@@ -498,7 +498,8 @@ async function restoreFromLayout(
     const project = projectStore.projects.find((p) => p.id === projectId)
 
     // Resolve project env vars for spawn
-    const { env } = resolveEnvForSpawn(project?.envVars)
+    // TODO: Pass actual system env from backend for variable expansion
+    const { env, hasProjectEnv } = resolveEnvForSpawn(project?.envVars, {})
 
     debugLog('restoreFromLayout', `START [${restoreId}] ACQUIRING LOCK`, {
       projectId,
@@ -555,7 +556,7 @@ for (const persistedTerminal of layout.terminals) {
         const spawnResult = await terminalApi.spawn({
           shell: normalizedShell,
           cwd: persistedTerminal.cwd,
-          env
+          ...(hasProjectEnv ? { env } : {})
         })
 
         debugLog('restoreFromLayout', `Spawn result [${terminalCallId}]`, {
@@ -714,7 +715,8 @@ async function createDefaultTerminal(
     const shell = normalizeShellForStartup(resolvedShell)
 
     // Resolve project env vars for spawn
-    const { env } = resolveEnvForSpawn(project?.envVars)
+    // TODO: Pass actual system env from backend for variable expansion
+    const { env, hasProjectEnv } = resolveEnvForSpawn(project?.envVars, {})
 
     debugLog('createDefaultTerminal', `Spawning default terminal [${defaultId}]`, {
       shell,
@@ -724,7 +726,7 @@ async function createDefaultTerminal(
     const spawnResult = await terminalApi.spawn({
       shell,
       cwd: project?.path,
-      env
+      ...(hasProjectEnv ? { env } : {})
     })
 
     debugLog('createDefaultTerminal', `Spawn result [${defaultId}]`, {

--- a/src/renderer/hooks/use-terminal-restore.ts
+++ b/src/renderer/hooks/use-terminal-restore.ts
@@ -5,6 +5,7 @@ import { useAppSettingsStore } from '../stores/app-settings-store'
 import { useWorkspaceStore, terminalTabId, findPaneContainingTab } from '../stores/workspace-store'
 import { terminalApi } from '@/lib/api'
 import { shellApi } from '@/lib/shell-api'
+import { resolveEnvForSpawn } from '@/lib/env-parser'
 import {
   loadPersistedTerminals,
   saveTerminalLayout,
@@ -493,6 +494,11 @@ async function restoreFromLayout(
     }
 
     const terminalStore = useTerminalStore.getState()
+    const projectStore = useProjectStore.getState()
+    const project = projectStore.projects.find((p) => p.id === projectId)
+
+    // Resolve project env vars for spawn
+    const { env } = resolveEnvForSpawn(project?.envVars)
 
     debugLog('restoreFromLayout', `START [${restoreId}] ACQUIRING LOCK`, {
       projectId,
@@ -517,7 +523,7 @@ async function restoreFromLayout(
     // Map old IDs to new IDs for active terminal selection and pane remapping
     const idMap = new Map<string, string>()
 
-    for (const persistedTerminal of layout.terminals) {
+for (const persistedTerminal of layout.terminals) {
       if (isCancelled()) {
         await cleanupSpawnedPtys(newTerminals, restoreId, 'during restore loop')
         debugLog('restoreFromLayout', `CANCELLED [${restoreId}] during restore loop`)
@@ -548,7 +554,8 @@ async function restoreFromLayout(
         const normalizedShell = normalizeShellForStartup(resolvedShell)
         const spawnResult = await terminalApi.spawn({
           shell: normalizedShell,
-          cwd: persistedTerminal.cwd
+          cwd: persistedTerminal.cwd,
+          env
         })
 
         debugLog('restoreFromLayout', `Spawn result [${terminalCallId}]`, {
@@ -706,6 +713,9 @@ async function createDefaultTerminal(
 
     const shell = normalizeShellForStartup(resolvedShell)
 
+    // Resolve project env vars for spawn
+    const { env } = resolveEnvForSpawn(project?.envVars)
+
     debugLog('createDefaultTerminal', `Spawning default terminal [${defaultId}]`, {
       shell,
       cwd: project?.path
@@ -713,7 +723,8 @@ async function createDefaultTerminal(
 
     const spawnResult = await terminalApi.spawn({
       shell,
-      cwd: project?.path
+      cwd: project?.path,
+      env
     })
 
     debugLog('createDefaultTerminal', `Spawn result [${defaultId}]`, {

--- a/src/renderer/layouts/WorkspaceLayout.tsx
+++ b/src/renderer/layouts/WorkspaceLayout.tsx
@@ -355,9 +355,14 @@ export default function WorkspaceLayout(): React.JSX.Element {
       const cwd = activeProject?.path
 
       // Resolve project env vars for spawn
-      const { env } = resolveEnvForSpawn(activeProject?.envVars)
+      // TODO: Pass actual system env from backend for variable expansion
+      const { env, hasProjectEnv } = resolveEnvForSpawn(activeProject?.envVars, {})
 
-      const spawnResult = await terminalApi.spawn({ shell, cwd, env })
+      const spawnResult = await terminalApi.spawn({
+        shell,
+        cwd,
+        ...(hasProjectEnv ? { env } : {})
+      })
       if (!spawnResult.success) {
         toast.error(spawnResult.error || 'Failed to create terminal')
         return

--- a/src/renderer/layouts/WorkspaceLayout.tsx
+++ b/src/renderer/layouts/WorkspaceLayout.tsx
@@ -67,6 +67,7 @@ import { useEditorPersistence } from '@/hooks/use-editor-persistence'
 import { DEFAULT_APP_SETTINGS } from '@/types/settings'
 import { toast } from 'sonner'
 import { TitleBar } from '@/components/TitleBar'
+import { resolveEnvForSpawn } from '@/lib/env-parser'
 
 export default function WorkspaceLayout(): React.JSX.Element {
   const location = useLocation()
@@ -353,7 +354,10 @@ export default function WorkspaceLayout(): React.JSX.Element {
       const shell = shellName || activeProject?.defaultShell || appDefaultShell || undefined
       const cwd = activeProject?.path
 
-      const spawnResult = await terminalApi.spawn({ shell, cwd })
+      // Resolve project env vars for spawn
+      const { env } = resolveEnvForSpawn(activeProject?.envVars)
+
+      const spawnResult = await terminalApi.spawn({ shell, cwd, env })
       if (!spawnResult.success) {
         toast.error(spawnResult.error || 'Failed to create terminal')
         return
@@ -368,7 +372,7 @@ export default function WorkspaceLayout(): React.JSX.Element {
         terminalId: terminal.id
       })
     },
-    [activeProject?.defaultShell, activeProject?.path, activeProjectId, addTerminal, appDefaultShell, maxTerminals, terminals.length]
+    [activeProject?.defaultShell, activeProject?.path, activeProject?.envVars, activeProjectId, addTerminal, appDefaultShell, maxTerminals, terminals.length]
   )
 
   const handleNewTerminal = useCallback(() => {

--- a/src/renderer/lib/dialog-api.ts
+++ b/src/renderer/lib/dialog-api.ts
@@ -31,6 +31,25 @@ function createTauriDialogApi(): DialogApi {
       } catch (err) {
         return { success: false, error: String(err), code: 'DIALOG_ERROR' }
       }
+    },
+
+    async selectFile(options?: {
+      filters?: Array<{ name: string; extensions: string[] }>
+      title?: string
+    }): Promise<IpcResult<string>> {
+      try {
+        const selected = await open({
+          multiple: false,
+          filters: options?.filters,
+          title: options?.title || 'Select File'
+        })
+        if (!selected) {
+          return { success: false, error: 'No file selected', code: 'CANCELLED' }
+        }
+        return { success: true, data: selected as string }
+      } catch (err) {
+        return { success: false, error: String(err), code: 'DIALOG_ERROR' }
+      }
     }
   }
 }

--- a/src/renderer/lib/env-parser.test.ts
+++ b/src/renderer/lib/env-parser.test.ts
@@ -149,14 +149,14 @@ describe('env-parser', () => {
 
   describe('resolveEnvForSpawn', () => {
     it('should return empty env for undefined project env vars', () => {
-      const result = resolveEnvForSpawn(undefined)
+      const result = resolveEnvForSpawn(undefined, {})
 
       expect(result.env).toEqual({})
       expect(result.hasProjectEnv).toBe(false)
     })
 
     it('should return empty env for empty project env vars', () => {
-      const result = resolveEnvForSpawn([])
+      const result = resolveEnvForSpawn([], {})
 
       expect(result.env).toEqual({})
       expect(result.hasProjectEnv).toBe(false)
@@ -168,7 +168,7 @@ describe('env-parser', () => {
         { key: 'PORT', value: '3000' }
       ]
 
-      const result = resolveEnvForSpawn(envVars)
+      const result = resolveEnvForSpawn(envVars, {})
 
       expect(result.env).toEqual({
         NODE_ENV: 'production',
@@ -184,7 +184,7 @@ describe('env-parser', () => {
         { key: '   ', value: 'whitespace-key' }
       ]
 
-      const result = resolveEnvForSpawn(envVars)
+      const result = resolveEnvForSpawn(envVars, {})
 
       expect(result.env).toEqual({ VALID: 'value' })
     })

--- a/src/renderer/lib/env-parser.test.ts
+++ b/src/renderer/lib/env-parser.test.ts
@@ -1,0 +1,248 @@
+import { describe, it, expect } from 'vitest'
+import { parseEnvFile, mergeEnvVars, resolveEnvForSpawn } from './env-parser'
+import type { EnvVariable } from '@/types/project'
+
+describe('env-parser', () => {
+  describe('parseEnvFile', () => {
+    it('should parse simple KEY=value pairs', () => {
+      const content = 'NODE_ENV=development\nAPI_KEY=test123'
+      const result = parseEnvFile(content)
+
+      expect(result.vars).toHaveLength(2)
+      expect(result.vars[0]).toEqual({ key: 'NODE_ENV', value: 'development' })
+      expect(result.vars[1]).toEqual({ key: 'API_KEY', value: 'test123' })
+      expect(result.invalidLines).toHaveLength(0)
+    })
+
+    it('should skip blank lines', () => {
+      const content = 'KEY1=value1\n\n\nKEY2=value2'
+      const result = parseEnvFile(content)
+
+      expect(result.vars).toHaveLength(2)
+    })
+
+    it('should skip comment lines starting with #', () => {
+      const content = '# This is a comment\nKEY=value\n# Another comment'
+      const result = parseEnvFile(content)
+
+      expect(result.vars).toHaveLength(1)
+      expect(result.vars[0].key).toBe('KEY')
+    })
+
+    it('should strip double quotes from values', () => {
+      const content = 'KEY="value with spaces"'
+      const result = parseEnvFile(content)
+
+      expect(result.vars[0].value).toBe('value with spaces')
+    })
+
+    it('should strip single quotes from values', () => {
+      const content = "KEY='value with spaces'"
+      const result = parseEnvFile(content)
+
+      expect(result.vars[0].value).toBe('value with spaces')
+    })
+
+    it('should handle values with = signs', () => {
+      const content = 'CONNECTION_STRING=host=localhost;port=5432'
+      const result = parseEnvFile(content)
+
+      expect(result.vars[0].value).toBe('host=localhost;port=5432')
+    })
+
+    it('should handle Windows line endings (CRLF)', () => {
+      const content = 'KEY1=value1\r\nKEY2=value2'
+      const result = parseEnvFile(content)
+
+      expect(result.vars).toHaveLength(2)
+    })
+
+    it('should report invalid lines without = sign', () => {
+      const content = 'VALID=value\nINVALID_LINE\nANOTHER=value'
+      const result = parseEnvFile(content)
+
+      expect(result.vars).toHaveLength(2)
+      expect(result.invalidLines).toHaveLength(1)
+      expect(result.invalidLines[0].line).toBe(2)
+      expect(result.invalidLines[0].content).toBe('INVALID_LINE')
+    })
+
+    it('should report invalid keys (empty or special chars)', () => {
+      const content = '=value\n123KEY=value\nVALID=value'
+      const result = parseEnvFile(content)
+
+      expect(result.vars).toHaveLength(1)
+      expect(result.vars[0].key).toBe('VALID')
+      expect(result.invalidLines.length).toBeGreaterThan(0)
+    })
+
+    it('should handle empty file', () => {
+      const result = parseEnvFile('')
+
+      expect(result.vars).toHaveLength(0)
+      expect(result.invalidLines).toHaveLength(0)
+    })
+
+    it('should handle file with only comments and blank lines', () => {
+      const content = '# Comment\n\n# Another comment\n'
+      const result = parseEnvFile(content)
+
+      expect(result.vars).toHaveLength(0)
+      expect(result.invalidLines).toHaveLength(0)
+    })
+  })
+
+  describe('mergeEnvVars', () => {
+    it('should merge env vars with imported overwriting existing', () => {
+      const existing: EnvVariable[] = [
+        { key: 'KEY1', value: 'old1' },
+        { key: 'KEY2', value: 'old2' }
+      ]
+      const imported: EnvVariable[] = [
+        { key: 'KEY2', value: 'new2' },
+        { key: 'KEY3', value: 'new3' }
+      ]
+
+      const result = mergeEnvVars(existing, imported)
+
+      expect(result).toHaveLength(3)
+      expect(result.find(v => v.key === 'KEY1')?.value).toBe('old1')
+      expect(result.find(v => v.key === 'KEY2')?.value).toBe('new2')
+      expect(result.find(v => v.key === 'KEY3')?.value).toBe('new3')
+    })
+
+    it('should handle empty existing array', () => {
+      const imported: EnvVariable[] = [
+        { key: 'KEY', value: 'value' }
+      ]
+
+      const result = mergeEnvVars([], imported)
+
+      expect(result).toHaveLength(1)
+      expect(result[0].key).toBe('KEY')
+    })
+
+    it('should handle empty imported array', () => {
+      const existing: EnvVariable[] = [
+        { key: 'KEY', value: 'value' }
+      ]
+
+      const result = mergeEnvVars(existing, [])
+
+      expect(result).toHaveLength(1)
+      expect(result[0].key).toBe('KEY')
+    })
+
+    it('should preserve isSecret flag from imported vars', () => {
+      const existing: EnvVariable[] = [
+        { key: 'KEY', value: 'old' }
+      ]
+      const imported: EnvVariable[] = [
+        { key: 'KEY', value: 'new', isSecret: true }
+      ]
+
+      const result = mergeEnvVars(existing, imported)
+
+      expect(result[0].isSecret).toBe(true)
+    })
+  })
+
+  describe('resolveEnvForSpawn', () => {
+    it('should return empty env for undefined project env vars', () => {
+      const result = resolveEnvForSpawn(undefined)
+
+      expect(result.env).toEqual({})
+      expect(result.hasProjectEnv).toBe(false)
+    })
+
+    it('should return empty env for empty project env vars', () => {
+      const result = resolveEnvForSpawn([])
+
+      expect(result.env).toEqual({})
+      expect(result.hasProjectEnv).toBe(false)
+    })
+
+    it('should convert env vars to record', () => {
+      const envVars: EnvVariable[] = [
+        { key: 'NODE_ENV', value: 'production' },
+        { key: 'PORT', value: '3000' }
+      ]
+
+      const result = resolveEnvForSpawn(envVars)
+
+      expect(result.env).toEqual({
+        NODE_ENV: 'production',
+        PORT: '3000'
+      })
+      expect(result.hasProjectEnv).toBe(true)
+    })
+
+    it('should skip empty keys', () => {
+      const envVars: EnvVariable[] = [
+        { key: 'VALID', value: 'value' },
+        { key: '', value: 'empty-key' },
+        { key: '   ', value: 'whitespace-key' }
+      ]
+
+      const result = resolveEnvForSpawn(envVars)
+
+      expect(result.env).toEqual({ VALID: 'value' })
+    })
+
+    it('should expand $VAR references against inherited env', () => {
+      const envVars: EnvVariable[] = [
+        { key: 'PATH_PREFIX', value: '$HOME/projects' }
+      ]
+      const inheritedEnv = { HOME: '/Users/test' }
+
+      const result = resolveEnvForSpawn(envVars, inheritedEnv)
+
+      expect(result.env.PATH_PREFIX).toBe('/Users/test/projects')
+    })
+
+    it('should expand ${VAR} references', () => {
+      const envVars: EnvVariable[] = [
+        { key: 'FULL_PATH', value: '${HOME}/workspace' }
+      ]
+      const inheritedEnv = { HOME: '/Users/test' }
+
+      const result = resolveEnvForSpawn(envVars, inheritedEnv)
+
+      expect(result.env.FULL_PATH).toBe('/Users/test/workspace')
+    })
+
+    it('should expand %VAR% references (Windows style)', () => {
+      const envVars: EnvVariable[] = [
+        { key: 'FULL_PATH', value: '%USERPROFILE%\\workspace' }
+      ]
+      const inheritedEnv = { USERPROFILE: 'C:\\Users\\test' }
+
+      const result = resolveEnvForSpawn(envVars, inheritedEnv)
+
+      expect(result.env.FULL_PATH).toBe('C:\\Users\\test\\workspace')
+    })
+
+    it('should replace missing var references with empty string', () => {
+      const envVars: EnvVariable[] = [
+        { key: 'PATH', value: '$UNDEFINED_VAR/path' }
+      ]
+
+      const result = resolveEnvForSpawn(envVars, {})
+
+      expect(result.env.PATH).toBe('/path')
+    })
+
+    it('should NOT expand references against other project vars', () => {
+      const envVars: EnvVariable[] = [
+        { key: 'BASE', value: '/app' },
+        { key: 'FULL', value: '$BASE/data' }
+      ]
+
+      const result = resolveEnvForSpawn(envVars, {})
+
+      // $BASE should not be expanded because BASE is a project var, not inherited
+      expect(result.env.BASE).toBe('/app')
+      expect(result.env.FULL).toBe('/data') // $BASE resolves to empty
+    })
+  })
+})

--- a/src/renderer/lib/env-parser.ts
+++ b/src/renderer/lib/env-parser.ts
@@ -1,0 +1,187 @@
+import type { EnvVariable } from '@/types/project'
+
+/**
+ * Result of parsing a .env file
+ */
+export interface EnvParseResult {
+  /** Successfully parsed environment variables */
+  vars: EnvVariable[]
+  /** Lines that couldn't be parsed (line number + raw content) */
+  invalidLines: Array<{ line: number; content: string }>
+}
+
+/**
+ * Parse a .env file content into environment variables.
+ *
+ * Supports:
+ * - KEY=value pairs
+ * - Comments starting with #
+ * - Blank lines (ignored)
+ * - Quoted values (single or double quotes, stripped)
+ * - Values containing = signs
+ *
+ * Does NOT support:
+ * - Variable expansion/substitution
+ * - Multi-line values
+ * - Shell command execution
+ *
+ * @param content - Raw .env file content
+ * @returns Parsed environment variables and any invalid lines
+ */
+export function parseEnvFile(content: string): EnvParseResult {
+  const lines = content.split(/\r?\n/)
+  const vars: EnvVariable[] = []
+  const invalidLines: Array<{ line: number; content: string }> = []
+
+  for (let i = 0; i < lines.length; i++) {
+    const lineNum = i + 1
+    const rawLine = lines[i]
+    const line = rawLine.trim()
+
+    // Skip empty lines
+    if (line === '') {
+      continue
+    }
+
+    // Skip comments
+    if (line.startsWith('#')) {
+      continue
+    }
+
+    // Find first = sign
+    const eqIndex = line.indexOf('=')
+    if (eqIndex === -1) {
+      // No = sign, invalid line
+      invalidLines.push({ line: lineNum, content: rawLine })
+      continue
+    }
+
+    const key = line.slice(0, eqIndex).trim()
+    let value = line.slice(eqIndex + 1)
+
+    // Validate key (must be non-empty and contain only valid chars)
+    if (key === '' || !/^[A-Za-z_][A-Za-z0-9_]*$/.test(key)) {
+      invalidLines.push({ line: lineNum, content: rawLine })
+      continue
+    }
+
+    // Strip surrounding quotes from value
+    if (
+      (value.startsWith('"') && value.endsWith('"')) ||
+      (value.startsWith("'") && value.endsWith("'"))
+    ) {
+      value = value.slice(1, -1)
+    }
+
+    vars.push({ key, value })
+  }
+
+  return { vars, invalidLines }
+}
+
+/**
+ * Merge parsed env vars into existing env vars.
+ * Imported keys overwrite existing keys with the same name.
+ *
+ * @param existing - Current environment variables
+ * @param imported - New variables from .env import
+ * @returns Merged environment variables list
+ */
+export function mergeEnvVars(
+  existing: EnvVariable[],
+  imported: EnvVariable[]
+): EnvVariable[] {
+  const merged = new Map<string, EnvVariable>()
+
+  // Add existing vars first
+  for (const envVar of existing) {
+    merged.set(envVar.key, envVar)
+  }
+
+  // Overwrite with imported vars
+  for (const envVar of imported) {
+    merged.set(envVar.key, envVar)
+  }
+
+  return Array.from(merged.values())
+}
+
+/**
+ * Result of resolving project env vars for spawn
+ */
+export interface ResolvedEnvResult {
+  /** Resolved environment map for spawn */
+  env: Record<string, string>
+  /** Whether any project env vars were applied */
+  hasProjectEnv: boolean
+}
+
+/**
+ * Resolve project environment variables for terminal spawn.
+ *
+ * Expands variable references against inherited system/process environment only.
+ * Does NOT expand against other project-defined vars.
+ *
+ * Supported reference formats:
+ * - Unix: $VAR, ${VAR}
+ * - Windows: %VAR%
+ *
+ * @param projectEnvVars - Project's saved environment variables
+ * @param inheritedEnv - Inherited system/process environment (from window or backend)
+ * @returns Resolved environment map and metadata
+ */
+export function resolveEnvForSpawn(
+  projectEnvVars: EnvVariable[] | undefined,
+  inheritedEnv: Record<string, string> = {}
+): ResolvedEnvResult {
+  if (!projectEnvVars || projectEnvVars.length === 0) {
+    return { env: {}, hasProjectEnv: false }
+  }
+
+  const resolved: Record<string, string> = {}
+
+  for (const envVar of projectEnvVars) {
+    if (!envVar.key || envVar.key.trim() === '') {
+      continue
+    }
+
+    // Expand variable references against inherited environment only
+    const expandedValue = expandEnvReferences(envVar.value, inheritedEnv)
+    resolved[envVar.key] = expandedValue
+  }
+
+  return {
+    env: resolved,
+    hasProjectEnv: Object.keys(resolved).length > 0
+  }
+}
+
+/**
+ * Expand environment variable references in a value.
+ *
+ * Supports:
+ * - Unix style: $VAR or ${VAR}
+ * - Windows style: %VAR%
+ *
+ * @param value - The value containing potential variable references
+ * @param env - Environment to resolve references against
+ * @returns Expanded value
+ */
+function expandEnvReferences(value: string, env: Record<string, string>): string {
+  // Handle ${VAR} syntax
+  let result = value.replace(/\$\{([A-Za-z_][A-Za-z0-9_]*)\}/g, (_, varName) => {
+    return env[varName] ?? ''
+  })
+
+  // Handle $VAR syntax (not followed by { which was already handled)
+  result = result.replace(/\$([A-Za-z_][A-Za-z0-9_]*)(?![{A-Za-z0-9_])/g, (_, varName) => {
+    return env[varName] ?? ''
+  })
+
+  // Handle %VAR% syntax (Windows style)
+  result = result.replace(/%([A-Za-z_][A-Za-z0-9_]*)%/g, (_, varName) => {
+    return env[varName] ?? ''
+  })
+
+  return result
+}

--- a/src/renderer/lib/env-parser.ts
+++ b/src/renderer/lib/env-parser.ts
@@ -127,12 +127,15 @@ export interface ResolvedEnvResult {
  * - Windows: %VAR%
  *
  * @param projectEnvVars - Project's saved environment variables
- * @param inheritedEnv - Inherited system/process environment (from window or backend)
+ * @param inheritedEnv - Inherited system/process environment. IMPORTANT: In the renderer
+ *   context, this should be fetched from the backend via a system API. Passing an empty
+ *   object will cause $VAR references to resolve to empty strings. TODO: Add a system
+ *   API to fetch process environment from Tauri backend.
  * @returns Resolved environment map and metadata
  */
 export function resolveEnvForSpawn(
   projectEnvVars: EnvVariable[] | undefined,
-  inheritedEnv: Record<string, string> = {}
+  inheritedEnv: Record<string, string>
 ): ResolvedEnvResult {
   if (!projectEnvVars || projectEnvVars.length === 0) {
     return { env: {}, hasProjectEnv: false }

--- a/src/renderer/pages/ProjectSettings.tsx
+++ b/src/renderer/pages/ProjectSettings.tsx
@@ -103,6 +103,9 @@ export default function ProjectSettings() {
   }
 
   const handleImportEnvFile = async () => {
+    // Capture the current project ID to detect concurrent project switches
+    const projectIdAtStart = activeProjectId
+
     setImportError(null)
     setImportWarnings(null)
 
@@ -111,12 +114,23 @@ export default function ProjectSettings() {
       title: 'Select .env File'
     })
 
+    // Check if project switched during dialog
+    if (projectIdAtStart !== activeProjectId) {
+      return
+    }
+
     if (!fileResult.success) {
       // User cancelled - not an error
       return
     }
 
     const readResult = await filesystemApi.readFile(fileResult.data)
+
+    // Check if project switched during file read
+    if (projectIdAtStart !== activeProjectId) {
+      return
+    }
+
     if (!readResult.success) {
       setImportError(`Failed to read file: ${readResult.error}`)
       return
@@ -129,9 +143,8 @@ export default function ProjectSettings() {
       return
     }
 
-    // Merge with existing env vars (imported keys overwrite existing)
-    const merged = mergeEnvVars(envVars, parseResult.vars)
-    setEnvVars(merged)
+    // Merge with existing env vars using functional update to avoid stale state
+    setEnvVars((prevEnvVars) => mergeEnvVars(prevEnvVars, parseResult.vars))
     setHasChanges(true)
 
     // Show warnings for invalid lines if any

--- a/src/renderer/pages/ProjectSettings.tsx
+++ b/src/renderer/pages/ProjectSettings.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react'
-import { Settings, Save, Info, Plus, X, ChevronDown } from 'lucide-react'
+import { Settings, Save, Info, Plus, X, ChevronDown, Upload } from 'lucide-react'
 import { useNavigate } from 'react-router-dom'
 import { NewProjectModal } from '@/components/NewProjectModal'
 import {
@@ -13,7 +13,8 @@ import type { ProjectColor, EnvVariable } from '@/types/project'
 import type { DetectedShells } from '@shared/types/ipc.types'
 import { cn } from '@/lib/utils'
 import { Skeleton } from '@/components/ui/skeleton'
-import { dialogApi, shellApi } from '@/lib/api'
+import { dialogApi, shellApi, filesystemApi } from '@/lib/api'
+import { parseEnvFile, mergeEnvVars } from '@/lib/env-parser'
 
 export default function ProjectSettings() {
   const navigate = useNavigate()
@@ -34,6 +35,8 @@ export default function ProjectSettings() {
   const [hasChanges, setHasChanges] = useState(false)
   const [availableShells, setAvailableShells] = useState<DetectedShells | null>(null)
   const [shellsLoading, setShellsLoading] = useState(true)
+  const [importError, setImportError] = useState<string | null>(null)
+  const [importWarnings, setImportWarnings] = useState<string | null>(null)
 
   // Platform-specific fallback shell
   const fallbackShell = navigator.platform.startsWith('Win') ? 'powershell' : 'bash'
@@ -70,13 +73,21 @@ export default function ProjectSettings() {
 
   const handleSave = () => {
     if (activeProject) {
+      const normalizedEnvVars = envVars
+        .map((envVar) => ({
+          ...envVar,
+          key: envVar.key.trim()
+        }))
+        .filter((envVar) => envVar.key !== '')
+
       updateProject(activeProject.id, {
         name: projectName,
         color: selectedColor,
         path: rootPath,
-        envVars: envVars.filter((v) => v.key.trim() !== ''),
+        envVars: normalizedEnvVars,
         defaultShell: shell
       })
+      setEnvVars(normalizedEnvVars)
       setHasChanges(false)
     }
   }
@@ -89,6 +100,49 @@ export default function ProjectSettings() {
   const removeEnvVar = (index: number) => {
     setEnvVars(envVars.filter((_, i) => i !== index))
     setHasChanges(true)
+  }
+
+  const handleImportEnvFile = async () => {
+    setImportError(null)
+    setImportWarnings(null)
+
+    const fileResult = await dialogApi.selectFile({
+      filters: [{ name: 'Environment Files', extensions: ['env'] }],
+      title: 'Select .env File'
+    })
+
+    if (!fileResult.success) {
+      // User cancelled - not an error
+      return
+    }
+
+    const readResult = await filesystemApi.readFile(fileResult.data)
+    if (!readResult.success) {
+      setImportError(`Failed to read file: ${readResult.error}`)
+      return
+    }
+
+    const parseResult = parseEnvFile(readResult.data.content)
+
+    if (parseResult.vars.length === 0 && parseResult.invalidLines.length === 0) {
+      setImportError('The .env file is empty.')
+      return
+    }
+
+    // Merge with existing env vars (imported keys overwrite existing)
+    const merged = mergeEnvVars(envVars, parseResult.vars)
+    setEnvVars(merged)
+    setHasChanges(true)
+
+    // Show warnings for invalid lines if any
+    if (parseResult.invalidLines.length > 0) {
+      const warningDetails = parseResult.invalidLines
+        .slice(0, 3)
+        .map((l) => `Line ${l.line}: ${l.content}`)
+        .join('\n')
+      const moreCount = parseResult.invalidLines.length > 3 ? ` (+${parseResult.invalidLines.length - 3} more)` : ''
+      setImportWarnings(`Imported ${parseResult.vars.length} variables.\nSkipped ${parseResult.invalidLines.length} invalid line(s):\n${warningDetails}${moreCount}`)
+    }
   }
 
   return (
@@ -218,6 +272,18 @@ export default function ProjectSettings() {
                   >
                     <Plus size={14} className="mr-1" /> Add Variable
                   </button>
+                  <button
+                    onClick={handleImportEnvFile}
+                    className="mt-2 text-xs flex items-center text-primary hover:text-primary/80 font-medium transition-colors"
+                  >
+                    <Upload size={14} className="mr-1" /> Import from .env
+                  </button>
+                  {importError && (
+                    <p className="mt-2 text-xs text-destructive">{importError}</p>
+                  )}
+                  {importWarnings && (
+                    <p className="mt-2 text-xs text-yellow-600 dark:text-yellow-400 whitespace-pre-line">{importWarnings}</p>
+                  )}
                 </div>
                 <div className="w-2/3">
                   <div className="bg-secondary/30 rounded-lg border border-border overflow-hidden">

--- a/src/shared/types/ipc.types.ts
+++ b/src/shared/types/ipc.types.ts
@@ -101,6 +101,10 @@ export type IpcErrorCode = (typeof IpcErrorCodes)[keyof typeof IpcErrorCodes]
 // Dialog API for file/directory selection
 export interface DialogApi {
   selectDirectory: () => Promise<IpcResult<string>>
+  selectFile: (options?: {
+    filters?: Array<{ name: string; extensions: string[] }>
+    title?: string
+  }) => Promise<IpcResult<string>>
 }
 
 // Shell detection types

--- a/src/shared/types/persistence.types.ts
+++ b/src/shared/types/persistence.types.ts
@@ -60,6 +60,12 @@ export interface PersistedProjectData {
   updatedAt: string // ISO timestamp
 }
 
+export interface PersistedEnvVariable {
+  key: string
+  value: string
+  isSecret?: boolean
+}
+
 // Minimal project data for persistence (matches Project from renderer)
 export interface PersistedProject {
   id: string
@@ -69,4 +75,5 @@ export interface PersistedProject {
   isArchived?: boolean
   gitBranch?: string
   defaultShell?: string
+  envVars?: PersistedEnvVariable[]
 }


### PR DESCRIPTION
## Summary
- open a draft branch for issue #41 before implementation begins
- track the planned work for project-specific environment variable runtime support
- implementation will follow the approved tech spec in `_bmad-output/implementation-artifacts/tech-spec-complete-project-specific-environment-variable-runtime-support.md`

## Test plan
- [ ] targeted Vitest coverage for persistence, spawn propagation, and `.env` import behavior
- [ ] manual verification of new terminal, startup restore, and snapshot restore flows
- [ ] verify one-time terminal info line appears when project env vars are applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Import .env files in Project Settings; parsed vars can be merged and saved.
  * Project env vars persist and are automatically applied when creating, restoring, or spawning terminals.
  * File picker dialog for selecting files with optional filters.
  * Env values support expansion with $VAR, ${VAR}, and %VAR% syntax.

* **UX**
  * A one-time informational line displays in terminals on spawn when env vars are applied.

* **Tests**
  * Comprehensive tests added for env parsing, merging, and resolution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->