### PR TITLE
fix: persist workspace panel visibility across restarts

### DIFF
--- a/src/renderer/components/TitleBar.test.tsx
+++ b/src/renderer/components/TitleBar.test.tsx
@@ -1,0 +1,91 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { TitleBar } from './TitleBar'
+import { useSidebarStore } from '@/stores/sidebar-store'
+import { useFileExplorerStore } from '@/stores/file-explorer-store'
+import * as appSettingsHooks from '@/hooks/use-app-settings'
+
+const { mockUpdatePanelVisibility, mockToastError, mockWindowApi } = vi.hoisted(() => ({
+  mockUpdatePanelVisibility: vi.fn(() => Promise.resolve()),
+  mockToastError: vi.fn(),
+  mockWindowApi: {
+    onMaximizeChange: vi.fn(() => vi.fn()),
+    minimize: vi.fn(),
+    toggleMaximize: vi.fn().mockResolvedValue({ success: true, data: false }),
+    close: vi.fn()
+  }
+}))
+
+vi.mock('@/lib/api', () => ({
+  windowApi: mockWindowApi
+}))
+
+vi.mock('sonner', () => ({
+  toast: {
+    error: mockToastError
+  }
+}))
+
+describe('TitleBar', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.spyOn(appSettingsHooks, 'useUpdatePanelVisibility').mockReturnValue(
+      mockUpdatePanelVisibility
+    )
+    useSidebarStore.setState({ isVisible: true })
+    useFileExplorerStore.setState({ isVisible: true })
+  })
+
+  function renderTitleBar() {
+    return render(
+      <MemoryRouter>
+        <TitleBar />
+      </MemoryRouter>
+    )
+  }
+
+  it('toggles sidebar via persistence-aware updater on click', async () => {
+    renderTitleBar()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Hide sidebar' }))
+
+    await waitFor(() => {
+      expect(mockUpdatePanelVisibility).toHaveBeenCalledWith('sidebarVisible', false)
+    })
+  })
+
+  it('toggles file explorer via persistence-aware updater on click', async () => {
+    renderTitleBar()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Hide file explorer' }))
+
+    await waitFor(() => {
+      expect(mockUpdatePanelVisibility).toHaveBeenCalledWith('fileExplorerVisible', false)
+    })
+  })
+
+  it('shows error toast when sidebar persistence update fails', async () => {
+    mockUpdatePanelVisibility.mockRejectedValueOnce(new Error('persist failed'))
+
+    renderTitleBar()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Hide sidebar' }))
+
+    await waitFor(() => {
+      expect(mockToastError).toHaveBeenCalledWith('persist failed')
+    })
+  })
+
+  it('shows error toast when file explorer persistence update fails', async () => {
+    mockUpdatePanelVisibility.mockRejectedValueOnce(new Error('persist failed'))
+
+    renderTitleBar()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Hide file explorer' }))
+
+    await waitFor(() => {
+      expect(mockToastError).toHaveBeenCalledWith('persist failed')
+    })
+  })
+})

--- a/src/renderer/components/TitleBar.tsx
+++ b/src/renderer/components/TitleBar.tsx
@@ -1,9 +1,11 @@
 import { useState, useEffect } from 'react'
 import { Minus, Square, Copy, X, PanelLeft, PanelRight, Settings, SlidersHorizontal } from 'lucide-react'
 import { useNavigate, useLocation } from 'react-router-dom'
-import { useSidebarStore, useSidebarVisible } from '@/stores/sidebar-store'
-import { useFileExplorerStore, useFileExplorerVisible } from '@/stores/file-explorer-store'
+import { useSidebarVisible } from '@/stores/sidebar-store'
+import { useFileExplorerVisible } from '@/stores/file-explorer-store'
+import { useUpdatePanelVisibility } from '@/hooks/use-app-settings'
 import { windowApi } from '@/lib/api'
+import { toast } from 'sonner'
 
 const focusableButtonClass = 'h-full px-3 hover:bg-secondary inline-flex items-center focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-inset'
 
