### PR TITLE
feat: redesign command palette power tools

### DIFF
--- a/src/renderer/components/CommandPalette.test.tsx
+++ b/src/renderer/components/CommandPalette.test.tsx
@@ -40,6 +40,13 @@ function renderPalette(overrides: Partial<React.ComponentProps<typeof CommandPal
     onOpenProjectSettings: vi.fn(),
     onOpenAppPreferences: vi.fn(),
     onOpenCommandHistory: vi.fn(),
+    getShortcutLabel: (id) =>
+      ({
+        newTerminal: 'Ctrl+T',
+        newBrowserTab: 'Ctrl+Shift+N',
+        commandHistory: 'Ctrl+R'
+      })[id],
+    getProjectShortcutLabel: (index) => `Ctrl+${index + 1}`,
     ...overrides
   }
 
@@ -69,6 +76,26 @@ describe('CommandPalette', () => {
     expect(screen.getByText('Navigate')).toBeInTheDocument()
     expect(screen.getByText('Select')).toBeInTheDocument()
     expect(screen.getByText('Close')).toBeInTheDocument()
+  })
+
+  it('uses resolved shortcut labels supplied by the shell', () => {
+    renderPalette({
+      getShortcutLabel: (id) =>
+        ({
+          newTerminal: 'Alt+T',
+          newBrowserTab: 'Alt+B',
+          commandHistory: 'Alt+H'
+        })[id],
+      getProjectShortcutLabel: (index) => `Alt+${index + 1}`
+    })
+
+    expect(screen.getByText('Alt+T')).toBeInTheDocument()
+    expect(screen.getByText('Alt+B')).toBeInTheDocument()
+    expect(screen.getByText('Alt+H')).toBeInTheDocument()
+    expect(screen.getByText('Alt+1')).toBeInTheDocument()
+    expect(screen.queryByText('Ctrl+T')).not.toBeInTheDocument()
+    expect(screen.queryByText('Ctrl+Shift+N')).not.toBeInTheDocument()
+    expect(screen.queryByText('Ctrl+R')).not.toBeInTheDocument()
   })
 
   it('searches settings, prefs, and history keywords', async () => {

--- a/src/renderer/components/CommandPalette.test.tsx
+++ b/src/renderer/components/CommandPalette.test.tsx
@@ -1,0 +1,197 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { CommandPalette } from './CommandPalette'
+import type { Project } from '@/types/project'
+
+window.HTMLElement.prototype.scrollIntoView = vi.fn()
+
+const saveRecentCommand = vi.fn(() => Promise.resolve())
+let recentCommandIds: string[] = []
+
+vi.mock('@/hooks/use-recent-commands', () => ({
+  useRecentCommandIds: () => recentCommandIds,
+  useSaveRecentCommand: () => saveRecentCommand
+}))
+
+const projects: Project[] = [
+  {
+    id: 'alpha',
+    name: 'Alpha',
+    color: 'blue',
+    path: '/work/alpha'
+  },
+  {
+    id: 'beta',
+    name: 'Beta',
+    color: 'green',
+    path: '/work/beta'
+  }
+]
+
+function renderPalette(overrides: Partial<React.ComponentProps<typeof CommandPalette>> = {}) {
+  const props: React.ComponentProps<typeof CommandPalette> = {
+    isOpen: true,
+    onClose: vi.fn(),
+    projects,
+    onSwitchProject: vi.fn(),
+    onAddTerminal: vi.fn(),
+    onSaveSnapshot: vi.fn(),
+    onNewBrowserTab: vi.fn(),
+    onOpenProjectSettings: vi.fn(),
+    onOpenAppPreferences: vi.fn(),
+    onOpenCommandHistory: vi.fn(),
+    ...overrides
+  }
+
+  return {
+    ...render(<CommandPalette {...props} />),
+    props
+  }
+}
+
+describe('CommandPalette', () => {
+  beforeEach(() => {
+    recentCommandIds = []
+    saveRecentCommand.mockClear()
+  })
+
+  it('renders a compact command-center layout with metadata, categories, shortcuts, and footer hints', () => {
+    renderPalette()
+
+    expect(screen.getByPlaceholderText('Search commands, projects, settings...')).toBeInTheDocument()
+    expect(screen.getByText('Workspace')).toBeInTheDocument()
+    expect(screen.getByText('Navigation')).toBeInTheDocument()
+    expect(screen.getByText('Projects')).toBeInTheDocument()
+    expect(screen.getByText('Tools')).toBeInTheDocument()
+    expect(screen.getByText('Open a terminal in the active pane')).toBeInTheDocument()
+    expect(screen.getByText('Ctrl+T')).toBeInTheDocument()
+    expect(screen.getByText('Recent commands saved')).toBeInTheDocument()
+    expect(screen.getByText('Navigate')).toBeInTheDocument()
+    expect(screen.getByText('Select')).toBeInTheDocument()
+    expect(screen.getByText('Close')).toBeInTheDocument()
+  })
+
+  it('searches settings, prefs, and history keywords', async () => {
+    renderPalette()
+    const input = screen.getByPlaceholderText('Search commands, projects, settings...')
+
+    fireEvent.change(input, { target: { value: 'settings' } })
+    await waitFor(() => {
+      expect(screen.getByText('Project Settings')).toBeInTheDocument()
+      expect(screen.getByText('App Preferences')).toBeInTheDocument()
+    })
+
+    fireEvent.change(input, { target: { value: 'prefs' } })
+    await waitFor(() => {
+      expect(screen.getByText('App Preferences')).toBeInTheDocument()
+    })
+
+    fireEvent.change(input, { target: { value: 'history' } })
+    await waitFor(() => {
+      expect(screen.getByText('Command History')).toBeInTheDocument()
+      expect(screen.getByText('Review and reuse recent terminal commands')).toBeInTheDocument()
+    })
+  })
+
+  it('switches projects, closes, and records recent command id', async () => {
+    const { props } = renderPalette()
+
+    fireEvent.click(screen.getByText('Switch to Project: Beta'))
+
+    await waitFor(() => {
+      expect(saveRecentCommand).toHaveBeenCalledWith('project-beta')
+      expect(props.onClose).toHaveBeenCalled()
+      expect(props.onSwitchProject).toHaveBeenCalledWith('beta')
+    })
+  })
+
+  it('executes optional callbacks after closing and records selected command ids', async () => {
+    const cases: Array<{
+      label: string
+      commandId: string
+      callback: keyof React.ComponentProps<typeof CommandPalette>
+    }> = [
+      { label: 'New Terminal', commandId: 'new-terminal', callback: 'onAddTerminal' },
+      { label: 'New Browser Tab', commandId: 'new-browser-tab', callback: 'onNewBrowserTab' },
+      { label: 'Save Workspace Snapshot', commandId: 'save-snapshot', callback: 'onSaveSnapshot' },
+      { label: 'Project Settings', commandId: 'open-project-settings', callback: 'onOpenProjectSettings' },
+      { label: 'App Preferences', commandId: 'open-app-preferences', callback: 'onOpenAppPreferences' },
+      { label: 'Command History', commandId: 'open-command-history', callback: 'onOpenCommandHistory' }
+    ]
+
+    for (const testCase of cases) {
+      saveRecentCommand.mockClear()
+      const { props, unmount } = renderPalette()
+
+      fireEvent.click(screen.getByText(testCase.label))
+
+      await waitFor(() => {
+        expect(saveRecentCommand).toHaveBeenCalledWith(testCase.commandId)
+        expect(props.onClose).toHaveBeenCalled()
+        expect(props[testCase.callback]).toHaveBeenCalled()
+      })
+
+      unmount()
+    }
+  })
+
+  it('omits optional commands when callbacks are unavailable', () => {
+    renderPalette({
+      onAddTerminal: undefined,
+      onSaveSnapshot: undefined,
+      onNewBrowserTab: undefined,
+      onOpenProjectSettings: undefined,
+      onOpenAppPreferences: undefined,
+      onOpenCommandHistory: undefined
+    })
+
+    expect(screen.queryByText('New Terminal')).not.toBeInTheDocument()
+    expect(screen.queryByText('New Browser Tab')).not.toBeInTheDocument()
+    expect(screen.queryByText('Save Workspace Snapshot')).not.toBeInTheDocument()
+    expect(screen.queryByText('Project Settings')).not.toBeInTheDocument()
+    expect(screen.queryByText('App Preferences')).not.toBeInTheDocument()
+    expect(screen.queryByText('Command History')).not.toBeInTheDocument()
+    expect(screen.getByText('Switch to Project: Alpha')).toBeInTheDocument()
+  })
+
+  it('keeps recent commands visible when the search is empty', () => {
+    recentCommandIds = ['open-command-history', 'project-alpha']
+
+    renderPalette()
+
+    expect(screen.getByText('Recent')).toBeInTheDocument()
+    expect(screen.getAllByText('Command History')).toHaveLength(2)
+    expect(screen.getAllByText('Switch to Project: Alpha')).toHaveLength(2)
+  })
+
+  it('runs a command when recent-command persistence fails', async () => {
+    const consoleWarn = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+    saveRecentCommand.mockRejectedValueOnce(new Error('storage unavailable'))
+    const { props } = renderPalette()
+
+    fireEvent.click(screen.getByText('Save Workspace Snapshot'))
+
+    await waitFor(() => {
+      expect(props.onClose).toHaveBeenCalled()
+      expect(props.onSaveSnapshot).toHaveBeenCalled()
+      expect(consoleWarn).toHaveBeenCalledWith(
+        'Failed to save recent command',
+        expect.any(Error)
+      )
+    })
+
+    consoleWarn.mockRestore()
+  })
+
+  it('closes on Escape and backdrop click', () => {
+    const { container, props } = renderPalette()
+
+    fireEvent.keyDown(window, { key: 'Escape' })
+    expect(props.onClose).toHaveBeenCalledTimes(1)
+
+    const backdrop = container.querySelector('.fixed.inset-0')
+    expect(backdrop).not.toBeNull()
+    fireEvent.click(backdrop as Element)
+    expect(props.onClose).toHaveBeenCalledTimes(2)
+  })
+})

--- a/src/renderer/components/CommandPalette.tsx
+++ b/src/renderer/components/CommandPalette.tsx
@@ -24,6 +24,8 @@ import { getColorClasses } from '@/lib/colors'
 import { cn } from '@/lib/utils'
 import { useRecentCommandIds, useSaveRecentCommand } from '@/hooks/use-recent-commands'
 
+type CommandShortcutId = 'newTerminal' | 'newBrowserTab' | 'commandHistory'
+
 interface CommandPaletteProps {
   isOpen: boolean
   onClose: () => void
@@ -35,6 +37,8 @@ interface CommandPaletteProps {
   onOpenProjectSettings?: () => void
   onOpenAppPreferences?: () => void
   onOpenCommandHistory?: () => void
+  getShortcutLabel?: (id: CommandShortcutId) => string | undefined
+  getProjectShortcutLabel?: (index: number) => string | undefined
 }
 
 type CommandCategory = 'workspace' | 'navigation' | 'projects' | 'tools'
@@ -87,7 +91,9 @@ export function CommandPalette({
   onNewBrowserTab,
   onOpenProjectSettings,
   onOpenAppPreferences,
-  onOpenCommandHistory
+  onOpenCommandHistory,
+  getShortcutLabel,
+  getProjectShortcutLabel
 }: CommandPaletteProps): React.JSX.Element {
   const [query, setQuery] = useState('')
   const recentCommandIds = useRecentCommandIds()
@@ -104,7 +110,7 @@ export function CommandPalette({
               label: 'New Terminal',
               description: 'Open a terminal in the active pane',
               keywords: ['shell', 'console', 'pty', 'workspace'],
-              shortcut: 'Ctrl+T',
+              shortcut: getShortcutLabel?.('newTerminal'),
               execute: onAddTerminal
             }
           ]
@@ -118,7 +124,7 @@ export function CommandPalette({
               label: 'New Browser Tab',
               description: 'Open a browser tab in the active pane',
               keywords: ['web', 'url', 'workspace'],
-              shortcut: 'Ctrl+Shift+N',
+              shortcut: getShortcutLabel?.('newBrowserTab'),
               execute: onNewBrowserTab
             }
           ]
@@ -177,7 +183,7 @@ export function CommandPalette({
         keywords: ['project', 'switch', project.name, project.path].filter(
           (keyword): keyword is string => Boolean(keyword)
         ),
-        shortcut: index < 9 ? `Ctrl+${index + 1}` : undefined,
+        shortcut: index < 9 ? getProjectShortcutLabel?.(index) : undefined,
         execute: () => onSwitchProject(project.id),
         projectColor: project.color
       })),
@@ -190,7 +196,7 @@ export function CommandPalette({
               label: 'Command History',
               description: 'Review and reuse recent terminal commands',
               keywords: ['history', 'recent', 'terminal', 'commands', 'shell'],
-              shortcut: 'Ctrl+R',
+              shortcut: getShortcutLabel?.('commandHistory'),
               execute: onOpenCommandHistory
             }
           ]
@@ -204,7 +210,9 @@ export function CommandPalette({
       onNewBrowserTab,
       onOpenProjectSettings,
       onOpenAppPreferences,
-      onOpenCommandHistory
+      onOpenCommandHistory,
+      getShortcutLabel,
+      getProjectShortcutLabel
     ]
   )
 

--- a/src/renderer/components/CommandPalette.tsx
+++ b/src/renderer/components/CommandPalette.tsx
@@ -1,5 +1,14 @@
 import { useState, useEffect, useRef, useCallback, useMemo } from 'react'
-import { Terminal, Layers, SplitSquareVertical, Save, Globe } from 'lucide-react'
+import {
+  Clock,
+  Globe,
+  History,
+  Layers,
+  Save,
+  Settings,
+  SlidersHorizontal,
+  Terminal
+} from 'lucide-react'
 import { motion, AnimatePresence } from 'framer-motion'
 import {
   Command,
@@ -10,8 +19,9 @@ import {
   CommandItem,
   CommandShortcut
 } from '@/components/ui/command'
-import type { Project } from '@/types/project'
+import type { Project, ProjectColor } from '@/types/project'
 import { getColorClasses } from '@/lib/colors'
+import { cn } from '@/lib/utils'
 import { useRecentCommandIds, useSaveRecentCommand } from '@/hooks/use-recent-commands'
 
 interface CommandPaletteProps {
@@ -22,16 +32,49 @@ interface CommandPaletteProps {
   onAddTerminal?: () => void
   onSaveSnapshot?: () => void
   onNewBrowserTab?: () => void
+  onOpenProjectSettings?: () => void
+  onOpenAppPreferences?: () => void
+  onOpenCommandHistory?: () => void
 }
+
+type CommandCategory = 'workspace' | 'navigation' | 'projects' | 'tools'
+
+const COMMAND_CATEGORY_LABELS: Record<CommandCategory, string> = {
+  workspace: 'Workspace',
+  navigation: 'Navigation',
+  projects: 'Projects',
+  tools: 'Tools'
+}
+
+const COMMAND_CATEGORY_ORDER: CommandCategory[] = [
+  'workspace',
+  'navigation',
+  'projects',
+  'tools'
+]
 
 interface CommandDef {
   id: string
+  category: CommandCategory
   icon: React.ReactNode
   label: string
+  description?: string
+  keywords?: string[]
   shortcut?: string
-  type: 'action' | 'project'
-  projectId?: string
-  projectColor?: string
+  execute: () => void
+  projectColor?: ProjectColor
+}
+
+function getSearchableValue(cmd: CommandDef): string {
+  return [
+    cmd.label,
+    cmd.description,
+    cmd.category,
+    COMMAND_CATEGORY_LABELS[cmd.category],
+    ...(cmd.keywords ?? [])
+  ]
+    .filter(Boolean)
+    .join(' ')
 }
 
 export function CommandPalette({
@@ -41,7 +84,10 @@ export function CommandPalette({
   onSwitchProject,
   onAddTerminal,
   onSaveSnapshot,
-  onNewBrowserTab
+  onNewBrowserTab,
+  onOpenProjectSettings,
+  onOpenAppPreferences,
+  onOpenCommandHistory
 }: CommandPaletteProps): React.JSX.Element {
   const [query, setQuery] = useState('')
   const recentCommandIds = useRecentCommandIds()
@@ -49,65 +95,139 @@ export function CommandPalette({
 
   const commands: CommandDef[] = useMemo(
     () => [
-      ...projects.map((p, i) => ({
-        id: `project-${p.id}`,
-        icon: <Layers size={18} className={getColorClasses(p.color).text} />,
-        label: `Switch to Project: ${p.name}`,
-        shortcut: `Ctrl+${i + 1}`,
-        type: 'project' as const,
-        projectId: p.id,
-        projectColor: p.color
+      ...(onAddTerminal
+        ? [
+            {
+              id: 'new-terminal',
+              category: 'workspace' as const,
+              icon: <Terminal aria-hidden="true" size={16} />,
+              label: 'New Terminal',
+              description: 'Open a terminal in the active pane',
+              keywords: ['shell', 'console', 'pty', 'workspace'],
+              shortcut: 'Ctrl+T',
+              execute: onAddTerminal
+            }
+          ]
+        : []),
+      ...(onNewBrowserTab
+        ? [
+            {
+              id: 'new-browser-tab',
+              category: 'workspace' as const,
+              icon: <Globe aria-hidden="true" size={16} />,
+              label: 'New Browser Tab',
+              description: 'Open a browser tab in the active pane',
+              keywords: ['web', 'url', 'workspace'],
+              shortcut: 'Ctrl+Shift+N',
+              execute: onNewBrowserTab
+            }
+          ]
+        : []),
+      ...(onSaveSnapshot
+        ? [
+            {
+              id: 'save-snapshot',
+              category: 'workspace' as const,
+              icon: <Save aria-hidden="true" size={16} />,
+              label: 'Save Workspace Snapshot',
+              description: 'Capture the current workspace layout',
+              keywords: ['snapshot', 'checkpoint', 'layout', 'save'],
+              execute: onSaveSnapshot
+            }
+          ]
+        : []),
+      ...(onOpenProjectSettings
+        ? [
+            {
+              id: 'open-project-settings',
+              category: 'navigation' as const,
+              icon: <Settings aria-hidden="true" size={16} />,
+              label: 'Project Settings',
+              description: 'Configure the active project workspace',
+              keywords: ['settings', 'project', 'configure', 'config'],
+              execute: onOpenProjectSettings
+            }
+          ]
+        : []),
+      ...(onOpenAppPreferences
+        ? [
+            {
+              id: 'open-app-preferences',
+              category: 'navigation' as const,
+              icon: <SlidersHorizontal aria-hidden="true" size={16} />,
+              label: 'App Preferences',
+              description: 'Open global application preferences',
+              keywords: ['preferences', 'prefs', 'settings', 'app', 'global'],
+              execute: onOpenAppPreferences
+            }
+          ]
+        : []),
+      ...projects.map((project, index) => ({
+        id: `project-${project.id}`,
+        category: 'projects' as const,
+        icon: (
+          <Layers
+            aria-hidden="true"
+            size={16}
+            className={getColorClasses(project.color).text}
+          />
+        ),
+        label: `Switch to Project: ${project.name}`,
+        description: project.path ?? 'Switch active workspace project',
+        keywords: ['project', 'switch', project.name, project.path].filter(
+          (keyword): keyword is string => Boolean(keyword)
+        ),
+        shortcut: index < 9 ? `Ctrl+${index + 1}` : undefined,
+        execute: () => onSwitchProject(project.id),
+        projectColor: project.color
       })),
-      {
-        id: 'new-terminal',
-        icon: <Terminal size={18} />,
-        label: 'New Terminal',
-        shortcut: 'Ctrl+T',
-        type: 'action'
-      },
-      {
-        id: 'split-v',
-        icon: <SplitSquareVertical size={18} />,
-        label: 'Split Terminal Vertically',
-        shortcut: 'Ctrl+Shift+D',
-        type: 'action'
-      },
-      {
-        id: 'new-browser-tab',
-        icon: <Globe size={18} />,
-        label: 'New Browser Tab',
-        shortcut: 'Ctrl+Shift+N',
-        type: 'action'
-      },
-      {
-        id: 'save-snapshot',
-        icon: <Save size={18} />,
-        label: 'Save Workspace Snapshot',
-        type: 'action'
-      }
+      ...(onOpenCommandHistory
+        ? [
+            {
+              id: 'open-command-history',
+              category: 'tools' as const,
+              icon: <History aria-hidden="true" size={16} />,
+              label: 'Command History',
+              description: 'Review and reuse recent terminal commands',
+              keywords: ['history', 'recent', 'terminal', 'commands', 'shell'],
+              shortcut: 'Ctrl+R',
+              execute: onOpenCommandHistory
+            }
+          ]
+        : [])
     ],
-    [projects]
+    [
+      projects,
+      onSwitchProject,
+      onAddTerminal,
+      onSaveSnapshot,
+      onNewBrowserTab,
+      onOpenProjectSettings,
+      onOpenAppPreferences,
+      onOpenCommandHistory
+    ]
   )
 
-  // Separate recent commands from others
-  const { recentCommands, otherCommands } = useMemo(() => {
+  const { recentCommands, commandsByCategory } = useMemo(() => {
     const recent: CommandDef[] = []
-    const others: CommandDef[] = []
+    const recentIds = new Set(recentCommandIds)
 
     for (const cmd of commands) {
-      if (recentCommandIds.includes(cmd.id)) {
+      if (recentIds.has(cmd.id)) {
         recent.push(cmd)
-      } else {
-        others.push(cmd)
       }
     }
 
-    // Sort recent by their order in recentCommandIds
     recent.sort(
       (a, b) => recentCommandIds.indexOf(a.id) - recentCommandIds.indexOf(b.id)
     )
 
-    return { recentCommands: recent, otherCommands: others }
+    const grouped = COMMAND_CATEGORY_ORDER.map((category) => ({
+      category,
+      commands: commands.filter((cmd) => cmd.category === category)
+    })).filter((group) => group.commands.length > 0)
+
+    return { recentCommands: recent, commandsByCategory: grouped }
   }, [commands, recentCommandIds])
 
   const inputRef = useRef<HTMLInputElement>(null)
@@ -126,21 +246,16 @@ export function CommandPalette({
 
   const executeCommand = useCallback(
     async (cmd: CommandDef) => {
-      await saveRecentCommand(cmd.id)
-
-      if (cmd.type === 'project' && cmd.projectId) {
-        onSwitchProject(cmd.projectId)
-      } else if (cmd.id === 'new-terminal') {
-        onAddTerminal?.()
-      } else if (cmd.id === 'new-browser-tab' && onNewBrowserTab) {
-        onNewBrowserTab()
-      } else if (cmd.id === 'save-snapshot' && onSaveSnapshot) {
-        onSaveSnapshot()
+      try {
+        await saveRecentCommand(cmd.id)
+      } catch (error) {
+        console.warn('Failed to save recent command', error)
       }
 
       onClose()
+      cmd.execute()
     },
-    [saveRecentCommand, onSwitchProject, onAddTerminal, onNewBrowserTab, onSaveSnapshot, onClose]
+    [saveRecentCommand, onClose]
   )
 
   // Handle Escape key - use capture phase to intercept before cmdk handles it
@@ -159,6 +274,39 @@ export function CommandPalette({
     return () => window.removeEventListener('keydown', handleKeyDown, { capture: true })
   }, [isOpen, onClose])
 
+  const renderCommandItem = (cmd: CommandDef): React.JSX.Element => (
+    <CommandItem
+      key={cmd.id}
+      value={getSearchableValue(cmd)}
+      onSelect={() => executeCommand(cmd)}
+      className="group flex items-center justify-between gap-3 px-2.5 py-2 cursor-pointer rounded-md"
+    >
+      <div className="flex min-w-0 items-center gap-2.5">
+        <span
+          className={cn(
+            'flex h-7 w-7 shrink-0 items-center justify-center rounded-md bg-secondary/70 text-muted-foreground group-data-[selected=true]:text-foreground',
+            cmd.projectColor && getColorClasses(cmd.projectColor).bg
+          )}
+        >
+          {cmd.icon}
+        </span>
+        <span className="flex min-w-0 flex-col">
+          <span className="truncate text-sm font-medium leading-5">{cmd.label}</span>
+          {cmd.description && (
+            <span className="truncate text-xs leading-4 text-muted-foreground">
+              {cmd.description}
+            </span>
+          )}
+        </span>
+      </div>
+      {cmd.shortcut && (
+        <CommandShortcut className="shrink-0 rounded border border-border bg-secondary/70 px-1.5 py-0.5 font-mono text-[10px] tracking-normal text-muted-foreground">
+          {cmd.shortcut}
+        </CommandShortcut>
+      )}
+    </CommandItem>
+  )
+
   return (
     <AnimatePresence>
       {isOpen && (
@@ -166,88 +314,65 @@ export function CommandPalette({
           initial={{ opacity: 0 }}
           animate={{ opacity: 1 }}
           exit={{ opacity: 0 }}
-          className="fixed inset-0 z-[60] flex flex-col items-center pt-[10vh] bg-black/40 backdrop-blur-sm"
+          className="fixed inset-0 z-[60] flex flex-col items-center pt-[7vh] bg-black/40 backdrop-blur-sm"
           onClick={onClose}
         >
           <motion.div
-            initial={{ opacity: 0, scale: 0.95, y: -10 }}
+            initial={{ opacity: 0, scale: 0.97, y: -8 }}
             animate={{ opacity: 1, scale: 1, y: 0 }}
-            exit={{ opacity: 0, scale: 0.95, y: -10 }}
+            exit={{ opacity: 0, scale: 0.97, y: -8 }}
             transition={{ duration: 0.15 }}
-            className="w-full max-w-2xl bg-card rounded-xl shadow-2xl border border-border overflow-hidden"
+            className="w-full max-w-xl overflow-hidden rounded-lg border border-border bg-card shadow-2xl"
             onClick={(e) => e.stopPropagation()}
           >
             <Command
-              className="[&_[cmdk-group-heading]]:text-muted-foreground"
+              className="[&_[cmdk-group-heading]]:px-2.5 [&_[cmdk-group-heading]]:py-1 [&_[cmdk-group-heading]]:text-[10px] [&_[cmdk-group-heading]]:font-semibold [&_[cmdk-group-heading]]:uppercase [&_[cmdk-group-heading]]:tracking-wider [&_[cmdk-group-heading]]:text-muted-foreground"
               shouldFilter={true}
             >
               <CommandInput
                 ref={inputRef}
-                placeholder="Type a command or search..."
+                placeholder="Search commands, projects, settings..."
                 value={query}
                 onValueChange={setQuery}
-                className="text-lg"
+                className="h-10 py-2 text-sm"
               />
-              <CommandList className="max-h-[60vh]">
+              <CommandList className="max-h-[52vh] px-1 py-1">
                 <CommandEmpty>No commands found.</CommandEmpty>
 
-                {/* Recent Commands - only show when no query */}
                 {recentCommands.length > 0 && query === '' && (
                   <CommandGroup heading="Recent">
-                    {recentCommands.map((cmd) => (
-                      <CommandItem
-                        key={cmd.id}
-                        value={cmd.label}
-                        onSelect={() => executeCommand(cmd)}
-                        className="flex items-center justify-between px-4 py-3 cursor-pointer"
-                      >
-                        <div className="flex items-center gap-3">
-                          {cmd.icon}
-                          <span className="text-sm font-medium">{cmd.label}</span>
-                        </div>
-                        {cmd.shortcut && (
-                          <CommandShortcut className="text-xs font-mono bg-secondary px-2 py-1 rounded border border-border">
-                            {cmd.shortcut}
-                          </CommandShortcut>
-                        )}
-                      </CommandItem>
-                    ))}
+                    {recentCommands.map(renderCommandItem)}
                   </CommandGroup>
                 )}
 
-                {/* All Commands */}
-                <CommandGroup heading={query === '' && recentCommands.length > 0 ? 'All Commands' : undefined}>
-                  {(query === '' ? otherCommands : commands).map((cmd) => (
-                    <CommandItem
-                      key={cmd.id}
-                      value={cmd.label}
-                      onSelect={() => executeCommand(cmd)}
-                      className="flex items-center justify-between px-4 py-3 cursor-pointer"
-                    >
-                      <div className="flex items-center gap-3">
-                        {cmd.icon}
-                        <span className="text-sm font-medium">{cmd.label}</span>
-                      </div>
-                      {cmd.shortcut && (
-                        <CommandShortcut className="text-xs font-mono bg-secondary px-2 py-1 rounded border border-border">
-                          {cmd.shortcut}
-                        </CommandShortcut>
-                      )}
-                    </CommandItem>
-                  ))}
-                </CommandGroup>
+                {commandsByCategory.map(({ category, commands: categoryCommands }) => (
+                  <CommandGroup
+                    key={category}
+                    heading={COMMAND_CATEGORY_LABELS[category]}
+                  >
+                    {categoryCommands.map(renderCommandItem)}
+                  </CommandGroup>
+                ))}
               </CommandList>
 
-              {/* Footer */}
-              <div className="bg-background px-4 py-2 border-t border-border flex items-center justify-end space-x-4 text-[10px] text-muted-foreground font-medium uppercase tracking-wider">
-                <span className="flex items-center">
-                  <kbd className="bg-secondary text-foreground px-1 rounded mr-1">↑↓</kbd> to navigate
+              <div className="flex items-center justify-between gap-3 border-t border-border bg-background px-3 py-2 text-[10px] font-medium uppercase tracking-wider text-muted-foreground">
+                <span className="flex items-center gap-1.5">
+                  <Clock aria-hidden="true" size={12} />
+                  Recent commands saved
                 </span>
-                <span className="flex items-center">
-                  <kbd className="bg-secondary text-foreground px-1 rounded mr-1">↵</kbd> to select
-                </span>
-                <span className="flex items-center">
-                  <kbd className="bg-secondary text-foreground px-1 rounded mr-1">Esc</kbd> to close
+                <span className="flex items-center gap-3">
+                  <span className="flex items-center">
+                    <kbd className="mr-1 rounded bg-secondary px-1 text-foreground">↑↓</kbd>
+                    Navigate
+                  </span>
+                  <span className="flex items-center">
+                    <kbd className="mr-1 rounded bg-secondary px-1 text-foreground">↵</kbd>
+                    Select
+                  </span>
+                  <span className="flex items-center">
+                    <kbd className="mr-1 rounded bg-secondary px-1 text-foreground">Esc</kbd>
+                    Close
+                  </span>
                 </span>
               </div>
             </Command>

--- a/src/renderer/layouts/WorkspaceLayout.test.tsx
+++ b/src/renderer/layouts/WorkspaceLayout.test.tsx
@@ -740,7 +740,7 @@ describe('WorkspaceLayout - Empty States', () => {
 
       fireEvent.keyDown(textarea, { key: 'k', ctrlKey: true })
 
-      expect(screen.getByPlaceholderText('Type a command or search...')).toBeInTheDocument()
+      expect(screen.getByPlaceholderText('Search commands, projects, settings...')).toBeInTheDocument()
 
       document.body.removeChild(terminalRoot)
     })

--- a/src/renderer/layouts/WorkspaceLayout.tsx
+++ b/src/renderer/layouts/WorkspaceLayout.tsx
@@ -70,6 +70,7 @@ import {
 import {
 	useKeyboardShortcutsStore,
 	matchesShortcut,
+	formatKeyForDisplay,
 } from "@/stores/keyboard-shortcuts-store";
 import { isMac } from "@/lib/platform";
 import {
@@ -446,6 +447,19 @@ export default function WorkspaceLayout(): React.JSX.Element {
 		},
 		[shortcuts],
 	);
+
+	const getShortcutLabel = useCallback(
+		(id: string): string | undefined => {
+			const key = getActiveKey(id);
+			return key ? formatKeyForDisplay(key) : undefined;
+		},
+		[getActiveKey],
+	);
+
+	const getProjectShortcutLabel = useCallback((index: number): string | undefined => {
+		if (index < 0 || index > 8) return undefined;
+		return formatKeyForDisplay(`ctrl+${index + 1}`);
+	}, []);
 
 	// Determine if we should show the terminal area (only on workspace dashboard)
 	const isWorkspaceRoute = location.pathname === "/";
@@ -1187,6 +1201,8 @@ export default function WorkspaceLayout(): React.JSX.Element {
 				onOpenProjectSettings={handleOpenProjectSettings}
 				onOpenAppPreferences={handleOpenAppPreferences}
 				onOpenCommandHistory={activeProjectId ? handleOpenCommandHistory : undefined}
+				getShortcutLabel={getShortcutLabel}
+				getProjectShortcutLabel={getProjectShortcutLabel}
 			/>
 
 			<CreateSnapshotModal

--- a/src/renderer/layouts/WorkspaceLayout.tsx
+++ b/src/renderer/layouts/WorkspaceLayout.tsx
@@ -1,6 +1,6 @@
 import { useState, useCallback, useRef, useEffect, useMemo } from "react";
 import type { ShellInfo } from "@shared/types/ipc.types";
-import { Outlet, useLocation } from "react-router-dom";
+import { Outlet, useLocation, useNavigate } from "react-router-dom";
 import { motion } from "framer-motion";
 import { FolderKanban, Terminal } from "lucide-react";
 import { ProjectSidebar } from "@/components/ProjectSidebar";
@@ -112,6 +112,7 @@ function getShortcutTargetContext(target: EventTarget | null): {
 
 export default function WorkspaceLayout(): React.JSX.Element {
 	const location = useLocation();
+	const navigate = useNavigate();
 	const [isNewProjectModalOpen, setIsNewProjectModalOpen] = useState(false);
 	const [isCommandPaletteOpen, setIsCommandPaletteOpen] = useState(false);
 	const [isCreateSnapshotModalOpen, setIsCreateSnapshotModalOpen] =
@@ -412,6 +413,21 @@ export default function WorkspaceLayout(): React.JSX.Element {
 	const handleOpenSnapshotModal = useCallback(() => {
 		setIsCommandPaletteOpen(false);
 		setIsCreateSnapshotModalOpen(true);
+	}, []);
+
+	const handleOpenProjectSettings = useCallback(() => {
+		setIsCommandPaletteOpen(false);
+		navigate("/settings");
+	}, [navigate]);
+
+	const handleOpenAppPreferences = useCallback(() => {
+		setIsCommandPaletteOpen(false);
+		navigate("/preferences");
+	}, [navigate]);
+
+	const handleOpenCommandHistory = useCallback(() => {
+		setIsCommandPaletteOpen(false);
+		setIsCommandHistoryOpen(true);
 	}, []);
 
 	// Keyboard shortcuts
@@ -1168,6 +1184,9 @@ export default function WorkspaceLayout(): React.JSX.Element {
 				onAddTerminal={() => handleAddTerminal(undefined)}
 				onNewBrowserTab={handleNewBrowserTab}
 				onSaveSnapshot={handleOpenSnapshotModal}
+				onOpenProjectSettings={handleOpenProjectSettings}
+				onOpenAppPreferences={handleOpenAppPreferences}
+				onOpenCommandHistory={activeProjectId ? handleOpenCommandHistory : undefined}
 			/>
 
 			<CreateSnapshotModal


### PR DESCRIPTION
## Summary

- Redesigns the command palette into a compact categorized power-user launcher.
- Adds command metadata, descriptions, aliases/keywords, and optional callback-based availability.
- Adds project settings, app preferences, and command history actions while preserving Save Workspace Snapshot and project switching.

## Related Issue

No linked issue; requested as an in-session UI improvement.

## Type of Change

- [x] feat: new feature
- [ ] fix: bug fix
- [ ] docs: documentation only
- [ ] style: formatting or non-functional styling changes
- [ ] refactor: internal cleanup with no behavior change
- [ ] perf: performance improvement
- [x] test: adds or updates tests
- [ ] build: build or dependency changes
- [ ] ci: CI/CD workflow changes
- [ ] chore: maintenance or tooling
- [ ] revert: reverts a previous change

## What Changed

- Refactored `CommandPalette` to use a data-driven command model with categories, descriptions, keywords, shortcuts, and execute callbacks.
- Made unavailable optional commands omit themselves instead of rendering dead actions.
- Added compact command rows, grouped sections, tighter overlay sizing, and footer keyboard hints.
- Added `WorkspaceLayout` shell callbacks for `/settings`, `/preferences`, and the command history modal.
- Kept `Save Workspace Snapshot`; intentionally did not add an Open Workspace Snapshots command.
- Added focused `CommandPalette` tests and updated the existing layout shortcut test for the new placeholder.

## How It Was Tested

- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm run test`
- [ ] Manual verification completed
- [ ] Not applicable

Additional focused checks run:

- `npm test -- CommandPalette`
- `npm test -- WorkspaceLayout`

## Screenshots or Recordings

Not attached. UI change is covered by component tests; recommend reviewer run locally for visual inspection.

## Checklist

- [x] My PR title follows the conventional commit format used by this repo
- [x] I linked the related issue or explained why none exists
- [x] I updated docs when needed
- [x] I added or updated tests when needed
- [x] I verified the change does not introduce unrelated modifications


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Command Palette: quick access to project settings, app preferences, and command history; navigation actions integrated with workspace.

* **Improvements**
  * Organized commands into category groups with improved layout, styling, and project color indicators.
  * Enhanced search/filtering and updated placeholder/footer hints.
  * Palette now closes before executing commands; recent-command persistence handled safely (warns on failure).

* **Tests**
  * Added comprehensive tests covering UI, search, shortcuts, project switching, execution, and closing behaviors.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gnoviawan/termul/pull/142)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->