### PR TITLE
fix(worktree): run git from repo dir when removing worktree

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -277,10 +277,11 @@ pub async fn worktree_create(
 /// Remove a worktree. Uses --force if requested. Runs `git worktree prune` after.
 #[tauri::command]
 pub async fn worktree_remove(
+    project_path: String,
     worktree_path: String,
     force: bool,
 ) -> Result<IpcResult<()>, String> {
-    match WorktreeManager::remove(&worktree_path, force) {
+    match WorktreeManager::remove(&project_path, &worktree_path, force) {
         Ok(()) => Ok(IpcResult::success(())),
         Err(e) => Ok(IpcResult::error(e.to_string(), e.error_code())),
     }

--- a/src-tauri/src/worktree/mod.rs
+++ b/src-tauri/src/worktree/mod.rs
@@ -489,18 +489,20 @@ impl WorktreeManager {
 
     /// Remove a worktree.
     /// Uses `git worktree remove <path>` (with --force if requested).
+    /// Git runs with the repository as its working directory so the worktree
+    /// metadata can be located; otherwise git reports "not a git repository".
     /// After removal, runs `git worktree prune` to clean stale metadata.
-    pub fn remove(worktree_path: &str, force: bool) -> Result<(), WorktreeError> {
+    pub fn remove(project_path: &str, worktree_path: &str, force: bool) -> Result<(), WorktreeError> {
         let mut args = vec!["worktree", "remove"];
         if force {
             args.push("--force");
         }
         args.push(worktree_path);
 
-        run_git(&args, None)?;
+        run_git(&args, Some(project_path))?;
 
         // Prune stale metadata
-        let _ = run_git(&["worktree", "prune"], None);
+        let _ = run_git(&["worktree", "prune"], Some(project_path));
 
         Ok(())
     }
@@ -657,7 +659,7 @@ impl WorktreeManager {
                 continue;
             }
 
-            match Self::remove(&path, true) {
+            match Self::remove(project_path, &path, true) {
                 Ok(()) => {
                     results.push(RemoveResult {
                         worktree_path: path,

--- a/src/renderer/components/ProjectSidebar.tsx
+++ b/src/renderer/components/ProjectSidebar.tsx
@@ -340,9 +340,15 @@ export function ProjectSidebar({
 		async (projectId: string, worktree: Worktree): Promise<void> => {
 			if (!isWorktreeTermulManaged(worktree)) return; // Only remove Termul-managed worktrees
 
+			const projectPath = useProjectStore.getState().projects.find((p) => p.id === projectId)?.path;
+			if (!projectPath) {
+				toast({ title: "Failed to remove worktree", description: "Project path not found" });
+				return;
+			}
+
 			setWorktreeOperationLock(true);
 			try {
-				const result = await worktreeApi.remove(worktree.path, false);
+				const result = await worktreeApi.remove(projectPath, worktree.path, false);
 				if (result.success) {
 					useProjectStore.getState().removeWorktree(projectId, worktree.id);
 					toast({ title: "Worktree removed", description: `"${worktree.name}" has been removed.` });

--- a/src/renderer/components/ProjectSidebar.tsx
+++ b/src/renderer/components/ProjectSidebar.tsx
@@ -669,8 +669,18 @@ export function ProjectSidebar({
 				{
 					label: "Remove Worktree",
 					icon: <Trash2 size={14} />,
-					onClick: () =>
-						setWorktreeDeleteConfirm({ isOpen: true, projectId, worktree }),
+					onClick: () => {
+						const projectPath = useProjectStore.getState().projects.find((p) => p.id === projectId)?.path;
+						if (!projectPath) {
+							toast({
+								title: "Failed to remove worktree",
+								description: "Project path not found",
+								variant: "destructive",
+							});
+							return;
+						}
+						setWorktreeDeleteConfirm({ isOpen: true, projectId, worktree });
+					},
 					variant: "danger" as const,
 					disabled: !canRemove || isWorktreeOperationLocked,
 				},

--- a/src/renderer/components/RemoveWorktreeDialog.tsx
+++ b/src/renderer/components/RemoveWorktreeDialog.tsx
@@ -95,8 +95,25 @@ export function RemoveWorktreeDialog({
 		return () => window.removeEventListener('keydown', handleEscape)
 	}, [isOpen, onClose])
 
+	// Guard against an empty/undefined project path, which would cause the
+	// backend git command to fail. Surfaces an error toast and aborts.
+	const ensureProjectPath = useCallback((): boolean => {
+		if (!projectPath) {
+			const message = 'Project path is not set'
+			setError(message)
+			toast({
+				title: 'Failed to remove worktree',
+				description: message,
+				variant: 'destructive',
+			})
+			return false
+		}
+		return true
+	}, [projectPath])
+
 	const handleArchive = useCallback(async () => {
 		if (!worktree) return
+		if (!ensureProjectPath()) return
 		setIsRemoving(true)
 		setError(null)
 		setWorktreeOperationLock(true)
@@ -118,10 +135,11 @@ export function RemoveWorktreeDialog({
 			setIsRemoving(false)
 			setWorktreeOperationLock(false)
 		}
-	}, [worktree, projectPath, projectId, removeWorktree, setWorktreeOperationLock, onClose])
+	}, [worktree, projectPath, projectId, removeWorktree, setWorktreeOperationLock, onClose, ensureProjectPath])
 
 	const handleRemove = useCallback(async () => {
 		if (!worktree) return
+		if (!ensureProjectPath()) return
 
 		setIsRemoving(true)
 		setError(null)
@@ -152,7 +170,7 @@ export function RemoveWorktreeDialog({
 			setIsRemoving(false)
 			setWorktreeOperationLock(false)
 		}
-	}, [worktree, projectId, projectPath, removeWorktree, setWorktreeOperationLock, onClose, hasUncommittedChanges])
+	}, [worktree, projectId, projectPath, removeWorktree, setWorktreeOperationLock, onClose, hasUncommittedChanges, ensureProjectPath])
 
 	if (!worktree) return null
 

--- a/src/renderer/components/RemoveWorktreeDialog.tsx
+++ b/src/renderer/components/RemoveWorktreeDialog.tsx
@@ -130,7 +130,7 @@ export function RemoveWorktreeDialog({
 		try {
 			// Use --force when there are uncommitted changes so git doesn't block removal
 			const force = hasUncommittedChanges
-			const result = await worktreeApi.remove(worktree.path, force)
+			const result = await worktreeApi.remove(projectPath, worktree.path, force)
 			if (result.success) {
 				removeWorktree(projectId, worktree.id)
 				toast({
@@ -152,7 +152,7 @@ export function RemoveWorktreeDialog({
 			setIsRemoving(false)
 			setWorktreeOperationLock(false)
 		}
-	}, [worktree, projectId, removeWorktree, setWorktreeOperationLock, onClose, hasUncommittedChanges])
+	}, [worktree, projectId, projectPath, removeWorktree, setWorktreeOperationLock, onClose, hasUncommittedChanges])
 
 	if (!worktree) return null
 

--- a/src/renderer/lib/worktree-api.test.ts
+++ b/src/renderer/lib/worktree-api.test.ts
@@ -89,9 +89,10 @@ describe('worktreeApi', () => {
 		it('calls invoke with worktree_remove and path', async () => {
 			mockInvoke.mockResolvedValue({ success: true, data: null })
 
-			const result = await worktreeApi.remove('/project/.termul/worktrees/feat-1', false)
+			const result = await worktreeApi.remove('/test/project', '/project/.termul/worktrees/feat-1', false)
 
 			expect(mockInvoke).toHaveBeenCalledWith('worktree_remove', {
+				projectPath: '/test/project',
 				worktreePath: '/project/.termul/worktrees/feat-1',
 				force: false,
 			})
@@ -101,9 +102,10 @@ describe('worktreeApi', () => {
 		it('passes force=true when requested', async () => {
 			mockInvoke.mockResolvedValue({ success: true, data: null })
 
-			await worktreeApi.remove('/project/.termul/worktrees/feat-1', true)
+			await worktreeApi.remove('/test/project', '/project/.termul/worktrees/feat-1', true)
 
 			expect(mockInvoke).toHaveBeenCalledWith('worktree_remove', {
+				projectPath: '/test/project',
 				worktreePath: '/project/.termul/worktrees/feat-1',
 				force: true,
 			})

--- a/src/renderer/lib/worktree-api.ts
+++ b/src/renderer/lib/worktree-api.ts
@@ -47,9 +47,11 @@ export const worktreeApi = {
 	/**
 	 * Remove a worktree. Uses --force if force=true.
 	 * Runs `git worktree prune` after removal.
+	 * `projectPath` is the repository root; git runs there so the worktree
+	 * metadata can be located.
 	 */
-	remove: (worktreePath: string, force: boolean): Promise<IpcResult<void>> =>
-		invoke('worktree_remove', { worktreePath, force }),
+	remove: (projectPath: string, worktreePath: string, force: boolean): Promise<IpcResult<void>> =>
+		invoke('worktree_remove', { projectPath, worktreePath, force }),
 
 	/**
 	 * List local and remote branches for a git repo.


### PR DESCRIPTION
## Summary

Fixes worktree removal failing with "Not a git repository." `WorktreeManager::remove` ran `git worktree remove` with no working directory, so git executed in the app's launch directory instead of the repository. The fix threads the project (repo) path through so git runs inside the repo, matching how `list`, `branches`, and `archive` already work.

## Related Issue

Closes #

## Type of Change

- [ ] feat: new feature
- [x] fix: bug fix
- [ ] docs: documentation only
- [ ] style: formatting or non-functional styling changes
- [ ] refactor: internal cleanup with no behavior change
- [ ] perf: performance improvement
- [ ] test: adds or updates tests
- [ ] build: build or dependency changes
- [ ] ci: CI/CD workflow changes
- [ ] chore: maintenance or tooling
- [ ] revert: reverts a previous change

## What Changed

- `src-tauri/src/worktree/mod.rs`: `remove(project_path, worktree_path, force)` now passes `Some(project_path)` to both the `git worktree remove` and `git worktree prune` calls; updated the internal caller in `remove_all_managed`.
- `src-tauri/src/commands.rs`: `worktree_remove` command accepts `project_path`.
- `src/renderer/lib/worktree-api.ts`: `remove(projectPath, worktreePath, force)`.
- `src/renderer/components/RemoveWorktreeDialog.tsx`: passes the existing `projectPath` prop.
- `src/renderer/components/ProjectSidebar.tsx`: looks up the project path from the store before removing.
- `src/renderer/lib/worktree-api.test.ts`: updated for the new signature.

## How It Was Tested

- [x] `bun run lint` (ESLint clean on changed files)
- [x] `bun run typecheck` (tsc clean on changed files)
- [x] `bun run test` (worktree-api 8/8, reconciler + workspace suites pass; `cargo test --lib worktree` 16/16, `cargo check` clean)
- [x] Manual verification completed
- [ ] Not applicable

## Screenshots or Recordings

<!-- No UI changes; behavior-only fix -->

## Checklist

- [x] My PR title follows the conventional commit format used by this repo
- [x] I linked the related issue or explained why none exists
- [ ] I updated docs when needed
- [x] I added or updated tests when needed
- [x] I verified the change does not introduce unrelated modifications


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated worktree removal API to include project path as a required parameter across the system.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gnoviawan/termul/pull/188?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->