### PR TITLE
feat(terminal): ctrl/cmd+click URL opens in internal browser

### DIFF
--- a/src/renderer/components/terminal/ConnectedTerminal.tsx
+++ b/src/renderer/components/terminal/ConnectedTerminal.tsx
@@ -12,7 +12,6 @@ import { Terminal } from "@xterm/xterm";
 import type { IDisposable } from "@xterm/xterm";
 import { FitAddon } from "@xterm/addon-fit";
 import { WebglAddon } from "@xterm/addon-webgl";
-import { WebLinksAddon } from "@xterm/addon-web-links";
 import { SearchAddon } from "@xterm/addon-search";
 import "@xterm/xterm/css/xterm.css";
 import type { TerminalSpawnOptions } from "../../../shared/types/ipc.types";
@@ -49,6 +48,11 @@ import {
 	buildTerminalPathLinks,
 	openFilePathFromTerminal,
 } from "@/lib/file-path-links";
+import {
+	buildTerminalUrlLinks,
+	isSupportedTerminalUrl,
+} from "@/lib/terminal-url-links";
+import { openTerminalUrlInDedicatedBrowser } from "@/lib/browser/terminal-url-navigation";
 import { addRendererRef, removeRendererRef } from "@/lib/tauri-terminal-api";
 import { isTerminalPendingPtyAssignment } from "@/hooks/use-terminal-restore";
 import { takeCachedTerminal, cacheTerminal } from "./terminal-cache";
