### PR TITLE
fix(secrets): redact persisted project env vars

### DIFF
--- a/docs/development-guide.md
+++ b/docs/development-guide.md
@@ -166,7 +166,7 @@ The app stores local state using Tauri plugin store adapters:
 - `termul-sessions.json` — session persistence
 - logical keys like `projects`, `terminals/{projectId}`, `snapshots/{projectId}`, `window-state`
 
-Project env vars are persisted, and the code notes a future improvement for moving secret values to secure OS storage.
+Project env vars are persisted in local store data, but secret-marked values are redacted before persistence and must be re-entered after app restart until secure OS storage is added.
 
 ## File Watching and Editor Behavior
 

--- a/src/renderer/hooks/use-projects-persistence.test.ts
+++ b/src/renderer/hooks/use-projects-persistence.test.ts
@@ -1,0 +1,109 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { renderHook, waitFor } from '@testing-library/react'
+import { useProjectStore } from '@/stores/project-store'
+import { PersistenceKeys } from '@shared/types/persistence.types'
+import {
+  usePersistProjectsImmediate,
+  useProjectsLoader
+} from './use-projects-persistence'
+
+const { mockPersistenceRead, mockPersistenceWrite } = vi.hoisted(() => ({
+  mockPersistenceRead: vi.fn(),
+  mockPersistenceWrite: vi.fn()
+}))
+
+vi.mock('@/lib/api', () => ({
+  persistenceApi: {
+    read: mockPersistenceRead,
+    write: mockPersistenceWrite,
+    writeDebounced: vi.fn(),
+    delete: vi.fn()
+  }
+}))
+
+describe('use-projects-persistence', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    useProjectStore.setState({
+      projects: [],
+      activeProjectId: '',
+      isLoaded: false
+    })
+  })
+
+  it('redacts secret env var values before persisting projects', async () => {
+    useProjectStore.setState({
+      projects: [
+        {
+          id: 'project-1',
+          name: 'Secure Project',
+          color: 'blue',
+          gitBranch: 'main',
+          envVars: [
+            { key: 'PUBLIC_URL', value: 'https://example.com' },
+            { key: 'API_TOKEN', value: 'super-secret-token', isSecret: true }
+          ]
+        }
+      ],
+      activeProjectId: 'project-1',
+      isLoaded: true
+    })
+
+    mockPersistenceWrite.mockResolvedValue({ success: true, data: undefined })
+
+    const { result } = renderHook(() => usePersistProjectsImmediate())
+    await result.current()
+
+    expect(mockPersistenceWrite).toHaveBeenCalledWith(
+      PersistenceKeys.projects,
+      expect.objectContaining({
+        projects: [
+          expect.objectContaining({
+            envVars: [
+              { key: 'PUBLIC_URL', value: 'https://example.com', isSecret: undefined },
+              { key: 'API_TOKEN', value: '', isSecret: true }
+            ]
+          })
+        ]
+      })
+    )
+  })
+
+  it('restores secret env vars as blank values after loading persisted projects', async () => {
+    mockPersistenceRead.mockResolvedValue({
+      success: true,
+      data: {
+        projects: [
+          {
+            id: 'project-1',
+            name: 'Secure Project',
+            color: 'blue',
+            gitBranch: 'main',
+            envVars: [
+              { key: 'PUBLIC_URL', value: 'https://example.com' },
+              { key: 'API_TOKEN', value: 'persisted-secret-should-not-survive', isSecret: true }
+            ]
+          }
+        ],
+        activeProjectId: 'project-1',
+        updatedAt: '2026-05-25T00:00:00.000Z'
+      }
+    })
+
+    renderHook(() => useProjectsLoader())
+
+    await waitFor(() => {
+      expect(useProjectStore.getState().isLoaded).toBe(true)
+    })
+
+    expect(useProjectStore.getState().projects).toEqual([
+      expect.objectContaining({
+        id: 'project-1',
+        envVars: [
+          { key: 'PUBLIC_URL', value: 'https://example.com', isSecret: undefined },
+          { key: 'API_TOKEN', value: '', isSecret: true }
+        ]
+      })
+    ])
+  })
+})

--- a/src/renderer/hooks/use-projects-persistence.ts
+++ b/src/renderer/hooks/use-projects-persistence.ts
@@ -5,6 +5,22 @@ import { PersistenceKeys } from '../../shared/types/persistence.types'
 import type { PersistedProjectData, PersistedProject } from '../../shared/types/persistence.types'
 import type { Project, ProjectColor } from '@/types/project'
 
