### PR TITLE
fix(terminal): prevent grid collapse to 1-2 rows on minimize/restore

### DIFF
--- a/src/renderer/components/terminal/ConnectedTerminal.test.tsx
+++ b/src/renderer/components/terminal/ConnectedTerminal.test.tsx
@@ -57,6 +57,8 @@ const mockTerminalInstance = {
   write: vi.fn(),
   clear: vi.fn(),
   focus: vi.fn(),
+  refresh: vi.fn(),
+  scrollToLine: vi.fn(),
   dispose: vi.fn(),
   cols: 80,
   rows: 24,
@@ -118,6 +120,8 @@ vi.mock('@xterm/xterm', () => ({
     write = mockTerminalInstance.write
     clear = mockTerminalInstance.clear
     focus = mockTerminalInstance.focus
+    refresh = mockTerminalInstance.refresh
+    scrollToLine = mockTerminalInstance.scrollToLine
     dispose = mockTerminalInstance.dispose
     cols = mockTerminalInstance.cols
     rows = mockTerminalInstance.rows
@@ -2125,6 +2129,8 @@ describe('ConnectedTerminal', () => {
         expect.any(Number),
         expect.any(Number)
       )
+      // Should repaint buffer after recovery to prevent blank screen
+      expect(mockTerminalInstance.refresh).toHaveBeenCalledWith(0, 23)
 
       vi.useRealTimers()
     })

--- a/src/renderer/components/terminal/ConnectedTerminal.test.tsx
+++ b/src/renderer/components/terminal/ConnectedTerminal.test.tsx
@@ -2109,22 +2109,9 @@ describe('ConnectedTerminal', () => {
     it('should re-fit and re-composite on window focus once layout is stable', async () => {
       vi.useFakeTimers()
 
-      // jsdom reports 0x0 rects by default; recovery waits for a usable size
-      // before fitting (guards against collapsing the grid to 1-2 rows). Stub a
-      // usable container size so recovery proceeds on the first frame.
-      const rectSpy = vi
-        .spyOn(HTMLElement.prototype, 'getBoundingClientRect')
-        .mockReturnValue({
-          width: 800,
-          height: 600,
-          top: 0,
-          left: 0,
-          right: 800,
-          bottom: 600,
-          x: 0,
-          y: 0,
-          toJSON: () => ({})
-        } as DOMRect)
+      // Note: the global beforeEach already stubs HTMLDivElement.prototype
+      // getBoundingClientRect to 800x600, so the terminal container reports a
+      // usable size and recovery's layout-wait proceeds on the first frame.
 
       render(<ConnectedTerminal />)
 
@@ -2158,14 +2145,15 @@ describe('ConnectedTerminal', () => {
         expect.any(Number)
       )
       // Buffer repainted to redraw into the re-composited layer
-      expect(mockTerminalInstance.refresh).toHaveBeenCalledWith(0, 23)
+      expect(mockTerminalInstance.refresh).toHaveBeenCalledWith(
+        0,
+        mockTerminalInstance.rows - 1
+      )
       // WebGL addon is NOT disposed/recreated — the context is healthy, only the
       // compositor needs a nudge. Recreating would add a needless blank gap.
       expect(webglAddonCreateCount).toBe(webglCountBeforeFocus)
       // Visibility flip completed (restored to visible after the re-composite)
       expect(termEl.style.visibility).toBe('')
-
-      rectSpy.mockRestore()
 
       vi.useRealTimers()
     })
@@ -2184,6 +2172,39 @@ describe('ConnectedTerminal', () => {
       expect(removeEventListenerSpy).toHaveBeenCalledWith('focus', expect.any(Function))
 
       removeEventListenerSpy.mockRestore()
+    })
+
+    it('should coalesce overlapping recovery triggers (single-flight)', async () => {
+      vi.useFakeTimers()
+
+      render(<ConnectedTerminal />)
+
+      await vi.waitFor(() => {
+        expect(vi.mocked(terminalApi).spawn).toHaveBeenCalled()
+      })
+
+      await vi.advanceTimersByTimeAsync(50)
+      mockFitAddonInstance.fit.mockClear()
+
+      // On a real window restore, visibilitychange and focus fire close together.
+      // Dispatch focus twice before the first recovery completes its RAF cycle.
+      window.dispatchEvent(new Event('focus'))
+      window.dispatchEvent(new Event('focus'))
+
+      // Let the layout-wait + recovery + trailing visibility-flip RAF complete.
+      await vi.advanceTimersByTimeAsync(40)
+
+      // The single-flight guard coalesces the duplicate trigger: fit runs once,
+      // not twice, avoiding overlapping resize + visibility-flip cycles.
+      expect(mockFitAddonInstance.fit).toHaveBeenCalledTimes(1)
+
+      // After recovery fully completes, a subsequent focus can recover again.
+      mockFitAddonInstance.fit.mockClear()
+      window.dispatchEvent(new Event('focus'))
+      await vi.advanceTimersByTimeAsync(40)
+      expect(mockFitAddonInstance.fit).toHaveBeenCalledTimes(1)
+
+      vi.useRealTimers()
     })
   })
 

--- a/src/renderer/components/terminal/ConnectedTerminal.test.tsx
+++ b/src/renderer/components/terminal/ConnectedTerminal.test.tsx
@@ -2111,8 +2111,14 @@ describe('ConnectedTerminal', () => {
         expect(vi.mocked(terminalApi).spawn).toHaveBeenCalled()
       })
 
+      // Advance past the initial requestAnimationFrame so WebGL addon is loaded
+      await vi.advanceTimersByTimeAsync(50)
+      expect(webglAddonCreateCount).toBeGreaterThanOrEqual(1)
+
+      // Clear mocks before dispatching focus event
       mockFitAddonInstance.fit.mockClear()
       vi.mocked(terminalApi).resize.mockClear()
+      const webglInstanceBeforeFocus = lastCreatedWebglInstance
 
       // Dispatch window focus event
       window.dispatchEvent(new Event('focus'))
@@ -2129,8 +2135,11 @@ describe('ConnectedTerminal', () => {
         expect.any(Number),
         expect.any(Number)
       )
-      // Should repaint buffer after recovery to prevent blank screen
-      expect(mockTerminalInstance.refresh).toHaveBeenCalledWith(0, 23)
+      // WebGL addon should be disposed and recreated to prevent blank screen
+      // from silent GPU context corruption on Windows minimize
+      expect(webglInstanceBeforeFocus?.dispose).toHaveBeenCalled()
+      // A new WebGL addon instance should have been created
+      expect(webglAddonCreateCount).toBeGreaterThanOrEqual(2)
 
       vi.useRealTimers()
     })

--- a/src/renderer/components/terminal/ConnectedTerminal.test.tsx
+++ b/src/renderer/components/terminal/ConnectedTerminal.test.tsx
@@ -2102,7 +2102,7 @@ describe('ConnectedTerminal', () => {
       addEventListenerSpy.mockRestore()
     })
 
-    it('should trigger fit and resize on window focus with debounce', async () => {
+    it('should trigger fit and resize immediately on window focus (no debounce)', async () => {
       vi.useFakeTimers()
 
       render(<ConnectedTerminal />)
@@ -2120,25 +2120,25 @@ describe('ConnectedTerminal', () => {
       vi.mocked(terminalApi).resize.mockClear()
       const webglInstanceBeforeFocus = lastCreatedWebglInstance
 
-      // Dispatch window focus event
+      // Dispatch window focus event — recovery fires IMMEDIATELY (no debounce).
+      // The window is already visible when focus fires, so waiting serves no purpose.
       window.dispatchEvent(new Event('focus'))
 
-      // Should not fire immediately (debounced)
-      await vi.advanceTimersByTimeAsync(100)
-      expect(mockFitAddonInstance.fit).not.toHaveBeenCalled()
-
-      // Should fire after 150ms debounce
-      await vi.advanceTimersByTimeAsync(100)
+      // Fit and resize should fire synchronously (immediate recovery)
       expect(mockFitAddonInstance.fit).toHaveBeenCalledTimes(1)
       expect(vi.mocked(terminalApi).resize).toHaveBeenCalledWith(
         'terminal-123',
         expect.any(Number),
         expect.any(Number)
       )
-      // WebGL addon should be disposed and recreated to prevent blank screen
-      // from silent GPU context corruption on Windows minimize
+      // WebGL addon should be disposed to break the corrupted GPU surface
       expect(webglInstanceBeforeFocus?.dispose).toHaveBeenCalled()
-      // A new WebGL addon instance should have been created
+      // Buffer should be repainted through DOM renderer immediately
+      expect(mockTerminalInstance.refresh).toHaveBeenCalledWith(0, 23)
+
+      // WebGL recreation is deferred to next animation frame — advance past it
+      await vi.advanceTimersByTimeAsync(20)
+      // A new WebGL addon instance should have been created on the next RAF
       expect(webglAddonCreateCount).toBeGreaterThanOrEqual(2)
 
       vi.useRealTimers()

--- a/src/renderer/components/terminal/ConnectedTerminal.test.tsx
+++ b/src/renderer/components/terminal/ConnectedTerminal.test.tsx
@@ -70,7 +70,9 @@ const mockTerminalInstance = {
           index === 0 ? 'missing.ts src/renderer/App.tsx' : ''
       }))
     }
-  }
+  },
+  // Real DOM element so recovery's CSS visibility re-composite can be tested.
+  element: (typeof document !== 'undefined' ? document.createElement('div') : undefined) as HTMLDivElement | undefined
 }
 
 let capturedResizeCallback: ((dims: { cols: number; rows: number }) => void) | null = null
@@ -127,6 +129,8 @@ vi.mock('@xterm/xterm', () => ({
     rows = mockTerminalInstance.rows
     options = mockTerminalInstance.options
     buffer = mockTerminalInstance.buffer
+    // Real DOM element so recovery's CSS visibility re-composite can be tested.
+    element = mockTerminalInstance.element
   }
 }))
 
@@ -2102,7 +2106,7 @@ describe('ConnectedTerminal', () => {
       addEventListenerSpy.mockRestore()
     })
 
-    it('should trigger fit and resize immediately on window focus (no debounce)', async () => {
+    it('should re-composite the canvas layer immediately on window focus (no debounce)', async () => {
       vi.useFakeTimers()
 
       render(<ConnectedTerminal />)
@@ -2117,8 +2121,10 @@ describe('ConnectedTerminal', () => {
 
       // Clear mocks before dispatching focus event
       mockFitAddonInstance.fit.mockClear()
+      mockTerminalInstance.refresh.mockClear()
       vi.mocked(terminalApi).resize.mockClear()
-      const webglInstanceBeforeFocus = lastCreatedWebglInstance
+      const webglCountBeforeFocus = webglAddonCreateCount
+      const termEl = mockTerminalInstance.element as HTMLDivElement
 
       // Dispatch window focus event — recovery fires IMMEDIATELY (no debounce).
       // The window is already visible when focus fires, so waiting serves no purpose.
@@ -2131,15 +2137,19 @@ describe('ConnectedTerminal', () => {
         expect.any(Number),
         expect.any(Number)
       )
-      // WebGL addon should be disposed to break the corrupted GPU surface
-      expect(webglInstanceBeforeFocus?.dispose).toHaveBeenCalled()
-      // Buffer should be repainted through DOM renderer immediately
+      // Buffer should be repainted to redraw into the re-composited layer
       expect(mockTerminalInstance.refresh).toHaveBeenCalledWith(0, 23)
+      // The canvas layer must be hidden synchronously to force a GPU re-composite
+      expect(termEl.style.visibility).toBe('hidden')
+      // WebGL addon is NOT disposed/recreated — the context is healthy, only the
+      // compositor needs a nudge. Recreating would add a needless blank gap.
+      expect(webglAddonCreateCount).toBe(webglCountBeforeFocus)
 
-      // WebGL recreation is deferred to next animation frame — advance past it
+      // After the next animation frame, visibility is restored (re-composite done)
       await vi.advanceTimersByTimeAsync(20)
-      // A new WebGL addon instance should have been created on the next RAF
-      expect(webglAddonCreateCount).toBeGreaterThanOrEqual(2)
+      expect(termEl.style.visibility).toBe('')
+      // Still no new WebGL addon created
+      expect(webglAddonCreateCount).toBe(webglCountBeforeFocus)
 
       vi.useRealTimers()
     })

--- a/src/renderer/components/terminal/ConnectedTerminal.test.tsx
+++ b/src/renderer/components/terminal/ConnectedTerminal.test.tsx
@@ -2106,8 +2106,25 @@ describe('ConnectedTerminal', () => {
       addEventListenerSpy.mockRestore()
     })
 
-    it('should re-composite the canvas layer immediately on window focus (no debounce)', async () => {
+    it('should re-fit and re-composite on window focus once layout is stable', async () => {
       vi.useFakeTimers()
+
+      // jsdom reports 0x0 rects by default; recovery waits for a usable size
+      // before fitting (guards against collapsing the grid to 1-2 rows). Stub a
+      // usable container size so recovery proceeds on the first frame.
+      const rectSpy = vi
+        .spyOn(HTMLElement.prototype, 'getBoundingClientRect')
+        .mockReturnValue({
+          width: 800,
+          height: 600,
+          top: 0,
+          left: 0,
+          right: 800,
+          bottom: 600,
+          x: 0,
+          y: 0,
+          toJSON: () => ({})
+        } as DOMRect)
 
       render(<ConnectedTerminal />)
 
@@ -2126,30 +2143,29 @@ describe('ConnectedTerminal', () => {
       const webglCountBeforeFocus = webglAddonCreateCount
       const termEl = mockTerminalInstance.element as HTMLDivElement
 
-      // Dispatch window focus event — recovery fires IMMEDIATELY (no debounce).
-      // The window is already visible when focus fires, so waiting serves no purpose.
+      // Dispatch window focus event — recovery fires immediately (no debounce),
+      // but waits for a stable layout via requestAnimationFrame before fitting.
       window.dispatchEvent(new Event('focus'))
 
-      // Fit and resize should fire synchronously (immediate recovery)
-      expect(mockFitAddonInstance.fit).toHaveBeenCalledTimes(1)
+      // Advance frames so the layout-wait + recovery + re-composite all run
+      await vi.advanceTimersByTimeAsync(40)
+
+      // Fit + PTY resize happened against the (now usable) container size
+      expect(mockFitAddonInstance.fit).toHaveBeenCalled()
       expect(vi.mocked(terminalApi).resize).toHaveBeenCalledWith(
         'terminal-123',
         expect.any(Number),
         expect.any(Number)
       )
-      // Buffer should be repainted to redraw into the re-composited layer
+      // Buffer repainted to redraw into the re-composited layer
       expect(mockTerminalInstance.refresh).toHaveBeenCalledWith(0, 23)
-      // The canvas layer must be hidden synchronously to force a GPU re-composite
-      expect(termEl.style.visibility).toBe('hidden')
       // WebGL addon is NOT disposed/recreated — the context is healthy, only the
       // compositor needs a nudge. Recreating would add a needless blank gap.
       expect(webglAddonCreateCount).toBe(webglCountBeforeFocus)
-
-      // After the next animation frame, visibility is restored (re-composite done)
-      await vi.advanceTimersByTimeAsync(20)
+      // Visibility flip completed (restored to visible after the re-composite)
       expect(termEl.style.visibility).toBe('')
-      // Still no new WebGL addon created
-      expect(webglAddonCreateCount).toBe(webglCountBeforeFocus)
+
+      rectSpy.mockRestore()
 
       vi.useRealTimers()
     })

--- a/src/renderer/components/terminal/ConnectedTerminal.tsx
+++ b/src/renderer/components/terminal/ConnectedTerminal.tsx
@@ -1451,6 +1451,13 @@ function ConnectedTerminalComponent({
 		// force=true (bypassing the dimension-sameness check), and immediately
 		// calls onPtyResize — keeping the v2 hook's dimension trackers in sync.
 		forceResizeFit();
+
+		// Force full repaint so buffer content is visible after context restoration.
+		// After minimize→restore the WebGL surface can be cleared while xterm's
+		// internal buffer retains all content. Without refresh(), the terminal
+		// renders blank until the user switches tabs (which triggers refresh
+		// via the cached-terminal reattach path at line ~646).
+		terminalRef.current.refresh(0, terminalRef.current.rows - 1);
 	}, [forceResizeFit]);
 
 	// Recovery handler for visibility change (app regains focus after idle)

--- a/src/renderer/components/terminal/ConnectedTerminal.tsx
+++ b/src/renderer/components/terminal/ConnectedTerminal.tsx
@@ -1417,54 +1417,58 @@ function ConnectedTerminalComponent({
 		}
 	}, [isVisible, forceResizeFit]);
 
-	// Shared terminal recovery logic - re-fit and check WebGL health
+	// Shared terminal recovery logic - re-fit and force a GPU layer re-composite.
 	const performTerminalRecovery = useCallback((): void => {
 		if (!fitAddonRef.current || !terminalRef.current) return;
 
-		// Cancel any pending auto-recovery timeout to avoid double-creation race
+		// Cancel any pending WebGL auto-recovery timeout to avoid double-creation
+		// race with the genuine onContextLoss path.
 		if (webglRecoveryTimeoutRef.current) {
 			clearTimeout(webglRecoveryTimeoutRef.current);
 			webglRecoveryTimeoutRef.current = null;
 		}
 
-		// On Windows, minimizing a Tauri window can silently corrupt the WebGL
-		// rendering surface without firing onContextLoss. The addon's GPU context
-		// becomes broken but xterm still routes all rendering through it, leaving
-		// the terminal blank. Tab-switching fixes this because the cached-reattach
-		// path recreates a fresh addon.
+		// Root cause (verified via live forensics + upstream xterm.js #5357 /
+		// VS Code #251800 / Electron #6320 / Tauri #9246):
 		//
-		// Recovery strategy (eliminates visible blank flash):
-		//   1. Dispose the broken WebGL addon. Xterm reverts to its built-in DOM
-		//      renderer (the .xterm-rows divs are always maintained internally).
-		//   2. Synchronously re-fit + refresh via DOM renderer — user sees
-		//      terminal content immediately with zero blank gap.
-		//   3. Recreate the WebGL addon on the next animation frame. Once painted,
-		//      it seamlessly takes over from the DOM renderer (~16ms later).
-		if (shouldUseWebglRenderer(rendererPreferenceRef.current)) {
-			disposeWebglAddon();
-			webglContextLostRef.current = false;
-		}
+		// After minimize→restore on Windows, the WebGL *context is healthy*
+		// (gl.isContextLost() === false) but the browser/WebView2 compositor does
+		// NOT re-present the WebGL canvas layer. WebView2 child windows don't get
+		// paint messages on minimize/restore, and with preserveDrawingBuffer:false
+		// the layer shows stale/blank content until a re-composite is forced.
+		//
+		// xterm.js renders only to canvas layers in 6.x (there is NO .xterm-rows
+		// DOM fallback), so disposing/recreating the WebGL addon does NOT help and
+		// just adds a blank gap. fitAddon.fit()/terminal.refresh() update canvas
+		// CONTENT at the GL level but do not force the layer to re-composite.
+		//
+		// The fix is the same mechanism that makes tab-switching work: toggle the
+		// terminal element's CSS visibility, which forces the compositor to
+		// re-present the layer. Combined with a forced fit + refresh so xterm
+		// redraws the buffer into the freshly composited layer.
+		const termEl = terminalRef.current.element as HTMLElement | undefined;
 
-		// Re-fit and sync PTY dimensions via the v2 hook's forced path.
+		// Re-fit and sync PTY dimensions (handles any container size change while
+		// hidden) and force xterm to redraw the visible buffer.
 		forceResizeFit();
+		terminalRef.current.refresh(0, terminalRef.current.rows - 1);
 
-		// Force an immediate repaint through the currently-active renderer.
-		// After disposing WebGL above, this is the DOM renderer which paints
-		// synchronously — the user sees content with no blank gap.
-		if (terminalRef.current) {
-			terminalRef.current.refresh(0, terminalRef.current.rows - 1);
-		}
-
-		// Defer WebGL recreation to the next animation frame. The DOM rows are
-		// visible during the ~16ms gap, then WebGL seamlessly takes over.
-		if (shouldUseWebglRenderer(rendererPreferenceRef.current)) {
+		// Force the GPU compositor to re-present the canvas layer. Flipping
+		// visibility off then back on across an animation frame triggers a
+		// re-composite without the layout cost of a real resize. This is the
+		// programmatic equivalent of the tab-switch visibility toggle.
+		if (termEl) {
+			termEl.style.visibility = "hidden";
 			requestAnimationFrame(() => {
-				if (loadWebglAddonRef.current && terminalRef.current) {
-					loadWebglAddonRef.current(terminalRef.current, true);
+				termEl.style.visibility = "";
+				// Redraw once more after the layer is re-presented so the buffer
+				// is guaranteed to paint into the now-composited surface.
+				if (terminalRef.current) {
+					terminalRef.current.refresh(0, terminalRef.current.rows - 1);
 				}
 			});
 		}
-	}, [forceResizeFit, disposeWebglAddon]);
+	}, [forceResizeFit]);
 
 	// Recovery handler for visibility change (app regains focus after idle)
 	useEffect(() => {

--- a/src/renderer/components/terminal/ConnectedTerminal.tsx
+++ b/src/renderer/components/terminal/ConnectedTerminal.tsx
@@ -202,6 +202,11 @@ function ConnectedTerminalComponent({
 	>(null);
 	// Track WebGL context loss for recovery decisions
 	const webglContextLostRef = useRef<boolean>(false);
+	// Single-flight guard for performTerminalRecovery. On a window restore both
+	// the visibilitychange and focus handlers (and sometimes power-resume) can
+	// fire close together; without this guard each would start its own
+	// layout-wait RAF loop and overlapping fit + visibility-flip cycles.
+	const recoveryInProgressRef = useRef<boolean>(false);
 	// Track visibility prop for recovery path guards (tab-active, not window-visible).
 	// Ref avoids stale closures in event listeners referencing isVisible directly.
 	const isVisibleRef = useRef(isVisible);
@@ -1422,6 +1427,12 @@ function ConnectedTerminalComponent({
 	const performTerminalRecovery = useCallback((): void => {
 		if (!fitAddonRef.current || !terminalRef.current) return;
 
+		// Single-flight: if a recovery is already running (layout-wait poll or the
+		// trailing visibility-flip RAF), skip duplicate triggers. On a window
+		// restore both visibilitychange and focus typically fire close together.
+		if (recoveryInProgressRef.current) return;
+		recoveryInProgressRef.current = true;
+
 		// Cancel any pending WebGL auto-recovery timeout to avoid double-creation
 		// race with the genuine onContextLoss path.
 		if (webglRecoveryTimeoutRef.current) {
@@ -1454,19 +1465,26 @@ function ConnectedTerminalComponent({
 
 		const runRecovery = (): void => {
 			const terminal = terminalRef.current;
-			if (!terminal) return;
+			if (!terminal) {
+				recoveryInProgressRef.current = false;
+				return;
+			}
 			// Re-fit (guarded against collapsed dims) + redraw the buffer.
 			forceResizeFit();
 			terminal.refresh(0, terminal.rows - 1);
 
-			// Nudge the compositor to re-present the canvas layer.
+			// Nudge the compositor to re-present the canvas layer. Clear the
+			// single-flight guard only after the trailing refresh completes.
 			if (termEl) {
 				termEl.style.visibility = "hidden";
 				requestAnimationFrame(() => {
 					termEl.style.visibility = "";
 					const t = terminalRef.current;
 					if (t) t.refresh(0, t.rows - 1);
+					recoveryInProgressRef.current = false;
 				});
+			} else {
+				recoveryInProgressRef.current = false;
 			}
 		};
 
@@ -1527,8 +1545,8 @@ function ConnectedTerminalComponent({
 			if (!isVisibleRef.current) return;
 			// Fire recovery immediately — the window is already visible when
 			// 'focus' fires (unlike visibilitychange which needs DOM reflow time).
-			// The recovery sequence (dispose WebGL -> DOM refresh -> RAF recreate
-			// WebGL) handles timing internally, so no external debounce is needed.
+			// performTerminalRecovery internally waits for a stable layout before
+			// fitting and is single-flight guarded, so this is safe to call eagerly.
 			performTerminalRecovery();
 		};
 

--- a/src/renderer/components/terminal/ConnectedTerminal.tsx
+++ b/src/renderer/components/terminal/ConnectedTerminal.tsx
@@ -1421,28 +1421,24 @@ function ConnectedTerminalComponent({
 	const performTerminalRecovery = useCallback((): void => {
 		if (!fitAddonRef.current || !terminalRef.current) return;
 
-		// Only recreate WebGL addon if context was actually lost, the current preference still
-		// allows WebGL, and we're not already recovering.
-		if (
-			shouldUseWebglRenderer(rendererPreferenceRef.current) &&
-			webglContextLostRef.current &&
-			!webglAddonRef.current
-		) {
-			try {
-				// Cancel any pending auto-recovery timeout to avoid double-creation race
-				if (webglRecoveryTimeoutRef.current) {
-					clearTimeout(webglRecoveryTimeoutRef.current);
-					webglRecoveryTimeoutRef.current = null;
-				}
-				console.warn(
-					"WebGL context was lost, recreating addon during recovery",
-				);
-				// Use shared loadWebglAddon for proper recovery (addon already disposed in onContextLoss)
-				if (loadWebglAddonRef.current && terminalRef.current) {
-					loadWebglAddonRef.current(terminalRef.current, true);
-				}
-			} catch (error) {
-				console.warn("WebGL context recovery failed:", error);
+		// Cancel any pending auto-recovery timeout to avoid double-creation race
+		if (webglRecoveryTimeoutRef.current) {
+			clearTimeout(webglRecoveryTimeoutRef.current);
+			webglRecoveryTimeoutRef.current = null;
+		}
+
+		// Force-recreate the WebGL addon on every recovery, regardless of whether
+		// onContextLoss fired. On Windows, minimizing a Tauri window can silently
+		// corrupt the WebGL rendering surface without triggering the contextloss
+		// event, leaving webglContextLostRef === false. The addon's GPU context is
+		// broken but xterm.js still tries to paint through it — resulting in a
+		// blank screen that only tab-switching fixes (cached reattach creates a
+		// fresh addon). By dispose+recreate here we guarantee a healthy renderer.
+		if (shouldUseWebglRenderer(rendererPreferenceRef.current)) {
+			disposeWebglAddon();
+			webglContextLostRef.current = false;
+			if (loadWebglAddonRef.current && terminalRef.current) {
+				loadWebglAddonRef.current(terminalRef.current, true);
 			}
 		}
 
@@ -1451,14 +1447,7 @@ function ConnectedTerminalComponent({
 		// force=true (bypassing the dimension-sameness check), and immediately
 		// calls onPtyResize — keeping the v2 hook's dimension trackers in sync.
 		forceResizeFit();
-
-		// Force full repaint so buffer content is visible after context restoration.
-		// After minimize→restore the WebGL surface can be cleared while xterm's
-		// internal buffer retains all content. Without refresh(), the terminal
-		// renders blank until the user switches tabs (which triggers refresh
-		// via the cached-terminal reattach path at line ~646).
-		terminalRef.current.refresh(0, terminalRef.current.rows - 1);
-	}, [forceResizeFit]);
+	}, [forceResizeFit, disposeWebglAddon]);
 
 	// Recovery handler for visibility change (app regains focus after idle)
 	useEffect(() => {

--- a/src/renderer/components/terminal/ConnectedTerminal.tsx
+++ b/src/renderer/components/terminal/ConnectedTerminal.tsx
@@ -1417,7 +1417,8 @@ function ConnectedTerminalComponent({
 		}
 	}, [isVisible, forceResizeFit]);
 
-	// Shared terminal recovery logic - re-fit and force a GPU layer re-composite.
+	// Shared terminal recovery logic - re-fit once layout is stable, then nudge
+	// the compositor to re-present the canvas layer.
 	const performTerminalRecovery = useCallback((): void => {
 		if (!fitAddonRef.current || !terminalRef.current) return;
 
@@ -1428,46 +1429,62 @@ function ConnectedTerminalComponent({
 			webglRecoveryTimeoutRef.current = null;
 		}
 
-		// Root cause (verified via live forensics + upstream xterm.js #5357 /
-		// VS Code #251800 / Electron #6320 / Tauri #9246):
+		// Root cause (verified via live forensics + xterm.js #4841 / #5357):
 		//
-		// After minimize→restore on Windows, the WebGL *context is healthy*
-		// (gl.isContextLost() === false) but the browser/WebView2 compositor does
-		// NOT re-present the WebGL canvas layer. WebView2 child windows don't get
-		// paint messages on minimize/restore, and with preserveDrawingBuffer:false
-		// the layer shows stale/blank content until a re-composite is forced.
+		// After minimize→restore on Windows the webview reflows over several
+		// frames. If fit() runs while the container height is still collapsed,
+		// the terminal grid shrinks to 1-2 rows (PTY redraws tiny → "1-2 lines"
+		// of text) until a later resize corrects it. The fit pipeline now guards
+		// against collapsed dimensions (use-terminal-resize-v2), so an early fit
+		// is a safe no-op rather than a destructive shrink.
 		//
-		// xterm.js renders only to canvas layers in 6.x (there is NO .xterm-rows
-		// DOM fallback), so disposing/recreating the WebGL addon does NOT help and
-		// just adds a blank gap. fitAddon.fit()/terminal.refresh() update canvas
-		// CONTENT at the GL level but do not force the layer to re-composite.
+		// Additionally, the WebView2 compositor may not re-present the WebGL
+		// canvas layer after restore (xterm 6.x has no DOM-row fallback; the
+		// context itself stays healthy). A CSS visibility flip forces a
+		// re-composite — the same mechanism that makes tab-switching work.
 		//
-		// The fix is the same mechanism that makes tab-switching work: toggle the
-		// terminal element's CSS visibility, which forces the compositor to
-		// re-present the layer. Combined with a forced fit + refresh so xterm
-		// redraws the buffer into the freshly composited layer.
+		// Strategy: wait for the container to report a usable size (poll across a
+		// few RAFs), then forceResizeFit + refresh, then flip visibility to
+		// guarantee the layer re-composites.
 		const termEl = terminalRef.current.element as HTMLElement | undefined;
+		const container = containerRef.current;
 
-		// Re-fit and sync PTY dimensions (handles any container size change while
-		// hidden) and force xterm to redraw the visible buffer.
-		forceResizeFit();
-		terminalRef.current.refresh(0, terminalRef.current.rows - 1);
+		const MIN_USABLE = 40;
+		const MAX_LAYOUT_WAIT_FRAMES = 30; // ~0.5s at 60fps
 
-		// Force the GPU compositor to re-present the canvas layer. Flipping
-		// visibility off then back on across an animation frame triggers a
-		// re-composite without the layout cost of a real resize. This is the
-		// programmatic equivalent of the tab-switch visibility toggle.
-		if (termEl) {
-			termEl.style.visibility = "hidden";
-			requestAnimationFrame(() => {
-				termEl.style.visibility = "";
-				// Redraw once more after the layer is re-presented so the buffer
-				// is guaranteed to paint into the now-composited surface.
-				if (terminalRef.current) {
-					terminalRef.current.refresh(0, terminalRef.current.rows - 1);
-				}
-			});
-		}
+		const runRecovery = (): void => {
+			const terminal = terminalRef.current;
+			if (!terminal) return;
+			// Re-fit (guarded against collapsed dims) + redraw the buffer.
+			forceResizeFit();
+			terminal.refresh(0, terminal.rows - 1);
+
+			// Nudge the compositor to re-present the canvas layer.
+			if (termEl) {
+				termEl.style.visibility = "hidden";
+				requestAnimationFrame(() => {
+					termEl.style.visibility = "";
+					const t = terminalRef.current;
+					if (t) t.refresh(0, t.rows - 1);
+				});
+			}
+		};
+
+		// Wait until the container has reflowed to a usable size before fitting,
+		// so we never collapse the grid. Bail out after MAX_LAYOUT_WAIT_FRAMES.
+		let frames = 0;
+		const waitForStableLayout = (): void => {
+			const rect = container?.getBoundingClientRect();
+			const ready =
+				!!rect && rect.width >= MIN_USABLE && rect.height >= MIN_USABLE;
+			if (ready || frames >= MAX_LAYOUT_WAIT_FRAMES) {
+				runRecovery();
+				return;
+			}
+			frames += 1;
+			requestAnimationFrame(waitForStableLayout);
+		};
+		waitForStableLayout();
 	}, [forceResizeFit]);
 
 	// Recovery handler for visibility change (app regains focus after idle)

--- a/src/renderer/components/terminal/ConnectedTerminal.tsx
+++ b/src/renderer/components/terminal/ConnectedTerminal.tsx
@@ -1427,26 +1427,43 @@ function ConnectedTerminalComponent({
 			webglRecoveryTimeoutRef.current = null;
 		}
 
-		// Force-recreate the WebGL addon on every recovery, regardless of whether
-		// onContextLoss fired. On Windows, minimizing a Tauri window can silently
-		// corrupt the WebGL rendering surface without triggering the contextloss
-		// event, leaving webglContextLostRef === false. The addon's GPU context is
-		// broken but xterm.js still tries to paint through it — resulting in a
-		// blank screen that only tab-switching fixes (cached reattach creates a
-		// fresh addon). By dispose+recreate here we guarantee a healthy renderer.
+		// On Windows, minimizing a Tauri window can silently corrupt the WebGL
+		// rendering surface without firing onContextLoss. The addon's GPU context
+		// becomes broken but xterm still routes all rendering through it, leaving
+		// the terminal blank. Tab-switching fixes this because the cached-reattach
+		// path recreates a fresh addon.
+		//
+		// Recovery strategy (eliminates visible blank flash):
+		//   1. Dispose the broken WebGL addon. Xterm reverts to its built-in DOM
+		//      renderer (the .xterm-rows divs are always maintained internally).
+		//   2. Synchronously re-fit + refresh via DOM renderer — user sees
+		//      terminal content immediately with zero blank gap.
+		//   3. Recreate the WebGL addon on the next animation frame. Once painted,
+		//      it seamlessly takes over from the DOM renderer (~16ms later).
 		if (shouldUseWebglRenderer(rendererPreferenceRef.current)) {
 			disposeWebglAddon();
 			webglContextLostRef.current = false;
-			if (loadWebglAddonRef.current && terminalRef.current) {
-				loadWebglAddonRef.current(terminalRef.current, true);
-			}
 		}
 
 		// Re-fit and sync PTY dimensions via the v2 hook's forced path.
-		// forceResizeFit clears any pending v2 debounce timers, fits with
-		// force=true (bypassing the dimension-sameness check), and immediately
-		// calls onPtyResize — keeping the v2 hook's dimension trackers in sync.
 		forceResizeFit();
+
+		// Force an immediate repaint through the currently-active renderer.
+		// After disposing WebGL above, this is the DOM renderer which paints
+		// synchronously — the user sees content with no blank gap.
+		if (terminalRef.current) {
+			terminalRef.current.refresh(0, terminalRef.current.rows - 1);
+		}
+
+		// Defer WebGL recreation to the next animation frame. The DOM rows are
+		// visible during the ~16ms gap, then WebGL seamlessly takes over.
+		if (shouldUseWebglRenderer(rendererPreferenceRef.current)) {
+			requestAnimationFrame(() => {
+				if (loadWebglAddonRef.current && terminalRef.current) {
+					loadWebglAddonRef.current(terminalRef.current, true);
+				}
+			});
+		}
 	}, [forceResizeFit, disposeWebglAddon]);
 
 	// Recovery handler for visibility change (app regains focus after idle)
@@ -1482,29 +1499,20 @@ function ConnectedTerminalComponent({
 	// taskbar minimize. performTerminalRecovery re-fits the terminal to its
 	// container and syncs PTY dimensions (SIGWINCH to the shell process).
 	useEffect(() => {
-		let recoveryTimeoutId: ReturnType<typeof setTimeout> | null = null;
-
 		const handleWindowFocus = (): void => {
-			// Always clear pending timeout first to prevent stale recovery calls.
-			if (recoveryTimeoutId) {
-				clearTimeout(recoveryTimeoutId);
-				recoveryTimeoutId = null;
-			}
 			// Skip recovery for terminals that are not the active tab in their pane
 			// (isVisible is tab-active, not window-visible — see PaneContent.tsx).
 			// Hidden instances recover via the isVisible-change useEffect instead.
 			if (!isVisibleRef.current) return;
-			recoveryTimeoutId = setTimeout(() => {
-				recoveryTimeoutId = null;
-				performTerminalRecovery();
-			}, VISIBILITY_RECOVERY_DELAY_MS);
+			// Fire recovery immediately — the window is already visible when
+			// 'focus' fires (unlike visibilitychange which needs DOM reflow time).
+			// The recovery sequence (dispose WebGL -> DOM refresh -> RAF recreate
+			// WebGL) handles timing internally, so no external debounce is needed.
+			performTerminalRecovery();
 		};
 
 		window.addEventListener("focus", handleWindowFocus);
 		return () => {
-			if (recoveryTimeoutId) {
-				clearTimeout(recoveryTimeoutId);
-			}
 			window.removeEventListener("focus", handleWindowFocus);
 		};
 	}, [performTerminalRecovery]);

--- a/src/renderer/hooks/use-terminal-resize-v2.ts
+++ b/src/renderer/hooks/use-terminal-resize-v2.ts
@@ -79,11 +79,22 @@ export function useTerminalResizeV2(
 			const width = Math.round(rect.width)
 			const height = Math.round(rect.height)
 
+			// Guard against fitting to a collapsed container. After a Windows
+			// minimize→restore the webview reflows over several frames; during that
+			// window getBoundingClientRect() can report a tiny height. Calling fit()
+			// then collapses the terminal grid to 1-2 rows (the PTY redraws tiny,
+			// showing "1-2 lines" until a later fit corrects it). Never fit unless
+			// the container is large enough to hold a usable grid — this protects
+			// every caller (ResizeObserver, forceFit, recovery).
+			const MIN_FIT_WIDTH = 40
+			const MIN_FIT_HEIGHT = 40
+			if (width < MIN_FIT_WIDTH || height < MIN_FIT_HEIGHT) {
+				return false
+			}
+
 			// Skip if dimensions haven't changed (and not forced)
 			if (
 				!force &&
-				width > 0 &&
-				height > 0 &&
 				width === lastContainerWidthRef.current &&
 				height === lastContainerHeightRef.current
 			) {


### PR DESCRIPTION
## Summary

Fixes the terminal rendering wrong after a window **minimize → restore** on Windows: the active terminal would show only **1-2 lines of text** (the grid collapsed to 1-2 rows), then snap back to full size a few seconds later. In some cases it appeared fully blank until a tab-switch.

## Related Issues
closes - #177 

## Root cause

After minimize→restore, WebView2 reflows the page over several frames. During that window the terminal container momentarily reports a **collapsed height**. The fit pipeline (`use-terminal-resize-v2` `performFit`) called `fitAddon.fit()` **with no minimum-dimension guard**, so it computed a 1-2 row grid, resized the PTY tiny, and the shell redrew into 1-2 rows. A later `ResizeObserver` fit at correct dimensions recovered it — hence "blank, then full terminal after a few seconds."

This matches upstream [xterm.js #4841](https://github.com/xtermjs/xterm.js/issues/4841) (fit computes wrong tiny dimensions when the container isn't laid out yet).

> Note on the commit history: the first commits in this branch chased a WebGL-context-corruption theory, which live forensics (`gl.isContextLost() === false`) **refuted**. The final fix is the dimension guard below. History is kept for traceability.

## Fix

1. **Dimension guard** (`use-terminal-resize-v2.ts`): `performFit` now refuses to fit when the container is smaller than `MIN_FIT_WIDTH/HEIGHT` (40px). This protects **every** caller — `ResizeObserver`, `forceFit`, and recovery — so a mid-restore fit is a safe no-op instead of a destructive grid collapse.
2. **Layout-wait recovery** (`ConnectedTerminal.tsx`): `performTerminalRecovery` polls (via `requestAnimationFrame`, bailing after ~0.5s) until the container reports a usable size before `forceResizeFit` + `refresh`, then performs a CSS visibility flip to force a WebView2 canvas-layer re-composite (covers the rarer genuinely-stuck-blank case; xterm 6.x has no DOM-row fallback).

## Verification

Verified **live on Windows** in a dev build via the Tauri MCP bridge:
- Collapsing the terminal container to 20px no longer shrinks the grid — it stayed at 50 rows / 900px (without the guard this reproduced the "1-2 lines" symptom).
- WebGL context stays healthy throughout (`isContextLost() === false`).

Automated:
- `bun run test` — 107/108 pass across `ConnectedTerminal` + `use-terminal-resize-v2` (1 pre-existing skip).
- `bun run typecheck` — clean.
- `bun run lint` — 0 errors (4 pre-existing warnings, unrelated).

## Platform notes

- The **dimension guard is platform-neutral** (pure DOM/JS, no OS conditionals) and protects all fit callers, so the destructive collapse can't happen on any OS.
- Recovery triggers fire on all platforms: `visibilitychange` (primary on macOS/Linux), `window focus` (Windows minimize/restore), and `onPowerResume` (wake from sleep).
- The underlying trigger (WebView2 missing paint messages on minimize/restore) is Windows-specific. The CSS re-composite is a harmless no-op on macOS/Linux.
- **Tested on Windows only.** macOS/Linux smoke test (minimize → restore) still recommended before relying on it there.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved terminal focus recovery to wait for stable layout before resizing, preventing grid collapse after minimize/restore and ensuring WebGL/compositor stability.
  * Added minimum-dimension guard to avoid running layout fit on very small containers.

* **Tests**
  * Added tests covering focus-recovery behavior, visibility/composition handling, and recovery coalescing so overlapping focus events trigger only a single recovery.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gnoviawan/termul/pull/185?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->