### PR TITLE
feat: add AUR update support

### DIFF
--- a/.github/workflows/publish-aur.yml
+++ b/.github/workflows/publish-aur.yml
@@ -1,0 +1,101 @@
+name: Publish AUR
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Version to publish, without leading v
+        required: true
+        type: string
+
+concurrency:
+  group: publish-aur-${{ github.event.release.tag_name || inputs.version }}
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    name: Update termul-manager on AUR
+    runs-on: ubuntu-latest
+    if: github.event_name == 'workflow_dispatch' || github.event.release.prerelease == false
+    container:
+      image: archlinux:base-devel
+    env:
+      AUR_PACKAGE: termul-manager
+      AUR_REPO: ssh://aur@aur.archlinux.org/termul-manager.git
+    steps:
+      - name: Install tools
+        run: |
+          pacman -Syu --noconfirm --needed git openssh pacman-contrib
+          useradd -m builder
+
+      - name: Configure Git
+        run: |
+          runuser -u builder -- git config --global user.name "github-actions[bot]"
+          runuser -u builder -- git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Configure AUR SSH
+        env:
+          AUR_SSH_PRIVATE_KEY: ${{ secrets.AUR_SSH_PRIVATE_KEY }}
+        run: |
+          test -n "$AUR_SSH_PRIVATE_KEY"
+          install -d -m 700 -o builder -g builder /home/builder/.ssh
+          printf '%s\n' "$AUR_SSH_PRIVATE_KEY" > /home/builder/.ssh/aur
+          chown builder:builder /home/builder/.ssh/aur
+          chmod 600 /home/builder/.ssh/aur
+          ssh-keyscan aur.archlinux.org > /home/builder/.ssh/known_hosts
+          chown builder:builder /home/builder/.ssh/known_hosts
+          cat > /home/builder/.ssh/config <<'EOF'
+          Host aur.archlinux.org
+            User aur
+            IdentityFile ~/.ssh/aur
+            IdentitiesOnly yes
+          EOF
+          chown builder:builder /home/builder/.ssh/config
+          chmod 600 /home/builder/.ssh/config
+
+      - name: Resolve version
+        id: version
+        shell: bash
+        run: |
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            VERSION="${{ inputs.version }}"
+          else
+            VERSION="${{ github.event.release.tag_name }}"
+          fi
+          VERSION="${VERSION#v}"
+          if [[ ! "$VERSION" =~ ^[0-9]+(\.[0-9]+){1,2}([._+-][0-9A-Za-z]+)?$ ]]; then
+            echo "Invalid version: $VERSION" >&2
+            exit 1
+          fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Clone AUR package
+        run: |
+          runuser -u builder -- git clone "$AUR_REPO" "/home/builder/$AUR_PACKAGE"
+
+      - name: Update PKGBUILD
+        working-directory: /home/builder/termul-manager
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          runuser -u builder -- sed -i \
+            -e "s/^pkgver=.*/pkgver=$VERSION/" \
+            -e "s/^pkgrel=.*/pkgrel=1/" \
+            PKGBUILD
+          runuser -u builder -- updpkgsums
+          runuser -u builder -- bash -c 'makepkg --printsrcinfo > .SRCINFO'
+
+      - name: Commit and push
+        working-directory: /home/builder/termul-manager
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          if runuser -u builder -- git diff --quiet; then
+            echo "AUR package already up to date."
+            exit 0
+          fi
+          runuser -u builder -- git add PKGBUILD .SRCINFO
+          runuser -u builder -- git commit -m "Update to $VERSION"
+          runuser -u builder -- git push origin HEAD:master

--- a/.github/workflows/publish-aur.yml
+++ b/.github/workflows/publish-aur.yml
@@ -44,7 +44,9 @@ jobs:
           printf '%s\n' "$AUR_SSH_PRIVATE_KEY" > /home/builder/.ssh/aur
           chown builder:builder /home/builder/.ssh/aur
           chmod 600 /home/builder/.ssh/aur
-          ssh-keyscan aur.archlinux.org > /home/builder/.ssh/known_hosts
+          printf '%s\n' \
+            'aur.archlinux.org ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIEuBKrPzbawxA/k2g6NcyV5jmqwJ2s+zpgZGZ7tpLIcN' \
+            > /home/builder/.ssh/known_hosts
           chown builder:builder /home/builder/.ssh/known_hosts
           cat > /home/builder/.ssh/config <<'EOF'
           Host aur.archlinux.org
