### PR TITLE
fix: terminal scrollback truncation on project switch

### DIFF
--- a/src/renderer/hooks/useTerminalAutoSave.test.ts
+++ b/src/renderer/hooks/useTerminalAutoSave.test.ts
@@ -2,10 +2,14 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 import {
   serializeTerminalsForProject,
   setTerminalRestoreInProgress,
-  isTerminalRestoreInProgress
+  isTerminalRestoreInProgress,
+  syncScrollbackToStore,
+  saveTerminalLayout
 } from './useTerminalAutoSave'
 import { extractScrollback } from '../utils/terminal-registry'
+import { useTerminalStore } from '../stores/terminal-store'
 import type { Terminal } from '@/types/project'
+import type { PersistedTerminal } from '../../shared/types/persistence.types'
 
 // Mock terminal-registry
 vi.mock('../utils/terminal-registry', () => ({
@@ -146,6 +150,101 @@ describe('useTerminalAutoSave', () => {
       serializeTerminalsForProject(terminals, 'proj-1', '1')
 
       expect(extractScrollback).toHaveBeenCalledWith('pty-1')
+    })
+  })
+
+  describe('syncScrollbackToStore', () => {
+    beforeEach(() => {
+      useTerminalStore.setState({
+        terminals: [],
+        activeTerminalId: '',
+        ptyIdIndex: new Map()
+      })
+    })
+
+    it('should update pendingScrollback in store for each terminal', () => {
+      const store = useTerminalStore.getState()
+      const terminal = store.addTerminal('Terminal 1', 'proj-1', 'bash')
+
+      const persistedTerminals: PersistedTerminal[] = [
+        {
+          id: terminal.id,
+          name: 'Terminal 1',
+          shell: 'bash',
+          scrollback: ['new scrollback line 1', 'new scrollback line 2']
+        }
+      ]
+
+      syncScrollbackToStore(persistedTerminals)
+
+      const updatedTerminal = useTerminalStore
+        .getState()
+        .terminals.find((t) => t.id === terminal.id)
+      expect(updatedTerminal?.pendingScrollback).toEqual([
+        'new scrollback line 1',
+        'new scrollback line 2'
+      ])
+    })
+
+    it('should skip terminals with undefined scrollback', () => {
+      const store = useTerminalStore.getState()
+      const terminal = store.addTerminal('Terminal 1', 'proj-1', 'bash', undefined, [
+        'existing scrollback'
+      ])
+
+      const persistedTerminals: PersistedTerminal[] = [
+        {
+          id: terminal.id,
+          name: 'Terminal 1',
+          shell: 'bash',
+          scrollback: undefined
+        }
+      ]
+
+      syncScrollbackToStore(persistedTerminals)
+
+      // Should not update - existing scrollback preserved
+      const updatedTerminal = useTerminalStore
+        .getState()
+        .terminals.find((t) => t.id === terminal.id)
+      expect(updatedTerminal?.pendingScrollback).toEqual(['existing scrollback'])
+    })
+
+    it('should handle non-existent terminal ids gracefully', () => {
+      const persistedTerminals: PersistedTerminal[] = [
+        {
+          id: 'non-existent-id',
+          name: 'Ghost Terminal',
+          shell: 'bash',
+          scrollback: ['some lines']
+        }
+      ]
+
+      // Should not throw
+      expect(() => syncScrollbackToStore(persistedTerminals)).not.toThrow()
+    })
+  })
+
+  describe('saveTerminalLayout', () => {
+    beforeEach(() => {
+      useTerminalStore.setState({
+        terminals: [],
+        activeTerminalId: '',
+        ptyIdIndex: new Map()
+      })
+    })
+
+    it('should sync scrollback to store before writing to disk', async () => {
+      const store = useTerminalStore.getState()
+      const terminal = store.addTerminal('Terminal 1', 'proj-1', 'bash')
+      store.setTerminalPtyId(terminal.id, 'pty-1')
+
+      await saveTerminalLayout('proj-1')
+
+      const updatedTerminal = useTerminalStore
+        .getState()
+        .terminals.find((t) => t.id === terminal.id)
+      expect(updatedTerminal?.pendingScrollback).toEqual(['line 1', 'line 2'])
     })
   })
 })

--- a/src/renderer/hooks/useTerminalAutoSave.ts
+++ b/src/renderer/hooks/useTerminalAutoSave.ts
@@ -140,7 +140,9 @@ export function useTerminalAutoSave(): void {
         state.activeTerminalId
       )
 
