### PR TITLE
fix(terminal): support clipboard image paste passthrough to CLI apps

### DIFF
--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -54,6 +54,7 @@
     "clipboard-manager:default",
     "clipboard-manager:allow-read-text",
     "clipboard-manager:allow-write-text",
+    "clipboard-manager:allow-read-image",
     "updater:allow-check",
     "updater:allow-download-and-install",
     "process:allow-restart",

--- a/src/renderer/components/terminal/ConnectedTerminal.test.tsx
+++ b/src/renderer/components/terminal/ConnectedTerminal.test.tsx
@@ -257,7 +257,8 @@ vi.mock('@/lib/api', () => ({
   },
   clipboardApi: {
     readText: vi.fn(),
-    writeText: vi.fn()
+    writeText: vi.fn(),
+    hasImage: vi.fn(() => Promise.resolve({ success: true, data: false }))
   }
 }))
 

--- a/src/renderer/components/terminal/ConnectedTerminal.tsx
+++ b/src/renderer/components/terminal/ConnectedTerminal.tsx
@@ -343,6 +343,12 @@ function ConnectedTerminalComponent({
 	const { copySelection, pasteFromClipboard, hasSelection } =
 		useTerminalClipboard({
 			terminal: terminalInstance,
+			onImagePaste: async () => {
+				const ptyId = ptyIdRef.current;
+				if (!ptyId) return;
+				// Send Ctrl+V byte to PTY - CLI apps like OpenCode read the OS clipboard directly
+				await terminalApi.write(ptyId, '\x16');
+			},
 		});
 
 	// Sync ptyIdRef with external terminal ID when provided

--- a/src/renderer/hooks/use-terminal-clipboard.test.ts
+++ b/src/renderer/hooks/use-terminal-clipboard.test.ts
@@ -5,7 +5,8 @@ import type { Terminal } from '@xterm/xterm'
 const { mockClipboardApi } = vi.hoisted(() => ({
   mockClipboardApi: {
     readText: vi.fn(),
-    writeText: vi.fn()
+    writeText: vi.fn(),
+    hasImage: vi.fn()
   }
 }))
 
@@ -34,6 +35,8 @@ describe('useTerminalClipboard', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     capturedSelectionCallback = null
+    // Default hasImage to false so existing text-paste tests work unchanged
+    mockClipboardApi.hasImage.mockResolvedValue({ success: true, data: false })
   })
 
   afterEach(() => {
@@ -391,6 +394,86 @@ Line 3`
         await result.current.copySelection()
       })
       expect(mockClipboardApi.writeText).toHaveBeenCalledWith('text2')
+    })
+  })
+
+  describe('pasteFromClipboard image branch', () => {
+    it('should call onImagePaste when clipboard has image', async () => {
+      const mockTerminal = createMockTerminal(false, '')
+      mockClipboardApi.hasImage.mockResolvedValue({ success: true, data: true })
+      const onImagePaste = vi.fn()
+
+      const { result } = renderHook(() => useTerminalClipboard({
+        terminal: mockTerminal as unknown as Terminal,
+        onImagePaste
+      }))
+
+      await act(async () => {
+        await result.current.pasteFromClipboard()
+      })
+
+      expect(mockClipboardApi.hasImage).toHaveBeenCalled()
+      expect(onImagePaste).toHaveBeenCalled()
+      expect(mockClipboardApi.readText).not.toHaveBeenCalled()
+      expect(mockTerminal.paste).not.toHaveBeenCalled()
+    })
+
+    it('should use text paste when clipboard has no image', async () => {
+      const mockTerminal = createMockTerminal(false, '')
+      mockClipboardApi.hasImage.mockResolvedValue({ success: true, data: false })
+      mockClipboardApi.readText.mockResolvedValue({ success: true, data: 'pasted text' })
+      const onImagePaste = vi.fn()
+
+      const { result } = renderHook(() => useTerminalClipboard({
+        terminal: mockTerminal as unknown as Terminal,
+        onImagePaste
+      }))
+
+      await act(async () => {
+        await result.current.pasteFromClipboard()
+      })
+
+      expect(mockClipboardApi.hasImage).toHaveBeenCalled()
+      expect(onImagePaste).not.toHaveBeenCalled()
+      expect(mockClipboardApi.readText).toHaveBeenCalled()
+      expect(mockTerminal.paste).toHaveBeenCalledWith('pasted text')
+    })
+
+    it('should fall back to text paste when hasImage throws', async () => {
+      const mockTerminal = createMockTerminal(false, '')
+      mockClipboardApi.hasImage.mockResolvedValue({ success: false, error: 'Unsupported' })
+      mockClipboardApi.readText.mockResolvedValue({ success: true, data: 'fallback text' })
+      const onImagePaste = vi.fn()
+
+      const { result } = renderHook(() => useTerminalClipboard({
+        terminal: mockTerminal as unknown as Terminal,
+        onImagePaste
+      }))
+
+      await act(async () => {
+        await result.current.pasteFromClipboard()
+      })
+
+      expect(onImagePaste).not.toHaveBeenCalled()
+      expect(mockClipboardApi.readText).toHaveBeenCalled()
+      expect(mockTerminal.paste).toHaveBeenCalledWith('fallback text')
+    })
+
+    it('should not call onImagePaste when not provided even if image present', async () => {
+      const mockTerminal = createMockTerminal(false, '')
+      mockClipboardApi.hasImage.mockResolvedValue({ success: true, data: true })
+      mockClipboardApi.readText.mockResolvedValue({ success: true, data: '' })
+
+      const { result } = renderHook(() => useTerminalClipboard({
+        terminal: mockTerminal as unknown as Terminal
+      }))
+
+      await act(async () => {
+        await result.current.pasteFromClipboard()
+      })
+
+      expect(mockClipboardApi.hasImage).toHaveBeenCalled()
+      expect(mockTerminal.paste).not.toHaveBeenCalled()
     })
   })
 })

--- a/src/renderer/hooks/use-terminal-clipboard.ts
+++ b/src/renderer/hooks/use-terminal-clipboard.ts
@@ -4,6 +4,7 @@ import { clipboardApi } from '@/lib/api'
 
 export interface UseTerminalClipboardOptions {
   terminal: Terminal | null
+  onImagePaste?: () => Promise<void> | void
 }
 
 export interface UseTerminalClipboardReturn {
@@ -18,7 +19,7 @@ const MAX_CLIPBOARD_SIZE = 10 * 1024 * 1024
 export function useTerminalClipboard(
   options: UseTerminalClipboardOptions
 ): UseTerminalClipboardReturn {
-  const { terminal } = options
+  const { terminal, onImagePaste } = options
   const [hasSelection, setHasSelection] = useState<boolean>(false)
   // Use a ref to track the current terminal instance for async operations
   const terminalRef = useRef<Terminal | null>(terminal)
@@ -89,6 +90,13 @@ export function useTerminalClipboard(
     isPastingRef.current = true
     
     try {
+      // Check for image first - if present, delegate to onImagePaste callback
+      const imageResult = await clipboardApi.hasImage()
+      if (imageResult.success && imageResult.data && onImagePaste) {
+        await onImagePaste()
+        return
+      }
+      
       const result = await clipboardApi.readText()
       if (result.success && result.data) {
         // Validate clipboard content size
@@ -106,7 +114,7 @@ export function useTerminalClipboard(
         isPastingRef.current = false
       }, 100)
     }
-  }, [])
+  }, [onImagePaste])
 
   return {
     copySelection,

--- a/src/renderer/lib/tauri-clipboard-api.ts
+++ b/src/renderer/lib/tauri-clipboard-api.ts
@@ -32,15 +32,13 @@ export const tauriClipboardApi = {
 
   async hasImage(): Promise<IpcResult<boolean>> {
     try {
-      const image = await readImage();
-      // readImage() returns an Image object when image data is present,
-      // and returns null when no image is on the clipboard.
-      return { success: true, data: image != null };
+      // readImage() resolves with an Image when image data is on the clipboard,
+      // and throws when no image is present or on unsupported platforms.
+      await readImage();
+      return { success: true, data: true };
     } catch (err) {
-      // readImage() throws on unsupported platforms or when clipboard has no image.
-      // Log unexpected errors but never block paste.
       if (import.meta.env.DEV) {
-        console.warn('hasImage check failed:', err);
+        console.warn('hasImage: readImage() rejected:', err);
       }
       return { success: true, data: false };
     }

--- a/src/renderer/lib/tauri-clipboard-api.ts
+++ b/src/renderer/lib/tauri-clipboard-api.ts
@@ -1,4 +1,4 @@
-import { readText, writeText } from '@tauri-apps/plugin-clipboard-manager';
+import { readText, writeText, readImage } from '@tauri-apps/plugin-clipboard-manager';
 import type { IpcResult } from '@shared/types/ipc.types';
 
 const MAX_CLIPBOARD_SIZE = 10 * 1024 * 1024; // 10MB
@@ -27,6 +27,22 @@ export const tauriClipboardApi = {
       return { success: true, data: undefined };
     } catch (err) {
       return { success: false, error: String(err), code: 'WRITE_ERROR' };
+    }
+  },
+
+  async hasImage(): Promise<IpcResult<boolean>> {
+    try {
+      const image = await readImage();
+      // readImage() returns an Image object when image data is present,
+      // and returns null when no image is on the clipboard.
+      return { success: true, data: image != null };
+    } catch (err) {
+      // readImage() throws on unsupported platforms or when clipboard has no image.
+      // Log unexpected errors but never block paste.
+      if (import.meta.env.DEV) {
+        console.warn('hasImage check failed:', err);
+      }
+      return { success: true, data: false };
     }
   },
 };

--- a/src/shared/types/ipc.types.ts
+++ b/src/shared/types/ipc.types.ts
@@ -261,6 +261,7 @@ export interface WindowApi {
 export interface ClipboardApi {
 	readText: () => Promise<IpcResult<string>>;
 	writeText: (text: string) => Promise<IpcResult<void>>;
+	hasImage: () => Promise<IpcResult<boolean>>;
 }
 
 // Visibility API for renderer to notify main process of visibility changes


### PR DESCRIPTION
## Summary

- Fixes clipboard image paste silently no-op-ing in terminal panes when clipboard contains image data (e.g., Win+Shift+S screenshot). Detects image on clipboard and sends raw Ctrl+V byte to PTY, allowing CLI apps like OpenCode to read the image directly from the OS clipboard.

## Related Issue

Closes #180

## Type of Change

- [ ] feat: new feature
- [x] fix: bug fix
- [ ] docs: documentation only
- [ ] style: formatting or non-functional styling changes
- [ ] refactor: internal cleanup with no behavior change
- [ ] perf: performance improvement
- [ ] test: adds or updates tests
- [ ] build: build or dependency changes
- [ ] ci: CI/CD workflow changes
- [ ] chore: maintenance or tooling
- [ ] revert: reverts a previous change

## What Changed

- **Tauri capability** (`src-tauri/capabilities/default.json`): Added `clipboard-manager:allow-read-image` permission to enable Tauri's image clipboard read at runtime.
- **IPC contract** (`src/shared/types/ipc.types.ts`): Extended `ClipboardApi` interface with `hasImage(): Promise<IpcResult<boolean>>` method for image detection.
- **Clipboard facade** (`src/renderer/lib/tauri-clipboard-api.ts`): Imported `readImage` from `@tauri-apps/plugin-clipboard-manager`; implemented `hasImage()` using null-check on the returned Image object (avoids wasteful RGBA transfer). Added DEV-only logging for unexpected failures.
- **Paste hook** (`src/renderer/hooks/use-terminal-clipboard.ts`): Added optional `onImagePaste` callback to `UseTerminalClipboardOptions`. In `pasteFromClipboard`, checks `clipboardApi.hasImage()` first — if image detected and callback provided, delegates to it; otherwise falls through to existing text paste path. Gracefully falls back on error.
- **Terminal wiring** (`src/renderer/components/terminal/ConnectedTerminal.tsx`): Passed `onImagePaste` callback that writes `\x16` (Ctrl+V byte) to the PTY via `terminalApi.write()`, triggering the CLI app's native clipboard-read pipeline.
- **Tests**: Added 4 new unit tests covering image-branch logic (image present → callback fires; no image → text paste; hasImage error → fallback; no callback → skip). Updated existing test mocks for `hasImage()` compatibility.

## How It Was Tested

- [ ] `bun run lint`
- [x] `bun run typecheck`
- [x] `bun run test`
- [x] Manual verification completed
- [ ] Not applicable

## Screenshots or Recordings

<img width="553" height="561" alt="image" src="https://github.com/user-attachments/assets/8c65b6bd-8f31-47cc-bfab-01d8e8d358f8" />


## Checklist

- [x] My PR title follows the conventional commit format used by this repo
- [x] I linked the related issue or explained why none exists
- [x] I updated docs when needed (no doc changes required)
- [x] I added or updated tests when needed
- [x] I verified the change does not introduce unrelated modifications

## Implementation Notes

**Why send `\x16` to PTY instead of image data:** OpenCode (and similar TUI apps) read the OS clipboard directly using platform-native tools — PowerShell on Windows (`[System.Windows.Forms.Clipboard]::GetImage()`), `osascript` on macOS, `wl-paste`/`xclip` on Linux. They don't expect image bytes piped through the terminal. The `input_paste` keybind (Ctrl+V, byte `\x16`) triggers their clipboard-read pipeline. By forwarding just the keypress, Termul acts like a normal terminal that doesn't intercept clipboard — same as Alacritty, which works correctly.

**Known limitation:** macOS Cmd+V has no single-byte control character equivalent. This fix targets Windows (Issue #180 is Windows 11). macOS support will be tracked separately.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clipboard image detection and handling to the terminal, enabling the system to recognize when images are in the clipboard
  * Terminal now properly routes image paste events to the active shell application

* **Tests**
  * Expanded test coverage for clipboard image detection behavior

* **Chores**
  * Updated system configuration with required clipboard image read permissions

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gnoviawan/termul/pull/182?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->