### PR TITLE
fix: restore tab drag-and-drop pane splitting

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -22,7 +22,8 @@
         "minHeight": 600,
         "decorations": false,
         "visible": false,
-        "transparent": false
+        "transparent": false,
+        "dragDropEnabled": false
       }
     ],
     "security": {

--- a/src/renderer/components/workspace/WorkspaceTabBar.tsx
+++ b/src/renderer/components/workspace/WorkspaceTabBar.tsx
@@ -466,7 +466,7 @@ export function WorkspaceTabBar({
   }
 
   return (
-    <div className="h-10 bg-card border-b border-border flex items-center">
+    <div className="h-10 bg-card border-b border-border flex items-center" onDragOver={(e) => { e.preventDefault(); e.dataTransfer.dropEffect = 'move' }}>
       <div className="relative flex items-center h-full min-w-0 shrink">
         <div
           ref={tabsContainerRef}

--- a/src/renderer/layouts/WorkspaceLayout.tsx
+++ b/src/renderer/layouts/WorkspaceLayout.tsx
@@ -189,6 +189,7 @@ export default function WorkspaceLayout(): React.JSX.Element {
     return () => {
       cancelled = true
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- activeProject?.path covers the only property used
   }, [activeProject?.path, activeProjectId])
 
   // Editor state persistence
@@ -825,40 +826,40 @@ export default function WorkspaceLayout(): React.JSX.Element {
         )}
 
         {/* Main Content and File Explorer Container */}
-        <div className="flex-1 flex min-h-0 h-full gap-0 overflow-hidden min-w-0">
-          {/* Main Content Area */}
-          <main className="flex-1 flex flex-col min-w-0 rounded-xl bg-card overflow-hidden">
-            {projects.length === 0 ? (
-              /* No Projects Empty State */
-              <div className="flex-1 flex flex-col items-center justify-center bg-background px-6 rounded-xl">
-                <motion.div
-                  initial={{ opacity: 0, scale: 0.9 }}
-                  animate={{ opacity: 1, scale: 1 }}
-                  transition={{ duration: 0.4, ease: 'easeOut' }}
-                  className="flex flex-col items-center text-center max-w-md"
-                >
-                  <div className="mb-6">
-                    <FolderKanban className="w-24 h-24 text-muted-foreground/50" />
-                  </div>
-                  <h2 className="text-xl font-semibold text-foreground mb-2">
-                    No Projects Yet
-                  </h2>
-                  <p className="text-muted-foreground text-sm mb-6 leading-relaxed">
-                    Create your first project to organize your terminals, snapshots, and commands
-                  </p>
-                  <button
-                    onClick={() => setIsNewProjectModalOpen(true)}
-                    className="px-6 py-2.5 bg-primary text-primary-foreground rounded-xl hover:bg-primary/90 transition-colors text-sm font-medium shadow-sm hover:shadow"
+        <PaneDndProvider>
+          <div className="flex-1 flex min-h-0 h-full gap-0 overflow-hidden min-w-0">
+            {/* Main Content Area */}
+            <main className="flex-1 flex flex-col min-w-0 rounded-xl bg-card overflow-hidden">
+              {projects.length === 0 ? (
+                /* No Projects Empty State */
+                <div className="flex-1 flex flex-col items-center justify-center bg-background px-6 rounded-xl">
+                  <motion.div
+                    initial={{ opacity: 0, scale: 0.9 }}
+                    animate={{ opacity: 1, scale: 1 }}
+                    transition={{ duration: 0.4, ease: 'easeOut' }}
+                    className="flex flex-col items-center text-center max-w-md"
                   >
-                    Create Your First Project
-                  </button>
-                </motion.div>
-              </div>
-            ) : (
-              <>
-                {isWorkspaceRoute ? (
-                  <div className="flex-1 min-h-0 h-full overflow-hidden">
-                    <PaneDndProvider>
+                    <div className="mb-6">
+                      <FolderKanban className="w-24 h-24 text-muted-foreground/50" />
+                    </div>
+                    <h2 className="text-xl font-semibold text-foreground mb-2">
+                      No Projects Yet
+                    </h2>
+                    <p className="text-muted-foreground text-sm mb-6 leading-relaxed">
+                      Create your first project to organize your terminals, snapshots, and commands
+                    </p>
+                    <button
+                      onClick={() => setIsNewProjectModalOpen(true)}
+                      className="px-6 py-2.5 bg-primary text-primary-foreground rounded-xl hover:bg-primary/90 transition-colors text-sm font-medium shadow-sm hover:shadow"
+                    >
+                      Create Your First Project
+                    </button>
+                  </motion.div>
+                </div>
+              ) : (
+                <>
+                  {isWorkspaceRoute ? (
+                    <div className="flex-1 min-h-0 h-full overflow-hidden">
                       <PaneRenderer
                         node={paneRoot}
                         onNewTerminal={(paneId) => {
@@ -872,31 +873,29 @@ export default function WorkspaceLayout(): React.JSX.Element {
                         onCloseEditorTab={handleCloseEditorTab}
                         defaultShell={activeProject?.defaultShell || appDefaultShell}
                       />
-                    </PaneDndProvider>
-                  </div>
-                ) : (
-                  <div className="flex-1 overflow-hidden bg-background relative rounded-xl">
-                    <div className="w-full h-full">
-                      <Outlet />
                     </div>
-                  </div>
-                )}
+                  ) : (
+                    <div className="flex-1 overflow-hidden bg-background relative rounded-xl">
+                      <div className="w-full h-full">
+                        <Outlet />
+                      </div>
+                    </div>
+                  )}
 
-                {/* Status Bar */}
-                <StatusBar project={activeProject} />
-              </>
-            )}
-          </main>
+                  {/* Status Bar */}
+                  <StatusBar project={activeProject} />
+                </>
+              )}
+            </main>
 
-          {/* File Explorer - separate floating panel */}
-          {isExplorerVisible && activeProject?.path && (
-            <div className="flex-shrink-0 ml-2">
-              <PaneDndProvider>
+            {/* File Explorer - separate floating panel */}
+            {isExplorerVisible && activeProject?.path && (
+              <div className="flex-shrink-0 ml-2">
                 <FileExplorer />
-              </PaneDndProvider>
-            </div>
-          )}
-        </div>
+              </div>
+            )}
+          </div>
+        </PaneDndProvider>
       </div>
 
       {/* Modals */}


### PR DESCRIPTION
## Summary
- Disabled Tauri's native `dragDropEnabled` so HTML5 DnD events reach the WebView2 DOM on Windows
- Reunified split `PaneDndProvider` into a single instance wrapping both `PaneRenderer` and `FileExplorer`, restoring shared `isDragging` state
- Added `onDragOver` handler to tab bar container to prevent no-drop cursor in gaps between tabs

## Root Cause
Three separate issues combined to break tab drag-and-drop:
1. **Tauri intercept**: `dragDropEnabled` defaults to `true`, which blocks all HTML5 drag events at the native level
2. **Split provider** (PR #75 regression): Two separate `PaneDndProvider` instances meant `isDragging` set in one was invisible to the other
3. **Missing handler**: Tab bar container lacked `onDragOver`, causing no-drop cursor between tabs

## Test plan
- [ ] Drag a tab from one pane to another pane's content area — DropZoneOverlay appears with split zones
- [ ] Drop on a zone (left/right/top/bottom) — tab moves to new split pane
- [ ] Drop on center zone — tab moves to target pane
- [ ] Drag tab across tab bar gaps — cursor shows move indicator, never no-drop
- [ ] Tab reorder within same pane still works
- [ ] File explorer drag to pane shows DropZoneOverlay
- [ ] Drag cancel (Escape / drop outside) resets cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Improved drag-and-drop handling in the workspace interface.
  * Enhanced empty state screen with better visual presentation and a "Create Your First Project" button for easier project creation.

* **Chores**
  * Updated workspace configuration for improved stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->