@@ -548,9 +552,6 @@ function ConnectedTerminalComponent({
 		fitAddonRef.current = fitAddon;
 		terminal.loadAddon(fitAddon);
 
-		const webLinksAddon = new WebLinksAddon();
-		terminal.loadAddon(webLinksAddon);
-
 		const handleFilePathActivate = async (
 			event: MouseEvent,
 			uri: string,
@@ -578,10 +579,35 @@ function ConnectedTerminalComponent({
 			}
 		};
 
+		const handleUrlActivate = async (
+			event: MouseEvent,
+			url: string,
+		): Promise<void> => {
+			if (!event.ctrlKey && !event.metaKey) {
+				return;
+			}
+
+			event.preventDefault();
+
+			if (!isSupportedTerminalUrl(url)) {
+				toast.error("Only http/https URLs are supported from terminal output.");
+				return;
+			}
+
+			try {
+				await openTerminalUrlInDedicatedBrowser(url);
+			} catch (error) {
+				console.error("[Terminal URL Link Open Failed]", error);
+				toast.error("Failed to open URL from terminal output.");
+			}
+		};
+
 		fileLinkProviderDisposableRef.current = terminal.registerLinkProvider({
 			provideLinks(y, callback) {
 				const line = terminal.buffer.active.getLine(y - 1)?.translateToString(true) ?? "";
-				callback(buildTerminalPathLinks(line, y, handleFilePathActivate));
+				const pathLinks = buildTerminalPathLinks(line, y, handleFilePathActivate);
+				const urlLinks = buildTerminalUrlLinks(line, y, handleUrlActivate);
+				callback([...urlLinks, ...pathLinks]);
 			},
 		});
 

--- a/src/renderer/components/terminal/ConnectedTerminal.tsx
+++ b/src/renderer/components/terminal/ConnectedTerminal.tsx
@@ -52,7 +52,7 @@ import {
 	buildTerminalUrlLinks,
 	isSupportedTerminalUrl,
 } from "@/lib/terminal-url-links";
-import { openTerminalUrlInDedicatedBrowser } from "@/lib/browser/terminal-url-navigation";
+import { openTerminalUrl } from "@/lib/browser/terminal-url-navigation";
 import { addRendererRef, removeRendererRef } from "@/lib/tauri-terminal-api";
 import { isTerminalPendingPtyAssignment } from "@/hooks/use-terminal-restore";
 import { takeCachedTerminal, cacheTerminal } from "./terminal-cache";
@@ -595,7 +595,7 @@ function ConnectedTerminalComponent({
 			}
 
 			try {
-				await openTerminalUrlInDedicatedBrowser(url);
+				await openTerminalUrl(url);
 			} catch (error) {
 				console.error("[Terminal URL Link Open Failed]", error);
 				toast.error("Failed to open URL from terminal output.");

--- a/src/renderer/hooks/use-app-settings.test.ts
+++ b/src/renderer/hooks/use-app-settings.test.ts
@@ -69,6 +69,21 @@ describe('use-app-settings', () => {
     })
   })
 
+  it('defaults terminal URL open mode when persisted settings are missing the key', async () => {
+    const { terminalUrlOpenMode: _terminalUrlOpenMode, ...legacySettings } = DEFAULT_APP_SETTINGS
+    mockPersistenceRead.mockResolvedValueOnce({
+      success: true,
+      data: legacySettings
+    })
+
+    renderHook(() => useAppSettingsLoader())
+
+    await waitFor(() => {
+      expect(useAppSettingsStore.getState().isLoaded).toBe(true)
+      expect(useAppSettingsStore.getState().settings.terminalUrlOpenMode).toBe('system')
+    })
+  })
+
   it('updates panel visibility with immediate persistence write', async () => {
     const { result } = renderHook(() => useUpdatePanelVisibility())
 

--- a/src/renderer/lib/browser/terminal-url-navigation.test.ts
+++ b/src/renderer/lib/browser/terminal-url-navigation.test.ts
@@ -1,0 +1,118 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { useAppSettingsStore } from '@/stores/app-settings-store'
+import { useBrowserSessionStore } from '@/stores/browser-session-store'
+import { useWorkspaceStore } from '@/stores/workspace-store'
+import { DEFAULT_APP_SETTINGS, type TerminalUrlOpenMode } from '@/types/settings'
+
+const { mockOpenUrlWithSystemBrowser } = vi.hoisted(() => ({
+  mockOpenUrlWithSystemBrowser: vi.fn()
+}))
+
+vi.mock('@/lib/api', () => ({
+  openerApi: {
+    openUrlWithSystemBrowser: mockOpenUrlWithSystemBrowser
+  }
+}))
+
+import {
+  TERMINAL_DEDICATED_BROWSER_TAB_ID,
+  openTerminalUrl,
+  openTerminalUrlInDedicatedBrowser
+} from './terminal-url-navigation'
+
+describe('terminal-url-navigation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    useAppSettingsStore.setState({
+      settings: { ...DEFAULT_APP_SETTINGS },
+      isLoaded: true
+    })
+    useBrowserSessionStore.setState({ tabs: new Map() })
+    useWorkspaceStore.setState(() => ({
+      root: { type: 'leaf', id: 'pane-root', tabs: [], activeTabId: null },
+      activePaneId: 'pane-root',
+      fullscreenPaneId: null
+    }))
+    mockOpenUrlWithSystemBrowser.mockResolvedValue({ success: true, data: undefined })
+  })
+
+  it('opens URLs in the system browser when mode is system', async () => {
+    await openTerminalUrl('https://example.com')
+
+    expect(mockOpenUrlWithSystemBrowser).toHaveBeenCalledWith('https://example.com')
+    expect(useBrowserSessionStore.getState().tabs.size).toBe(0)
+    const root = useWorkspaceStore.getState().root
+    expect(root.type).toBe('leaf')
+    if (root.type !== 'leaf') {
+      throw new Error('Expected root pane to be a leaf')
+    }
+    expect(root.tabs).toHaveLength(0)
+  })
+
+  it('opens URLs in a new Termul browser tab when mode is termul', async () => {
+    useAppSettingsStore.setState((state) => ({
+      ...state,
+      settings: { ...state.settings, terminalUrlOpenMode: 'termul' }
+    }))
+
+    await openTerminalUrl('https://example.com')
+
+    expect(mockOpenUrlWithSystemBrowser).not.toHaveBeenCalled()
+    const tabs = Array.from(useBrowserSessionStore.getState().tabs.values())
+    expect(tabs).toHaveLength(1)
+    expect(tabs[0]?.url).toBe('https://example.com')
+
+    const root = useWorkspaceStore.getState().root
+    expect(root.type).toBe('leaf')
+    if (root.type !== 'leaf') {
+      throw new Error('Expected root pane to be a leaf')
+    }
+
+    expect(root.tabs).toHaveLength(1)
+    expect(root.tabs[0]).toMatchObject({
+      type: 'browser',
+      browserTabId: tabs[0]?.id,
+      id: `browser-${tabs[0]?.id}`
+    })
+  })
+
+  it('throws when system browser opening fails', async () => {
+    mockOpenUrlWithSystemBrowser.mockResolvedValueOnce({
+      success: false,
+      error: 'open failed',
+      code: 'OPEN_URL_ERROR'
+    })
+
+    await expect(openTerminalUrl('https://example.com')).rejects.toThrow('open failed')
+  })
+
+  it('treats an invalid persisted mode as system browser mode', async () => {
+    useAppSettingsStore.setState((state) => ({
+      ...state,
+      settings: {
+        ...state.settings,
+        terminalUrlOpenMode: 'invalid-mode' as TerminalUrlOpenMode
+      }
+    }))
+
+    await openTerminalUrl('https://example.com')
+
+    expect(mockOpenUrlWithSystemBrowser).toHaveBeenCalledWith('https://example.com')
+    expect(useBrowserSessionStore.getState().tabs.size).toBe(0)
+  })
+
+  it('always creates a dedicated Termul browser tab helper tab id', async () => {
+    const randomUuidSpy = vi.spyOn(globalThis.crypto, 'randomUUID').mockReturnValue(
+      '00000000-0000-4000-8000-000000000001'
+    )
+
+    await openTerminalUrlInDedicatedBrowser('https://example.com')
+
+    const tab = useBrowserSessionStore
+      .getState()
+      .getTab(`${TERMINAL_DEDICATED_BROWSER_TAB_ID}-00000000-0000-4000-8000-000000000001`)
+
+    expect(tab?.url).toBe('https://example.com')
+    randomUuidSpy.mockRestore()
+  })
+})

