### PR TITLE
chore(release): v0.3.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "termul-manager",
 	"productName": "Termul Manager",
-	"version": "0.3.3",
+	"version": "0.3.4",
 	"description": "Project-aware terminal that treats workspaces as first-class citizens",
 	"author": "gnoviawan",
 	"contributors": [

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "termul-manager"
-version = "0.3.3"
+version = "0.3.4"
 description = "Project-aware terminal that treats workspaces as first-class citizens"
 authors = ["gnoviawan", "mannnrachman (Tauri port)"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "https://schema.tauri.app/config/2",
 	"productName": "Termul Manager",
-	"version": "0.3.3",
+	"version": "0.3.4",
 	"identifier": "com.termul-manager.app",
 	"build": {
 		"beforeDevCommand": "npx vite --config vite.config.tauri.ts",

--- a/src/renderer/components/ProjectSidebar.tsx
+++ b/src/renderer/components/ProjectSidebar.tsx
@@ -438,7 +438,7 @@ export function ProjectSidebar({
 			{/* Bottom toolbar - Version */}
 			<div className="p-2 rounded-b-xl">
 				<div className="w-full h-6 inline-flex items-center justify-center">
-					<span className="text-xs text-muted-foreground">Termul v0.3.3</span>
+					<span className="text-xs text-muted-foreground">Termul v0.3.4</span>
 				</div>
 			</div>
 


### PR DESCRIPTION
## What's Changed

Bugfixes:
- Auto-update recovery from missing latest.json
- GitHub API fallback for updater check
- Manual update mode with browser open
- CI hardening: createUpdaterArtifacts + latest.json/.sig verification

**Note:** This replaces the broken v0.3.3 release.