### PR TITLE
fix(tsconfig): use bundler moduleResolution in tsconfig.node.json

### DIFF
--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -3,7 +3,7 @@
     "composite": true,
     "skipLibCheck": true,
     "module": "ESNext",
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "allowSyntheticDefaultImports": true,
     "esModuleInterop": true,
     "resolveJsonModule": true,


### PR DESCRIPTION


## Summary

Previously used "node" (alias for node10) which uses the pre-2014 resolution algorithm and does not understand package.json `exports` fields. "bundler" aligns with how Vite resolves modules at runtime, ensuring TypeScript sees the same module graph.
## Related Issue

-

## Type of Change

- [ ] feat: new feature
- [x] fix: bug fix
- [ ] docs: documentation only
- [ ] style: formatting or non-functional styling changes
- [x] refactor: internal cleanup with no behavior change
- [x] perf: performance improvement
- [ ] test: adds or updates tests
- [ ] build: build or dependency changes
- [ ] ci: CI/CD workflow changes
- [x] chore: maintenance or tooling
- [ ] revert: reverts a previous change

## What Changed

Use bundler as the moduleResolution for node tsconfig instead of node

## How It Was Tested

-

## Screenshots or Recordings

-

## Checklist

- [x] My PR title follows the conventional commit format used by this repo
- [ ] I linked the related issue or explained why none exists
- [ ] I updated docs when needed
- [ ] I added or updated tests when needed
- [ ] I verified the change does not introduce unrelated modifications


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated TypeScript configuration to optimize module resolution behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gnoviawan/termul/pull/161?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->