### PR TITLE
fix: terminal shortcut passthrough — app shortcuts now fire from terminal focus

### DIFF
--- a/src/renderer/components/terminal/ConnectedTerminal.test.tsx
+++ b/src/renderer/components/terminal/ConnectedTerminal.test.tsx
@@ -1172,7 +1172,7 @@ describe('ConnectedTerminal', () => {
       expect(result).toBe(false)
     })
 
-    it('should pass Ctrl+R through to PTY as a readline passthrough (reverse-i-search)', async () => {
+    it('should treat Ctrl+R as app-owned when it matches an app shortcut', async () => {
       render(<ConnectedTerminal />)
 
       await vi.waitFor(() => {
@@ -1181,8 +1181,8 @@ describe('ConnectedTerminal', () => {
 
       const handler = mockTerminalInstance.attachCustomKeyEventHandler.mock.calls[0][0]
 
-      // Ctrl+R is a readline binding (reverse-i-search) and must reach the PTY
-      // on all platforms even though it may also match the commandHistory app shortcut.
+      // Ctrl+R matches commandHistory app shortcut — should be app-owned so the
+      // workspace handler can open the command history panel from terminal focus.
       const event = new KeyboardEvent('keydown', {
         key: 'r',
         ctrlKey: true,
@@ -1191,10 +1191,10 @@ describe('ConnectedTerminal', () => {
 
       const result = handler(event)
 
-      expect(result).toBe(true)
+      expect(result).toBe(false)
     })
 
-    it('should pass Ctrl+K through to PTY as a readline passthrough (kill to EOL)', async () => {
+    it('should treat Ctrl+K as app-owned when it matches an app shortcut', async () => {
       render(<ConnectedTerminal />)
 
       await vi.waitFor(() => {
@@ -1203,10 +1203,32 @@ describe('ConnectedTerminal', () => {
 
       const handler = mockTerminalInstance.attachCustomKeyEventHandler.mock.calls[0][0]
 
-      // Ctrl+K is a readline binding (kill to end of line) and must reach the PTY
-      // on all platforms even though it may also match the commandPalette app shortcut.
+      // Ctrl+K matches commandPalette app shortcut — should be app-owned so the
+      // workspace handler can open the command palette from terminal focus.
       const event = new KeyboardEvent('keydown', {
         key: 'k',
+        ctrlKey: true,
+        bubbles: true
+      })
+
+      const result = handler(event)
+
+      expect(result).toBe(false)
+    })
+
+    it('should pass pure readline passthrough Ctrl+E when it matches no app shortcut', async () => {
+      render(<ConnectedTerminal />)
+
+      await vi.waitFor(() => {
+        expect(mockTerminalInstance.attachCustomKeyEventHandler).toHaveBeenCalled()
+      })
+
+      const handler = mockTerminalInstance.attachCustomKeyEventHandler.mock.calls[0][0]
+
+      // Ctrl+E is a readline binding (end of line) and does NOT match any app
+      // shortcut — must reach the PTY.
+      const event = new KeyboardEvent('keydown', {
+        key: 'e',
         ctrlKey: true,
         bubbles: true
       })

--- a/src/renderer/components/terminal/ConnectedTerminal.tsx
+++ b/src/renderer/components/terminal/ConnectedTerminal.tsx
@@ -58,10 +58,12 @@ import {
 } from "@/lib/terminal-continuity-instrumentation";
 import { useActiveProject } from "@/stores/project-store";
 
-// Common readline/shell Ctrl sequences that should always pass through to the
-// PTY regardless of platform. On macOS these are already protected by the
-// isMac guard, but on Windows/Linux they would otherwise be swallowed when a
-// matching app shortcut exists (e.g. commandPalette=ctrl+k, commandHistory=ctrl+r).
+// Common readline/shell Ctrl sequences that pass through to the PTY only when
+// no configured app shortcut claims them. Checking these LAST (after app
+// shortcuts) ensures that app bindings like commandPalette=ctrl+k,
+// commandHistory=ctrl+r, newProject=ctrl+n work from terminal focus.
+// On macOS readline Ctrl sequences are already protected by matchesShortcut's
+// isMac guard (Ctrl+key never triggers app shortcuts on macOS).
 const READLINE_PASSTHROUGH_KEYS = new Set([
 	"a", // Ctrl+A  move to beginning of line
 	"e", // Ctrl+E  move to end of line
@@ -91,18 +93,22 @@ function isAppOwnedTerminalShortcut(
 	event: KeyboardEvent,
 	shortcuts: ReturnType<typeof useKeyboardShortcutsStore.getState>["shortcuts"],
 ): boolean {
-	// Ctrl+letter readline bindings must reach the PTY on every platform.
-	// On macOS the isMac guard below handles this, but on Windows/Linux the
-	// same Ctrl+key might be configured as an app shortcut — pass them through.
-	if (!isMac && isReadlinePassthrough(event)) {
-		return false;
-	}
-
+	// 1. App shortcuts take priority over readline passthrough.
+	// This ensures commandPalette, commandHistory, etc. work from terminal
+	// focus even though their Ctrl+key also matches a readline binding.
 	for (const shortcut of Object.values(shortcuts)) {
 		const activeKey = shortcut.customKey ?? shortcut.defaultKey;
 		if (matchesShortcut(event, activeKey)) {
 			return true;
 		}
+	}
+
+	// 2. No app shortcut matched — check readline passthrough.
+	// Ctrl+letter readline bindings must reach the PTY on every platform.
+	// On macOS the isMac guard in matchesShortcut already prevents Ctrl+key
+	// from matching app shortcuts, so the readline behavior is preserved.
+	if (isReadlinePassthrough(event)) {
+		return false;
 	}
 
 	return false;

--- a/src/renderer/layouts/WorkspaceLayout.tsx
+++ b/src/renderer/layouts/WorkspaceLayout.tsx
@@ -536,6 +536,11 @@ export default function WorkspaceLayout(): React.JSX.Element {
 
 	useEffect(() => {
 		const handleKeyDown = (e: KeyboardEvent) => {
+			// Safety net: skip workspace handling when an earlier handler has already
+			// processed this event by calling preventDefault() — e.g. xterm clipboard
+			// ops or ConnectedTerminal's customKeyEventHandler for terminal-owned keys.
+			if (e.defaultPrevented) return;
+
 			const { isInEditor, isInTerminal, isInInput } = getShortcutTargetContext(
 				e.target,
 			);


### PR DESCRIPTION
## Summary

App-level keyboard shortcuts (command palette Ctrl+K, command history Ctrl+R, new project Ctrl+N, etc.) don't fire when the terminal has focus — users must click outside the terminal first.

## Related Issue

Fixes the lingering shortcut passthrough issue after the xterm 5.5 → 6.1 upgrade.

## Type of Change

- [x] fix: bug fix

## What Changed

- **src/renderer/components/terminal/ConnectedTerminal.tsx** — Reversed priority in `isAppOwnedTerminalShortcut`: app shortcuts are now checked BEFORE readline passthrough. This prevents xterm 6.1's internal `stopPropagation()` from swallowing app shortcuts when the terminal has focus.

- **src/renderer/layouts/WorkspaceLayout.tsx** — Added `if (e.defaultPrevented) return` safety guard as defense-in-depth against stale propagation.

- **src/renderer/components/terminal/ConnectedTerminal.test.tsx** — Updated Ctrl+R and Ctrl+K tests to expect app-owned (false), added test for pure readline passthrough (Ctrl+E, expects true).

## How It Was Tested

- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm run test` — 1052 tests pass, 0 regressions
- [ ] Manual verification completed
- [ ] Not applicable

## Screenshots or Recordings

N/A — internal keyboard event routing, no UI changes.

## Checklist

- [x] My PR title follows the conventional commit format used by this repo
- [ ] I linked the related issue or explained why none exists
- [ ] I updated docs when needed
- [x] I added or updated tests when needed
- [x] I verified the change does not introduce unrelated modifications


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced keyboard shortcut prioritization to ensure app shortcuts consistently take precedence over terminal-level bindings.
  * Fixed event handling to prevent duplicate shortcut processing when an earlier handler has already claimed the event.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gnoviawan/termul/pull/138)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->