### PR TITLE
fix: align tauri auto-update release flow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,7 @@ jobs:
     outputs:
       changelog: ${{ steps.cliff.outputs.content }}
       is_prerelease: ${{ steps.check.outputs.is_prerelease }}
+      normalized_version: ${{ steps.version.outputs.normalized_version }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -34,6 +35,18 @@ jobs:
         env:
           OUTPUT: CHANGELOG.md
           GITHUB_REPO: ${{ github.repository }}
+
+      - name: Normalize tag version
+        id: version
+        shell: bash
+        run: |
+          TAG="${GITHUB_REF#refs/tags/}"
+          VERSION="${TAG#v}"
+          if [[ -z "$VERSION" ]]; then
+            echo "Tag must include a version" >&2
+            exit 1
+          fi
+          echo "normalized_version=$VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Check prerelease
         id: check
@@ -163,6 +176,43 @@ jobs:
       - name: Install npm dependencies
         run: npm ci
 
+      - name: Align app versions with tag
+        shell: bash
+        env:
+          TAG_VERSION: ${{ needs.changelog.outputs.normalized_version }}
+        run: |
+          node <<'NODE'
+          const fs = require('fs')
+
+          const tagVersion = process.env.TAG_VERSION
+          const pkg = JSON.parse(fs.readFileSync('package.json', 'utf8'))
+          if (pkg.version !== tagVersion) {
+            throw new Error(
+              `package.json version ${pkg.version} does not match tag ${tagVersion}`
+            )
+          }
+
+          const cargo = fs.readFileSync('src-tauri/Cargo.toml', 'utf8')
+          const cargoMatch = cargo.match(/^version\s*=\s*"([^"]+)"/m)
+          if (!cargoMatch || cargoMatch[1] !== tagVersion) {
+            const cargoVersion = cargoMatch?.[1] ?? 'missing'
+            throw new Error(
+              `src-tauri/Cargo.toml version ${cargoVersion} ` +
+                `does not match tag ${tagVersion}`
+            )
+          }
+
+          const tauri = JSON.parse(
+            fs.readFileSync('src-tauri/tauri.conf.json', 'utf8')
+          )
+          if (tauri.version !== tagVersion) {
+            throw new Error(
+              `src-tauri/tauri.conf.json version ${tauri.version} ` +
+                `does not match tag ${tagVersion}`
+            )
+          }
+          NODE
+
       - name: Build and publish release artifacts
         uses: tauri-apps/tauri-action@v0
         env:
@@ -185,6 +235,54 @@ jobs:
     needs: [changelog, create_release, build]
     runs-on: ubuntu-latest
     steps:
+      - name: Verify updater assets before publish
+        uses: actions/github-script@v7
+        env:
+          IS_PRERELEASE: ${{ needs.changelog.outputs.is_prerelease }}
+          RELEASE_ID: ${{ needs.create_release.outputs.release_id }}
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const releaseId = Number(process.env.RELEASE_ID)
+            const isPrerelease = process.env.IS_PRERELEASE === 'true'
+            const stableManifestPath =
+              '/releases/latest/download/latest.json'
+            const channelPolicy = isPrerelease
+              ? 'stable clients intentionally ignore prerelease tags'
+              : 'stable clients consume the stable latest.json manifest'
+
+            core.info(`Updater channel policy: ${channelPolicy}`)
+
+            const { data: assets } = await github.rest.repos.listReleaseAssets({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              release_id: releaseId,
+              per_page: 100,
+            })
+
+            const assetNames = assets.map((asset) => asset.name)
+            core.info(`Draft release assets: ${assetNames.join(', ')}`)
+
+            if (isPrerelease) {
+              core.notice(
+                [
+                  'This tag is marked as a prerelease.',
+                  'Stable clients intentionally ignore prerelease tags',
+                  `because they only check ${stableManifestPath}.`,
+                ].join(' ')
+              )
+              return
+            }
+
+            const hasLatestJson = assetNames.includes('latest.json')
+            if (!hasLatestJson) {
+              const publishedAssets = assetNames.join(', ')
+              core.setFailed(
+                `Stable release is missing latest.json. ` +
+                  `Draft assets: ${publishedAssets}`
+              )
+            }
+
       - name: Publish draft release
         uses: actions/github-script@v7
         env:

