### PR TITLE
fix(terminal): resolve terminal skew after minimize/restore

### DIFF
--- a/src/renderer/components/terminal/ConnectedTerminal.test.tsx
+++ b/src/renderer/components/terminal/ConnectedTerminal.test.tsx
@@ -2083,6 +2083,69 @@ describe('ConnectedTerminal', () => {
     })
   })
 
+  describe('Window focus recovery (Tauri minimize/restore)', () => {
+    it('should register window focus listener on mount', async () => {
+      const addEventListenerSpy = vi.spyOn(window, 'addEventListener')
+
+      render(<ConnectedTerminal />)
+
+      await vi.waitFor(() => {
+        expect(vi.mocked(terminalApi).spawn).toHaveBeenCalled()
+      })
+
+      expect(addEventListenerSpy).toHaveBeenCalledWith('focus', expect.any(Function))
+
+      addEventListenerSpy.mockRestore()
+    })
+
+    it('should trigger fit and resize on window focus with debounce', async () => {
+      vi.useFakeTimers()
+
+      render(<ConnectedTerminal />)
+
+      await vi.waitFor(() => {
+        expect(vi.mocked(terminalApi).spawn).toHaveBeenCalled()
+      })
+
+      mockFitAddonInstance.fit.mockClear()
+      vi.mocked(terminalApi).resize.mockClear()
+
+      // Dispatch window focus event
+      window.dispatchEvent(new Event('focus'))
+
+      // Should not fire immediately (debounced)
+      await vi.advanceTimersByTimeAsync(100)
+      expect(mockFitAddonInstance.fit).not.toHaveBeenCalled()
+
+      // Should fire after 150ms debounce
+      await vi.advanceTimersByTimeAsync(100)
+      expect(mockFitAddonInstance.fit).toHaveBeenCalledTimes(1)
+      expect(vi.mocked(terminalApi).resize).toHaveBeenCalledWith(
+        'terminal-123',
+        expect.any(Number),
+        expect.any(Number)
+      )
+
+      vi.useRealTimers()
+    })
+
+    it('should cleanup window focus listener on unmount', async () => {
+      const removeEventListenerSpy = vi.spyOn(window, 'removeEventListener')
+
+      const { unmount } = render(<ConnectedTerminal />)
+
+      await vi.waitFor(() => {
+        expect(vi.mocked(terminalApi).spawn).toHaveBeenCalled()
+      })
+
+      unmount()
+
+      expect(removeEventListenerSpy).toHaveBeenCalledWith('focus', expect.any(Function))
+
+      removeEventListenerSpy.mockRestore()
+    })
+  })
+
   describe('Regression: Visibility transition + recovery scenarios', () => {
     /**
      * REGRESSION TEST: Ensure terminal properly handles visibility state transitions

--- a/src/renderer/components/terminal/ConnectedTerminal.tsx
+++ b/src/renderer/components/terminal/ConnectedTerminal.tsx
@@ -202,6 +202,10 @@ function ConnectedTerminalComponent({
 	>(null);
 	// Track WebGL context loss for recovery decisions
 	const webglContextLostRef = useRef<boolean>(false);
+	// Track visibility prop for recovery path guards (tab-active, not window-visible).
+	// Ref avoids stale closures in event listeners referencing isVisible directly.
+	const isVisibleRef = useRef(isVisible);
+	isVisibleRef.current = isVisible;
 
 	// Get font settings from app settings store
 	const fontFamily = useTerminalFontFamily();
@@ -1485,9 +1489,15 @@ function ConnectedTerminalComponent({
 		let recoveryTimeoutId: ReturnType<typeof setTimeout> | null = null;
 
 		const handleWindowFocus = (): void => {
+			// Always clear pending timeout first to prevent stale recovery calls.
 			if (recoveryTimeoutId) {
 				clearTimeout(recoveryTimeoutId);
+				recoveryTimeoutId = null;
 			}
+			// Skip recovery for terminals that are not the active tab in their pane
+			// (isVisible is tab-active, not window-visible — see PaneContent.tsx).
+			// Hidden instances recover via the isVisible-change useEffect instead.
+			if (!isVisibleRef.current) return;
 			recoveryTimeoutId = setTimeout(() => {
 				recoveryTimeoutId = null;
 				performTerminalRecovery();

--- a/src/renderer/components/terminal/ConnectedTerminal.tsx
+++ b/src/renderer/components/terminal/ConnectedTerminal.tsx
@@ -1442,18 +1442,12 @@ function ConnectedTerminalComponent({
 			}
 		}
 
-		// Re-fit terminal to current dimensions
-		performFit(true);
-
-		// Sync PTY dimensions
-		const terminal = terminalRef.current;
-		const ptyId = ptyIdRef.current;
-		if (terminal && ptyId) {
-			terminalApi.resize(ptyId, terminal.cols, terminal.rows).catch(() => {
-				// Ignore resize errors - terminal may have been killed
-			});
-		}
-	}, []);
+		// Re-fit and sync PTY dimensions via the v2 hook's forced path.
+		// forceResizeFit clears any pending v2 debounce timers, fits with
+		// force=true (bypassing the dimension-sameness check), and immediately
+		// calls onPtyResize — keeping the v2 hook's dimension trackers in sync.
+		forceResizeFit();
+	}, [forceResizeFit]);
 
 	// Recovery handler for visibility change (app regains focus after idle)
 	useEffect(() => {
@@ -1479,6 +1473,33 @@ function ConnectedTerminalComponent({
 				clearTimeout(recoveryTimeoutId);
 			}
 			document.removeEventListener("visibilitychange", handleVisibilityChange);
+		};
+	}, [performTerminalRecovery]);
+
+	// Recovery handler for window focus — critical for Tauri minimize/restore
+	// on Windows where document.visibilitychange is unreliable.
+	// The window 'focus' event reliably fires when the window is restored from
+	// taskbar minimize. performTerminalRecovery re-fits the terminal to its
+	// container and syncs PTY dimensions (SIGWINCH to the shell process).
+	useEffect(() => {
+		let recoveryTimeoutId: ReturnType<typeof setTimeout> | null = null;
+
+		const handleWindowFocus = (): void => {
+			if (recoveryTimeoutId) {
+				clearTimeout(recoveryTimeoutId);
+			}
+			recoveryTimeoutId = setTimeout(() => {
+				recoveryTimeoutId = null;
+				performTerminalRecovery();
+			}, VISIBILITY_RECOVERY_DELAY_MS);
+		};
+
+		window.addEventListener("focus", handleWindowFocus);
+		return () => {
+			if (recoveryTimeoutId) {
+				clearTimeout(recoveryTimeoutId);
+			}
+			window.removeEventListener("focus", handleWindowFocus);
 		};
 	}, [performTerminalRecovery]);
 


### PR DESCRIPTION
## Summary

Terminal view becomes skewed/shrunk and unusable after minimizing and restoring the app window. The xterm grid stays at pre-minimize dimensions while the window is larger.

## Root Cause

After minimize→maximize, **no recovery path reliably fires** to re-fit the terminal:

1. **`isVisible` useEffect is dead code for this scenario** — it tracks "active tab in pane" (`PaneContent.tsx:200`: `const isVisible = activeTab?.id === tab.id`), not window visibility. During minimize/restore the tab stays active, so `isVisible` never changes and `forceResizeFit()` is never called.

2. **`document.visibilitychange` is unreliable** on Tauri Windows for minimize/restore cycles — the webview may not emit this event.

3. **ResizeObserver may not fire** if the container rect doesn't actually change (flex layout preserves last rendered dimensions during minimize).

Net result: no `fit()` runs after restore → xterm grid stays at old dimensions → skewed/shrunk appearance.

## Fix

- **Add `window "focus"` event listener** that triggers `performTerminalRecovery()` with 150ms debounce. The `focus` event reliably fires on window restore from taskbar minimize on all platforms.
- **Switch `performTerminalRecovery` to use `forceResizeFit()`** from `useTerminalResizeV2` instead of the local `performFit(true)` + manual `terminalApi.resize()`. This keeps the v2 hook's internal dimension trackers in sync and prevents drift between the two tracking systems.

## Changes

| File | Change |
|------|--------|
| `src/renderer/components/terminal/ConnectedTerminal.tsx` | Added `window "focus"` recovery useEffect; replaced local fit+resize with `forceResizeFit()` in `performTerminalRecovery` |
| `src/renderer/components/terminal/ConnectedTerminal.test.tsx` | Added 3 regression tests for window focus recovery (mount, debounced trigger, unmount cleanup) |

## Testing

- All **92 ConnectedTerminal tests pass** (89 existing + 3 new)
- All **15 use-terminal-resize-v2 tests pass**
- `bun run typecheck` — clean
- `bun run lint` — clean (0 errors, 2 pre-existing warnings in unrelated file)

## How to Verify

1. Run the app in dev mode
2. Open a terminal, run a command with visible output
3. Minimize the window via taskbar
4. Restore the window via taskbar
5. Terminal should immediately re-fit to the restored window size with no skewing or shrinking

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Terminal automatically recovers and resizes when the application window regains focus after being minimized or restored.

* **Tests**
  * Added comprehensive test coverage for window focus recovery behavior, including event listener registration, debouncing, and cleanup on unmount.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gnoviawan/termul/pull/173?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->