### PR TITLE
chore: bump Cargo version to 0.3.3

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4976,7 +4976,7 @@ dependencies = [
 
 [[package]]
 name = "termul-manager"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "anyhow",
  "chrono",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "termul-manager"
-version = "0.3.2"
+version = "0.3.3"
 description = "Project-aware terminal that treats workspaces as first-class citizens"
 authors = ["gnoviawan", "mannnrachman (Tauri port)"]
 edition = "2021"


### PR DESCRIPTION
Updates src-tauri/Cargo.toml and src-tauri/Cargo.lock to match the v0.3.3 release tag.