### PR TITLE
feat: add close button to AppPreferences and ProjectSettings headers

### DIFF
--- a/src/renderer/pages/AppPreferences.tsx
+++ b/src/renderer/pages/AppPreferences.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react'
-import { RotateCcw, Keyboard, Download, CheckCircle2, AlertCircle, ExternalLink } from 'lucide-react'
+import { useNavigate } from 'react-router-dom'
+import { RotateCcw, Keyboard, Download, CheckCircle2, AlertCircle, ExternalLink, X } from 'lucide-react'
 import {
   useTerminalFontFamily,
   useTerminalFontSize,
@@ -30,6 +31,7 @@ import { shellApi, terminalApi } from '@/lib/api'
 import { isAurUpdateMode } from '@/lib/tauri-updater-api'
 
 export default function AppPreferences(): React.JSX.Element {
+  const navigate = useNavigate()
   const isAurUpdater = isAurUpdateMode()
   const fontFamily = useTerminalFontFamily()
   const fontSize = useTerminalFontSize()
@@ -156,6 +158,14 @@ export default function AppPreferences(): React.JSX.Element {
               Configure global application settings
             </p>
           </div>
+          <button
+            onClick={() => { navigate('/') }}
+            className="group flex items-center justify-center h-8 w-8 rounded-md hover:bg-secondary transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-primary"
+            title="Close"
+            aria-label="Close preferences"
+          >
+            <X size={18} className="text-muted-foreground group-hover:text-foreground" />
+          </button>
         </div>
 
         {/* Content */}

--- a/src/renderer/pages/ProjectSettings.tsx
+++ b/src/renderer/pages/ProjectSettings.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from 'react'
 import { Settings, Save, Info, Plus, X, ChevronDown, Upload } from 'lucide-react'
 import { useNavigate } from 'react-router-dom'
 import { NewProjectModal } from '@/components/NewProjectModal'
+import { ConfirmDialog } from '@/components/ConfirmDialog'
 import {
   useProjects,
   useActiveProject,
@@ -19,6 +20,7 @@ import { parseEnvFile, mergeEnvVars } from '@/lib/env-parser'
 export default function ProjectSettings() {
   const navigate = useNavigate()
   const [isNewProjectModalOpen, setIsNewProjectModalOpen] = useState(false)
+  const [isCloseConfirmOpen, setIsCloseConfirmOpen] = useState(false)
   const activeProject = useActiveProject()
   const activeProjectId = useActiveProjectId()
   const {
@@ -179,6 +181,20 @@ export default function ProjectSettings() {
               </p>
             </div>
           </div>
+          <button
+            onClick={() => {
+              if (hasChanges) {
+                setIsCloseConfirmOpen(true)
+              } else {
+                navigate('/')
+              }
+            }}
+            className="group flex items-center justify-center h-8 w-8 rounded-md hover:bg-secondary transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-primary"
+            title="Close"
+            aria-label="Close project settings"
+          >
+            <X size={18} className="text-muted-foreground group-hover:text-foreground" />
+          </button>
         </div>
 
         {/* Content */}
@@ -456,6 +472,20 @@ export default function ProjectSettings() {
         isOpen={isNewProjectModalOpen}
         onClose={() => setIsNewProjectModalOpen(false)}
         onCreateProject={addProject}
+      />
+
+      <ConfirmDialog
+        isOpen={isCloseConfirmOpen}
+        title="Unsaved Changes"
+        message={`You have unsaved changes in ${activeProject?.name ?? 'this project'}. Leaving will discard them.`}
+        confirmLabel="Leave"
+        cancelLabel="Cancel"
+        variant="danger"
+        onConfirm={() => {
+          setIsCloseConfirmOpen(false)
+          navigate('/')
+        }}
+        onCancel={() => setIsCloseConfirmOpen(false)}
       />
     </>
   )


### PR DESCRIPTION
Users navigating to the preferences or project settings pages had no obvious way to return to the workspace. They had to discover that clicking a project in the sidebar was the implicit close mechanism.

This PR adds an explicit **X** close button to each page header, making navigation intuitive and consistent with other modals/panels in the app.

### Changes
- `src/renderer/pages/AppPreferences.tsx` — added close button that navigates back to `/`
- `src/renderer/pages/ProjectSettings.tsx` — added close button that navigates back to `/`

Both buttons:
- Match existing focus/hover styling (`hover:bg-secondary`, `focus-visible:ring-2`)
- Include proper `title` and `aria-label` for accessibility

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added close (X) buttons to the app preferences and project settings pages for easier navigation back to the main view.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->