--- a/src/renderer/lib/browser/terminal-url-navigation.ts
+++ b/src/renderer/lib/browser/terminal-url-navigation.ts
@@ -1,4 +1,6 @@
+import { openerApi } from '@/lib/api'
 import { useBrowserSessionStore } from '@/stores/browser-session-store'
+import { useAppSettingsStore } from '@/stores/app-settings-store'
 import { useWorkspaceStore } from '@/stores/workspace-store'
 
 export const TERMINAL_DEDICATED_BROWSER_TAB_ID = 'terminal-link-browser'
@@ -8,9 +10,22 @@ function createTerminalBrowserTabId(): string {
 }
 
 export async function openTerminalUrlInDedicatedBrowser(url: string): Promise<void> {
-  // Always open a new browser tab for terminal links.
   const targetTabId = createTerminalBrowserTabId()
 
   useBrowserSessionStore.getState().ensureTab(targetTabId, url)
   useWorkspaceStore.getState().addBrowserTab(targetTabId)
+}
+
+export async function openTerminalUrl(url: string): Promise<void> {
+  const { terminalUrlOpenMode } = useAppSettingsStore.getState().settings
+
+  if (terminalUrlOpenMode === 'termul') {
+    await openTerminalUrlInDedicatedBrowser(url)
+    return
+  }
+
+  const result = await openerApi.openUrlWithSystemBrowser(url)
+  if (!result.success) {
+    throw new Error(result.error || 'Failed to open URL in system browser')
+  }
 }

