### PR TITLE
fix: prevent explorer search from opening console window on Windows

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -805,12 +805,13 @@ fn detect_rg_path() -> String {
 #[cfg(target_os = "windows")]
 const CREATE_NO_WINDOW: u32 = 0x08000000;
 
+#[cfg(target_os = "windows")]
 fn configure_background_command(command: &mut Command) {
-    #[cfg(target_os = "windows")]
-    {
-        command.creation_flags(CREATE_NO_WINDOW);
-    }
+    command.creation_flags(CREATE_NO_WINDOW);
 }
+
+#[cfg(not(target_os = "windows"))]
+fn configure_background_command(_command: &mut Command) {}
 
 fn build_search_args(query: &str, root_path: &str, max_matches_per_file: usize) -> Vec<String> {
     let mut args = vec![

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -9,6 +9,8 @@ use std::collections::{BTreeMap, HashMap};
 use std::io::{BufRead, BufReader};
 use std::path::PathBuf;
 use std::process::{Child, Command, Stdio};
+#[cfg(target_os = "windows")]
+use std::os::windows::process::CommandExt;
 use std::sync::{Arc, Mutex, OnceLock};
 use tauri::ipc::{Channel, Response};
 use tauri::{AppHandle, Emitter, State, Webview};
@@ -800,6 +802,16 @@ fn detect_rg_path() -> String {
     detected
 }
 
+#[cfg(target_os = "windows")]
+const CREATE_NO_WINDOW: u32 = 0x08000000;
+
+fn configure_background_command(command: &mut Command) {
+    #[cfg(target_os = "windows")]
+    {
+        command.creation_flags(CREATE_NO_WINDOW);
+    }
+}
+
 fn build_search_args(query: &str, root_path: &str, max_matches_per_file: usize) -> Vec<String> {
     let mut args = vec![
         "--json".to_string(),
@@ -880,12 +892,10 @@ pub async fn search_content_stream(
     let args = build_search_args(&trimmed_query, &request.root_path, max_matches_per_file);
 
     let rg_path = detect_rg_path();
-    let mut child = match Command::new(&rg_path)
-        .args(args)
-        .stdout(Stdio::piped())
-        .stderr(Stdio::null())
-        .spawn()
-    {
+    let mut rg_command = Command::new(&rg_path);
+    rg_command.args(args).stdout(Stdio::piped()).stderr(Stdio::null());
+    configure_background_command(&mut rg_command);
+    let mut child = match rg_command.spawn() {
         Ok(c) => c,
         Err(e) => {
             let _ = app_handle.emit(
@@ -1162,7 +1172,10 @@ pub async fn search_content(
     let args = build_search_args(trimmed_query, &request.root_path, max_matches_per_file);
 
     let rg_path = detect_rg_path();
-    let output = Command::new(&rg_path).args(args).output();
+    let mut rg_command = Command::new(&rg_path);
+    rg_command.args(args);
+    configure_background_command(&mut rg_command);
+    let output = rg_command.output();
     let output = match output {
         Ok(o) => o,
         Err(e) => {


### PR DESCRIPTION
## Summary
- prevent `rg` search child processes from opening a console window in packaged Windows builds
- apply Windows-only `CREATE_NO_WINDOW` process flag for explorer search commands
- keep behavior unchanged for macOS/Linux

## Root Cause
In packaged Windows (`.exe`) runs, explorer search (>=2 chars) spawns `rg` via Rust `Command`.
Without Windows no-window flags, child console windows can appear and steal focus from the search input.

## Changes
- `src-tauri/src/commands.rs`
  - add Windows-only `CommandExt` import
  - add helper to configure background command with `CREATE_NO_WINDOW`
  - use helper in:
    - `search_content_stream`
    - `search_content`

## Verification
### Manual
- reproduced issue in installed Windows app before fix
- after fix: typing in explorer search (including >=2 chars) no longer opens/focus-steals terminal window

### Automated
- `cargo check --manifest-path src-tauri/Cargo.toml -q` ✅
- `npm run lint` ✅
- repository currently has unrelated pre-existing frontend type/test failures:
  - missing module `@xterm/addon-serialize` in renderer tests/typecheck
  - not introduced by this change

## Notes
This PR is intentionally minimal and scoped only to the Windows process-spawn behavior for search.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows user experience by optimizing how search processes are created to prevent console windows from appearing in the background.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gnoviawan/termul/pull/157?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->