### PR TITLE
feat(terminal): open file paths on ctrl/cmd click

### DIFF
--- a/src/renderer/components/terminal/ConnectedTerminal.test.tsx
+++ b/src/renderer/components/terminal/ConnectedTerminal.test.tsx
@@ -1099,7 +1099,7 @@ describe('ConnectedTerminal', () => {
 
   describe('Terminal file path link handling', () => {
     it('should open a file path only on ctrl/meta click', async () => {
-      vi.mocked(openFilePathFromTerminal).mockResolvedValue(true)
+      vi.mocked(openFilePathFromTerminal).mockResolvedValue({ ok: true })
       render(<ConnectedTerminal terminalId="external-123" />)
 
       await vi.waitFor(() => {
@@ -1115,6 +1115,8 @@ describe('ConnectedTerminal', () => {
       provider.provideLinks(1, (provided) => {
         links = provided
       })
+
+      expect(links.find((link) => link.text === 'missing.ts')).toBeUndefined()
 
       const fileLink = links.find((link) => link.text === 'src/renderer/App.tsx')
       expect(fileLink).toBeDefined()
@@ -1138,7 +1140,11 @@ describe('ConnectedTerminal', () => {
     })
 
     it('should invoke path open with missing terminal cwd context on ctrl+click', async () => {
-      vi.mocked(openFilePathFromTerminal).mockResolvedValue(false)
+      vi.mocked(openFilePathFromTerminal).mockResolvedValue({
+        ok: false,
+        reason: 'missing-context',
+        message: 'No project or working directory found; set a project/cwd to open paths: src/renderer/App.tsx'
+      })
       mockTerminalStoreState.findTerminalByPtyId.mockReturnValue(undefined)
       render(<ConnectedTerminal terminalId="external-123" />)
 
@@ -1168,6 +1174,9 @@ describe('ConnectedTerminal', () => {
         cwd: undefined,
         projectRoot: '/project-root'
       })
+      expect(toast.error).toHaveBeenCalledWith(
+        'No project or working directory found; set a project/cwd to open paths: src/renderer/App.tsx'
+      )
     })
 
     it('should report unexpected ctrl click open failures with toast and console error', async () => {

--- a/src/renderer/components/terminal/ConnectedTerminal.test.tsx
+++ b/src/renderer/components/terminal/ConnectedTerminal.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { render, cleanup } from '@testing-library/react'
+import { toast } from 'sonner'
 
 // Mock Tauri APIs BEFORE importing the component
 vi.mock('@tauri-apps/api/event', () => ({
@@ -17,6 +18,12 @@ vi.mock('@tauri-apps/api/core', () => ({
   )
 }))
 
+vi.mock('sonner', () => ({
+  toast: {
+    error: vi.fn()
+  }
+}))
+
 // Import the mocked modules
 import { listen } from '@tauri-apps/api/event'
 import { invoke } from '@tauri-apps/api/core'
@@ -25,6 +32,10 @@ import { invoke } from '@tauri-apps/api/core'
 const mockTerminalConstructor = vi.fn()
 const mockTerminalInstance = {
   loadAddon: vi.fn(),
+  registerLinkProvider: vi.fn((provider) => {
+    capturedLinkProviders.push(provider)
+    return { dispose: vi.fn() }
+  }),
   open: vi.fn(),
   onData: vi.fn<(_cb: (data: string) => void) => { dispose: () => void }>((cb) => {
     capturedDataCallback = cb
@@ -48,7 +59,15 @@ const mockTerminalInstance = {
   dispose: vi.fn(),
   cols: 80,
   rows: 24,
-  options: {} as Record<string, unknown>
+  options: {} as Record<string, unknown>,
+  buffer: {
+    active: {
+      getLine: vi.fn((index: number) => ({
+        translateToString: () =>
+          index === 0 ? 'missing.ts src/renderer/App.tsx' : ''
+      }))
+    }
+  }
 }
 
 let capturedResizeCallback: ((dims: { cols: number; rows: number }) => void) | null = null
@@ -72,9 +91,12 @@ let lastCreatedWebglInstance: {
   onContextLoss: ReturnType<typeof vi.fn>
 } | null = null
 
-const mockWebLinksAddonInstance = {
-  dispose: vi.fn()
-}
+const capturedLinkProviders: Array<{
+  provideLinks: (
+    y: number,
+    callback: (links: Array<{ activate: (event: MouseEvent, text: string) => void | Promise<void>; text: string }>) => void
+  ) => void
+}> = []
 
 vi.mock('@xterm/xterm', () => ({
   Terminal: class MockTerminal {
@@ -82,6 +104,7 @@ vi.mock('@xterm/xterm', () => ({
       mockTerminalConstructor(options)
     }
     loadAddon = mockTerminalInstance.loadAddon
+    registerLinkProvider = mockTerminalInstance.registerLinkProvider
     open = mockTerminalInstance.open
     onData = mockTerminalInstance.onData
     onResize = mockTerminalInstance.onResize
@@ -98,6 +121,7 @@ vi.mock('@xterm/xterm', () => ({
     cols = mockTerminalInstance.cols
     rows = mockTerminalInstance.rows
     options = mockTerminalInstance.options
+    buffer = mockTerminalInstance.buffer
   }
 }))
 
@@ -125,10 +149,17 @@ vi.mock('@xterm/addon-webgl', () => ({
   }
 }))
 
-vi.mock('@xterm/addon-web-links', () => ({
-  WebLinksAddon: class MockWebLinksAddon {
-    dispose = mockWebLinksAddonInstance.dispose
+
+vi.mock('@/lib/file-path-links', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/file-path-links')>()
+  return {
+    ...actual,
+    openFilePathFromTerminal: vi.fn()
   }
+})
+
+vi.mock('@/stores/project-store', () => ({
+  useActiveProject: vi.fn(() => ({ path: '/project-root' }))
 }))
 
 // Mock window.api with proper typing for mocks
@@ -187,6 +218,7 @@ Object.defineProperty(window, 'api', {
 import { ConnectedTerminal } from './ConnectedTerminal'
 import { terminalApi, systemApi, clipboardApi } from '@/lib/api'
 import { addRendererRef, removeRendererRef } from '@/lib/tauri-terminal-api'
+import { openFilePathFromTerminal } from '@/lib/file-path-links'
 
 vi.mock('@/hooks/use-terminal-restore', () => ({
   isTerminalPendingPtyAssignment: vi.fn(() => false)
@@ -244,6 +276,7 @@ describe('ConnectedTerminal', () => {
     capturedDataCallback = null
     capturedExitCallback = null
     lastCreatedWebglInstance = null
+    capturedLinkProviders.length = 0
 
     global.ResizeObserver = class MockResizeObserver {
       observe = vi.fn()
@@ -268,6 +301,7 @@ describe('ConnectedTerminal', () => {
     })
 
     mockTerminalStoreState.findTerminalByPtyId.mockReset()
+    mockTerminalStoreState.findTerminalByPtyId.mockReturnValue({ cwd: '/terminal-cwd' })
     mockTerminalStoreState.updateTerminalActivity.mockReset()
     mockTerminalStoreState.updateTerminalLastActivityTimestamp.mockReset()
     mockTerminalStoreState.updateTerminalActivityBatch.mockReset()
@@ -1060,6 +1094,112 @@ describe('ConnectedTerminal', () => {
       // Terminal container should be in the DOM
       expect(container.querySelector('div')).toBeTruthy()
     })
+  })
+
+
+  describe('Terminal file path link handling', () => {
+    it('should open a file path only on ctrl/meta click', async () => {
+      vi.mocked(openFilePathFromTerminal).mockResolvedValue(true)
+      render(<ConnectedTerminal terminalId="external-123" />)
+
+      await vi.waitFor(() => {
+        expect(capturedLinkProviders.at(-1)).toBeDefined()
+      })
+
+      const provider = capturedLinkProviders.at(-1)!
+      let links: Array<{
+        activate: (event: MouseEvent, text: string) => void | Promise<void>
+        text: string
+      }> = []
+
+      provider.provideLinks(1, (provided) => {
+        links = provided
+      })
+
+      const fileLink = links.find((link) => link.text === 'src/renderer/App.tsx')
+      expect(fileLink).toBeDefined()
+
+      const plainClick = new MouseEvent('click', { ctrlKey: false, metaKey: false })
+      const plainPreventDefaultSpy = vi.spyOn(plainClick, 'preventDefault')
+      await fileLink!.activate(plainClick, fileLink!.text)
+
+      expect(openFilePathFromTerminal).not.toHaveBeenCalled()
+      expect(plainPreventDefaultSpy).not.toHaveBeenCalled()
+
+      const ctrlClick = new MouseEvent('click', { ctrlKey: true, metaKey: false })
+      const ctrlPreventDefaultSpy = vi.spyOn(ctrlClick, 'preventDefault')
+      await fileLink!.activate(ctrlClick, fileLink!.text)
+
+      expect(ctrlPreventDefaultSpy).toHaveBeenCalled()
+      expect(openFilePathFromTerminal).toHaveBeenCalledWith('src/renderer/App.tsx', {
+        cwd: '/terminal-cwd',
+        projectRoot: '/project-root'
+      })
+    })
+
+    it('should invoke path open with missing terminal cwd context on ctrl+click', async () => {
+      vi.mocked(openFilePathFromTerminal).mockResolvedValue(false)
+      mockTerminalStoreState.findTerminalByPtyId.mockReturnValue(undefined)
+      render(<ConnectedTerminal terminalId="external-123" />)
+
+      await vi.waitFor(() => {
+        expect(capturedLinkProviders.at(-1)).toBeDefined()
+      })
+
+      const provider = capturedLinkProviders.at(-1)!
+      let links: Array<{
+        activate: (event: MouseEvent, text: string) => void | Promise<void>
+        text: string
+      }> = []
+
+      provider.provideLinks(1, (provided) => {
+        links = provided
+      })
+
+      const fileLink = links.find((link) => link.text === 'src/renderer/App.tsx')
+      expect(fileLink).toBeDefined()
+
+      const ctrlClick = new MouseEvent('click', { ctrlKey: true, metaKey: false })
+      const ctrlPreventDefaultSpy = vi.spyOn(ctrlClick, 'preventDefault')
+      await fileLink!.activate(ctrlClick, fileLink!.text)
+
+      expect(ctrlPreventDefaultSpy).toHaveBeenCalled()
+      expect(openFilePathFromTerminal).toHaveBeenCalledWith('src/renderer/App.tsx', {
+        cwd: undefined,
+        projectRoot: '/project-root'
+      })
+    })
+
+    it('should report unexpected ctrl click open failures with toast and console error', async () => {
+      const failure = new Error('boom')
+      const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+      vi.mocked(openFilePathFromTerminal).mockRejectedValue(failure)
+      render(<ConnectedTerminal terminalId="external-123" />)
+
+      await vi.waitFor(() => {
+        expect(capturedLinkProviders.at(-1)).toBeDefined()
+      })
+
+      const provider = capturedLinkProviders.at(-1)!
+      let links: Array<{
+        activate: (event: MouseEvent, text: string) => void | Promise<void>
+        text: string
+      }> = []
+
+      provider.provideLinks(1, (provided) => {
+        links = provided
+      })
+
+      const fileLink = links.find((link) => link.text === 'src/renderer/App.tsx')
+      expect(fileLink).toBeDefined()
+
+      const ctrlClick = new MouseEvent('click', { ctrlKey: true, metaKey: false })
+      await fileLink!.activate(ctrlClick, fileLink!.text)
+
+      expect(consoleErrorSpy).toHaveBeenCalledWith('[Terminal File Link Open Failed]', failure)
+      expect(toast.error).toHaveBeenCalledWith('Failed to open file from terminal output.')
+    })
+
   })
 
   describe('WebGL context loss recovery', () => {

--- a/src/renderer/components/terminal/ConnectedTerminal.tsx
+++ b/src/renderer/components/terminal/ConnectedTerminal.tsx
@@ -7,7 +7,9 @@ import {
 	useImperativeHandle,
 	useState,
 } from "react";
+import { toast } from "sonner";
 import { Terminal } from "@xterm/xterm";
+import type { IDisposable } from "@xterm/xterm";
 import { FitAddon } from "@xterm/addon-fit";
 import { WebglAddon } from "@xterm/addon-webgl";
 import { WebLinksAddon } from "@xterm/addon-web-links";
@@ -41,8 +43,13 @@ import {
 } from "@/components/ui/context-menu";
 import { useTerminalClipboard } from "@/hooks/use-terminal-clipboard";
 import { terminalApi, systemApi } from "@/lib/api";
+import {
+	buildTerminalPathLinks,
+	openFilePathFromTerminal,
+} from "@/lib/file-path-links";
 import { addRendererRef, removeRendererRef } from "@/lib/tauri-terminal-api";
 import { isTerminalPendingPtyAssignment } from "@/hooks/use-terminal-restore";
+import { useActiveProject } from "@/stores/project-store";
 
 // Module-level constants - defined once per module
 const MAX_WEBGL_RECOVERY_ATTEMPTS = 3;
@@ -101,6 +108,7 @@ function ConnectedTerminalComponent({
 	const fitAddonRef = useRef<FitAddon | null>(null);
 	const searchAddonRef = useRef<SearchAddon | null>(null);
 	const webglAddonRef = useRef<WebglAddon | null>(null);
+	const fileLinkProviderDisposableRef = useRef<IDisposable | null>(null);
 	const webglRecoveryAttemptsRef = useRef<number>(0);
 	const webglRecoveryTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(
 		null,
@@ -115,6 +123,10 @@ function ConnectedTerminalComponent({
 	const fontFamily = useTerminalFontFamily();
 	const fontSize = useTerminalFontSize();
 	const bufferSize = useTerminalBufferSize();
+
+	const activeProject = useActiveProject();
+	const activeProjectPathRef = useRef<string | undefined>(activeProject?.path);
+	activeProjectPathRef.current = activeProject?.path;
 
 	// Get keyboard shortcuts to intercept app shortcuts before xterm handles them
 	const shortcuts = useKeyboardShortcutsStore((state) => state.shortcuts);
@@ -381,6 +393,36 @@ function ConnectedTerminalComponent({
 
 		const webLinksAddon = new WebLinksAddon();
 		terminal.loadAddon(webLinksAddon);
+
+		const handleFilePathActivate = async (
+			event: MouseEvent,
+			uri: string,
+		): Promise<void> => {
+			if (!event.ctrlKey && !event.metaKey) {
+				return;
+			}
+
+			event.preventDefault();
+
+			try {
+				await openFilePathFromTerminal(uri, {
+					cwd:
+						useTerminalStore.getState().findTerminalByPtyId(ptyIdRef.current || "")
+							?.cwd,
+					projectRoot: activeProjectPathRef.current,
+				});
+			} catch (error) {
+				console.error("[Terminal File Link Open Failed]", error);
+				toast.error("Failed to open file from terminal output.");
+			}
+		};
+
+		fileLinkProviderDisposableRef.current = terminal.registerLinkProvider({
+			provideLinks(y, callback) {
+				const line = terminal.buffer.active.getLine(y - 1)?.translateToString(true) ?? "";
+				callback(buildTerminalPathLinks(line, y, handleFilePathActivate));
+			},
+		});
 
 		// Load search addon
 		const searchAddon = new SearchAddon();
@@ -848,6 +890,10 @@ function ConnectedTerminalComponent({
 			if (webglAddonRef.current) {
 				webglAddonRef.current.dispose();
 				webglAddonRef.current = null;
+			}
+			if (fileLinkProviderDisposableRef.current) {
+				fileLinkProviderDisposableRef.current.dispose();
+				fileLinkProviderDisposableRef.current = null;
 			}
 
 			terminal.dispose();

--- a/src/renderer/components/terminal/ConnectedTerminal.tsx
+++ b/src/renderer/components/terminal/ConnectedTerminal.tsx
@@ -405,12 +405,16 @@ function ConnectedTerminalComponent({
 			event.preventDefault();
 
 			try {
-				await openFilePathFromTerminal(uri, {
+				const result = await openFilePathFromTerminal(uri, {
 					cwd:
 						useTerminalStore.getState().findTerminalByPtyId(ptyIdRef.current || "")
 							?.cwd,
 					projectRoot: activeProjectPathRef.current,
 				});
+
+				if (!result.ok) {
+					toast.error(result.message);
+				}
 			} catch (error) {
 				console.error("[Terminal File Link Open Failed]", error);
 				toast.error("Failed to open file from terminal output.");

--- a/src/renderer/components/workspace/WorkspaceTabBar.test.tsx
+++ b/src/renderer/components/workspace/WorkspaceTabBar.test.tsx
@@ -8,24 +8,37 @@ const mockSetActiveTab = vi.fn()
 const mockSetActivePane = vi.fn()
 const mockReorderTabsInPane = vi.fn()
 const mockCloseTab = vi.fn()
+const mockCloseFileIfIdle = vi.fn(() => true)
+
+const mockWorkspaceStoreState = {
+  setActiveTab: mockSetActiveTab,
+  setActivePane: mockSetActivePane,
+  reorderTabsInPane: mockReorderTabsInPane,
+  closeTab: mockCloseTab
+}
+
+const mockEditorOpenFiles = new Map<string, { isDirty: boolean; operationStatus?: string }>()
+const mockEditorStoreState = {
+  openFiles: mockEditorOpenFiles,
+  closeFileIfIdle: mockCloseFileIfIdle
+}
 
 vi.mock('@/stores/workspace-store', () => ({
-  useWorkspaceStore: vi.fn((selector: (state: unknown) => unknown) =>
-    selector({
-      setActiveTab: mockSetActiveTab,
-      setActivePane: mockSetActivePane,
-      reorderTabsInPane: mockReorderTabsInPane,
-      closeTab: mockCloseTab
-    })
+  useWorkspaceStore: Object.assign(
+    vi.fn((selector: (state: typeof mockWorkspaceStoreState) => unknown) => selector(mockWorkspaceStoreState)),
+    {
+      getState: () => mockWorkspaceStoreState
+    }
   ),
   editorTabId: (filePath: string) => `edit-${filePath}`
 }))
 
 vi.mock('@/stores/editor-store', () => ({
-  useEditorStore: vi.fn((selector: (state: { openFiles: Map<string, { isDirty: boolean }> }) => unknown) =>
-    selector({
-      openFiles: new Map<string, { isDirty: boolean }>()
-    })
+  useEditorStore: Object.assign(
+    vi.fn((selector: (state: typeof mockEditorStoreState) => unknown) => selector(mockEditorStoreState)),
+    {
+      getState: () => mockEditorStoreState
+    }
   )
 }))
 
@@ -75,6 +88,9 @@ beforeEach(() => {
   mockSetActivePane.mockReset()
   mockReorderTabsInPane.mockReset()
   mockCloseTab.mockReset()
+  mockCloseFileIfIdle.mockReset()
+  mockCloseFileIfIdle.mockReturnValue(true)
+  mockEditorOpenFiles.clear()
   mockStartTabDrag.mockReset()
   mockSetReorderPreview.mockReset()
   mockClearReorderPreview.mockReset()
@@ -185,15 +201,75 @@ describe('WorkspaceTabBar', () => {
 
     await flushShellEffect()
 
-    const closeButtons = screen.getAllByRole('button')
-    const tabCloseButton = closeButtons.find((button) =>
-      button.className.includes('opacity-0 group-hover:opacity-100')
-    )
+    const tabCloseButton = screen.getByTitle('Close tab')
 
-    expect(tabCloseButton).toBeTruthy()
-    fireEvent.click(tabCloseButton!)
+    fireEvent.click(tabCloseButton)
 
     expect(onCloseEditorTab).toHaveBeenCalledWith('/a.ts')
+    expect(mockCloseTab).not.toHaveBeenCalled()
+  })
+
+  it('uses the fallback close path when no onCloseEditorTab callback is provided', async () => {
+    const tabs: WorkspaceTab[] = [{ type: 'editor', id: 'edit-/a.ts', filePath: '/a.ts' }]
+
+    render(
+      <WorkspaceTabBar
+        paneId="pane-a"
+        tabs={tabs}
+        activeTabId="edit-/a.ts"
+      />
+    )
+
+    await flushShellEffect()
+
+    fireEvent.click(screen.getByTitle('Close tab'))
+
+    expect(mockCloseFileIfIdle).toHaveBeenCalledWith('/a.ts')
+    expect(mockCloseTab).toHaveBeenCalledWith('pane-a', 'edit-/a.ts')
+  })
+
+  it('does not close editor tabs while the file is saving', async () => {
+    mockEditorOpenFiles.set('/a.ts', { isDirty: true, operationStatus: 'saving' })
+    const onCloseEditorTab = vi.fn()
+    const tabs: WorkspaceTab[] = [{ type: 'editor', id: 'edit-/a.ts', filePath: '/a.ts' }]
+
+    render(
+      <WorkspaceTabBar
+        paneId="pane-a"
+        tabs={tabs}
+        activeTabId="edit-/a.ts"
+        onCloseEditorTab={onCloseEditorTab}
+      />
+    )
+
+    await flushShellEffect()
+
+    const savingButton = screen.getByTitle('Saving file')
+    expect(savingButton).toBeDisabled()
+    fireEvent.click(savingButton)
+
+    expect(onCloseEditorTab).not.toHaveBeenCalled()
+    expect(mockCloseFileIfIdle).not.toHaveBeenCalled()
+    expect(mockCloseTab).not.toHaveBeenCalled()
+  })
+
+  it('does not remove the workspace tab when fallback closeFileIfIdle returns false', async () => {
+    mockCloseFileIfIdle.mockReturnValue(false)
+    const tabs: WorkspaceTab[] = [{ type: 'editor', id: 'edit-/a.ts', filePath: '/a.ts' }]
+
+    render(
+      <WorkspaceTabBar
+        paneId="pane-a"
+        tabs={tabs}
+        activeTabId="edit-/a.ts"
+      />
+    )
+
+    await flushShellEffect()
+
+    fireEvent.click(screen.getByTitle('Close tab'))
+
+    expect(mockCloseFileIfIdle).toHaveBeenCalledWith('/a.ts')
     expect(mockCloseTab).not.toHaveBeenCalled()
   })
 

--- a/src/renderer/layouts/WorkspaceLayout.close-persistence.test.tsx
+++ b/src/renderer/layouts/WorkspaceLayout.close-persistence.test.tsx
@@ -153,7 +153,8 @@ vi.mock('@/stores/keyboard-shortcuts-store', () => ({
 vi.mock('@/stores/app-settings-store', () => ({
   useTerminalFontSize: () => 14,
   useDefaultShell: () => 'bash',
-  useMaxTerminalsPerProject: () => 10
+  useMaxTerminalsPerProject: () => 10,
+  useConfirmTerminalClose: () => true
 }))
 
 vi.mock('@/hooks/use-snapshots', () => ({

--- a/src/renderer/layouts/WorkspaceLayout.test.tsx
+++ b/src/renderer/layouts/WorkspaceLayout.test.tsx
@@ -70,6 +70,7 @@ vi.mock('@/stores/app-settings-store', () => ({
   useTerminalBufferSize: vi.fn(() => 10000),
   useDefaultShell: vi.fn(() => 'bash'),
   useMaxTerminalsPerProject: vi.fn(() => 10),
+  useConfirmTerminalClose: vi.fn(() => true),
   useUpdateAppSetting: vi.fn(() => vi.fn()),
   useDefaultProjectColor: vi.fn(() => 'blue')
 }))
@@ -696,6 +697,38 @@ describe('WorkspaceLayout - Empty States', () => {
       })
 
       getStateSpy.mockRestore()
+    })
+
+    it('still closes when waiting for app-settings persistence rejects', async () => {
+      let closeRequestedCallback: (() => Promise<boolean>) | undefined
+      mockApi.window.onCloseRequested.mockImplementation((callback: () => Promise<boolean>) => {
+        closeRequestedCallback = callback
+        return vi.fn()
+      })
+
+      const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+      const project = createProject('a', '/workspace/a', 'blue')
+      mockUseProjects.mockReturnValue([project])
+      mockUseActiveProject.mockReturnValue(project)
+      mockUseActiveProjectId.mockReturnValue('a')
+
+      mockWaitForPendingAppSettingsPersistence.mockRejectedValueOnce(new Error('settings flush failed'))
+
+      renderWithRouter()
+      expect(closeRequestedCallback).toBeDefined()
+      if (!closeRequestedCallback) throw new Error('close callback missing')
+
+      await expect(closeRequestedCallback()).resolves.toBe(false)
+
+      await waitFor(() => {
+        expect(mockApi.window.respondToClose).toHaveBeenCalledWith('close')
+      })
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        'Failed to wait for app settings persistence before close:',
+        expect.any(Error)
+      )
+
+      consoleErrorSpy.mockRestore()
     })
   })
 

--- a/src/renderer/lib/__tests__/tauri-filesystem-api.test.ts
+++ b/src/renderer/lib/__tests__/tauri-filesystem-api.test.ts
@@ -209,6 +209,7 @@ describe("tauriFilesystemApi", () => {
 			if (result.success) {
 				expect(result.data.size).toBe(2048);
 				expect(result.data.path).toBe("/test/file.txt");
+				expect(result.data.type).toBe("file");
 				expect(result.data.isReadOnly).toBe(false);
 				expect(result.data.isBinary).toBe(false);
 			}

--- a/src/renderer/lib/__tests__/tauri-filesystem-api.test.ts
+++ b/src/renderer/lib/__tests__/tauri-filesystem-api.test.ts
@@ -31,7 +31,12 @@ const defaultStat: FileInfo = {
 
 // Mock @tauri-apps/plugin-fs BEFORE importing
 vi.mock("@tauri-apps/plugin-fs", () => ({
+	open: vi.fn(async () => ({
+		read: vi.fn(async () => 0),
+		close: vi.fn(async () => {}),
+	})),
 	readDir: vi.fn(async () => []),
+	readFile: vi.fn(async () => new Uint8Array()),
 	readTextFile: vi.fn(async () => ""),
 	writeTextFile: vi.fn(async () => {}),
 	mkdir: vi.fn(async () => {}),
@@ -44,7 +49,9 @@ vi.mock("@tauri-apps/plugin-fs", () => ({
 }));
 
 import {
+	open,
 	readDir,
+	readFile,
 	readTextFile,
 	writeTextFile,
 	mkdir,
@@ -72,7 +79,12 @@ describe("tauriFilesystemApi", () => {
 		_resetFilesystemStateForTesting();
 
 		// Restore default mocks after clearing
+		vi.mocked(open).mockResolvedValue({
+			read: vi.fn(async () => 0),
+			close: vi.fn(async () => {}),
+		} as never);
 		vi.mocked(readDir).mockResolvedValue([]);
+		vi.mocked(readFile).mockResolvedValue(new Uint8Array());
 		vi.mocked(readTextFile).mockResolvedValue("");
 		vi.mocked(writeTextFile).mockResolvedValue(undefined);
 		vi.mocked(mkdir).mockResolvedValue(undefined);
@@ -198,10 +210,17 @@ describe("tauriFilesystemApi", () => {
 	describe("getFileInfo", () => {
 		it("should return file metadata", async () => {
 			const testDate = new Date("2024-01-01T00:00:00Z");
+			const close = vi.fn(async () => {});
 			vi.mocked(stat).mockResolvedValue(
 				makeFileInfo({ size: 2048, mtime: testDate }),
 			);
-			vi.mocked(readTextFile).mockResolvedValue("some content");
+			vi.mocked(open).mockResolvedValue({
+				read: vi.fn(async (buffer: Uint8Array) => {
+					buffer.set(new TextEncoder().encode("some content"));
+					return 12;
+				}),
+				close,
+			} as never);
 
 			const result = await tauriFilesystemApi.getFileInfo("/test/file.txt");
 
@@ -213,14 +232,41 @@ describe("tauriFilesystemApi", () => {
 				expect(result.data.isReadOnly).toBe(false);
 				expect(result.data.isBinary).toBe(false);
 			}
+			expect(open).toHaveBeenCalledWith("/test/file.txt", { read: true });
+			expect(close).toHaveBeenCalled();
+			expect(readTextFile).not.toHaveBeenCalled();
 		});
 
-		it("should detect binary files", async () => {
+		it("should not read directory contents when returning directory metadata", async () => {
 			const testDate = new Date("2024-01-01T00:00:00Z");
+			vi.mocked(stat).mockResolvedValue(
+				makeFileInfo({ isFile: false, isDirectory: true, size: 0, mtime: testDate }),
+			);
+
+			const result = await tauriFilesystemApi.getFileInfo("/test/folder");
+
+			expect(result.success).toBe(true);
+			if (result.success) {
+				expect(result.data.type).toBe("directory");
+				expect(result.data.isBinary).toBe(false);
+			}
+			expect(open).not.toHaveBeenCalled();
+			expect(readTextFile).not.toHaveBeenCalled();
+		});
+
+		it("should detect binary files from a bounded byte sample", async () => {
+			const testDate = new Date("2024-01-01T00:00:00Z");
+			const close = vi.fn(async () => {});
 			vi.mocked(stat).mockResolvedValue(
 				makeFileInfo({ size: 10, mtime: testDate }),
 			);
-			vi.mocked(readTextFile).mockResolvedValue("Hello\x00World");
+			vi.mocked(open).mockResolvedValue({
+				read: vi.fn(async (buffer: Uint8Array) => {
+					buffer.set(new Uint8Array([72, 101, 108, 108, 111, 0, 87, 111, 114, 108, 100]));
+					return 11;
+				}),
+				close,
+			} as never);
 
 			const result = await tauriFilesystemApi.getFileInfo("/test/binary.bin");
 
@@ -228,6 +274,9 @@ describe("tauriFilesystemApi", () => {
 			if (result.success) {
 				expect(result.data.isBinary).toBe(true);
 			}
+			expect(open).toHaveBeenCalledWith("/test/binary.bin", { read: true });
+			expect(close).toHaveBeenCalled();
+			expect(readTextFile).not.toHaveBeenCalled();
 		});
 
 		it("should handle errors", async () => {
@@ -410,13 +459,10 @@ describe("tauriFilesystemApi", () => {
 			const mockUnlisten = vi.fn();
 			vi.mocked(watchImmediate).mockResolvedValue(mockUnlisten);
 
-			// First watch
 			await tauriFilesystemApi.watchDirectory("/test");
-			// Second watch on same path
 			const result = await tauriFilesystemApi.watchDirectory("/test");
 
 			expect(result.success).toBe(true);
-			// watchImmediate should only be called once
 			expect(vi.mocked(watchImmediate)).toHaveBeenCalledTimes(1);
 		});
 	});
@@ -426,9 +472,7 @@ describe("tauriFilesystemApi", () => {
 			const mockUnlisten = vi.fn();
 			vi.mocked(watchImmediate).mockResolvedValue(mockUnlisten);
 
-			// First watch
 			await tauriFilesystemApi.watchDirectory("/test");
-			// Then unwatch
 			const result = await tauriFilesystemApi.unwatchDirectory("/test");
 
 			expect(result.success).toBe(true);
@@ -438,11 +482,10 @@ describe("tauriFilesystemApi", () => {
 		it("should handle unwatching non-watched directory gracefully", async () => {
 			const result = await tauriFilesystemApi.unwatchDirectory("/non-existent");
 
-			expect(result.success).toBe(true); // Should succeed even if not watching
+			expect(result.success).toBe(true);
 		});
 
 		it("should handle errors", async () => {
-			// Force an error by making unlisten throw
 			const badUnlisten = () => {
 				throw new Error("Unlisten failed");
 			};
@@ -473,7 +516,6 @@ describe("tauriFilesystemApi", () => {
 			await tauriFilesystemApi.watchDirectory("/test");
 			const cleanupFirst = tauriFilesystemApi.onFileChanged(callback);
 
-			// Cleanup should remove callback
 			const cleanup = tauriFilesystemApi.onFileChanged(callback);
 			cleanupFirst();
 			cleanup();

--- a/src/renderer/lib/__tests__/tauri-updater-api.test.ts
+++ b/src/renderer/lib/__tests__/tauri-updater-api.test.ts
@@ -64,6 +64,8 @@ async function flushPromises(): Promise<void> {
   await Promise.resolve()
 }
 
+const mockFetch = vi.fn()
+
 describe('tauri-updater-api', () => {
   beforeEach(() => {
     vi.clearAllMocks()
@@ -90,6 +92,8 @@ describe('tauri-updater-api', () => {
         size: 2048
       }
     } as never)
+    mockFetch.mockReset()
+    vi.stubGlobal('fetch', mockFetch)
   })
 
   describe('checkForUpdates', () => {
@@ -129,12 +133,42 @@ describe('tauri-updater-api', () => {
       )
     })
 
-    it('preserves non-Error check failure details', async () => {
+    it('falls back to GitHub release metadata for missing-manifest style failures', async () => {
       vi.mocked(check).mockRejectedValue({ status: 404, url: 'latest.json' })
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          tag_name: 'v0.3.4',
+          body: 'release notes',
+          html_url: 'https://github.com/gnoviawan/termul/releases/tag/v0.3.4',
+          published_at: '2026-05-01T15:13:12Z'
+        })
+      })
+
+      await expect(checkForUpdates()).resolves.toEqual({
+        version: '0.3.4',
+        releaseDate: '2026-05-01T15:13:12Z',
+        releaseNotes: 'release notes',
+        isSecurityUpdate: false,
+        downloadUrl: 'https://github.com/gnoviawan/termul/releases/tag/v0.3.4'
+      })
+
+      const state = await getUpdaterState()
+      expect(state.success).toBe(true)
+      if (state.success) {
+        expect(state.data.updateAvailable).toBe(true)
+        expect(state.data.version).toBe('0.3.4')
+        expect(state.data.isManualUpdateMode).toBe(true)
+      }
+    })
+
+    it('preserves non-fallback error details when the manifest error is not eligible for GitHub fallback', async () => {
+      vi.mocked(check).mockRejectedValue({ status: 500, url: 'latest.json' })
 
       await expect(checkForUpdates()).rejects.toThrow(
-        'Failed to check for updates from https://github.com/gnoviawan/termul/releases/latest/download/latest.json: {"status":404,"url":"latest.json"}'
+        'Failed to check for updates from https://github.com/gnoviawan/termul/releases/latest/download/latest.json: {"status":500,"url":"latest.json"}'
       )
+      expect(mockFetch).not.toHaveBeenCalled()
     })
   })
 

--- a/src/renderer/lib/file-path-links.test.ts
+++ b/src/renderer/lib/file-path-links.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import {
+  buildTerminalPathLinks,
   extractPathCandidate,
   openFilePathFromTerminal,
   resolveFilePathCandidate,
@@ -44,6 +45,10 @@ describe('file-path-links parsing', () => {
     expect(trimWrappedPath('(src/foo.ts)')).toBe('src/foo.ts')
   })
 
+  it('strips only one wrapping layer per call', () => {
+    expect(trimWrappedPath('("src/foo.ts")')).toBe('"src/foo.ts"')
+  })
+
   it('strips line and column suffixes', () => {
     expect(stripLineColumnSuffix('src/foo.ts:12')).toBe('src/foo.ts')
     expect(stripLineColumnSuffix('src/foo.ts:12:3')).toBe('src/foo.ts')
@@ -58,6 +63,38 @@ describe('file-path-links parsing', () => {
   it('keeps plain file paths unchanged', () => {
     expect(extractPathCandidate('src/renderer/App.tsx')).toBe('src/renderer/App.tsx')
     expect(extractPathCandidate('./src/renderer/App.tsx')).toBe('./src/renderer/App.tsx')
+  })
+
+  it('does not extract file links from URL host/path fragments', () => {
+    const links = buildTerminalPathLinks('See https://example.com/src/App.tsx for details', 1, vi.fn())
+
+    expect(links).toEqual([])
+  })
+
+  it('does not extract file links from file URLs', () => {
+    const links = buildTerminalPathLinks('file:///c:/repo/src/App.tsx', 1, vi.fn())
+
+    expect(links).toEqual([])
+  })
+
+  it('does not extract file links from wrapped URLs', () => {
+    const links = buildTerminalPathLinks('(https://example.com/src/App.tsx)', 1, vi.fn())
+
+    expect(links).toEqual([])
+  })
+
+  it('keeps labeled absolute paths outside URLs', () => {
+    const links = buildTerminalPathLinks('Path: /repo/src/App.tsx', 1, vi.fn())
+
+    expect(links).toHaveLength(1)
+    expect(links[0]?.text).toBe('/repo/src/App.tsx')
+  })
+
+  it('keeps UNC-style file links outside URLs', () => {
+    const links = buildTerminalPathLinks('\\\\server\\share\\workspace\\src\\App.tsx', 1, vi.fn())
+
+    expect(links).toHaveLength(1)
+    expect(links[0]?.text).toBe('\\\\server\\share\\workspace\\src\\App.tsx')
   })
 })
 
@@ -91,8 +128,9 @@ describe('file-path-links resolution', () => {
       ok: true,
       path: '/repo/src/renderer/App.tsx'
     })
-    expect(mocks.getFileInfo).toHaveBeenCalledTimes(1)
+    expect(mocks.getFileInfo).toHaveBeenCalledTimes(2)
     expect(mocks.getFileInfo).toHaveBeenNthCalledWith(1, '/repo/src/renderer/App.tsx')
+    expect(mocks.getFileInfo).toHaveBeenNthCalledWith(2, '/fallback/src/renderer/App.tsx')
   })
 
   it('returns not-file when getFileInfo reports a directory', async () => {
@@ -143,6 +181,53 @@ describe('file-path-links resolution', () => {
     })
 
     expect(result).toEqual({ ok: true, path: '/repo/src/App.tsx' })
+    expect(mocks.getFileInfo).toHaveBeenCalledTimes(2)
+    expect(mocks.getFileInfo).toHaveBeenNthCalledWith(1, '/tmp/shell/src/App.tsx')
+    expect(mocks.getFileInfo).toHaveBeenNthCalledWith(2, '/repo/src/App.tsx')
+  })
+
+  it('resolves paths with line and column suffixes using the plain file path', async () => {
+    mocks.getFileInfo.mockResolvedValue({
+      success: true,
+      data: {
+        path: '/repo/src/App.tsx',
+        size: 100,
+        modifiedAt: 1,
+        type: 'file',
+        isReadOnly: false,
+        isBinary: false
+      }
+    })
+
+    const result = await resolveFilePathCandidate('src/App.tsx:12:3', {
+      cwd: '/repo',
+      projectRoot: '/repo'
+    })
+
+    expect(result).toEqual({ ok: true, path: '/repo/src/App.tsx' })
+    expect(mocks.getFileInfo).toHaveBeenCalledTimes(1)
+    expect(mocks.getFileInfo).toHaveBeenCalledWith('/repo/src/App.tsx')
+  })
+
+  it('keeps first candidate precedence when parallel checks find multiple files', async () => {
+    mocks.getFileInfo.mockResolvedValue({
+      success: true,
+      data: {
+        path: '/repo/src/App.tsx',
+        size: 100,
+        modifiedAt: 1,
+        type: 'file',
+        isReadOnly: false,
+        isBinary: false
+      }
+    })
+
+    const result = await resolveFilePathCandidate('src/App.tsx', {
+      cwd: '/tmp/shell',
+      projectRoot: '/repo'
+    })
+
+    expect(result).toEqual({ ok: true, path: '/tmp/shell/src/App.tsx' })
     expect(mocks.getFileInfo).toHaveBeenCalledTimes(2)
     expect(mocks.getFileInfo).toHaveBeenNthCalledWith(1, '/tmp/shell/src/App.tsx')
     expect(mocks.getFileInfo).toHaveBeenNthCalledWith(2, '/repo/src/App.tsx')
@@ -217,27 +302,32 @@ describe('file-path-links resolution', () => {
       cwd: '/repo'
     })
 
-    expect(opened).toBe(true)
+    expect(opened).toEqual({ ok: true })
     expect(mocks.openFile).toHaveBeenCalledWith('/repo/src/renderer/App.tsx')
     expect(mocks.addEditorTab).toHaveBeenCalledWith('/repo/src/renderer/App.tsx')
     expect(mocks.toastError).not.toHaveBeenCalled()
   })
 
-  it('rejects missing files and shows toast during open', async () => {
+  it('returns not-found details and does not open missing files', async () => {
     mocks.getFileInfo.mockResolvedValue({ success: false, error: 'not found' })
 
-    await openFilePathFromTerminal('missing.ts', {
+    const opened = await openFilePathFromTerminal('missing.ts', {
       projectRoot: '/repo'
     })
 
+    expect(opened).toEqual({
+      ok: false,
+      reason: 'not-found',
+      message: 'File not found: missing.ts'
+    })
     expect(mocks.getFileInfo).toHaveBeenCalledTimes(1)
     expect(mocks.getFileInfo).toHaveBeenCalledWith('/repo/missing.ts')
     expect(mocks.openFile).not.toHaveBeenCalled()
     expect(mocks.addEditorTab).not.toHaveBeenCalled()
-    expect(mocks.toastError).toHaveBeenCalledWith('File not found: missing.ts')
+    expect(mocks.toastError).not.toHaveBeenCalled()
   })
 
-  it('shows toast and does not open when resolved target is not a file', async () => {
+  it('returns a not-file message and does not open when resolved target is not a file', async () => {
     mocks.getFileInfo.mockResolvedValue({
       success: true,
       data: {
@@ -252,19 +342,27 @@ describe('file-path-links resolution', () => {
 
     const opened = await openFilePathFromTerminal('src', { cwd: '/repo' })
 
-    expect(opened).toBe(false)
+    expect(opened).toEqual({
+      ok: false,
+      reason: 'not-file',
+      message: 'Path is a directory, not a file: src'
+    })
     expect(mocks.openFile).not.toHaveBeenCalled()
     expect(mocks.addEditorTab).not.toHaveBeenCalled()
-    expect(mocks.toastError).toHaveBeenCalledWith('File not found: src')
+    expect(mocks.toastError).not.toHaveBeenCalled()
   })
 
-  it('shows toast and does not open when context is missing', async () => {
+  it('returns a missing-context message and does not open when context is missing', async () => {
     const opened = await openFilePathFromTerminal('src/App.tsx', {})
 
-    expect(opened).toBe(false)
+    expect(opened).toEqual({
+      ok: false,
+      reason: 'missing-context',
+      message: 'No project or working directory found; set a project/cwd to open paths: src/App.tsx'
+    })
     expect(mocks.getFileInfo).not.toHaveBeenCalled()
     expect(mocks.openFile).not.toHaveBeenCalled()
     expect(mocks.addEditorTab).not.toHaveBeenCalled()
-    expect(mocks.toastError).toHaveBeenCalledWith('File not found: src/App.tsx')
+    expect(mocks.toastError).not.toHaveBeenCalled()
   })
 })

--- a/src/renderer/lib/file-path-links.test.ts
+++ b/src/renderer/lib/file-path-links.test.ts
@@ -1,0 +1,270 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  extractPathCandidate,
+  openFilePathFromTerminal,
+  resolveFilePathCandidate,
+  stripLineColumnSuffix,
+  trimWrappedPath
+} from './file-path-links'
+
+const mocks = vi.hoisted(() => ({
+  getFileInfo: vi.fn(),
+  openFile: vi.fn(),
+  addEditorTab: vi.fn(),
+  toastError: vi.fn()
+}))
+
+vi.mock('@/lib/api', () => ({
+  filesystemApi: {
+    getFileInfo: mocks.getFileInfo
+  }
+}))
+vi.mock('@/stores/editor-store', () => ({
+  useEditorStore: {
+    getState: () => ({ openFile: mocks.openFile })
+  }
+}))
+
+vi.mock('@/stores/workspace-store', () => ({
+  useWorkspaceStore: {
+    getState: () => ({ addEditorTab: mocks.addEditorTab })
+  }
+}))
+
+vi.mock('sonner', () => ({
+  toast: {
+    error: mocks.toastError
+  }
+}))
+
+describe('file-path-links parsing', () => {
+  it('trims wrapped paths', () => {
+    expect(trimWrappedPath('`src/foo.ts`')).toBe('src/foo.ts')
+    expect(trimWrappedPath('"src/foo.ts"')).toBe('src/foo.ts')
+    expect(trimWrappedPath('(src/foo.ts)')).toBe('src/foo.ts')
+  })
+
+  it('strips line and column suffixes', () => {
+    expect(stripLineColumnSuffix('src/foo.ts:12')).toBe('src/foo.ts')
+    expect(stripLineColumnSuffix('src/foo.ts:12:3')).toBe('src/foo.ts')
+    expect(stripLineColumnSuffix('C:/repo/src/foo.ts:4:9')).toBe('C:/repo/src/foo.ts')
+  })
+
+  it('extracts wrapped paths with line and column suffixes', () => {
+    expect(extractPathCandidate('(src/renderer/App.tsx:42:7)')).toBe('src/renderer/App.tsx')
+    expect(extractPathCandidate('`./src/main.ts:3`')).toBe('./src/main.ts')
+  })
+
+  it('keeps plain file paths unchanged', () => {
+    expect(extractPathCandidate('src/renderer/App.tsx')).toBe('src/renderer/App.tsx')
+    expect(extractPathCandidate('./src/renderer/App.tsx')).toBe('./src/renderer/App.tsx')
+  })
+})
+
+describe('file-path-links resolution', () => {
+  beforeEach(() => {
+    mocks.getFileInfo.mockReset()
+    mocks.openFile.mockReset()
+    mocks.addEditorTab.mockReset()
+    mocks.toastError.mockReset()
+  })
+
+  it('resolves relative paths against terminal cwd', async () => {
+    mocks.getFileInfo.mockResolvedValue({
+      success: true,
+      data: {
+        path: '/repo/src/renderer/App.tsx',
+        size: 100,
+        modifiedAt: 1,
+        type: 'file',
+        isReadOnly: false,
+        isBinary: false
+      }
+    })
+
+    const result = await resolveFilePathCandidate('src/renderer/App.tsx', {
+      cwd: '/repo',
+      projectRoot: '/fallback'
+    })
+
+    expect(result).toEqual({
+      ok: true,
+      path: '/repo/src/renderer/App.tsx'
+    })
+    expect(mocks.getFileInfo).toHaveBeenCalledTimes(1)
+    expect(mocks.getFileInfo).toHaveBeenNthCalledWith(1, '/repo/src/renderer/App.tsx')
+  })
+
+  it('returns not-file when getFileInfo reports a directory', async () => {
+    mocks.getFileInfo.mockResolvedValue({
+      success: true,
+      data: {
+        path: '/repo/src',
+        size: 100,
+        modifiedAt: 1,
+        type: 'directory',
+        isReadOnly: false,
+        isBinary: false
+      }
+    })
+
+    const result = await resolveFilePathCandidate('src', {
+      cwd: '/repo'
+    })
+
+    expect(result).toEqual({ ok: false, reason: 'not-file' })
+  })
+
+  it('returns missing-context when relative path has no cwd or project root', async () => {
+    const result = await resolveFilePathCandidate('src/App.tsx', {})
+
+    expect(result).toEqual({ ok: false, reason: 'missing-context' })
+    expect(mocks.getFileInfo).not.toHaveBeenCalled()
+  })
+
+  it('falls back to project root for relative paths when cwd resolution fails', async () => {
+    mocks.getFileInfo
+      .mockResolvedValueOnce({ success: false, error: 'not found' })
+      .mockResolvedValueOnce({
+        success: true,
+        data: {
+          path: '/repo/src/App.tsx',
+          size: 100,
+          modifiedAt: 1,
+          type: 'file',
+          isReadOnly: false,
+          isBinary: false
+        }
+      })
+
+    const result = await resolveFilePathCandidate('src/App.tsx', {
+      cwd: '/tmp/shell',
+      projectRoot: '/repo'
+    })
+
+    expect(result).toEqual({ ok: true, path: '/repo/src/App.tsx' })
+    expect(mocks.getFileInfo).toHaveBeenCalledTimes(2)
+    expect(mocks.getFileInfo).toHaveBeenNthCalledWith(1, '/tmp/shell/src/App.tsx')
+    expect(mocks.getFileInfo).toHaveBeenNthCalledWith(2, '/repo/src/App.tsx')
+  })
+
+  it('rejects relative paths that escape the allowed roots', async () => {
+    const result = await resolveFilePathCandidate('../../outside.ts', {
+      cwd: '/repo/apps/termul',
+      projectRoot: '/repo/apps/termul'
+    })
+
+    expect(result).toEqual({ ok: false, reason: 'not-found' })
+    expect(mocks.getFileInfo).not.toHaveBeenCalled()
+  })
+
+  it('rejects absolute paths outside the allowed roots', async () => {
+    const result = await resolveFilePathCandidate('/etc/hosts', {
+      cwd: '/repo/apps/termul',
+      projectRoot: '/repo/apps/termul'
+    })
+
+    expect(result).toEqual({ ok: false, reason: 'not-found' })
+    expect(mocks.getFileInfo).not.toHaveBeenCalled()
+  })
+
+  it('resolves UNC paths within the allowed root', async () => {
+    mocks.getFileInfo.mockResolvedValue({
+      success: true,
+      data: {
+        path: '//server/share/workspace/src/App.tsx',
+        size: 100,
+        modifiedAt: 1,
+        type: 'file',
+        isReadOnly: false,
+        isBinary: false
+      }
+    })
+
+    const result = await resolveFilePathCandidate('\\\\server\\share\\workspace\\src\\App.tsx', {
+      cwd: '\\\\server\\share\\workspace',
+      projectRoot: '\\\\server\\share\\workspace'
+    })
+
+    expect(result).toEqual({ ok: true, path: '//server/share/workspace/src/App.tsx' })
+    expect(mocks.getFileInfo).toHaveBeenCalledWith('//server/share/workspace/src/App.tsx')
+  })
+
+  it('rejects UNC paths outside the allowed root', async () => {
+    const result = await resolveFilePathCandidate('\\\\server\\other-share\\secret.txt', {
+      cwd: '\\\\server\\share\\workspace',
+      projectRoot: '\\\\server\\share\\workspace'
+    })
+
+    expect(result).toEqual({ ok: false, reason: 'not-found' })
+    expect(mocks.getFileInfo).not.toHaveBeenCalled()
+  })
+
+  it('opens the resolved file and adds an editor tab', async () => {
+    mocks.getFileInfo.mockResolvedValue({
+      success: true,
+      data: {
+        path: '/repo/src/renderer/App.tsx',
+        size: 100,
+        modifiedAt: 1,
+        type: 'file',
+        isReadOnly: false,
+        isBinary: false
+      }
+    })
+
+    const opened = await openFilePathFromTerminal('src/renderer/App.tsx', {
+      cwd: '/repo'
+    })
+
+    expect(opened).toBe(true)
+    expect(mocks.openFile).toHaveBeenCalledWith('/repo/src/renderer/App.tsx')
+    expect(mocks.addEditorTab).toHaveBeenCalledWith('/repo/src/renderer/App.tsx')
+    expect(mocks.toastError).not.toHaveBeenCalled()
+  })
+
+  it('rejects missing files and shows toast during open', async () => {
+    mocks.getFileInfo.mockResolvedValue({ success: false, error: 'not found' })
+
+    await openFilePathFromTerminal('missing.ts', {
+      projectRoot: '/repo'
+    })
+
+    expect(mocks.getFileInfo).toHaveBeenCalledTimes(1)
+    expect(mocks.getFileInfo).toHaveBeenCalledWith('/repo/missing.ts')
+    expect(mocks.openFile).not.toHaveBeenCalled()
+    expect(mocks.addEditorTab).not.toHaveBeenCalled()
+    expect(mocks.toastError).toHaveBeenCalledWith('File not found: missing.ts')
+  })
+
+  it('shows toast and does not open when resolved target is not a file', async () => {
+    mocks.getFileInfo.mockResolvedValue({
+      success: true,
+      data: {
+        path: '/repo/src',
+        size: 0,
+        modifiedAt: 1,
+        type: 'directory',
+        isReadOnly: false,
+        isBinary: false
+      }
+    })
+
+    const opened = await openFilePathFromTerminal('src', { cwd: '/repo' })
+
+    expect(opened).toBe(false)
+    expect(mocks.openFile).not.toHaveBeenCalled()
+    expect(mocks.addEditorTab).not.toHaveBeenCalled()
+    expect(mocks.toastError).toHaveBeenCalledWith('File not found: src')
+  })
+
+  it('shows toast and does not open when context is missing', async () => {
+    const opened = await openFilePathFromTerminal('src/App.tsx', {})
+
+    expect(opened).toBe(false)
+    expect(mocks.getFileInfo).not.toHaveBeenCalled()
+    expect(mocks.openFile).not.toHaveBeenCalled()
+    expect(mocks.addEditorTab).not.toHaveBeenCalled()
+    expect(mocks.toastError).toHaveBeenCalledWith('File not found: src/App.tsx')
+  })
+})

--- a/src/renderer/lib/file-path-links.test.ts
+++ b/src/renderer/lib/file-path-links.test.ts
@@ -11,6 +11,7 @@ import {
 const mocks = vi.hoisted(() => ({
   getFileInfo: vi.fn(),
   openFile: vi.fn(),
+  updateCursorPosition: vi.fn(),
   addEditorTab: vi.fn(),
   toastError: vi.fn()
 }))
@@ -22,7 +23,10 @@ vi.mock('@/lib/api', () => ({
 }))
 vi.mock('@/stores/editor-store', () => ({
   useEditorStore: {
-    getState: () => ({ openFile: mocks.openFile })
+    getState: () => ({
+      openFile: mocks.openFile,
+      updateCursorPosition: mocks.updateCursorPosition
+    })
   }
 }))
 
@@ -102,6 +106,7 @@ describe('file-path-links resolution', () => {
   beforeEach(() => {
     mocks.getFileInfo.mockReset()
     mocks.openFile.mockReset()
+    mocks.updateCursorPosition.mockReset()
     mocks.addEditorTab.mockReset()
     mocks.toastError.mockReset()
   })
@@ -304,6 +309,7 @@ describe('file-path-links resolution', () => {
 
     expect(opened).toEqual({ ok: true })
     expect(mocks.openFile).toHaveBeenCalledWith('/repo/src/renderer/App.tsx')
+    expect(mocks.updateCursorPosition).not.toHaveBeenCalled()
     expect(mocks.addEditorTab).toHaveBeenCalledWith('/repo/src/renderer/App.tsx')
     expect(mocks.toastError).not.toHaveBeenCalled()
   })
@@ -323,6 +329,7 @@ describe('file-path-links resolution', () => {
     expect(mocks.getFileInfo).toHaveBeenCalledTimes(1)
     expect(mocks.getFileInfo).toHaveBeenCalledWith('/repo/missing.ts')
     expect(mocks.openFile).not.toHaveBeenCalled()
+    expect(mocks.updateCursorPosition).not.toHaveBeenCalled()
     expect(mocks.addEditorTab).not.toHaveBeenCalled()
     expect(mocks.toastError).not.toHaveBeenCalled()
   })
@@ -348,6 +355,7 @@ describe('file-path-links resolution', () => {
       message: 'Path is a directory, not a file: src'
     })
     expect(mocks.openFile).not.toHaveBeenCalled()
+    expect(mocks.updateCursorPosition).not.toHaveBeenCalled()
     expect(mocks.addEditorTab).not.toHaveBeenCalled()
     expect(mocks.toastError).not.toHaveBeenCalled()
   })
@@ -362,7 +370,79 @@ describe('file-path-links resolution', () => {
     })
     expect(mocks.getFileInfo).not.toHaveBeenCalled()
     expect(mocks.openFile).not.toHaveBeenCalled()
+    expect(mocks.updateCursorPosition).not.toHaveBeenCalled()
     expect(mocks.addEditorTab).not.toHaveBeenCalled()
     expect(mocks.toastError).not.toHaveBeenCalled()
+  })
+
+  it('updates cursor position from line and column suffixes after opening', async () => {
+    mocks.getFileInfo.mockResolvedValue({
+      success: true,
+      data: {
+        path: '/repo/src/App.tsx',
+        size: 100,
+        modifiedAt: 1,
+        type: 'file',
+        isReadOnly: false,
+        isBinary: false
+      }
+    })
+
+    const opened = await openFilePathFromTerminal('src/App.tsx:12:3', {
+      cwd: '/repo'
+    })
+
+    expect(opened).toEqual({ ok: true })
+    expect(mocks.openFile).toHaveBeenCalledWith('/repo/src/App.tsx')
+    expect(mocks.updateCursorPosition).toHaveBeenCalledWith('/repo/src/App.tsx', 12, 3)
+    expect(mocks.addEditorTab).toHaveBeenCalledWith('/repo/src/App.tsx')
+  })
+
+  it('defaults column to 1 when only line suffix is provided', async () => {
+    mocks.getFileInfo.mockResolvedValue({
+      success: true,
+      data: {
+        path: '/repo/src/App.tsx',
+        size: 100,
+        modifiedAt: 1,
+        type: 'file',
+        isReadOnly: false,
+        isBinary: false
+      }
+    })
+
+    const opened = await openFilePathFromTerminal('src/App.tsx:9', {
+      cwd: '/repo'
+    })
+
+    expect(opened).toEqual({ ok: true })
+    expect(mocks.updateCursorPosition).toHaveBeenCalledWith('/repo/src/App.tsx', 9, 1)
+  })
+
+  it('returns open-failed when editor open throws', async () => {
+    mocks.getFileInfo.mockResolvedValue({
+      success: true,
+      data: {
+        path: '/repo/src/App.tsx',
+        size: 100,
+        modifiedAt: 1,
+        type: 'file',
+        isReadOnly: false,
+        isBinary: false
+      }
+    })
+    mocks.openFile.mockRejectedValue(new Error('boom'))
+
+    const opened = await openFilePathFromTerminal('src/App.tsx:2:5', {
+      cwd: '/repo'
+    })
+
+    expect(opened).toEqual({
+      ok: false,
+      reason: 'open-failed',
+      message: 'Failed to open file: src/App.tsx (boom)'
+    })
+    expect(mocks.updateCursorPosition).not.toHaveBeenCalled()
+    expect(mocks.addEditorTab).not.toHaveBeenCalled()
   })
 })

--- a/src/renderer/lib/file-path-links.ts
+++ b/src/renderer/lib/file-path-links.ts
@@ -13,11 +13,13 @@ export type FilePathResolutionResult =
   | { ok: true; path: string }
   | { ok: false; reason: 'missing-context' | 'not-found' | 'not-file' }
 
+type OpenFilePathFailureReason = Extract<FilePathResolutionResult, { ok: false }>['reason'] | 'open-failed'
+
 export type OpenFilePathResult =
   | { ok: true }
   | {
       ok: false
-      reason: Extract<FilePathResolutionResult, { ok: false }>['reason']
+      reason: OpenFilePathFailureReason
       message: string
     }
 
@@ -257,6 +259,24 @@ export function stripLineColumnSuffix(value: string): string {
   return value.replace(/:(\d+)(?::\d+)?$/, '')
 }
 
+function parseLineColumnSuffix(value: string): { line?: number; column?: number } {
+  const match = value.match(/:(\d+)(?::(\d+))?$/)
+  if (!match) {
+    return {}
+  }
+
+  const line = Number.parseInt(match[1], 10)
+  const parsedColumn = match[2] ? Number.parseInt(match[2], 10) : null
+
+  return {
+    line: Number.isFinite(line) && line > 0 ? line : undefined,
+    column:
+      parsedColumn !== null && Number.isFinite(parsedColumn) && parsedColumn > 0
+        ? parsedColumn
+        : undefined
+  }
+}
+
 /** Normalizes a terminal token into a file path candidate before filesystem resolution. */
 export function extractPathCandidate(value: string): string {
   return stripLineColumnSuffix(trimWrappedPath(value))
@@ -313,7 +333,8 @@ export async function resolveFilePathCandidate(
 
 function getErrorMessage(
   rawCandidate: string,
-  reason: Extract<FilePathResolutionResult, { ok: false }>['reason']
+  reason: OpenFilePathFailureReason,
+  details?: string
 ): string {
   const candidate = extractPathCandidate(rawCandidate)
 
@@ -324,6 +345,8 @@ function getErrorMessage(
       return `Path is a directory, not a file: ${candidate}`
     case 'not-found':
       return `File not found: ${candidate}`
+    case 'open-failed':
+      return details ? `Failed to open file: ${candidate} (${details})` : `Failed to open file: ${candidate}`
   }
 }
 
@@ -342,7 +365,24 @@ export async function openFilePathFromTerminal(
     }
   }
 
-  await useEditorStore.getState().openFile(resolution.path)
-  useWorkspaceStore.getState().addEditorTab(resolution.path)
-  return { ok: true }
+  const wrappedCandidate = trimWrappedPath(rawCandidate)
+  const position = parseLineColumnSuffix(wrappedCandidate)
+
+  try {
+    await useEditorStore.getState().openFile(resolution.path)
+
+    if (position.line) {
+      useEditorStore.getState().updateCursorPosition(resolution.path, position.line, position.column ?? 1)
+    }
+
+    useWorkspaceStore.getState().addEditorTab(resolution.path)
+    return { ok: true }
+  } catch (error) {
+    const details = error instanceof Error ? error.message : String(error)
+    return {
+      ok: false,
+      reason: 'open-failed',
+      message: getErrorMessage(rawCandidate, 'open-failed', details)
+    }
+  }
 }

--- a/src/renderer/lib/file-path-links.ts
+++ b/src/renderer/lib/file-path-links.ts
@@ -1,4 +1,3 @@
-import { toast } from 'sonner'
 import { filesystemApi } from '@/lib/api'
 import { useEditorStore } from '@/stores/editor-store'
 import { useWorkspaceStore } from '@/stores/workspace-store'
@@ -13,6 +12,14 @@ export interface FilePathResolutionContext {
 export type FilePathResolutionResult =
   | { ok: true; path: string }
   | { ok: false; reason: 'missing-context' | 'not-found' | 'not-file' }
+
+export type OpenFilePathResult =
+  | { ok: true }
+  | {
+      ok: false
+      reason: Extract<FilePathResolutionResult, { ok: false }>['reason']
+      message: string
+    }
 
 /** A 1-based xterm link range on a single rendered line. */
 export interface TerminalPathLinkRange {
@@ -52,7 +59,24 @@ function looksLikeFilePath(text: string): boolean {
   return text.includes('/') || text.includes('\\') || /^[A-Za-z]:/.test(text)
 }
 
+function isUrlAdjacentPathMatch(line: string, start: number, text: string): boolean {
+  if (!text.startsWith('/')) {
+    return false
+  }
+
+  const tokenStart = line.slice(0, start).search(/\S+$/)
+  if (tokenStart < 0) {
+    return false
+  }
+
+  const tokenPrefix = line.slice(tokenStart, start + 1).replace(/^[`"'([{]+/, '')
+  return URI_SCHEME_REGEX.test(tokenPrefix)
+}
+
 /** Extracts file-like links from a rendered terminal line for Ctrl/Cmd+Click activation. */
+// Range x-coordinates are based on JavaScript string indices. Wide or combining
+// terminal characters can render to different cell widths, and this module only
+// receives plain text, so it cannot accurately map visual cells here.
 export function buildTerminalPathLinks(
   line: string,
   lineNumber: number,
@@ -71,7 +95,7 @@ export function buildTerminalPathLinks(
     }
 
     const start = match.index ?? -1
-    if (start < 0) {
+    if (start < 0 || isUrlAdjacentPathMatch(line, start, text)) {
       continue
     }
 
@@ -217,11 +241,11 @@ function buildResolutionCandidates(candidate: string, roots: string[]): string[]
 
 /** Removes a single layer of wrapping quotes, brackets, or backticks from a path token. */
 export function trimWrappedPath(value: string): string {
-  let result = value.trim()
+  const result = value.trim()
 
   for (const [start, end] of WRAPPER_PAIRS) {
-    if (result.startsWith(start) && result.endsWith(end) && result.length >= 2) {
-      result = result.slice(1, -1).trim()
+    if (result.startsWith(start) && result.endsWith(end) && result.length >= start.length + end.length) {
+      return result.slice(start.length, result.length - end.length).trim()
     }
   }
 
@@ -261,10 +285,16 @@ export async function resolveFilePathCandidate(
     return { ok: false, reason: 'not-found' }
   }
 
+  const infoResults = await Promise.all(
+    absoluteCandidates.map(async (absolutePath) => ({
+      absolutePath,
+      infoResult: await filesystemApi.getFileInfo(absolutePath)
+    }))
+  )
+
   let sawDirectoryCandidate = false
 
-  for (const absolutePath of absoluteCandidates) {
-    const infoResult = await filesystemApi.getFileInfo(absolutePath)
+  for (const { absolutePath, infoResult } of infoResults) {
     if (!infoResult.success) {
       continue
     }
@@ -281,23 +311,38 @@ export async function resolveFilePathCandidate(
     : { ok: false, reason: 'not-found' }
 }
 
-function getErrorMessage(rawCandidate: string): string {
-  return `File not found: ${extractPathCandidate(rawCandidate)}`
+function getErrorMessage(
+  rawCandidate: string,
+  reason: Extract<FilePathResolutionResult, { ok: false }>['reason']
+): string {
+  const candidate = extractPathCandidate(rawCandidate)
+
+  switch (reason) {
+    case 'missing-context':
+      return `No project or working directory found; set a project/cwd to open paths: ${candidate}`
+    case 'not-file':
+      return `Path is a directory, not a file: ${candidate}`
+    case 'not-found':
+      return `File not found: ${candidate}`
+  }
 }
 
 /** Opens a resolved file path from terminal output and adds it to the editor workspace. */
 export async function openFilePathFromTerminal(
   rawCandidate: string,
   context: FilePathResolutionContext
-): Promise<boolean> {
+): Promise<OpenFilePathResult> {
   const resolution = await resolveFilePathCandidate(rawCandidate, context)
 
   if (!resolution.ok) {
-    toast.error(getErrorMessage(rawCandidate))
-    return false
+    return {
+      ok: false,
+      reason: resolution.reason,
+      message: getErrorMessage(rawCandidate, resolution.reason)
+    }
   }
 
   await useEditorStore.getState().openFile(resolution.path)
   useWorkspaceStore.getState().addEditorTab(resolution.path)
-  return true
+  return { ok: true }
 }

--- a/src/renderer/lib/file-path-links.ts
+++ b/src/renderer/lib/file-path-links.ts
@@ -1,0 +1,303 @@
+import { toast } from 'sonner'
+import { filesystemApi } from '@/lib/api'
+import { useEditorStore } from '@/stores/editor-store'
+import { useWorkspaceStore } from '@/stores/workspace-store'
+
+/** Resolves relative terminal paths against the terminal cwd and active project root. */
+export interface FilePathResolutionContext {
+  cwd?: string
+  projectRoot?: string
+}
+
+/** The result of resolving a terminal path candidate to an openable file. */
+export type FilePathResolutionResult =
+  | { ok: true; path: string }
+  | { ok: false; reason: 'missing-context' | 'not-found' | 'not-file' }
+
+/** A 1-based xterm link range on a single rendered line. */
+export interface TerminalPathLinkRange {
+  start: { x: number; y: number }
+  end: { x: number; y: number }
+}
+
+/** A clickable file path link extracted from terminal output. */
+export interface TerminalPathLink {
+  range: TerminalPathLinkRange
+  text: string
+  activate: (event: MouseEvent, text: string) => void | Promise<void>
+}
+
+const FILE_PATH_LINK_REGEX =
+  /(?:\.{1,2}[\\/]|[A-Za-z]:[\\/]|\\\\|\/)?(?:[^\s\\/:*?"<>|`]+[\\/])*[^\s\\/:*?"<>|`]+(?:\.[A-Za-z0-9_-]+)?(?::\d+(?::\d+)?)?/g
+
+const URI_SCHEME_REGEX = /^[a-zA-Z][a-zA-Z0-9+.-]*:\/\//
+
+const WRAPPER_PAIRS: Array<[string, string]> = [
+  ['`', '`'],
+  ['"', '"'],
+  ["'", "'"],
+  ['(', ')'],
+  ['[', ']']
+]
+
+function normalizePathSeparators(value: string): string {
+  return value.replace(/\\/g, '/')
+}
+
+function looksLikeFilePath(text: string): boolean {
+  if (URI_SCHEME_REGEX.test(text)) {
+    return false
+  }
+
+  return text.includes('/') || text.includes('\\') || /^[A-Za-z]:/.test(text)
+}
+
+/** Extracts file-like links from a rendered terminal line for Ctrl/Cmd+Click activation. */
+export function buildTerminalPathLinks(
+  line: string,
+  lineNumber: number,
+  onActivate: (event: MouseEvent, text: string) => void | Promise<void>
+): TerminalPathLink[] {
+  if (!line.includes('/') && !line.includes('\\') && !line.includes(':')) {
+    return []
+  }
+
+  const links: TerminalPathLink[] = []
+
+  for (const match of line.matchAll(FILE_PATH_LINK_REGEX)) {
+    const text = match[0]
+    if (!text || !looksLikeFilePath(text)) {
+      continue
+    }
+
+    const start = match.index ?? -1
+    if (start < 0) {
+      continue
+    }
+
+    links.push({
+      range: {
+        start: { x: start + 1, y: lineNumber },
+        end: { x: start + text.length, y: lineNumber }
+      },
+      text,
+      activate: onActivate
+    })
+  }
+
+  return links
+}
+
+function normalizeAbsolutePath(value: string): string {
+  const normalized = normalizePathSeparators(value)
+
+  if (normalized.startsWith('//')) {
+    return `//${normalized.slice(2).replace(/\/+/g, '/')}`
+  }
+
+  return normalized.replace(/\/+/g, '/')
+}
+
+function isAbsolutePath(value: string): boolean {
+  const normalized = normalizePathSeparators(value)
+  return normalized.startsWith('//') || normalized.startsWith('/') || /^[a-zA-Z]:\//.test(normalized)
+}
+
+function joinPath(base: string, candidate: string): string {
+  const normalizedBase = normalizePathSeparators(base).replace(/\/+$/, '')
+  const normalizedCandidate = normalizePathSeparators(candidate).replace(/^\/+/, '')
+  return normalizeAbsolutePath(`${normalizedBase}/${normalizedCandidate}`)
+}
+
+function canonicalizeAbsolutePath(value: string): string | null {
+  const normalized = normalizeAbsolutePath(value)
+
+  let root = '/'
+  let remainder = normalized
+
+  if (/^[a-zA-Z]:\//.test(normalized)) {
+    root = `${normalized.slice(0, 2)}/`
+    remainder = normalized.slice(3)
+  } else if (normalized.startsWith('//')) {
+    const segments = normalized.split('/').filter(Boolean)
+    if (segments.length < 2) {
+      return null
+    }
+    root = `//${segments[0]}/${segments[1]}`
+    remainder = segments.slice(2).join('/')
+  } else if (normalized.startsWith('/')) {
+    remainder = normalized.slice(1)
+  } else {
+    return null
+  }
+
+  const parts = remainder.split('/').filter(Boolean)
+  const resolvedParts: string[] = []
+
+  for (const part of parts) {
+    if (part === '.') {
+      continue
+    }
+
+    if (part === '..') {
+      if (resolvedParts.length === 0) {
+        return null
+      }
+      resolvedParts.pop()
+      continue
+    }
+
+    resolvedParts.push(part)
+  }
+
+  const joinedParts = resolvedParts.join('/')
+  const canonicalPath = joinedParts
+    ? root === '/'
+      ? `/${joinedParts}`
+      : normalizeAbsolutePath(`${root}/${joinedParts}`)
+    : root
+
+  return canonicalPath
+}
+
+function shouldCompareCaseInsensitively(path: string, root: string): boolean {
+  return /^[a-zA-Z]:\//.test(path) || /^[a-zA-Z]:\//.test(root) || path.startsWith('//') || root.startsWith('//')
+}
+
+function isPathWithinRoot(path: string, root: string): boolean {
+  const comparablePath = shouldCompareCaseInsensitively(path, root) ? path.toLowerCase() : path
+  const comparableRoot = shouldCompareCaseInsensitively(path, root) ? root.toLowerCase() : root
+
+  if (comparablePath === comparableRoot) {
+    return true
+  }
+
+  if (comparableRoot === '/') {
+    return comparablePath.startsWith('/')
+  }
+
+  return comparablePath.startsWith(`${comparableRoot}/`)
+}
+
+function getAllowedRoots(context: FilePathResolutionContext): string[] {
+  const roots = [context.cwd, context.projectRoot]
+    .map((value) => (value ? canonicalizeAbsolutePath(value) : null))
+    .filter((value): value is string => Boolean(value))
+
+  return [...new Set(roots)]
+}
+
+function buildResolutionCandidates(candidate: string, roots: string[]): string[] {
+  if (isAbsolutePath(candidate)) {
+    const absoluteCandidate = canonicalizeAbsolutePath(candidate)
+    if (!absoluteCandidate) {
+      return []
+    }
+
+    return roots.some((root) => isPathWithinRoot(absoluteCandidate, root))
+      ? [absoluteCandidate]
+      : []
+  }
+
+  const paths: string[] = []
+
+  for (const root of roots) {
+    const resolvedCandidate = canonicalizeAbsolutePath(joinPath(root, candidate))
+    if (!resolvedCandidate || !isPathWithinRoot(resolvedCandidate, root)) {
+      continue
+    }
+
+    if (!paths.includes(resolvedCandidate)) {
+      paths.push(resolvedCandidate)
+    }
+  }
+
+  return paths
+}
+
+/** Removes a single layer of wrapping quotes, brackets, or backticks from a path token. */
+export function trimWrappedPath(value: string): string {
+  let result = value.trim()
+
+  for (const [start, end] of WRAPPER_PAIRS) {
+    if (result.startsWith(start) && result.endsWith(end) && result.length >= 2) {
+      result = result.slice(1, -1).trim()
+    }
+  }
+
+  return result
+}
+
+/** Removes trailing :line or :line:column suffixes from a path token. */
+export function stripLineColumnSuffix(value: string): string {
+  return value.replace(/:(\d+)(?::\d+)?$/, '')
+}
+
+/** Normalizes a terminal token into a file path candidate before filesystem resolution. */
+export function extractPathCandidate(value: string): string {
+  return stripLineColumnSuffix(trimWrappedPath(value))
+}
+
+/** Resolves a terminal path token to an existing file using terminal and project context. */
+export async function resolveFilePathCandidate(
+  rawCandidate: string,
+  context: FilePathResolutionContext
+): Promise<FilePathResolutionResult> {
+  const candidate = extractPathCandidate(rawCandidate)
+
+  if (candidate.endsWith('/') || candidate.endsWith('\\')) {
+    return { ok: false, reason: 'not-file' }
+  }
+
+  const allowedRoots = getAllowedRoots(context)
+
+  if (allowedRoots.length === 0) {
+    return { ok: false, reason: 'missing-context' }
+  }
+
+  const absoluteCandidates = buildResolutionCandidates(candidate, allowedRoots)
+
+  if (absoluteCandidates.length === 0) {
+    return { ok: false, reason: 'not-found' }
+  }
+
+  let sawDirectoryCandidate = false
+
+  for (const absolutePath of absoluteCandidates) {
+    const infoResult = await filesystemApi.getFileInfo(absolutePath)
+    if (!infoResult.success) {
+      continue
+    }
+
+    if (infoResult.data.type === 'file') {
+      return { ok: true, path: absolutePath }
+    }
+
+    sawDirectoryCandidate = true
+  }
+
+  return sawDirectoryCandidate
+    ? { ok: false, reason: 'not-file' }
+    : { ok: false, reason: 'not-found' }
+}
+
+function getErrorMessage(rawCandidate: string): string {
+  return `File not found: ${extractPathCandidate(rawCandidate)}`
+}
+
+/** Opens a resolved file path from terminal output and adds it to the editor workspace. */
+export async function openFilePathFromTerminal(
+  rawCandidate: string,
+  context: FilePathResolutionContext
+): Promise<boolean> {
+  const resolution = await resolveFilePathCandidate(rawCandidate, context)
+
+  if (!resolution.ok) {
+    toast.error(getErrorMessage(rawCandidate))
+    return false
+  }
+
+  await useEditorStore.getState().openFile(resolution.path)
+  useWorkspaceStore.getState().addEditorTab(resolution.path)
+  return true
+}

--- a/src/renderer/lib/tauri-filesystem-api.ts
+++ b/src/renderer/lib/tauri-filesystem-api.ts
@@ -1,4 +1,5 @@
 import {
+	open,
 	readDir,
 	readTextFile,
 	writeTextFile,
@@ -69,6 +70,22 @@ function isBinaryFile(content: string): boolean {
 	const sample = content.slice(0, 512);
 	// eslint-disable-next-line no-control-regex
 	return /[\x00-\x08]/.test(sample);
+}
+
+async function readBinarySample(filePath: string, byteCount: number): Promise<string> {
+	const file = await open(filePath, { read: true });
+
+	try {
+		const bytes = new Uint8Array(byteCount);
+		const bytesRead = await file.read(bytes);
+		if (!bytesRead) {
+			return "";
+		}
+
+		return new TextDecoder().decode(bytes.subarray(0, bytesRead));
+	} finally {
+		await file.close();
+	}
 }
 
 function getExtension(filename: string): string | null {
@@ -155,15 +172,31 @@ export function createTauriFilesystemApi(): FilesystemApi {
 		async getFileInfo(filePath: string): Promise<IpcResult<FileInfo>> {
 			try {
 				const info = await stat(filePath);
-				const content = await readTextFile(filePath).catch(() => "");
+				const modifiedAt = info.mtime?.getTime() ?? Date.now();
+
+				if (info.isDirectory) {
+					return {
+						success: true,
+						data: {
+							path: filePath,
+							size: info.size,
+							modifiedAt,
+							type: "directory",
+							isReadOnly: false,
+							isBinary: false,
+						},
+					};
+				}
+
+				const content = await readBinarySample(filePath, 512).catch(() => "");
 
 				return {
 					success: true,
 					data: {
 						path: filePath,
 						size: info.size,
-						modifiedAt: info.mtime?.getTime() ?? Date.now(),
-						type: info.isDirectory ? "directory" : "file",
+						modifiedAt,
+						type: "file",
 						isReadOnly: false, // Tauri plugin-fs doesn't expose readonly
 						isBinary: isBinaryFile(content),
 					},

--- a/src/renderer/lib/tauri-filesystem-api.ts
+++ b/src/renderer/lib/tauri-filesystem-api.ts
@@ -163,6 +163,7 @@ export function createTauriFilesystemApi(): FilesystemApi {
 						path: filePath,
 						size: info.size,
 						modifiedAt: info.mtime?.getTime() ?? Date.now(),
+						type: info.isDirectory ? "directory" : "file",
 						isReadOnly: false, // Tauri plugin-fs doesn't expose readonly
 						isBinary: isBinaryFile(content),
 					},

--- a/src/shared/types/filesystem.types.ts
+++ b/src/shared/types/filesystem.types.ts
@@ -18,6 +18,7 @@ export interface FileInfo {
   path: string
   size: number
   modifiedAt: number
+  type: 'file' | 'directory'
   isReadOnly: boolean
   isBinary: boolean
 }


### PR DESCRIPTION
## Summary
- add Ctrl/Cmd-click terminal file path links in the connected terminal
- resolve terminal file paths against cwd and project root with root-boundary and UNC handling
- extend filesystem file info typing and add focused regression tests

## Test plan
- [x] npm run typecheck:web
- [x] npm test -- --run src/renderer/lib/file-path-links.test.ts src/renderer/lib/__tests__/tauri-filesystem-api.test.ts src/renderer/components/terminal/ConnectedTerminal.test.tsx

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Terminal file paths are clickable: Ctrl/Cmd+Click opens files from terminal output in the editor using terminal/project context.
* **Improvements**
  * Filesystem metadata now distinguishes files vs directories and improves binary detection.
  * Link handling is more robust with better cwd/project fallbacks and clearer user-facing error messages on failures.
* **Tests**
  * Expanded test coverage for terminal link parsing, path resolution, opening flows, filesystem API responses, and updater edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->