-      // Sync scrollback to store before debounced write
+      // Sync layout.terminals scrollback to the in-memory store's pendingScrollback.
+      // This ensures extractScrollback() values survive xterm disposal during project switches,
+      // preserving scrollback in memory so it can be restored when switching back.
       syncScrollbackToStore(layout.terminals)
 
       // Use debounced write via API
@@ -189,7 +191,9 @@ export async function saveTerminalLayout(projectId: string): Promise<void> {
   const state = useTerminalStore.getState()
   const layout = serializeTerminalsForProject(state.terminals, projectId, state.activeTerminalId)
 
-  // Sync scrollback to store before writing to disk
+  // Sync layout.terminals scrollback to the in-memory store's pendingScrollback.
+  // This preserves scrollback across project switches by updating the store before
+  // the xterm instance is disposed, avoiding state loss when switching projects.
   syncScrollbackToStore(layout.terminals)
 
   const result = await persistenceApi.write(PersistenceKeys.terminals(projectId), layout)

--- a/src/renderer/hooks/useTerminalAutoSave.ts
+++ b/src/renderer/hooks/useTerminalAutoSave.ts
@@ -36,6 +36,20 @@ export function isTerminalRestoreInProgress(): boolean {
 }
 
 /**
+ * Sync extracted scrollback to the terminal store
+ * Updates each terminal's pendingScrollback field in memory
+ * Skips terminals where scrollback extraction returns undefined
+ */
+export function syncScrollbackToStore(terminals: PersistedTerminal[]): void {
+  const store = useTerminalStore.getState()
+  for (const t of terminals) {
+    // Skip if scrollback is undefined (terminal not in registry)
+    if (t.scrollback === undefined) continue
+    store.updateTerminalScrollback(t.id, t.scrollback)
+  }
+}
+
+/**
  * Serialize terminal store state for persistence
  * Includes scrollback extraction from terminal registry
  */
@@ -126,6 +140,9 @@ export function useTerminalAutoSave(): void {
         state.activeTerminalId
       )
 
+      // Sync scrollback to store before debounced write
+      syncScrollbackToStore(layout.terminals)
+
       // Use debounced write via API
       persistenceApi
         .writeDebounced(PersistenceKeys.terminals(projectId), layout)
@@ -171,6 +188,9 @@ export async function loadPersistedTerminals(
 export async function saveTerminalLayout(projectId: string): Promise<void> {
   const state = useTerminalStore.getState()
   const layout = serializeTerminalsForProject(state.terminals, projectId, state.activeTerminalId)
+
+  // Sync scrollback to store before writing to disk
+  syncScrollbackToStore(layout.terminals)
 
   const result = await persistenceApi.write(PersistenceKeys.terminals(projectId), layout)
 

--- a/src/renderer/stores/terminal-store.test.ts
+++ b/src/renderer/stores/terminal-store.test.ts
@@ -370,6 +370,53 @@ describe('terminal-store', () => {
     })
   })
 
+  describe('updateTerminalScrollback', () => {
+    it('should update pendingScrollback field when called with scrollback array', () => {
+      const { updateTerminalScrollback } = useTerminalStore.getState()
+
+      updateTerminalScrollback('t1', ['line 1', 'line 2', 'line 3'])
+
+      const { terminals } = useTerminalStore.getState()
+      const terminal = terminals.find((t) => t.id === 't1')
+      expect(terminal?.pendingScrollback).toEqual(['line 1', 'line 2', 'line 3'])
+    })
+
+    it('should set pendingScrollback to undefined when called with undefined', () => {
+      const { updateTerminalScrollback } = useTerminalStore.getState()
+
+      // First set a value
+      updateTerminalScrollback('t1', ['existing line 1', 'existing line 2'])
+      expect(useTerminalStore.getState().terminals.find((t) => t.id === 't1')?.pendingScrollback).toHaveLength(2)
+
+      // Then clear it
+      updateTerminalScrollback('t1', undefined)
+      expect(useTerminalStore.getState().terminals.find((t) => t.id === 't1')?.pendingScrollback).toBeUndefined()
+    })
+
+    it('should not affect other terminals', () => {
+      const { updateTerminalScrollback } = useTerminalStore.getState()
+
+      updateTerminalScrollback('t1', ['terminal 1 lines'])
+
+      const { terminals } = useTerminalStore.getState()
+      const terminal1 = terminals.find((t) => t.id === 't1')
+      const terminal2 = terminals.find((t) => t.id === 't2')
+
+      expect(terminal1?.pendingScrollback).toEqual(['terminal 1 lines'])
+      expect(terminal2?.pendingScrollback).toBeUndefined()
+    })
+
+    it('should handle non-existent terminal id gracefully', () => {
+      const { updateTerminalScrollback } = useTerminalStore.getState()
+
+      // Should not throw
+      expect(() => updateTerminalScrollback('non-existent-id', ['lines'])).not.toThrow()
+
+      const { terminals } = useTerminalStore.getState()
+      expect(terminals).toHaveLength(3)
+    })
+  })
+
   describe('updateTerminalActivity', () => {
     it('should set hasActivity to true', () => {
       const { updateTerminalActivity } = useTerminalStore.getState()

--- a/src/renderer/stores/terminal-store.ts
+++ b/src/renderer/stores/terminal-store.ts
@@ -33,6 +33,7 @@ export interface TerminalState {
   updateTerminalGitBranch: (id: string, gitBranch: string | null) => void
   updateTerminalGitStatus: (id: string, gitStatus: GitStatus | null) => void
   updateTerminalExitCode: (id: string, exitCode: number | null) => void
+  updateTerminalScrollback: (id: string, scrollback: string[] | undefined) => void
   setTerminalHealthStatus: (id: string, status: TerminalHealthStatus) => void
   setTerminalHidden: (id: string, isHidden: boolean) => void
   /** @deprecated Use updateTerminalActivityBatch instead */
@@ -205,6 +206,12 @@ export const useTerminalStore = create<TerminalState>((set, get) => ({
     }))
   },
 
+  updateTerminalScrollback: (id: string, scrollback: string[] | undefined): void => {
+    set((state) => ({
+      terminals: state.terminals.map((t) => (t.id === id ? { ...t, pendingScrollback: scrollback } : t))
+    }))
+  },
+
   setTerminalHealthStatus: (id: string, status: TerminalHealthStatus): void => {
     set((state) => ({
       terminals: state.terminals.map((t) => (t.id === id ? { ...t, healthStatus: status } : t))
@@ -327,6 +334,7 @@ export function useTerminalActions(): Pick<
   | 'renameTerminal'
   | 'reorderTerminals'
   | 'updateTerminalCwd'
+  | 'updateTerminalScrollback'
   | 'setTerminalPtyId'
   | 'clearTerminalPtyId'
 > {
@@ -338,6 +346,7 @@ export function useTerminalActions(): Pick<
       renameTerminal: state.renameTerminal,
       reorderTerminals: state.reorderTerminals,
       updateTerminalCwd: state.updateTerminalCwd,
+      updateTerminalScrollback: state.updateTerminalScrollback,
       setTerminalPtyId: state.setTerminalPtyId,
       clearTerminalPtyId: state.clearTerminalPtyId
     }))


### PR DESCRIPTION
## Summary

- Adds `updateTerminalScrollback` action to terminal store to update `pendingScrollback` field
- Creates `syncScrollbackToStore` helper to sync extracted scrollback to memory before persistence
- Updates both `saveTerminalLayout()` and the auto-save hook to sync scrollback to store

## Problem

When switching between projects, terminal scrollback history was getting truncated. The root cause was that scrollback was being extracted and saved to disk, but never synced to the terminal store's `pendingScrollback` field. When the xterm instance was disposed, the scrollback was lost from memory.

## Solution

This PR ensures scrollback is synced to the store's `pendingScrollback` field during both explicit saves and auto-saves. This preserves the scrollback in memory when switching projects, allowing it to be restored correctly when switching back.

## Test plan

- [x] Added unit tests for `updateTerminalScrollback` action
- [x] Added integration tests for `syncScrollbackToStore` helper
- [x] Added tests for `saveTerminalLayout` scrollback sync
- [x] All 805 tests pass

## Manual verification

1. Run `ls` command 5+ times in Project A terminal
2. Switch to Project B, then back to Project A
3. Scroll up and verify all `ls` output is visible and scrollable

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive tests covering terminal scrollback synchronization, clearing, and persistence behavior.

* **Refactor**
  * Improved terminal state synchronization so scrollback is reliably captured before layouts are saved.

* **Bug Fixes**
  * Prevented lost or inconsistent scrollback during save operations and ensured graceful handling of missing terminals.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->