### PR TITLE
feat(git): git panel staging, unstaging, and discard

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2084,6 +2084,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "keyring"
+version = "3.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eebcc3aff044e5944a8fbaf69eb277d11986064cba30c468730e8b9909fb551c"
+dependencies = [
+ "log",
+ "zeroize",
+]
+
+[[package]]
 name = "kqueue"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5047,6 +5057,7 @@ dependencies = [
  "anyhow",
  "chrono",
  "env_logger",
+ "keyring",
  "lazy_static",
  "log",
  "parking_lot",

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1686,14 +1686,35 @@ pub async fn git_get_status(
         .map_err(|e: String| e)
 }
 
-/// Get git diff for a file
+/// Get git diff for a file. `staged` selects the index-vs-HEAD diff
+/// (`git diff --cached`) instead of the worktree-vs-index diff.
 #[tauri::command]
 pub async fn git_get_diff(
     cwd: String,
     path: String,
+    staged: Option<bool>,
 ) -> Result<String, String> {
-    crate::trackers::git_tracker::git_get_diff(&cwd, &path)
+    crate::trackers::git_tracker::git_get_diff(&cwd, &path, staged.unwrap_or(false))
         .map_err(|e: String| e)
+}
+
+/// Stage a single file (`git add`).
+#[tauri::command]
+pub async fn git_stage(cwd: String, path: String) -> Result<(), String> {
+    crate::trackers::git_tracker::git_stage_file(&cwd, &path).map_err(|e: String| e)
+}
+
+/// Unstage a single file (`git restore --staged`).
+#[tauri::command]
+pub async fn git_unstage(cwd: String, path: String) -> Result<(), String> {
+    crate::trackers::git_tracker::git_unstage_file(&cwd, &path).map_err(|e: String| e)
+}
+
+/// Discard changes to a single file. Untracked files are deleted; tracked
+/// changes revert to HEAD. This is destructive and irreversible.
+#[tauri::command]
+pub async fn git_discard(cwd: String, path: String) -> Result<(), String> {
+    crate::trackers::git_tracker::git_discard_file(&cwd, &path).map_err(|e: String| e)
 }
 
 /// Get available shells

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -780,6 +780,9 @@ pub fn run() {
             // Git commands
             commands::git_get_status,
             commands::git_get_diff,
+            commands::git_stage,
+            commands::git_unstage,
+            commands::git_discard,
             // Secure storage commands
             secure_storage::secure_storage_set,
             secure_storage::secure_storage_get,

--- a/src-tauri/src/trackers/git_tracker.rs
+++ b/src-tauri/src/trackers/git_tracker.rs
@@ -723,7 +723,7 @@ const NULL_DEVICE: &str = "/dev/null";
 ///   additions via `--no-index`.
 /// - Staged rows compare the index against HEAD (`--cached`).
 /// - Unstaged rows compare the working tree against the index.
-fn build_diff_args<'a>(path: &'a str, is_untracked: bool, staged: bool) -> Vec<&'a str> {
+fn build_diff_args(path: &str, is_untracked: bool, staged: bool) -> Vec<&str> {
     if is_untracked {
         vec!["diff", "--no-index", "--", NULL_DEVICE, path]
     } else if staged {

--- a/src-tauri/src/trackers/git_tracker.rs
+++ b/src-tauri/src/trackers/git_tracker.rs
@@ -713,7 +713,27 @@ fn git_get_status_detail_from_output(output: &str) -> Vec<GitStatusDetail> {
     details
 }
 
-pub fn git_get_diff(cwd: &str, path: &str) -> Result<String, String> {
+/// Git treats `/dev/null` as a magic empty-file token on all platforms,
+/// including Git for Windows, so it is safe to use for `diff --no-index`.
+const NULL_DEVICE: &str = "/dev/null";
+
+/// Select the `git diff` argument vector for a single path.
+///
+/// - Untracked files have nothing in the index, so they are shown in full as
+///   additions via `--no-index`.
+/// - Staged rows compare the index against HEAD (`--cached`).
+/// - Unstaged rows compare the working tree against the index.
+fn build_diff_args<'a>(path: &'a str, is_untracked: bool, staged: bool) -> Vec<&'a str> {
+    if is_untracked {
+        vec!["diff", "--no-index", "--", NULL_DEVICE, path]
+    } else if staged {
+        vec!["diff", "--cached", "--", path]
+    } else {
+        vec!["diff", "--", path]
+    }
+}
+
+pub fn git_get_diff(cwd: &str, path: &str, staged: bool) -> Result<String, String> {
     if is_git_ignored(cwd, path)? {
         return Ok(String::new());
     }
@@ -725,11 +745,7 @@ pub fn git_get_diff(cwd: &str, path: &str) -> Result<String, String> {
     let status_str = String::from_utf8_lossy(&status_output.stdout);
     let is_untracked = status_str.starts_with("??");
 
-    let args = if is_untracked {
-        vec!["diff", "--no-index", "--", "/dev/null", path]
-    } else {
-        vec!["diff", "HEAD", "--", path]
-    };
+    let args = build_diff_args(path, is_untracked, staged);
 
     let output = GitTracker::run_git_command(cwd, &args)
         .ok_or_else(|| "Failed to run git diff".to_string())?;
@@ -744,6 +760,124 @@ pub fn git_get_diff(cwd: &str, path: &str) -> Result<String, String> {
     }
 
     Ok(stdout)
+}
+
+/// What discarding a path should do, derived from its `git status --porcelain` line.
+#[derive(Debug, PartialEq, Eq)]
+enum DiscardAction {
+    /// Untracked entry: delete it from disk.
+    DeleteUntracked,
+    /// Tracked change: revert the working tree to the index (`git checkout -- <path>`).
+    /// This never touches the index, so staged content is preserved.
+    RevertWorktree,
+    /// Nothing to discard (clean or unknown path).
+    Noop,
+}
+
+/// Classify the discard action from a `git status --porcelain` line.
+/// The first column is the index (staged) status; `??` marks untracked entries.
+fn classify_discard_action(status_line: &str) -> DiscardAction {
+    if status_line.trim().is_empty() {
+        return DiscardAction::Noop;
+    }
+    if status_line.starts_with('?') {
+        return DiscardAction::DeleteUntracked;
+    }
+    DiscardAction::RevertWorktree
+}
+
+/// Whether `path` is a safe repo-relative path (no absolute root, drive prefix,
+/// or `..` traversal). Used to gate raw filesystem deletes against escaping `cwd`.
+fn is_safe_relative_path(path: &str) -> bool {
+    use std::path::Component;
+    let p = std::path::Path::new(path);
+    if p.is_absolute() {
+        return false;
+    }
+    !p.components().any(|c| {
+        matches!(
+            c,
+            Component::ParentDir | Component::RootDir | Component::Prefix(_)
+        )
+    })
+}
+
+fn git_command_result(
+    cwd: &str,
+    args: &[&str],
+    failure_context: &str,
+) -> Result<(), String> {
+    let output = GitTracker::run_git_command(cwd, args)
+        .ok_or_else(|| format!("Failed to run {failure_context}"))?;
+    if output.status.success() {
+        Ok(())
+    } else {
+        Err(String::from_utf8_lossy(&output.stderr).trim().to_string())
+    }
+}
+
+/// Whether the repository has a resolvable HEAD (i.e. at least one commit).
+fn repo_has_head(cwd: &str) -> bool {
+    GitTracker::run_git_command(cwd, &["rev-parse", "--verify", "--quiet", "HEAD"])
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+/// Stage a single file (`git add -- <path>`). Works for modified and untracked files.
+pub fn git_stage_file(cwd: &str, path: &str) -> Result<(), String> {
+    git_command_result(cwd, &["add", "--", path], "git add")
+}
+
+/// Unstage a single file.
+///
+/// When the repo has a HEAD, `git reset -q HEAD -- <path>` restores the index
+/// entry to its committed version. `git reset` only touches the index (never
+/// the working tree) and works on all Git versions, unlike `git restore`
+/// (Git >= 2.23). With no commits yet there is no HEAD to reset to, so the
+/// entry is removed from the index while the working-tree file is kept intact.
+pub fn git_unstage_file(cwd: &str, path: &str) -> Result<(), String> {
+    if repo_has_head(cwd) {
+        git_command_result(cwd, &["reset", "-q", "HEAD", "--", path], "git reset")
+    } else {
+        git_command_result(cwd, &["rm", "--cached", "--", path], "git rm --cached")
+    }
+}
+
+/// Delete an untracked file or directory from disk. Treats an already-missing
+/// path as success (a concurrent delete still satisfies the intent).
+fn delete_untracked_path(cwd: &str, path: &str) -> Result<(), String> {
+    if !is_safe_relative_path(path) {
+        return Err(format!("Refusing to delete unsafe path: {path}"));
+    }
+    let target = std::path::Path::new(cwd).join(path);
+    let result = if target.is_dir() {
+        std::fs::remove_dir_all(&target)
+    } else {
+        std::fs::remove_file(&target)
+    };
+    match result {
+        Ok(()) => Ok(()),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(e) => Err(e.to_string()),
+    }
+}
+
+/// Discard changes to a single file. Untracked entries are deleted from disk;
+/// tracked changes revert the working tree to the index (`git checkout -- <path>`),
+/// which preserves any staged content. A clean/unknown path is a no-op.
+pub fn git_discard_file(cwd: &str, path: &str) -> Result<(), String> {
+    let status_output = GitTracker::run_git_command(cwd, &["status", "--porcelain", "--", path])
+        .ok_or_else(|| "Failed to run git status".to_string())?;
+    let status_str = String::from_utf8_lossy(&status_output.stdout);
+    let status_line = status_str.lines().next().unwrap_or("");
+
+    match classify_discard_action(status_line) {
+        DiscardAction::DeleteUntracked => delete_untracked_path(cwd, path),
+        DiscardAction::RevertWorktree => {
+            git_command_result(cwd, &["checkout", "--", path], "git checkout")
+        }
+        DiscardAction::Noop => Ok(()),
+    }
 }
 
 fn is_git_ignored(cwd: &str, path: &str) -> Result<bool, String> {
@@ -1078,6 +1212,99 @@ mod tests {
     use super::*;
 
     #[test]
+    fn test_build_diff_args_untracked_uses_no_index() {
+        // Untracked files have no index entry; staged flag is irrelevant.
+        assert_eq!(
+            build_diff_args("new.txt", true, false),
+            vec!["diff", "--no-index", "--", NULL_DEVICE, "new.txt"]
+        );
+        assert_eq!(
+            build_diff_args("new.txt", true, true),
+            vec!["diff", "--no-index", "--", NULL_DEVICE, "new.txt"]
+        );
+    }
+
+    #[test]
+    fn test_build_diff_args_staged_uses_cached() {
+        assert_eq!(
+            build_diff_args("a.txt", false, true),
+            vec!["diff", "--cached", "--", "a.txt"]
+        );
+    }
+
+    #[test]
+    fn test_build_diff_args_unstaged_uses_worktree() {
+        // Unstaged tracked diff compares worktree against the index (no HEAD,
+        // no --cached), so the staged and unstaged rows of one file differ.
+        assert_eq!(
+            build_diff_args("a.txt", false, false),
+            vec!["diff", "--", "a.txt"]
+        );
+    }
+
+    #[test]
+    fn test_classify_discard_action_untracked() {
+        assert_eq!(
+            classify_discard_action("?? new.txt"),
+            DiscardAction::DeleteUntracked
+        );
+    }
+
+    #[test]
+    fn test_classify_discard_action_added_reverts_worktree() {
+        // A staged-added file with no worktree change reverts the worktree only;
+        // git checkout -- <path> is a safe no-op that never deletes staged content.
+        assert_eq!(
+            classify_discard_action("A  added.txt"),
+            DiscardAction::RevertWorktree
+        );
+    }
+
+    #[test]
+    fn test_classify_discard_action_modified_variants_revert_worktree() {
+        // Worktree-modified, staged-modified, MM, and deleted all revert the
+        // working tree to the index without touching staged content.
+        assert_eq!(
+            classify_discard_action(" M mod.txt"),
+            DiscardAction::RevertWorktree
+        );
+        assert_eq!(
+            classify_discard_action("M  staged.txt"),
+            DiscardAction::RevertWorktree
+        );
+        assert_eq!(
+            classify_discard_action("MM both.txt"),
+            DiscardAction::RevertWorktree
+        );
+        assert_eq!(
+            classify_discard_action(" D del.txt"),
+            DiscardAction::RevertWorktree
+        );
+    }
+
+    #[test]
+    fn test_classify_discard_action_empty_is_noop() {
+        assert_eq!(classify_discard_action(""), DiscardAction::Noop);
+        assert_eq!(classify_discard_action("   "), DiscardAction::Noop);
+    }
+
+    #[test]
+    fn test_is_safe_relative_path() {
+        assert!(is_safe_relative_path("src/main.rs"));
+        assert!(is_safe_relative_path("a.txt"));
+        assert!(is_safe_relative_path("dir/sub/file"));
+        // Traversal and absolute / drive-rooted paths are rejected.
+        assert!(!is_safe_relative_path("../escape.txt"));
+        assert!(!is_safe_relative_path("a/../../b"));
+        assert!(!is_safe_relative_path("/etc/passwd"));
+        #[cfg(target_os = "windows")]
+        {
+            assert!(!is_safe_relative_path("C:\\Windows\\x"));
+            assert!(!is_safe_relative_path("\\\\server\\share"));
+        }
+    }
+
+    #[test]
     fn test_parse_git_status_empty() {
         let status = GitTracker::parse_git_status("");
         assert_eq!(status.modified, 0);
@@ -1352,5 +1579,196 @@ mod tests {
             Instant::now().duration_since(state.last_checked)
                 < Duration::from_millis(POLL_INTERVAL_MS)
         );
+    }
+
+    // ---- Integration tests for stage / unstage / discard against real repos ----
+
+    fn unique_temp_dir(tag: &str) -> std::path::PathBuf {
+        use std::sync::atomic::{AtomicU32, Ordering};
+        static COUNTER: AtomicU32 = AtomicU32::new(0);
+        let n = COUNTER.fetch_add(1, Ordering::SeqCst);
+        let pid = std::process::id();
+        let nanos = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_nanos())
+            .unwrap_or(0);
+        let dir = std::env::temp_dir().join(format!("termul-git-it-{tag}-{pid}-{n}-{nanos}"));
+        std::fs::create_dir_all(&dir).expect("create temp dir");
+        dir
+    }
+
+    fn git(cwd: &std::path::Path, args: &[&str]) -> std::process::Output {
+        let out = GitTracker::run_git_command(cwd.to_str().unwrap(), args)
+            .expect("git command should run");
+        assert!(
+            out.status.success(),
+            "git {:?} failed: {}",
+            args,
+            String::from_utf8_lossy(&out.stderr)
+        );
+        out
+    }
+
+    /// Init a repo with deterministic identity. Returns the repo path.
+    fn init_repo(tag: &str) -> std::path::PathBuf {
+        let dir = unique_temp_dir(tag);
+        git(&dir, &["init", "-q"]);
+        git(&dir, &["config", "user.email", "t@example.com"]);
+        git(&dir, &["config", "user.name", "Test"]);
+        git(&dir, &["config", "commit.gpgsign", "false"]);
+        // Keep line endings byte-exact so content assertions are deterministic
+        // across platforms (Windows git defaults can rewrite LF -> CRLF).
+        git(&dir, &["config", "core.autocrlf", "false"]);
+        dir
+    }
+
+    fn porcelain(cwd: &std::path::Path, path: &str) -> String {
+        let out = git(cwd, &["status", "--porcelain", "--", path]);
+        String::from_utf8_lossy(&out.stdout).to_string()
+    }
+
+    /// Skip the test body (returning true) when git is unavailable in the env.
+    fn git_missing() -> bool {
+        GitTracker::run_git_command(std::env::temp_dir().to_str().unwrap(), &["--version"]).is_none()
+    }
+
+    #[test]
+    fn it_stage_then_unstage_modified_file_roundtrips() {
+        if git_missing() {
+            return;
+        }
+        let repo = init_repo("stage-unstage");
+        std::fs::write(repo.join("a.txt"), "one\n").unwrap();
+        git(&repo, &["add", "-A"]);
+        git(&repo, &["commit", "-qm", "init"]);
+        std::fs::write(repo.join("a.txt"), "one\ntwo\n").unwrap();
+
+        let cwd = repo.to_str().unwrap();
+        git_stage_file(cwd, "a.txt").unwrap();
+        assert!(porcelain(&repo, "a.txt").starts_with("M "), "should be staged");
+
+        git_unstage_file(cwd, "a.txt").unwrap();
+        assert!(
+            porcelain(&repo, "a.txt").starts_with(" M"),
+            "should be unstaged but still modified"
+        );
+        std::fs::remove_dir_all(&repo).ok();
+    }
+
+    #[test]
+    fn it_unstage_preserves_worktree_on_staged_modified_file() {
+        if git_missing() {
+            return;
+        }
+        let repo = init_repo("unstage-preserve");
+        std::fs::write(repo.join("a.txt"), "one\n").unwrap();
+        git(&repo, &["add", "-A"]);
+        git(&repo, &["commit", "-qm", "init"]);
+        std::fs::write(repo.join("a.txt"), "changed\n").unwrap();
+        git(&repo, &["add", "--", "a.txt"]);
+
+        // Unstage must NOT delete or revert the working-tree content.
+        git_unstage_file(repo.to_str().unwrap(), "a.txt").unwrap();
+        assert_eq!(std::fs::read_to_string(repo.join("a.txt")).unwrap(), "changed\n");
+        assert!(porcelain(&repo, "a.txt").starts_with(" M"));
+        std::fs::remove_dir_all(&repo).ok();
+    }
+
+    #[test]
+    fn it_unstage_no_head_repo_removes_from_index_keeps_file() {
+        if git_missing() {
+            return;
+        }
+        let repo = init_repo("unstage-nohead");
+        std::fs::write(repo.join("a.txt"), "x\n").unwrap();
+        git(&repo, &["add", "--", "a.txt"]); // staged-added, no commit -> no HEAD
+        assert!(!repo_has_head(repo.to_str().unwrap()));
+
+        git_unstage_file(repo.to_str().unwrap(), "a.txt").unwrap();
+        // File stays on disk, now untracked.
+        assert!(repo.join("a.txt").exists());
+        assert!(porcelain(&repo, "a.txt").starts_with("??"));
+        std::fs::remove_dir_all(&repo).ok();
+    }
+
+    #[test]
+    fn it_discard_reverts_tracked_modification_to_index() {
+        if git_missing() {
+            return;
+        }
+        let repo = init_repo("discard-modified");
+        std::fs::write(repo.join("a.txt"), "orig\n").unwrap();
+        git(&repo, &["add", "-A"]);
+        git(&repo, &["commit", "-qm", "init"]);
+        std::fs::write(repo.join("a.txt"), "dirty\n").unwrap();
+
+        git_discard_file(repo.to_str().unwrap(), "a.txt").unwrap();
+        assert_eq!(std::fs::read_to_string(repo.join("a.txt")).unwrap(), "orig\n");
+        assert!(porcelain(&repo, "a.txt").is_empty(), "clean after discard");
+        std::fs::remove_dir_all(&repo).ok();
+    }
+
+    #[test]
+    fn it_discard_staged_row_of_mm_file_preserves_staged_content() {
+        if git_missing() {
+            return;
+        }
+        // MM: staged edit + further worktree edit. Discard reverts the worktree
+        // to the index and must keep the staged edit intact.
+        let repo = init_repo("discard-mm");
+        std::fs::write(repo.join("a.txt"), "orig\n").unwrap();
+        git(&repo, &["add", "-A"]);
+        git(&repo, &["commit", "-qm", "init"]);
+        std::fs::write(repo.join("a.txt"), "staged\n").unwrap();
+        git(&repo, &["add", "--", "a.txt"]);
+        std::fs::write(repo.join("a.txt"), "staged-plus-worktree\n").unwrap();
+        assert!(porcelain(&repo, "a.txt").starts_with("MM"));
+
+        git_discard_file(repo.to_str().unwrap(), "a.txt").unwrap();
+        // Worktree reverts to the staged (index) version, not HEAD.
+        assert_eq!(std::fs::read_to_string(repo.join("a.txt")).unwrap(), "staged\n");
+        assert!(porcelain(&repo, "a.txt").starts_with("M "));
+        std::fs::remove_dir_all(&repo).ok();
+    }
+
+    #[test]
+    fn it_discard_untracked_file_deletes_it() {
+        if git_missing() {
+            return;
+        }
+        let repo = init_repo("discard-untracked");
+        std::fs::write(repo.join("n.txt"), "new\n").unwrap();
+        assert!(porcelain(&repo, "n.txt").starts_with("??"));
+
+        git_discard_file(repo.to_str().unwrap(), "n.txt").unwrap();
+        assert!(!repo.join("n.txt").exists());
+        std::fs::remove_dir_all(&repo).ok();
+    }
+
+    #[test]
+    fn it_discard_untracked_directory_deletes_it() {
+        if git_missing() {
+            return;
+        }
+        let repo = init_repo("discard-untracked-dir");
+        std::fs::create_dir_all(repo.join("sub")).unwrap();
+        std::fs::write(repo.join("sub/inner.txt"), "x\n").unwrap();
+        // Porcelain collapses the untracked dir to "?? sub/".
+        assert!(porcelain(&repo, "sub").starts_with("??"));
+
+        git_discard_file(repo.to_str().unwrap(), "sub").unwrap();
+        assert!(!repo.join("sub").exists());
+        std::fs::remove_dir_all(&repo).ok();
+    }
+
+    #[test]
+    fn it_discard_already_missing_untracked_is_ok() {
+        if git_missing() {
+            return;
+        }
+        let repo = init_repo("discard-missing");
+        // No such file; classified clean -> Noop, must not error.
+        git_discard_file(repo.to_str().unwrap(), "ghost.txt").unwrap();
+        std::fs::remove_dir_all(&repo).ok();
     }
 }

--- a/src/renderer/components/git/GitPanel.tsx
+++ b/src/renderer/components/git/GitPanel.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState, useMemo } from "react";
-import { useGitStatusStore } from "@/stores/git-status-store";
+import { useGitStatusStore, diffKey } from "@/stores/git-status-store";
 import { cn } from "@/lib/utils";
 import { 
   FileCode, 
@@ -12,11 +12,12 @@ import {
   ChevronDown,
   GitBranch,
   RefreshCw,
-  Search
+  Search,
+  Undo2
 } from "lucide-react";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { Button } from "@/components/ui/button";
-import { gitApi } from "@/lib/git-api";
+import { ConfirmDialog } from "@/components/ConfirmDialog";
 import { toast } from "sonner";
 import { GitFileStatus, GitStatusDetail } from "@shared/types/ipc.types";
 
@@ -32,11 +33,21 @@ export function GitPanel({ cwd, isVisible }: GitPanelProps) {
   const setSelectedFile = useGitStatusStore((state) => state.setSelectedFile);
   const refreshStatus = useGitStatusStore((state) => state.refreshStatus);
   const fetchDiff = useGitStatusStore((state) => state.fetchDiff);
+  const stageFile = useGitStatusStore((state) => state.stageFile);
+  const unstageFile = useGitStatusStore((state) => state.unstageFile);
+  const discardFile = useGitStatusStore((state) => state.discardFile);
   const isFetchingStatus = useGitStatusStore((state) => state.isFetchingStatus);
 
   const [searchQuery, setSearchQuery] = useState("");
-  
-  const currentDiff = selectedFile ? diffs[`${cwd}:${selectedFile}`] : null;
+  // Track which side (staged vs unstaged) of the selected path is shown, since
+  // an `MM` file appears in both sections under the same path.
+  const [selectedStaged, setSelectedStaged] = useState(false);
+  const [isMutating, setIsMutating] = useState(false);
+  const [confirmDiscardOpen, setConfirmDiscardOpen] = useState(false);
+
+  const currentDiff = selectedFile
+    ? diffs[diffKey(cwd, selectedFile, selectedStaged)]
+    : null;
 
   useEffect(() => {
     if (isVisible) {
@@ -49,11 +60,11 @@ export function GitPanel({ cwd, isVisible }: GitPanelProps) {
       return;
     }
 
-    const key = `${cwd}:${selectedFile}`;
+    const key = diffKey(cwd, selectedFile, selectedStaged);
     if (!Object.prototype.hasOwnProperty.call(diffs, key)) {
-      fetchDiff(cwd, selectedFile);
+      fetchDiff(cwd, selectedFile, selectedStaged);
     }
-  }, [isVisible, selectedFile, cwd, diffs, fetchDiff]);
+  }, [isVisible, selectedFile, selectedStaged, cwd, diffs, fetchDiff]);
 
   const filteredStatuses = useMemo(() => {
     const currentStatuses = statuses[cwd] || [];
@@ -69,9 +80,58 @@ export function GitPanel({ cwd, isVisible }: GitPanelProps) {
     return { stagedFiles: staged, unstagedFiles: unstaged };
   }, [filteredStatuses]);
 
-  const handleFileClick = (path: string) => {
+  const handleFileClick = (path: string, staged: boolean) => {
     setSelectedFile(path);
-    fetchDiff(cwd, path);
+    setSelectedStaged(staged);
+    fetchDiff(cwd, path, staged);
+  };
+
+  const handleStage = async () => {
+    if (!selectedFile) return;
+    setIsMutating(true);
+    try {
+      await stageFile(cwd, selectedFile);
+      setSelectedStaged(true);
+    } catch (error) {
+      toast.error(`Failed to stage file: ${String(error)}`);
+    } finally {
+      setIsMutating(false);
+    }
+  };
+
+  const handleUnstage = async () => {
+    if (!selectedFile) return;
+    setIsMutating(true);
+    try {
+      await unstageFile(cwd, selectedFile);
+      setSelectedStaged(false);
+    } catch (error) {
+      toast.error(`Failed to unstage file: ${String(error)}`);
+    } finally {
+      setIsMutating(false);
+    }
+  };
+
+  const handleDiscard = () => {
+    if (!selectedFile) return;
+    // Use the app's ConfirmDialog rather than window.confirm, which is
+    // unreliable inside the Tauri webview and bypasses the app's styling.
+    setConfirmDiscardOpen(true);
+  };
+
+  const confirmDiscard = async () => {
+    if (!selectedFile) return;
+    setIsMutating(true);
+    try {
+      await discardFile(cwd, selectedFile);
+      setSelectedFile(null);
+      setSelectedStaged(false);
+    } catch (error) {
+      toast.error(`Failed to discard changes: ${String(error)}`);
+    } finally {
+      setIsMutating(false);
+      setConfirmDiscardOpen(false);
+    }
   };
 
   const getFileIcon = (status: GitFileStatus) => {
@@ -122,8 +182,8 @@ export function GitPanel({ cwd, isVisible }: GitPanelProps) {
                   <FileItem 
                     key={file.path} 
                     file={file} 
-                    isSelected={selectedFile === file.path}
-                    onClick={() => handleFileClick(file.path)}
+                    isSelected={selectedFile === file.path && selectedStaged}
+                    onClick={() => handleFileClick(file.path, true)}
                     icon={getFileIcon(file.status)}
                   />
                 ))}
@@ -144,8 +204,8 @@ export function GitPanel({ cwd, isVisible }: GitPanelProps) {
                   <FileItem 
                     key={file.path} 
                     file={file} 
-                    isSelected={selectedFile === file.path}
-                    onClick={() => handleFileClick(file.path)}
+                    isSelected={selectedFile === file.path && !selectedStaged}
+                    onClick={() => handleFileClick(file.path, false)}
                     icon={getFileIcon(file.status)}
                   />
                 ))
@@ -165,12 +225,42 @@ export function GitPanel({ cwd, isVisible }: GitPanelProps) {
                 <span className="text-sm font-medium truncate">{selectedFile}</span>
               </div>
               <div className="flex items-center gap-2">
-                <Button variant="outline" size="sm" className="h-8 text-xs gap-2" disabled aria-disabled="true" title="Not implemented yet">
-                   Discard
+                <Button
+                  variant="outline"
+                  size="sm"
+                  className="h-8 text-xs gap-2"
+                  onClick={handleDiscard}
+                  disabled={isMutating}
+                  title="Discard changes to this file"
+                >
+                  <RotateCcw size={14} />
+                  Discard
                 </Button>
-                <Button variant="default" size="sm" className="h-8 text-xs gap-2" disabled aria-disabled="true" title="Not implemented yet">
-                   Stage
-                </Button>
+                {selectedStaged ? (
+                  <Button
+                    variant="default"
+                    size="sm"
+                    className="h-8 text-xs gap-2"
+                    onClick={handleUnstage}
+                    disabled={isMutating}
+                    title="Unstage this file"
+                  >
+                    <Undo2 size={14} />
+                    Unstage
+                  </Button>
+                ) : (
+                  <Button
+                    variant="default"
+                    size="sm"
+                    className="h-8 text-xs gap-2"
+                    onClick={handleStage}
+                    disabled={isMutating}
+                    title="Stage this file"
+                  >
+                    <Check size={14} />
+                    Stage
+                  </Button>
+                )}
               </div>
             </div>
             <ScrollArea className="flex-1 font-mono text-xs">
@@ -226,6 +316,21 @@ export function GitPanel({ cwd, isVisible }: GitPanelProps) {
           </div>
         )}
       </div>
+
+      <ConfirmDialog
+        isOpen={confirmDiscardOpen}
+        variant="danger"
+        title="Discard changes"
+        message={
+          selectedFile
+            ? `Discard changes to "${selectedFile}"? This cannot be undone.`
+            : ""
+        }
+        confirmLabel="Discard"
+        isLoading={isMutating}
+        onConfirm={confirmDiscard}
+        onCancel={() => setConfirmDiscardOpen(false)}
+      />
     </div>
   );
 }

--- a/src/renderer/components/git/GitPanel.tsx
+++ b/src/renderer/components/git/GitPanel.tsx
@@ -81,9 +81,10 @@ export function GitPanel({ cwd, isVisible }: GitPanelProps) {
   }, [filteredStatuses]);
 
   const handleFileClick = (path: string, staged: boolean) => {
+    // Only update selection; the effect below is the single source of truth for
+    // fetching the diff, which avoids a duplicate request on click.
     setSelectedFile(path);
     setSelectedStaged(staged);
-    fetchDiff(cwd, path, staged);
   };
 
   const handleStage = async () => {
@@ -114,6 +115,9 @@ export function GitPanel({ cwd, isVisible }: GitPanelProps) {
 
   const handleDiscard = () => {
     if (!selectedFile) return;
+    // Discard only reverts unstaged (working-tree) changes via `git checkout`.
+    // Staged content is not affected, so block the action on staged rows.
+    if (selectedStaged) return;
     // Use the app's ConfirmDialog rather than window.confirm, which is
     // unreliable inside the Tauri webview and bypasses the app's styling.
     setConfirmDiscardOpen(true);
@@ -230,8 +234,12 @@ export function GitPanel({ cwd, isVisible }: GitPanelProps) {
                   size="sm"
                   className="h-8 text-xs gap-2"
                   onClick={handleDiscard}
-                  disabled={isMutating}
-                  title="Discard changes to this file"
+                  disabled={isMutating || selectedStaged}
+                  title={
+                    selectedStaged
+                      ? "Unstage first to discard — Discard only reverts unstaged (working-tree) changes"
+                      : "Discard unstaged changes to this file"
+                  }
                 >
                   <RotateCcw size={14} />
                   Discard

--- a/src/renderer/lib/git-api.ts
+++ b/src/renderer/lib/git-api.ts
@@ -2,9 +2,18 @@ import { invoke } from "@tauri-apps/api/core";
 import { GitStatusDetail } from "@shared/types/ipc.types";
 
 export const gitApi = {
-  getStatus: (cwd: string) => 
+  getStatus: (cwd: string) =>
     invoke<GitStatusDetail[]>("git_get_status", { cwd }),
-    
-  getDiff: (cwd: string, path: string) => 
-    invoke<string>("git_get_diff", { cwd, path }),
+
+  getDiff: (cwd: string, path: string, staged = false) =>
+    invoke<string>("git_get_diff", { cwd, path, staged }),
+
+  stage: (cwd: string, path: string) =>
+    invoke<void>("git_stage", { cwd, path }),
+
+  unstage: (cwd: string, path: string) =>
+    invoke<void>("git_unstage", { cwd, path }),
+
+  discard: (cwd: string, path: string) =>
+    invoke<void>("git_discard", { cwd, path }),
 };

--- a/src/renderer/stores/git-status-store.ts
+++ b/src/renderer/stores/git-status-store.ts
@@ -1,19 +1,28 @@
 import { create } from "zustand";
+import { toast } from "sonner";
 import { gitApi } from "@/lib/git-api";
 import { GitStatusDetail } from "@shared/types/ipc.types";
+
+/** Build the staged-aware diff cache key so the staged and unstaged rows of the
+ * same file (porcelain `MM`) do not collide. */
+export const diffKey = (cwd: string, path: string, staged: boolean) =>
+  `${cwd}:${path}:${staged}`;
 
 export interface GitStatusState {
   // statuses[cwd] = GitStatusDetail[]
   statuses: Record<string, GitStatusDetail[]>;
-  // diffs["cwd:path"] = string
+  // diffs["cwd:path:staged"] = string
   diffs: Record<string, string>;
   selectedFile: string | null;
   isFetchingStatus: boolean;
   statusFetchCount: number;
-  
+
   setSelectedFile: (path: string | null) => void;
   refreshStatus: (cwd: string) => Promise<void>;
-  fetchDiff: (cwd: string, path: string) => Promise<void>;
+  fetchDiff: (cwd: string, path: string, staged: boolean) => Promise<void>;
+  stageFile: (cwd: string, path: string) => Promise<void>;
+  unstageFile: (cwd: string, path: string) => Promise<void>;
+  discardFile: (cwd: string, path: string) => Promise<void>;
 }
 
 export const useGitStatusStore = create<GitStatusState>((set, get) => ({
@@ -46,15 +55,54 @@ export const useGitStatusStore = create<GitStatusState>((set, get) => ({
     }
   },
 
-  fetchDiff: async (cwd, path) => {
-    const diffKey = `${cwd}:${path}`;
+  fetchDiff: async (cwd, path, staged) => {
+    const key = diffKey(cwd, path, staged);
     try {
-      const diff = await gitApi.getDiff(cwd, path);
+      const diff = await gitApi.getDiff(cwd, path, staged);
       set((state) => ({
-        diffs: { ...state.diffs, [diffKey]: diff }
+        diffs: { ...state.diffs, [key]: diff }
       }));
     } catch (error) {
       console.error("Failed to fetch diff:", error);
+      // Write an empty sentinel so the panel stops retrying on every render and
+      // shows the "no diff available" state instead of an infinite spinner.
+      set((state) => ({
+        diffs: { ...state.diffs, [key]: "" }
+      }));
+      toast.error(`Failed to load diff: ${String(error)}`);
     }
   },
+
+  stageFile: async (cwd, path) => {
+    await gitApi.stage(cwd, path);
+    invalidateFileDiffs(set, cwd, path);
+    await get().refreshStatus(cwd);
+  },
+
+  unstageFile: async (cwd, path) => {
+    await gitApi.unstage(cwd, path);
+    invalidateFileDiffs(set, cwd, path);
+    await get().refreshStatus(cwd);
+  },
+
+  discardFile: async (cwd, path) => {
+    await gitApi.discard(cwd, path);
+    invalidateFileDiffs(set, cwd, path);
+    await get().refreshStatus(cwd);
+  },
 }));
+
+/** Drop cached staged and unstaged diffs for a file after it mutates so the
+ * panel refetches the now-current diff instead of showing a stale one. */
+function invalidateFileDiffs(
+  set: (fn: (state: GitStatusState) => Partial<GitStatusState>) => void,
+  cwd: string,
+  path: string,
+) {
+  set((state) => {
+    const diffs = { ...state.diffs };
+    delete diffs[diffKey(cwd, path, true)];
+    delete diffs[diffKey(cwd, path, false)];
+    return { diffs };
+  });
+}

--- a/src/renderer/stores/git-status-store.ts
+++ b/src/renderer/stores/git-status-store.ts
@@ -57,13 +57,20 @@ export const useGitStatusStore = create<GitStatusState>((set, get) => ({
 
   fetchDiff: async (cwd, path, staged) => {
     const key = diffKey(cwd, path, staged);
+    // Capture the request token before awaiting so a mutation that invalidates
+    // this key while the fetch is in flight causes the late response to be
+    // discarded instead of overwriting the cache with a stale diff.
+    const token = diffRequestVersions[key] ?? 0;
+    const isCurrent = () => (diffRequestVersions[key] ?? 0) === token;
     try {
       const diff = await gitApi.getDiff(cwd, path, staged);
+      if (!isCurrent()) return;
       set((state) => ({
         diffs: { ...state.diffs, [key]: diff }
       }));
     } catch (error) {
       console.error("Failed to fetch diff:", error);
+      if (!isCurrent()) return;
       // Write an empty sentinel so the panel stops retrying on every render and
       // shows the "no diff available" state instead of an infinite spinner.
       set((state) => ({
@@ -92,17 +99,31 @@ export const useGitStatusStore = create<GitStatusState>((set, get) => ({
   },
 }));
 
+/** Monotonic request token per diff key. Bumped whenever a key is invalidated
+ * so an in-flight `fetchDiff` can detect it has been superseded. Kept outside
+ * React state because it is control metadata, not render data. */
+const diffRequestVersions: Record<string, number> = {};
+
+function bumpDiffVersion(key: string) {
+  diffRequestVersions[key] = (diffRequestVersions[key] ?? 0) + 1;
+}
+
 /** Drop cached staged and unstaged diffs for a file after it mutates so the
- * panel refetches the now-current diff instead of showing a stale one. */
+ * panel refetches the now-current diff instead of showing a stale one. Also
+ * bumps each key's request token to discard any in-flight fetch. */
 function invalidateFileDiffs(
   set: (fn: (state: GitStatusState) => Partial<GitStatusState>) => void,
   cwd: string,
   path: string,
 ) {
+  const stagedKey = diffKey(cwd, path, true);
+  const unstagedKey = diffKey(cwd, path, false);
+  bumpDiffVersion(stagedKey);
+  bumpDiffVersion(unstagedKey);
   set((state) => {
     const diffs = { ...state.diffs };
-    delete diffs[diffKey(cwd, path, true)];
-    delete diffs[diffKey(cwd, path, false)];
+    delete diffs[stagedKey];
+    delete diffs[unstagedKey];
     return { diffs };
   });
 }

--- a/src/shared/types/ipc.types.ts
+++ b/src/shared/types/ipc.types.ts
@@ -79,7 +79,10 @@ export interface GitStatusDetail {
 
 export interface GitApi {
 	getStatus: (cwd: string) => Promise<GitStatusDetail[]>;
-	getDiff: (cwd: string, path: string) => Promise<string>;
+	getDiff: (cwd: string, path: string, staged?: boolean) => Promise<string>;
+	stage: (cwd: string, path: string) => Promise<void>;
+	unstage: (cwd: string, path: string) => Promise<void>;
+	discard: (cwd: string, path: string) => Promise<void>;
 }
 
 // Terminal API exposed via preload


### PR DESCRIPTION
## Summary

- Implement Git panel staging, unstaging, and discard, and fix staged-vs-unstaged diffs showing identical output.

## Related Issue

Closes #

<!-- No tracked issue; reported directly: the Git panel Stage button did nothing (buttons were hard-disabled with "Not implemented yet" and no backend command existed). -->

## Type of Change

- [x] feat: new feature
- [ ] fix: bug fix
- [ ] docs: documentation only
- [ ] style: formatting or non-functional styling changes
- [ ] refactor: internal cleanup with no behavior change
- [ ] perf: performance improvement
- [ ] test: adds or updates tests
- [ ] build: build or dependency changes
- [ ] ci: CI/CD workflow changes
- [ ] chore: maintenance or tooling
- [ ] revert: reverts a previous change

## What Changed

The Git panel was read-only: the Stage and Discard buttons were hard-coded `disabled` with "Not implemented yet", and the Rust backend exposed only `git_get_status` / `git_get_diff`. Separately, `git_get_diff` always ran `git diff HEAD`, so the staged and unstaged rows of the same file showed an identical combined diff.

Backend (`src-tauri`):
- `git_stage_file` (`git add -- <path>`), `git_unstage_file` (`git reset -q HEAD -- <path>`, with a no-HEAD `git rm --cached` fallback), and `git_discard_file` (untracked → delete file/dir; tracked → `git checkout -- <path>` worktree revert that preserves staged content; clean/unknown → no-op).
- `staged` flag on `git_get_diff` selecting `git diff --cached` for staged rows.
- Path-safety guard on filesystem deletes; all git calls use argument vectors (no shell interpolation) through the existing runner.
- Registered `git_stage` / `git_unstage` / `git_discard` commands.

Frontend (`src/renderer`):
- Typed `stage` / `unstage` / `discard` invokers and a `staged` arg on `getDiff`.
- Staged-aware diff cache key (`cwd:path:staged`) so the two rows of an `MM` file no longer collide.
- Mutation actions invalidate both diff keys then refresh status.
- `fetchDiff` surfaces errors via toast + empty sentinel instead of silently swallowing (no blank-panel retry loop).
- Buttons enabled (Stage for unstaged rows, Unstage for staged rows), with confirm-before-discard using the app's `ConfirmDialog`.

## How It Was Tested

- [x] `bun run lint`
- [x] `bun run typecheck`
- [x] `bun run test`
- [x] Manual verification completed
- [ ] Not applicable

Details:
- `cargo test git` — 50 git tests pass, including 8 new integration tests against real temp repos (stage/unstage roundtrip, unstage worktree preservation, no-HEAD unstage, discard of modified/`MM`/untracked-file/untracked-dir/already-missing) and path-safety unit tests.
- `cargo build` + `cargo clippy --lib` clean.
- `bun run typecheck` (node + web) clean; `bun run lint` passes (0 errors; remaining warnings are pre-existing files untouched by this PR).
- `bun run test` — 1193 frontend tests pass.

## Screenshots or Recordings

<!-- UI change: Stage/Unstage/Discard now function in the Git panel. -->

## Checklist

- [x] My PR title follows the conventional commit format used by this repo
- [x] I linked the related issue or explained why none exists
- [ ] I updated docs when needed
- [x] I added or updated tests when needed
- [x] I verified the change does not introduce unrelated modifications

<!-- Note: src-tauri/Cargo.lock picked up a `keyring` entry that was already declared in Cargo.toml but missing from the lock; building regenerated it. No new dependency was added. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Stage and unstage files from the Git panel.
  * Destructive discard action with confirmation to remove or revert file changes.
  * Diff viewer can toggle between staged and unstaged views per file.
  * Git panel buttons now perform Stage / Unstage / Discard with loading and error feedback.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gnoviawan/termul/pull/190?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->