@@ -98,4 +100,6 @@ jobs:
           fi
           runuser -u builder -- git add PKGBUILD .SRCINFO
           runuser -u builder -- git commit -m "Update to $VERSION"
+          runuser -u builder -- git fetch origin master
+          runuser -u builder -- git rebase origin/master
           runuser -u builder -- git push origin HEAD:master

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4976,7 +4976,7 @@ dependencies = [
 
 [[package]]
 name = "termul-manager"
-version = "0.3.0"
+version = "0.3.2"
 dependencies = [
  "anyhow",
  "chrono",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -27,7 +27,7 @@
 			}
 		],
 		"security": {
-			"csp": "default-src 'self'; script-src 'self' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; connect-src ipc: http://ipc.localhost ws://localhost:* ws://127.0.0.1:*; worker-src 'self' blob:; img-src 'self' asset: http://asset.localhost data: https://picsum.photos; font-src 'self' data:; media-src 'self' blob:;"
+			"csp": "default-src 'self'; script-src 'self' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; connect-src ipc: http://ipc.localhost ws://localhost:* ws://127.0.0.1:* https://api.github.com; worker-src 'self' blob:; img-src 'self' asset: http://asset.localhost data: https://picsum.photos; font-src 'self' data:; media-src 'self' blob:;"
 		}
 	},
 	"plugins": {

--- a/src/renderer/components/UpdateAvailableToast.tsx
+++ b/src/renderer/components/UpdateAvailableToast.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef } from 'react'
 import { toast } from 'sonner'
