### PR TITLE
feat: add per-project settings gear button and compact context menu

### DIFF
--- a/src/renderer/components/ContextMenu.tsx
+++ b/src/renderer/components/ContextMenu.tsx
@@ -34,7 +34,7 @@ export function ContextMenu({ items, x, y, onClose }: ContextMenuProps): React.J
   // Adjust position if menu would overflow viewport
   const adjustedPosition = useCallback((): { left: number; top: number } => {
     const menuWidth = 180
-    const menuHeight = items.length * 36 + 8
+    const menuHeight = items.length * 28 + 4
     const viewportWidth = window.innerWidth
     const viewportHeight = window.innerHeight
 
@@ -83,7 +83,7 @@ export function ContextMenu({ items, x, y, onClose }: ContextMenuProps): React.J
   return (
     <div
       ref={menuRef}
-      className="fixed z-50 bg-card border border-border rounded-md shadow-lg py-1 min-w-[180px]"
+      className="fixed z-50 bg-card border border-border rounded-md shadow-lg py-0.5 min-w-[160px]"
       style={{ left: position.left, top: position.top }}
     >
       {items.map((item, index) => {
@@ -108,22 +108,22 @@ export function ContextMenu({ items, x, y, onClose }: ContextMenuProps): React.J
                 }}
                 disabled={item.disabled}
                 className={cn(
-                  'w-full flex items-center px-3 py-2 text-sm transition-colors',
+                  'w-full flex items-center px-2 py-1 text-xs transition-colors',
                   item.disabled && 'opacity-50 cursor-not-allowed',
                   item.variant === 'danger'
                     ? 'text-red-400 hover:bg-red-500/10'
                     : 'text-foreground hover:bg-secondary'
                 )}
               >
-                {item.icon && <span className="mr-2">{item.icon}</span>}
+                {item.icon && <span className="mr-1.5">{item.icon}</span>}
                 {item.label}
-                {item.submenu && <ChevronRight size={14} className="ml-auto" />}
+                {item.submenu && <ChevronRight size={12} className="ml-auto" />}
               </button>
 
               {/* Submenu */}
               {item.submenu && hoveredIndex === index && (
                 <div
-                  className="absolute left-full top-0 ml-1 bg-card border border-border rounded-md shadow-lg py-1 min-w-[160px]"
+                  className="absolute left-full top-0 ml-1 bg-card border border-border rounded-md shadow-lg py-0.5 min-w-[140px]"
                 >
                   {item.submenu.map((subItem) => (
                     <button
@@ -134,14 +134,14 @@ export function ContextMenu({ items, x, y, onClose }: ContextMenuProps): React.J
                         }
                         onClose()
                       }}
-                      className="w-full flex items-center px-3 py-2 text-sm text-foreground hover:bg-secondary transition-colors"
+                      className="w-full flex items-center px-2 py-1 text-xs text-foreground hover:bg-secondary transition-colors"
                     >
                       {subItem.isSelected ? (
-                        <Check size={14} className="mr-2 text-primary" />
+                        <Check size={12} className="mr-1.5 text-primary" />
                       ) : (
-                        <span className="w-[14px] mr-2" />
+                        <span className="w-[12px] mr-1.5" />
                       )}
-                      {subItem.icon && <span className="mr-2">{subItem.icon}</span>}
+                      {subItem.icon && <span className="mr-1.5">{subItem.icon}</span>}
                       {subItem.label}
                     </button>
                   ))}

--- a/src/renderer/components/ProjectSidebar.test.tsx
+++ b/src/renderer/components/ProjectSidebar.test.tsx
@@ -400,7 +400,7 @@ describe('ProjectSidebar Default Shell Submenu', () => {
     fireEvent.contextMenu(projectItem)
 
     await waitFor(() => {
-      expect(screen.getByText('Set Default Shell')).toBeInTheDocument()
+      expect(screen.getByText('Default Shell')).toBeInTheDocument()
     })
   })
 
@@ -416,8 +416,8 @@ describe('ProjectSidebar Default Shell Submenu', () => {
     const projectItem = screen.getByText('Project One')
     fireEvent.contextMenu(projectItem)
 
-    // Hover over Set Default Shell to show submenu
-    const shellMenuItem = await screen.findByText('Set Default Shell')
+    // Hover over Default Shell to show submenu
+    const shellMenuItem = await screen.findByText('Default Shell')
     fireEvent.mouseEnter(shellMenuItem.closest('div')!)
 
     // Click on Zsh in submenu

--- a/src/renderer/components/ProjectSidebar.tsx
+++ b/src/renderer/components/ProjectSidebar.tsx
@@ -10,6 +10,7 @@ import {
 	RotateCcw,
 	ChevronDown,
 	ChevronRight,
+	Settings,
 } from "lucide-react";
 import { useNavigate } from "react-router-dom";
 import type { Project, ProjectColor } from "@/types/project";
@@ -21,6 +22,7 @@ import type { ContextMenuItem, ContextMenuSubItem } from "./ContextMenu";
 import { ConfirmDialog } from "./ConfirmDialog";
 import { ColorPickerPopover } from "./ColorPickerPopover";
 import { shellApi } from "@/lib/api";
+import { useProjectActions } from "@/stores/project-store";
 
 function getFirstLetter(name: string): string {
 	if (!name) return "?";
@@ -73,6 +75,7 @@ export function ProjectSidebar({
 	onReorderProjects,
 }: ProjectSidebarProps): React.JSX.Element {
 	const navigate = useNavigate();
+	const { selectProject } = useProjectActions();
 
 	// Show archived toggle state
 	const [showArchived, setShowArchived] = useState(false);
@@ -240,6 +243,14 @@ export function ProjectSidebar({
 
 			const items: ContextMenuItem[] = [
 				{
+					label: "Settings",
+					icon: <Settings size={14} />,
+					onClick: () => {
+						selectProject(projectId);
+						navigate("/settings");
+					},
+				},
+				{
 					label: "Rename",
 					icon: <Edit2 size={14} />,
 					onClick: () => handleStartRename(projectId),
@@ -254,7 +265,7 @@ export function ProjectSidebar({
 
 			if (shellSubmenu.length > 0) {
 				items.push({
-					label: "Set Default Shell",
+					label: "Default Shell",
 					icon: <Terminal size={14} />,
 					submenu: shellSubmenu,
 					onSubmenuSelect: (shellPath: string) => {
@@ -289,6 +300,8 @@ export function ProjectSidebar({
 			onUpdateProject,
 			onArchiveProject,
 			handleConfirmDelete,
+			selectProject,
+			navigate,
 		],
 	);
 
@@ -387,7 +400,6 @@ export function ProjectSidebar({
 										isActive={project.id === activeProjectId}
 										isEditing={editingId === project.id}
 										editName={editName}
-										shortcut={index < 9 ? `Ctrl+${index + 1}` : undefined}
 										onClick={() => {
 											onSelectProject(project.id);
 											navigate("/");
@@ -396,6 +408,10 @@ export function ProjectSidebar({
 										onEditNameChange={setEditName}
 										onSaveRename={() => handleSaveRename(project.id)}
 										onCancelRename={handleCancelRename}
+										onSettingsClick={() => {
+											selectProject(project.id);
+											navigate("/settings");
+										}}
 									/>
 								</Reorder.Item>
 							))}
@@ -483,12 +499,12 @@ interface ProjectItemProps {
 	isActive: boolean;
 	isEditing: boolean;
 	editName: string;
-	shortcut?: string;
 	onClick: () => void;
 	onContextMenu: (e: React.MouseEvent) => void;
 	onEditNameChange: (name: string) => void;
 	onSaveRename: () => void;
 	onCancelRename: () => void;
+	onSettingsClick: () => void;
 }
 
 function ProjectItem({
@@ -496,12 +512,12 @@ function ProjectItem({
 	isActive,
 	isEditing,
 	editName,
-	shortcut,
 	onClick,
 	onContextMenu,
 	onEditNameChange,
 	onSaveRename,
 	onCancelRename,
+	onSettingsClick,
 }: ProjectItemProps): React.JSX.Element {
 	const colors = getColorClasses(project.color);
 	const inputRef = useRef<HTMLInputElement>(null);
@@ -578,15 +594,18 @@ function ProjectItem({
 					{project.name}
 				</span>
 			)}
-			{!isEditing && shortcut && (
-				<span
-					className={cn(
-						"text-xs font-mono text-muted-foreground transition-opacity mr-3",
-						isActive ? "opacity-100" : "opacity-0 group-hover:opacity-100",
-					)}
+			{!isEditing && (
+				<button
+					onClick={(e) => {
+						e.stopPropagation();
+						onSettingsClick();
+					}}
+					className="h-5 w-5 inline-flex items-center justify-center rounded opacity-0 group-hover:opacity-100 hover:bg-sidebar-accent transition-all mr-2 flex-shrink-0 focus:outline-none focus-visible:ring-1 focus-visible:ring-primary"
+					title="Project settings"
+					aria-label={`Settings for ${project.name}`}
 				>
-					{shortcut}
-				</span>
+					<Settings size={12} className="text-muted-foreground" />
+				</button>
 			)}
 		</button>
 	);

--- a/src/renderer/components/TitleBar.tsx
+++ b/src/renderer/components/TitleBar.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react'
-import { Minus, Square, Copy, X, PanelLeft, PanelRight, Settings, SlidersHorizontal } from 'lucide-react'
+import { Minus, Square, Copy, X, PanelLeft, PanelRight, SlidersHorizontal } from 'lucide-react'
 import { TitleBarShortcutsPopover } from '@/components/TitleBarShortcutsPopover'
 import { useNavigate, useLocation } from 'react-router-dom'
 import { useSidebarVisible } from '@/stores/sidebar-store'
@@ -116,19 +116,6 @@ export function TitleBar({
           open={isShortcutsOpen}
           onOpenChange={onShortcutsOpenChange}
         />
-
-        <button
-          onClick={(e) => { e.stopPropagation(); navigate('/settings'); }}
-          className={focusableButtonClass}
-          title="Settings"
-          aria-label="Open settings"
-          aria-current={location.pathname === '/settings' ? 'page' : undefined}
-        >
-          <Settings
-            size={16}
-            className={location.pathname === '/settings' ? 'text-foreground' : 'text-muted-foreground'}
-          />
-        </button>
 
         <button
           onClick={(e) => { e.stopPropagation(); navigate('/preferences'); }}


### PR DESCRIPTION
Summary:

- Add Settings gear button on each project item (appears on hover)
- Click gear navigates to Project Settings page with correct project selected
- Add 'Settings' item to right-click context menu
- Remove Settings button from TitleBar (top right)
- Remove Ctrl+N shortcut labels from project items
- Compact context menu styling (smaller padding, font, icons)
- Rename 'Set Default Shell' to 'Default Shell' in context menu

## How It Was Tested

- ✅ 
> termul-manager@0.3.8 typecheck
> npm run typecheck:node && npm run typecheck:web


> termul-manager@0.3.8 typecheck:node
> tsc --noEmit -p tsconfig.node.json


> termul-manager@0.3.8 typecheck:web
> tsc --noEmit -p tsconfig.web.json
- ✅ 
> termul-manager@0.3.8 test
> vitest run


 RUN  v4.1.6 E:/open-source/PecutAPP/termul


 Test Files  80 passed | 1 skipped (81)
      Tests  1132 passed | 5 skipped (1137)
   Start at  10:48:45
   Duration  70.20s (transform 14.11s, setup 53.77s, import 237.21s, tests 20.09s, environment 328.34s)
- ✅ Manual verification completed

## Screenshots or Recordings

UI changes:
- Project sidebar now shows gear icon on hover for each project
- Right-click context menu now has 'Settings' as first item
- Settings button removed from TitleBar

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Settings option to project context menu
  * Added dedicated settings button for each project row
  * Renamed header navigation from Settings to Preferences with updated icon

* **Style**
  * Redesigned context menu with more compact layout and spacing
  * Refined menu item typography and visual hierarchy
  * Updated shell submenu label for improved clarity

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gnoviawan/termul/pull/159?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->