+function toPersistedEnvVars(project: Project): PersistedProject['envVars'] {
+  return project.envVars?.map((envVar) => ({
+    key: envVar.key,
+    value: envVar.isSecret ? '' : envVar.value,
+    isSecret: envVar.isSecret
+  }))
+}
+
+function fromPersistedEnvVars(persisted: PersistedProject): Project['envVars'] {
+  return persisted.envVars?.map((envVar) => ({
+    key: envVar.key,
+    value: envVar.isSecret ? '' : envVar.value,
+    isSecret: envVar.isSecret
+  }))
+}
+
 function toPersistedProject(project: Project): PersistedProject {
   return {
     id: project.id,
@@ -15,13 +31,8 @@ function toPersistedProject(project: Project): PersistedProject {
     gitBranch: project.gitBranch,
     defaultShell: project.defaultShell,
     // TODO: Secret values (isSecret===true) should be stored in secure OS storage (keyring/secureStore)
-    // instead of plaintext. For now, we persist all values but this is a security concern.
-    // A future PR should implement secure storage for secrets.
-    envVars: project.envVars?.map((envVar) => ({
-      key: envVar.key,
-      value: envVar.value,
-      isSecret: envVar.isSecret
-    }))
+    // instead of plaintext. Until secure storage exists, secret keys are preserved but values are redacted.
+    envVars: toPersistedEnvVars(project)
   }
 }
 
@@ -34,11 +45,7 @@ function fromPersistedProject(persisted: PersistedProject): Project {
     isArchived: persisted.isArchived,
     gitBranch: persisted.gitBranch,
     defaultShell: persisted.defaultShell,
-    envVars: persisted.envVars?.map((envVar) => ({
-      key: envVar.key,
-      value: envVar.value,
-      isSecret: envVar.isSecret
-    }))
+    envVars: fromPersistedEnvVars(persisted)
   }
 }
 

--- a/src/renderer/pages/ProjectSettings.tsx
+++ b/src/renderer/pages/ProjectSettings.tsx
@@ -293,7 +293,7 @@ export default function ProjectSettings() {
                 <div className="w-1/3 pt-1">
                   <h2 className="text-lg font-medium text-foreground">Environment Variables</h2>
                   <p className="text-sm text-muted-foreground mt-1">
-                    Secrets and config injected into your shell session.
+                    Secrets and config injected into your shell session. Secret values are cleared on app restart until secure storage is added.
                   </p>
                   <button
                     onClick={addEnvVar}


### PR DESCRIPTION
## Summary

This change stops project-level secret environment variables from being persisted in plaintext.

Right now, Termul lets users mark env vars as secrets, but those values were still being written into the normal local persistence store. This patch keeps the variable keys and `isSecret` metadata so the project configuration still survives a restart, while redacting the secret values themselves before anything is saved.

As a result, secret entries still exist after reload, but their values come back empty until proper secure OS storage is added.

## What changed

- Redact `envVars[].value` during project persistence when `isSecret === true`
- Apply the same redaction rule when loading persisted project data, so old plaintext secret values are not surfaced back into the app
- Add a regression test covering both persistence and restore behavior
- Update the settings copy and developer docs to make the current behavior explicit

## Why

This is a small change, but it closes a real local security gap.

The app already treats some env vars as secrets from a UX point of view. Persisting those same values in plaintext undermines that expectation and makes accidental local disclosure much easier than it needs to be.

This patch does not pretend to solve secret management completely. It just removes the most obvious unsafe behavior until secure storage is implemented properly.

## Validation

I verified the change with:

- `npm.cmd run lint`
- `npm.cmd run typecheck`
- `npx.cmd vitest run src/renderer/hooks/use-projects-persistence.test.ts`
- `npm.cmd test`

## Notes

After this change, secret env var values are intentionally cleared after app restart.

That is a tradeoff, but it is a safer default than continuing to keep those values in plaintext local persistence.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated development guide and project settings description regarding secret environment variable persistence behavior.

* **Improvements**
  * Secret environment variable values are now redacted before persistence (stored as empty) and must be re-entered after app restart until secure storage is implemented.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gnoviawan/termul/pull/164?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->