### PR TITLE
fix(updater): hardcode ed25519 public key in config

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -36,7 +36,7 @@
 		},
 		"updater": {
 			"active": true,
-			"pubkey": "${TAURI_SIGNING_PUBLIC_KEY}",
+			"pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDFBRTc4RDBDQUIzMUMwQjEKUldTeHdER3JESTNuR3VGOVRBdjNMTlJEVWk5bWNKTnpCRDExc2JiODVycjV1UTQ3TjdCQU52MWIK",
 			"endpoints": [
 				"https://github.com/gnoviawan/termul/releases/latest/download/latest.json"
 			],


### PR DESCRIPTION
Fixes pubkey env var expansion not supported in tauri.conf.json.