--- a/docs/auto-update-release-verification.md
+++ b/docs/auto-update-release-verification.md
@@ -1,0 +1,40 @@
+# Auto-update Release Verification
+
+Use this checklist after publishing a tagged release to verify that stable clients can detect and apply the update.
+
+## Preconditions
+
+- The release tag is stable unless you are intentionally testing prerelease behavior.
+- `package.json`, `src-tauri/Cargo.toml`, and `src-tauri/tauri.conf.json` all use the same app version as the tag without the leading `v`.
+- CI release workflow completed successfully.
+
+## Stable release verification
+
+1. Install or keep a locally packaged build older than the target release.
+2. Confirm the GitHub release contains a `latest.json` asset.
+3. Open the asset URL in a browser:
+   - `https://github.com/gnoviawan/termul/releases/latest/download/latest.json`
+4. Verify the manifest version matches the released app version.
+5. Launch the older installed app.
+6. Trigger **Check for Updates** from the app menu or preferences.
+7. Confirm the app surfaces the new version.
+8. Start the download.
+9. Confirm the UI describes the next step as restart-based application of the update.
+10. Restart from the updater action and verify the relaunched app reports the new version.
+
+## Prerelease verification
+
+Current policy: stable clients intentionally ignore prerelease tags because the shipped app checks only the stable updater manifest at `/releases/latest/download/latest.json`.
+
+1. Publish a prerelease tag such as `v0.3.2-beta.1`.
+2. Confirm CI marks the GitHub release as prerelease.
+3. Confirm CI logs the stable-channel notice for prereleases.
+4. Verify stable clients do **not** detect that prerelease via `/releases/latest/download/latest.json`.
+5. If prerelease support is needed later, add a separate prerelease channel strategy before expecting stable clients to consume it.
+
+## Failure triage
+
+- If update checks fail, capture the full in-app error message.
+- If stable clients cannot detect the release, confirm `latest.json` exists on the published stable release.
+- If CI fails before publish, confirm the tag version matches all three version files exactly.
+- If the UI implies install-on-quit behavior, treat that as a regression; the current supported flow is download/stage then restart.

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,67 +1,69 @@
 {
-  "$schema": "https://schema.tauri.app/config/2",
-  "productName": "Termul Manager",
-  "version": "0.3.1",
-  "identifier": "com.termul-manager.app",
-  "build": {
-    "beforeDevCommand": "npx vite --config vite.config.tauri.ts",
-    "devUrl": "http://localhost:5173/tauri-index.html",
-    "beforeBuildCommand": "npx vite build --config vite.config.tauri.ts",
-    "frontendDist": "../dist-tauri"
-  },
-  "app": {
-    "withGlobalTauri": true,
-    "windows": [
-      {
-        "label": "main",
-        "url": "tauri-index.html",
-        "title": "Termul Manager",
-        "width": 1200,
-        "height": 800,
-        "minWidth": 800,
-        "minHeight": 600,
-        "decorations": false,
-        "visible": false,
-        "transparent": false,
-        "dragDropEnabled": false
-      }
-    ],
-    "security": {
-      "csp": "default-src 'self'; script-src 'self' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; connect-src ipc: http://ipc.localhost ws://localhost:* ws://127.0.0.1:*; worker-src 'self' blob:; img-src 'self' asset: http://asset.localhost data: https://picsum.photos; font-src 'self' data:; media-src 'self' blob:;"
-    }
-  },
-  "plugins": {
-    "fs": {
-      "requireLiteralLeadingDot": false
-    },
-    "updater": {
-      "active": true,
-      "pubkey": "${TAURI_SIGNING_PUBLIC_KEY}",
-      "endpoints": ["https://github.com/gnoviawan/termul/releases/latest/download/latest.json"],
-      "windows": {
-        "installMode": "passive"
-      }
-    }
-  },
-  "bundle": {
-    "active": true,
-    "targets": "all",
-    "icon": [
-      "icons/32x32.png",
-      "icons/128x128.png",
-      "icons/128x128@2x.png",
-      "icons/icon.icns",
-      "icons/icon.ico"
-    ],
-    "publisher": "gnoviawan",
-    "copyright": "Copyright © 2025 gnoviawan",
-    "category": "Productivity",
-    "shortDescription": "Termul Manager - Project-aware terminal manager",
-    "longDescription": "Termul Manager is a desktop application built with Tauri for enhanced productivity. Organize terminals by project with persistent sessions and snapshots.",
-    "windows": {
-      "nsis": {
-        "displayLanguageSelector": false
-      }
-    }
-  }
+	"$schema": "https://schema.tauri.app/config/2",
+	"productName": "Termul Manager",
+	"version": "0.3.1",
+	"identifier": "com.termul-manager.app",
+	"build": {
+		"beforeDevCommand": "npx vite --config vite.config.tauri.ts",
+		"devUrl": "http://localhost:5173/tauri-index.html",
+		"beforeBuildCommand": "npx vite build --config vite.config.tauri.ts",
+		"frontendDist": "../dist-tauri"
+	},
+	"app": {
+		"withGlobalTauri": true,
+		"windows": [
+			{
+				"label": "main",
+				"url": "tauri-index.html",
+				"title": "Termul Manager",
+				"width": 1200,
+				"height": 800,
+				"minWidth": 800,
+				"minHeight": 600,
+				"decorations": false,
+				"visible": false,
+				"transparent": false,
+				"dragDropEnabled": false
+			}
+		],
+		"security": {
+			"csp": "default-src 'self'; script-src 'self' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; connect-src ipc: http://ipc.localhost ws://localhost:* ws://127.0.0.1:*; worker-src 'self' blob:; img-src 'self' asset: http://asset.localhost data: https://picsum.photos; font-src 'self' data:; media-src 'self' blob:;"
+		}
+	},
+	"plugins": {
+		"fs": {
+			"requireLiteralLeadingDot": false
+		},
+		"updater": {
+			"active": true,
+			"pubkey": "${TAURI_SIGNING_PUBLIC_KEY}",
+			"endpoints": [
+				"https://github.com/gnoviawan/termul/releases/latest/download/latest.json"
+			],
+			"windows": {
+				"installMode": "passive"
+			}
+		}
+	},
+	"bundle": {
+		"active": true,
+		"targets": "all",
+		"icon": [
+			"icons/32x32.png",
+			"icons/128x128.png",
+			"icons/128x128@2x.png",
+			"icons/icon.icns",
+			"icons/icon.ico"
+		],
+		"publisher": "gnoviawan",
+		"copyright": "Copyright © 2025 gnoviawan",
+		"category": "Productivity",
+		"shortDescription": "Termul Manager - Project-aware terminal manager",
+		"longDescription": "Termul Manager is a desktop application built with Tauri for enhanced productivity. Organize terminals by project with persistent sessions and snapshots.",
+		"windows": {
+			"nsis": {
+				"displayLanguageSelector": false
+			}
+		}
+	}
 }

