### PR TITLE
feat: add middle-click close for terminal and browser tabs

### DIFF
--- a/src/renderer/components/workspace/WorkspaceTabBar.test.tsx
+++ b/src/renderer/components/workspace/WorkspaceTabBar.test.tsx
@@ -10,6 +10,8 @@ const mockReorderTabsInPane = vi.fn()
 const mockCloseTab = vi.fn()
 const mockTogglePaneFullscreen = vi.fn()
 const mockCloseFileIfIdle = vi.fn(() => true)
+const mockRemoveBrowserTab = vi.fn()
+const mockClearAnnotationsForTab = vi.fn()
 
 const mockWorkspaceStoreState = {
   fullscreenPaneId: null as string | null,
@@ -57,6 +59,29 @@ vi.mock('@/stores/terminal-store', () => ({
       ]
     })
   )
+}))
+
+vi.mock('@/stores/browser-session-store', () => ({
+  useBrowserSessionStore: Object.assign(
+    vi.fn((selector: (state: { getTab: (id: string) => { title: string; url: string } | null }) => unknown) =>
+      selector({
+        getTab: () => ({ title: 'Docs', url: 'https://example.com' })
+      })
+    ),
+    {
+      getState: () => ({
+        removeTab: mockRemoveBrowserTab
+      })
+    }
+  )
+}))
+
+vi.mock('@/stores/annotation-store', () => ({
+  useAnnotationStore: {
+    getState: () => ({
+      clearAnnotationsForTab: mockClearAnnotationsForTab
+    })
+  }
 }))
 
 const mockStartTabDrag = vi.hoisted(() => vi.fn())
@@ -118,6 +143,8 @@ beforeEach(() => {
   mockCloseTab.mockReset()
   mockTogglePaneFullscreen.mockReset()
   mockCloseFileIfIdle.mockReset()
+  mockRemoveBrowserTab.mockReset()
+  mockClearAnnotationsForTab.mockReset()
   mockWorkspaceStoreState.fullscreenPaneId = null
   mockCloseFileIfIdle.mockReturnValue(true)
   mockEditorOpenFiles.clear()
@@ -350,6 +377,55 @@ describe('WorkspaceTabBar', () => {
 
     expect(mockCloseFileIfIdle).toHaveBeenCalledWith('/a.ts')
     expect(mockCloseTab).not.toHaveBeenCalled()
+  })
+
+  it('closes terminal tab on middle click without affecting regular click behavior', async () => {
+    const onCloseTerminal = vi.fn()
+    const tabs: WorkspaceTab[] = [{ type: 'terminal', id: 'tab-1', terminalId: 'term-1' }]
+
+    const { container } = render(
+      <WorkspaceTabBar
+        paneId="pane-a"
+        tabs={tabs}
+        activeTabId="tab-1"
+        onCloseTerminal={onCloseTerminal}
+      />
+    )
+
+    await flushShellEffect()
+
+    const tabEl = container.querySelector('[draggable="true"]') as HTMLElement
+    expect(tabEl).toBeTruthy()
+
+    fireEvent.click(tabEl)
+    expect(mockSetActiveTab).toHaveBeenCalledWith('pane-a', 'tab-1')
+    expect(onCloseTerminal).not.toHaveBeenCalled()
+
+    fireEvent(tabEl, new MouseEvent('auxclick', { bubbles: true, button: 1 }))
+    expect(onCloseTerminal).toHaveBeenCalledWith('term-1', 'tab-1')
+  })
+
+  it('closes browser tab on middle click', async () => {
+    const tabs: WorkspaceTab[] = [{ type: 'browser', id: 'browser-1', browserTabId: 'btab-1' }]
+
+    const { container } = render(
+      <WorkspaceTabBar
+        paneId="pane-a"
+        tabs={tabs}
+        activeTabId="browser-1"
+      />
+    )
+
+    await flushShellEffect()
+
+    const tabEl = container.querySelector('[draggable="true"]') as HTMLElement
+    expect(tabEl).toBeTruthy()
+
+    fireEvent(tabEl, new MouseEvent('auxclick', { bubbles: true, button: 1 }))
+
+    expect(mockRemoveBrowserTab).toHaveBeenCalledWith('btab-1')
+    expect(mockClearAnnotationsForTab).toHaveBeenCalledWith('btab-1')
+    expect(mockCloseTab).toHaveBeenCalledWith('pane-a', 'browser-1')
   })
 
   it('calls startTabDrag when dragging a terminal tab', async () => {

--- a/src/renderer/components/workspace/WorkspaceTabBar.tsx
+++ b/src/renderer/components/workspace/WorkspaceTabBar.tsx
@@ -113,6 +113,14 @@ function TerminalTabInline({
 				onDragLeave={onDragLeave}
 				onDrop={onDrop}
 				onClick={onSelect}
+				onAuxClick={(e) => {
+					if (e.button !== 1) return;
+					e.preventDefault();
+					e.stopPropagation();
+					if (!isClosing) {
+						onClose();
+					}
+				}}
 				onContextMenu={(e) => {
 					e.preventDefault();
 					e.stopPropagation();
@@ -354,6 +362,12 @@ function BrowserTabInline({
 				onDragLeave={onDragLeave}
 				onDrop={onDrop}
 				onClick={onSelect}
+				onAuxClick={(e) => {
+					if (e.button !== 1) return;
+					e.preventDefault();
+					e.stopPropagation();
+					onClose();
+				}}
 				onContextMenu={(e) => {
 					e.preventDefault();
 					e.stopPropagation();


### PR DESCRIPTION
## Summary
- add middle-click close support (`auxclick`, button `1`) for terminal tabs in `WorkspaceTabBar`
- add middle-click close support (`auxclick`, button `1`) for browser tabs in `WorkspaceTabBar`
- preserve existing interactions: left-click select, right-click context menu, drag-reorder, and existing close flows
- add regression tests for terminal/browser middle-click close behavior

## Related Issue
- N/A

## Screenshots
- N/A (interaction-only behavior change)

## Testing Steps
- `bun run lint` (passes with existing repository warnings)
- `bun run typecheck`
- `bun run test`
- `bun run dev`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Workspace tabs can now be closed by middle-clicking on them in the tab bar

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gnoviawan/termul/pull/176?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->