### PR TITLE
fix(git): align git tab height and remove panel gap

### DIFF
--- a/src/renderer/components/git/GitPanel.tsx
+++ b/src/renderer/components/git/GitPanel.tsx
@@ -85,7 +85,7 @@ export function GitPanel({ cwd, isVisible }: GitPanelProps) {
   };
 
   return (
-    <div className="flex h-full w-full bg-background overflow-hidden border-t border-border">
+    <div className="flex h-full w-full bg-background overflow-hidden">
       {/* File List Sidebar */}
       <div className="w-80 border-r border-border flex flex-col shrink-0">
         <div className="p-3 border-b border-border flex items-center justify-between gap-2">
@@ -180,7 +180,7 @@ export function GitPanel({ cwd, isVisible }: GitPanelProps) {
                   Loading diff...
                 </div>
               ) : currentDiff.trim().length > 0 ? (
-                <div className="p-4 whitespace-pre">
+                <div className="p-4 whitespace-pre" style={{ tabSize: 4, MozTabSize: 4 }}>
                   {currentDiff.split('\n').map((line: string, i: number) => {
                     const isAddition = line.startsWith('+');
                     const isDeletion = line.startsWith('-');

--- a/src/renderer/components/workspace/WorkspaceTabBar.tsx
+++ b/src/renderer/components/workspace/WorkspaceTabBar.tsx
@@ -475,11 +475,11 @@ function GitTabInline({
 					setContextMenu({ x: e.clientX, y: e.clientY });
 				}}
 				className={cn(
-					"group relative flex items-center h-7 px-3 min-w-[120px] max-w-[200px] gap-2 cursor-pointer select-none border-r border-border/40 transition-colors",
+					"group relative h-full px-3 flex items-center min-w-[120px] max-w-[200px] gap-2 cursor-pointer select-none border-r border-border transition-all duration-150 ease-out border-b-2 border-b-transparent",
 					isActive
-						? "bg-secondary text-foreground"
+						? "bg-background border-b-primary text-foreground"
 						: "text-muted-foreground hover:bg-secondary/50 hover:text-foreground",
-					isDragging && "opacity-50",
+					isDragging && "opacity-50 scale-[0.98]",
 					isDropTarget &&
 						dropPosition === "before" &&
 						"border-l-2 border-l-primary",
@@ -513,10 +513,6 @@ function GitTabInline({
 				>
 					<XIcon size={10} />
 				</button>
-
-				{isActive && (
-					<div className="absolute bottom-0 left-0 right-0 h-[1.5px] bg-primary" />
-				)}
 			</div>
 
 			{contextMenu && (


### PR DESCRIPTION
## Summary

- Align the Git tab in the workspace tab bar with terminal tabs and remove a doubled border that read as a gap below the active Git tab.

## Related Issue

Closes #

<!-- No tracked issue; small UI consistency fix surfaced during manual use. -->

## Type of Change

- [x] fix: bug fix
- [ ] feat: new feature
- [ ] style: formatting or non-functional styling changes

## What Changed

- `GitTabInline` now uses `h-full` (matching `TerminalTabInline`) instead of a hardcoded `h-7`, so the Git tab fills the tab bar at the same height as terminal tabs.
- Switched the active-tab styling to the terminal tab convention (`bg-background` + `border-b-primary` with a transparent `border-b-2` baseline) and removed the redundant absolute bottom indicator bar.
- Removed the extra `border-t border-border` on the `GitPanel` root, which was stacking on top of the tab bar's `border-b` and showing as a thin gap/double line under the active Git tab (terminal panels have no such border).

## How It Was Tested

- [x] `bun run lint` (eslint on changed files, clean)
- [x] `bun run typecheck` (web + node, clean)
- [ ] `bun run test`
- [x] Manual verification completed
- [ ] Not applicable

## Screenshots or Recordings

<!-- UI change: Git tab now matches terminal tab height with no gap below the active tab. -->

## Checklist

- [x] My PR title follows the conventional commit format used by this repo
- [x] I linked the related issue or explained why none exists
- [ ] I updated docs when needed
- [ ] I added or updated tests when needed
- [x] I verified the change does not introduce unrelated modifications


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  - Refined styling for Git panel and Git tab components.
  - Removed bottom underline indicator from the active Git tab.
  - Updated text rendering configuration in diff view.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gnoviawan/termul/pull/189?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->