### PR TITLE
ci: remove macos build targets from release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -128,14 +128,7 @@ jobs:
             runner: windows-latest
             rust_target: x86_64-pc-windows-msvc
             args: --target x86_64-pc-windows-msvc
-          - platform: macos-arm64
-            runner: macos-14
-            rust_target: aarch64-apple-darwin
-            args: --target aarch64-apple-darwin
-          - platform: macos-x64
-            runner: macos-13
-            rust_target: x86_64-apple-darwin
-            args: --target x86_64-apple-darwin
+
           - platform: linux-x64
             runner: ubuntu-22.04
             rust_target: x86_64-unknown-linux-gnu


### PR DESCRIPTION
Removing macOS build targets from release pipeline to prevent hanging builds. The macos runner queued for >24h.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed macOS builds from the release workflow. Releases are now available for Windows and Linux only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->