### PR TITLE
fix(signing): update ed25519 public key for new key pair

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -36,7 +36,7 @@
 		},
 		"updater": {
 			"active": true,
-			"pubkey": "${TAURI_SIGNING_PUBLIC_KEY}",
+			"pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDZFNDdGQUQ5NTc4M0Q5OTIKUldTUzJZTlgyZnBIYmdObmg3dFc0QS9PN3F5N2Y5dUNoTy94dWcvTmNxam10Y25tS240dm0ySnYK",
 			"endpoints": [
 				"https://github.com/gnoviawan/termul/releases/latest/download/latest.json"
 			],


### PR DESCRIPTION
Fix signing key mismatch that caused v0.3.6 release build to fail with "Wrong password for that key".

### Problem
- PR #121 merged  into  which reverted the hardcoded public key back to `${TAURI_SIGNING_PUBLIC_KEY}` (env var)
- Tauri runtime cannot resolve env vars in config at build time
- Generated key pair had mismatched password in GitHub Secret

### Changes
- Restore hardcoded ed25519 public key in `tauri.conf.json`
- Key pair re-generated and all GitHub Secrets already updated:
  - `TAURI_SIGNING_PRIVATE_KEY`
  - `TAURI_SIGNING_PRIVATE_KEY_PASSWORD`
  - `TAURI_SIGNING_PUBLIC_KEY"

### After merge
Retag v0.3.6 on the merged commit to trigger CD pipeline again.