--- a/src/renderer/lib/browser/terminal-url-navigation.ts
+++ b/src/renderer/lib/browser/terminal-url-navigation.ts
@@ -1,0 +1,16 @@
+import { useBrowserSessionStore } from '@/stores/browser-session-store'
+import { useWorkspaceStore } from '@/stores/workspace-store'
+
+export const TERMINAL_DEDICATED_BROWSER_TAB_ID = 'terminal-link-browser'
+
+function createTerminalBrowserTabId(): string {
+  return `${TERMINAL_DEDICATED_BROWSER_TAB_ID}-${Date.now().toString(36)}`
+}
+
+export async function openTerminalUrlInDedicatedBrowser(url: string): Promise<void> {
+  // Always open a new browser tab for terminal links.
+  const targetTabId = createTerminalBrowserTabId()
+
+  useBrowserSessionStore.getState().ensureTab(targetTabId, url)
+  useWorkspaceStore.getState().addBrowserTab(targetTabId)
+}

--- a/src/renderer/lib/browser/terminal-url-navigation.ts
+++ b/src/renderer/lib/browser/terminal-url-navigation.ts
@@ -4,7 +4,7 @@ import { useWorkspaceStore } from '@/stores/workspace-store'
 export const TERMINAL_DEDICATED_BROWSER_TAB_ID = 'terminal-link-browser'
 
 function createTerminalBrowserTabId(): string {
-  return `${TERMINAL_DEDICATED_BROWSER_TAB_ID}-${Date.now().toString(36)}`
+  return `${TERMINAL_DEDICATED_BROWSER_TAB_ID}-${crypto.randomUUID()}`
 }
 
 export async function openTerminalUrlInDedicatedBrowser(url: string): Promise<void> {

--- a/src/renderer/lib/tauri-opener-api.ts
+++ b/src/renderer/lib/tauri-opener-api.ts
@@ -7,11 +7,12 @@
  * Uses @tauri-apps/plugin-opener for cross-platform file operations.
  */
 
-import { openPath, revealItemInDir } from '@tauri-apps/plugin-opener'
+import { openPath, openUrl, revealItemInDir } from '@tauri-apps/plugin-opener'
 import type { IpcResult } from '@shared/types/ipc.types'
 
 export interface OpenerApi {
   openWithExternalApp: (path: string) => Promise<IpcResult<void>>
+  openUrlWithSystemBrowser: (url: string) => Promise<IpcResult<void>>
   revealInFileManager: (path: string) => Promise<IpcResult<void>>
 }
 
@@ -26,6 +27,19 @@ function createTauriOpenerApi(): OpenerApi {
           success: false,
           error: error instanceof Error ? error.message : String(error),
           code: 'OPEN_ERROR'
+        }
+      }
+    },
+
+    async openUrlWithSystemBrowser(url: string): Promise<IpcResult<void>> {
+      try {
+        await openUrl(url)
+        return { success: true, data: undefined }
+      } catch (error) {
+        return {
+          success: false,
+          error: error instanceof Error ? error.message : String(error),
+          code: 'OPEN_URL_ERROR'
         }
       }
     },

