### PR TITLE
ci: add macos intel release target

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -149,6 +149,11 @@ jobs:
             rust_target: aarch64-apple-darwin
             args: --target aarch64-apple-darwin
 
+          - platform: macos-x64
+            runner: macos-latest
+            rust_target: x86_64-apple-darwin
+            args: --target x86_64-apple-darwin
+
     steps:
       - name: Harden runner
         if: matrix.runner == 'ubuntu-22.04'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -150,7 +150,7 @@ jobs:
             args: --target aarch64-apple-darwin
 
           - platform: macos-x64
-            runner: macos-latest
+            runner: macos-13
             rust_target: x86_64-apple-darwin
             args: --target x86_64-apple-darwin
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -150,7 +150,7 @@ jobs:
             args: --target aarch64-apple-darwin
 
           - platform: macos-x64
-            runner: macos-13
+            runner: macos-15-intel
             rust_target: x86_64-apple-darwin
             args: --target x86_64-apple-darwin
 

--- a/docs/deployment-guide.md
+++ b/docs/deployment-guide.md
@@ -72,12 +72,13 @@ The main release pipeline is `.github/workflows/release.yml`.
    - Windows x64
    - Linux x64
    - macOS arm64
+   - macOS x64 / Intel
 
 4. **Validate versions**
    - `package.json`
    - `src-tauri/Cargo.toml`
    - `src-tauri/tauri.conf.json`
-   must all match the tag version
+     must all match the tag version
 
 5. **Publish via Tauri action**
    - builds bundles
@@ -134,6 +135,7 @@ git push origin v0.3.7
 ## Platform-Specific Notes
 
 ### Linux
+
 The release workflow installs Linux build dependencies such as:
 
 - `libwebkit2gtk-4.1-dev`
@@ -142,14 +144,17 @@ The release workflow installs Linux build dependencies such as:
 - `patchelf`
 
 ### Windows
+
 Windows builds target:
 
 - `x86_64-pc-windows-msvc`
 
 ### macOS
+
 Release workflow currently targets:
 
 - `aarch64-apple-darwin`
+- `x86_64-apple-darwin`
 
 Repository scripts also support Intel macOS builds locally.
 


### PR DESCRIPTION
## Summary
- Add a macOS x64/Intel target to the release workflow matrix.
- Update deployment documentation to list macOS Intel as a release target.

## Why
The current release pipeline only builds macOS arm64 artifacts, so Intel Macs do not receive a compatible DMG or updater manifest entry. Adding `x86_64-apple-darwin` lets Tauri publish Intel macOS artifacts and include `darwin-x86_64` in future updater manifests.

## Validation
- Checked workflow/docs diagnostics in VS Code.
- Verified the existing Intel ripgrep sidecar is present and built as a Mach-O x86_64 binary.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI now builds and publishes macOS x64 (Intel) artifacts alongside existing macOS ARM64 releases, enabling Intel macOS build targets in the release pipeline.

* **Documentation**
  * Deployment and release docs updated to include the new macOS x64 platform entry and expanded platform-specific notes, with minor formatting improvements for clarity.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gnoviawan/termul/pull/163?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->