### PR TITLE
fix: prevent mermaid DOM leak on syntax error

### DIFF
--- a/src/renderer/components/editor/MermaidBlock.tsx
+++ b/src/renderer/components/editor/MermaidBlock.tsx
@@ -98,6 +98,7 @@ export function MermaidBlock({ source }: MermaidBlockProps): React.JSX.Element {
 		mermaid.initialize({
 			startOnLoad: false,
 			theme: isDark ? "dark" : "default",
+			suppressErrorRendering: true,
 		});
 
 		const id = `mb-${Math.random().toString(36).slice(2, 11)}`;


### PR DESCRIPTION
## Description

When markdown contains a mermaid chart with a syntax error, `mermaid.render()` creates a temporary `<div>` in `document.body` to render an error SVG, then throws without cleaning it up. These leaked elements accumulate below the sidebar and terminal, causing uncontrolled scrolling.

**Root cause:** `mermaid.render(id, source)` is called without a container element (3rd arg). On syntax error, mermaid's internal error rendering renders an SVG into a body-level temp div, then throws — skipping `removeTempElements()`.

## Fix

Added `suppressErrorRendering: true` to the `mermaid.initialize()` config in `MermaidBlock.tsx`. This tells mermaid to clean up its temp DOM elements before throwing on parse errors.

## Changes

- `src/renderer/components/editor/MermaidBlock.tsx:100` — added `suppressErrorRendering: true`

## Verification

- TypeScript typecheck ✅ passed
- No lint issues
- Existing error handling in `.catch()` unaffected — still shows red error box

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved diagram rendering by preventing error messages from appearing in generated diagrams, resulting in cleaner visual output.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gnoviawan/termul/pull/156?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->