@@ -11,8 +13,27 @@ export function TitleBar(): React.JSX.Element {
   const [isMaximized, setIsMaximized] = useState(false)
   const isSidebarVisible = useSidebarVisible()
   const isExplorerVisible = useFileExplorerVisible()
+  const updatePanelVisibility = useUpdatePanelVisibility()
   const navigate = useNavigate()
   const location = useLocation()
+
+  const handleToggleSidebar = async (e: React.MouseEvent<HTMLButtonElement>): Promise<void> => {
+    e.stopPropagation()
+    try {
+      await updatePanelVisibility('sidebarVisible', !isSidebarVisible)
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : 'Failed to update sidebar visibility')
+    }
+  }
+
+  const handleToggleFileExplorer = async (e: React.MouseEvent<HTMLButtonElement>): Promise<void> => {
+    e.stopPropagation()
+    try {
+      await updatePanelVisibility('fileExplorerVisible', !isExplorerVisible)
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : 'Failed to update file explorer visibility')
+    }
+  }
 
   useEffect(() => {
     return windowApi.onMaximizeChange((maximized) => {
@@ -42,7 +63,9 @@ export function TitleBar(): React.JSX.Element {
         style={{ WebkitAppRegion: 'no-drag' } as React.CSSProperties}
       >
         <button
-          onClick={(e) => { e.stopPropagation(); useSidebarStore.getState().toggleVisibility(); }}
+          onClick={(e) => {
+            void handleToggleSidebar(e)
+          }}
           className={focusableButtonClass}
           title="Toggle sidebar"
           aria-label={isSidebarVisible ? 'Hide sidebar' : 'Show sidebar'}
@@ -55,7 +78,9 @@ export function TitleBar(): React.JSX.Element {
         </button>
 
         <button
-          onClick={(e) => { e.stopPropagation(); useFileExplorerStore.getState().toggleVisibility(); }}
+          onClick={(e) => {
+            void handleToggleFileExplorer(e)
+          }}
           className={focusableButtonClass}
           title="Toggle file explorer"
           aria-label={isExplorerVisible ? 'Hide file explorer' : 'Show file explorer'}

--- a/src/renderer/hooks/use-app-settings.test.ts
+++ b/src/renderer/hooks/use-app-settings.test.ts
@@ -1,0 +1,218 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { renderHook, waitFor } from '@testing-library/react'
+import type { IpcResult } from '@shared/types/ipc.types'
+import {
+  useAppSettingsLoader,
+  useResetAppSettings,
+  useUpdateAppSetting,
+  useUpdatePanelVisibility,
+  waitForPendingAppSettingsPersistence,
+  resetAppSettingsPersistenceQueueForTests
+} from './use-app-settings'
+import { useAppSettingsStore } from '@/stores/app-settings-store'
+import { useFileExplorerStore } from '@/stores/file-explorer-store'
+import { useSidebarStore } from '@/stores/sidebar-store'
+import { APP_SETTINGS_KEY, DEFAULT_APP_SETTINGS } from '@/types/settings'
+
+const { mockPersistenceRead, mockPersistenceWrite, mockPersistenceWriteDebounced, mockUpdateOrphanDetection } = vi.hoisted(() => ({
+  mockPersistenceRead: vi.fn(),
+  mockPersistenceWrite: vi.fn(),
+  mockPersistenceWriteDebounced: vi.fn(),
+  mockUpdateOrphanDetection: vi.fn()
+}))
+
+vi.mock('@/lib/api', () => ({
+  persistenceApi: {
+    read: mockPersistenceRead,
+    write: mockPersistenceWrite,
+    writeDebounced: mockPersistenceWriteDebounced
+  },
+  terminalApi: {
+    updateOrphanDetection: mockUpdateOrphanDetection
+  }
+}))
+
+describe('use-app-settings', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    resetAppSettingsPersistenceQueueForTests()
+
+    useAppSettingsStore.setState({
+      settings: { ...DEFAULT_APP_SETTINGS },
+      isLoaded: false
+    })
+    useSidebarStore.setState({ isVisible: true })
+    useFileExplorerStore.setState({ isVisible: true })
+
+    mockPersistenceRead.mockResolvedValue({ success: true, data: null })
+    mockPersistenceWrite.mockResolvedValue({ success: true, data: undefined })
+    mockPersistenceWriteDebounced.mockResolvedValue({ success: true, data: undefined })
+    mockUpdateOrphanDetection.mockResolvedValue({ success: true, data: undefined })
+  })
+
+  it('hydrates sidebar and file explorer visibility from persisted app settings', async () => {
+    mockPersistenceRead.mockResolvedValueOnce({
+      success: true,
+      data: {
+        ...DEFAULT_APP_SETTINGS,
+        sidebarVisible: false,
+        fileExplorerVisible: true
+      }
+    })
+
+    renderHook(() => useAppSettingsLoader())
+
+    await waitFor(() => {
+      expect(useAppSettingsStore.getState().isLoaded).toBe(true)
+      expect(useSidebarStore.getState().isVisible).toBe(false)
+      expect(useFileExplorerStore.getState().isVisible).toBe(true)
+    })
+  })
+
+  it('updates panel visibility with immediate persistence write', async () => {
+    const { result } = renderHook(() => useUpdatePanelVisibility())
+
+    await result.current('sidebarVisible', false)
+
+    expect(useAppSettingsStore.getState().settings.sidebarVisible).toBe(false)
+    expect(useSidebarStore.getState().isVisible).toBe(false)
+    expect(mockPersistenceWrite).toHaveBeenCalledWith(
+      APP_SETTINGS_KEY,
+      expect.objectContaining({ sidebarVisible: false })
+    )
+    expect(mockPersistenceWriteDebounced).not.toHaveBeenCalled()
+  })
+
+  it('serializes rapid panel writes and keeps last state', async () => {
+    const deferredResolvers: Array<(result: IpcResult<void>) => void> = []
+    mockPersistenceWrite.mockImplementation(
+      () =>
+        new Promise<IpcResult<void>>((resolve) => {
+          deferredResolvers.push(resolve)
+        })
+    )
+
+    const { result } = renderHook(() => useUpdatePanelVisibility())
+
+    const first = result.current('sidebarVisible', false)
+    const second = result.current('sidebarVisible', true)
+
+    await waitFor(() => {
+      expect(mockPersistenceWrite).toHaveBeenCalledTimes(1)
+    })
+
+    deferredResolvers[0]?.({ success: true, data: undefined })
+    await first
+
+    await waitFor(() => {
+      expect(mockPersistenceWrite).toHaveBeenCalledTimes(2)
+    })
+
+    deferredResolvers[1]?.({ success: true, data: undefined })
+    await second
+
+    expect(useAppSettingsStore.getState().settings.sidebarVisible).toBe(true)
+    expect(useSidebarStore.getState().isVisible).toBe(true)
+  })
+
+  it('reverts panel visibility in stores when immediate persistence fails', async () => {
+    mockPersistenceWrite.mockResolvedValueOnce({
+      success: false,
+      error: 'write failed',
+      code: 'WRITE_FAILED'
+    })
+
+    const { result } = renderHook(() => useUpdatePanelVisibility())
+
+    let thrown: unknown
+    try {
+      await result.current('sidebarVisible', false)
+    } catch (error) {
+      thrown = error
+    }
+
+    expect(thrown).toBeInstanceOf(Error)
+    expect((thrown as Error).message).toBe('write failed')
+    expect(useAppSettingsStore.getState().settings.sidebarVisible).toBe(true)
+    expect(useSidebarStore.getState().isVisible).toBe(true)
+  })
+
+  it('keeps newer panel value when older queued write fails', async () => {
+    mockPersistenceWrite
+      .mockResolvedValueOnce({ success: false, error: 'first failed', code: 'WRITE_FAILED' })
+      .mockResolvedValueOnce({ success: true, data: undefined })
+
+    const { result } = renderHook(() => useUpdatePanelVisibility())
+
+    let firstError: unknown
+    const first = result.current('fileExplorerVisible', false).catch((error) => {
+      firstError = error
+    })
+    const second = result.current('fileExplorerVisible', true)
+
+    await first
+    await second
+
+    expect(firstError).toBeInstanceOf(Error)
+    expect((firstError as Error).message).toBe('first failed')
+
+    expect(useAppSettingsStore.getState().settings.fileExplorerVisible).toBe(true)
+    expect(useFileExplorerStore.getState().isVisible).toBe(true)
+  })
+
+  it('keeps debounced writes for non-panel app settings', async () => {
+    const { result } = renderHook(() => useUpdateAppSetting())
+
+    await result.current('terminalFontSize', 16)
+
+    expect(useAppSettingsStore.getState().settings.terminalFontSize).toBe(16)
+    expect(mockPersistenceWriteDebounced).toHaveBeenCalledWith(
+      APP_SETTINGS_KEY,
+      expect.objectContaining({ terminalFontSize: 16 })
+    )
+  })
+
+  it('resets panel stores when app settings are reset', async () => {
+    useSidebarStore.setState({ isVisible: false })
+    useFileExplorerStore.setState({ isVisible: false })
+
+    const { result } = renderHook(() => useResetAppSettings())
+
+    await result.current()
+
+    expect(useSidebarStore.getState().isVisible).toBe(DEFAULT_APP_SETTINGS.sidebarVisible)
+    expect(useFileExplorerStore.getState().isVisible).toBe(
+      DEFAULT_APP_SETTINGS.fileExplorerVisible
+    )
+    expect(mockPersistenceWrite).toHaveBeenCalledWith(APP_SETTINGS_KEY, DEFAULT_APP_SETTINGS)
+  })
+
+  it('waits for queued panel writes before close-flow synchronization', async () => {
+    let resolveWrite: ((result: IpcResult<void>) => void) | undefined
+    mockPersistenceWrite.mockImplementationOnce(
+      () =>
+        new Promise<IpcResult<void>>((resolve) => {
+          resolveWrite = resolve
+        })
+    )
+
+    const { result } = renderHook(() => useUpdatePanelVisibility())
+    const pendingWrite = result.current('sidebarVisible', false)
+
+    const waiter = waitForPendingAppSettingsPersistence()
+
+    let waiterResolved = false
+    void waiter.then(() => {
+      waiterResolved = true
+    })
+
+    await Promise.resolve()
+    expect(waiterResolved).toBe(false)
+
+    resolveWrite?.({ success: true, data: undefined })
+    await pendingWrite
+    await waiter
+
+    expect(waiterResolved).toBe(true)
+  })
+})

--- a/src/renderer/hooks/use-app-settings.test.ts
+++ b/src/renderer/hooks/use-app-settings.test.ts
@@ -83,7 +83,7 @@ describe('use-app-settings', () => {
     expect(mockPersistenceWriteDebounced).not.toHaveBeenCalled()
   })
 
-  it('serializes rapid panel writes and keeps last state', async () => {
+  it('serializes rapid panel writes and persists each queued request payload', async () => {
     const deferredResolvers: Array<(result: IpcResult<void>) => void> = []
     mockPersistenceWrite.mockImplementation(
       () =>
@@ -101,12 +101,24 @@ describe('use-app-settings', () => {
       expect(mockPersistenceWrite).toHaveBeenCalledTimes(1)
     })
 
+    expect(mockPersistenceWrite).toHaveBeenNthCalledWith(
+      1,
+      APP_SETTINGS_KEY,
+      expect.objectContaining({ sidebarVisible: false })
+    )
+
     deferredResolvers[0]?.({ success: true, data: undefined })
     await first
 
     await waitFor(() => {
       expect(mockPersistenceWrite).toHaveBeenCalledTimes(2)
     })
+
+    expect(mockPersistenceWrite).toHaveBeenNthCalledWith(
+      2,
+      APP_SETTINGS_KEY,
+      expect.objectContaining({ sidebarVisible: true })
+    )
 
     deferredResolvers[1]?.({ success: true, data: undefined })
     await second
@@ -156,6 +168,16 @@ describe('use-app-settings', () => {
     expect(firstError).toBeInstanceOf(Error)
     expect((firstError as Error).message).toBe('first failed')
 
+    expect(mockPersistenceWrite).toHaveBeenNthCalledWith(
+      1,
+      APP_SETTINGS_KEY,
+      expect.objectContaining({ fileExplorerVisible: false })
+    )
+    expect(mockPersistenceWrite).toHaveBeenNthCalledWith(
+      2,
+      APP_SETTINGS_KEY,
+      expect.objectContaining({ fileExplorerVisible: true })
+    )
     expect(useAppSettingsStore.getState().settings.fileExplorerVisible).toBe(true)
     expect(useFileExplorerStore.getState().isVisible).toBe(true)
   })
@@ -214,5 +236,37 @@ describe('use-app-settings', () => {
     await waiter
 
     expect(waiterResolved).toBe(true)
+  })
+
+  it('does not let an older failed revision roll back a newer successful state', async () => {
+    const deferredResolvers: Array<(result: IpcResult<void>) => void> = []
+    mockPersistenceWrite.mockImplementation(
+      () =>
+        new Promise<IpcResult<void>>((resolve) => {
+          deferredResolvers.push(resolve)
+        })
+    )
+
+    const { result } = renderHook(() => useUpdatePanelVisibility())
+
+    const first = result.current('sidebarVisible', false).catch((error) => error)
+    const second = result.current('sidebarVisible', true)
+
+    await waitFor(() => {
+      expect(mockPersistenceWrite).toHaveBeenCalledTimes(1)
+    })
+
+    deferredResolvers[0]?.({ success: false, error: 'first failed', code: 'WRITE_FAILED' })
+    await first
+
+    await waitFor(() => {
+      expect(mockPersistenceWrite).toHaveBeenCalledTimes(2)
+    })
+
+    deferredResolvers[1]?.({ success: true, data: undefined })
+    await second
+
+    expect(useAppSettingsStore.getState().settings.sidebarVisible).toBe(true)
+    expect(useSidebarStore.getState().isVisible).toBe(true)
   })
 })

--- a/src/renderer/hooks/use-app-settings.ts
+++ b/src/renderer/hooks/use-app-settings.ts
@@ -1,8 +1,76 @@
 import { useEffect, useCallback } from 'react'
 import { useAppSettingsStore } from '@/stores/app-settings-store'
+import { useSidebarStore } from '@/stores/sidebar-store'
+import { useFileExplorerStore } from '@/stores/file-explorer-store'
 import { persistenceApi, terminalApi } from '@/lib/api'
 import type { AppSettings } from '@/types/settings'
 import { DEFAULT_APP_SETTINGS, APP_SETTINGS_KEY } from '@/types/settings'
+
+type PanelSettingKey = 'sidebarVisible' | 'fileExplorerVisible'
+
+let panelWriteChain: Promise<void> = Promise.resolve()
+const panelWriteRequestIds: Record<PanelSettingKey, number> = {
+  sidebarVisible: 0,
+  fileExplorerVisible: 0
+}
+let pendingPanelWriteCount = 0
+let pendingPanelWriteWaiters: Array<() => void> = []
+
+function notifyPanelWriteSettled(): void {
+  if (pendingPanelWriteCount === 0 && pendingPanelWriteWaiters.length > 0) {
+    const waiters = pendingPanelWriteWaiters
+    pendingPanelWriteWaiters = []
+    waiters.forEach((resolve) => resolve())
+  }
+}
+
+function enqueuePanelWrite(task: () => Promise<void>): Promise<void> {
+  pendingPanelWriteCount += 1
+  const run = panelWriteChain.then(task)
+  panelWriteChain = run.catch(() => undefined)
+
+  return run.finally(() => {
+    pendingPanelWriteCount = Math.max(0, pendingPanelWriteCount - 1)
+    notifyPanelWriteSettled()
+  })
+}
+
+export async function waitForPendingAppSettingsPersistence(): Promise<void> {
+  await panelWriteChain.catch(() => undefined)
+
+  if (pendingPanelWriteCount === 0) {
+    return
+  }
+
+  await new Promise<void>((resolve) => {
+    pendingPanelWriteWaiters.push(resolve)
+  })
+}
+
+export function resetAppSettingsPersistenceQueueForTests(): void {
+  panelWriteChain = Promise.resolve()
+  panelWriteRequestIds.sidebarVisible = 0
+  panelWriteRequestIds.fileExplorerVisible = 0
+  pendingPanelWriteCount = 0
+  pendingPanelWriteWaiters = []
+}
+
+function applyPanelVisibilityToUi(panel: PanelSettingKey, visible: boolean): void {
+  if (panel === 'sidebarVisible') {
+    useSidebarStore.getState().setVisible(visible)
+    return
+  }
+
+  useFileExplorerStore.getState().setVisible(visible)
+}
+
+function getPanelVisibility(panel: PanelSettingKey): boolean {
+  if (panel === 'sidebarVisible') {
+    return useSidebarStore.getState().isVisible
+  }
+
+  return useFileExplorerStore.getState().isVisible
+}
 
 export function useAppSettingsLoader(): void {
   const setSettings = useAppSettingsStore((state) => state.setSettings)
@@ -20,6 +88,9 @@ export function useAppSettingsLoader(): void {
         settings = DEFAULT_APP_SETTINGS
         setSettings(settings)
       }
+
+      useSidebarStore.getState().setVisible(settings.sidebarVisible)
+      useFileExplorerStore.getState().setVisible(settings.fileExplorerVisible)
 
       // Apply orphan detection settings to PtyManager after settings load
       try {
@@ -53,11 +124,45 @@ export function useUpdateAppSetting<K extends keyof AppSettings>(): (
   )
 }
 
+export function useUpdatePanelVisibility(): (
+  panel: PanelSettingKey,
+  visible: boolean
+) => Promise<void> {
+  const updateSetting = useAppSettingsStore((state) => state.updateSetting)
+
+  return useCallback(
+    async (panel: PanelSettingKey, visible: boolean) => {
+      const requestId = ++panelWriteRequestIds[panel]
+      const previousValue = getPanelVisibility(panel)
+
+      updateSetting(panel, visible)
+      applyPanelVisibilityToUi(panel, visible)
+
+      return enqueuePanelWrite(async () => {
+        const settingsSnapshot = useAppSettingsStore.getState().settings
+        const result = await persistenceApi.write(APP_SETTINGS_KEY, settingsSnapshot)
+
+        if (!result.success) {
+          // Revert only if no newer panel write request has superseded this one.
+          if (panelWriteRequestIds[panel] === requestId) {
+            updateSetting(panel, previousValue)
+            applyPanelVisibilityToUi(panel, previousValue)
+          }
+          throw new Error(result.error || `Failed to persist ${panel}`)
+        }
+      })
+    },
+    [updateSetting]
+  )
+}
+
 export function useResetAppSettings(): () => Promise<void> {
   const resetToDefaults = useAppSettingsStore((state) => state.resetToDefaults)
 
   return useCallback(async () => {
     resetToDefaults()
+    useSidebarStore.getState().setVisible(DEFAULT_APP_SETTINGS.sidebarVisible)
+    useFileExplorerStore.getState().setVisible(DEFAULT_APP_SETTINGS.fileExplorerVisible)
     await persistenceApi.write(APP_SETTINGS_KEY, DEFAULT_APP_SETTINGS)
   }, [resetToDefaults])
 }

--- a/src/renderer/hooks/use-app-settings.ts
+++ b/src/renderer/hooks/use-app-settings.ts
@@ -8,11 +8,21 @@ import { DEFAULT_APP_SETTINGS, APP_SETTINGS_KEY } from '@/types/settings'
 
 type PanelSettingKey = 'sidebarVisible' | 'fileExplorerVisible'
 
+type PanelWriteRequest = {
+  panel: PanelSettingKey
+  visible: boolean
+  requestId: number
+  revision: number
+}
+
 let panelWriteChain: Promise<void> = Promise.resolve()
 const panelWriteRequestIds: Record<PanelSettingKey, number> = {
   sidebarVisible: 0,
   fileExplorerVisible: 0
 }
+let panelWriteRevision = 0
+let lastSuccessfulPanelWriteRevision = 0
+let persistedPanelSettingsSnapshot: AppSettings = { ...DEFAULT_APP_SETTINGS }
 let pendingPanelWriteCount = 0
 let pendingPanelWriteWaiters: Array<() => void> = []
 
@@ -20,13 +30,49 @@ function notifyPanelWriteSettled(): void {
   if (pendingPanelWriteCount === 0 && pendingPanelWriteWaiters.length > 0) {
     const waiters = pendingPanelWriteWaiters
     pendingPanelWriteWaiters = []
-    waiters.forEach((resolve) => resolve())
+    waiters.forEach((resolve) => {
+      resolve()
+    })
   }
 }
 
-function enqueuePanelWrite(task: () => Promise<void>): Promise<void> {
+function syncPersistedPanelSettingsSnapshot(settings: AppSettings): void {
+  persistedPanelSettingsSnapshot = { ...settings }
+}
+
+function buildPanelWriteSnapshot(request: PanelWriteRequest): AppSettings {
+  const currentSettings = useAppSettingsStore.getState().settings
+
+  return {
+    ...currentSettings,
+    sidebarVisible: persistedPanelSettingsSnapshot.sidebarVisible,
+    fileExplorerVisible: persistedPanelSettingsSnapshot.fileExplorerVisible,
+    [request.panel]: request.visible
+  }
+}
+
+function enqueuePanelWrite(request: PanelWriteRequest): Promise<void> {
   pendingPanelWriteCount += 1
-  const run = panelWriteChain.then(task)
+  const run = panelWriteChain.then(async () => {
+    const settingsSnapshot = buildPanelWriteSnapshot(request)
+    const result = await persistenceApi.write(APP_SETTINGS_KEY, settingsSnapshot)
+
+    if (!result.success) {
+      const isLatestPanelRequest = panelWriteRequestIds[request.panel] === request.requestId
+      const canRollbackToLastPersistedValue = request.revision > lastSuccessfulPanelWriteRevision
+
+      if (isLatestPanelRequest && canRollbackToLastPersistedValue) {
+        const rollbackValue = persistedPanelSettingsSnapshot[request.panel]
+        useAppSettingsStore.getState().updateSetting(request.panel, rollbackValue)
+        applyPanelVisibilityToUi(request.panel, rollbackValue)
+      }
+
+      throw new Error(result.error || `Failed to persist ${request.panel}`)
+    }
+
+    syncPersistedPanelSettingsSnapshot(settingsSnapshot)
+    lastSuccessfulPanelWriteRevision = request.revision
+  })
   panelWriteChain = run.catch(() => undefined)
 
   return run.finally(() => {
@@ -51,6 +97,9 @@ export function resetAppSettingsPersistenceQueueForTests(): void {
   panelWriteChain = Promise.resolve()
   panelWriteRequestIds.sidebarVisible = 0
   panelWriteRequestIds.fileExplorerVisible = 0
+  panelWriteRevision = 0
+  lastSuccessfulPanelWriteRevision = 0
+  persistedPanelSettingsSnapshot = { ...DEFAULT_APP_SETTINGS }
   pendingPanelWriteCount = 0
   pendingPanelWriteWaiters = []
 }
@@ -62,14 +111,6 @@ function applyPanelVisibilityToUi(panel: PanelSettingKey, visible: boolean): voi
   }
 
   useFileExplorerStore.getState().setVisible(visible)
-}
-
-function getPanelVisibility(panel: PanelSettingKey): boolean {
-  if (panel === 'sidebarVisible') {
-    return useSidebarStore.getState().isVisible
-  }
-
-  return useFileExplorerStore.getState().isVisible
 }
 
 export function useAppSettingsLoader(): void {
@@ -88,6 +129,8 @@ export function useAppSettingsLoader(): void {
         settings = DEFAULT_APP_SETTINGS
         setSettings(settings)
       }
+
+      syncPersistedPanelSettingsSnapshot(settings)
 
       useSidebarStore.getState().setVisible(settings.sidebarVisible)
       useFileExplorerStore.getState().setVisible(settings.fileExplorerVisible)
@@ -133,24 +176,17 @@ export function useUpdatePanelVisibility(): (
   return useCallback(
     async (panel: PanelSettingKey, visible: boolean) => {
       const requestId = ++panelWriteRequestIds[panel]
-      const previousValue = getPanelVisibility(panel)
+      const request: PanelWriteRequest = {
+        panel,
+        visible,
+        requestId,
+        revision: ++panelWriteRevision
+      }
 
       updateSetting(panel, visible)
       applyPanelVisibilityToUi(panel, visible)
 
-      return enqueuePanelWrite(async () => {
-        const settingsSnapshot = useAppSettingsStore.getState().settings
-        const result = await persistenceApi.write(APP_SETTINGS_KEY, settingsSnapshot)
-
-        if (!result.success) {
-          // Revert only if no newer panel write request has superseded this one.
-          if (panelWriteRequestIds[panel] === requestId) {
-            updateSetting(panel, previousValue)
-            applyPanelVisibilityToUi(panel, previousValue)
-          }
-          throw new Error(result.error || `Failed to persist ${panel}`)
-        }
-      })
+      return enqueuePanelWrite(request)
     },
     [updateSetting]
   )
@@ -163,6 +199,10 @@ export function useResetAppSettings(): () => Promise<void> {
     resetToDefaults()
     useSidebarStore.getState().setVisible(DEFAULT_APP_SETTINGS.sidebarVisible)
     useFileExplorerStore.getState().setVisible(DEFAULT_APP_SETTINGS.fileExplorerVisible)
-    await persistenceApi.write(APP_SETTINGS_KEY, DEFAULT_APP_SETTINGS)
+
+    const result = await persistenceApi.write(APP_SETTINGS_KEY, DEFAULT_APP_SETTINGS)
+    if (result.success) {
+      syncPersistedPanelSettingsSnapshot(DEFAULT_APP_SETTINGS)
+    }
   }, [resetToDefaults])
 }

--- a/src/renderer/hooks/use-editor-persistence.test.ts
+++ b/src/renderer/hooks/use-editor-persistence.test.ts
@@ -55,7 +55,6 @@ const mockEditorState = {
 const mockExplorerState = {
   expandedDirs: new Set<string>(),
   isVisible: true,
-  setVisible: vi.fn(),
   setExpandedDirs: vi.fn(),
   restoreExpandedDirs: vi.fn().mockResolvedValue(undefined)
 }
@@ -149,7 +148,6 @@ beforeEach(() => {
 
   mockExplorerState.expandedDirs = new Set<string>()
   mockExplorerState.isVisible = true
-  mockExplorerState.setVisible.mockReset()
   mockExplorerState.setExpandedDirs.mockReset()
   mockExplorerState.restoreExpandedDirs.mockReset()
   mockExplorerState.restoreExpandedDirs.mockResolvedValue(undefined)
@@ -182,7 +180,6 @@ describe('useEditorPersistence', () => {
         openFiles: [],
         activeFilePath: null,
         expandedDirs: ['/projects/a', '/projects/a/src', '/projects/b/src', '/outside/path'],
-        fileExplorerVisible: true,
         activeTabId: null
       }
     })
@@ -200,6 +197,29 @@ describe('useEditorPersistence', () => {
     })
   })
 
+  it('ignores legacy fileExplorerVisible in persisted payload', async () => {
+    mockExplorerState.isVisible = true
+
+    mockPersistenceRead.mockResolvedValue({
+      success: true,
+      data: {
+        openFiles: [],
+        activeFilePath: null,
+        expandedDirs: ['/projects/a/src'],
+        fileExplorerVisible: false,
+        activeTabId: null
+      }
+    })
+
+    renderHook(() => useEditorPersistence('project-a'))
+
+    await waitFor(() => {
+      expect(mockExplorerState.restoreExpandedDirs).toHaveBeenCalledWith(['/projects/a/src'])
+    })
+
+    expect(mockExplorerState.isVisible).toBe(true)
+  })
+
   it('keeps expanded dir persistence isolated per project', async () => {
     mockPersistenceRead
       .mockResolvedValueOnce({
@@ -208,7 +228,6 @@ describe('useEditorPersistence', () => {
           openFiles: [],
           activeFilePath: null,
           expandedDirs: ['/projects/a/src'],
-          fileExplorerVisible: true,
           activeTabId: null
         }
       })
@@ -218,7 +237,6 @@ describe('useEditorPersistence', () => {
           openFiles: [],
           activeFilePath: null,
           expandedDirs: ['/projects/b/docs'],
-          fileExplorerVisible: true,
           activeTabId: null
         }
       })
@@ -318,7 +336,6 @@ describe('useEditorPersistence', () => {
         ],
         activeFilePath: '/projects/a/src/existing.ts',
         expandedDirs: ['/projects/a/src'],
-        fileExplorerVisible: true,
         activeTabId: null,
         activePaneId: 'pane-drop',
         paneLayout: {
@@ -402,7 +419,6 @@ describe('useEditorPersistence', () => {
         ],
         activeFilePath: '/projects/a/src/legacy.ts',
         expandedDirs: ['/projects/a/src'],
-        fileExplorerVisible: true,
         activeTabId: null,
         activePaneId: 'pane-legacy',
         paneLayout: {

--- a/src/renderer/hooks/use-editor-persistence.ts
+++ b/src/renderer/hooks/use-editor-persistence.ts
@@ -67,7 +67,6 @@ interface PersistedEditorState {
   openFiles: PersistedEditorFile[]
   activeFilePath: string | null
   expandedDirs: string[]
-  fileExplorerVisible: boolean
   activeTabId: string | null
   // v2: pane layout
   paneLayout?: PersistedPaneNodeInput
@@ -262,9 +261,8 @@ export function useEditorPersistence(projectId: string): void {
 
         const persisted = result.data
 
-        // Restore file explorer visibility and expanded dirs for this project root
+        // Restore expanded dirs for this project root
         const explorerStore = useFileExplorerStore.getState()
-        explorerStore.setVisible(persisted.fileExplorerVisible)
 
         const rootPath = useProjectStore
           .getState()
@@ -375,7 +373,11 @@ export function useEditorPersistence(projectId: string): void {
     }
 
     const unsubEditor = useEditorStore.subscribe(schedulePersist)
-    const unsubExplorer = useFileExplorerStore.subscribe(schedulePersist)
+    const unsubExplorer = useFileExplorerStore.subscribe((state, prevState) => {
+      if (state.expandedDirs !== prevState.expandedDirs) {
+        schedulePersist()
+      }
+    })
     const unsubWorkspace = useWorkspaceStore.subscribe(schedulePersist)
 
     return () => {
@@ -414,7 +416,6 @@ export function persistState(projectId: string): void {
     openFiles,
     activeFilePath: editorState.activeFilePath,
     expandedDirs,
-    fileExplorerVisible: explorerState.isVisible,
     activeTabId: (() => {
       const pane = findPaneById(workspaceState.root, workspaceState.activePaneId)
       return pane && pane.type === 'leaf' ? pane.activeTabId : null

--- a/src/renderer/layouts/WorkspaceLayout.test.tsx
+++ b/src/renderer/layouts/WorkspaceLayout.test.tsx
@@ -1,8 +1,10 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { render, screen, waitFor } from '@testing-library/react'
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
 import { TooltipProvider } from '@/components/ui/tooltip'
 import WorkspaceLayout from './WorkspaceLayout'
+import { useFileExplorerStore } from '@/stores/file-explorer-store'
+import { useSidebarStore } from '@/stores/sidebar-store'
 import type { Project, Terminal, ProjectColor } from '@/types/project'
 
 function createProject(id: string, path: string, color: ProjectColor): Project {
@@ -72,24 +74,35 @@ vi.mock('@/stores/app-settings-store', () => ({
   useDefaultProjectColor: vi.fn(() => 'blue')
 }))
 
-vi.mock('@/stores/keyboard-shortcuts-store', () => ({
-  useKeyboardShortcutsStore: vi.fn(() => ({
-    shortcuts: {
-      commandPalette: { customKey: 'Ctrl+K', defaultKey: 'Ctrl+K' },
-      commandPaletteAlt: { customKey: 'Ctrl+Shift+P', defaultKey: 'Ctrl+Shift+P' },
-      terminalSearch: { customKey: 'Ctrl+F', defaultKey: 'Ctrl+F' },
-      commandHistory: { customKey: 'Ctrl+R', defaultKey: 'Ctrl+R' },
-      newProject: { customKey: 'Ctrl+N', defaultKey: 'Ctrl+N' },
-      newTerminal: { customKey: 'Ctrl+T', defaultKey: 'Ctrl+T' },
-      nextTerminal: { customKey: 'Ctrl+PageDown', defaultKey: 'Ctrl+PageDown' },
-      prevTerminal: { customKey: 'Ctrl+PageUp', defaultKey: 'Ctrl+PageUp' },
-      zoomIn: { customKey: 'Ctrl+=', defaultKey: 'Ctrl+=' },
-      zoomOut: { customKey: 'Ctrl+-', defaultKey: 'Ctrl+-' },
-      zoomReset: { customKey: 'Ctrl+0', defaultKey: 'Ctrl+0' }
-    }
-  })),
-  matchesShortcut: vi.fn(() => false)
-}))
+vi.mock('@/stores/keyboard-shortcuts-store', async () => {
+  const actual = await vi.importActual<typeof import('@/stores/keyboard-shortcuts-store')>(
+    '@/stores/keyboard-shortcuts-store'
+  )
+
+  const shortcuts = {
+    commandPalette: { customKey: 'ctrl+k', defaultKey: 'ctrl+k' },
+    commandPaletteAlt: { customKey: 'ctrl+shift+p', defaultKey: 'ctrl+shift+p' },
+    terminalSearch: { customKey: 'ctrl+f', defaultKey: 'ctrl+f' },
+    commandHistory: { customKey: 'ctrl+r', defaultKey: 'ctrl+r' },
+    newProject: { customKey: 'ctrl+n', defaultKey: 'ctrl+n' },
+    newTerminal: { customKey: 'ctrl+t', defaultKey: 'ctrl+t' },
+    nextTerminal: { customKey: 'ctrl+pagedown', defaultKey: 'ctrl+pagedown' },
+    prevTerminal: { customKey: 'ctrl+pageup', defaultKey: 'ctrl+pageup' },
+    zoomIn: { customKey: 'ctrl+=', defaultKey: 'ctrl+=' },
+    zoomOut: { customKey: 'ctrl+-', defaultKey: 'ctrl+-' },
+    zoomReset: { customKey: 'ctrl+0', defaultKey: 'ctrl+0' },
+    sidebarToggle: { customKey: 'ctrl+shift+b', defaultKey: 'ctrl+shift+b' }
+  }
+
+  return {
+    ...actual,
+    useKeyboardShortcutsStore: vi.fn((selector?: (state: { shortcuts: typeof shortcuts }) => unknown) => {
+      const state = { shortcuts }
+      return selector ? selector(state) : state
+    }),
+    matchesShortcut: actual.matchesShortcut
+  }
+})
 
 // Mock hooks
 vi.mock('@/hooks/use-snapshots', () => ({
@@ -109,8 +122,15 @@ vi.mock('@/hooks/use-command-history', () => ({
   useCommandHistory: vi.fn(() => [])
 }))
 
+const { mockUpdatePanelVisibility, mockWaitForPendingAppSettingsPersistence } = vi.hoisted(() => ({
+  mockUpdatePanelVisibility: vi.fn(() => Promise.resolve()),
+  mockWaitForPendingAppSettingsPersistence: vi.fn(() => Promise.resolve())
+}))
+
 vi.mock('@/hooks/use-app-settings', () => ({
-  useUpdateAppSetting: vi.fn(() => vi.fn())
+  useUpdateAppSetting: vi.fn(() => vi.fn()),
+  useUpdatePanelVisibility: vi.fn(() => mockUpdatePanelVisibility),
+  waitForPendingAppSettingsPersistence: mockWaitForPendingAppSettingsPersistence
 }))
 
 vi.mock('@/hooks/use-file-watcher', () => ({
@@ -130,7 +150,7 @@ vi.mock('@/components/file-explorer/FileExplorer', () => ({
 const { mockApi } = vi.hoisted(() => ({
   mockApi: {
     keyboard: {
-      onShortcut: vi.fn(() => vi.fn())
+      onShortcut: vi.fn((_callback: () => void) => vi.fn())
     },
     shell: {
       getAvailableShells: vi.fn().mockResolvedValue({ success: true, data: { default: null, available: [] } })
@@ -169,7 +189,7 @@ const { mockApi } = vi.hoisted(() => ({
       toggleMaximize: vi.fn().mockResolvedValue({ success: true, data: false }),
       close: vi.fn(),
       onMaximizeChange: vi.fn(() => vi.fn()),
-      onCloseRequested: vi.fn(() => vi.fn()),
+      onCloseRequested: vi.fn<(callback: () => void) => () => void>((_callback) => vi.fn()),
       respondToClose: vi.fn()
     },
     clipboard: {
@@ -238,9 +258,16 @@ beforeEach(() => {
   mockUseAllTerminals.mockReturnValue([])
   mockUseActiveTerminal.mockReturnValue(null)
   mockUseActiveTerminalId.mockReturnValue('')
+  mockUpdatePanelVisibility.mockReset()
+  mockWaitForPendingAppSettingsPersistence.mockReset()
+  useFileExplorerStore.setState({ isVisible: true })
+  useSidebarStore.setState({ isVisible: true })
   mockApi.filesystem.watchDirectory.mockReset()
   mockApi.filesystem.unwatchDirectory.mockReset()
   mockApi.filesystem.watchDirectory.mockResolvedValue({ success: true })
+  mockApi.window.onCloseRequested.mockReset()
+  mockApi.window.onCloseRequested.mockImplementation(() => vi.fn())
+  mockApi.window.respondToClose.mockReset()
 })
 
 afterEach(() => {
@@ -522,6 +549,149 @@ describe('WorkspaceLayout - Empty States', () => {
 
       expect(screen.queryByText('No Projects Yet')).not.toBeInTheDocument()
       expect(screen.queryByText('No Terminals Yet')).not.toBeInTheDocument()
+    })
+  })
+
+  describe('Keyboard panel visibility shortcuts', () => {
+    beforeEach(() => {
+      const project = createProject('a', '/workspace/a', 'blue')
+      mockUseProjects.mockReturnValue([project])
+      mockUseActiveProject.mockReturnValue(project)
+      mockUseActiveProjectId.mockReturnValue('a')
+      mockUseTerminals.mockReturnValue([])
+      mockUseAllTerminals.mockReturnValue([])
+      mockUseActiveTerminal.mockReturnValue(null)
+      mockUseActiveTerminalId.mockReturnValue('')
+    })
+
+    it('keeps Ctrl+B toggling file explorer and persists globally', () => {
+      renderWithRouter()
+
+      fireEvent.keyDown(window, { key: 'b', ctrlKey: true })
+
+      expect(mockUpdatePanelVisibility).toHaveBeenCalledWith('fileExplorerVisible', false)
+    })
+
+    it('toggles sidebar with configured sidebar shortcut and persists globally', () => {
+      renderWithRouter()
+
+      fireEvent.keyDown(window, { key: 'B', ctrlKey: true, shiftKey: true })
+
+      expect(mockUpdatePanelVisibility).toHaveBeenCalledWith('sidebarVisible', false)
+    })
+
+    it('does not toggle panel shortcuts when focus is in input', () => {
+      renderWithRouter()
+
+      const input = document.createElement('input')
+      document.body.appendChild(input)
+      input.focus()
+
+      fireEvent.keyDown(input, { key: 'b', ctrlKey: true })
+      fireEvent.keyDown(input, { key: 'B', ctrlKey: true, shiftKey: true })
+
+      expect(useFileExplorerStore.getState().isVisible).toBe(true)
+      expect(useSidebarStore.getState().isVisible).toBe(true)
+      expect(mockUpdatePanelVisibility).not.toHaveBeenCalled()
+
+      document.body.removeChild(input)
+    })
+  })
+
+  describe('Close flow persistence coordination', () => {
+    it('waits for pending app-settings persistence before responding to close with no dirty files', async () => {
+      let closeRequestedCallback: (() => void) | undefined
+      mockApi.window.onCloseRequested.mockImplementation((callback: () => void) => {
+        closeRequestedCallback = callback
+        return vi.fn()
+      })
+
+      const project = createProject('a', '/workspace/a', 'blue')
+      mockUseProjects.mockReturnValue([project])
+      mockUseActiveProject.mockReturnValue(project)
+      mockUseActiveProjectId.mockReturnValue('a')
+
+      const deferred = new Promise<void>((resolve) => {
+        mockWaitForPendingAppSettingsPersistence.mockImplementationOnce(async () => {
+          await new Promise<void>((r) => setTimeout(r, 0))
+          resolve()
+        })
+      })
+
+      renderWithRouter()
+      expect(closeRequestedCallback).toBeDefined()
+      if (!closeRequestedCallback) throw new Error('close callback missing')
+
+      closeRequestedCallback()
+
+      expect(mockApi.window.respondToClose).not.toHaveBeenCalled()
+      await deferred
+      await waitFor(() => {
+        expect(mockApi.window.respondToClose).toHaveBeenCalledWith('close')
+      })
+    })
+
+    it('waits for pending app-settings persistence before confirm-dialog discard close', async () => {
+      let closeRequestedCallback: (() => void) | undefined
+      mockApi.window.onCloseRequested.mockImplementation((callback: () => void) => {
+        closeRequestedCallback = callback
+        return vi.fn()
+      })
+
+      const project = createProject('a', '/workspace/a', 'blue')
+      mockUseProjects.mockReturnValue([project])
+      mockUseActiveProject.mockReturnValue(project)
+      mockUseActiveProjectId.mockReturnValue('a')
+
+      const dirtyEditorState = {
+        activeFilePath: '/workspace/a/src/file.ts',
+        openFiles: new Map([
+          [
+            '/workspace/a/src/file.ts',
+            {
+              filePath: '/workspace/a/src/file.ts',
+              isDirty: true
+            }
+          ]
+        ]),
+        getDirtyFileCount: vi.fn(() => 1),
+        saveAllDirty: vi.fn().mockResolvedValue(undefined),
+        closeFile: vi.fn(),
+        saveFile: vi.fn().mockResolvedValue(true)
+      }
+
+      const useEditorStoreModule = await import('@/stores/editor-store')
+      const getStateSpy = vi.spyOn(useEditorStoreModule.useEditorStore, 'getState').mockReturnValue(
+        dirtyEditorState as unknown as ReturnType<typeof useEditorStoreModule.useEditorStore.getState>
+      )
+
+      renderWithRouter()
+      expect(closeRequestedCallback).toBeDefined()
+      if (!closeRequestedCallback) throw new Error('close callback missing')
+
+      closeRequestedCallback()
+
+      const dontSaveButton = await screen.findByRole('button', { name: "Don't Save" })
+
+      let resolveWait: (() => void) | undefined
+      mockWaitForPendingAppSettingsPersistence.mockImplementationOnce(
+        () =>
+          new Promise<void>((resolve) => {
+            resolveWait = resolve
+          })
+      )
+
+      await act(async () => {
+        fireEvent.click(dontSaveButton)
+      })
+
+      expect(mockApi.window.respondToClose).not.toHaveBeenCalled()
+      resolveWait?.()
+      await waitFor(() => {
+        expect(mockApi.window.respondToClose).toHaveBeenCalledWith('close')
+      })
+
+      getStateSpy.mockRestore()
     })
   })
 

--- a/src/renderer/layouts/WorkspaceLayout.test.tsx
+++ b/src/renderer/layouts/WorkspaceLayout.test.tsx
@@ -150,7 +150,7 @@ vi.mock('@/components/file-explorer/FileExplorer', () => ({
 const { mockApi } = vi.hoisted(() => ({
   mockApi: {
     keyboard: {
-      onShortcut: vi.fn((_callback: () => void) => vi.fn())
+      onShortcut: vi.fn((_callback: () => Promise<boolean>) => vi.fn())
     },
     shell: {
       getAvailableShells: vi.fn().mockResolvedValue({ success: true, data: { default: null, available: [] } })
@@ -189,7 +189,7 @@ const { mockApi } = vi.hoisted(() => ({
       toggleMaximize: vi.fn().mockResolvedValue({ success: true, data: false }),
       close: vi.fn(),
       onMaximizeChange: vi.fn(() => vi.fn()),
-      onCloseRequested: vi.fn<(callback: () => void) => () => void>((_callback) => vi.fn()),
+      onCloseRequested: vi.fn<(callback: () => Promise<boolean>) => () => void>((_callback) => vi.fn()),
       respondToClose: vi.fn()
     },
     clipboard: {
@@ -600,8 +600,8 @@ describe('WorkspaceLayout - Empty States', () => {
 
   describe('Close flow persistence coordination', () => {
     it('waits for pending app-settings persistence before responding to close with no dirty files', async () => {
-      let closeRequestedCallback: (() => void) | undefined
-      mockApi.window.onCloseRequested.mockImplementation((callback: () => void) => {
+      let closeRequestedCallback: (() => Promise<boolean>) | undefined
+      mockApi.window.onCloseRequested.mockImplementation((callback: () => Promise<boolean>) => {
         closeRequestedCallback = callback
         return vi.fn()
       })
@@ -622,7 +622,7 @@ describe('WorkspaceLayout - Empty States', () => {
       expect(closeRequestedCallback).toBeDefined()
       if (!closeRequestedCallback) throw new Error('close callback missing')
 
-      closeRequestedCallback()
+      await expect(closeRequestedCallback()).resolves.toBe(false)
 
       expect(mockApi.window.respondToClose).not.toHaveBeenCalled()
       await deferred
@@ -632,8 +632,8 @@ describe('WorkspaceLayout - Empty States', () => {
     })
 
     it('waits for pending app-settings persistence before confirm-dialog discard close', async () => {
-      let closeRequestedCallback: (() => void) | undefined
-      mockApi.window.onCloseRequested.mockImplementation((callback: () => void) => {
+      let closeRequestedCallback: (() => Promise<boolean>) | undefined
+      mockApi.window.onCloseRequested.mockImplementation((callback: () => Promise<boolean>) => {
         closeRequestedCallback = callback
         return vi.fn()
       })
@@ -669,7 +669,7 @@ describe('WorkspaceLayout - Empty States', () => {
       expect(closeRequestedCallback).toBeDefined()
       if (!closeRequestedCallback) throw new Error('close callback missing')
 
-      closeRequestedCallback()
+      await expect(closeRequestedCallback()).resolves.toBe(false)
 
       const dontSaveButton = await screen.findByRole('button', { name: "Don't Save" })
 

--- a/src/renderer/layouts/WorkspaceLayout.tsx
+++ b/src/renderer/layouts/WorkspaceLayout.tsx
@@ -250,6 +250,8 @@ export default function WorkspaceLayout(): React.JSX.Element {
           windowApi.respondToClose('close')
         })
       }
+
+      return Promise.resolve(false)
     })
   }, [])
 

--- a/src/renderer/layouts/WorkspaceLayout.tsx
+++ b/src/renderer/layouts/WorkspaceLayout.tsx
@@ -50,7 +50,6 @@ import {
   useAddCommand,
   useCommandHistory
 } from '@/hooks/use-command-history'
-import type { KeyboardShortcutCallback } from '@shared/types/ipc.types'
 import { filesystemApi, windowApi, keyboardApi, terminalApi } from '@/lib/api'
 import { useKeyboardShortcutsStore, matchesShortcut } from '@/stores/keyboard-shortcuts-store'
 import {
@@ -58,7 +57,11 @@ import {
   useDefaultShell,
   useMaxTerminalsPerProject
 } from '@/stores/app-settings-store'
-import { useUpdateAppSetting } from '@/hooks/use-app-settings'
+import {
+  useUpdateAppSetting,
+  useUpdatePanelVisibility,
+  waitForPendingAppSettingsPersistence
+} from '@/hooks/use-app-settings'
 import { useFileWatcher } from '@/hooks/use-file-watcher'
 import { useEditorPersistence } from '@/hooks/use-editor-persistence'
 import { DEFAULT_APP_SETTINGS } from '@/types/settings'
@@ -243,7 +246,9 @@ export default function WorkspaceLayout(): React.JSX.Element {
         setAppCloseDirtyCount(dirtyCount)
         setIsAppCloseDialogOpen(true)
       } else {
-        windowApi.respondToClose('close')
+        void waitForPendingAppSettingsPersistence().then(() => {
+          windowApi.respondToClose('close')
+        })
       }
     })
   }, [])
@@ -276,6 +281,7 @@ export default function WorkspaceLayout(): React.JSX.Element {
   const appDefaultShell = useDefaultShell()
   const maxTerminals = useMaxTerminalsPerProject()
   const updateAppSetting = useUpdateAppSetting()
+  const updatePanelVisibility = useUpdatePanelVisibility()
 
   // Helper to get active key for a shortcut
   const getActiveKey = useCallback(
@@ -339,7 +345,7 @@ export default function WorkspaceLayout(): React.JSX.Element {
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
       // Skip if typing in an input/textarea/editable element
-      const target = e.target as HTMLElement
+      const target = e.target instanceof HTMLElement ? e.target : document.body
       const isInEditor = target.closest('.cm-content') || target.closest('.bn-editor')
       const isInInput =
         target.tagName === 'INPUT' ||
@@ -377,7 +383,26 @@ export default function WorkspaceLayout(): React.JSX.Element {
       if (e.ctrlKey && e.key === 'b' && !e.shiftKey && !e.altKey) {
         if (!isInEditor && !isInInput) {
           e.preventDefault()
-          useFileExplorerStore.getState().toggleVisibility()
+          void updatePanelVisibility('fileExplorerVisible', !isExplorerVisible).catch((error) => {
+            toast.error(
+              error instanceof Error
+                ? error.message
+                : 'Failed to update file explorer visibility'
+            )
+          })
+        }
+        return
+      }
+
+      if (matchesShortcut(e, getActiveKey('sidebarToggle'))) {
+        if (!isInEditor && !isInInput) {
+          e.preventDefault()
+          e.stopPropagation()
+          void updatePanelVisibility('sidebarVisible', !isSidebarVisible).catch((error) => {
+            toast.error(
+              error instanceof Error ? error.message : 'Failed to update sidebar visibility'
+            )
+          })
         }
         return
       }
@@ -522,7 +547,10 @@ export default function WorkspaceLayout(): React.JSX.Element {
     isWorkspaceRoute,
     cycleTab,
     activeTab,
-    handleCreateTerminalInPane
+    handleCreateTerminalInPane,
+    updatePanelVisibility,
+    isExplorerVisible,
+    isSidebarVisible
   ])
 
   // Listen for optional backend shortcut callbacks. In current Tauri fallback mode this is effectively a future-compat shim.
@@ -554,9 +582,14 @@ export default function WorkspaceLayout(): React.JSX.Element {
             updateAppSetting('terminalFontSize', DEFAULT_APP_SETTINGS.terminalFontSize)
           }
           break
+        case 'sidebarToggle':
+          void updatePanelVisibility('sidebarVisible', !isSidebarVisible).catch((error) => {
+            toast.error(error instanceof Error ? error.message : 'Failed to update sidebar visibility')
+          })
+          break
       }
     })
-  }, [cycleTab, fontSize, updateAppSetting])
+  }, [cycleTab, fontSize, updateAppSetting, updatePanelVisibility, isSidebarVisible])
 
   const handleCloseTerminal = useCallback((id: string, tabId: string) => {
     setCloseConfirmTerminal({ terminalId: id, tabId })
@@ -665,11 +698,13 @@ export default function WorkspaceLayout(): React.JSX.Element {
       toast.error('Some files failed to save. Please try again or discard changes.')
       return
     }
+    await waitForPendingAppSettingsPersistence()
     windowApi.respondToClose('close')
     setIsAppCloseDialogOpen(false)
   }, [])
 
-  const handleDiscardAllAndClose = useCallback(() => {
+  const handleDiscardAllAndClose = useCallback(async () => {
+    await waitForPendingAppSettingsPersistence()
     windowApi.respondToClose('close')
     setIsAppCloseDialogOpen(false)
   }, [])

--- a/src/renderer/lib/tauri-keyboard-api.ts
+++ b/src/renderer/lib/tauri-keyboard-api.ts
@@ -50,7 +50,7 @@ const IPC_EVENTS = {
  */
 export function createTauriKeyboardApi(): KeyboardApi {
   return {
-    onShortcut(callback: (shortcut: 'nextTerminal' | 'prevTerminal' | 'zoomIn' | 'zoomOut' | 'zoomReset') => void): () => void {
+    onShortcut(callback: (shortcut: 'nextTerminal' | 'prevTerminal' | 'zoomIn' | 'zoomOut' | 'zoomReset' | 'sidebarToggle') => void): () => void {
       if (!isTauriContext()) {
         return () => {}
       }
@@ -61,7 +61,15 @@ export function createTauriKeyboardApi(): KeyboardApi {
 
       try {
         unlisten = listen<string>(IPC_EVENTS.SHORTCUT, ({ payload }) => {
-          callback(payload as 'nextTerminal' | 'prevTerminal' | 'zoomIn' | 'zoomOut' | 'zoomReset')
+          callback(
+            payload as
+              | 'nextTerminal'
+              | 'prevTerminal'
+              | 'zoomIn'
+              | 'zoomOut'
+              | 'zoomReset'
+              | 'sidebarToggle'
+          )
         })
       } catch (error) {
         console.error('[TauriKeyboardAPI] Failed to register shortcut listener:', error)

--- a/src/renderer/lib/tauri-keyboard-api.ts
+++ b/src/renderer/lib/tauri-keyboard-api.ts
@@ -1,5 +1,5 @@
 import { listen, type UnlistenFn } from '@tauri-apps/api/event'
-import type { KeyboardApi } from '@shared/types/ipc.types'
+import type { KeyboardApi, KeyboardShortcutCallback } from '@shared/types/ipc.types'
 import { cleanupTauriListener, isTauriContext } from './tauri-runtime'
 
 /**
@@ -50,7 +50,7 @@ const IPC_EVENTS = {
  */
 export function createTauriKeyboardApi(): KeyboardApi {
   return {
-    onShortcut(callback: (shortcut: 'nextTerminal' | 'prevTerminal' | 'zoomIn' | 'zoomOut' | 'zoomReset' | 'sidebarToggle') => void): () => void {
+    onShortcut(callback: KeyboardShortcutCallback): () => void {
       if (!isTauriContext()) {
         return () => {}
       }
@@ -61,15 +61,7 @@ export function createTauriKeyboardApi(): KeyboardApi {
 
       try {
         unlisten = listen<string>(IPC_EVENTS.SHORTCUT, ({ payload }) => {
-          callback(
-            payload as
-              | 'nextTerminal'
-              | 'prevTerminal'
-              | 'zoomIn'
-              | 'zoomOut'
-              | 'zoomReset'
-              | 'sidebarToggle'
-          )
+          callback(payload as Parameters<KeyboardShortcutCallback>[0])
         })
       } catch (error) {
         console.error('[TauriKeyboardAPI] Failed to register shortcut listener:', error)

--- a/src/renderer/lib/tauri-window-api.ts
+++ b/src/renderer/lib/tauri-window-api.ts
@@ -1,5 +1,5 @@
 import { getCurrentWindow, LogicalPosition, LogicalSize } from '@tauri-apps/api/window'
-import type { IpcResult, WindowApi } from '@shared/types/ipc.types'
+import type { AppCloseRequestedCallback, IpcResult, WindowApi } from '@shared/types/ipc.types'
 
 /**
  * Wrap window operations in IpcResult<T> pattern with try/catch
@@ -86,12 +86,14 @@ export function createTauriWindowApi(): WindowApi {
       }
     },
 
-    onCloseRequested(callback: () => void): () => void {
+    onCloseRequested(callback: AppCloseRequestedCallback): () => void {
       if (!isTauriContext()) return () => { /* noop in browser */ }
       const window = getCurrentWindow()
-      const unlisten = window.onCloseRequested((event) => {
-        event.preventDefault()
-        callback()
+      const unlisten = window.onCloseRequested(async (event) => {
+        const shouldClose = await callback()
+        if (!shouldClose) {
+          event.preventDefault()
+        }
       })
       // Return sync cleanup function - unwrap the Promise
       return () => {

--- a/src/renderer/stores/app-settings-store.test.ts
+++ b/src/renderer/stores/app-settings-store.test.ts
@@ -83,7 +83,9 @@ describe('app-settings-store', () => {
         defaultProjectColor: 'blue',
         maxTerminalsPerProject: 10,
         orphanDetectionEnabled: true,
-        orphanDetectionTimeout: 600000
+        orphanDetectionTimeout: 600000,
+        sidebarVisible: false,
+        fileExplorerVisible: true
       }
 
       const { setSettings } = useAppSettingsStore.getState()
@@ -107,7 +109,9 @@ describe('app-settings-store', () => {
           defaultProjectColor: 'red',
           maxTerminalsPerProject: 5,
           orphanDetectionEnabled: false,
-          orphanDetectionTimeout: 300000
+          orphanDetectionTimeout: 300000,
+          sidebarVisible: false,
+          fileExplorerVisible: false
         },
         isLoaded: true
       })
@@ -117,6 +121,28 @@ describe('app-settings-store', () => {
 
       const { settings } = useAppSettingsStore.getState()
       expect(settings).toEqual(DEFAULT_APP_SETTINGS)
+    })
+  })
+
+  describe('panel visibility settings', () => {
+    it('should default sidebar and file explorer visibility to true', () => {
+      const { settings } = useAppSettingsStore.getState()
+      expect(settings.sidebarVisible).toBe(true)
+      expect(settings.fileExplorerVisible).toBe(true)
+    })
+
+    it('should update sidebar visibility setting', () => {
+      const { updateSetting } = useAppSettingsStore.getState()
+      updateSetting('sidebarVisible', false)
+      const { settings } = useAppSettingsStore.getState()
+      expect(settings.sidebarVisible).toBe(false)
+    })
+
+    it('should update file explorer visibility setting', () => {
+      const { updateSetting } = useAppSettingsStore.getState()
+      updateSetting('fileExplorerVisible', false)
+      const { settings } = useAppSettingsStore.getState()
+      expect(settings.fileExplorerVisible).toBe(false)
     })
   })
 

--- a/src/renderer/stores/app-settings-store.ts
+++ b/src/renderer/stores/app-settings-store.ts
@@ -43,3 +43,7 @@ export const useOrphanDetectionEnabled = () =>
   useAppSettingsStore((state) => state.settings.orphanDetectionEnabled)
 export const useOrphanDetectionTimeout = () =>
   useAppSettingsStore((state) => state.settings.orphanDetectionTimeout)
+export const useSidebarVisibilitySetting = () =>
+  useAppSettingsStore((state) => state.settings.sidebarVisible)
+export const useFileExplorerVisibilitySetting = () =>
+  useAppSettingsStore((state) => state.settings.fileExplorerVisible)

--- a/src/renderer/stores/keyboard-shortcuts-store.test.ts
+++ b/src/renderer/stores/keyboard-shortcuts-store.test.ts
@@ -21,6 +21,12 @@ describe('keyboard-shortcuts-store', () => {
       expect(Object.keys(shortcuts).length).toBe(Object.keys(DEFAULT_KEYBOARD_SHORTCUTS).length)
     })
 
+    it('should include sidebar toggle shortcut defaults', () => {
+      const { shortcuts } = useKeyboardShortcutsStore.getState()
+      expect(shortcuts.sidebarToggle.defaultKey).toBe('ctrl+shift+b')
+      expect(shortcuts.sidebarToggle.customKey).toBeUndefined()
+    })
+
     it('should have commandPalette shortcut with default key', () => {
       const { shortcuts } = useKeyboardShortcutsStore.getState()
       expect(shortcuts.commandPalette.defaultKey).toBe('ctrl+k')

--- a/src/renderer/stores/sidebar-store.test.ts
+++ b/src/renderer/stores/sidebar-store.test.ts
@@ -1,0 +1,30 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import { useSidebarStore } from './sidebar-store'
+
+describe('sidebar-store', () => {
+  beforeEach(() => {
+    useSidebarStore.setState({
+      isVisible: true
+    })
+  })
+
+  it('starts visible by default', () => {
+    expect(useSidebarStore.getState().isVisible).toBe(true)
+  })
+
+  it('toggles visibility', () => {
+    useSidebarStore.getState().toggleVisibility()
+    expect(useSidebarStore.getState().isVisible).toBe(false)
+
+    useSidebarStore.getState().toggleVisibility()
+    expect(useSidebarStore.getState().isVisible).toBe(true)
+  })
+
+  it('sets visibility directly', () => {
+    useSidebarStore.getState().setVisible(false)
+    expect(useSidebarStore.getState().isVisible).toBe(false)
+
+    useSidebarStore.getState().setVisible(true)
+    expect(useSidebarStore.getState().isVisible).toBe(true)
+  })
+})

--- a/src/renderer/types/settings.ts
+++ b/src/renderer/types/settings.ts
@@ -27,6 +27,8 @@ export interface AppSettings {
   maxTerminalsPerProject: number // Maximum terminals allowed per project
   orphanDetectionEnabled: boolean // Enable automatic cleanup of inactive terminals
   orphanDetectionTimeout: number | null // Timeout in ms, null = disabled
+  sidebarVisible: boolean
+  fileExplorerVisible: boolean
 }
 
 // Terminal buffer size options
@@ -76,7 +78,9 @@ export const DEFAULT_APP_SETTINGS: AppSettings = {
   defaultProjectColor: 'blue',
   maxTerminalsPerProject: 10,
   orphanDetectionEnabled: true,
-  orphanDetectionTimeout: 600000 // 10 minutes
+  orphanDetectionTimeout: 600000, // 10 minutes
+  sidebarVisible: true,
+  fileExplorerVisible: true
 }
 
 // Persistence key for app settings
@@ -161,6 +165,12 @@ export const DEFAULT_KEYBOARD_SHORTCUTS: KeyboardShortcutsConfig = {
     label: 'Reset Zoom',
     description: 'Reset terminal font size to default',
     defaultKey: 'ctrl+0'
+  },
+  sidebarToggle: {
+    id: 'sidebarToggle',
+    label: 'Toggle Sidebar',
+    description: 'Show or hide the project sidebar',
+    defaultKey: 'ctrl+shift+b'
   }
 }
 

--- a/src/shared/types/ipc.types.ts
+++ b/src/shared/types/ipc.types.ts
@@ -149,7 +149,7 @@ export type WindowMaximizeChangedCallback = (isMaximized: boolean) => void
 
 // App close coordination types
 export type AppCloseResponse = 'close' | 'cancel'
-export type AppCloseRequestedCallback = () => void
+export type AppCloseRequestedCallback = () => Promise<boolean>
 
 // Window API for renderer
 export interface WindowApi {

--- a/src/shared/types/ipc.types.ts
+++ b/src/shared/types/ipc.types.ts
@@ -135,7 +135,9 @@ export interface SystemApi {
 }
 
 // Keyboard shortcut callback for main -> renderer communication
-export type KeyboardShortcutCallback = (shortcut: 'nextTerminal' | 'prevTerminal' | 'zoomIn' | 'zoomOut' | 'zoomReset') => void
+export type KeyboardShortcutCallback = (
+  shortcut: 'nextTerminal' | 'prevTerminal' | 'zoomIn' | 'zoomOut' | 'zoomReset' | 'sidebarToggle'
+) => void
 
 // Keyboard API for renderer
 export interface KeyboardApi {


### PR DESCRIPTION
## Summary
- persist sidebar and file explorer visibility in global app settings so panel state survives restarts and project switches
- preserve `Ctrl+B` for the file explorer and add a dedicated configurable sidebar shortcut
- harden panel persistence with serialized immediate writes, rollback on failure, and close-flow synchronization
- remove project-scoped explorer visibility persistence and add regression coverage for click, keyboard, failure, and legacy restore paths

## Test plan
- [x] `src/renderer/hooks/use-app-settings.test.ts`
- [x] `src/renderer/components/TitleBar.test.tsx`
- [x] `src/renderer/hooks/use-editor-persistence.test.ts`
- [x] `src/renderer/layouts/WorkspaceLayout.test.tsx`
- [x] `src/renderer/stores/keyboard-shortcuts-store.test.ts`
- [x] `src/renderer/stores/sidebar-store.test.ts`
- [x] `src/renderer/stores/app-settings-store.test.ts`
- [x] `src/renderer/stores/file-explorer-store.test.ts`
- [x] `bun run typecheck`
- [x] `bunx lint-staged`

Closes #40.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Panel visibility (sidebar and file explorer) persisted across sessions.
  * Added keyboard shortcut Ctrl+Shift+B to toggle the sidebar.

* **Improvements**
  * Close flow now waits for pending settings to finish before exiting.
  * Visibility changes use unified update calls with toast error notifications on failure.

* **Tests**
  * Extensive new and updated tests covering panel persistence, shortcuts, and close-flow behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->