### PR TITLE
feat: add pane-level fullscreen toggle with animation

### DIFF
--- a/src/renderer/components/workspace/PaneContent.tsx
+++ b/src/renderer/components/workspace/PaneContent.tsx
@@ -56,9 +56,10 @@ export function PaneContent({
 	);
 
 	// FIX: Batch workspace store subscriptions with useShallow to prevent cascading re-renders
-	const { activePaneId, setActivePane } = useWorkspaceStore(
+	const { activePaneId, fullscreenPaneId, setActivePane } = useWorkspaceStore(
 		useShallow((state) => ({
 			activePaneId: state.activePaneId,
+			fullscreenPaneId: state.fullscreenPaneId,
 			setActivePane: state.setActivePane,
 		})),
 	);
@@ -70,10 +71,13 @@ export function PaneContent({
 	const { setTerminalPtyId } = useTerminalActions();
 	const { isDragging, previewTarget } = usePaneDnd();
 
+	const isFullscreenPane = fullscreenPaneId === pane.id;
 	const isActivePane = activePaneId === pane.id;
 	const activeTab = pane.tabs.find((t) => t.id === pane.activeTabId);
 	const panePreviewPosition =
-		previewTarget?.paneId === pane.id ? previewTarget.position : null;
+		previewTarget?.paneId === pane.id && !isFullscreenPane
+			? previewTarget.position
+			: null;
 
 	const handleFocus = useCallback(() => {
 		if (!isActivePane) {
@@ -107,7 +111,8 @@ export function PaneContent({
 		<div
 			className={cn(
 				"flex flex-col h-full relative",
-				isActivePane && hasMultiplePanes && "ring-1 ring-primary/30",
+				isActivePane && hasMultiplePanes && !isFullscreenPane && "ring-1 ring-primary/30",
+				isFullscreenPane && "ring-1 ring-primary/30 rounded-xl overflow-hidden",
 			)}
 			onMouseDown={handleFocus}
 		>
@@ -281,7 +286,7 @@ export function PaneContent({
 					</div>
 				</div>
 
-				{isDragging && <DropZoneOverlay paneId={pane.id} />}
+				{isDragging && !isFullscreenPane && <DropZoneOverlay paneId={pane.id} />}
 			</div>
 		</div>
 	);

--- a/src/renderer/components/workspace/WorkspaceTabBar.test.tsx
+++ b/src/renderer/components/workspace/WorkspaceTabBar.test.tsx
@@ -33,6 +33,8 @@ vi.mock('@/stores/workspace-store', () => ({
       getState: () => mockWorkspaceStoreState
     }
   ),
+  useFullscreenPaneId: () => null,
+  useLeafCount: () => 3,
   editorTabId: (filePath: string) => `edit-${filePath}`
 }))
 

--- a/src/renderer/components/workspace/WorkspaceTabBar.test.tsx
+++ b/src/renderer/components/workspace/WorkspaceTabBar.test.tsx
@@ -8,11 +8,14 @@ const mockSetActiveTab = vi.fn()
 const mockSetActivePane = vi.fn()
 const mockReorderTabsInPane = vi.fn()
 const mockCloseTab = vi.fn()
+const mockTogglePaneFullscreen = vi.fn()
 const mockCloseFileIfIdle = vi.fn(() => true)
 
 const mockWorkspaceStoreState = {
+  fullscreenPaneId: null as string | null,
   setActiveTab: mockSetActiveTab,
   setActivePane: mockSetActivePane,
+  togglePaneFullscreen: mockTogglePaneFullscreen,
   reorderTabsInPane: mockReorderTabsInPane,
   closeTab: mockCloseTab
 }
@@ -111,7 +114,9 @@ beforeEach(() => {
   mockSetActivePane.mockReset()
   mockReorderTabsInPane.mockReset()
   mockCloseTab.mockReset()
+  mockTogglePaneFullscreen.mockReset()
   mockCloseFileIfIdle.mockReset()
+  mockWorkspaceStoreState.fullscreenPaneId = null
   mockCloseFileIfIdle.mockReturnValue(true)
   mockEditorOpenFiles.clear()
   mockStartTabDrag.mockReset()
@@ -203,6 +208,39 @@ describe('WorkspaceTabBar', () => {
     fireEvent.click(screen.getByTitle('New Browser Tab'))
 
     expect(onAddBrowserTab).toHaveBeenCalledTimes(1)
+  })
+
+  it('shows a focus control for non-fullscreen panes and toggles fullscreen for the current pane', async () => {
+    render(
+      <WorkspaceTabBar
+        paneId="pane-a"
+        tabs={[]}
+        activeTabId={null}
+      />
+    )
+
+    await flushShellEffect()
+
+    fireEvent.click(screen.getByTitle('Focus pane'))
+
+    expect(mockTogglePaneFullscreen).toHaveBeenCalledWith('pane-a')
+  })
+
+  it('shows a restore control for the fullscreen pane', async () => {
+    mockWorkspaceStoreState.fullscreenPaneId = 'pane-a'
+
+    render(
+      <WorkspaceTabBar
+        paneId="pane-a"
+        tabs={[]}
+        activeTabId={null}
+      />
+    )
+
+    await flushShellEffect()
+
+    expect(screen.getByTitle('Restore pane layout')).toBeInTheDocument()
+    expect(screen.queryByTitle('Focus pane')).not.toBeInTheDocument()
   })
 
   it('renders editor tab with non-jitter active style class', async () => {

--- a/src/renderer/components/workspace/WorkspaceTabBar.tsx
+++ b/src/renderer/components/workspace/WorkspaceTabBar.tsx
@@ -13,7 +13,7 @@ import {
 import { cn } from "@/lib/utils";
 import { EditorTab } from "./EditorTab";
 import { Skeleton } from "@/components/ui/skeleton";
-import { useWorkspaceStore, editorTabId } from "@/stores/workspace-store";
+import { useWorkspaceStore, useLeafCount, editorTabId } from "@/stores/workspace-store";
 import { useEditorStore } from "@/stores/editor-store";
 import { useTerminalStore } from "@/stores/terminal-store";
 import { usePaneDnd } from "@/hooks/use-pane-dnd";
@@ -445,6 +445,7 @@ export function WorkspaceTabBar({
 				togglePaneFullscreen: state.togglePaneFullscreen,
 			}))
 		);
+	const leafCount = useLeafCount();
 	const {
 		startTabDrag,
 		dragPayload,
@@ -809,14 +810,16 @@ export function WorkspaceTabBar({
 			</div>
 
 			<div className="ml-auto flex items-center gap-1 px-2 shrink-0 h-full border-l border-border/60">
-				<button
-					onClick={() => togglePaneFullscreen(paneId)}
-					className="h-7 w-7 flex items-center justify-center rounded hover:bg-secondary text-muted-foreground hover:text-foreground transition-colors"
-					title={isFullscreenPane ? "Restore pane layout" : "Focus pane"}
-					aria-label={isFullscreenPane ? "Restore pane layout" : "Focus pane"}
-				>
-					{isFullscreenPane ? <Minimize2 size={12} /> : <Maximize2 size={12} />}
-				</button>
+				{leafCount > 1 && (
+					<button
+						onClick={() => togglePaneFullscreen(paneId)}
+						className="h-7 w-7 flex items-center justify-center rounded hover:bg-secondary text-muted-foreground hover:text-foreground transition-colors"
+						title={isFullscreenPane ? "Restore pane layout" : "Focus pane"}
+						aria-label={isFullscreenPane ? "Restore pane layout" : "Focus pane"}
+					>
+						{isFullscreenPane ? <Minimize2 size={12} /> : <Maximize2 size={12} />}
+					</button>
+				)}
 				{onAddTerminal && (
 					<div ref={terminalMenuRef} className="relative flex items-center h-full">
 						<button

--- a/src/renderer/components/workspace/WorkspaceTabBar.tsx
+++ b/src/renderer/components/workspace/WorkspaceTabBar.tsx
@@ -7,6 +7,8 @@ import {
 	Loader2,
 	Skull,
 	Globe,
+	Maximize2,
+	Minimize2,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { EditorTab } from "./EditorTab";
@@ -434,8 +436,15 @@ export function WorkspaceTabBar({
 	onCloseEditorTab,
 	defaultShell,
 }: WorkspaceTabBarProps): React.JSX.Element {
-	const setActiveTab = useWorkspaceStore((state) => state.setActiveTab);
-	const setActivePane = useWorkspaceStore((state) => state.setActivePane);
+	const { setActiveTab, setActivePane, fullscreenPaneId, togglePaneFullscreen } =
+		useWorkspaceStore(
+			useShallow((state) => ({
+				setActiveTab: state.setActiveTab,
+				setActivePane: state.setActivePane,
+				fullscreenPaneId: state.fullscreenPaneId,
+				togglePaneFullscreen: state.togglePaneFullscreen,
+			}))
+		);
 	const {
 		startTabDrag,
 		dragPayload,
@@ -662,6 +671,7 @@ export function WorkspaceTabBar({
 	});
 
 	const terminalStoreTerminals = useTerminalStore((state) => state.terminals);
+	const isFullscreenPane = fullscreenPaneId === paneId;
 
 	// Check if this tab is being dragged
 	const isTabDragging = (tabId: string): boolean =>
@@ -799,6 +809,14 @@ export function WorkspaceTabBar({
 			</div>
 
 			<div className="ml-auto flex items-center gap-1 px-2 shrink-0 h-full border-l border-border/60">
+				<button
+					onClick={() => togglePaneFullscreen(paneId)}
+					className="h-7 w-7 flex items-center justify-center rounded hover:bg-secondary text-muted-foreground hover:text-foreground transition-colors"
+					title={isFullscreenPane ? "Restore pane layout" : "Focus pane"}
+					aria-label={isFullscreenPane ? "Restore pane layout" : "Focus pane"}
+				>
+					{isFullscreenPane ? <Minimize2 size={12} /> : <Maximize2 size={12} />}
+				</button>
 				{onAddTerminal && (
 					<div ref={terminalMenuRef} className="relative flex items-center h-full">
 						<button

--- a/src/renderer/layouts/WorkspaceLayout.close-persistence.test.tsx
+++ b/src/renderer/layouts/WorkspaceLayout.close-persistence.test.tsx
@@ -125,6 +125,7 @@ vi.mock('@/stores/workspace-store', () => ({
   },
   useActiveTab: () => undefined,
   useFullscreenPaneId: () => null,
+  useLeafCount: () => 1,
   usePaneRoot: () => ({ type: 'leaf', id: 'pane-root', tabs: [], activeTabId: null }),
   editorTabId: (filePath: string) => `editor:${filePath}`,
   getActiveTerminalIdFromTree: () => null,

--- a/src/renderer/layouts/WorkspaceLayout.close-persistence.test.tsx
+++ b/src/renderer/layouts/WorkspaceLayout.close-persistence.test.tsx
@@ -124,6 +124,7 @@ vi.mock('@/stores/workspace-store', () => ({
     subscribe: () => vi.fn()
   },
   useActiveTab: () => undefined,
+  useFullscreenPaneId: () => null,
   usePaneRoot: () => ({ type: 'leaf', id: 'pane-root', tabs: [], activeTabId: null }),
   editorTabId: (filePath: string) => `editor:${filePath}`,
   getActiveTerminalIdFromTree: () => null,

--- a/src/renderer/layouts/WorkspaceLayout.test.tsx
+++ b/src/renderer/layouts/WorkspaceLayout.test.tsx
@@ -5,6 +5,8 @@ import { TooltipProvider } from '@/components/ui/tooltip'
 import WorkspaceLayout from './WorkspaceLayout'
 import { useFileExplorerStore } from '@/stores/file-explorer-store'
 import { useSidebarStore } from '@/stores/sidebar-store'
+import { useWorkspaceStore } from '@/stores/workspace-store'
+import type { SplitNode } from '@/types/workspace.types'
 import type { Project, Terminal, ProjectColor } from '@/types/project'
 
 function createProject(id: string, path: string, color: ProjectColor): Project {
@@ -305,6 +307,9 @@ const renderWithRouter = (initialEntries = ['/']) => {
 }
 
 describe('WorkspaceLayout - Empty States', () => {
+	beforeEach(() => {
+		useWorkspaceStore.getState().resetLayout()
+	})
   describe('No Projects Empty State', () => {
     beforeEach(() => {
       // Ensure no projects
@@ -471,6 +476,68 @@ describe('WorkspaceLayout - Empty States', () => {
         /Create your first project to organize your terminals/
       )
       expect(description.className).toContain('text-muted-foreground')
+    })
+  })
+
+  describe('Pane fullscreen mode', () => {
+    beforeEach(() => {
+      const project = createProject('a', '/workspace/a', 'blue')
+      mockUseProjects.mockReturnValue([project])
+      mockUseActiveProject.mockReturnValue(project)
+      mockUseActiveProjectId.mockReturnValue('a')
+      mockUseTerminals.mockReturnValue([])
+      mockUseAllTerminals.mockReturnValue([])
+      mockUseActiveTerminal.mockReturnValue(null)
+      mockUseActiveTerminalId.mockReturnValue('')
+
+      const workspace = useWorkspaceStore.getState()
+      workspace.resetLayout()
+      workspace.addEditorTab('/workspace/a/src/a.ts')
+      const leftPaneId = useWorkspaceStore.getState().activePaneId
+      workspace.splitPane(
+        leftPaneId,
+        'horizontal',
+        { type: 'editor', id: 'edit-/workspace/a/src/b.ts', filePath: '/workspace/a/src/b.ts' },
+        'right'
+      )
+    })
+
+    it('renders only the fullscreened leaf while fullscreen mode is active', () => {
+      const root = useWorkspaceStore.getState().root
+      expect(root.type).toBe('split')
+      const split = root as SplitNode
+      const fullscreenPaneId = split.children[1]!.id
+
+      useWorkspaceStore.getState().togglePaneFullscreen(fullscreenPaneId)
+
+      renderWithRouter()
+
+      expect(screen.getByText('b.ts')).toBeInTheDocument()
+      expect(screen.queryByText('a.ts')).not.toBeInTheDocument()
+      expect(screen.getByTitle('Restore pane layout')).toBeInTheDocument()
+    })
+
+    it('returns to the multi-pane layout after exiting fullscreen mode', () => {
+      const root = useWorkspaceStore.getState().root
+      expect(root.type).toBe('split')
+      const split = root as SplitNode
+      const fullscreenPaneId = split.children[1]!.id
+
+      useWorkspaceStore.getState().togglePaneFullscreen(fullscreenPaneId)
+      const view = renderWithRouter()
+
+      fireEvent.click(screen.getByTitle('Restore pane layout'))
+      view.rerender(
+        <TooltipProvider>
+          <MemoryRouter initialEntries={['/']}>
+            <WorkspaceLayout />
+          </MemoryRouter>
+        </TooltipProvider>
+      )
+
+      expect(screen.getByText('a.ts')).toBeInTheDocument()
+      expect(screen.getByText('b.ts')).toBeInTheDocument()
+      expect(screen.queryByTitle('Restore pane layout')).not.toBeInTheDocument()
     })
   })
 

--- a/src/renderer/layouts/WorkspaceLayout.test.tsx
+++ b/src/renderer/layouts/WorkspaceLayout.test.tsx
@@ -535,9 +535,8 @@ describe('WorkspaceLayout - Empty States', () => {
         </TooltipProvider>
       )
 
-      // Both panes should be present (may be duplicated during exit animation)
-      expect(screen.getAllByText('a.ts').length).toBeGreaterThanOrEqual(1)
-      expect(screen.getAllByText('b.ts').length).toBeGreaterThanOrEqual(1)
+      expect(screen.getByText('a.ts')).toBeInTheDocument()
+      expect(screen.getByText('b.ts')).toBeInTheDocument()
       expect(screen.queryByTitle('Restore pane layout')).not.toBeInTheDocument()
     })
   })

--- a/src/renderer/layouts/WorkspaceLayout.test.tsx
+++ b/src/renderer/layouts/WorkspaceLayout.test.tsx
@@ -535,8 +535,9 @@ describe('WorkspaceLayout - Empty States', () => {
         </TooltipProvider>
       )
 
-      expect(screen.getByText('a.ts')).toBeInTheDocument()
-      expect(screen.getByText('b.ts')).toBeInTheDocument()
+      // Both panes should be present (may be duplicated during exit animation)
+      expect(screen.getAllByText('a.ts').length).toBeGreaterThanOrEqual(1)
+      expect(screen.getAllByText('b.ts').length).toBeGreaterThanOrEqual(1)
       expect(screen.queryByTitle('Restore pane layout')).not.toBeInTheDocument()
     })
   })

--- a/src/renderer/layouts/WorkspaceLayout.tsx
+++ b/src/renderer/layouts/WorkspaceLayout.tsx
@@ -1,7 +1,7 @@
 import { useState, useCallback, useRef, useEffect, useMemo } from "react";
 import type { ShellInfo } from "@shared/types/ipc.types";
 import { Outlet, useLocation } from "react-router-dom";
-import { motion, AnimatePresence } from "framer-motion";
+import { motion } from "framer-motion";
 import { FolderKanban, Terminal } from "lucide-react";
 import { ProjectSidebar } from "@/components/ProjectSidebar";
 import { PaneRenderer } from "@/components/workspace/PaneRenderer";
@@ -1109,55 +1109,26 @@ export default function WorkspaceLayout(): React.JSX.Element {
 							) : (
 								<>
 									{isWorkspaceRoute ? (
-											<AnimatePresence mode="popLayout">
-												{fullscreenPane ? (
-													<motion.div
-														key="fullscreen"
-														layout
-														initial={{ opacity: 0, x: 40 }}
-														animate={{ opacity: 1, x: 0 }}
-														exit={{ opacity: 0, x: -40 }}
-														transition={{ duration: 0.25, ease: [0.25, 0.1, 0.25, 1] }}
-														className="flex-1 min-h-0 h-full overflow-hidden"
-													>
-														<PaneRenderer
-															node={fullscreenPane}
-															onAddTerminal={handleAddTerminal}
-															onAddBrowserTab={handleNewBrowserTab}
-															onCloseTerminal={handleCloseTerminal}
-															onRenameTerminal={renameTerminal}
-															onCloseEditorTab={handleCloseEditorTab}
-																closingTerminalIds={closingTerminalIds}
-																defaultShell={
-																	activeProject?.defaultShell || appDefaultShell
-																}
-														/>
-													</motion.div>
-												) : (
-													<motion.div
-														key="normal"
-														layout
-														initial={{ opacity: 0, x: -40 }}
-														animate={{ opacity: 1, x: 0 }}
-														exit={{ opacity: 0, x: 40 }}
-														transition={{ duration: 0.25, ease: [0.25, 0.1, 0.25, 1] }}
-														className="flex-1 min-h-0 h-full overflow-hidden"
-													>
-														<PaneRenderer
-															node={paneRoot}
-															onAddTerminal={handleAddTerminal}
-															onAddBrowserTab={handleNewBrowserTab}
-															onCloseTerminal={handleCloseTerminal}
-															onRenameTerminal={renameTerminal}
-															onCloseEditorTab={handleCloseEditorTab}
-																closingTerminalIds={closingTerminalIds}
-																defaultShell={
-																	activeProject?.defaultShell || appDefaultShell
-																}
-														/>
-													</motion.div>
-												)}
-											</AnimatePresence>
+										<motion.div
+											key={fullscreenPaneId ? "fullscreen" : "normal"}
+											initial={{ opacity: 0.85, scale: 0.97 }}
+											animate={{ opacity: 1, scale: 1 }}
+											transition={{ duration: 0.2, ease: "easeOut" }}
+											className="flex-1 min-h-0 h-full overflow-hidden"
+										>
+											<PaneRenderer
+												node={fullscreenPane ?? paneRoot}
+												onAddTerminal={handleAddTerminal}
+												onAddBrowserTab={handleNewBrowserTab}
+												onCloseTerminal={handleCloseTerminal}
+												onRenameTerminal={renameTerminal}
+												onCloseEditorTab={handleCloseEditorTab}
+												closingTerminalIds={closingTerminalIds}
+												defaultShell={
+													activeProject?.defaultShell || appDefaultShell
+												}
+											/>
+										</motion.div>
 									) : (
 										<div className="flex-1 overflow-hidden bg-background relative rounded-xl">
 											<div className="w-full h-full">

--- a/src/renderer/layouts/WorkspaceLayout.tsx
+++ b/src/renderer/layouts/WorkspaceLayout.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useRef, useEffect } from "react";
+import { useState, useCallback, useRef, useEffect, useMemo } from "react";
 import type { ShellInfo } from "@shared/types/ipc.types";
 import { Outlet, useLocation } from "react-router-dom";
 import { motion } from "framer-motion";
@@ -43,6 +43,8 @@ import {
 	useWorkspaceStore,
 	useActiveTab,
 	usePaneRoot,
+	useFullscreenPaneId,
+	findPaneById,
 	editorTabId,
 	getActiveTerminalIdFromTree,
 	getActiveFilePathFromTree,
@@ -153,7 +155,16 @@ export default function WorkspaceLayout(): React.JSX.Element {
 	const isExplorerVisible = useFileExplorerVisible();
 	const isSidebarVisible = useSidebarVisible();
 	const activeTab = useActiveTab();
+	const fullscreenPaneId = useFullscreenPaneId();
 	const paneRoot = usePaneRoot();
+	const fullscreenPane = useMemo(
+		() => {
+			if (!fullscreenPaneId) return null;
+			const pane = findPaneById(paneRoot, fullscreenPaneId);
+			return pane?.type === "leaf" ? pane : null;
+		},
+		[fullscreenPaneId, paneRoot],
+	);
 	const prevProjectIdRef = useRef<string>("");
 	const watchedRootPathRef = useRef<string | null>(null);
 	const projectSwitchRequestIdRef = useRef(0);
@@ -1082,7 +1093,7 @@ export default function WorkspaceLayout(): React.JSX.Element {
 									{isWorkspaceRoute ? (
 										<div className="flex-1 min-h-0 h-full overflow-hidden">
 											<PaneRenderer
-												node={paneRoot}
+												node={fullscreenPane ?? paneRoot}
 												onAddTerminal={handleAddTerminal}
 												onAddBrowserTab={handleNewBrowserTab}
 												onCloseTerminal={handleCloseTerminal}

--- a/src/renderer/layouts/WorkspaceLayout.tsx
+++ b/src/renderer/layouts/WorkspaceLayout.tsx
@@ -157,21 +157,20 @@ export default function WorkspaceLayout(): React.JSX.Element {
 	const activeTab = useActiveTab();
 	const fullscreenPaneId = useFullscreenPaneId();
 	const paneRoot = usePaneRoot();
-	const fullscreenPane = useMemo(
-		() => {
-			if (!fullscreenPaneId) return null;
-			const pane = findPaneById(paneRoot, fullscreenPaneId);
-			return pane?.type === "leaf" ? pane : null;
-		},
-		[fullscreenPaneId, paneRoot],
-	);
+	const fullscreenPane = useMemo(() => {
+		if (!fullscreenPaneId) return null;
+		const pane = findPaneById(paneRoot, fullscreenPaneId);
+		return pane?.type === "leaf" ? pane : null;
+	}, [fullscreenPaneId, paneRoot]);
 	const prevProjectIdRef = useRef<string>("");
 	const watchedRootPathRef = useRef<string | null>(null);
 	const projectSwitchRequestIdRef = useRef(0);
 
 	// Ref for terminal close handler — used inside keydown effect to avoid
 	// declaration-order dependency. The ref is updated each render.
-	const handleCloseTerminalRef = useRef<((id: string, tabId: string) => void) | null>(null);
+	const handleCloseTerminalRef = useRef<
+		((id: string, tabId: string) => void) | null
+	>(null);
 
 	// File watcher hook
 	useFileWatcher();
@@ -513,15 +512,18 @@ export default function WorkspaceLayout(): React.JSX.Element {
 		handleCreateTerminalInPane(paneId);
 	}, [handleCreateTerminalInPane]);
 
-	const handleAddTerminal = useCallback((paneId: string | undefined, shell?: ShellInfo) => {
-		const targetPaneId = paneId ?? useWorkspaceStore.getState().activePaneId;
-		if (!targetPaneId) return;
-		if (shell) {
-			handleCreateTerminalInPane(targetPaneId, shell.path);
-		} else {
-			handleCreateTerminalInPane(targetPaneId);
-		}
-	}, [handleCreateTerminalInPane]);
+	const handleAddTerminal = useCallback(
+		(paneId: string | undefined, shell?: ShellInfo) => {
+			const targetPaneId = paneId ?? useWorkspaceStore.getState().activePaneId;
+			if (!targetPaneId) return;
+			if (shell) {
+				handleCreateTerminalInPane(targetPaneId, shell.path);
+			} else {
+				handleCreateTerminalInPane(targetPaneId);
+			}
+		},
+		[handleCreateTerminalInPane],
+	);
 
 	const handleNewBrowserTab = useCallback((paneId?: string) => {
 		const resolvedPaneId = paneId ?? useWorkspaceStore.getState().activePaneId;
@@ -534,8 +536,9 @@ export default function WorkspaceLayout(): React.JSX.Element {
 
 	useEffect(() => {
 		const handleKeyDown = (e: KeyboardEvent) => {
-			const { isInEditor, isInTerminal, isInInput } =
-				getShortcutTargetContext(e.target);
+			const { isInEditor, isInTerminal, isInInput } = getShortcutTargetContext(
+				e.target,
+			);
 
 			// Save File (Ctrl+S / ⌘+S) — should work even in editors
 			if (matchesShortcut(e, getActiveKey("saveFile"))) {
@@ -550,7 +553,6 @@ export default function WorkspaceLayout(): React.JSX.Element {
 			// On macOS: ⌘+W closes tab, Ctrl+W is forwarded to shell (backward-kill-word)
 			// On Windows/Linux: Ctrl+W closes tab
 			if (matchesShortcut(e, getActiveKey("closeTab"))) {
-
 				e.preventDefault();
 				if (activeTab?.type === "editor") {
 					const fileState = useEditorStore
@@ -559,7 +561,9 @@ export default function WorkspaceLayout(): React.JSX.Element {
 					if (fileState?.isDirty) {
 						setDirtyCloseFilePath(activeTab.filePath);
 					} else {
-						const didClose = useEditorStore.getState().closeFileIfIdle(activeTab.filePath);
+						const didClose = useEditorStore
+							.getState()
+							.closeFileIfIdle(activeTab.filePath);
 						if (didClose) {
 							useWorkspaceStore.getState().removeTab(activeTab.id);
 						}
@@ -614,7 +618,10 @@ export default function WorkspaceLayout(): React.JSX.Element {
 			// reachable while typing in the editor, browser, or terminal.
 
 			// Command palette (Ctrl+K / Ctrl+Shift+P)
-			if (matchesShortcut(e, getActiveKey("commandPalette")) || matchesShortcut(e, getActiveKey("commandPaletteAlt"))) {
+			if (
+				matchesShortcut(e, getActiveKey("commandPalette")) ||
+				matchesShortcut(e, getActiveKey("commandPaletteAlt"))
+			) {
 				e.preventDefault();
 				e.stopPropagation();
 				if (document.activeElement instanceof HTMLElement) {
@@ -704,13 +711,21 @@ export default function WorkspaceLayout(): React.JSX.Element {
 				e.preventDefault();
 				e.stopPropagation();
 				if (fontSize !== DEFAULT_APP_SETTINGS.terminalFontSize) {
-					updateAppSetting("terminalFontSize", DEFAULT_APP_SETTINGS.terminalFontSize);
+					updateAppSetting(
+						"terminalFontSize",
+						DEFAULT_APP_SETTINGS.terminalFontSize,
+					);
 				}
 				return;
 			}
 
 			// Cmd/Ctrl + 1-9 for project switching
-			if ((e.metaKey || e.ctrlKey) && !e.shiftKey && !e.altKey && /^[1-9]$/.test(e.key)) {
+			if (
+				(e.metaKey || e.ctrlKey) &&
+				!e.shiftKey &&
+				!e.altKey &&
+				/^[1-9]$/.test(e.key)
+			) {
 				e.preventDefault();
 				const index = parseInt(e.key) - 1;
 				if (projects[index]) selectProject(projects[index].id);
@@ -930,7 +945,10 @@ export default function WorkspaceLayout(): React.JSX.Element {
 	// Dirty file close handlers
 	const handleCloseEditorTab = useCallback((filePath: string) => {
 		const fileState = useEditorStore.getState().openFiles.get(filePath);
-		if (fileState?.operationStatus === "saving" || fileState?.operationStatus === "reloading") {
+		if (
+			fileState?.operationStatus === "saving" ||
+			fileState?.operationStatus === "reloading"
+		) {
 			return;
 		}
 		if (fileState?.isDirty) {
@@ -1091,7 +1109,13 @@ export default function WorkspaceLayout(): React.JSX.Element {
 							) : (
 								<>
 									{isWorkspaceRoute ? (
-										<div className="flex-1 min-h-0 h-full overflow-hidden">
+										<motion.div
+											key={fullscreenPaneId ? "fullscreen" : "normal"}
+											initial={{ opacity: 0.85, scale: 0.97 }}
+											animate={{ opacity: 1, scale: 1 }}
+											transition={{ duration: 0.2, ease: "easeOut" }}
+											className="flex-1 min-h-0 h-full overflow-hidden"
+										>
 											<PaneRenderer
 												node={fullscreenPane ?? paneRoot}
 												onAddTerminal={handleAddTerminal}
@@ -1104,7 +1128,7 @@ export default function WorkspaceLayout(): React.JSX.Element {
 													activeProject?.defaultShell || appDefaultShell
 												}
 											/>
-										</div>
+										</motion.div>
 									) : (
 										<div className="flex-1 overflow-hidden bg-background relative rounded-xl">
 											<div className="w-full h-full">

--- a/src/renderer/layouts/WorkspaceLayout.tsx
+++ b/src/renderer/layouts/WorkspaceLayout.tsx
@@ -1,7 +1,7 @@
 import { useState, useCallback, useRef, useEffect, useMemo } from "react";
 import type { ShellInfo } from "@shared/types/ipc.types";
 import { Outlet, useLocation } from "react-router-dom";
-import { motion } from "framer-motion";
+import { motion, AnimatePresence } from "framer-motion";
 import { FolderKanban, Terminal } from "lucide-react";
 import { ProjectSidebar } from "@/components/ProjectSidebar";
 import { PaneRenderer } from "@/components/workspace/PaneRenderer";
@@ -1109,26 +1109,55 @@ export default function WorkspaceLayout(): React.JSX.Element {
 							) : (
 								<>
 									{isWorkspaceRoute ? (
-										<motion.div
-											key={fullscreenPaneId ? "fullscreen" : "normal"}
-											initial={{ opacity: 0.85, scale: 0.97 }}
-											animate={{ opacity: 1, scale: 1 }}
-											transition={{ duration: 0.2, ease: "easeOut" }}
-											className="flex-1 min-h-0 h-full overflow-hidden"
-										>
-											<PaneRenderer
-												node={fullscreenPane ?? paneRoot}
-												onAddTerminal={handleAddTerminal}
-												onAddBrowserTab={handleNewBrowserTab}
-												onCloseTerminal={handleCloseTerminal}
-												onRenameTerminal={renameTerminal}
-												onCloseEditorTab={handleCloseEditorTab}
-												closingTerminalIds={closingTerminalIds}
-												defaultShell={
-													activeProject?.defaultShell || appDefaultShell
-												}
-											/>
-										</motion.div>
+											<AnimatePresence mode="popLayout">
+												{fullscreenPane ? (
+													<motion.div
+														key="fullscreen"
+														layout
+														initial={{ opacity: 0, x: 40 }}
+														animate={{ opacity: 1, x: 0 }}
+														exit={{ opacity: 0, x: -40 }}
+														transition={{ duration: 0.25, ease: [0.25, 0.1, 0.25, 1] }}
+														className="flex-1 min-h-0 h-full overflow-hidden"
+													>
+														<PaneRenderer
+															node={fullscreenPane}
+															onAddTerminal={handleAddTerminal}
+															onAddBrowserTab={handleNewBrowserTab}
+															onCloseTerminal={handleCloseTerminal}
+															onRenameTerminal={renameTerminal}
+															onCloseEditorTab={handleCloseEditorTab}
+																closingTerminalIds={closingTerminalIds}
+																defaultShell={
+																	activeProject?.defaultShell || appDefaultShell
+																}
+														/>
+													</motion.div>
+												) : (
+													<motion.div
+														key="normal"
+														layout
+														initial={{ opacity: 0, x: -40 }}
+														animate={{ opacity: 1, x: 0 }}
+														exit={{ opacity: 0, x: 40 }}
+														transition={{ duration: 0.25, ease: [0.25, 0.1, 0.25, 1] }}
+														className="flex-1 min-h-0 h-full overflow-hidden"
+													>
+														<PaneRenderer
+															node={paneRoot}
+															onAddTerminal={handleAddTerminal}
+															onAddBrowserTab={handleNewBrowserTab}
+															onCloseTerminal={handleCloseTerminal}
+															onRenameTerminal={renameTerminal}
+															onCloseEditorTab={handleCloseEditorTab}
+																closingTerminalIds={closingTerminalIds}
+																defaultShell={
+																	activeProject?.defaultShell || appDefaultShell
+																}
+														/>
+													</motion.div>
+												)}
+											</AnimatePresence>
 									) : (
 										<div className="flex-1 overflow-hidden bg-background relative rounded-xl">
 											<div className="w-full h-full">

--- a/src/renderer/stores/workspace-store.test.ts
+++ b/src/renderer/stores/workspace-store.test.ts
@@ -35,7 +35,8 @@ describe('workspace-store split/move invariants', () => {
       const root: LeafNode = { type: 'leaf', id: 'pane-root', tabs: [], activeTabId: null }
       return {
         root,
-        activePaneId: 'pane-root'
+        activePaneId: 'pane-root',
+        fullscreenPaneId: null
       }
     })
   })
@@ -230,5 +231,124 @@ describe('workspace-store split/move invariants', () => {
 
     expect(left.tabs).toEqual([{ type: 'terminal', id: 'term-a', terminalId: 'a' }])
     expect(right.tabs).toEqual([])
+  })
+
+  it('toggles fullscreen state for a valid leaf pane and restores on second toggle', () => {
+    const store = useWorkspaceStore.getState()
+    const tabA = createEditorTab('edit-/a.ts')
+    const tabB = createEditorTab('edit-/b.ts')
+
+    store.addTabToPane('pane-root', tabA)
+    store.splitPane('pane-root', 'horizontal', tabB, 'right')
+
+    const split = useWorkspaceStore.getState().root as SplitNode
+    const rightPane = split.children[1] as LeafNode
+
+    store.togglePaneFullscreen(rightPane.id)
+    expect(useWorkspaceStore.getState().fullscreenPaneId).toBe(rightPane.id)
+    expect(useWorkspaceStore.getState().activePaneId).toBe(rightPane.id)
+
+    store.togglePaneFullscreen(rightPane.id)
+    expect(useWorkspaceStore.getState().fullscreenPaneId).toBeNull()
+    expect((useWorkspaceStore.getState().root as SplitNode).children).toHaveLength(2)
+  })
+
+  it('clears fullscreen state when the fullscreened pane is collapsed away', () => {
+    const store = useWorkspaceStore.getState()
+    const tabA = createEditorTab('edit-/a.ts')
+    const tabB = createEditorTab('edit-/b.ts')
+
+    store.addTabToPane('pane-root', tabA)
+    store.splitPane('pane-root', 'horizontal', tabB, 'right')
+
+    const split = useWorkspaceStore.getState().root as SplitNode
+    const leftPane = split.children[0] as LeafNode
+    const rightPane = split.children[1] as LeafNode
+
+    store.togglePaneFullscreen(rightPane.id)
+    store.moveTabToPane(tabB.id, rightPane.id, leftPane.id)
+
+    expect(useWorkspaceStore.getState().fullscreenPaneId).toBeNull()
+    expect(getLeavesFromNode(useWorkspaceStore.getState().root)).toHaveLength(1)
+  })
+
+  it('clears stale fullscreen state during reset and invalid workspace loads', () => {
+    const store = useWorkspaceStore.getState()
+    const tabA = createEditorTab('edit-/a.ts')
+    const tabB = createEditorTab('edit-/b.ts')
+
+    store.addTabToPane('pane-root', tabA)
+    store.splitPane('pane-root', 'horizontal', tabB, 'right')
+
+    const split = useWorkspaceStore.getState().root as SplitNode
+    const rightPane = split.children[1] as LeafNode
+    store.togglePaneFullscreen(rightPane.id)
+
+    store.loadProjectWorkspace({ type: 'leaf', id: 'replacement-pane', tabs: [], activeTabId: null })
+    expect(useWorkspaceStore.getState().fullscreenPaneId).toBeNull()
+
+    // After loading a single-pane workspace, fullscreen is a no-op
+    store.togglePaneFullscreen('replacement-pane')
+    expect(useWorkspaceStore.getState().fullscreenPaneId).toBeNull()
+
+    store.resetLayout()
+    expect(useWorkspaceStore.getState().fullscreenPaneId).toBeNull()
+  })
+
+  it('guards togglePaneFullscreen to no-op when only one leaf pane exists', () => {
+    const store = useWorkspaceStore.getState()
+    const paneId = useWorkspaceStore.getState().activePaneId
+
+    store.togglePaneFullscreen(paneId)
+    expect(useWorkspaceStore.getState().fullscreenPaneId).toBeNull()
+  })
+
+  it('redirects setActivePane to the fullscreen pane during fullscreen', () => {
+    const store = useWorkspaceStore.getState()
+    const tabA = createEditorTab('edit-/a.ts')
+    const tabB = createEditorTab('edit-/b.ts')
+
+    store.addTabToPane('pane-root', tabA)
+    store.splitPane('pane-root', 'horizontal', tabB, 'right')
+
+    const split = useWorkspaceStore.getState().root as SplitNode
+    const leftPane = split.children[0] as LeafNode
+    const rightPane = split.children[1] as LeafNode
+
+    store.togglePaneFullscreen(leftPane.id)
+    store.setActivePane(rightPane.id)
+    expect(useWorkspaceStore.getState().activePaneId).toBe(leftPane.id)
+  })
+
+  it('redirects setActiveTab to the fullscreen pane during fullscreen', () => {
+    const store = useWorkspaceStore.getState()
+    const tabA = createEditorTab('edit-/a.ts')
+    const tabB = createEditorTab('edit-/b.ts')
+
+    store.addTabToPane('pane-root', tabA)
+    store.splitPane('pane-root', 'horizontal', tabB, 'right')
+
+    const split = useWorkspaceStore.getState().root as SplitNode
+    const leftPane = split.children[0] as LeafNode
+    const rightPane = split.children[1] as LeafNode
+
+    store.togglePaneFullscreen(leftPane.id)
+    store.setActiveTab(leftPane.id, tabA.id)
+    expect(useWorkspaceStore.getState().activePaneId).toBe(leftPane.id)
+  })
+
+  it('allows setActivePane/setActiveTab to work normally when fullscreen is not active', () => {
+    const store = useWorkspaceStore.getState()
+    const tabA = createEditorTab('edit-/a.ts')
+    const tabB = createEditorTab('edit-/b.ts')
+
+    store.addTabToPane('pane-root', tabA)
+    store.splitPane('pane-root', 'horizontal', tabB, 'right')
+
+    const split = useWorkspaceStore.getState().root as SplitNode
+    const rightPane = split.children[1] as LeafNode
+
+    store.setActivePane(rightPane.id)
+    expect(useWorkspaceStore.getState().activePaneId).toBe(rightPane.id)
   })
 })

--- a/src/renderer/stores/workspace-store.test.ts
+++ b/src/renderer/stores/workspace-store.test.ts
@@ -333,7 +333,7 @@ describe('workspace-store split/move invariants', () => {
     const rightPane = split.children[1] as LeafNode
 
     store.togglePaneFullscreen(leftPane.id)
-    store.setActiveTab(leftPane.id, tabA.id)
+    store.setActiveTab(rightPane.id, tabB.id)
     expect(useWorkspaceStore.getState().activePaneId).toBe(leftPane.id)
   })
 

--- a/src/renderer/stores/workspace-store.ts
+++ b/src/renderer/stores/workspace-store.ts
@@ -957,6 +957,10 @@ export function useFullscreenPaneId(): string | null {
   return useWorkspaceStore((state) => state.fullscreenPaneId)
 }
 
+export function useLeafCount(): number {
+	return useWorkspaceStore((state) => getAllLeafPanes(state.root).length)
+}
+
 export function usePaneRoot(): PaneNode {
   return useWorkspaceStore((state) => state.root)
 }

--- a/src/renderer/stores/workspace-store.ts
+++ b/src/renderer/stores/workspace-store.ts
@@ -131,6 +131,7 @@ function updateLeaf(
 export interface WorkspaceState {
   root: PaneNode
   activePaneId: string
+  fullscreenPaneId: string | null
 
   // Pane tree actions
   splitPane: (
@@ -150,6 +151,8 @@ export interface WorkspaceState {
   closeTab: (paneId: string, tabId: string) => WorkspaceTab | null
   setActiveTab: (paneId: string, tabId: string) => void
   setActivePane: (paneId: string) => void
+  togglePaneFullscreen: (paneId: string) => void
+  clearFullscreenPane: () => void
   updatePaneSizes: (splitId: string, sizes: number[]) => void
   collapsePane: (paneId: string) => void
   reorderTabsInPane: (paneId: string, orderedIds: string[]) => void
@@ -183,6 +186,21 @@ function terminalTabId(terminalId: string): string {
 
 function editorTabId(filePath: string): string {
   return 'edit-' + filePath
+}
+
+function resolveFullscreenPaneId(root: PaneNode, fullscreenPaneId: string | null): string | null {
+  if (!fullscreenPaneId) return null
+  const pane = findPaneById(root, fullscreenPaneId)
+  return pane && pane.type === 'leaf' ? fullscreenPaneId : null
+}
+
+function resolveActivePaneId(
+  fullscreenPaneId: string | null,
+  requestedPaneId: string
+): string {
+  return fullscreenPaneId && fullscreenPaneId !== requestedPaneId
+    ? fullscreenPaneId
+    : requestedPaneId
 }
 
 function normalizePaneTree(root: PaneNode): PaneNode {
@@ -232,6 +250,7 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => {
   return {
     root: initialLeaf,
     activePaneId: initialLeaf.id,
+    fullscreenPaneId: null,
 
     splitPane: (
       paneId: string,
@@ -254,7 +273,7 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => {
       }
 
       const newRoot = replaceNode(root, paneId, split)
-      set({ root: newRoot, activePaneId: newLeaf.id })
+      set({ root: newRoot, activePaneId: newLeaf.id, fullscreenPaneId: null })
     },
 
     addTabToPane: (paneId: string, tab: WorkspaceTab): void => {
@@ -273,7 +292,10 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => {
         tabs: [...leaf.tabs, tab],
         activeTabId: tab.id
       }))
-      set({ root: newRoot, activePaneId: paneId })
+      set((state) => ({
+        root: newRoot,
+        activePaneId: resolveActivePaneId(state.fullscreenPaneId, paneId)
+      }))
     },
 
     moveTabToPane: (tabId: string, sourcePaneId: string, targetPaneId: string): void => {
@@ -309,7 +331,11 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => {
         newRoot = removeNode(newRoot, sourcePaneId) ?? createLeaf()
       }
 
-      set({ root: newRoot, activePaneId: targetPaneId })
+      set((state) => ({
+        root: newRoot,
+        activePaneId: targetPaneId,
+        fullscreenPaneId: resolveFullscreenPaneId(newRoot, state.fullscreenPaneId)
+      }))
     },
 
     moveTabToNewSplit: (
@@ -351,7 +377,7 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => {
       if (!target || target.type !== 'leaf') {
         // If target was the same pane that got removed, just create a single leaf
         const newLeaf = createLeaf([tab], tab.id)
-        set({ root: newLeaf, activePaneId: newLeaf.id })
+        set({ root: newLeaf, activePaneId: newLeaf.id, fullscreenPaneId: null })
         return
       }
 
@@ -372,7 +398,11 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => {
       }
 
       newRoot = replaceNode(newRoot, targetPaneId, split)
-      set({ root: newRoot, activePaneId: newLeaf.id })
+      set((state) => ({
+        root: newRoot,
+        activePaneId: newLeaf.id,
+        fullscreenPaneId: resolveFullscreenPaneId(newRoot, state.fullscreenPaneId)
+      }))
     },
 
     closeTab: (paneId: string, tabId: string): WorkspaceTab | null => {
@@ -417,7 +447,11 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => {
             }
           }
           newRoot = removeNode(newRoot, paneId) ?? createLeaf()
-          set({ root: newRoot, activePaneId: newActivePaneId })
+          set((state) => ({
+            root: newRoot,
+            activePaneId: newActivePaneId,
+            fullscreenPaneId: resolveFullscreenPaneId(newRoot, state.fullscreenPaneId)
+          }))
           return removedTab
         }
       }
@@ -427,16 +461,38 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => {
     },
 
     setActiveTab: (paneId: string, tabId: string): void => {
-      const { root } = get()
+      const { root, fullscreenPaneId } = get()
       const newRoot = updateLeaf(root, paneId, (leaf) => ({
         ...leaf,
         activeTabId: tabId
       }))
-      set({ root: newRoot, activePaneId: paneId })
+      set({
+        root: newRoot,
+        activePaneId: resolveActivePaneId(fullscreenPaneId, paneId)
+      })
     },
 
     setActivePane: (paneId: string): void => {
-      set({ activePaneId: paneId })
+      const { fullscreenPaneId } = get()
+      set({ activePaneId: resolveActivePaneId(fullscreenPaneId, paneId) })
+    },
+
+    togglePaneFullscreen: (paneId: string): void => {
+      const { root, fullscreenPaneId } = get()
+      const pane = findPaneById(root, paneId)
+      if (!pane || pane.type !== 'leaf') return
+
+      // If only one leaf pane exists, toggling fullscreen is a no-op
+      if (getAllLeafPanes(root).length <= 1 && fullscreenPaneId !== paneId) return
+
+      set({
+        activePaneId: paneId,
+        fullscreenPaneId: fullscreenPaneId === paneId ? null : paneId
+      })
+    },
+
+    clearFullscreenPane: (): void => {
+      set({ fullscreenPaneId: null })
     },
 
     updatePaneSizes: (splitId: string, sizes: number[]): void => {
@@ -476,7 +532,11 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => {
       }
 
       const newRoot = removeNode(root, paneId) ?? createLeaf()
-      set({ root: newRoot, activePaneId: newActivePaneId })
+      set((state) => ({
+        root: newRoot,
+        activePaneId: newActivePaneId,
+        fullscreenPaneId: resolveFullscreenPaneId(newRoot, state.fullscreenPaneId)
+      }))
     },
 
     reorderTabsInPane: (paneId: string, orderedIds: string[]): void => {
@@ -521,9 +581,10 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => {
       const existing = findPaneContainingTab(root, id)
       if (existing) {
         // Just activate it
+        const { fullscreenPaneId } = get()
         set({
           root: updateLeaf(root, existing.id, (l) => ({ ...l, activeTabId: id })),
-          activePaneId: existing.id
+          activePaneId: resolveActivePaneId(fullscreenPaneId, existing.id)
         })
         return
       }
@@ -568,9 +629,10 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => {
       // Check if already exists in target pane — activate it
       const targetPane = findPaneById(root, paneId)
       if (targetPane && targetPane.type === 'leaf' && targetPane.tabs.some((t) => t.id === id)) {
+        const { fullscreenPaneId } = get()
         set({
           root: updateLeaf(root, paneId, (l) => ({ ...l, activeTabId: id })),
-          activePaneId: paneId
+          activePaneId: resolveActivePaneId(fullscreenPaneId, paneId)
         })
         return
       }
@@ -587,9 +649,10 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => {
       // Check if already exists in any pane — activate it
       const existing = findPaneContainingTab(root, id)
       if (existing) {
+        const { fullscreenPaneId } = get()
         set({
           root: updateLeaf(root, existing.id, (l) => ({ ...l, activeTabId: id })),
-          activePaneId: existing.id
+          activePaneId: resolveActivePaneId(fullscreenPaneId, existing.id)
         })
         return
       }
@@ -662,7 +725,11 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => {
           }
         }
 
-        set({ root: normalizePaneTree(newRoot) })
+        const normalizedRoot = normalizePaneTree(newRoot)
+        set((state) => ({
+          root: normalizedRoot,
+          fullscreenPaneId: resolveFullscreenPaneId(normalizedRoot, state.fullscreenPaneId)
+        }))
       } finally {
         // CRITICAL: Always release the lock
         SYNC_TERMINAL_TABS_LOCK = false
@@ -693,7 +760,7 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => {
 
     resetLayout: (): void => {
       const leaf = createLeaf()
-      set({ root: leaf, activePaneId: leaf.id })
+      set({ root: leaf, activePaneId: leaf.id, fullscreenPaneId: null })
     },
 
     loadProjectWorkspace: (root: PaneNode, activePaneId?: string | null): void => {
@@ -704,7 +771,11 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => {
           ? activePaneId
           : leaves[0]?.id ?? normalizedRoot.id
 
-      set({ root: normalizedRoot, activePaneId: resolvedActivePaneId })
+      set((state) => ({
+        root: normalizedRoot,
+        activePaneId: resolvedActivePaneId,
+        fullscreenPaneId: resolveFullscreenPaneId(normalizedRoot, state.fullscreenPaneId)
+      }))
     },
 
     syncEditorTabs: (filePaths: string[], restoredActiveTabId?: string | null): void => {
@@ -749,7 +820,11 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => {
         return { ...leaf, tabs: newTabs, activeTabId: newActive }
       })
 
-      set({ root: normalizePaneTree(newRoot) })
+      const normalizedRoot = normalizePaneTree(newRoot)
+      set((state) => ({
+        root: normalizedRoot,
+        fullscreenPaneId: resolveFullscreenPaneId(normalizedRoot, state.fullscreenPaneId)
+      }))
     },
 
     remapTerminalTabs: (idMap: Record<string, string>): void => {
@@ -824,7 +899,11 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => {
         ? activePaneId
         : leaves[0]?.id ?? remappedRoot.id
 
-      set({ root: remappedRoot, activePaneId: nextActivePaneId })
+      set((state) => ({
+        root: remappedRoot,
+        activePaneId: nextActivePaneId,
+        fullscreenPaneId: resolveFullscreenPaneId(remappedRoot, state.fullscreenPaneId)
+      }))
     },
 
     getNextTabId: (direction: 1 | -1): string | null => {
@@ -874,6 +953,10 @@ export function useActivePaneId(): string {
   return useWorkspaceStore((state) => state.activePaneId)
 }
 
+export function useFullscreenPaneId(): string | null {
+  return useWorkspaceStore((state) => state.fullscreenPaneId)
+}
+
 export function usePaneRoot(): PaneNode {
   return useWorkspaceStore((state) => state.root)
 }
@@ -896,6 +979,8 @@ export function useWorkspaceActions(): Pick<
   | 'moveTabToNewSplit'
   | 'closeTab'
   | 'setActivePane'
+  | 'togglePaneFullscreen'
+  | 'clearFullscreenPane'
   | 'collapsePane'
   | 'updatePaneSizes'
 > {
@@ -917,6 +1002,8 @@ export function useWorkspaceActions(): Pick<
       moveTabToNewSplit: state.moveTabToNewSplit,
       closeTab: state.closeTab,
       setActivePane: state.setActivePane,
+      togglePaneFullscreen: state.togglePaneFullscreen,
+      clearFullscreenPane: state.clearFullscreenPane,
       collapsePane: state.collapsePane,
       updatePaneSizes: state.updatePaneSizes
     }))


### PR DESCRIPTION
## Summary

Adds a pane-level fullscreen toggle button to the selected pane's tab bar, letting users temporarily focus on one pane and restore the multi-pane layout with one click. Includes a subtle scale+fade motion animation when entering/exiting fullscreen.

## Related Issue

Closes # (no issue — feature request directly implemented)

## Type of Change

- [x] feat: new feature

## What Changed

- **workspace-store.ts**: Added `fullscreenPaneId` state, `togglePaneFullscreen`/`clearFullscreenPane` actions, `resolveFullscreenPaneId`/`resolveActivePaneId` helpers with single-pane guard and invalid-pane fallback
- **WorkspaceLayout.tsx**: Conditional rendering via `fullscreenPane ?? paneRoot` — a memoized rendering decision, not a tree mutation. Preserves original split sizes and tabs without rebuilding
- **WorkspaceTabBar.tsx**: Focus (Maximize2) and Restore (Minimize2) toggle button on each pane's tab bar, visible when workspace has >1 leaf pane
- **PaneContent.tsx**: Fullscreen flag integration, suppresses DnD overlay and preview targets during fullscreen
- **Motion animation**: `<motion.div>` wrapper with scale 0.97 → 1 and opacity 0.85 → 1, 0.2s easeOut
- **Active-pane redirect**: During fullscreen, `setActivePane`, `setActiveTab`, and tab-add operations redirect back to the fullscreen pane
- **Tests**: 10 new tests across workspace-store, WorkspaceTabBar, and WorkspaceLayout covering toggle, restore, single-pane guard, and active-pane redirect
- **Spec**: `_bmad-output/implementation-artifacts/spec-add-selected-pane-fullscreen-toggle.md`

## How It Was Tested

- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm run test` (61/61 passing)
- [x] Manual verification completed

## Checklist

- [x] My PR title follows the conventional commit format used by this repo
- [x] I linked the related issue or explained why none exists
- [x] I updated docs when needed
- [x] I added or updated tests when needed
- [x] I verified the change does not introduce unrelated modifications


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Fullscreen mode for workspace panes with a toggle button in the tab bar.
  * Restoring the full pane layout returns hidden panes to view.

* **User Experience**
  * Fullscreen panes show only focused content and retain pane focus while active.
  * Visual styling and drag-and-drop overlays are adjusted/suppressed when a pane is fullscreen.

* **Tests**
  * Added coverage for pane fullscreen and restore behaviors.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gnoviawan/termul/pull/141)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->