-import { Download, X, Clock } from 'lucide-react'
+import { Download, Terminal, Clock } from 'lucide-react'
 import {
   updaterStore,
   useUpdaterState,
@@ -10,6 +10,7 @@ import {
   useIsDownloading,
   useDownloadProgress
 } from '@/stores/updater-store'
+import { isAurUpdateMode } from '@/lib/tauri-updater-api'
 
 // Local storage keys
 const UPDATE_REMINDER_KEY = 'update-reminder-timestamp'
@@ -40,20 +41,30 @@ function setReminderForTomorrow(): void {
  * Show a toast notification for available update
  */
 export function showUpdateToast(version: string, releaseNotes?: string): void {
+  const isAur = isAurUpdateMode()
+
   toast.success(`Update available: version ${version}`, {
     duration: 30000,
     description: releaseNotes
       ? `What's new:\n${releaseNotes.slice(0, 100)}${releaseNotes.length > 100 ? '...' : ''}`
-      : 'A new version is available for download.',
+      : isAur
+        ? 'A new version is available. Update with yay.'
+        : 'A new version is available for download.',
     action: {
       label: (
         <div className="flex items-center gap-2">
-          <Download size={14} />
-          <span>Download</span>
+          {isAur ? <Terminal size={14} /> : <Download size={14} />}
+          <span>{isAur ? 'Use yay' : 'Download'}</span>
         </div>
       ),
       onClick: () => {
-        // Trigger download via global store
+        if (isAur) {
+          toast.info('Run in terminal', {
+            description: 'yay -S termul-manager'
+          })
+          return
+        }
+
         const { downloadUpdate } = updaterStore.getState()
         downloadUpdate()
       }

--- a/src/renderer/lib/tauri-updater-api.ts
+++ b/src/renderer/lib/tauri-updater-api.ts
@@ -14,6 +14,7 @@ import { keepPreviousVersion, setCurrentVersion } from './tauri-rollback-api'
 const STABLE_UPDATE_MANIFEST_URL =
   'https://github.com/gnoviawan/termul/releases/latest/download/latest.json'
 const UPSTREAM_LATEST_RELEASE_URL = 'https://api.github.com/repos/gnoviawan/termul/releases/latest'
+const AUR_UPDATE_CHECK_TIMEOUT_MS = 8000
 
 export type UpdateMode = 'tauri' | 'aur'
 
@@ -185,6 +186,7 @@ interface GitHubRelease {
 }
 
 function normalizeVersion(version: string): string {
+  // Ignore AUR pkgrel/build metadata; app updates only track upstream release versions.
   return version.trim().replace(/^v/i, '').split(/[+-]/)[0] ?? version
 }
 
@@ -213,14 +215,22 @@ function mapGitHubReleaseToInfo(release: GitHubRelease): UpdateInfo {
 }
 
 async function checkAurUpdate(): Promise<UpdateInfo | null> {
+  const controller = new AbortController()
+  const timeoutId = window.setTimeout(() => {
+    controller.abort()
+  }, AUR_UPDATE_CHECK_TIMEOUT_MS)
+
   const [currentVersion, response] = await Promise.all([
     getVersion(),
     fetch(UPSTREAM_LATEST_RELEASE_URL, {
       headers: {
         Accept: 'application/vnd.github+json'
-      }
+      },
+      signal: controller.signal
     })
-  ])
+  ]).finally(() => {
+    window.clearTimeout(timeoutId)
+  })
 
   if (!response.ok) {
     throw new Error(`GitHub returned HTTP ${response.status}`)

--- a/src/renderer/lib/tauri-updater-api.ts
+++ b/src/renderer/lib/tauri-updater-api.ts
@@ -13,14 +13,20 @@ import { keepPreviousVersion, setCurrentVersion } from './tauri-rollback-api'
 
 const STABLE_UPDATE_MANIFEST_URL =
   'https://github.com/gnoviawan/termul/releases/latest/download/latest.json'
+const UPSTREAM_LATEST_RELEASE_URL = 'https://api.github.com/repos/gnoviawan/termul/releases/latest'
+
+export type UpdateMode = 'tauri' | 'aur'
+
+const UPDATE_MODE: UpdateMode =
+  import.meta.env.VITE_TERMUL_UPDATE_MODE === 'aur' ? 'aur' : 'tauri'
 
 /**
- * Stable channel policy: the shipped app only checks the stable GitHub Releases
- * manifest at /releases/latest/download/latest.json. Prerelease tags are
- * intentionally excluded from automatic detection by stable clients.
+ * Default mode uses Tauri's signed updater manifest and self-update flow.
+ * AUR mode only checks upstream GitHub Releases and asks users to update with yay.
  */
 
-let pendingUpdate: Update | null = null
+let pendingTauriUpdate: Update | null = null
+let pendingAurUpdate: UpdateInfo | null = null
 let autoUpdateEnabled = true
 let lastCheckedAt: string | null = null
 let downloadedVersion: string | null = null
@@ -31,6 +37,14 @@ export interface TauriUpdaterEventHandlers {
   onDownloadProgress?: (progress: DownloadProgress) => void
   onUpdateDownloaded?: (update: Update) => void
   onError?: (error: string) => void
+}
+
+export function getUpdateMode(): UpdateMode {
+  return UPDATE_MODE
+}
+
+export function isAurUpdateMode(): boolean {
+  return UPDATE_MODE === 'aur'
 }
 
 function getErrorMessage(error: unknown, fallback: string): string {
@@ -54,9 +68,9 @@ function getErrorMessage(error: unknown, fallback: string): string {
   return fallback
 }
 
-function createUpdaterCheckError(error: unknown): Error {
+function createUpdaterCheckError(error: unknown, sourceUrl: string): Error {
   const details = getErrorMessage(error, 'Unknown updater error')
-  return new Error(`Failed to check for updates from ${STABLE_UPDATE_MANIFEST_URL}: ${details}`)
+  return new Error(`Failed to check for updates from ${sourceUrl}: ${details}`)
 }
 
 async function syncRecoveryVersionMetadata(): Promise<string> {
@@ -162,10 +176,79 @@ function mapDownloadEventToProgress(
   }
 }
 
+interface GitHubRelease {
+  tag_name?: string
+  name?: string
+  body?: string
+  html_url?: string
+  published_at?: string
+}
+
+function normalizeVersion(version: string): string {
+  return version.trim().replace(/^v/i, '').split(/[+-]/)[0] ?? version
+}
+
+function compareVersions(a: string, b: string): number {
+  const partsA = normalizeVersion(a).split('.').map((part) => Number.parseInt(part, 10) || 0)
+  const partsB = normalizeVersion(b).split('.').map((part) => Number.parseInt(part, 10) || 0)
+  const length = Math.max(partsA.length, partsB.length, 3)
+
+  for (let index = 0; index < length; index += 1) {
+    const diff = (partsA[index] ?? 0) - (partsB[index] ?? 0)
+    if (diff !== 0) return diff
+  }
+
+  return 0
+}
+
+function mapGitHubReleaseToInfo(release: GitHubRelease): UpdateInfo {
+  const version = normalizeVersion(release.tag_name ?? release.name ?? '')
+  return {
+    version,
+    releaseDate: release.published_at ?? new Date().toISOString(),
+    releaseNotes: release.body ?? undefined,
+    isSecurityUpdate: false,
+    downloadUrl: release.html_url
+  }
+}
+
+async function checkAurUpdate(): Promise<UpdateInfo | null> {
+  const [currentVersion, response] = await Promise.all([
+    getVersion(),
+    fetch(UPSTREAM_LATEST_RELEASE_URL, {
+      headers: {
+        Accept: 'application/vnd.github+json'
+      }
+    })
+  ])
+
+  if (!response.ok) {
+    throw new Error(`GitHub returned HTTP ${response.status}`)
+  }
+
+  const release = (await response.json()) as GitHubRelease
+  const latestVersion = normalizeVersion(release.tag_name ?? release.name ?? '')
+
+  if (!latestVersion) {
+    throw new Error('Latest release has no version tag')
+  }
+
+  return compareVersions(latestVersion, currentVersion) > 0
+    ? mapGitHubReleaseToInfo(release)
+    : null
+}
+
 export async function checkForUpdates(): Promise<UpdateInfo | null> {
   try {
+    if (isAurUpdateMode()) {
+      const update = await checkAurUpdate()
+      pendingAurUpdate = update
+      lastCheckedAt = new Date().toISOString()
+      return update
+    }
+
     const update = await check()
-    pendingUpdate = update
+    pendingTauriUpdate = update
     downloadedVersion = update && downloadedVersion === update.version ? downloadedVersion : null
     preparedUpdateVersion =
       update && preparedUpdateVersion === update.version ? preparedUpdateVersion : null
@@ -173,23 +256,42 @@ export async function checkForUpdates(): Promise<UpdateInfo | null> {
     return update ? mapTauriUpdateToInfo(update) : null
   } catch (error) {
     lastCheckedAt = new Date().toISOString()
-    throw createUpdaterCheckError(error)
+    throw createUpdaterCheckError(
+      error,
+      isAurUpdateMode() ? UPSTREAM_LATEST_RELEASE_URL : STABLE_UPDATE_MANIFEST_URL
+    )
   }
 }
 
 export async function downloadUpdate(
   onProgress?: (progress: DownloadProgress) => void
 ): Promise<IpcResult<void>> {
-  if (!pendingUpdate) {
+  if (isAurUpdateMode()) {
+    if (!pendingAurUpdate) {
+      return {
+        success: false,
+        error: 'No update available to download',
+        code: UpdaterErrorCodes.UPDATE_NOT_AVAILABLE
+      }
+    }
+
+    return {
+      success: false,
+      error: 'AUR build cannot self-update. Update with: yay -S termul-manager',
+      code: UpdaterErrorCodes.UPDATE_NOT_AVAILABLE
+    }
+  }
+
+  if (!pendingTauriUpdate) {
     return {
       success: false,
       error: 'No update available to download',
-      code: 'UPDATE_NOT_AVAILABLE'
+      code: UpdaterErrorCodes.UPDATE_NOT_AVAILABLE
     }
   }
 
   try {
-    const updateVersion = pendingUpdate.version
+    const updateVersion = pendingTauriUpdate.version
 
     if (preparedUpdateVersion !== updateVersion) {
       const preparationResult = await prepareUpdateRecovery()
@@ -211,7 +313,7 @@ export async function downloadUpdate(
       })
     }
 
-    await pendingUpdate.downloadAndInstall((event) => {
+    await pendingTauriUpdate.downloadAndInstall((event) => {
       if (!onProgress) return
 
       const mapped = mapDownloadEventToProgress(event, downloadedSoFar, totalBytes)
@@ -233,7 +335,15 @@ export async function downloadUpdate(
 }
 
 export async function installAndRestart(): Promise<IpcResult<void>> {
-  if (!pendingUpdate || downloadedVersion !== pendingUpdate.version) {
+  if (isAurUpdateMode()) {
+    return {
+      success: false,
+      error: 'AUR build cannot self-install updates. Update with: yay -S termul-manager',
+      code: UpdaterErrorCodes.UPDATE_NOT_AVAILABLE
+    }
+  }
+
+  if (!pendingTauriUpdate || downloadedVersion !== pendingTauriUpdate.version) {
     return {
       success: false,
       error: 'No downloaded update ready to install',
@@ -254,12 +364,20 @@ export async function installAndRestart(): Promise<IpcResult<void>> {
 }
 
 export async function getUpdaterState(): Promise<IpcResult<UpdateState>> {
+  const updateAvailable = isAurUpdateMode() ? pendingAurUpdate !== null : pendingTauriUpdate !== null
+  const version = isAurUpdateMode()
+    ? pendingAurUpdate?.version ?? null
+    : pendingTauriUpdate?.version ?? null
+  const downloaded = isAurUpdateMode()
+    ? false
+    : pendingTauriUpdate !== null && downloadedVersion === pendingTauriUpdate.version
+
   return {
     success: true,
     data: {
-      updateAvailable: pendingUpdate !== null,
-      downloaded: pendingUpdate !== null && downloadedVersion === pendingUpdate.version,
-      version: pendingUpdate?.version ?? null,
+      updateAvailable,
+      downloaded,
+      version,
       isChecking: false,
       isDownloading: false,
       downloadProgress: null,
@@ -291,13 +409,15 @@ export function registerUpdateEventHandlers(handlers: TauriUpdaterEventHandlers)
 }
 
 export async function clearPendingUpdate(): Promise<void> {
-  pendingUpdate = null
+  pendingTauriUpdate = null
+  pendingAurUpdate = null
   downloadedVersion = null
   preparedUpdateVersion = null
 }
 
 export function _resetUpdaterStateForTesting(): void {
-  pendingUpdate = null
+  pendingTauriUpdate = null
+  pendingAurUpdate = null
   downloadedVersion = null
   preparedUpdateVersion = null
   lastCheckedAt = null

--- a/src/renderer/pages/AppPreferences.tsx
+++ b/src/renderer/pages/AppPreferences.tsx
@@ -26,8 +26,10 @@ import {
 } from '@/hooks/use-keyboard-shortcuts'
 import { useUpdaterState, useUpdaterActions } from '@/stores/updater-store'
 import { shellApi, terminalApi } from '@/lib/api'
+import { isAurUpdateMode } from '@/lib/tauri-updater-api'
 
 export default function AppPreferences(): React.JSX.Element {
+  const isAurUpdater = isAurUpdateMode()
   const fontFamily = useTerminalFontFamily()
   const fontSize = useTerminalFontSize()
   const bufferSize = useTerminalBufferSize()
@@ -492,7 +494,9 @@ export default function AppPreferences(): React.JSX.Element {
                       <div className="flex-1">
                         <div className="text-sm font-medium text-foreground">Version {version} is available!</div>
                         <div className="text-xs text-muted-foreground mt-0.5">
-                          A new version is ready to download.
+                          {isAurUpdater
+                            ? 'Update through AUR with: yay -S termul-manager'
+                            : 'A new version is ready to download.'}
                         </div>
                       </div>
                     </div>

--- a/src/renderer/vite-env.d.ts
+++ b/src/renderer/vite-env.d.ts
@@ -2,6 +2,7 @@
 
 interface ImportMetaEnv {
   readonly PACKAGE_VERSION: string
+  readonly VITE_TERMUL_UPDATE_MODE?: 'tauri' | 'aur'
 }
 
 interface ImportMeta {


### PR DESCRIPTION
## Summary
- add AUR update mode that checks upstream GitHub releases and points users to yay
- keep signed Tauri updater as the default for official builds
- add release workflow to publish termul-manager updates to AUR

## AUR CD setup
The upstream repo needs an `AUR_SSH_PRIVATE_KEY` secret. The matching public key must belong to an AUR account that maintains or co-maintains `termul-manager`.

## Testing
- AUR package built locally as termul-manager 0.3.2-12


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for Arch Linux (AUR) installations with yay-based updates
  * Update notifications now display platform-specific instructions based on your installation method
  * AUR users are guided to use `yay -S termul-manager` for updates through in-app notifications

<!-- end of auto-generated comment: release notes by coderabbit.ai -->