### PR TITLE
feat: add project-specific command history filtering and clear functionality

### DIFF
--- a/src/renderer/components/CommandHistoryModal.test.tsx
+++ b/src/renderer/components/CommandHistoryModal.test.tsx
@@ -31,11 +31,25 @@ describe('CommandHistoryModal', () => {
     }
   ]
 
+  const mockAllEntries: CommandHistoryEntry[] = [
+    ...mockEntries,
+    {
+      id: '4',
+      command: 'cargo build',
+      terminalName: 'rust',
+      terminalId: 'term-2',
+      projectId: 'proj-2',
+      timestamp: Date.now() - 30000
+    }
+  ]
+
   const defaultProps = {
     isOpen: true,
     entries: mockEntries,
+    allEntries: mockAllEntries,
     onClose: vi.fn(),
-    onSelectCommand: vi.fn()
+    onSelectCommand: vi.fn(),
+    onClearHistory: vi.fn().mockResolvedValue(undefined)
   }
 
   it('should render title when open', () => {
@@ -83,7 +97,7 @@ describe('CommandHistoryModal', () => {
   })
 
   it('should show empty state when no entries', () => {
-    render(<CommandHistoryModal {...defaultProps} entries={[]} />)
+    render(<CommandHistoryModal {...defaultProps} entries={[]} allEntries={[]} />)
 
     expect(screen.getByText('No command history yet')).toBeInTheDocument()
   })
@@ -110,7 +124,13 @@ describe('CommandHistoryModal', () => {
   it('should call onSelectCommand and onClose when clicking an entry', async () => {
     const onSelectCommand = vi.fn()
     const onClose = vi.fn()
-    render(<CommandHistoryModal {...defaultProps} onSelectCommand={onSelectCommand} onClose={onClose} />)
+    render(
+      <CommandHistoryModal
+        {...defaultProps}
+        onSelectCommand={onSelectCommand}
+        onClose={onClose}
+      />
+    )
 
     await waitFor(() => {
       const entry = screen.getByText('npm install')
@@ -124,7 +144,13 @@ describe('CommandHistoryModal', () => {
   it('should select command and close on Enter key', () => {
     const onSelectCommand = vi.fn()
     const onClose = vi.fn()
-    render(<CommandHistoryModal {...defaultProps} onSelectCommand={onSelectCommand} onClose={onClose} />)
+    render(
+      <CommandHistoryModal
+        {...defaultProps}
+        onSelectCommand={onSelectCommand}
+        onClose={onClose}
+      />
+    )
 
     const input = screen.getByPlaceholderText('Search commands...')
     fireEvent.keyDown(input, { key: 'Enter' })
@@ -176,5 +202,188 @@ describe('CommandHistoryModal', () => {
     expect(screen.getByText(/to navigate/)).toBeInTheDocument()
     expect(screen.getByText(/to insert/)).toBeInTheDocument()
     expect(screen.getByText(/to close/)).toBeInTheDocument()
+  })
+
+  // Project filter tests
+  describe('Project Filter', () => {
+    it('should render filter dropdown showing "This Project" by default', () => {
+      render(<CommandHistoryModal {...defaultProps} />)
+
+      expect(screen.getByText('This Project')).toBeInTheDocument()
+    })
+
+    it('should show only current project entries by default', async () => {
+      render(<CommandHistoryModal {...defaultProps} />)
+
+      await waitFor(() => {
+        expect(screen.getByText('npm install')).toBeInTheDocument()
+        expect(screen.getByText('git status')).toBeInTheDocument()
+        expect(screen.queryByText('cargo build')).not.toBeInTheDocument()
+      })
+    })
+
+    it('should show entries from all projects when filter is changed to "All Projects"', async () => {
+      render(<CommandHistoryModal {...defaultProps} />)
+
+      // Click on the filter dropdown
+      const trigger = screen.getByRole('combobox')
+      fireEvent.click(trigger)
+
+      // Select "All Projects"
+      const allProjectsOption = screen.getByRole('option', { name: 'All Projects' })
+      fireEvent.click(allProjectsOption)
+
+      await waitFor(() => {
+        expect(screen.getByText('npm install')).toBeInTheDocument()
+        expect(screen.getByText('cargo build')).toBeInTheDocument()
+      })
+    })
+
+    it('should filter back to current project when switching back to "This Project"', async () => {
+      render(<CommandHistoryModal {...defaultProps} />)
+
+      // Switch to All Projects
+      const trigger = screen.getByRole('combobox')
+      fireEvent.click(trigger)
+      const allProjectsOption = screen.getByRole('option', { name: 'All Projects' })
+      fireEvent.click(allProjectsOption)
+
+      await waitFor(() => {
+        expect(screen.getByText('cargo build')).toBeInTheDocument()
+      })
+
+      // Switch back to This Project
+      fireEvent.click(trigger)
+      const thisProjectOption = screen.getByRole('option', { name: 'This Project' })
+      fireEvent.click(thisProjectOption)
+
+      await waitFor(() => {
+        expect(screen.getByText('npm install')).toBeInTheDocument()
+        expect(screen.queryByText('cargo build')).not.toBeInTheDocument()
+      })
+    })
+
+    it('should maintain search query when changing project filter', async () => {
+      render(<CommandHistoryModal {...defaultProps} />)
+
+      // Type search query
+      const input = screen.getByPlaceholderText('Search commands...')
+      fireEvent.change(input, { target: { value: 'npm' } })
+
+      await waitFor(() => {
+        expect(screen.getByText('npm install')).toBeInTheDocument()
+        expect(screen.queryByText('git status')).not.toBeInTheDocument()
+      })
+
+      // Switch to All Projects
+      const trigger = screen.getByRole('combobox')
+      fireEvent.click(trigger)
+      const allProjectsOption = screen.getByRole('option', { name: 'All Projects' })
+      fireEvent.click(allProjectsOption)
+
+      // Search should still filter
+      await waitFor(() => {
+        expect(screen.getByText('npm install')).toBeInTheDocument()
+        expect(screen.queryByText('cargo build')).not.toBeInTheDocument()
+      })
+    })
+  })
+
+  // Clear history tests
+  describe('Clear History', () => {
+    it('should render Clear History button in footer', () => {
+      render(<CommandHistoryModal {...defaultProps} />)
+
+      expect(screen.getByText('Clear History')).toBeInTheDocument()
+    })
+
+    it('should disable Clear History button when no entries', () => {
+      render(<CommandHistoryModal {...defaultProps} entries={[]} allEntries={[]} />)
+
+      const clearButton = screen.getByText('Clear History').closest('button')
+      expect(clearButton).toBeDisabled()
+    })
+
+    it('should disable Clear History button when viewing All Projects', async () => {
+      render(<CommandHistoryModal {...defaultProps} />)
+
+      // Switch to All Projects
+      const trigger = screen.getByRole('combobox')
+      fireEvent.click(trigger)
+      const allProjectsOption = screen.getByRole('option', { name: 'All Projects' })
+      fireEvent.click(allProjectsOption)
+
+      await waitFor(() => {
+        const clearButton = screen.getByText('Clear History').closest('button')
+        expect(clearButton).toBeDisabled()
+      })
+    })
+
+    it('should show confirmation dialog when clicking Clear History', async () => {
+      render(<CommandHistoryModal {...defaultProps} />)
+
+      const clearButton = screen.getByText('Clear History')
+      fireEvent.click(clearButton)
+
+      await waitFor(() => {
+        expect(screen.getByText('Clear Command History')).toBeInTheDocument()
+        expect(
+          screen.getByText(/Are you sure you want to clear the command history/)
+        ).toBeInTheDocument()
+      })
+    })
+
+    it('should call onClearHistory when confirming clear', async () => {
+      const onClearHistory = vi.fn().mockResolvedValue(undefined)
+      render(<CommandHistoryModal {...defaultProps} onClearHistory={onClearHistory} />)
+
+      const clearButton = screen.getByText('Clear History')
+      fireEvent.click(clearButton)
+
+      await waitFor(() => {
+        expect(screen.getByText('Clear Command History')).toBeInTheDocument()
+      })
+
+      const confirmButton = screen.getByRole('button', { name: 'Clear' })
+      fireEvent.click(confirmButton)
+
+      expect(onClearHistory).toHaveBeenCalledTimes(1)
+    })
+
+    it('should not call onClearHistory when canceling clear', async () => {
+      const onClearHistory = vi.fn().mockResolvedValue(undefined)
+      render(<CommandHistoryModal {...defaultProps} onClearHistory={onClearHistory} />)
+
+      const clearButton = screen.getByText('Clear History')
+      fireEvent.click(clearButton)
+
+      await waitFor(() => {
+        expect(screen.getByText('Clear Command History')).toBeInTheDocument()
+      })
+
+      const cancelButton = screen.getByRole('button', { name: 'Cancel' })
+      fireEvent.click(cancelButton)
+
+      expect(onClearHistory).not.toHaveBeenCalled()
+    })
+
+    it('should close confirmation dialog after clearing', async () => {
+      const onClearHistory = vi.fn().mockResolvedValue(undefined)
+      render(<CommandHistoryModal {...defaultProps} onClearHistory={onClearHistory} />)
+
+      const clearButton = screen.getByText('Clear History')
+      fireEvent.click(clearButton)
+
+      await waitFor(() => {
+        expect(screen.getByText('Clear Command History')).toBeInTheDocument()
+      })
+
+      const confirmButton = screen.getByRole('button', { name: 'Clear' })
+      fireEvent.click(confirmButton)
+
+      await waitFor(() => {
+        expect(screen.queryByText('Clear Command History')).not.toBeInTheDocument()
+      })
+    })
   })
 })

--- a/src/renderer/components/CommandHistoryModal.tsx
+++ b/src/renderer/components/CommandHistoryModal.tsx
@@ -252,6 +252,7 @@ export function CommandHistoryModal({
         confirmLabel="Clear"
         cancelLabel="Cancel"
         variant="danger"
+        isLoading={isClearing}
         onConfirm={handleClearConfirm}
         onCancel={() => setShowClearConfirm(false)}
       />

--- a/src/renderer/components/CommandHistoryModal.tsx
+++ b/src/renderer/components/CommandHistoryModal.tsx
@@ -1,46 +1,66 @@
 import { useState, useEffect, useMemo, useCallback, useRef } from 'react'
 import { motion, AnimatePresence } from 'framer-motion'
-import { History, Terminal, Clock } from 'lucide-react'
+import { History, Terminal, Clock, Trash2 } from 'lucide-react'
 import { Virtuoso, VirtuosoHandle } from 'react-virtuoso'
 import { CommandHistoryEntry } from '@/stores/command-history-store'
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
+import { ConfirmDialog } from '@/components/ConfirmDialog'
+
+type FilterMode = 'this-project' | 'all-projects'
 
 interface CommandHistoryModalProps {
   isOpen: boolean
   onClose: () => void
   entries: CommandHistoryEntry[]
+  allEntries: CommandHistoryEntry[]
   onSelectCommand: (command: string) => void
+  onClearHistory: () => Promise<void>
 }
 
 export function CommandHistoryModal({
   isOpen,
   onClose,
   entries,
-  onSelectCommand
+  allEntries,
+  onSelectCommand,
+  onClearHistory
 }: CommandHistoryModalProps): React.JSX.Element {
   const [query, setQuery] = useState('')
   const [selectedIndex, setSelectedIndex] = useState(0)
+  const [filterMode, setFilterMode] = useState<FilterMode>('this-project')
+  const [showClearConfirm, setShowClearConfirm] = useState(false)
+  const [isClearing, setIsClearing] = useState(false)
   const inputRef = useRef<HTMLInputElement>(null)
   const virtuosoRef = useRef<VirtuosoHandle>(null)
 
+  // Get entries based on filter mode
+  const baseEntries = useMemo(() => {
+    return filterMode === 'this-project' ? entries : allEntries
+  }, [filterMode, entries, allEntries])
+
   // Filter entries based on query
   const filteredEntries = useMemo(() => {
-    if (!query) return entries
+    if (!query) return baseEntries
     const lowerQuery = query.toLowerCase()
-    return entries.filter((e) => e.command.toLowerCase().includes(lowerQuery))
-  }, [entries, query])
+    return baseEntries.filter((e) => e.command.toLowerCase().includes(lowerQuery))
+  }, [baseEntries, query])
 
-  // Reset selection when query changes
+  // Reset selection when query or filter changes
   useEffect(() => {
     setSelectedIndex(0)
-  }, [query])
+  }, [query, filterMode])
 
-  // Focus input when opened
+  // Reset state when modal opens or closes
   useEffect(() => {
-    if (isOpen && inputRef.current) {
+    if (isOpen) {
       setQuery('')
       setSelectedIndex(0)
+      setFilterMode('this-project')
       setTimeout(() => inputRef.current?.focus(), 50)
     }
+    // Always reset confirmation state on any isOpen change
+    setShowClearConfirm(false)
+    setIsClearing(false)
   }, [isOpen])
 
   // Scroll selected item into view using Virtuoso
@@ -71,6 +91,19 @@ export function CommandHistoryModal({
     },
     [filteredEntries, selectedIndex, onSelectCommand, onClose]
   )
+
+  const handleClearConfirm = useCallback(async () => {
+    if (isClearing) return
+    setIsClearing(true)
+    try {
+      await onClearHistory()
+      setShowClearConfirm(false)
+    } catch {
+      // Keep dialog open on failure - parent already showed toast
+    } finally {
+      setIsClearing(false)
+    }
+  }, [onClearHistory, isClearing])
 
   const formatTime = (timestamp: number): string => {
     const date = new Date(timestamp)
@@ -106,9 +139,23 @@ export function CommandHistoryModal({
             onClick={(e) => e.stopPropagation()}
           >
             {/* Header */}
-            <div className="flex items-center gap-2 px-4 py-3 border-b border-border">
-              <History size={18} className="text-muted-foreground" />
-              <span className="text-sm font-medium">Command History</span>
+            <div className="flex items-center justify-between gap-2 px-4 py-3 border-b border-border">
+              <div className="flex items-center gap-2">
+                <History size={18} className="text-muted-foreground" />
+                <span className="text-sm font-medium">Command History</span>
+              </div>
+              <Select
+                value={filterMode}
+                onValueChange={(value) => setFilterMode(value as FilterMode)}
+              >
+                <SelectTrigger className="w-[140px] h-8 text-xs">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="this-project">This Project</SelectItem>
+                  <SelectItem value="all-projects">All Projects</SelectItem>
+                </SelectContent>
+              </Select>
             </div>
 
             {/* Search Input */}
@@ -129,7 +176,7 @@ export function CommandHistoryModal({
               <div className="p-8 text-center text-muted-foreground">
                 <History size={32} className="mx-auto mb-2 opacity-50" />
                 <p className="text-sm">
-                  {entries.length === 0 ? 'No command history yet' : 'No matching commands'}
+                  {baseEntries.length === 0 ? 'No command history yet' : 'No matching commands'}
                 </p>
               </div>
             ) : (
@@ -171,20 +218,43 @@ export function CommandHistoryModal({
             )}
 
             {/* Footer */}
-            <div className="bg-background px-4 py-2 border-t border-border flex items-center justify-end space-x-4 text-[10px] text-muted-foreground font-medium uppercase tracking-wider">
-              <span className="flex items-center">
-                <kbd className="bg-secondary text-foreground px-1 rounded mr-1">↑↓</kbd> to navigate
-              </span>
-              <span className="flex items-center">
-                <kbd className="bg-secondary text-foreground px-1 rounded mr-1">↵</kbd> to insert
-              </span>
-              <span className="flex items-center">
-                <kbd className="bg-secondary text-foreground px-1 rounded mr-1">Esc</kbd> to close
-              </span>
+            <div className="bg-background px-4 py-2 border-t border-border flex items-center justify-between text-[10px] text-muted-foreground font-medium uppercase tracking-wider">
+              <div className="flex items-center space-x-4">
+                <span className="flex items-center">
+                  <kbd className="bg-secondary text-foreground px-1 rounded mr-1">↑↓</kbd> to navigate
+                </span>
+                <span className="flex items-center">
+                  <kbd className="bg-secondary text-foreground px-1 rounded mr-1">↵</kbd> to insert
+                </span>
+                <span className="flex items-center">
+                  <kbd className="bg-secondary text-foreground px-1 rounded mr-1">Esc</kbd> to close
+                </span>
+              </div>
+              <button
+                onClick={() => setShowClearConfirm(true)}
+                className="flex items-center gap-1 px-2 py-1 rounded hover:bg-secondary/50 text-red-400 hover:text-red-300 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                disabled={entries.length === 0 || filterMode !== 'this-project' || isClearing}
+                title={filterMode === 'all-projects' ? 'Switch to "This Project" to clear history' : undefined}
+              >
+                <Trash2 size={12} />
+                <span>{isClearing ? 'Clearing...' : 'Clear History'}</span>
+              </button>
             </div>
           </motion.div>
         </motion.div>
       )}
+
+      {/* Clear History Confirmation Dialog */}
+      <ConfirmDialog
+        isOpen={showClearConfirm}
+        title="Clear Command History"
+        message="Are you sure you want to clear the command history for this project? This action cannot be undone."
+        confirmLabel="Clear"
+        cancelLabel="Cancel"
+        variant="danger"
+        onConfirm={handleClearConfirm}
+        onCancel={() => setShowClearConfirm(false)}
+      />
     </AnimatePresence>
   )
 }

--- a/src/renderer/components/ConfirmDialog.tsx
+++ b/src/renderer/components/ConfirmDialog.tsx
@@ -14,6 +14,7 @@ interface ConfirmDialogProps {
     onClick: () => void
   }
   variant?: 'default' | 'danger'
+  isLoading?: boolean
   onConfirm: () => void
   onCancel: () => void
 }
@@ -26,6 +27,7 @@ export function ConfirmDialog({
   cancelLabel = 'Cancel',
   secondaryAction,
   variant = 'default',
+  isLoading = false,
   onConfirm,
   onCancel
 }: ConfirmDialogProps): React.JSX.Element {
@@ -96,28 +98,31 @@ export function ConfirmDialog({
             <div className="px-6 py-3 bg-secondary/50 flex justify-end gap-2 border-t border-border">
               <button
                 onClick={onCancel}
-                className="px-3 py-1.5 text-xs font-medium text-muted-foreground hover:text-foreground transition-colors"
+                disabled={isLoading}
+                className="px-3 py-1.5 text-xs font-medium text-muted-foreground hover:text-foreground transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
               >
                 {cancelLabel}
               </button>
               {secondaryAction && (
                 <button
                   onClick={secondaryAction.onClick}
-                  className="px-3 py-1.5 text-xs font-medium rounded transition-all text-red-400 hover:text-red-300 hover:bg-red-500/10"
+                  disabled={isLoading}
+                  className="px-3 py-1.5 text-xs font-medium rounded transition-all text-red-400 hover:text-red-300 hover:bg-red-500/10 disabled:opacity-50 disabled:cursor-not-allowed"
                 >
                   {secondaryAction.label}
                 </button>
               )}
               <button
                 onClick={onConfirm}
+                disabled={isLoading}
                 className={cn(
-                  'px-3 py-1.5 text-xs font-medium rounded transition-all',
+                  'px-3 py-1.5 text-xs font-medium rounded transition-all disabled:opacity-50 disabled:cursor-not-allowed',
                   variant === 'danger'
                     ? 'bg-red-500 text-white hover:bg-red-600'
                     : 'bg-primary text-primary-foreground hover:bg-primary/90'
                 )}
               >
-                {confirmLabel}
+                {isLoading ? 'Loading...' : confirmLabel}
               </button>
             </div>
           </motion.div>

--- a/src/renderer/hooks/use-command-history.ts
+++ b/src/renderer/hooks/use-command-history.ts
@@ -73,3 +73,9 @@ export function useCommandHistory(projectId: string | null): CommandHistoryEntry
   if (!projectId) return []
   return entries.filter((e) => e.projectId === projectId)
 }
+
+export function useAllCommandHistory(): CommandHistoryEntry[] {
+  const entries = useCommandHistoryStore((state) => state.entries)
+  // Return a sorted copy (newest-first) across all projects
+  return [...entries].sort((a, b) => b.timestamp - a.timestamp)
+}

--- a/src/renderer/layouts/WorkspaceLayout.close-persistence.test.tsx
+++ b/src/renderer/layouts/WorkspaceLayout.close-persistence.test.tsx
@@ -168,7 +168,8 @@ vi.mock('@/hooks/use-recent-commands', () => ({
 vi.mock('@/hooks/use-command-history', () => ({
   useCommandHistoryLoader: () => undefined,
   useAddCommand: () => vi.fn(),
-  useCommandHistory: () => []
+  useCommandHistory: () => [],
+  useAllCommandHistory: () => []
 }))
 
 vi.mock('@/hooks/use-app-settings', () => ({

--- a/src/renderer/layouts/WorkspaceLayout.test.tsx
+++ b/src/renderer/layouts/WorkspaceLayout.test.tsx
@@ -119,7 +119,8 @@ vi.mock('@/hooks/use-recent-commands', () => ({
 vi.mock('@/hooks/use-command-history', () => ({
   useCommandHistoryLoader: vi.fn(),
   useAddCommand: vi.fn(() => vi.fn()),
-  useCommandHistory: vi.fn(() => [])
+  useCommandHistory: vi.fn(() => []),
+  useAllCommandHistory: vi.fn(() => [])
 }))
 
 const { mockUpdatePanelVisibility, mockWaitForPendingAppSettingsPersistence } = vi.hoisted(() => ({

--- a/src/renderer/layouts/WorkspaceLayout.tsx
+++ b/src/renderer/layouts/WorkspaceLayout.tsx
@@ -766,14 +766,15 @@ export default function WorkspaceLayout(): React.JSX.Element {
 
   const handleClearCommandHistory = useCallback(async () => {
     if (!activeProjectId) return
-    const { clearHistory } = useCommandHistoryStore.getState()
-    clearHistory(activeProjectId)
-    // Persist the cleared state
+    // Persist empty array first, then clear in-memory on success
     const result = await persistenceApi.write(`projects/${activeProjectId}/command-history`, [])
     if (!result.success) {
       toast.error(`Failed to clear history: ${result.error}`)
       throw new Error(result.error)
     }
+    // Only clear in-memory state after successful persistence
+    const { clearHistory } = useCommandHistoryStore.getState()
+    clearHistory(activeProjectId)
   }, [activeProjectId])
 
   const terminalToClose = terminals.find((t) => t.id === closeConfirmTerminal?.terminalId)

--- a/src/renderer/layouts/WorkspaceLayout.tsx
+++ b/src/renderer/layouts/WorkspaceLayout.tsx
@@ -34,6 +34,7 @@ import {
 import { useFileExplorerStore, useFileExplorerVisible } from '@/stores/file-explorer-store'
 import { useSidebarVisible } from '@/stores/sidebar-store'
 import { useEditorStore } from '@/stores/editor-store'
+import { useCommandHistoryStore } from '@/stores/command-history-store'
 import {
   useWorkspaceStore,
   useActiveTab,
@@ -48,7 +49,8 @@ import { useRecentCommandsLoader } from '@/hooks/use-recent-commands'
 import {
   useCommandHistoryLoader,
   useAddCommand,
-  useCommandHistory
+  useCommandHistory,
+  useAllCommandHistory
 } from '@/hooks/use-command-history'
 import { filesystemApi, windowApi, keyboardApi, terminalApi, persistenceApi } from '@/lib/api'
 import { useKeyboardShortcutsStore, matchesShortcut } from '@/stores/keyboard-shortcuts-store'
@@ -296,6 +298,7 @@ export default function WorkspaceLayout(): React.JSX.Element {
   useCommandHistoryLoader(activeProjectId)
   const addCommand = useAddCommand()
   const commandHistory = useCommandHistory(activeProjectId)
+  const allCommandHistory = useAllCommandHistory()
   const createSnapshot = useCreateSnapshot()
 
   const handleCreateSnapshot = useCallback(
@@ -761,6 +764,18 @@ export default function WorkspaceLayout(): React.JSX.Element {
     }
   }, [activeTerminal])
 
+  const handleClearCommandHistory = useCallback(async () => {
+    if (!activeProjectId) return
+    const { clearHistory } = useCommandHistoryStore.getState()
+    clearHistory(activeProjectId)
+    // Persist the cleared state
+    const result = await persistenceApi.write(`projects/${activeProjectId}/command-history`, [])
+    if (!result.success) {
+      toast.error(`Failed to clear history: ${result.error}`)
+      throw new Error(result.error)
+    }
+  }, [activeProjectId])
+
   const terminalToClose = terminals.find((t) => t.id === closeConfirmTerminal?.terminalId)
 
   // Show loading state while projects are being loaded
@@ -899,7 +914,9 @@ export default function WorkspaceLayout(): React.JSX.Element {
         isOpen={isCommandHistoryOpen}
         onClose={() => setIsCommandHistoryOpen(false)}
         entries={commandHistory}
+        allEntries={allCommandHistory}
         onSelectCommand={handleInsertCommand}
+        onClearHistory={handleClearCommandHistory}
       />
 
       {/* Close Terminal Confirmation */}


### PR DESCRIPTION
## Summary

- Add project filter dropdown to CommandHistoryModal ("This Project" / "All Projects")
- Add "Clear History" button with confirmation dialog for current project
- Disable Clear History button when viewing "All Projects" mode
- Add loading state during clear operation
- Add error handling with toast notification for persistence failures
- Add `useAllCommandHistory` hook to retrieve all entries from store
- Add comprehensive tests for filter and clear functionality

## Test plan

- [ ] Open command history modal with `Ctrl+R`
- [ ] Verify "This Project" is default filter selection
- [ ] Run commands in different projects, switch filter to "All Projects"
- [ ] Verify all commands from all projects appear
- [ ] Click "Clear History", verify confirmation dialog appears
- [ ] Confirm clear, verify only current project's history is cleared
- [ ] Verify Clear History button is disabled when viewing "All Projects"
- [ ] Verify Clear History button is disabled when history is empty

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Command history modal: switch between current-project and all-project history; search query persists when switching.
  * Global history view added and wired to the modal.
  * Clear History flow: project-scoped clear with confirmation dialog, loading state, and disabled when viewing all-projects or when history is empty.
  * Confirmation dialogs now support a loading/disabled state.

* **Tests**
  * Expanded coverage for project filter behavior, multi-project results, clear-history confirmation/cancel flows, disabled states, and empty/match messaging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->