### PR TITLE
feat(worktree): simplify worktree UX for non-technical users

### DIFF
--- a/src/renderer/components/NewWorktreeModal.tsx
+++ b/src/renderer/components/NewWorktreeModal.tsx
@@ -5,9 +5,7 @@ import type { BranchInfo } from '@shared/types/ipc.types'
 import type { Worktree } from '@/types/project'
 import { worktreeApi } from '@/lib/api'
 import { useProjectStore, useProjectActions } from '@/stores/project-store'
-import { useWorkspaceStore } from '@/stores/workspace-store'
-import { useAppSettingsStore } from '@/stores/app-settings-store'
-import { spawnTerminalInPane } from '@/lib/terminal-spawn'
+import { activateAndOpenTerminal } from '@/lib/terminal-spawn'
 import { toast } from '@/hooks/use-toast'
 import { cn } from '@/lib/utils'
 
@@ -20,7 +18,7 @@ interface NewWorktreeModalProps {
 export function NewWorktreeModal({ isOpen, onClose, projectId }: NewWorktreeModalProps) {
 	const project = useProjectStore((state) => state.projects.find((p) => p.id === projectId))
 	const isWorktreeOperationLocked = useProjectStore((state) => state.isWorktreeOperationLocked)
-	const { addWorktree, setActiveWorktree, setWorktreeOperationLock } = useProjectActions()
+	const { addWorktree, setWorktreeOperationLock } = useProjectActions()
 
 	// Form state
 	const [branchType, setBranchType] = useState<'existing' | 'new'>('new')
@@ -266,26 +264,17 @@ export function NewWorktreeModal({ isOpen, onClose, projectId }: NewWorktreeModa
 
 				// Land the user inside the new worktree: activate it and open a terminal there.
 				// Best-effort — a spawn failure must not block the (already successful) creation.
-				setActiveWorktree(projectId, newWorktree.id)
-				try {
-					const paneId = useWorkspaceStore.getState().activePaneId
-					if (paneId) {
-						const maxTerminalsPerProject = useAppSettingsStore.getState().settings.maxTerminalsPerProject
-						const spawnResult = await spawnTerminalInPane(paneId, projectId, result.data.path, { maxTerminalsPerProject })
-						if (!spawnResult.success) {
-							toast({
-								title: 'Worktree ready — terminal not opened',
-								description: spawnResult.error || 'Could not open a terminal in the new worktree.',
-							})
-						}
-					} else {
-						toast({
-							title: 'Worktree ready — terminal not opened',
-							description: 'No active pane to open a terminal in. Switch to a workspace pane first.',
-						})
-					}
-				} catch {
-					// Terminal spawn is non-blocking; the worktree is already created and active.
+				const outcome = await activateAndOpenTerminal(projectId, newWorktree.id, result.data.path)
+				if (outcome.status === 'no-pane') {
+					toast({
+						title: 'Worktree ready — terminal not opened',
+						description: 'No active pane to open a terminal in. Switch to a workspace pane first.',
+					})
+				} else if (outcome.status === 'spawn-failed') {
+					toast({
+						title: 'Worktree ready — terminal not opened',
+						description: outcome.error || 'Could not open a terminal in the new worktree.',
+					})
 				}
 
 				onClose()
@@ -319,7 +308,6 @@ export function NewWorktreeModal({ isOpen, onClose, projectId }: NewWorktreeModa
 		projectPath,
 		projectId,
 		addWorktree,
-		setActiveWorktree,
 		setWorktreeOperationLock,
 		onClose,
 		enabledSymlinkDirs,

--- a/src/renderer/components/NewWorktreeModal.tsx
+++ b/src/renderer/components/NewWorktreeModal.tsx
@@ -1,10 +1,13 @@
 import { useState, useCallback, useEffect, KeyboardEvent } from 'react'
-import { X, GitBranch, Search, AlertTriangle, Loader2, Link2 } from 'lucide-react'
+import { X, GitBranch, Search, AlertTriangle, Loader2, Link2, Terminal } from 'lucide-react'
 import { motion, AnimatePresence } from 'framer-motion'
 import type { BranchInfo } from '@shared/types/ipc.types'
 import type { Worktree } from '@/types/project'
 import { worktreeApi } from '@/lib/api'
 import { useProjectStore, useProjectActions } from '@/stores/project-store'
+import { useWorkspaceStore } from '@/stores/workspace-store'
+import { useAppSettingsStore } from '@/stores/app-settings-store'
+import { spawnTerminalInPane } from '@/lib/terminal-spawn'
 import { toast } from '@/hooks/use-toast'
 import { cn } from '@/lib/utils'
 
@@ -17,7 +20,7 @@ interface NewWorktreeModalProps {
 export function NewWorktreeModal({ isOpen, onClose, projectId }: NewWorktreeModalProps) {
 	const project = useProjectStore((state) => state.projects.find((p) => p.id === projectId))
 	const isWorktreeOperationLocked = useProjectStore((state) => state.isWorktreeOperationLocked)
-	const { addWorktree, setWorktreeOperationLock } = useProjectActions()
+	const { addWorktree, setActiveWorktree, setWorktreeOperationLock } = useProjectActions()
 
 	// Form state
 	const [branchType, setBranchType] = useState<'existing' | 'new'>('new')
@@ -40,6 +43,9 @@ export function NewWorktreeModal({ isOpen, onClose, projectId }: NewWorktreeModa
 	const [enabledSymlinkDirs, setEnabledSymlinkDirs] = useState<Set<string>>(new Set())
 	const [showSymlinkSection, setShowSymlinkSection] = useState(false)
 
+	// Advanced (git plumbing) disclosure — collapsed by default for non-technical users
+	const [showAdvanced, setShowAdvanced] = useState(false)
+
 	const projectPath = project?.path ?? ''
 	const isGitRepo = project?.isGitRepo ?? false
 
@@ -51,8 +57,10 @@ export function NewWorktreeModal({ isOpen, onClose, projectId }: NewWorktreeModa
 			.replace(/^-|-$/g, '')
 	}
 
-	// Auto-fill worktree name from branch name
+	// Auto-fill worktree name from branch ONLY when the user hasn't named it yet.
+	// Name is the primary field now; never clobber a user-entered name.
 	useEffect(() => {
+		if (worktreeName.trim()) return
 		if (branchType === 'new' && newBranchName) {
 			setWorktreeName(sanitizeBranchName(newBranchName))
 		} else if (branchType === 'existing' && selectedBranch) {
@@ -60,7 +68,7 @@ export function NewWorktreeModal({ isOpen, onClose, projectId }: NewWorktreeModa
 			const name = selectedBranch.split('/').pop() ?? selectedBranch
 			setWorktreeName(name)
 		}
-	}, [branchType, newBranchName, selectedBranch])
+	}, [branchType, newBranchName, selectedBranch, worktreeName])
 
 	// Reset form when modal opens
 	useEffect(() => {
@@ -75,6 +83,7 @@ export function NewWorktreeModal({ isOpen, onClose, projectId }: NewWorktreeModa
 			setValidationError(null)
 			setIsCreating(false)
 			setShowSymlinkSection(false)
+			setShowAdvanced(false)
 
 			// Initialize symlink dirs from project settings
 			const projectSymlinkDirs = project?.symlinkDirs ?? []
@@ -128,8 +137,12 @@ export function NewWorktreeModal({ isOpen, onClose, projectId }: NewWorktreeModa
 		if (!isGitRepo) return 'Project is not a git repository'
 		if (isWorktreeOperationLocked) return 'Another worktree operation is in progress'
 
+		// Simple path: when creating a new branch and the Advanced branch field is empty,
+		// derive the branch from the worktree name.
+		const effectiveNewBranch = newBranchName.trim() || worktreeName.trim()
+
 		// Check if branch already has a worktree
-		const branch = branchType === 'existing' ? selectedBranch : sanitizeBranchName(newBranchName)
+		const branch = branchType === 'existing' ? selectedBranch : sanitizeBranchName(effectiveNewBranch)
 		const existingWorktree = project?.worktrees?.find(
 			(w: Worktree) => w.branch === branch || w.name === worktreeName,
 		)
@@ -138,14 +151,14 @@ export function NewWorktreeModal({ isOpen, onClose, projectId }: NewWorktreeModa
 		}
 
 		if (branchType === 'new') {
-			if (!newBranchName.trim()) return 'Branch name is required'
-			// Also validate that the sanitized branch name is non-empty
-			if (!sanitizeBranchName(newBranchName).trim()) return 'Branch name is required'
+			if (!effectiveNewBranch) return 'Name is required'
+			// A name was entered but sanitized to nothing (e.g. "---") — it's invalid, not missing.
+			if (!sanitizeBranchName(effectiveNewBranch).trim()) return 'Name contains no usable characters'
 		} else {
 			if (!selectedBranch) return 'Select a branch'
 		}
 
-		if (!worktreeName.trim()) return 'Worktree name is required'
+		if (!worktreeName.trim()) return 'Name is required'
 
 		// Check for path length (Windows MAX_PATH = 260)
 		const targetPath = `${projectPath}/.termul/worktrees/${worktreeName}/`
@@ -186,7 +199,7 @@ export function NewWorktreeModal({ isOpen, onClose, projectId }: NewWorktreeModa
 		try {
 			const branch = branchType === 'existing'
 				? selectedBranch
-				: sanitizeBranchName(newBranchName)
+				: sanitizeBranchName(newBranchName.trim() || worktreeName.trim())
 
 			const result = await worktreeApi.create({
 				projectPath,
@@ -251,6 +264,30 @@ export function NewWorktreeModal({ isOpen, onClose, projectId }: NewWorktreeModa
 					})
 				}
 
+				// Land the user inside the new worktree: activate it and open a terminal there.
+				// Best-effort — a spawn failure must not block the (already successful) creation.
+				setActiveWorktree(projectId, newWorktree.id)
+				try {
+					const paneId = useWorkspaceStore.getState().activePaneId
+					if (paneId) {
+						const maxTerminalsPerProject = useAppSettingsStore.getState().settings.maxTerminalsPerProject
+						const spawnResult = await spawnTerminalInPane(paneId, projectId, result.data.path, { maxTerminalsPerProject })
+						if (!spawnResult.success) {
+							toast({
+								title: 'Worktree ready — terminal not opened',
+								description: spawnResult.error || 'Could not open a terminal in the new worktree.',
+							})
+						}
+					} else {
+						toast({
+							title: 'Worktree ready — terminal not opened',
+							description: 'No active pane to open a terminal in. Switch to a workspace pane first.',
+						})
+					}
+				} catch {
+					// Terminal spawn is non-blocking; the worktree is already created and active.
+				}
+
 				onClose()
 			} else {
 				setValidationError(!result.success ? result.error : 'Failed to create worktree')
@@ -282,6 +319,7 @@ export function NewWorktreeModal({ isOpen, onClose, projectId }: NewWorktreeModa
 		projectPath,
 		projectId,
 		addWorktree,
+		setActiveWorktree,
 		setWorktreeOperationLock,
 		onClose,
 		enabledSymlinkDirs,
@@ -355,6 +393,38 @@ export function NewWorktreeModal({ isOpen, onClose, projectId }: NewWorktreeModa
 								/>
 							</div>
 
+							{/* Worktree name — primary, only required field for the simple path */}
+							<div>
+								<label className="block text-xs font-medium text-muted-foreground mb-1">
+									Name
+								</label>
+								<input
+									type="text"
+									value={worktreeName}
+									onChange={(e) => setWorktreeName(e.target.value)}
+									placeholder="e.g. try-new-hero"
+									className="w-full bg-secondary border border-border rounded px-3 py-1.5 text-sm text-foreground focus:ring-1 focus:ring-primary outline-none placeholder-muted-foreground"
+									autoFocus
+								/>
+								<p className="text-[10px] text-muted-foreground mt-0.5">
+									A separate place to work. Your main project stays untouched.
+								</p>
+							</div>
+
+							{/* Advanced (git plumbing) — collapsed by default for non-technical users */}
+							<button
+								type="button"
+								onClick={() => setShowAdvanced(!showAdvanced)}
+								className="flex items-center gap-1.5 text-xs font-medium text-muted-foreground hover:text-foreground transition-colors"
+								aria-expanded={showAdvanced}
+							>
+								<GitBranch size={12} aria-hidden="true" />
+								<span>Advanced (branch options)</span>
+								<span className="text-[10px]" aria-hidden="true">{showAdvanced ? '▼' : '▶'}</span>
+							</button>
+
+							{showAdvanced && (
+							<div className="space-y-4">
 							{/* Branch type toggle */}
 							<div>
 								<label className="block text-xs font-medium text-muted-foreground mb-1">
@@ -455,26 +525,25 @@ export function NewWorktreeModal({ isOpen, onClose, projectId }: NewWorktreeModa
 								</div>
 							)}
 
-							{/* New branch name */}
+							{/* New branch name + start ref */}
 							{branchType === 'new' && (
 								<>
 									<div>
 										<label className="block text-xs font-medium text-muted-foreground mb-1">
-											Branch Name
+											Branch Name <span className="text-muted-foreground/60">(optional)</span>
 										</label>
 										<input
 											type="text"
 											value={newBranchName}
 											onChange={(e) => setNewBranchName(e.target.value)}
-											placeholder="feature/my-feature"
+											placeholder={worktreeName ? sanitizeBranchName(worktreeName) : 'feature/my-feature'}
 											className="w-full bg-secondary border border-border rounded px-3 py-1.5 text-sm text-foreground focus:ring-1 focus:ring-primary outline-none placeholder-muted-foreground"
-											autoFocus
 										/>
-										{newBranchName && sanitizeBranchName(newBranchName) !== newBranchName && (
-											<p className="text-[10px] text-muted-foreground mt-0.5">
-												Will be sanitized to: {sanitizeBranchName(newBranchName)}
-											</p>
-										)}
+										<p className="text-[10px] text-muted-foreground mt-0.5">
+											{newBranchName && sanitizeBranchName(newBranchName) !== newBranchName
+												? `Will be sanitized to: ${sanitizeBranchName(newBranchName)}`
+												: 'Defaults to the name above.'}
+										</p>
 									</div>
 									<div>
 										<label className="block text-xs font-medium text-muted-foreground mb-1">
@@ -493,23 +562,9 @@ export function NewWorktreeModal({ isOpen, onClose, projectId }: NewWorktreeModa
 									</div>
 								</>
 							)}
-
-							{/* Worktree name */}
-							<div>
-								<label className="block text-xs font-medium text-muted-foreground mb-1">
-									Worktree Name
-								</label>
-								<input
-									type="text"
-									value={worktreeName}
-									onChange={(e) => setWorktreeName(e.target.value)}
-									placeholder="my-worktree"
-									className="w-full bg-secondary border border-border rounded px-3 py-1.5 text-sm text-foreground focus:ring-1 focus:ring-primary outline-none placeholder-muted-foreground"
-								/>
-								<p className="text-[10px] text-muted-foreground mt-0.5">
-									Auto-filled from branch name
-								</p>
 							</div>
+							)}
+
 
 							{/* Path preview */}
 							<div>
@@ -596,7 +651,8 @@ export function NewWorktreeModal({ isOpen, onClose, projectId }: NewWorktreeModa
 								className="px-3 py-1.5 text-xs font-medium bg-primary text-primary-foreground rounded hover:bg-primary/90 shadow-md shadow-primary/20 transition-all disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-1.5"
 							>
 								{isCreating && <Loader2 size={12} className="animate-spin" />}
-								{isCreating ? 'Creating...' : 'Create Worktree'}
+								{!isCreating && <Terminal size={12} />}
+								{isCreating ? 'Creating...' : 'Create & open'}
 							</button>
 						</div>
 					</motion.div>

--- a/src/renderer/components/ProjectSidebar.test.tsx
+++ b/src/renderer/components/ProjectSidebar.test.tsx
@@ -4,9 +4,10 @@ import { MemoryRouter } from 'react-router-dom'
 import { ProjectSidebar } from './ProjectSidebar'
 import type { Project } from '@/types/project'
 
-const { mockGetAvailableShells, mockSpawnTerminalInPane, mockUseProjectsWithActivity, mockUseProjectsWithErrors } = vi.hoisted(() => ({
+const { mockGetAvailableShells, mockSpawnTerminalInPane, mockActivateAndOpenTerminal, mockUseProjectsWithActivity, mockUseProjectsWithErrors } = vi.hoisted(() => ({
   mockGetAvailableShells: vi.fn(),
   mockSpawnTerminalInPane: vi.fn(),
+  mockActivateAndOpenTerminal: vi.fn(),
   mockUseProjectsWithActivity: vi.fn(),
   mockUseProjectsWithErrors: vi.fn()
 }))
@@ -36,7 +37,8 @@ vi.mock('@/stores/terminal-store', async () => {
 })
 
 vi.mock('@/lib/terminal-spawn', () => ({
-  spawnTerminalInPane: mockSpawnTerminalInPane
+  spawnTerminalInPane: mockSpawnTerminalInPane,
+  activateAndOpenTerminal: mockActivateAndOpenTerminal
 }))
 
 vi.mock('@/lib/utils', async () => {
@@ -49,6 +51,8 @@ beforeEach(() => {
   mockGetAvailableShells.mockReset()
   mockSpawnTerminalInPane.mockReset()
   mockSpawnTerminalInPane.mockResolvedValue({ success: true, data: { id: 'term-1' } })
+  mockActivateAndOpenTerminal.mockReset()
+  mockActivateAndOpenTerminal.mockResolvedValue({ status: 'opened', terminalId: 'term-1' })
   mockGetAvailableShells.mockResolvedValue({
     success: true,
     data: {
@@ -544,7 +548,7 @@ describe('ProjectSidebar Worktree Row', () => {
     fireEvent.click(screen.getByLabelText('Open terminal in try-new-hero'))
 
     await waitFor(() => {
-      expect(mockSpawnTerminalInPane).toHaveBeenCalled()
+      expect(mockActivateAndOpenTerminal).toHaveBeenCalled()
     })
     // The terminal-button click must not bubble to the project row's select handler
     expect(onSelectProject).not.toHaveBeenCalled()
@@ -557,7 +561,7 @@ describe('ProjectSidebar Worktree Row', () => {
     // Enter on the nested terminal button must not bubble to the row's onKeyDown select
     fireEvent.keyDown(termButton, { key: 'Enter' })
 
-    // The shared select handler is not invoked by the key event (spawn happens on click)
-    expect(mockSpawnTerminalInPane).not.toHaveBeenCalled()
+    // The shared open handler is not invoked by the key event (spawn happens on click)
+    expect(mockActivateAndOpenTerminal).not.toHaveBeenCalled()
   })
 })

--- a/src/renderer/components/ProjectSidebar.test.tsx
+++ b/src/renderer/components/ProjectSidebar.test.tsx
@@ -4,8 +4,9 @@ import { MemoryRouter } from 'react-router-dom'
 import { ProjectSidebar } from './ProjectSidebar'
 import type { Project } from '@/types/project'
 
-const { mockGetAvailableShells, mockUseProjectsWithActivity, mockUseProjectsWithErrors } = vi.hoisted(() => ({
+const { mockGetAvailableShells, mockSpawnTerminalInPane, mockUseProjectsWithActivity, mockUseProjectsWithErrors } = vi.hoisted(() => ({
   mockGetAvailableShells: vi.fn(),
+  mockSpawnTerminalInPane: vi.fn(),
   mockUseProjectsWithActivity: vi.fn(),
   mockUseProjectsWithErrors: vi.fn()
 }))
@@ -13,6 +14,15 @@ const { mockGetAvailableShells, mockUseProjectsWithActivity, mockUseProjectsWith
 vi.mock('@/lib/api', () => ({
   shellApi: {
     getAvailableShells: mockGetAvailableShells
+  },
+  worktreeApi: {
+    list: vi.fn().mockResolvedValue({ success: true, data: [] }),
+    checkDirty: vi.fn().mockResolvedValue({ success: true, data: { modified: 0, staged: 0, untracked: 0, hasChanges: false } }),
+    ensureSymlinks: vi.fn().mockResolvedValue({ success: true, data: [] }),
+    remove: vi.fn().mockResolvedValue({ success: true })
+  },
+  clipboardApi: {
+    writeText: vi.fn().mockResolvedValue({ success: true })
   }
 }))
 
@@ -25,6 +35,10 @@ vi.mock('@/stores/terminal-store', async () => {
   }
 })
 
+vi.mock('@/lib/terminal-spawn', () => ({
+  spawnTerminalInPane: mockSpawnTerminalInPane
+}))
+
 vi.mock('@/lib/utils', async () => {
   const actual = await vi.importActual('@/lib/utils')
   return { ...actual }
@@ -33,6 +47,8 @@ vi.mock('@/lib/utils', async () => {
 // Setup mock data
 beforeEach(() => {
   mockGetAvailableShells.mockReset()
+  mockSpawnTerminalInPane.mockReset()
+  mockSpawnTerminalInPane.mockResolvedValue({ success: true, data: { id: 'term-1' } })
   mockGetAvailableShells.mockResolvedValue({
     success: true,
     data: {
@@ -474,5 +490,74 @@ describe('ProjectSidebar Terminal Activity Indicator', () => {
     const item = screen.getByTestId('project-item-1')
     const spinner = item.querySelector('svg.animate-spin')
     expect(spinner).not.toBeNull()
+  })
+})
+
+describe('ProjectSidebar Worktree Row', () => {
+  const projectWithWorktree: Project[] = [
+    {
+      id: '1',
+      name: 'Project One',
+      color: 'blue',
+      gitBranch: 'main',
+      isGitRepo: true,
+      worktrees: [
+        {
+          id: 'wt-1',
+          name: 'try-new-hero',
+          branch: 'feature/try-new-hero',
+          path: '/repo/.termul/worktrees/try-new-hero',
+          createdAt: new Date().toISOString()
+        }
+      ]
+    }
+  ]
+
+  it('shows the worktree name but not the branch chip on the row face', () => {
+    renderWithRouter({ projects: projectWithWorktree, activeProjectId: '1' })
+
+    // Name is shown
+    expect(screen.getByText('try-new-hero')).toBeInTheDocument()
+    // Branch is NOT shown as a visible chip on the row
+    expect(screen.queryByText('feature/try-new-hero')).not.toBeInTheDocument()
+  })
+
+  it('keeps the branch available via the row tooltip', () => {
+    renderWithRouter({ projects: projectWithWorktree, activeProjectId: '1' })
+
+    const row = screen.getByLabelText('Worktree try-new-hero on feature/try-new-hero')
+    expect(row).toHaveAttribute('title', expect.stringContaining('feature/try-new-hero'))
+  })
+
+  it('exposes an accessible "Open terminal" button on the worktree row', () => {
+    renderWithRouter({ projects: projectWithWorktree, activeProjectId: '1' })
+
+    expect(
+      screen.getByLabelText('Open terminal in try-new-hero')
+    ).toBeInTheDocument()
+  })
+
+  it('opens a terminal in the worktree when the terminal button is clicked, without triggering row select', async () => {
+    const onSelectProject = vi.fn()
+    renderWithRouter({ projects: projectWithWorktree, activeProjectId: '1', onSelectProject })
+
+    fireEvent.click(screen.getByLabelText('Open terminal in try-new-hero'))
+
+    await waitFor(() => {
+      expect(mockSpawnTerminalInPane).toHaveBeenCalled()
+    })
+    // The terminal-button click must not bubble to the project row's select handler
+    expect(onSelectProject).not.toHaveBeenCalled()
+  })
+
+  it('does not trigger row select when activating the terminal button via keyboard', () => {
+    renderWithRouter({ projects: projectWithWorktree, activeProjectId: '1' })
+
+    const termButton = screen.getByLabelText('Open terminal in try-new-hero')
+    // Enter on the nested terminal button must not bubble to the row's onKeyDown select
+    fireEvent.keyDown(termButton, { key: 'Enter' })
+
+    // The shared select handler is not invoked by the key event (spawn happens on click)
+    expect(mockSpawnTerminalInPane).not.toHaveBeenCalled()
   })
 })

--- a/src/renderer/components/ProjectSidebar.tsx
+++ b/src/renderer/components/ProjectSidebar.tsx
@@ -42,10 +42,8 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { shellApi, dialogApi, worktreeApi, clipboardApi } from "@/lib/api";
 import { useProjectsWithActivity, useProjectsWithErrors } from "@/stores/terminal-store";
 import { useProjectStore, useProjectActions } from "@/stores/project-store";
-import { useWorkspaceStore } from "@/stores/workspace-store";
 import { toast } from "@/hooks/use-toast";
-import { spawnTerminalInPane } from "@/lib/terminal-spawn";
-import { useAppSettingsStore } from "@/stores/app-settings-store";
+import { activateAndOpenTerminal } from "@/lib/terminal-spawn";
 import type { WorktreeHealthStatus } from "@/types/worktree-status";
 import { getWorktreeStatusFromCache } from "@/hooks/use-worktree-status";
 import { useWorktreeStatus } from "@/hooks/use-worktree-status";
@@ -278,23 +276,16 @@ export function ProjectSidebar({
 	// Shared by the row hover terminal button and the "Open Terminal Here" context menu.
 	const handleOpenTerminalInWorktree = useCallback(
 		async (projectId: string, worktreeId: string | null, worktreePath: string, worktreeName: string): Promise<void> => {
-			setActiveWorktree(projectId, worktreeId);
-			const paneId = useWorkspaceStore.getState().activePaneId;
-			if (!paneId) {
-				toast({ title: "No active pane", description: "Cannot open terminal without an active workspace pane." });
-				return;
-			}
-			const maxTerminalsPerProject = useAppSettingsStore.getState().settings.maxTerminalsPerProject;
-			const result = await spawnTerminalInPane(paneId, projectId, worktreePath, {
-				maxTerminalsPerProject,
-			});
-			if (result.success) {
+			const outcome = await activateAndOpenTerminal(projectId, worktreeId, worktreePath);
+			if (outcome.status === "opened") {
 				toast({ title: "Terminal opened", description: `Terminal opened in "${worktreeName}"` });
+			} else if (outcome.status === "no-pane") {
+				toast({ title: "No active pane", description: "Cannot open terminal without an active workspace pane." });
 			} else {
-				toast({ title: "Failed to open terminal", description: result.error || "Could not create a terminal in this worktree." });
+				toast({ title: "Failed to open terminal", description: outcome.error || "Could not create a terminal in this worktree." });
 			}
 		},
-		[setActiveWorktree],
+		[],
 	);
 
 	const handleWorktreeContextMenu = useCallback(

--- a/src/renderer/components/ProjectSidebar.tsx
+++ b/src/renderer/components/ProjectSidebar.tsx
@@ -274,6 +274,29 @@ export function ProjectSidebar({
 		[setActiveWorktree],
 	);
 
+	// Activate a worktree AND open a terminal in it, in one action.
+	// Shared by the row hover terminal button and the "Open Terminal Here" context menu.
+	const handleOpenTerminalInWorktree = useCallback(
+		async (projectId: string, worktreeId: string | null, worktreePath: string, worktreeName: string): Promise<void> => {
+			setActiveWorktree(projectId, worktreeId);
+			const paneId = useWorkspaceStore.getState().activePaneId;
+			if (!paneId) {
+				toast({ title: "No active pane", description: "Cannot open terminal without an active workspace pane." });
+				return;
+			}
+			const maxTerminalsPerProject = useAppSettingsStore.getState().settings.maxTerminalsPerProject;
+			const result = await spawnTerminalInPane(paneId, projectId, worktreePath, {
+				maxTerminalsPerProject,
+			});
+			if (result.success) {
+				toast({ title: "Terminal opened", description: `Terminal opened in "${worktreeName}"` });
+			} else {
+				toast({ title: "Failed to open terminal", description: result.error || "Could not create a terminal in this worktree." });
+			}
+		},
+		[setActiveWorktree],
+	);
+
 	const handleWorktreeContextMenu = useCallback(
 		(e: React.MouseEvent, projectId: string, worktree: Worktree): void => {
 			e.preventDefault();
@@ -633,23 +656,7 @@ export function ProjectSidebar({
 				{
 					label: "Open Terminal Here",
 					icon: <Terminal size={14} />,
-					onClick: async () => {
-						handleWorktreeSelect(projectId, worktree.id);
-						const paneId = useWorkspaceStore.getState().activePaneId;
-						if (!paneId) {
-							toast({ title: "No active pane", description: "Cannot open terminal without an active workspace pane." });
-							return;
-						}
-						const maxTerminalsPerProject = useAppSettingsStore.getState().settings.maxTerminalsPerProject;
-						const result = await spawnTerminalInPane(paneId, projectId, worktree.path, {
-							maxTerminalsPerProject,
-						});
-						if (result.success) {
-							toast({ title: "Terminal opened", description: `Terminal opened in "${worktree.name}"` });
-						} else {
-							toast({ title: "Failed to open terminal", description: result.error || "Could not create a terminal in this worktree." });
-						}
-					},
+					onClick: () => void handleOpenTerminalInWorktree(projectId, worktree.id, worktree.path, worktree.name),
 				},
 				{
 					label: "Open in File Explorer",
@@ -672,7 +679,7 @@ export function ProjectSidebar({
 				},
 			];
 		},
-		[handleWorktreeSelect, handleOpenInFileExplorer, handleCopyWorktreePath, isWorktreeOperationLocked],
+		[handleOpenTerminalInWorktree, handleOpenInFileExplorer, handleCopyWorktreePath, isWorktreeOperationLocked],
 	);
 
 	const colorPickerProject = projects.find(
@@ -772,6 +779,9 @@ export function ProjectSidebar({
 											}}
 											onWorktreeSelect={(worktreeId) => handleWorktreeSelect(project.id, worktreeId)}
 											onWorktreeContextMenu={(e, worktree) => handleWorktreeContextMenu(e, project.id, worktree)}
+											onOpenTerminalInWorktree={(worktreeId, worktreePath, worktreeName) =>
+												void handleOpenTerminalInWorktree(project.id, worktreeId, worktreePath, worktreeName)
+											}
 											isWorktreeOperationLocked={isWorktreeOperationLocked}
 											onNewWorktree={(pId) => setNewWorktreeModal({ isOpen: true, projectId: pId })}
 										/>
@@ -1041,6 +1051,7 @@ interface ProjectItemProps {
 	onSettingsClick: () => void;
 	onWorktreeSelect: (worktreeId: string | null) => void;
 	onWorktreeContextMenu: (e: React.MouseEvent, worktree: Worktree) => void;
+	onOpenTerminalInWorktree: (worktreeId: string | null, worktreePath: string, worktreeName: string) => void;
 	isWorktreeOperationLocked: boolean;
 	onNewWorktree: (projectId: string) => void;
 }
@@ -1063,6 +1074,7 @@ const ProjectItem = memo(function ProjectItem({
 	onSettingsClick,
 	onWorktreeSelect,
 	onWorktreeContextMenu,
+	onOpenTerminalInWorktree,
 	isWorktreeOperationLocked,
 	onNewWorktree,
 }: ProjectItemProps): React.JSX.Element {
@@ -1244,6 +1256,7 @@ const ProjectItem = memo(function ProjectItem({
 							isRoot
 							isActive={project.activeWorktreeId === null || project.activeWorktreeId === undefined}
 							onClick={() => onWorktreeSelect(null)}
+							onOpenTerminal={project.path ? () => onOpenTerminalInWorktree(null, project.path as string, "project root") : undefined}
 						/>
 						{/* Grouped worktree items with search filter */}
 						{(() => {
@@ -1286,6 +1299,7 @@ const ProjectItem = memo(function ProjectItem({
 												isTermulManaged={isWorktreeTermulManaged(wt)}
 												onClick={() => onWorktreeSelect(wt.id)}
 												onContextMenu={(e) => onWorktreeContextMenu(e, wt)}
+												onOpenTerminal={() => onOpenTerminalInWorktree(wt.id, wt.path, wt.name)}
 											/>
 										))}
 									</div>
@@ -1324,6 +1338,7 @@ interface WorktreeItemProps {
 	worktreeId?: string;
 	onClick: () => void;
 	onContextMenu?: (e: React.MouseEvent) => void;
+	onOpenTerminal?: () => void;
 }
 
 /** Icon + color for worktree health status */
@@ -1352,6 +1367,7 @@ const WorktreeItem = memo(function WorktreeItem({
 	worktreeId,
 	onClick,
 	onContextMenu,
+	onOpenTerminal,
 }: WorktreeItemProps): React.JSX.Element {
 	// Read health status from cache (updated by useWorktreeStatus polling in ProjectSidebar)
 	// This reads a shared Map — no hook subscription needed; the parent sidebar
@@ -1365,31 +1381,56 @@ const WorktreeItem = memo(function WorktreeItem({
 		: `${name} on ${branch}${path ? ` — ${path}` : ''}${isTermulManaged === false ? ' — External worktree' : ''}`
 
 	return (
-		<button
+		<div
 			onClick={onClick}
 			onContextMenu={onContextMenu}
+			role="button"
+			tabIndex={0}
+			onKeyDown={(e) => {
+				// Only activate row-select for keys on the row itself, not on nested
+				// controls (e.g. the terminal button), which handle their own keys.
+				if (e.target !== e.currentTarget) return;
+				if (e.key === 'Enter' || e.key === ' ') {
+					e.preventDefault();
+					onClick();
+				}
+			}}
 			className={cn(
-				"w-full flex items-center px-2 py-1 text-xs transition-colors text-left",
+				"group w-full flex items-center px-2 py-1 text-xs transition-colors text-left cursor-pointer",
 				isActive
 					? "bg-primary/15 text-foreground"
 					: "text-muted-foreground hover:bg-sidebar-accent/50 hover:text-foreground",
 			)}
 			title={tooltip}
+			aria-current={isActive ? "page" : undefined}
+			aria-label={isRoot ? `Project root on ${branch}` : `Worktree ${name} on ${branch}`}
 		>
 			<div className="mr-1.5 flex-shrink-0 inline-flex items-center" aria-hidden="true">
 				{isRoot ? <Home size={12} className="text-muted-foreground" /> : <GitBranch size={12} className="text-primary/70" />}
 			</div>
 			<span className="truncate flex-1">{isRoot ? "Root" : name}</span>
 			{!isRoot && <HealthBadge status={healthStatus} />}
-			<span className="text-[10px] text-muted-foreground ml-1 truncate max-w-[60px]">
-				{branch}
-			</span>
 			{!isRoot && isTermulManaged === false && (
 				<span className="text-[10px] text-amber-500/70 ml-1" title="External worktree (not created by Termul)">
 					ext
 				</span>
 			)}
-		</button>
+			{onOpenTerminal && (
+				<button
+					type="button"
+					onClick={(e) => {
+						e.stopPropagation();
+						onOpenTerminal();
+					}}
+					onKeyDown={(e) => e.stopPropagation()}
+					className="h-5 w-5 inline-flex items-center justify-center rounded opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 focus-visible:opacity-100 hover:bg-sidebar-accent transition-all ml-1 flex-shrink-0 focus:outline-none focus-visible:ring-1 focus-visible:ring-primary"
+					title={`Open terminal in ${isRoot ? "project root" : name}`}
+					aria-label={`Open terminal in ${isRoot ? "project root" : name}`}
+				>
+					<Terminal size={12} className="text-muted-foreground" aria-hidden="true" />
+				</button>
+			)}
+		</div>
 	);
 });
 

--- a/src/renderer/lib/terminal-spawn.ts
+++ b/src/renderer/lib/terminal-spawn.ts
@@ -8,6 +8,7 @@
 
 import { terminalApi } from '@/lib/api'
 import { resolveEnvForSpawn } from '@/lib/env-parser'
+import { useAppSettingsStore } from '@/stores/app-settings-store'
 import { useProjectStore } from '@/stores/project-store'
 import { useTerminalStore } from '@/stores/terminal-store'
 import { useWorkspaceStore } from '@/stores/workspace-store'
@@ -122,4 +123,40 @@ export async function spawnTerminalInPane(
 			error: err instanceof Error ? err.message : String(err),
 		}
 	}
+}
+
+/** Outcome of {@link activateAndOpenTerminal}, so callers can phrase their own toast. */
+export type ActivateAndOpenTerminalOutcome =
+	| { status: 'opened'; terminalId?: string }
+	| { status: 'no-pane' }
+	| { status: 'spawn-failed'; error?: string }
+
+/**
+ * Activate a worktree (or the project root when `worktreeId` is null) and open a
+ * terminal in `worktreePath`, reading `activePaneId` and the per-project terminal
+ * limit from the stores. Centralizes the mechanics shared by the sidebar hover
+ * button, the context menu, and the create-worktree flow. Callers own the toast
+ * copy via the returned outcome.
+ */
+export async function activateAndOpenTerminal(
+	projectId: string,
+	worktreeId: string | null,
+	worktreePath: string,
+): Promise<ActivateAndOpenTerminalOutcome> {
+	useProjectStore.getState().setActiveWorktree(projectId, worktreeId)
+
+	const paneId = useWorkspaceStore.getState().activePaneId
+	if (!paneId) {
+		return { status: 'no-pane' }
+	}
+
+	const maxTerminalsPerProject = useAppSettingsStore.getState().settings.maxTerminalsPerProject
+	const result = await spawnTerminalInPane(paneId, projectId, worktreePath, {
+		maxTerminalsPerProject,
+	})
+
+	if (result.success) {
+		return { status: 'opened', terminalId: result.terminalId }
+	}
+	return { status: 'spawn-failed', error: result.error }
 }

--- a/src/renderer/pages/ProjectSettings.tsx
+++ b/src/renderer/pages/ProjectSettings.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useRef } from 'react'
 import { Settings, Save, Info, Plus, X, ChevronDown, Upload, Link2, RefreshCw } from 'lucide-react'
 import { useNavigate } from 'react-router-dom'
 import { NewProjectModal } from '@/components/NewProjectModal'
@@ -67,6 +67,12 @@ export default function ProjectSettings() {
     fetchShells()
   }, [])
 
+  // Tracks which project's form fields have been initialized, so a late async
+  // availableShells load (which re-runs the sync effect) cannot wipe fields the
+  // user — or the D5 auto-fill — has since changed.
+  const symlinkInitProjectRef = useRef<string | null>(null)
+  const autoFilledSymlinkRef = useRef<string | null>(null)
+
   // Sync state when activeProject changes
   useEffect(() => {
     if (activeProject) {
@@ -75,10 +81,56 @@ export default function ProjectSettings() {
       setRootPath(activeProject.path || '')
       setEnvVars(activeProject.envVars || [])
       setShell(activeProject.defaultShell || availableShells?.default?.name || fallbackShell)
-      setSymlinkDirs(activeProject.symlinkDirs ?? [])
-      setHasChanges(false)
+      // Only (re)initialize symlinkDirs the first time we see a given project.
+      // The effect also re-runs when availableShells resolves; without this guard
+      // that late run would reset symlinkDirs to the (empty) stored value and wipe
+      // the D5 .gitignore auto-fill held in local state.
+      if (symlinkInitProjectRef.current !== activeProject.id) {
+        symlinkInitProjectRef.current = activeProject.id
+        setSymlinkDirs(activeProject.symlinkDirs ?? [])
+        setHasChanges(false)
+      }
     }
   }, [activeProject, availableShells?.default?.name, fallbackShell])
+
+  // D5: default worktree symlinks ON. For a git project that has never configured
+  // symlink dirs, pre-fill them from .gitignore so fresh worktrees inherit shared
+  // deps (e.g. node_modules) and don't break with "module not found". Runs once per
+  // project and never overwrites a list the user has already configured (non-empty).
+  useEffect(() => {
+    const proj = activeProject
+    if (!proj?.path || !proj.isGitRepo) return
+    if ((proj.symlinkDirs ?? []).length > 0) return
+    if (autoFilledSymlinkRef.current === proj.id) return
+
+    let cancelled = false
+    const projId = proj.id
+    const projPath = proj.path
+    autoFilledSymlinkRef.current = projId
+    void (async () => {
+      try {
+        const result = await worktreeApi.parseGitignore(projPath)
+        // Ignore the result if the effect was cleaned up or the selected project changed.
+        if (cancelled || activeProject?.id !== projId) return
+        if (result.success && result.data) {
+          const dirs = result.data.filter((d) => d.exists).map((d) => d.dirName)
+          if (dirs.length > 0) {
+            setSymlinkDirs(dirs)
+            setHasChanges(true)
+          }
+        }
+      } catch {
+        // Best-effort: leave the list empty if .gitignore can't be parsed.
+      }
+    })()
+    return () => {
+      cancelled = true
+    }
+    // Keyed on project identity only: this must run once per project selection and
+    // not re-fire when other activeProject fields change (which would re-parse and
+    // fight user edits). The in-closure activeProject read is a freshness guard.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [activeProject?.id, activeProject?.path, activeProject?.isGitRepo])
 
   const handleSave = () => {
     if (activeProject) {

--- a/src/renderer/pages/ProjectSettings.tsx
+++ b/src/renderer/pages/ProjectSettings.tsx
@@ -76,17 +76,19 @@ export default function ProjectSettings() {
   // Sync state when activeProject changes
   useEffect(() => {
     if (activeProject) {
-      setProjectName(activeProject.name)
-      setSelectedColor(activeProject.color)
-      setRootPath(activeProject.path || '')
-      setEnvVars(activeProject.envVars || [])
+      // setShell is intentionally outside the per-project guard: availableShells
+      // resolves asynchronously after mount, and the resolved default must be
+      // applied when it arrives.
       setShell(activeProject.defaultShell || availableShells?.default?.name || fallbackShell)
-      // Only (re)initialize symlinkDirs the first time we see a given project.
-      // The effect also re-runs when availableShells resolves; without this guard
-      // that late run would reset symlinkDirs to the (empty) stored value and wipe
-      // the D5 .gitignore auto-fill held in local state.
+      // Everything else initializes once per project. The effect also re-runs when
+      // availableShells resolves; without this guard that late run would wipe user
+      // edits (and the D5 .gitignore auto-fill) made before shells loaded.
       if (symlinkInitProjectRef.current !== activeProject.id) {
         symlinkInitProjectRef.current = activeProject.id
+        setProjectName(activeProject.name)
+        setSelectedColor(activeProject.color)
+        setRootPath(activeProject.path || '')
+        setEnvVars(activeProject.envVars || [])
         setSymlinkDirs(activeProject.symlinkDirs ?? [])
         setHasChanges(false)
       }
@@ -106,15 +108,18 @@ export default function ProjectSettings() {
     let cancelled = false
     const projId = proj.id
     const projPath = proj.path
-    autoFilledSymlinkRef.current = projId
     void (async () => {
       try {
         const result = await worktreeApi.parseGitignore(projPath)
-        // Ignore the result if the effect was cleaned up or the selected project changed.
-        if (cancelled || activeProject?.id !== projId) return
+        // Bail if the effect was cleaned up (project switched / unmounted). Cleanup
+        // sets `cancelled`, so this is sufficient on its own.
+        if (cancelled) return
         if (result.success && result.data) {
           const dirs = result.data.filter((d) => d.exists).map((d) => d.dirName)
           if (dirs.length > 0) {
+            // Mark done only after a successful fill so a cancelled StrictMode
+            // double-invoke doesn't suppress the real run.
+            autoFilledSymlinkRef.current = projId
             setSymlinkDirs(dirs)
             setHasChanges(true)
           }
@@ -128,7 +133,7 @@ export default function ProjectSettings() {
     }
     // Keyed on project identity only: this must run once per project selection and
     // not re-fire when other activeProject fields change (which would re-parse and
-    // fight user edits). The in-closure activeProject read is a freshness guard.
+    // fight user edits).
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [activeProject?.id, activeProject?.path, activeProject?.isGitRepo])
 


### PR DESCRIPTION
## Summary

- Simplify the worktree feature so a non-technical "vibe coder" can work with it: enter a worktree in one click, create one without git jargon, and never hit "module not found" in a fresh worktree.

## Related Issue

Closes #

<!-- No tracked issue — this is UX-driven work from the worktree UX design spines (EXPERIENCE.md / DESIGN.md, decisions D1–D5). -->

## Type of Change

- [x] feat: new feature
- [ ] fix: bug fix
- [ ] docs: documentation only
- [ ] style: formatting or non-functional styling changes
- [ ] refactor: internal cleanup with no behavior change
- [ ] perf: performance improvement
- [ ] test: adds or updates tests
- [ ] build: build or dependency changes
- [ ] ci: CI/CD workflow changes
- [ ] chore: maintenance or tooling
- [ ] revert: reverts a previous change

## What Changed

- **D1 — One-click "open terminal here" on worktree rows.** Hovering or keyboard-focusing a worktree row reveals a terminal button (same affordance as the project settings gear). Clicking it activates that worktree and opens a terminal in it. The existing "Open Terminal Here" context-menu logic was extracted into one shared handler so both paths agree.
- **D3 — Quieter rows.** Removed the redundant inline branch chip from the row face. The branch stays available in the tooltip and the row `aria-label` (so screen readers keep the context).
- **D4 — Name-first create.** The New Worktree modal now leads with a single **Name** field and a "Create & open" button; branch type / branch picker / start-ref moved into a collapsed **Advanced** disclosure. The branch is derived from the name when not set explicitly, and on success you land in a terminal inside the new worktree.
- **D5 — Symlinks default on.** Project Settings auto-fills the worktree symlink directories from `.gitignore` for git projects that never configured them, so fresh worktrees inherit shared deps (e.g. `node_modules`) and don't break with "module not found". An already-configured list is left untouched.

Renderer-only; all required Tauri backend commands already existed. Implements decisions D1/D3/D4/D5 from the worktree UX spines.

## How It Was Tested

- [x] `bun run lint`
- [x] `bun run typecheck`
- [x] `bun run test`
- [x] Manual verification completed
- [ ] Not applicable

Notes: `typecheck` clean; `lint` clean for the changed files (only two pre-existing `react-hooks/exhaustive-deps` warnings in `NewWorktreeModal.tsx` remain, present on the base commit); `ProjectSidebar.test.tsx` passes 34/34 including new worktree-row coverage (name-only label, branch in tooltip, terminal button present, click + keyboard activation isolation). Reviewed adversarially (blind hunter + edge-case hunter + acceptance auditor); critical findings patched — notably a race where a late shell-list load could wipe the D5 auto-fill, and keyboard double-fire on the nested terminal button.

## Screenshots or Recordings

<!-- UI change — screenshots/GIF of the hover terminal button, the simplified create modal, and the settings symlink prefill to be added. -->

## Checklist

- [x] My PR title follows the conventional commit format used by this repo
- [x] I linked the related issue or explained why none exists
- [ ] I updated docs when needed
- [x] I added or updated tests when needed
- [x] I verified the change does not introduce unrelated modifications


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Collapsible "Advanced" options in the worktree creation modal
  * "Create & open" activates new worktree and attempts to open a terminal (non-blocking; toast on failures)
  * Quick-access terminal button on worktree rows with improved keyboard/ARIA behavior
  * Project settings now auto-populate symlink directories from .gitignore once per project

* **Improvements**
  * Safer Name input: user-entered names aren’t overwritten; branch derivation respects sanitized input
  * Better branch validation and sanitization feedback

* **Tests**
  * Added tests covering worktree terminal behavior and UI interactions

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gnoviawan/termul/pull/186?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->