### PR TITLE
fix: consolidate tab drag-and-drop to native HTML5 API

### DIFF
--- a/src/renderer/components/workspace/WorkspaceTabBar.test.tsx
+++ b/src/renderer/components/workspace/WorkspaceTabBar.test.tsx
@@ -1,7 +1,8 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { act, createEvent, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { WorkspaceTabBar } from './WorkspaceTabBar'
 import type { WorkspaceTab } from '@/stores/workspace-store'
+import type { DragPayload } from '@/types/workspace.types'
 
 const mockSetActiveTab = vi.fn()
 const mockSetActivePane = vi.fn()
@@ -31,32 +32,42 @@ vi.mock('@/stores/editor-store', () => ({
 vi.mock('@/stores/terminal-store', () => ({
   useTerminalStore: vi.fn((selector: (state: { terminals: Array<{ id: string; name: string; shell: string }> }) => unknown) =>
     selector({
-      terminals: [{ id: 'term-1', name: 'Terminal 1', shell: 'bash' }]
+      terminals: [
+        { id: 'term-1', name: 'Terminal 1', shell: 'bash' },
+        { id: 'term-2', name: 'Terminal 2', shell: 'zsh' },
+        { id: 'term-3', name: 'Terminal 3', shell: 'bash' }
+      ]
     })
   )
 }))
 
 const mockStartTabDrag = vi.hoisted(() => vi.fn())
+const mockSetReorderPreview = vi.hoisted(() => vi.fn())
+const mockClearReorderPreview = vi.hoisted(() => vi.fn())
+const mockHandleTabReorder = vi.hoisted(() => vi.fn())
+
+interface MockPaneDndValue {
+  startTabDrag: typeof mockStartTabDrag
+  dragPayload: DragPayload | null
+  reorderPreview: { paneId: string; targetTabId: string; position: 'before' | 'after' } | null
+  setReorderPreview: typeof mockSetReorderPreview
+  clearReorderPreview: typeof mockClearReorderPreview
+  handleTabReorder: typeof mockHandleTabReorder
+}
+
 const mockUsePaneDnd = vi.hoisted(() =>
-  vi.fn(() => ({
+  vi.fn<() => MockPaneDndValue>(() => ({
     startTabDrag: mockStartTabDrag,
-    dragPayload: null
+    dragPayload: null,
+    reorderPreview: null,
+    setReorderPreview: mockSetReorderPreview,
+    clearReorderPreview: mockClearReorderPreview,
+    handleTabReorder: mockHandleTabReorder
   }))
 )
 
 vi.mock('@/hooks/use-pane-dnd', () => ({
   usePaneDnd: mockUsePaneDnd
-}))
-
-vi.mock('framer-motion', () => ({
-  Reorder: {
-    Group: ({ children, onReorder }: { children: React.ReactNode; onReorder: (tabs: WorkspaceTab[]) => void }) => (
-      <div data-testid="reorder-group" data-has-onreorder={Boolean(onReorder)}>
-        {children}
-      </div>
-    ),
-    Item: ({ children }: { children: React.ReactNode }) => <div>{children}</div>
-  }
 }))
 
 beforeEach(() => {
@@ -65,10 +76,17 @@ beforeEach(() => {
   mockReorderTabsInPane.mockReset()
   mockCloseTab.mockReset()
   mockStartTabDrag.mockReset()
+  mockSetReorderPreview.mockReset()
+  mockClearReorderPreview.mockReset()
+  mockHandleTabReorder.mockReset()
   mockUsePaneDnd.mockReset()
   mockUsePaneDnd.mockReturnValue({
     startTabDrag: mockStartTabDrag,
-    dragPayload: null
+    dragPayload: null,
+    reorderPreview: null,
+    setReorderPreview: mockSetReorderPreview,
+    clearReorderPreview: mockClearReorderPreview,
+    handleTabReorder: mockHandleTabReorder
   })
 
   vi.stubGlobal('api', {
@@ -177,5 +195,260 @@ describe('WorkspaceTabBar', () => {
 
     expect(onCloseEditorTab).toHaveBeenCalledWith('/a.ts')
     expect(mockCloseTab).not.toHaveBeenCalled()
+  })
+
+  it('calls startTabDrag when dragging a terminal tab', async () => {
+    const tabs: WorkspaceTab[] = [{ type: 'terminal', id: 'tab-1', terminalId: 'term-1' }]
+
+    const { container } = render(
+      <WorkspaceTabBar
+        paneId="pane-a"
+        tabs={tabs}
+        activeTabId="tab-1"
+      />
+    )
+
+    await flushShellEffect()
+
+    const tabEl = container.querySelector('[draggable="true"]') as HTMLElement
+    expect(tabEl).toBeTruthy()
+
+    fireEvent.dragStart(tabEl, {
+      dataTransfer: {
+        setData: vi.fn(),
+        effectAllowed: null
+      }
+    })
+
+    expect(mockStartTabDrag).toHaveBeenCalledWith('tab-1', 'pane-a', expect.anything())
+  })
+
+  it('shows drop indicator on left side when dragging over left half of tab', async () => {
+    // Mock dragPayload to indicate we're dragging a tab from the same pane
+    mockUsePaneDnd.mockReturnValue({
+      startTabDrag: mockStartTabDrag,
+      dragPayload: { type: 'tab', tabId: 'tab-3', sourcePaneId: 'pane-a' },
+      reorderPreview: null,
+      setReorderPreview: mockSetReorderPreview,
+      clearReorderPreview: mockClearReorderPreview,
+      handleTabReorder: mockHandleTabReorder
+    })
+
+    const tabs: WorkspaceTab[] = [
+      { type: 'terminal', id: 'tab-1', terminalId: 'term-1' },
+      { type: 'terminal', id: 'tab-2', terminalId: 'term-2' }
+    ]
+
+    const { container } = render(
+      <WorkspaceTabBar
+        paneId="pane-a"
+        tabs={tabs}
+        activeTabId="tab-1"
+      />
+    )
+
+    await flushShellEffect()
+
+    const tabEls = container.querySelectorAll('[draggable="true"]')
+    const targetTab = tabEls[1] as HTMLElement // Second tab
+
+    // Mock getBoundingClientRect to return a known width
+    targetTab.getBoundingClientRect = vi.fn(() => ({
+      left: 0,
+      top: 0,
+      right: 200,
+      bottom: 40,
+      width: 200,
+      height: 40,
+      x: 0,
+      y: 0,
+      toJSON: vi.fn()
+    }))
+
+    // Create drag event and set clientX manually
+    const dragEvent = createEvent.dragOver(targetTab, {
+      dataTransfer: { dropEffect: null }
+    })
+    Object.defineProperty(dragEvent, 'clientX', { value: 50, writable: false })
+    Object.defineProperty(dragEvent, 'clientY', { value: 20, writable: false })
+    fireEvent(targetTab, dragEvent)
+
+    expect(mockSetReorderPreview).toHaveBeenCalledWith('pane-a', 'tab-2', 'before')
+  })
+
+  it('shows drop indicator on right side when dragging over right half of tab', async () => {
+    // Mock dragPayload to indicate we're dragging a tab from the same pane
+    mockUsePaneDnd.mockReturnValue({
+      startTabDrag: mockStartTabDrag,
+      dragPayload: { type: 'tab', tabId: 'tab-3', sourcePaneId: 'pane-a' },
+      reorderPreview: null,
+      setReorderPreview: mockSetReorderPreview,
+      clearReorderPreview: mockClearReorderPreview,
+      handleTabReorder: mockHandleTabReorder
+    })
+
+    const tabs: WorkspaceTab[] = [
+      { type: 'terminal', id: 'tab-1', terminalId: 'term-1' },
+      { type: 'terminal', id: 'tab-2', terminalId: 'term-2' }
+    ]
+
+    const { container } = render(
+      <WorkspaceTabBar
+        paneId="pane-a"
+        tabs={tabs}
+        activeTabId="tab-1"
+      />
+    )
+
+    await flushShellEffect()
+
+    const tabEls = container.querySelectorAll('[draggable="true"]')
+    const targetTab = tabEls[1] as HTMLElement // Second tab
+
+    // Mock getBoundingClientRect to return a known width
+    targetTab.getBoundingClientRect = vi.fn(() => ({
+      left: 0,
+      top: 0,
+      right: 200,
+      bottom: 40,
+      width: 200,
+      height: 40,
+      x: 0,
+      y: 0,
+      toJSON: vi.fn()
+    }))
+
+    // Drag over right half (x = 150, which is > 100)
+    fireEvent.dragOver(targetTab, {
+      clientX: 150,
+      clientY: 20,
+      dataTransfer: { dropEffect: null }
+    })
+
+    expect(mockSetReorderPreview).toHaveBeenCalledWith('pane-a', 'tab-2', 'after')
+  })
+
+  it('calls handleTabReorder when dropping on a tab', async () => {
+    // Mock dragPayload to indicate we're dragging a tab from the same pane
+    mockUsePaneDnd.mockReturnValue({
+      startTabDrag: mockStartTabDrag,
+      dragPayload: { type: 'tab', tabId: 'tab-1', sourcePaneId: 'pane-a' },
+      reorderPreview: null,
+      setReorderPreview: mockSetReorderPreview,
+      clearReorderPreview: mockClearReorderPreview,
+      handleTabReorder: mockHandleTabReorder
+    })
+
+    const tabs: WorkspaceTab[] = [
+      { type: 'terminal', id: 'tab-1', terminalId: 'term-1' },
+      { type: 'terminal', id: 'tab-2', terminalId: 'term-2' }
+    ]
+
+    const { container } = render(
+      <WorkspaceTabBar
+        paneId="pane-a"
+        tabs={tabs}
+        activeTabId="tab-1"
+      />
+    )
+
+    await flushShellEffect()
+
+    const tabEls = container.querySelectorAll('[draggable="true"]')
+    const targetTab = tabEls[1] as HTMLElement // Second tab
+
+    // Mock getBoundingClientRect to return a known width
+    targetTab.getBoundingClientRect = vi.fn(() => ({
+      left: 0,
+      top: 0,
+      right: 200,
+      bottom: 40,
+      width: 200,
+      height: 40,
+      x: 0,
+      y: 0,
+      toJSON: vi.fn()
+    }))
+
+    // Drop on right half
+    fireEvent.drop(targetTab, {
+      clientX: 150,
+      clientY: 20
+    })
+
+    expect(mockHandleTabReorder).toHaveBeenCalledWith('pane-a', 'tab-2', 'after')
+  })
+
+  it('does not show drop indicator when dragging from different pane', async () => {
+    // Mock dragPayload to indicate we're dragging a tab from a different pane
+    mockUsePaneDnd.mockReturnValue({
+      startTabDrag: mockStartTabDrag,
+      dragPayload: { type: 'tab', tabId: 'tab-3', sourcePaneId: 'pane-b' },
+      reorderPreview: null,
+      setReorderPreview: mockSetReorderPreview,
+      clearReorderPreview: mockClearReorderPreview,
+      handleTabReorder: mockHandleTabReorder
+    })
+
+    const tabs: WorkspaceTab[] = [
+      { type: 'terminal', id: 'tab-1', terminalId: 'term-1' },
+      { type: 'terminal', id: 'tab-2', terminalId: 'term-2' }
+    ]
+
+    const { container } = render(
+      <WorkspaceTabBar
+        paneId="pane-a"
+        tabs={tabs}
+        activeTabId="tab-1"
+      />
+    )
+
+    await flushShellEffect()
+
+    const tabEls = container.querySelectorAll('[draggable="true"]')
+    const targetTab = tabEls[1] as HTMLElement
+
+    fireEvent.dragOver(targetTab, {
+      clientX: 50,
+      clientY: 20,
+      dataTransfer: { dropEffect: null }
+    })
+
+    // Should NOT call setReorderPreview when dragging from different pane
+    expect(mockSetReorderPreview).not.toHaveBeenCalled()
+  })
+
+  it('applies opacity and scale to dragged tab', async () => {
+    // Mock dragPayload to indicate tab-1 is being dragged
+    mockUsePaneDnd.mockReturnValue({
+      startTabDrag: mockStartTabDrag,
+      dragPayload: { type: 'tab', tabId: 'tab-1', sourcePaneId: 'pane-a' },
+      reorderPreview: null,
+      setReorderPreview: mockSetReorderPreview,
+      clearReorderPreview: mockClearReorderPreview,
+      handleTabReorder: mockHandleTabReorder
+    })
+
+    const tabs: WorkspaceTab[] = [
+      { type: 'terminal', id: 'tab-1', terminalId: 'term-1' },
+      { type: 'terminal', id: 'tab-2', terminalId: 'term-2' }
+    ]
+
+    const { container } = render(
+      <WorkspaceTabBar
+        paneId="pane-a"
+        tabs={tabs}
+        activeTabId="tab-1"
+      />
+    )
+
+    await flushShellEffect()
+
+    const tabEls = container.querySelectorAll('[draggable="true"]')
+    const draggedTab = tabEls[0] as HTMLElement // First tab (the one being dragged)
+
+    // The dragged tab should have opacity-50 and scale classes
+    expect(draggedTab.className).toContain('opacity-50')
+    expect(draggedTab.className).toContain('scale-[0.98]')
   })
 })

--- a/src/renderer/components/workspace/WorkspaceTabBar.tsx
+++ b/src/renderer/components/workspace/WorkspaceTabBar.tsx
@@ -7,7 +7,6 @@ import {
   Edit2,
   Skull
 } from 'lucide-react'
-import { Reorder } from 'framer-motion'
 import { cn } from '@/lib/utils'
 import { EditorTab } from './EditorTab'
 import { Skeleton } from '@/components/ui/skeleton'
@@ -18,22 +17,49 @@ import { usePaneDnd } from '@/hooks/use-pane-dnd'
 import type { WorkspaceTab } from '@/stores/workspace-store'
 import type { ShellInfo, DetectedShells } from '@shared/types/ipc.types'
 import type { Terminal } from '@/types/project'
+import type { TabReorderPosition } from '@/types/workspace.types'
 import { ContextMenu } from '@/components/ContextMenu'
-import type { ContextMenuItem } from '@/components/ContextMenu'
 import { shellApi, clipboardApi } from '@/lib/api'
+
+// Helper to compute drop position from mouse coordinates
+function computeTabPosition(target: HTMLElement, clientX: number): TabReorderPosition {
+  const rect = target.getBoundingClientRect()
+  const x = clientX - rect.left
+  const halfWidth = rect.width / 2
+  return x < halfWidth ? 'before' : 'after'
+}
 
 // Inline TerminalTab matching the style from TerminalTabBar
 
 interface TerminalTabInlineProps {
   terminal: Terminal
   isActive: boolean
+  isDragging: boolean
+  isDropTarget: boolean
+  dropPosition: TabReorderPosition | null
   onSelect: () => void
   onClose: () => void
   onRename: (name: string) => void
   onDragStart: (e: React.DragEvent) => void
+  onDragOver: (e: React.DragEvent) => void
+  onDragLeave: () => void
+  onDrop: (e: React.DragEvent) => void
 }
 
-function TerminalTabInline({ terminal, isActive, onSelect, onClose, onRename, onDragStart }: TerminalTabInlineProps): React.JSX.Element {
+function TerminalTabInline({
+  terminal,
+  isActive,
+  isDragging,
+  isDropTarget,
+  dropPosition,
+  onSelect,
+  onClose,
+  onRename,
+  onDragStart,
+  onDragOver,
+  onDragLeave,
+  onDrop
+}: TerminalTabInlineProps): React.JSX.Element {
   const [isEditing, setIsEditing] = useState(false)
   const [editName, setEditName] = useState(terminal.name)
   const [contextMenu, setContextMenu] = useState<{ x: number; y: number } | null>(null)
@@ -69,6 +95,9 @@ function TerminalTabInline({ terminal, isActive, onSelect, onClose, onRename, on
       <div
         draggable={!isEditing}
         onDragStart={onDragStart}
+        onDragOver={onDragOver}
+        onDragLeave={onDragLeave}
+        onDrop={onDrop}
         onClick={onSelect}
         onContextMenu={(e) => {
           e.preventDefault()
@@ -76,12 +105,21 @@ function TerminalTabInline({ terminal, isActive, onSelect, onClose, onRename, on
           setContextMenu({ x: e.clientX, y: e.clientY })
         }}
         className={cn(
-          'h-full px-4 flex items-center border-r border-border min-w-[150px] cursor-pointer group transition-colors border-b-2 border-b-transparent',
+          'relative h-full px-4 flex items-center border-r border-border min-w-[150px] cursor-pointer group transition-all duration-150 ease-out border-b-2 border-b-transparent',
           isActive
             ? 'bg-background border-b-primary'
-            : 'hover:bg-secondary/50 text-muted-foreground'
+            : 'hover:bg-secondary/50 text-muted-foreground',
+          isDragging && 'opacity-50 scale-[0.98]'
         )}
       >
+        {/* Drop indicator line */}
+        {isDropTarget && dropPosition === 'before' && (
+          <div className="absolute left-0 top-1 bottom-1 w-0.5 bg-primary rounded-full" />
+        )}
+        {isDropTarget && dropPosition === 'after' && (
+          <div className="absolute right-0 top-1 bottom-1 w-0.5 bg-primary rounded-full" />
+        )}
+
         <TerminalIcon size={14} className={cn('mr-2', isActive ? 'text-primary' : '')} />
         {isEditing ? (
           <input
@@ -90,8 +128,13 @@ function TerminalTabInline({ terminal, isActive, onSelect, onClose, onRename, on
             value={editName}
             onChange={(e) => setEditName(e.target.value)}
             onKeyDown={(e) => {
-              if (e.key === 'Enter') { e.preventDefault(); handleSave() }
-              else if (e.key === 'Escape') { e.preventDefault(); handleCancel() }
+              if (e.key === 'Enter') {
+                e.preventDefault()
+                handleSave()
+              } else if (e.key === 'Escape') {
+                e.preventDefault()
+                handleCancel()
+              }
             }}
             onBlur={handleSave}
             onClick={(e) => e.stopPropagation()}
@@ -106,7 +149,10 @@ function TerminalTabInline({ terminal, isActive, onSelect, onClose, onRename, on
           </span>
         )}
         <button
-          onClick={(e) => { e.stopPropagation(); onClose() }}
+          onClick={(e) => {
+            e.stopPropagation()
+            onClose()
+          }}
           className="ml-auto p-0.5 rounded-md hover:bg-secondary opacity-0 group-hover:opacity-100 transition-opacity"
         >
           <XIcon size={12} />
@@ -116,9 +162,21 @@ function TerminalTabInline({ terminal, isActive, onSelect, onClose, onRename, on
       {contextMenu && (
         <ContextMenu
           items={[
-            { label: 'Rename', icon: <Edit2 size={14} />, onClick: () => { setEditName(terminal.name); setIsEditing(true) } },
+            {
+              label: 'Rename',
+              icon: <Edit2 size={14} />,
+              onClick: () => {
+                setEditName(terminal.name)
+                setIsEditing(true)
+              }
+            },
             { label: 'Close', icon: <XIcon size={14} />, onClick: onClose },
-            { label: 'Kill Process', icon: <Skull size={14} />, onClick: onClose, variant: 'danger' }
+            {
+              label: 'Kill Process',
+              icon: <Skull size={14} />,
+              onClick: onClose,
+              variant: 'danger'
+            }
           ]}
           x={contextMenu.x}
           y={contextMenu.y}
@@ -126,6 +184,70 @@ function TerminalTabInline({ terminal, isActive, onSelect, onClose, onRename, on
         />
       )}
     </>
+  )
+}
+
+interface EditorTabWrapperProps {
+  tab: { type: 'editor'; id: string; filePath: string }
+  isActive: boolean
+  isDragging: boolean
+  isDropTarget: boolean
+  dropPosition: TabReorderPosition | null
+  onSelect: () => void
+  onClose: () => void
+  onCloseOthers: () => void
+  onCloseAll: () => void
+  onCopyPath: () => void
+  onDragStart: (e: React.DragEvent) => void
+  onDragOver: (e: React.DragEvent) => void
+  onDragLeave: () => void
+  onDrop: (e: React.DragEvent) => void
+}
+
+function EditorTabWrapper({
+  tab,
+  isActive,
+  isDragging,
+  isDropTarget,
+  dropPosition,
+  onSelect,
+  onClose,
+  onCloseOthers,
+  onCloseAll,
+  onCopyPath,
+  onDragStart,
+  onDragOver,
+  onDragLeave,
+  onDrop
+}: EditorTabWrapperProps): React.JSX.Element {
+  const isDirty = useEditorStore((state) => state.openFiles.get(tab.filePath)?.isDirty ?? false)
+  return (
+    <div
+      draggable
+      onDragStart={onDragStart}
+      onDragOver={onDragOver}
+      onDragLeave={onDragLeave}
+      onDrop={onDrop}
+      className={cn('relative h-full transition-all duration-150 ease-out', isDragging && 'opacity-50 scale-[0.98]')}
+    >
+      {/* Drop indicator line */}
+      {isDropTarget && dropPosition === 'before' && (
+        <div className="absolute left-0 top-1 bottom-1 w-0.5 bg-primary rounded-full z-10" />
+      )}
+      {isDropTarget && dropPosition === 'after' && (
+        <div className="absolute right-0 top-1 bottom-1 w-0.5 bg-primary rounded-full z-10" />
+      )}
+      <EditorTab
+        filePath={tab.filePath}
+        isActive={isActive}
+        isDirty={isDirty}
+        onSelect={onSelect}
+        onClose={onClose}
+        onCloseOthers={onCloseOthers}
+        onCloseAll={onCloseAll}
+        onCopyPath={onCopyPath}
+      />
+    </div>
   )
 }
 
@@ -141,35 +263,6 @@ interface WorkspaceTabBarProps {
   defaultShell?: string
 }
 
-interface EditorTabWrapperProps {
-  tab: { type: 'editor'; id: string; filePath: string }
-  isActive: boolean
-  onSelect: () => void
-  onClose: () => void
-  onCloseOthers: () => void
-  onCloseAll: () => void
-  onCopyPath: () => void
-  onDragStart: (e: React.DragEvent) => void
-}
-
-function EditorTabWrapper({ tab, isActive, onSelect, onClose, onCloseOthers, onCloseAll, onCopyPath, onDragStart }: EditorTabWrapperProps): React.JSX.Element {
-  const isDirty = useEditorStore((state) => state.openFiles.get(tab.filePath)?.isDirty ?? false)
-  return (
-    <div draggable onDragStart={onDragStart} className="h-full">
-      <EditorTab
-        filePath={tab.filePath}
-        isActive={isActive}
-        isDirty={isDirty}
-        onSelect={onSelect}
-        onClose={onClose}
-        onCloseOthers={onCloseOthers}
-        onCloseAll={onCloseAll}
-        onCopyPath={onCopyPath}
-      />
-    </div>
-  )
-}
-
 export function WorkspaceTabBar({
   paneId,
   tabs,
@@ -183,8 +276,14 @@ export function WorkspaceTabBar({
 }: WorkspaceTabBarProps): React.JSX.Element {
   const setActiveTab = useWorkspaceStore((state) => state.setActiveTab)
   const setActivePane = useWorkspaceStore((state) => state.setActivePane)
-  const reorderTabsInPane = useWorkspaceStore((state) => state.reorderTabsInPane)
-  const { startTabDrag, dragPayload } = usePaneDnd()
+  const {
+    startTabDrag,
+    dragPayload,
+    reorderPreview,
+    setReorderPreview,
+    clearReorderPreview,
+    handleTabReorder
+  } = usePaneDnd()
 
   const [isDropdownOpen, setIsDropdownOpen] = useState(false)
   const [shells, setShells] = useState<DetectedShells | null>(null)
@@ -293,6 +392,54 @@ export function WorkspaceTabBar({
     [startTabDrag, paneId]
   )
 
+  const handleTabDragOver = useCallback(
+    (tabId: string, e: React.DragEvent) => {
+      e.preventDefault()
+      e.dataTransfer.dropEffect = 'move'
+
+      if (!dragPayload || dragPayload.type !== 'tab') return
+      if (dragPayload.sourcePaneId !== paneId) return
+
+      const position = computeTabPosition(e.currentTarget as HTMLElement, e.clientX)
+      setReorderPreview(paneId, tabId, position)
+    },
+    [dragPayload, paneId, setReorderPreview]
+  )
+
+  const handleTabDragLeave = useCallback(() => {
+    // Only clear if we're not entering a child element
+    // This is handled by the individual tab components
+  }, [])
+
+  const handleContainerDragLeave = useCallback(
+    (e: React.DragEvent) => {
+      // Only clear preview if actually leaving the container (not moving to child)
+      const relatedTarget = e.relatedTarget as Node | null
+      if (relatedTarget && e.currentTarget.contains(relatedTarget)) {
+        return
+      }
+      clearReorderPreview()
+    },
+    [clearReorderPreview]
+  )
+
+  const handleTabDrop = useCallback(
+    (tabId: string, e: React.DragEvent) => {
+      // Only prevent/stop if this is a same-pane tab reorder
+      // Otherwise, let the event bubble for cross-pane drops
+      if (!dragPayload || dragPayload.type !== 'tab' || dragPayload.sourcePaneId !== paneId) {
+        return
+      }
+
+      e.preventDefault()
+      e.stopPropagation()
+
+      const position = computeTabPosition(e.currentTarget as HTMLElement, e.clientX)
+      handleTabReorder(paneId, tabId, position)
+    },
+    [dragPayload, paneId, handleTabReorder]
+  )
+
   const sortedShells = shells?.available?.slice().sort((a, b) => {
     if (defaultShell) {
       if (a.name === defaultShell) return -1
@@ -303,70 +450,90 @@ export function WorkspaceTabBar({
 
   const terminalStoreTerminals = useTerminalStore((state) => state.terminals)
 
+  // Check if this tab is being dragged
+  const isTabDragging = (tabId: string): boolean =>
+    dragPayload?.type === 'tab' && dragPayload.tabId === tabId
+
+  // Check if this tab is a drop target
+  const isTabDropTarget = (tabId: string): { isTarget: boolean; position: TabReorderPosition | null } => {
+    if (!reorderPreview || reorderPreview.paneId !== paneId) {
+      return { isTarget: false, position: null }
+    }
+    if (reorderPreview.targetTabId === tabId) {
+      return { isTarget: true, position: reorderPreview.position }
+    }
+    return { isTarget: false, position: null }
+  }
+
   return (
     <div className="h-10 bg-card border-b border-border flex items-center">
       <div className="relative flex items-center h-full min-w-0 shrink">
         <div
           ref={tabsContainerRef}
           onWheel={handleWheel}
+          onDragLeave={handleContainerDragLeave}
           className="overflow-x-auto scrollbar-hide flex items-center h-full"
         >
-          <Reorder.Group
-            axis="x"
-            values={tabs}
-            onReorder={(reordered: WorkspaceTab[]) => {
-              if (dragPayload) return
-              reorderTabsInPane(paneId, reordered.map((t) => t.id))
-            }}
-            className="flex items-center h-full"
-          >
-            {tabs.map((tab) => (
-              <Reorder.Item
-                key={tab.id}
-                value={tab}
-                className="list-none h-full"
-                whileDrag={{ scale: 1.02, boxShadow: '0 4px 12px rgba(0,0,0,0.15)' }}
-              >
-                {tab.type === 'terminal' ? (
-                  (() => {
-                    const terminal = terminalStoreTerminals.find((t) => t.id === tab.terminalId)
-                    if (!terminal) return null
-                    return (
-                      <TerminalTabInline
-                        terminal={terminal}
-                        isActive={tab.id === activeTabId}
-                        onSelect={() => {
-                          setActiveTab(paneId, tab.id)
-                          setActivePane(paneId)
-                        }}
-                        onClose={() => {
-                          if (onCloseTerminal) onCloseTerminal(tab.terminalId, tab.id)
-                        }}
-                        onRename={(name) => {
-                          if (onRenameTerminal) onRenameTerminal(tab.terminalId, name)
-                        }}
-                        onDragStart={(e) => handleTabDragStart(tab.id, e)}
-                      />
-                    )
-                  })()
-                ) : (
-                  <EditorTabWrapper
-                    tab={tab as { type: 'editor'; id: string; filePath: string }}
-                    isActive={tab.id === activeTabId}
-                    onSelect={() => {
-                      setActiveTab(paneId, tab.id)
-                      setActivePane(paneId)
-                    }}
-                    onClose={() => handleCloseEditorTab(tab.filePath)}
-                    onCloseOthers={() => handleCloseOtherEditorTabs(tab.filePath)}
-                    onCloseAll={handleCloseAllEditorTabs}
-                    onCopyPath={() => void clipboardApi.writeText(tab.filePath)}
-                    onDragStart={(e) => handleTabDragStart(tab.id, e)}
-                  />
-                )}
-              </Reorder.Item>
-            ))}
-          </Reorder.Group>
+          <div className="flex items-center h-full">
+            {tabs.map((tab) => {
+              const dragging = isTabDragging(tab.id)
+              const { isTarget, position } = isTabDropTarget(tab.id)
+
+              return (
+                <div key={tab.id} className="list-none h-full">
+                  {tab.type === 'terminal' ? (
+                    (() => {
+                      const terminal = terminalStoreTerminals.find((t) => t.id === tab.terminalId)
+                      if (!terminal) return null
+                      return (
+                        <TerminalTabInline
+                          terminal={terminal}
+                          isActive={tab.id === activeTabId}
+                          isDragging={dragging}
+                          isDropTarget={isTarget}
+                          dropPosition={position}
+                          onSelect={() => {
+                            setActiveTab(paneId, tab.id)
+                            setActivePane(paneId)
+                          }}
+                          onClose={() => {
+                            if (onCloseTerminal) onCloseTerminal(tab.terminalId, tab.id)
+                          }}
+                          onRename={(name) => {
+                            if (onRenameTerminal) onRenameTerminal(tab.terminalId, name)
+                          }}
+                          onDragStart={(e) => handleTabDragStart(tab.id, e)}
+                          onDragOver={(e) => handleTabDragOver(tab.id, e)}
+                          onDragLeave={handleTabDragLeave}
+                          onDrop={(e) => handleTabDrop(tab.id, e)}
+                        />
+                      )
+                    })()
+                  ) : (
+                    <EditorTabWrapper
+                      tab={tab as { type: 'editor'; id: string; filePath: string }}
+                      isActive={tab.id === activeTabId}
+                      isDragging={dragging}
+                      isDropTarget={isTarget}
+                      dropPosition={position}
+                      onSelect={() => {
+                        setActiveTab(paneId, tab.id)
+                        setActivePane(paneId)
+                      }}
+                      onClose={() => handleCloseEditorTab(tab.filePath)}
+                      onCloseOthers={() => handleCloseOtherEditorTabs(tab.filePath)}
+                      onCloseAll={handleCloseAllEditorTabs}
+                      onCopyPath={() => void clipboardApi.writeText(tab.filePath)}
+                      onDragStart={(e) => handleTabDragStart(tab.id, e)}
+                      onDragOver={(e) => handleTabDragOver(tab.id, e)}
+                      onDragLeave={handleTabDragLeave}
+                      onDrop={(e) => handleTabDrop(tab.id, e)}
+                    />
+                  )}
+                </div>
+              )
+            })}
+          </div>
         </div>
 
         {hasOverflow && (

--- a/src/renderer/hooks/use-pane-dnd.tsx
+++ b/src/renderer/hooks/use-pane-dnd.tsx
@@ -1,13 +1,19 @@
 import { createContext, useContext, useState, useCallback, useEffect } from 'react'
-import { useWorkspaceStore } from '@/stores/workspace-store'
+import { useWorkspaceStore, findPaneById } from '@/stores/workspace-store'
 import { useEditorStore } from '@/stores/editor-store'
 import { editorTabId } from '@/stores/workspace-store'
-import type { DragPayload, DropPosition } from '@/types/workspace.types'
+import type { DragPayload, DropPosition, TabReorderPosition } from '@/types/workspace.types'
 import type { WorkspaceTab } from '@/stores/workspace-store'
 
 interface DropPreviewTarget {
   paneId: string
   position: DropPosition
+}
+
+export interface ReorderPreview {
+  paneId: string
+  targetTabId: string
+  position: TabReorderPosition
 }
 
 interface PaneDndContextValue {
@@ -16,9 +22,13 @@ interface PaneDndContextValue {
   previewTarget: DropPreviewTarget | null
   setPreviewTarget: (paneId: string, position: DropPosition) => void
   clearPreviewTarget: (paneId?: string, position?: DropPosition) => void
+  reorderPreview: ReorderPreview | null
+  setReorderPreview: (paneId: string, targetTabId: string, position: TabReorderPosition) => void
+  clearReorderPreview: () => void
   startTabDrag: (tabId: string, paneId: string, event: React.DragEvent) => void
   startFileDrag: (filePath: string, event: React.DragEvent) => void
   handleDrop: (targetPaneId: string, position: DropPosition, event: React.DragEvent) => void
+  handleTabReorder: (sourcePaneId: string, targetTabId: string, position: TabReorderPosition) => void
 }
 
 const PaneDndContext = createContext<PaneDndContextValue | null>(null)
@@ -76,6 +86,7 @@ export function PaneDndProvider({ children }: PaneDndProviderProps): React.JSX.E
   const [isDragging, setIsDragging] = useState(false)
   const [dragPayload, setDragPayload] = useState<DragPayload | null>(null)
   const [previewTarget, setPreviewTargetState] = useState<DropPreviewTarget | null>(null)
+  const [reorderPreview, setReorderPreviewState] = useState<ReorderPreview | null>(null)
 
   const clearPreviewTarget = useCallback((paneId?: string, position?: DropPosition) => {
     setPreviewTargetState((current) => {
@@ -95,19 +106,40 @@ export function PaneDndProvider({ children }: PaneDndProviderProps): React.JSX.E
     })
   }, [])
 
+  const setReorderPreview = useCallback(
+    (paneId: string, targetTabId: string, position: TabReorderPosition) => {
+      setReorderPreviewState((current) => {
+        if (
+          current?.paneId === paneId &&
+          current.targetTabId === targetTabId &&
+          current.position === position
+        ) {
+          return current
+        }
+        return { paneId, targetTabId, position }
+      })
+    },
+    []
+  )
+
+  const clearReorderPreview = useCallback(() => {
+    setReorderPreviewState(null)
+  }, [])
+
   // Track drag state via document-level events
   useEffect(() => {
     const handleDragEnd = (): void => {
       setIsDragging(false)
       setDragPayload(null)
       clearPreviewTarget()
+      clearReorderPreview()
     }
 
     document.addEventListener('dragend', handleDragEnd)
     return () => {
       document.removeEventListener('dragend', handleDragEnd)
     }
-  }, [clearPreviewTarget])
+  }, [clearPreviewTarget, clearReorderPreview])
 
   const startTabDrag = useCallback(
     (tabId: string, paneId: string, event: React.DragEvent) => {
@@ -199,6 +231,57 @@ export function PaneDndProvider({ children }: PaneDndProviderProps): React.JSX.E
     [dragPayload, clearPreviewTarget]
   )
 
+  const handleTabReorder = useCallback(
+    (sourcePaneId: string, targetTabId: string, position: TabReorderPosition) => {
+      if (!dragPayload || dragPayload.type !== 'tab' || !dragPayload.tabId) {
+        return
+      }
+
+      const sourceTabId = dragPayload.tabId
+
+      // Don't reorder if dropping on self
+      if (sourceTabId === targetTabId) {
+        return
+      }
+
+      const store = useWorkspaceStore.getState()
+      const pane = findPaneById(store.root, sourcePaneId)
+
+      if (!pane || pane.type !== 'leaf') {
+        return
+      }
+
+      const tabs = pane.tabs
+      const sourceIndex = tabs.findIndex((t: WorkspaceTab) => t.id === sourceTabId)
+      const targetIndex = tabs.findIndex((t: WorkspaceTab) => t.id === targetTabId)
+
+      if (sourceIndex === -1 || targetIndex === -1) {
+        return
+      }
+
+      // Calculate new order
+      const newTabs = [...tabs]
+      const [movedTab] = newTabs.splice(sourceIndex, 1)
+
+      // Adjust target index if source was before target
+      let insertIndex = targetIndex
+      if (sourceIndex < targetIndex) {
+        insertIndex = targetIndex - 1
+      }
+
+      // Add offset for 'after' position
+      if (position === 'after') {
+        insertIndex += 1
+      }
+
+      newTabs.splice(insertIndex, 0, movedTab)
+
+      store.reorderTabsInPane(sourcePaneId, newTabs.map((t: WorkspaceTab) => t.id))
+      clearReorderPreview()
+    },
+    [dragPayload, clearReorderPreview]
+  )
+
   return (
     <PaneDndContext.Provider
       value={{
@@ -207,9 +290,13 @@ export function PaneDndProvider({ children }: PaneDndProviderProps): React.JSX.E
         previewTarget,
         setPreviewTarget,
         clearPreviewTarget,
+        reorderPreview,
+        setReorderPreview,
+        clearReorderPreview,
         startTabDrag,
         startFileDrag,
-        handleDrop
+        handleDrop,
+        handleTabReorder
       }}
     >
       {children}

--- a/src/renderer/types/workspace.types.ts
+++ b/src/renderer/types/workspace.types.ts
@@ -19,7 +19,11 @@ export interface LeafNode {
 
 export type PaneNode = SplitNode | LeafNode
 
+// Pane-relative drop positions for creating splits
 export type DropPosition = 'left' | 'right' | 'top' | 'bottom' | 'center'
+
+// Tab-relative positions for intra-pane reordering
+export type TabReorderPosition = 'before' | 'after'
 
 export interface DragPayload {
   type: 'tab' | 'file'


### PR DESCRIPTION
## Summary
- Removed Framer Motion `Reorder` component which conflicted with native HTML5 drag events
- Consolidated to a single native HTML5 drag system for both intra-pane reordering and cross-pane movement
- Added visual drop indicator line for tab reorder preview
- Added CSS transitions for smooth tab movement animations

## Problem Solved
Users could not reliably reorder tabs within a pane because two competing drag systems (Framer Motion Reorder and native HTML5 drag) fired simultaneously on the same tab elements.

## Test plan
- [x] Drag a tab left/right within the same tab bar - verify reordering works
- [x] Verify drop indicator appears at correct position (left/right of target tab)
- [x] Drag a tab to another pane - verify split creation still works
- [x] Verify source tab becomes semi-transparent during drag
- [x] All 10 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Custom tab drag-and-drop with explicit before/after drop indicators and drop previews for precise reordering.

* **Improvements**
  * Subtle drag visuals (opacity/scale) and clearer drop-target cues.
  * Context menu actions reflect tab editing state (rename / kill-process).

* **Tests**
  * Expanded coverage for drag start, drop positioning, reordering, and visual state assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->