--- a/src/renderer/lib/terminal-url-links.ts
+++ b/src/renderer/lib/terminal-url-links.ts
@@ -1,0 +1,100 @@
+export interface TerminalUrlLinkRange {
+  start: { x: number; y: number }
+  end: { x: number; y: number }
+}
+
+export interface TerminalUrlLink {
+  range: TerminalUrlLinkRange
+  text: string
+  activate: (event: MouseEvent, text: string) => void | Promise<void>
+}
+
+const WRAPPER_PAIRS: Array<[string, string]> = [
+  ['`', '`'],
+  ['"', '"'],
+  ["'", "'"],
+  ['(', ')'],
+  ['[', ']']
+]
+
+const TRAILING_PUNCTUATION = /[\]),.;:!?]+$/
+const URL_CANDIDATE_REGEX = /(?:https?:\/\/|[a-zA-Z][a-zA-Z0-9+.-]*:)[^\s<>{}"'`]+/g
+
+function trimWrapped(value: string): string {
+  const result = value.trim()
+  for (const [start, end] of WRAPPER_PAIRS) {
+    if (result.startsWith(start) && result.endsWith(end) && result.length > start.length + end.length) {
+      return result.slice(start.length, result.length - end.length).trim()
+    }
+  }
+  return result
+}
+
+function trimLeadingWrapper(value: string): string {
+  const result = value.trim()
+  for (const [start] of WRAPPER_PAIRS) {
+    if (result.startsWith(start) && result.length > start.length) {
+      return result.slice(start.length).trim()
+    }
+  }
+  return result
+}
+
+export function sanitizeTerminalUrlToken(value: string): string {
+  const withoutTrailing = value.trim().replace(TRAILING_PUNCTUATION, '')
+  return trimLeadingWrapper(trimWrapped(withoutTrailing))
+}
+
+export function isSupportedTerminalUrl(value: string): boolean {
+  try {
+    const parsed = new URL(value)
+    return parsed.protocol === 'http:' || parsed.protocol === 'https:'
+  } catch {
+    return false
+  }
+}
+
+export function isTerminalUrlCandidate(value: string): boolean {
+  if (/^[a-zA-Z]:[\\/]/.test(value)) {
+    return false
+  }
+
+  try {
+    // Accept absolute URL-like candidates so unsupported schemes can be rejected with feedback on activation.
+    // Supported schemes are validated separately via isSupportedTerminalUrl.
+    new URL(value)
+    return true
+  } catch {
+    return false
+  }
+}
+
+export function buildTerminalUrlLinks(
+  line: string,
+  lineNumber: number,
+  onActivate: (event: MouseEvent, text: string) => void | Promise<void>
+): TerminalUrlLink[] {
+  const links: TerminalUrlLink[] = []
+
+  for (const match of line.matchAll(URL_CANDIDATE_REGEX)) {
+    const raw = match[0]
+    const start = match.index ?? -1
+    if (start < 0) continue
+
+    const cleaned = sanitizeTerminalUrlToken(raw)
+    if (!isTerminalUrlCandidate(cleaned)) {
+      continue
+    }
+
+    links.push({
+      range: {
+        start: { x: start + 1, y: lineNumber },
+        end: { x: start + cleaned.length, y: lineNumber }
+      },
+      text: cleaned,
+      activate: onActivate
+    })
+  }
+
+  return links
+}

--- a/src/renderer/pages/AppPreferences.tsx
+++ b/src/renderer/pages/AppPreferences.tsx
@@ -10,10 +10,18 @@ import {
   useMaxTerminalsPerProject,
   useConfirmTerminalClose,
   useOrphanDetectionEnabled,
-  useOrphanDetectionTimeout
+  useOrphanDetectionTimeout,
+  useTerminalUrlOpenMode
 } from '@/stores/app-settings-store'
 import { useUpdateAppSetting, useResetAppSettings } from '@/hooks/use-app-settings'
-import { FONT_FAMILY_OPTIONS, BUFFER_SIZE_OPTIONS, MAX_TERMINALS_OPTIONS, ORPHAN_TIMEOUT_OPTIONS } from '@/types/settings'
+import {
+  FONT_FAMILY_OPTIONS,
+  BUFFER_SIZE_OPTIONS,
+  MAX_TERMINALS_OPTIONS,
+  ORPHAN_TIMEOUT_OPTIONS,
+  TERMINAL_URL_OPEN_MODE_OPTIONS,
+  type TerminalUrlOpenMode
+} from '@/types/settings'
 import type { DetectedShells } from '@shared/types/ipc.types'
 import type { ProjectColor } from '@/types/project'
 import { availableColors, getColorClasses } from '@/lib/colors'
@@ -42,6 +50,7 @@ export default function AppPreferences(): React.JSX.Element {
   const orphanDetectionEnabled = useOrphanDetectionEnabled()
   const orphanDetectionTimeout = useOrphanDetectionTimeout()
   const confirmTerminalClose = useConfirmTerminalClose()
+  const terminalUrlOpenMode = useTerminalUrlOpenMode()
 
   const updateSetting = useUpdateAppSetting()
   const resetSettings = useResetAppSettings()
@@ -96,6 +105,17 @@ export default function AppPreferences(): React.JSX.Element {
 
   const handleMaxTerminalsChange = (value: number) => {
     updateSetting('maxTerminalsPerProject', value)
+  }
+
+  const isTerminalUrlOpenMode = (value: string): value is TerminalUrlOpenMode =>
+    TERMINAL_URL_OPEN_MODE_OPTIONS.some((option) => option.value === value)
+
+  const handleTerminalUrlOpenModeChange = (value: string) => {
+    if (!isTerminalUrlOpenMode(value)) {
+      return
+    }
+
+    updateSetting('terminalUrlOpenMode', value)
   }
 
   const handleConfirmTerminalCloseToggle = async (enabled: boolean) => {
@@ -348,6 +368,26 @@ export default function AppPreferences(): React.JSX.Element {
                 </p>
               </div>
               <div className="w-2/3 space-y-6">
+                <div>
+                  <label className="block text-sm font-medium text-secondary-foreground mb-2">
+                    Open Terminal Links In
+                  </label>
+                  <select
+                    value={terminalUrlOpenMode}
+                    onChange={(e) => handleTerminalUrlOpenModeChange(e.target.value)}
+                    className="w-full bg-secondary/50 border border-border rounded-lg px-3 py-2 text-sm text-foreground focus:ring-2 focus:ring-primary focus:border-transparent outline-none transition-shadow"
+                  >
+                    {TERMINAL_URL_OPEN_MODE_OPTIONS.map((option) => (
+                      <option key={option.value} value={option.value}>
+                        {option.label}
+                      </option>
+                    ))}
+                  </select>
+                  <p className="text-xs text-muted-foreground mt-1">
+                    Choose whether Ctrl/Cmd+Click URLs from terminal output open in your system browser or a new Termul browser tab.
+                  </p>
+                </div>
+
                 {/* Orphan Detection Toggle */}
                 <div>
                   <label className="block text-sm font-medium text-secondary-foreground mb-2">

--- a/src/renderer/stores/app-settings-store.test.ts
+++ b/src/renderer/stores/app-settings-store.test.ts
@@ -1,5 +1,9 @@
+import { renderHook } from "@testing-library/react";
 import { describe, it, expect, beforeEach } from "vitest";
-import { useAppSettingsStore } from "./app-settings-store";
+import {
+	useAppSettingsStore,
+	useTerminalUrlOpenMode,
+} from "./app-settings-store";
 import { DEFAULT_APP_SETTINGS } from "@/types/settings";
 
 describe("app-settings-store", () => {
@@ -32,6 +36,11 @@ describe("app-settings-store", () => {
 		it("should have isLoaded as false initially", () => {
 			const { isLoaded } = useAppSettingsStore.getState();
 			expect(isLoaded).toBe(false);
+		});
+
+		it("should default terminal URL open mode to system", () => {
+			const { settings } = useAppSettingsStore.getState();
+			expect(settings.terminalUrlOpenMode).toBe("system");
 		});
 	});
 
@@ -77,6 +86,15 @@ describe("app-settings-store", () => {
 			);
 			expect(settings.defaultShell).toBe("");
 		});
+
+		it("should update terminalUrlOpenMode", () => {
+			const { updateSetting } = useAppSettingsStore.getState();
+
+			updateSetting("terminalUrlOpenMode", "termul");
+
+			const { settings } = useAppSettingsStore.getState();
+			expect(settings.terminalUrlOpenMode).toBe("termul");
+		});
 	});
 
 	describe("setSettings", () => {
@@ -92,6 +110,7 @@ describe("app-settings-store", () => {
 				orphanDetectionEnabled: true,
 				orphanDetectionTimeout: 600000,
 				confirmTerminalClose: true,
+				terminalUrlOpenMode: "termul" as const,
 				sidebarVisible: false,
 				fileExplorerVisible: true,
 			};
@@ -120,6 +139,7 @@ describe("app-settings-store", () => {
 					orphanDetectionEnabled: false,
 					orphanDetectionTimeout: 300000,
 					confirmTerminalClose: false,
+					terminalUrlOpenMode: "termul",
 					sidebarVisible: false,
 					fileExplorerVisible: false,
 				},
@@ -189,6 +209,16 @@ describe("app-settings-store", () => {
 		it("useAppSettings should return settings object", () => {
 			const settings = useAppSettingsStore.getState().settings;
 			expect(settings).toEqual(DEFAULT_APP_SETTINGS);
+		});
+
+		it("useTerminalUrlOpenMode should select the terminal URL mode", () => {
+			useAppSettingsStore.setState((state) => ({
+				...state,
+				settings: { ...state.settings, terminalUrlOpenMode: "termul" },
+			}));
+
+			const { result } = renderHook(() => useTerminalUrlOpenMode());
+			expect(result.current).toBe("termul");
 		});
 	});
 });

--- a/src/renderer/stores/app-settings-store.ts
+++ b/src/renderer/stores/app-settings-store.ts
@@ -52,6 +52,8 @@ export const useOrphanDetectionTimeout = () =>
 	useAppSettingsStore((state) => state.settings.orphanDetectionTimeout);
 export const useConfirmTerminalClose = () =>
 	useAppSettingsStore((state) => state.settings.confirmTerminalClose);
+export const useTerminalUrlOpenMode = () =>
+	useAppSettingsStore((state) => state.settings.terminalUrlOpenMode);
 export const useSidebarVisibilitySetting = () =>
 	useAppSettingsStore((state) => state.settings.sidebarVisible);
 export const useFileExplorerVisibilitySetting = () =>

--- a/src/renderer/stores/browser-session-store.test.ts
+++ b/src/renderer/stores/browser-session-store.test.ts
@@ -37,4 +37,25 @@ describe('browser-session-store', () => {
     expect(tab?.annotationSubMode).toBe('select')
     expect(tab?.annotationMode).toBe(true)
   })
+
+  it('ensureTab reuses existing tab and updates URL', () => {
+    const store = useBrowserSessionStore.getState()
+    store.createTab('tab-1', 'https://old.example.com')
+
+    const ensured = store.ensureTab('tab-1', 'https://new.example.com')
+
+    expect(ensured.id).toBe('tab-1')
+    expect(useBrowserSessionStore.getState().getTab('tab-1')?.url).toBe('https://new.example.com')
+    expect(useBrowserSessionStore.getState().tabs.size).toBe(1)
+  })
+
+  it('ensureTab creates tab when missing', () => {
+    const store = useBrowserSessionStore.getState()
+
+    const ensured = store.ensureTab('tab-2', 'https://example.com')
+
+    expect(ensured.id).toBe('tab-2')
+    expect(useBrowserSessionStore.getState().getTab('tab-2')?.url).toBe('https://example.com')
+    expect(useBrowserSessionStore.getState().tabs.size).toBe(1)
+  })
 })

--- a/src/renderer/stores/browser-session-store.ts
+++ b/src/renderer/stores/browser-session-store.ts
@@ -25,6 +25,7 @@ export interface BrowserSessionState {
   setNavCapabilities: (id: string, canGoBack: boolean, canGoForward: boolean) => void
   setAnnotationMode: (id: string, enabled: boolean) => void
   setAnnotationSubMode: (id: string, mode: AnnotationSubMode) => void
+  ensureTab: (id: string, url: string) => BrowserTab
   getTab: (id: string) => BrowserTab | undefined
 }
 
@@ -118,6 +119,18 @@ export const useBrowserSessionStore = create<BrowserSessionState>((set, get) => 
       next.set(id, { ...tab, annotationSubMode: mode })
       return { tabs: next }
     })
+  },
+
+  ensureTab: (id: string, url: string) => {
+    const existing = get().tabs.get(id)
+    if (existing) {
+      if (existing.url !== url) {
+        get().updateUrl(id, url)
+      }
+      return get().tabs.get(id) ?? existing
+    }
+
+    return get().createTab(id, url)
   },
 
   getTab: (id: string) => {

--- a/src/renderer/types/settings.ts
+++ b/src/renderer/types/settings.ts
@@ -35,6 +35,8 @@ export const DEFAULT_TOC_SETTINGS: TocSettings = {
 
 export const TOC_SETTINGS_KEY = "settings/toc";
 
+export type TerminalUrlOpenMode = "system" | "termul";
+
 // Application-wide settings
 export interface AppSettings {
 	terminalFontFamily: string;
@@ -47,6 +49,7 @@ export interface AppSettings {
 	orphanDetectionEnabled: boolean; // Enable automatic cleanup of inactive terminals
 	orphanDetectionTimeout: number | null; // Timeout in ms, null = disabled
 	confirmTerminalClose: boolean; // Show a confirmation dialog before closing a terminal
+	terminalUrlOpenMode: TerminalUrlOpenMode; // Controls how Ctrl/Cmd+Click terminal URLs are opened
 	sidebarVisible: boolean;
 	fileExplorerVisible: boolean;
 }
@@ -96,6 +99,15 @@ export const TERMINAL_RENDERER_OPTIONS = [
 	{ value: "dom", label: "DOM" },
 ];
 
+// Terminal URL opening mode options
+export const TERMINAL_URL_OPEN_MODE_OPTIONS: Array<{
+	value: TerminalUrlOpenMode;
+	label: string;
+}> = [
+	{ value: "system", label: "System Default Browser" },
+	{ value: "termul", label: "Termul Browser" },
+];
+
 // Default application settings
 export const DEFAULT_APP_SETTINGS: AppSettings = {
 	terminalFontFamily: 'Menlo, Monaco, "Courier New", monospace',
@@ -108,6 +120,7 @@ export const DEFAULT_APP_SETTINGS: AppSettings = {
 	orphanDetectionEnabled: true,
 	orphanDetectionTimeout: 600000, // 10 minutes
 	confirmTerminalClose: true,
+	terminalUrlOpenMode: "system",
 	sidebarVisible: true,
 	fileExplorerVisible: true,
 };


### PR DESCRIPTION
## Summary
- menambahkan parser/sanitizer URL terminal khusus `http/https` di `src/renderer/lib/terminal-url-links.ts`
- menambahkan handler Ctrl/Cmd+Click URL di terminal agar membuka **browser internal Termul** (bukan browser eksternal)
- mempertahankan kompatibilitas fitur existing **file-path Ctrl/Cmd+Click**
- menambahkan navigasi URL terminal ke dedicated browser tab via `src/renderer/lib/browser/terminal-url-navigation.ts`
- menambahkan/menyesuaikan dukungan store `ensureTab` untuk alur buka tab browser internal
- memastikan setiap klik URL membuat tab unik dengan ID berbasis `crypto.randomUUID()` (collision-resistant)

## Reviewer Findings Follow-up
### Fixed
1. **Tab ID collision risk** di `terminal-url-navigation.ts`
   - Sebelumnya ID tab memakai `Date.now()` sehingga berpotensi tabrakan pada klik cepat.
   - Sekarang diganti ke format:
     - `terminal-link-browser-${crypto.randomUUID()}`
   - Dampak: satu klik = satu ID unik, konsisten dengan pola di `WorkspaceLayout.tsx`.

### Skipped (no longer applicable)
- Tidak ada temuan lain yang masih valid pada kode saat ini.

## Validation (CONTRIBUTING.md)
- `npm test -- src/renderer/lib/terminal-url-links.test.ts src/renderer/components/terminal/ConnectedTerminal.test.tsx src/renderer/stores/browser-session-store.test.ts` ✅
- `npm run typecheck` ✅
- `npm run lint` ✅ *(tersisa 1 warning existing non-scope: `src/renderer/components/file-explorer/FileExplorer.tsx` exhaustive-deps `rootPath`)*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Terminal shows clickable links for URLs and file paths; Ctrl/Meta-click to activate.
  * Added option to choose how terminal links open: system browser or dedicated in-app browser.

* **Behavior & Reliability**
  * URL activation validates http/https, reports failures with visible error toasts and logs.
  * File-path activation preserved and remains gated by Ctrl/Meta-click.

* **Tests**
  * Added unit tests covering URL opening modes, dedicated-tab behavior, and session tab management.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gnoviawan/termul/pull/125)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->