### PR TITLE
feat: add shortcut menu

### DIFF
--- a/src/renderer/components/CommandPalette.test.tsx
+++ b/src/renderer/components/CommandPalette.test.tsx
@@ -40,6 +40,7 @@ function renderPalette(overrides: Partial<React.ComponentProps<typeof CommandPal
     onOpenProjectSettings: vi.fn(),
     onOpenAppPreferences: vi.fn(),
     onOpenCommandHistory: vi.fn(),
+    onOpenShortcutMenu: vi.fn(),
     getShortcutLabel: (id) =>
       ({
         newTerminal: 'Ctrl+T',
@@ -143,7 +144,8 @@ describe('CommandPalette', () => {
       { label: 'Save Workspace Snapshot', commandId: 'save-snapshot', callback: 'onSaveSnapshot' },
       { label: 'Project Settings', commandId: 'open-project-settings', callback: 'onOpenProjectSettings' },
       { label: 'App Preferences', commandId: 'open-app-preferences', callback: 'onOpenAppPreferences' },
-      { label: 'Command History', commandId: 'open-command-history', callback: 'onOpenCommandHistory' }
+      { label: 'Command History', commandId: 'open-command-history', callback: 'onOpenCommandHistory' },
+      { label: 'Open Shortcut Menu', commandId: 'open-shortcut-menu', callback: 'onOpenShortcutMenu' }
     ]
 
     for (const testCase of cases) {
@@ -169,7 +171,8 @@ describe('CommandPalette', () => {
       onNewBrowserTab: undefined,
       onOpenProjectSettings: undefined,
       onOpenAppPreferences: undefined,
-      onOpenCommandHistory: undefined
+      onOpenCommandHistory: undefined,
+      onOpenShortcutMenu: undefined
     })
 
     expect(screen.queryByText('New Terminal')).not.toBeInTheDocument()
@@ -178,6 +181,7 @@ describe('CommandPalette', () => {
     expect(screen.queryByText('Project Settings')).not.toBeInTheDocument()
     expect(screen.queryByText('App Preferences')).not.toBeInTheDocument()
     expect(screen.queryByText('Command History')).not.toBeInTheDocument()
+    expect(screen.queryByText('Open Shortcut Menu')).not.toBeInTheDocument()
     expect(screen.getByText('Switch to Project: Alpha')).toBeInTheDocument()
   })
 

--- a/src/renderer/components/CommandPalette.tsx
+++ b/src/renderer/components/CommandPalette.tsx
@@ -3,6 +3,7 @@ import {
   Clock,
   Globe,
   History,
+  Keyboard,
   Layers,
   Save,
   Settings,
@@ -37,6 +38,7 @@ interface CommandPaletteProps {
   onOpenProjectSettings?: () => void
   onOpenAppPreferences?: () => void
   onOpenCommandHistory?: () => void
+  onOpenShortcutMenu?: () => void
   getShortcutLabel?: (id: CommandShortcutId) => string | undefined
   getProjectShortcutLabel?: (index: number) => string | undefined
 }
@@ -92,6 +94,7 @@ export function CommandPalette({
   onOpenProjectSettings,
   onOpenAppPreferences,
   onOpenCommandHistory,
+  onOpenShortcutMenu,
   getShortcutLabel,
   getProjectShortcutLabel
 }: CommandPaletteProps): React.JSX.Element {
@@ -200,6 +203,19 @@ export function CommandPalette({
               execute: onOpenCommandHistory
             }
           ]
+        : []),
+      ...(onOpenShortcutMenu
+        ? [
+            {
+              id: 'open-shortcut-menu',
+              category: 'tools' as const,
+              icon: <Keyboard aria-hidden="true" size={16} />,
+              label: 'Open Shortcut Menu',
+              description: 'View and edit common keyboard shortcuts',
+              keywords: ['keyboard', 'shortcuts', 'hotkeys', 'keys'],
+              execute: onOpenShortcutMenu
+            }
+          ]
         : [])
     ],
     [
@@ -211,6 +227,7 @@ export function CommandPalette({
       onOpenProjectSettings,
       onOpenAppPreferences,
       onOpenCommandHistory,
+      onOpenShortcutMenu,
       getShortcutLabel,
       getProjectShortcutLabel
     ]

--- a/src/renderer/components/ShortcutRecorder.tsx
+++ b/src/renderer/components/ShortcutRecorder.tsx
@@ -67,12 +67,11 @@ export function ShortcutRecorder({
   )
 
   const handleBlur = useCallback(() => {
-    if (!conflict) {
-      setIsRecording(false)
-      setPendingKey(null)
-    }
+    window.removeEventListener('keydown', handleKeyDown, { capture: true })
+    setIsRecording(false)
+    setPendingKey(null)
     setConflict(null)
-  }, [conflict])
+  }, [handleKeyDown])
 
   const handleClick = useCallback(() => {
     if (!isRecording) {
@@ -210,7 +209,9 @@ export function ShortcutRecorder({
         <div
           ref={inputRef}
           tabIndex={0}
+          role="button"
           data-shortcut-recorder="true"
+          aria-label={`Record ${shortcut.label} shortcut`}
           onClick={handleClick}
           onBlur={handleBlur}
           onKeyDown={handleKeyboardActivate}

--- a/src/renderer/components/ShortcutRecorder.tsx
+++ b/src/renderer/components/ShortcutRecorder.tsx
@@ -147,6 +147,7 @@ export function ShortcutRecorder({
             ref={inputRef}
             tabIndex={0}
             role="button"
+            data-shortcut-recorder="true"
             aria-label={`Record ${shortcut.label} shortcut`}
             onClick={handleClick}
             onBlur={handleBlur}
@@ -209,6 +210,7 @@ export function ShortcutRecorder({
         <div
           ref={inputRef}
           tabIndex={0}
+          data-shortcut-recorder="true"
           onClick={handleClick}
           onBlur={handleBlur}
           onKeyDown={handleKeyboardActivate}

--- a/src/renderer/components/ShortcutRecorder.tsx
+++ b/src/renderer/components/ShortcutRecorder.tsx
@@ -12,13 +12,15 @@ interface ShortcutRecorderProps {
   allShortcuts: KeyboardShortcutsConfig
   onUpdate: (id: string, customKey: string) => void
   onReset: (id: string) => void
+  variant?: 'default' | 'compact'
 }
 
 export function ShortcutRecorder({
   shortcut,
   allShortcuts,
   onUpdate,
-  onReset
+  onReset,
+  variant = 'default'
 }: ShortcutRecorderProps): React.JSX.Element {
   const [isRecording, setIsRecording] = useState(false)
   const [pendingKey, setPendingKey] = useState<string | null>(null)
@@ -34,18 +36,18 @@ export function ShortcutRecorder({
       e.preventDefault()
       e.stopPropagation()
 
-      const normalized = normalizeKeyEvent(e)
-
-      // Ignore if only modifiers pressed
-      if (!normalized || normalized.split('+').every((p) => ['ctrl', 'alt', 'shift'].includes(p))) {
-        return
-      }
-
-      // Check for escape to cancel
+      // Check for escape to cancel before normalizing so Esc is never recorded.
       if (e.key === 'Escape') {
         setIsRecording(false)
         setPendingKey(null)
         setConflict(null)
+        return
+      }
+
+      const normalized = normalizeKeyEvent(e)
+
+      // Ignore if only modifiers pressed
+      if (!normalized || normalized.split('+').every((p) => ['ctrl', 'cmd', 'meta', 'alt', 'shift'].includes(p))) {
         return
       }
 
@@ -54,18 +56,23 @@ export function ShortcutRecorder({
       // Check for conflicts
       const conflicting = findConflictingShortcut(allShortcuts, normalized, shortcut.id)
       setConflict(conflicting ?? null)
+
+      if (!conflicting) {
+        onUpdate(shortcut.id, normalized)
+        setIsRecording(false)
+        setPendingKey(null)
+      }
     },
-    [allShortcuts, shortcut.id]
+    [allShortcuts, onUpdate, shortcut.id]
   )
 
   const handleBlur = useCallback(() => {
-    if (pendingKey && !conflict) {
-      onUpdate(shortcut.id, pendingKey)
+    if (!conflict) {
+      setIsRecording(false)
+      setPendingKey(null)
     }
-    setIsRecording(false)
-    setPendingKey(null)
     setConflict(null)
-  }, [pendingKey, conflict, onUpdate, shortcut.id])
+  }, [conflict])
 
   const handleClick = useCallback(() => {
     if (!isRecording) {
@@ -92,14 +99,93 @@ export function ShortcutRecorder({
     [onReset, shortcut.id]
   )
 
+  const handleKeyboardActivate = useCallback(
+    (e: React.KeyboardEvent<HTMLDivElement>) => {
+      if (!isRecording && (e.key === 'Enter' || e.key === ' ')) {
+        e.preventDefault()
+        handleClick()
+      }
+    },
+    [handleClick, isRecording]
+  )
+
   // Attach keydown listener when recording
   useEffect(() => {
     if (isRecording && inputRef.current) {
       inputRef.current.focus()
-      window.addEventListener('keydown', handleKeyDown)
-      return () => window.removeEventListener('keydown', handleKeyDown)
+      window.addEventListener('keydown', handleKeyDown, { capture: true })
+      return () => window.removeEventListener('keydown', handleKeyDown, { capture: true })
     }
   }, [isRecording, handleKeyDown])
+
+  if (variant === 'compact') {
+    return (
+      <div className="rounded-md px-2 py-1.5 hover:bg-secondary/40">
+        <div className="flex items-center gap-2">
+          <div className="min-w-0 flex-1">
+            <div className="truncate text-xs font-medium text-secondary-foreground">
+              {shortcut.label}
+            </div>
+            <div className="truncate text-[11px] text-muted-foreground">
+              {shortcut.description}
+            </div>
+          </div>
+
+          {isCustomized && (
+            <button
+              type="button"
+              onClick={handleReset}
+              className="shrink-0 rounded p-1 text-muted-foreground transition-colors hover:bg-secondary hover:text-foreground"
+              title="Reset to default"
+              aria-label={`Reset ${shortcut.label} shortcut to default`}
+            >
+              <RotateCcw size={13} />
+            </button>
+          )}
+
+          <div
+            ref={inputRef}
+            tabIndex={0}
+            role="button"
+            aria-label={`Record ${shortcut.label} shortcut`}
+            onClick={handleClick}
+            onBlur={handleBlur}
+            onKeyDown={handleKeyboardActivate}
+            className={`
+              min-w-[88px] shrink-0 rounded-md border px-2 py-1 text-center font-mono text-[11px] transition-all cursor-pointer
+              ${
+                isRecording
+                  ? 'border-primary bg-primary/10 ring-2 ring-primary/30'
+                  : 'border-border bg-secondary/50 hover:bg-secondary'
+              }
+              ${conflict ? 'border-red-500' : ''}
+              ${isCustomized ? 'text-primary' : 'text-foreground'}
+            `}
+          >
+            {isRecording && !pendingKey ? (
+              <span className="text-muted-foreground">Press keys...</span>
+            ) : (
+              formatKeyForDisplay(displayKey)
+            )}
+          </div>
+        </div>
+
+        {conflict && (
+          <div className="mt-1 text-[11px] text-red-500">
+            Conflicts with "{conflict.label}".{' '}
+            <button
+              type="button"
+              onMouseDown={(event) => event.preventDefault()}
+              onClick={handleConfirmWithConflict}
+              className="underline hover:no-underline"
+            >
+              Use anyway
+            </button>
+          </div>
+        )}
+      </div>
+    )
+  }
 
   return (
     <div className="flex items-center gap-2">
@@ -108,9 +194,11 @@ export function ShortcutRecorder({
           <span className="text-sm font-medium text-secondary-foreground">{shortcut.label}</span>
           {isCustomized && (
             <button
+              type="button"
               onClick={handleReset}
               className="p-1 hover:bg-secondary rounded text-muted-foreground hover:text-foreground transition-colors"
               title="Reset to default"
+              aria-label={`Reset ${shortcut.label} shortcut to default`}
             >
               <RotateCcw size={14} />
             </button>
@@ -123,6 +211,7 @@ export function ShortcutRecorder({
           tabIndex={0}
           onClick={handleClick}
           onBlur={handleBlur}
+          onKeyDown={handleKeyboardActivate}
           className={`
             px-3 py-2 rounded-md border text-sm font-mono cursor-pointer transition-all
             ${
@@ -145,6 +234,8 @@ export function ShortcutRecorder({
           <div className="mt-2 text-xs text-red-500">
             Conflicts with "{conflict.label}".{' '}
             <button
+              type="button"
+              onMouseDown={(event) => event.preventDefault()}
               onClick={handleConfirmWithConflict}
               className="underline hover:no-underline"
             >

--- a/src/renderer/components/TitleBar.tsx
+++ b/src/renderer/components/TitleBar.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react'
 import { Minus, Square, Copy, X, PanelLeft, PanelRight, Settings, SlidersHorizontal } from 'lucide-react'
+import { TitleBarShortcutsPopover } from '@/components/TitleBarShortcutsPopover'
 import { useNavigate, useLocation } from 'react-router-dom'
 import { useSidebarVisible } from '@/stores/sidebar-store'
 import { useFileExplorerVisible } from '@/stores/file-explorer-store'
@@ -10,7 +11,15 @@ import { isMac } from '@/lib/platform'
 
 const focusableButtonClass = 'h-full px-3 hover:bg-secondary/80 inline-flex items-center focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-inset'
 
-export function TitleBar(): React.JSX.Element {
+interface TitleBarProps {
+  isShortcutsOpen?: boolean
+  onShortcutsOpenChange?: (open: boolean) => void
+}
+
+export function TitleBar({
+  isShortcutsOpen,
+  onShortcutsOpenChange
+}: TitleBarProps = {}): React.JSX.Element {
   const [isMaximized, setIsMaximized] = useState(false)
   const isSidebarVisible = useSidebarVisible()
   const isExplorerVisible = useFileExplorerVisible()
@@ -101,6 +110,12 @@ export function TitleBar(): React.JSX.Element {
             className={isExplorerVisible ? 'text-foreground' : 'text-muted-foreground'}
           />
         </button>
+
+        <TitleBarShortcutsPopover
+          buttonClassName={focusableButtonClass}
+          open={isShortcutsOpen}
+          onOpenChange={onShortcutsOpenChange}
+        />
 
         <button
           onClick={(e) => { e.stopPropagation(); navigate('/settings'); }}

--- a/src/renderer/components/TitleBarShortcutsPopover.tsx
+++ b/src/renderer/components/TitleBarShortcutsPopover.tsx
@@ -1,11 +1,8 @@
+import { useCallback, useEffect, useRef } from 'react'
 import { Keyboard } from 'lucide-react'
+import { AnimatePresence, motion } from 'framer-motion'
 import { toast } from 'sonner'
 import { ShortcutRecorder } from '@/components/ShortcutRecorder'
-import {
-  Popover,
-  PopoverContent,
-  PopoverTrigger
-} from '@/components/ui/popover'
 import {
   useResetShortcut,
   useUpdateShortcut
@@ -33,15 +30,23 @@ interface TitleBarShortcutsPopoverProps {
 
 export function TitleBarShortcutsPopover({
   buttonClassName,
-  open,
+  open = false,
   onOpenChange
 }: TitleBarShortcutsPopoverProps): React.JSX.Element {
   const shortcuts = useKeyboardShortcutsStore((state) => state.shortcuts)
   const updateShortcut = useUpdateShortcut()
   const resetShortcut = useResetShortcut()
+  const closeButtonRef = useRef<HTMLButtonElement>(null)
 
   const quickShortcuts = QUICK_SHORTCUT_IDS.map((id) => shortcuts[id]).filter(
     (shortcut): shortcut is KeyboardShortcut => Boolean(shortcut)
+  )
+
+  const setOpen = useCallback(
+    (nextOpen: boolean) => {
+      onOpenChange?.(nextOpen)
+    },
+    [onOpenChange]
   )
 
   const handleUpdate = (id: string, customKey: string): void => {
@@ -56,56 +61,121 @@ export function TitleBarShortcutsPopover({
     })
   }
 
-  return (
-    <Popover open={open} onOpenChange={onOpenChange}>
-      <PopoverTrigger asChild>
-        <button
-          type="button"
-          className={buttonClassName}
-          title="Keyboard shortcuts"
-          aria-label="Open keyboard shortcuts menu"
-          aria-expanded={open}
-        >
-          <Keyboard size={16} className="text-muted-foreground" />
-        </button>
-      </PopoverTrigger>
-      <PopoverContent
-        align="end"
-        sideOffset={6}
-        className="z-[120] w-[360px] max-w-[calc(100vw-1rem)] p-0"
-        onOpenAutoFocus={(event) => event.preventDefault()}
-      >
-        <div className="border-b border-border px-3 py-2">
-          <div className="flex items-center gap-2 text-sm font-semibold text-foreground">
-            <Keyboard aria-hidden="true" size={15} />
-            Shortcut Menu
-          </div>
-          <p className="mt-1 text-xs text-muted-foreground">
-            View and edit common workspace shortcuts.
-          </p>
-        </div>
+  useEffect(() => {
+    if (!open) return
 
-        <div className="max-h-[420px] overflow-y-auto p-2">
-          {quickShortcuts.length === 0 ? (
-            <div className="px-2 py-6 text-center text-xs text-muted-foreground">
-              No shortcuts available.
-            </div>
-          ) : (
-            <div className="space-y-1">
-              {quickShortcuts.map((shortcut) => (
-                <ShortcutRecorder
-                  key={shortcut.id}
-                  shortcut={shortcut}
-                  allShortcuts={shortcuts}
-                  onUpdate={handleUpdate}
-                  onReset={handleReset}
-                  variant="compact"
-                />
-              ))}
-            </div>
-          )}
-        </div>
-      </PopoverContent>
-    </Popover>
+    if (document.activeElement instanceof HTMLElement) {
+      document.activeElement.blur()
+    }
+    setTimeout(() => closeButtonRef.current?.focus(), 0)
+  }, [open])
+
+  useEffect(() => {
+    if (!open) return
+
+    const handleKeyDown = (event: KeyboardEvent): void => {
+      if (event.key !== 'Escape') return
+
+      const activeElement = document.activeElement
+      if (
+        activeElement instanceof HTMLElement &&
+        activeElement.closest('[data-shortcut-recorder="true"]')
+      ) {
+        return
+      }
+
+      event.preventDefault()
+      event.stopPropagation()
+      setOpen(false)
+    }
+
+    window.addEventListener('keydown', handleKeyDown, { capture: true })
+    return () => window.removeEventListener('keydown', handleKeyDown, { capture: true })
+  }, [open, setOpen])
+
+  return (
+    <>
+      <button
+        type="button"
+        className={buttonClassName}
+        title="Keyboard shortcuts"
+        aria-label="Open keyboard shortcuts menu"
+        aria-expanded={open}
+        onClick={(event) => {
+          event.stopPropagation()
+          setOpen(!open)
+        }}
+      >
+        <Keyboard size={16} className={open ? 'text-foreground' : 'text-muted-foreground'} />
+      </button>
+
+      <AnimatePresence>
+        {open && (
+          <motion.div
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            className="fixed inset-0 z-[110] flex flex-col items-center pt-[7vh] bg-black/40 backdrop-blur-sm"
+            onClick={() => setOpen(false)}
+          >
+            <motion.div
+              role="dialog"
+              aria-modal="true"
+              aria-labelledby="shortcut-menu-title"
+              initial={{ opacity: 0, scale: 0.97, y: -8 }}
+              animate={{ opacity: 1, scale: 1, y: 0 }}
+              exit={{ opacity: 0, scale: 0.97, y: -8 }}
+              transition={{ duration: 0.15 }}
+              className="w-full max-w-lg overflow-hidden rounded-lg border border-border bg-card shadow-2xl"
+              onClick={(event) => event.stopPropagation()}
+            >
+              <div className="flex items-start justify-between gap-3 border-b border-border px-4 py-3">
+                <div>
+                  <div
+                    id="shortcut-menu-title"
+                    className="flex items-center gap-2 text-sm font-semibold text-foreground"
+                  >
+                    <Keyboard aria-hidden="true" size={15} />
+                    Shortcut Menu
+                  </div>
+                  <p className="mt-1 text-xs text-muted-foreground">
+                    View and edit common workspace shortcuts.
+                  </p>
+                </div>
+                <button
+                  ref={closeButtonRef}
+                  type="button"
+                  onClick={() => setOpen(false)}
+                  className="rounded px-2 py-1 text-xs font-medium text-muted-foreground hover:bg-secondary hover:text-foreground focus:outline-none focus-visible:ring-2 focus-visible:ring-primary"
+                >
+                  Esc
+                </button>
+              </div>
+
+              <div className="max-h-[52vh] overflow-y-auto px-2 py-2">
+                {quickShortcuts.length === 0 ? (
+                  <div className="px-2 py-6 text-center text-xs text-muted-foreground">
+                    No shortcuts available.
+                  </div>
+                ) : (
+                  <div className="space-y-1">
+                    {quickShortcuts.map((shortcut) => (
+                      <ShortcutRecorder
+                        key={shortcut.id}
+                        shortcut={shortcut}
+                        allShortcuts={shortcuts}
+                        onUpdate={handleUpdate}
+                        onReset={handleReset}
+                        variant="compact"
+                      />
+                    ))}
+                  </div>
+                )}
+              </div>
+            </motion.div>
+          </motion.div>
+        )}
+      </AnimatePresence>
+    </>
   )
 }

--- a/src/renderer/components/TitleBarShortcutsPopover.tsx
+++ b/src/renderer/components/TitleBarShortcutsPopover.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { Keyboard } from 'lucide-react'
 import { AnimatePresence, motion } from 'framer-motion'
 import { toast } from 'sonner'
@@ -30,9 +30,11 @@ interface TitleBarShortcutsPopoverProps {
 
 export function TitleBarShortcutsPopover({
   buttonClassName,
-  open = false,
+  open,
   onOpenChange
 }: TitleBarShortcutsPopoverProps): React.JSX.Element {
+  const [openFallback, setOpenFallback] = useState(false)
+  const isOpen = open ?? openFallback
   const shortcuts = useKeyboardShortcutsStore((state) => state.shortcuts)
   const updateShortcut = useUpdateShortcut()
   const resetShortcut = useResetShortcut()
@@ -44,7 +46,12 @@ export function TitleBarShortcutsPopover({
 
   const setOpen = useCallback(
     (nextOpen: boolean) => {
-      onOpenChange?.(nextOpen)
+      if (onOpenChange) {
+        onOpenChange(nextOpen)
+        return
+      }
+
+      setOpenFallback(nextOpen)
     },
     [onOpenChange]
   )
@@ -62,16 +69,16 @@ export function TitleBarShortcutsPopover({
   }
 
   useEffect(() => {
-    if (!open) return
+    if (!isOpen) return
 
     if (document.activeElement instanceof HTMLElement) {
       document.activeElement.blur()
     }
     setTimeout(() => closeButtonRef.current?.focus(), 0)
-  }, [open])
+  }, [isOpen])
 
   useEffect(() => {
-    if (!open) return
+    if (!isOpen) return
 
     const handleKeyDown = (event: KeyboardEvent): void => {
       if (event.key !== 'Escape') return
@@ -91,7 +98,7 @@ export function TitleBarShortcutsPopover({
 
     window.addEventListener('keydown', handleKeyDown, { capture: true })
     return () => window.removeEventListener('keydown', handleKeyDown, { capture: true })
-  }, [open, setOpen])
+  }, [isOpen, setOpen])
 
   return (
     <>
@@ -100,17 +107,17 @@ export function TitleBarShortcutsPopover({
         className={buttonClassName}
         title="Keyboard shortcuts"
         aria-label="Open keyboard shortcuts menu"
-        aria-expanded={open}
+        aria-expanded={isOpen}
         onClick={(event) => {
           event.stopPropagation()
-          setOpen(!open)
+          setOpen(!isOpen)
         }}
       >
-        <Keyboard size={16} className={open ? 'text-foreground' : 'text-muted-foreground'} />
+        <Keyboard size={16} className={isOpen ? 'text-foreground' : 'text-muted-foreground'} />
       </button>
 
       <AnimatePresence>
-        {open && (
+        {isOpen && (
           <motion.div
             initial={{ opacity: 0 }}
             animate={{ opacity: 1 }}

--- a/src/renderer/components/TitleBarShortcutsPopover.tsx
+++ b/src/renderer/components/TitleBarShortcutsPopover.tsx
@@ -1,0 +1,111 @@
+import { Keyboard } from 'lucide-react'
+import { toast } from 'sonner'
+import { ShortcutRecorder } from '@/components/ShortcutRecorder'
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger
+} from '@/components/ui/popover'
+import {
+  useResetShortcut,
+  useUpdateShortcut
+} from '@/hooks/use-keyboard-shortcuts'
+import { useKeyboardShortcutsStore } from '@/stores/keyboard-shortcuts-store'
+import type { KeyboardShortcut } from '@/types/settings'
+
+const QUICK_SHORTCUT_IDS = [
+  'commandPalette',
+  'commandHistory',
+  'newTerminal',
+  'newBrowserTab',
+  'toggleFileExplorer',
+  'sidebarToggle',
+  'zoomIn',
+  'zoomOut',
+  'zoomReset'
+] as const
+
+interface TitleBarShortcutsPopoverProps {
+  buttonClassName: string
+  open?: boolean
+  onOpenChange?: (open: boolean) => void
+}
+
+export function TitleBarShortcutsPopover({
+  buttonClassName,
+  open,
+  onOpenChange
+}: TitleBarShortcutsPopoverProps): React.JSX.Element {
+  const shortcuts = useKeyboardShortcutsStore((state) => state.shortcuts)
+  const updateShortcut = useUpdateShortcut()
+  const resetShortcut = useResetShortcut()
+
+  const quickShortcuts = QUICK_SHORTCUT_IDS.map((id) => shortcuts[id]).filter(
+    (shortcut): shortcut is KeyboardShortcut => Boolean(shortcut)
+  )
+
+  const handleUpdate = (id: string, customKey: string): void => {
+    void updateShortcut(id, customKey).catch((error: unknown) => {
+      toast.error(error instanceof Error ? error.message : 'Failed to save shortcut')
+    })
+  }
+
+  const handleReset = (id: string): void => {
+    void resetShortcut(id).catch((error: unknown) => {
+      toast.error(error instanceof Error ? error.message : 'Failed to reset shortcut')
+    })
+  }
+
+  return (
+    <Popover open={open} onOpenChange={onOpenChange}>
+      <PopoverTrigger asChild>
+        <button
+          type="button"
+          className={buttonClassName}
+          title="Keyboard shortcuts"
+          aria-label="Open keyboard shortcuts menu"
+          aria-expanded={open}
+        >
+          <Keyboard size={16} className="text-muted-foreground" />
+        </button>
+      </PopoverTrigger>
+      <PopoverContent
+        align="end"
+        sideOffset={6}
+        className="z-[120] w-[360px] max-w-[calc(100vw-1rem)] p-0"
+        onOpenAutoFocus={(event) => event.preventDefault()}
+      >
+        <div className="border-b border-border px-3 py-2">
+          <div className="flex items-center gap-2 text-sm font-semibold text-foreground">
+            <Keyboard aria-hidden="true" size={15} />
+            Shortcut Menu
+          </div>
+          <p className="mt-1 text-xs text-muted-foreground">
+            View and edit common workspace shortcuts.
+          </p>
+        </div>
+
+        <div className="max-h-[420px] overflow-y-auto p-2">
+          {quickShortcuts.length === 0 ? (
+            <div className="px-2 py-6 text-center text-xs text-muted-foreground">
+              No shortcuts available.
+            </div>
+          ) : (
+            <div className="space-y-1">
+              {quickShortcuts.map((shortcut) => (
+                <ShortcutRecorder
+                  key={shortcut.id}
+                  shortcut={shortcut}
+                  allShortcuts={shortcuts}
+                  onUpdate={handleUpdate}
+                  onReset={handleReset}
+                  variant="compact"
+                />
+              ))}
+            </div>
+          )}
+        </div>
+      </PopoverContent>
+    </Popover>
+  )
+}

--- a/src/renderer/layouts/WorkspaceLayout.tsx
+++ b/src/renderer/layouts/WorkspaceLayout.tsx
@@ -116,6 +116,7 @@ export default function WorkspaceLayout(): React.JSX.Element {
 	const navigate = useNavigate();
 	const [isNewProjectModalOpen, setIsNewProjectModalOpen] = useState(false);
 	const [isCommandPaletteOpen, setIsCommandPaletteOpen] = useState(false);
+	const [isShortcutMenuOpen, setIsShortcutMenuOpen] = useState(false);
 	const [isCreateSnapshotModalOpen, setIsCreateSnapshotModalOpen] =
 		useState(false);
 	const [closeConfirmTerminal, setCloseConfirmTerminal] = useState<{
@@ -429,6 +430,11 @@ export default function WorkspaceLayout(): React.JSX.Element {
 	const handleOpenCommandHistory = useCallback(() => {
 		setIsCommandPaletteOpen(false);
 		setIsCommandHistoryOpen(true);
+	}, []);
+
+	const handleOpenShortcutMenu = useCallback(() => {
+		setIsCommandPaletteOpen(false);
+		setIsShortcutMenuOpen(true);
 	}, []);
 
 	// Keyboard shortcuts
@@ -1079,7 +1085,10 @@ export default function WorkspaceLayout(): React.JSX.Element {
 	if (!isLoaded) {
 		return (
 			<div className="h-screen flex flex-col overflow-hidden bg-background">
-				<TitleBar />
+				<TitleBar
+					isShortcutsOpen={isShortcutMenuOpen}
+					onShortcutsOpenChange={setIsShortcutMenuOpen}
+				/>
 				<div className="flex-1 flex items-center justify-center">
 					<div className="text-muted-foreground text-sm">Loading...</div>
 				</div>
@@ -1089,7 +1098,10 @@ export default function WorkspaceLayout(): React.JSX.Element {
 
 	return (
 		<div className="h-screen flex flex-col overflow-hidden bg-background">
-			<TitleBar />
+			<TitleBar
+				isShortcutsOpen={isShortcutMenuOpen}
+				onShortcutsOpenChange={setIsShortcutMenuOpen}
+			/>
 
 			<div className="flex-1 flex overflow-hidden min-h-0 h-full p-2 gap-0">
 				{/* Sidebar */}
@@ -1206,6 +1218,7 @@ export default function WorkspaceLayout(): React.JSX.Element {
 				onOpenProjectSettings={handleOpenProjectSettings}
 				onOpenAppPreferences={handleOpenAppPreferences}
 				onOpenCommandHistory={activeProjectId ? handleOpenCommandHistory : undefined}
+				onOpenShortcutMenu={handleOpenShortcutMenu}
 				getShortcutLabel={getShortcutLabel}
 				getProjectShortcutLabel={getProjectShortcutLabel}
 			/>


### PR DESCRIPTION
## Summary
- add a compact keyboard shortcut menu accessible from the title bar
- add an Open Shortcut Menu action to the Ctrl+K command palette
- allow inline shortcut editing/resetting with the existing shortcut recorder and persistence hooks
- present the shortcut menu as a command-palette-style modal with blurred backdrop

## Validation
- npm run typecheck:web
- npm run lint -- src/renderer/components/TitleBarShortcutsPopover.tsx src/renderer/components/ShortcutRecorder.tsx src/renderer/components/TitleBar.tsx src/renderer/layouts/WorkspaceLayout.tsx
- npm test -- TitleBar CommandPalette

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "Open Shortcut Menu" command to the command palette
  * New title-bar shortcuts popover providing a keyboard-shortcuts menu and quick-edit UI
  * Compact variant for the shortcut recorder

* **Improvements**
  * Shortcut recorder: keyboard activation (Enter/Space), immediate apply on valid input, improved Escape/blur behavior, and conflict handling

* **Tests**
  * Extended command-palette tests to cover the new shortcut-menu command and omission when callbacks are missing

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gnoviawan/termul/pull/145)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->