--- a/src/renderer/components/UpdateAvailableToast.tsx
+++ b/src/renderer/components/UpdateAvailableToast.tsx
@@ -76,14 +76,14 @@ export function showUpdateToast(version: string, releaseNotes?: string): void {
  * Show a toast notification when update is downloaded
  */
 export function showUpdateDownloadedToast(version: string): void {
-  toast.success(`Update ready to install!`, {
+  toast.success(`Update ready to restart`, {
     duration: 30000,
-    description: `Version ${version} has been downloaded and is ready to install.`,
+    description: `Version ${version} has been downloaded. Restart the app to finish applying the update.`,
     action: {
       label: (
         <div className="flex items-center gap-2">
           <Download size={14} />
-          <span>Install & Restart</span>
+          <span>Restart to Update</span>
         </div>
       ),
       onClick: () => {

--- a/src/renderer/components/UpdateReadyModal.tsx
+++ b/src/renderer/components/UpdateReadyModal.tsx
@@ -7,7 +7,6 @@ interface UpdateReadyModalProps {
   version: string
   releaseNotes?: string
   hasActiveTerminals: boolean
-  onInstallWhenQuit: () => void
   onRestartNow: () => void
   onSkip: () => void
   onClose: () => void
@@ -18,7 +17,6 @@ export function UpdateReadyModal({
   version,
   releaseNotes,
   hasActiveTerminals,
-  onInstallWhenQuit,
   onRestartNow,
   onSkip,
   onClose
@@ -74,7 +72,7 @@ export function UpdateReadyModal({
                 <div className="w-5 h-5 rounded bg-green-500/10 flex items-center justify-center">
                   <Download className="w-3 h-3 text-green-500" />
                 </div>
-                <h3 className="text-sm font-semibold text-foreground">Update Ready to Install</h3>
+                <h3 className="text-sm font-semibold text-foreground">Update Ready to Apply</h3>
               </div>
               <button
                 onClick={onClose}
@@ -101,7 +99,9 @@ export function UpdateReadyModal({
                     Release Notes
                   </label>
                   <div className="bg-secondary border border-border rounded px-3 py-2 text-sm text-foreground max-h-[200px] overflow-y-auto">
-                    <div className="whitespace-pre-wrap text-xs leading-relaxed">{releaseNotes}</div>
+                    <div className="whitespace-pre-wrap text-xs leading-relaxed">
+                      {releaseNotes}
+                    </div>
                   </div>
                 </div>
               )}
@@ -112,8 +112,8 @@ export function UpdateReadyModal({
                   <AlertTriangle className="w-4 h-4 text-amber-500 flex-shrink-0 mt-0.5" />
                   <div className="flex-1">
                     <p className="text-xs text-amber-600 dark:text-amber-400">
-                      You have active terminal sessions. Restarting will close all terminals. Make sure
-                      you've saved any important work.
+                      Restarting now will close all active terminal sessions. Make sure you've saved
+                      any important work before applying the update.
                     </p>
                   </div>
                 </div>
@@ -130,16 +130,9 @@ export function UpdateReadyModal({
               </button>
               <button
                 onClick={onRestartNow}
-                disabled={hasActiveTerminals}
-                className="px-3 py-1.5 text-xs font-medium rounded border border-border bg-secondary text-foreground hover:bg-secondary/80 transition-all disabled:opacity-50 disabled:cursor-not-allowed"
-              >
-                Restart Now
-              </button>
-              <button
-                onClick={onInstallWhenQuit}
                 className="px-3 py-1.5 text-xs font-medium rounded bg-green-600 text-white hover:bg-green-700 shadow-md shadow-green-500/20 transition-all"
               >
-                Install When I Quit
+                Restart to Update
               </button>
             </div>
           </motion.div>

--- a/src/renderer/lib/__tests__/tauri-updater-api.test.ts
+++ b/src/renderer/lib/__tests__/tauri-updater-api.test.ts
@@ -121,10 +121,20 @@ describe('tauri-updater-api', () => {
       })
     })
 
-    it('throws standardized error when check fails', async () => {
+    it('throws actionable error details when check fails', async () => {
       vi.mocked(check).mockRejectedValue(new Error('network down'))
 
-      await expect(checkForUpdates()).rejects.toThrow('Failed to check for updates')
+      await expect(checkForUpdates()).rejects.toThrow(
+        'Failed to check for updates from https://github.com/gnoviawan/termul/releases/latest/download/latest.json: network down'
+      )
+    })
+
+    it('preserves non-Error check failure details', async () => {
+      vi.mocked(check).mockRejectedValue({ status: 404, url: 'latest.json' })
+
+      await expect(checkForUpdates()).rejects.toThrow(
+        'Failed to check for updates from https://github.com/gnoviawan/termul/releases/latest/download/latest.json: {"status":404,"url":"latest.json"}'
+      )
     })
   })
 
@@ -291,7 +301,9 @@ describe('tauri-updater-api', () => {
     })
 
     it('mapTauriUpdateToInfo maps body/date correctly', () => {
-      const info = mapTauriUpdateToInfo(createMockUpdate('3.0.0', 'notes', '2026-03-01T12:00:00.000Z') as never)
+      const info = mapTauriUpdateToInfo(
+        createMockUpdate('3.0.0', 'notes', '2026-03-01T12:00:00.000Z') as never
+      )
 
       expect(info).toEqual({
         version: '3.0.0',

--- a/src/renderer/lib/tauri-updater-api.ts
+++ b/src/renderer/lib/tauri-updater-api.ts
@@ -11,6 +11,15 @@ import {
 import { BackupErrorCodes, createBackup, setAppVersion } from './tauri-backup-api'
 import { keepPreviousVersion, setCurrentVersion } from './tauri-rollback-api'
 
+const STABLE_UPDATE_MANIFEST_URL =
+  'https://github.com/gnoviawan/termul/releases/latest/download/latest.json'
+
+/**
+ * Stable channel policy: the shipped app only checks the stable GitHub Releases
+ * manifest at /releases/latest/download/latest.json. Prerelease tags are
+ * intentionally excluded from automatic detection by stable clients.
+ */
+
 let pendingUpdate: Update | null = null
 let autoUpdateEnabled = true
 let lastCheckedAt: string | null = null
@@ -25,7 +34,29 @@ export interface TauriUpdaterEventHandlers {
 }
 
 function getErrorMessage(error: unknown, fallback: string): string {
-  return error instanceof Error ? error.message : fallback
+  if (error instanceof Error && error.message.trim()) {
+    return error.message
+  }
+
+  if (typeof error === 'string' && error.trim()) {
+    return error
+  }
+
+  try {
+    const serialized = JSON.stringify(error)
+    if (serialized && serialized !== '{}') {
+      return serialized
+    }
+  } catch {
+    // Ignore serialization failures and use the fallback below.
+  }
+
+  return fallback
+}
+
+function createUpdaterCheckError(error: unknown): Error {
+  const details = getErrorMessage(error, 'Unknown updater error')
+  return new Error(`Failed to check for updates from ${STABLE_UPDATE_MANIFEST_URL}: ${details}`)
 }
 
 async function syncRecoveryVersionMetadata(): Promise<string> {
@@ -136,12 +167,13 @@ export async function checkForUpdates(): Promise<UpdateInfo | null> {
     const update = await check()
     pendingUpdate = update
     downloadedVersion = update && downloadedVersion === update.version ? downloadedVersion : null
-    preparedUpdateVersion = update && preparedUpdateVersion === update.version ? preparedUpdateVersion : null
+    preparedUpdateVersion =
+      update && preparedUpdateVersion === update.version ? preparedUpdateVersion : null
     lastCheckedAt = new Date().toISOString()
     return update ? mapTauriUpdateToInfo(update) : null
-  } catch {
+  } catch (error) {
     lastCheckedAt = new Date().toISOString()
-    throw new Error('Failed to check for updates')
+    throw createUpdaterCheckError(error)
   }
 }
 

--- a/src/renderer/stores/updater-store.test.ts
+++ b/src/renderer/stores/updater-store.test.ts
@@ -6,9 +6,8 @@ import * as tauriUpdaterApi from '@/lib/tauri-updater-api'
 import * as tauriVersionSkip from '@/lib/tauri-version-skip'
 
 vi.mock('@/lib/tauri-updater-api', async () => {
-  const actual = await vi.importActual<typeof import('@/lib/tauri-updater-api')>(
-    '@/lib/tauri-updater-api'
-  )
+  const actual =
+    await vi.importActual<typeof import('@/lib/tauri-updater-api')>('@/lib/tauri-updater-api')
   return {
     ...actual,
     checkForUpdates: vi.fn(),
@@ -36,9 +35,8 @@ vi.mock('@/lib/tauri-version-skip', async () => {
 })
 
 vi.mock('@/lib/tauri-safe-update', async () => {
-  const actual = await vi.importActual<typeof import('@/lib/tauri-safe-update')>(
-    '@/lib/tauri-safe-update'
-  )
+  const actual =
+    await vi.importActual<typeof import('@/lib/tauri-safe-update')>('@/lib/tauri-safe-update')
   return {
     ...actual,
     hasActiveTerminalSessions: vi.fn(() => false)
@@ -180,15 +178,22 @@ describe('updater-store', () => {
       expect(state.version).toBe('2.0.0')
     })
 
-    it('should not call updater when active terminals exist', async () => {
+    it('should still check for updates when active terminals exist', async () => {
       vi.mocked(tauriSafeUpdate.hasActiveTerminalSessions).mockReturnValue(true)
+      vi.mocked(tauriUpdaterApi.checkForUpdates).mockResolvedValue({
+        version: '2.0.0',
+        releaseDate: '2026-01-01T00:00:00.000Z',
+        releaseNotes: 'Important fixes',
+        isSecurityUpdate: false
+      })
 
       await useUpdaterStore.getState().checkForUpdates()
 
-      expect(tauriUpdaterApi.checkForUpdates).not.toHaveBeenCalled()
-      expect(useUpdaterStore.getState().error).toBe(
-        'Update checks paused because active terminal sessions are running.'
-      )
+      const state = useUpdaterStore.getState()
+      expect(tauriUpdaterApi.checkForUpdates).toHaveBeenCalledTimes(1)
+      expect(state.hasActiveTerminals).toBe(true)
+      expect(state.updateAvailable).toBe(true)
+      expect(state.error).toBeNull()
     })
 
     it('should surface Tauri updater errors', async () => {
@@ -287,16 +292,19 @@ describe('updater-store', () => {
       expect(tauriUpdaterApi.checkForUpdates).toHaveBeenCalledTimes(1)
     })
 
-    it('should not retry when check pause is caused by active terminals', async () => {
+    it('should still run checks without retry loops when active terminals are present and the check succeeds', async () => {
       vi.useFakeTimers()
       vi.mocked(tauriSafeUpdate.hasActiveTerminalSessions).mockReturnValue(true)
+      vi.mocked(tauriUpdaterApi.checkForUpdates).mockResolvedValue({
+        version: '2.0.0',
+        releaseDate: '2026-01-01T00:00:00.000Z',
+        isSecurityUpdate: false
+      })
 
       await useUpdaterStore.getState().runCheckWithRetry()
 
-      expect(tauriUpdaterApi.checkForUpdates).not.toHaveBeenCalled()
-      expect(useUpdaterStore.getState().error).toBe(
-        'Update checks paused because active terminal sessions are running.'
-      )
+      expect(tauriUpdaterApi.checkForUpdates).toHaveBeenCalledTimes(1)
+      expect(useUpdaterStore.getState().error).toBeNull()
 
       vi.useRealTimers()
     })

--- a/src/renderer/stores/updater-store.ts
+++ b/src/renderer/stores/updater-store.ts
@@ -1,10 +1,6 @@
 import { create } from 'zustand'
 import { useShallow } from 'zustand/shallow'
-import type {
-  UpdateInfo,
-  UpdateState,
-  DownloadProgress
-} from '@shared/types/updater.types'
+import type { UpdateInfo, UpdateState, DownloadProgress } from '@shared/types/updater.types'
 import {
   checkForUpdates as tauriCheckForUpdates,
   downloadUpdate as tauriDownloadUpdate,
@@ -116,14 +112,6 @@ export const useUpdaterStore = create<UpdaterStoreState>((set, get) => ({
     try {
       const activeTerminals = hasActiveTerminalSessions()
       set({ hasActiveTerminals: activeTerminals })
-
-      if (activeTerminals) {
-        set({
-          isChecking: false,
-          error: 'Update checks paused because active terminal sessions are running.'
-        })
-        return
-      }
 
       const updateInfo = await tauriCheckForUpdates()
       const checkedAt = new Date()
@@ -443,10 +431,6 @@ export const useUpdaterStore = create<UpdaterStoreState>((set, get) => ({
 
       const currentError = get().error
       if (!currentError) return
-
-      const isRetryablePauseError =
-        currentError === 'Update checks paused because active terminal sessions are running.'
-      if (isRetryablePauseError) return
 
       if (attempt === RETRY_DELAYS_MS.length) return
 


### PR DESCRIPTION
## Summary
- align Tauri release CI with the shipped stable updater manifest flow
- fail CI when tag/app versions drift or stable releases are missing latest.json
- preserve actionable updater errors and align restart-based updater UI copy
- allow update checks even with active terminals and add verification/test coverage

## Testing
- npx vitest run src/renderer/lib/__tests__/tauri-updater-api.test.ts src/renderer/stores/updater-store.test.ts