### PR TITLE
fix: replace display:none with visibility hidden for editor panels

### DIFF
--- a/src/renderer/components/editor/CodeEditor.tsx
+++ b/src/renderer/components/editor/CodeEditor.tsx
@@ -149,7 +149,9 @@ export function CodeEditor({
   }, [canRenderToc, getTocPanelSizePercent])
 
   return (
-    <div className="h-full w-full" style={{ display: isVisible ? 'block' : 'none' }}>
+    <div
+      className={isVisible ? 'h-full w-full' : 'h-full w-full absolute inset-0 invisible pointer-events-none overflow-hidden'}
+    >
       <div ref={layoutRef} className="h-full w-full">
         <ResizablePanelGroup ref={panelGroupRef} direction="horizontal">
           <ResizablePanel defaultSize={canRenderToc ? 100 - tocPanelDefaultSize : 100} minSize={60}>

--- a/src/renderer/components/editor/MarkdownEditor.tsx
+++ b/src/renderer/components/editor/MarkdownEditor.tsx
@@ -183,7 +183,9 @@ export function MarkdownEditor({
   }, [canRenderToc, getTocPanelSizePercent])
 
   return (
-    <div className="w-full h-full" style={{ display: isVisible ? 'block' : 'none' }}>
+    <div
+      className={isVisible ? 'w-full h-full' : 'w-full h-full absolute inset-0 invisible pointer-events-none overflow-hidden'}
+    >
       <div ref={layoutRef} className="h-full w-full">
         <ResizablePanelGroup ref={panelGroupRef} direction="horizontal">
           <ResizablePanel defaultSize={canRenderToc ? 100 - tocPanelDefaultSize : 100} minSize={60}>


### PR DESCRIPTION
## Problem

`prosemirror-dropcursor` (via `@blocknote/core`) crashes when the MarkdownEditor container uses `display: none`:

```
TypeError: null is not an object (evaluating 'parent.appendChild')
TypeError: null is not an object (evaluating 'this.element.parentNode')
```

**Root cause**: dragover events reach the hidden prosemirror view, which tries to position a drop cursor overlay via `offsetParent.appendChild`. With `display: none`, the element has no layout → `offsetParent` is `null`.

## Fix

Replace `display: none` with `visibility: hidden` + `pointer-events: none` + `overflow: hidden` for both `MarkdownEditor` and `CodeEditor` when `isVisible` is false. Keeps DOM layout intact while preventing visual display and user interaction.

Also adds **middle-click to close tab** for faster tab management.

## Files Changed
- `src/renderer/components/editor/MarkdownEditor.tsx` — visibility-based hiding
- `src/renderer/components/editor/CodeEditor.tsx` — visibility-based hiding
- `src/renderer/components/workspace/WorkspaceTabBar.tsx` — middle-click close tab

## Testing
- 64 test files, 920 tests passing
- TypeScript clean, ESLint clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized code and markdown editor visibility handling for improved performance and DOM consistency while maintaining existing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->