### PR TITLE
fix(terminal): xterm canvas overflows right-side padding

### DIFF
--- a/src/renderer/components/terminal/ConnectedTerminal.tsx
+++ b/src/renderer/components/terminal/ConnectedTerminal.tsx
@@ -1539,7 +1539,6 @@ function ConnectedTerminalComponent({
 		<ContextMenu>
 			<ContextMenuTrigger asChild>
 				<div
-					ref={containerRef}
 					className={`w-full h-full bg-[#1e1e1e] px-4 py-0.5 pb-1 ${className}`}
 					onClick={handleContainerClick}
 					onMouseDown={(e) => {
@@ -1550,7 +1549,9 @@ function ConnectedTerminalComponent({
 							terminalRef.current.focus();
 						}
 					}}
-				/>
+				>
+					<div ref={containerRef} className="w-full h-full" />
+				</div>
 			</ContextMenuTrigger>
 			<ContextMenuContent className="w-40">
 				<ContextMenuItem


### PR DESCRIPTION
## Summary

The xterm.js canvas layers (link layer, selection layer, screen) use absolute positioning (`position: absolute; top: 0; left: 0`) and span the element's full `clientWidth`. When `containerRef` was on the outer padded div (`px-4`), the canvas extended past the content area — causing the right terminal edge to have no padding.

## Root Cause

In `ConnectedTerminal.tsx`, the render structure was:

```tsx
<div ref={containerRef} className="px-4 py-0.5 pb-1">
  {/* xterm.open() appends absolute-positioned canvases here */}
</div>
```

xterm renders canvases at the full width of the parent element, ignoring CSS padding. The left side appeared padded by coincidence (text starts at x=0 from the element edge), but the right side canvas overflowed the padded region.

## Fix

Nest `containerRef` inside a separate inner `<div>`:

```diff
- <div ref={containerRef} className="px-4 py-0.5 pb-1" />
+ <div className="px-4 py-0.5 pb-1">
+   <div ref={containerRef} className="w-full h-full" />
+ </div>
```

The inner div's dimensions are naturally constrained by the parent's padding, so `FitAddon.fit()` correctly measures the content area. Both left and right edges now have proper padding.

## Changes

- **`src/renderer/components/terminal/ConnectedTerminal.tsx`** — moved `containerRef` to a new inner wrapper div

## Testing

- [ ] Visual: both left and right terminal edges show proper padding
- [ ] FitAddon: terminal text fills the padded area without overflow
- [ ] WebGL renderer: canvas layers stay within padded bounds
- [ ] Resize: terminal re-fits correctly on pane resize/split
- [ ] Project switch: cached terminal re-attaches correctly in nested container

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified the terminal component's internal markup structure to improve code maintainability and clarity, with no changes to user-facing functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gnoviawan/termul/pull/172?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->