### PR TITLE
fix(updater): repair auto-update download/install flow with confirm-before-restart

### DIFF
--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -25,6 +25,7 @@
     "fs:allow-write-text-file",
     "fs:allow-read-dir",
     "fs:allow-mkdir",
+    "fs:allow-copy-file",
     "fs:allow-remove",
     "fs:allow-rename",
     "fs:allow-stat",

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -57,6 +57,8 @@
     "clipboard-manager:allow-write-text",
     "clipboard-manager:allow-read-image",
     "updater:allow-check",
+    "updater:allow-download",
+    "updater:allow-install",
     "updater:allow-download-and-install",
     "process:allow-restart",
     "shell:default",

--- a/src/renderer/components/UpdateAvailableToast.test.tsx
+++ b/src/renderer/components/UpdateAvailableToast.test.tsx
@@ -1,0 +1,108 @@
+/**
+ * Unit tests for UpdateAvailableToast download/install error surfacing.
+ *
+ * Regression coverage for the silent-failure bug: clicking Download or
+ * Restart in the toast must surface store errors via toast.error instead of
+ * doing nothing visible. Success paths must NOT show an error toast.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+vi.mock('sonner', () => ({
+  toast: Object.assign(vi.fn(), {
+    success: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+    loading: vi.fn(),
+    dismiss: vi.fn()
+  })
+}))
+
+const downloadUpdate = vi.fn(async () => {})
+const installAndRestart = vi.fn(async () => {})
+let storeError: string | null = null
+
+vi.mock('@/stores/updater-store', () => ({
+  updaterStore: {
+    getState: () => ({ downloadUpdate, installAndRestart, error: storeError })
+  },
+  // Hooks are unused by the functions under test but imported by the module.
+  useUpdaterState: vi.fn(),
+  useUpdaterActions: vi.fn(),
+  useUpdateVersion: vi.fn(),
+  useUpdateDownloaded: vi.fn(),
+  useIsDownloading: vi.fn(),
+  useDownloadProgress: vi.fn()
+}))
+
+vi.mock('@/lib/tauri-updater-api', () => ({
+  isAurUpdateMode: vi.fn(() => false)
+}))
+
+import { toast } from 'sonner'
+import { showUpdateToast, showUpdateDownloadedToast } from './UpdateAvailableToast'
+
+type ToastAction = { onClick: () => void | Promise<void> }
+
+function lastToastAction(mockFn: ReturnType<typeof vi.fn>): ToastAction {
+  const calls = mockFn.mock.calls
+  const opts = calls[calls.length - 1][1] as { action: ToastAction }
+  return opts.action
+}
+
+describe('UpdateAvailableToast error surfacing', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    storeError = null
+    downloadUpdate.mockResolvedValue(undefined)
+    installAndRestart.mockResolvedValue(undefined)
+  })
+
+  it('does not show an error toast when download succeeds', async () => {
+    showUpdateToast('0.3.8')
+    const action = lastToastAction(vi.mocked(toast.success))
+
+    await action.onClick()
+
+    expect(downloadUpdate).toHaveBeenCalledTimes(1)
+    expect(vi.mocked(toast.error)).not.toHaveBeenCalled()
+  })
+
+  it('shows an error toast when download fails (store error set)', async () => {
+    storeError = 'signature verification failed'
+    showUpdateToast('0.3.8')
+    const action = lastToastAction(vi.mocked(toast.success))
+
+    await action.onClick()
+
+    expect(downloadUpdate).toHaveBeenCalledTimes(1)
+    expect(vi.mocked(toast.error)).toHaveBeenCalledWith(
+      'Update download failed',
+      expect.objectContaining({ description: 'signature verification failed' })
+    )
+  })
+
+  it('shows an error toast when install/restart fails (store error set)', async () => {
+    storeError = 'relaunch failed'
+    showUpdateDownloadedToast('0.3.8')
+    const action = lastToastAction(vi.mocked(toast.success))
+
+    await action.onClick()
+
+    expect(installAndRestart).toHaveBeenCalledTimes(1)
+    expect(vi.mocked(toast.error)).toHaveBeenCalledWith(
+      'Update install failed',
+      expect.objectContaining({ description: 'relaunch failed' })
+    )
+  })
+
+  it('does not show an error toast when install/restart succeeds', async () => {
+    showUpdateDownloadedToast('0.3.8')
+    const action = lastToastAction(vi.mocked(toast.success))
+
+    await action.onClick()
+
+    expect(installAndRestart).toHaveBeenCalledTimes(1)
+    expect(vi.mocked(toast.error)).not.toHaveBeenCalled()
+  })
+})

--- a/src/renderer/components/UpdateAvailableToast.test.tsx
+++ b/src/renderer/components/UpdateAvailableToast.test.tsx
@@ -39,6 +39,16 @@ vi.mock('@/lib/tauri-updater-api', () => ({
   isAurUpdateMode: vi.fn(() => false)
 }))
 
+const confirmMock = vi.fn(async (_message: string, _options?: unknown) => true)
+vi.mock('@tauri-apps/plugin-dialog', () => ({
+  confirm: (message: string, options?: unknown) => confirmMock(message, options)
+}))
+
+const hasActiveTerminalSessions = vi.fn(() => false)
+vi.mock('@/lib/tauri-safe-update', () => ({
+  hasActiveTerminalSessions: () => hasActiveTerminalSessions()
+}))
+
 import { toast } from 'sonner'
 import { showUpdateToast, showUpdateDownloadedToast } from './UpdateAvailableToast'
 
@@ -56,6 +66,8 @@ describe('UpdateAvailableToast error surfacing', () => {
     storeError = null
     downloadUpdate.mockResolvedValue(undefined)
     installAndRestart.mockResolvedValue(undefined)
+    confirmMock.mockResolvedValue(true)
+    hasActiveTerminalSessions.mockReturnValue(false)
   })
 
   it('does not show an error toast when download succeeds', async () => {
@@ -89,6 +101,7 @@ describe('UpdateAvailableToast error surfacing', () => {
 
     await action.onClick()
 
+    expect(confirmMock).toHaveBeenCalledTimes(1)
     expect(installAndRestart).toHaveBeenCalledTimes(1)
     expect(vi.mocked(toast.error)).toHaveBeenCalledWith(
       'Update install failed',
@@ -102,7 +115,32 @@ describe('UpdateAvailableToast error surfacing', () => {
 
     await action.onClick()
 
+    expect(confirmMock).toHaveBeenCalledTimes(1)
     expect(installAndRestart).toHaveBeenCalledTimes(1)
     expect(vi.mocked(toast.error)).not.toHaveBeenCalled()
+  })
+
+  it('does not install when the user cancels the confirmation dialog', async () => {
+    confirmMock.mockResolvedValue(false)
+    showUpdateDownloadedToast('0.3.8')
+    const action = lastToastAction(vi.mocked(toast.success))
+
+    await action.onClick()
+
+    expect(confirmMock).toHaveBeenCalledTimes(1)
+    expect(installAndRestart).not.toHaveBeenCalled()
+    expect(vi.mocked(toast.error)).not.toHaveBeenCalled()
+  })
+
+  it('warns about active terminal sessions in the confirmation dialog', async () => {
+    hasActiveTerminalSessions.mockReturnValue(true)
+    showUpdateDownloadedToast('0.3.8')
+    const action = lastToastAction(vi.mocked(toast.success))
+
+    await action.onClick()
+
+    expect(confirmMock).toHaveBeenCalledTimes(1)
+    const message = confirmMock.mock.calls[0][0]
+    expect(message).toContain('terminal sessions')
   })
 })

--- a/src/renderer/components/UpdateAvailableToast.tsx
+++ b/src/renderer/components/UpdateAvailableToast.tsx
@@ -57,7 +57,7 @@ export function showUpdateToast(version: string, releaseNotes?: string): void {
           <span>{isAur ? 'Use yay' : 'Download'}</span>
         </div>
       ),
-      onClick: () => {
+      onClick: async () => {
         if (isAur) {
           toast.info('Run in terminal', {
             description: 'yay -S termul-manager'
@@ -66,7 +66,13 @@ export function showUpdateToast(version: string, releaseNotes?: string): void {
         }
 
         const { downloadUpdate } = updaterStore.getState()
-        downloadUpdate()
+        await downloadUpdate()
+        const downloadError = updaterStore.getState().error
+        if (downloadError) {
+          toast.error('Update download failed', {
+            description: downloadError
+          })
+        }
       }
     },
     cancel: {
@@ -97,9 +103,15 @@ export function showUpdateDownloadedToast(version: string): void {
           <span>Restart to Update</span>
         </div>
       ),
-      onClick: () => {
+      onClick: async () => {
         const { installAndRestart } = updaterStore.getState()
-        installAndRestart()
+        await installAndRestart()
+        const installError = updaterStore.getState().error
+        if (installError) {
+          toast.error('Update install failed', {
+            description: installError
+          })
+        }
       }
     }
   })

--- a/src/renderer/components/UpdateAvailableToast.tsx
+++ b/src/renderer/components/UpdateAvailableToast.tsx
@@ -68,11 +68,17 @@ export function showUpdateToast(version: string, releaseNotes?: string): void {
         }
 
         const { downloadUpdate } = updaterStore.getState()
-        await downloadUpdate()
-        const downloadError = updaterStore.getState().error
-        if (downloadError) {
+        try {
+          await downloadUpdate()
+          const downloadError = updaterStore.getState().error
+          if (downloadError) {
+            toast.error('Update download failed', {
+              description: downloadError
+            })
+          }
+        } catch (error) {
           toast.error('Update download failed', {
-            description: downloadError
+            description: error instanceof Error ? error.message : 'Unexpected error during download'
           })
         }
       }
@@ -106,21 +112,27 @@ export function showUpdateDownloadedToast(version: string): void {
         </div>
       ),
       onClick: async () => {
-        const hasActiveTerminals = hasActiveTerminalSessions()
-        const confirmed = await confirm(
-          hasActiveTerminals
-            ? `Termul will install version ${version} and restart. Your running terminal sessions will be closed. Continue?`
-            : `Termul will install version ${version} and restart now. Continue?`,
-          { title: 'Install update', kind: 'warning', okLabel: 'Install & Restart', cancelLabel: 'Not now' }
-        )
-        if (!confirmed) return
+        try {
+          const hasActiveTerminals = hasActiveTerminalSessions()
+          const confirmed = await confirm(
+            hasActiveTerminals
+              ? `Termul will install version ${version} and restart. Your running terminal sessions will be closed. Continue?`
+              : `Termul will install version ${version} and restart now. Continue?`,
+            { title: 'Install update', kind: 'warning', okLabel: 'Install & Restart', cancelLabel: 'Not now' }
+          )
+          if (!confirmed) return
 
-        const { installAndRestart } = updaterStore.getState()
-        await installAndRestart()
-        const installError = updaterStore.getState().error
-        if (installError) {
+          const { installAndRestart } = updaterStore.getState()
+          await installAndRestart()
+          const installError = updaterStore.getState().error
+          if (installError) {
+            toast.error('Update install failed', {
+              description: installError
+            })
+          }
+        } catch (error) {
           toast.error('Update install failed', {
-            description: installError
+            description: error instanceof Error ? error.message : 'Unexpected error during install'
           })
         }
       }

--- a/src/renderer/components/UpdateAvailableToast.tsx
+++ b/src/renderer/components/UpdateAvailableToast.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef } from 'react'
 import { toast } from 'sonner'
 import { Download, Terminal, Clock } from 'lucide-react'
+import { confirm } from '@tauri-apps/plugin-dialog'
 import {
   updaterStore,
   useUpdaterState,
@@ -11,6 +12,7 @@ import {
   useDownloadProgress
 } from '@/stores/updater-store'
 import { isAurUpdateMode } from '@/lib/tauri-updater-api'
+import { hasActiveTerminalSessions } from '@/lib/tauri-safe-update'
 
 // Local storage keys
 const UPDATE_REMINDER_KEY = 'update-reminder-timestamp'
@@ -93,17 +95,26 @@ export function showUpdateToast(version: string, releaseNotes?: string): void {
  * Show a toast notification when update is downloaded
  */
 export function showUpdateDownloadedToast(version: string): void {
-  toast.success(`Update ready to restart`, {
+  toast.success(`Update ready to install`, {
     duration: 30000,
-    description: `Version ${version} has been downloaded. Restart the app to finish applying the update.`,
+    description: `Version ${version} has been downloaded. Install now to apply it — the app will restart and any running terminal sessions will close.`,
     action: {
       label: (
         <div className="flex items-center gap-2">
           <Download size={14} />
-          <span>Restart to Update</span>
+          <span>Install &amp; Restart</span>
         </div>
       ),
       onClick: async () => {
+        const hasActiveTerminals = hasActiveTerminalSessions()
+        const confirmed = await confirm(
+          hasActiveTerminals
+            ? `Termul will install version ${version} and restart. Your running terminal sessions will be closed. Continue?`
+            : `Termul will install version ${version} and restart now. Continue?`,
+          { title: 'Install update', kind: 'warning', okLabel: 'Install & Restart', cancelLabel: 'Not now' }
+        )
+        if (!confirmed) return
+
         const { installAndRestart } = updaterStore.getState()
         await installAndRestart()
         const installError = updaterStore.getState().error

--- a/src/renderer/components/ui/sonner.tsx
+++ b/src/renderer/components/ui/sonner.tsx
@@ -33,19 +33,15 @@ const Toaster = ({ ...props }: ToasterProps) => {
       toastOptions={{
         classNames: {
           // Default (neutral) toast keeps the app's surface colour. Typed
-          // toasts (success / info / warning / error) opt out of
-          // bg-background so Sonner's richColors palette can show
-          // through — otherwise the only visible signal of severity is
-          // the close button tint, which defeats the point of
-          // richColors.
+          // toasts (success / info / warning / error) rely on Sonner's
+          // richColors palette for their tinted background. Do NOT force a
+          // background here: a `!bg-transparent` override beats richColors'
+          // own `background: var(--success-bg)` rule (Tailwind emits
+          // !important), leaving the toast see-through over the app.
           toast:
-            'group toast group-[.toaster]:bg-background group-[.toaster]:text-foreground group-[.toaster]:border-border group-[.toaster]:shadow-lg',
+            'group toast group-[.toaster]:text-foreground group-[.toaster]:border-border group-[.toaster]:shadow-lg',
           default:
             'group-[.toaster]:bg-background group-[.toaster]:text-foreground',
-          success: 'group-[.toaster]:!bg-transparent',
-          info: 'group-[.toaster]:!bg-transparent',
-          warning: 'group-[.toaster]:!bg-transparent',
-          error: 'group-[.toaster]:!bg-transparent',
           description: 'group-[.toast]:text-muted-foreground',
           actionButton: 'group-[.toast]:bg-primary group-[.toast]:text-primary-foreground',
           cancelButton: 'group-[.toast]:bg-muted group-[.toast]:text-muted-foreground'

--- a/src/renderer/lib/__tests__/tauri-backup-api.test.ts
+++ b/src/renderer/lib/__tests__/tauri-backup-api.test.ts
@@ -1,0 +1,97 @@
+/**
+ * Unit tests for tauri-backup-api.ts
+ *
+ * Focused on createBackup's directory-skip behavior: the backup must copy the
+ * userData directory while excluding both the `backups/` folder (its own
+ * destination) and the `versions/` rollback store, so backups stay small and
+ * cannot silently fail/block the updater download path.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import type { DirEntry } from '@tauri-apps/plugin-fs'
+
+vi.mock('@tauri-apps/api/path', () => ({
+  appDataDir: vi.fn(async () => '/appdata')
+}))
+
+vi.mock('@tauri-apps/plugin-store', () => ({
+  Store: {
+    load: vi.fn(async () => ({
+      get: vi.fn(async () => undefined),
+      set: vi.fn(async () => {}),
+      delete: vi.fn(async () => {}),
+      keys: vi.fn(async () => []),
+      save: vi.fn(async () => {})
+    }))
+  }
+}))
+
+vi.mock('@tauri-apps/plugin-fs', () => ({
+  readDir: vi.fn(async () => [] as DirEntry[]),
+  readTextFile: vi.fn(async () => ''),
+  writeTextFile: vi.fn(async () => {}),
+  copyFile: vi.fn(async () => {}),
+  remove: vi.fn(async () => {}),
+  mkdir: vi.fn(async () => {}),
+  rename: vi.fn(async () => {}),
+  stat: vi.fn(async () => ({ size: 0 }))
+}))
+
+import { readDir, copyFile, mkdir } from '@tauri-apps/plugin-fs'
+import { createBackup, _resetBackupStateForTesting } from '../tauri-backup-api'
+
+function dir(name: string): DirEntry {
+  return { name, isDirectory: true, isFile: false, isSymlink: false } as DirEntry
+}
+
+function file(name: string): DirEntry {
+  return { name, isDirectory: false, isFile: true, isSymlink: false } as DirEntry
+}
+
+describe('tauri-backup-api createBackup directory skipping', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    _resetBackupStateForTesting()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('skips the backups and versions directories but copies other content', async () => {
+    const topLevel: DirEntry[] = [
+      dir('backups'),
+      dir('versions'),
+      dir('projects'),
+      file('settings.json')
+    ]
+
+    // First readDir call enumerates the userData root; subsequent calls (size
+    // calc, file count, cleanup) read the freshly created backup tree.
+    vi.mocked(readDir).mockImplementation(async (path: string | URL) => {
+      const p = String(path)
+      if (p === '/appdata') return topLevel
+      return []
+    })
+
+    const result = await createBackup()
+
+    expect(result.success).toBe(true)
+
+    // The destination backup root is created via mkdir; the `projects` dir is
+    // recursively copied (its destination dir is created via mkdir), while
+    // `versions` is never recreated as a copy destination.
+    const mkdirPaths = vi.mocked(mkdir).mock.calls.map((c) => String(c[0]))
+    expect(mkdirPaths.some((p) => p.endsWith('/projects'))).toBe(true)
+    expect(mkdirPaths.some((p) => p.endsWith('/versions'))).toBe(false)
+
+    // The top-level file is copied; nothing under versions/ or backups/ is.
+    const copyDestPaths = vi.mocked(copyFile).mock.calls.map((c) => String(c[1]))
+    expect(copyDestPaths.some((p) => p.endsWith('/settings.json'))).toBe(true)
+    expect(copyDestPaths.some((p) => p.includes('/versions'))).toBe(false)
+
+    const copySrcPaths = vi.mocked(copyFile).mock.calls.map((c) => String(c[0]))
+    expect(copySrcPaths.some((p) => p.includes('/appdata/versions'))).toBe(false)
+    expect(copySrcPaths.some((p) => p.includes('/appdata/backups'))).toBe(false)
+  })
+})

--- a/src/renderer/lib/__tests__/tauri-updater-api.test.ts
+++ b/src/renderer/lib/__tests__/tauri-updater-api.test.ts
@@ -339,6 +339,31 @@ describe('tauri-updater-api', () => {
         code: 'INSTALL_FAILED'
       })
     })
+
+    it('preserves the downloaded update across a re-check of the same version', async () => {
+      const update = createMockUpdate('2.1.0')
+      vi.mocked(check).mockResolvedValue(update as never)
+      await checkForUpdates()
+
+      vi.mocked(update.download).mockImplementation(async () => {})
+      vi.mocked(update.install).mockResolvedValue(undefined)
+      await downloadUpdate()
+
+      // A periodic re-check returns the SAME version; the already-downloaded
+      // Update handle (and its bytes) must survive so install still works.
+      vi.mocked(check).mockResolvedValue(update as never)
+      await checkForUpdates()
+
+      vi.mocked(relaunch).mockResolvedValue(undefined)
+      const result = await installAndRestart()
+
+      expect(update.install).toHaveBeenCalledTimes(1)
+      expect(relaunch).toHaveBeenCalledTimes(1)
+      expect(vi.mocked(update.install).mock.invocationCallOrder[0]).toBeLessThan(
+        vi.mocked(relaunch).mock.invocationCallOrder[0]
+      )
+      expect(result).toEqual({ success: true, data: undefined })
+    })
   })
 
   describe('state and helpers', () => {

--- a/src/renderer/lib/__tests__/tauri-updater-api.test.ts
+++ b/src/renderer/lib/__tests__/tauri-updater-api.test.ts
@@ -55,6 +55,8 @@ function createMockUpdate(version: string, body?: string, date?: string) {
     version,
     body,
     date,
+    download: vi.fn(),
+    install: vi.fn(),
     downloadAndInstall: vi.fn()
   }
 }
@@ -192,7 +194,7 @@ describe('tauri-updater-api', () => {
       vi.mocked(check).mockResolvedValue(update as never)
       await checkForUpdates()
 
-      vi.mocked(update.downloadAndInstall).mockImplementation(
+      vi.mocked(update.download).mockImplementation(
         async (onEvent?: (event: DownloadEvent) => void) => {
           onEvent?.({ event: 'Started', data: { contentLength: 100 } })
           onEvent?.({ event: 'Progress', data: { chunkLength: 40 } })
@@ -209,11 +211,13 @@ describe('tauri-updater-api', () => {
       expect(result).toEqual({ success: true, data: undefined })
       expect(createBackup).toHaveBeenCalledTimes(1)
       expect(keepPreviousVersion).toHaveBeenCalledWith('0.2.3')
+      // Download must not install/restart the app on its own.
+      expect(update.install).not.toHaveBeenCalled()
       expect(vi.mocked(createBackup).mock.invocationCallOrder[0]).toBeLessThan(
-        vi.mocked(update.downloadAndInstall).mock.invocationCallOrder[0]
+        vi.mocked(update.download).mock.invocationCallOrder[0]
       )
       expect(vi.mocked(keepPreviousVersion).mock.invocationCallOrder[0]).toBeLessThan(
-        vi.mocked(update.downloadAndInstall).mock.invocationCallOrder[0]
+        vi.mocked(update.download).mock.invocationCallOrder[0]
       )
       expect(progressEvents[0]).toBe(0)
       expect(progressEvents).toContain(40)
@@ -232,7 +236,7 @@ describe('tauri-updater-api', () => {
       vi.mocked(check).mockResolvedValue(update as never)
       await checkForUpdates()
 
-      vi.mocked(update.downloadAndInstall).mockRejectedValue(new Error('download failed'))
+      vi.mocked(update.download).mockRejectedValue(new Error('download failed'))
 
       const result = await downloadUpdate()
 
@@ -256,7 +260,7 @@ describe('tauri-updater-api', () => {
 
       const result = await downloadUpdate()
 
-      expect(update.downloadAndInstall).not.toHaveBeenCalled()
+      expect(update.download).not.toHaveBeenCalled()
       expect(keepPreviousVersion).not.toHaveBeenCalled()
       expect(result).toEqual({
         success: false,
@@ -277,19 +281,44 @@ describe('tauri-updater-api', () => {
       })
     })
 
-    it('calls relaunch when update has been downloaded', async () => {
+    it('installs the downloaded package then relaunches', async () => {
       const update = createMockUpdate('2.1.0')
       vi.mocked(check).mockResolvedValue(update as never)
       await checkForUpdates()
 
-      vi.mocked(update.downloadAndInstall).mockImplementation(async () => {})
+      vi.mocked(update.download).mockImplementation(async () => {})
+      vi.mocked(update.install).mockResolvedValue(undefined)
       await downloadUpdate()
 
       vi.mocked(relaunch).mockResolvedValue(undefined)
       const result = await installAndRestart()
 
+      expect(update.install).toHaveBeenCalledTimes(1)
       expect(relaunch).toHaveBeenCalledTimes(1)
+      // install must run before relaunch.
+      expect(vi.mocked(update.install).mock.invocationCallOrder[0]).toBeLessThan(
+        vi.mocked(relaunch).mock.invocationCallOrder[0]
+      )
       expect(result).toEqual({ success: true, data: undefined })
+    })
+
+    it('returns INSTALL_FAILED when install throws', async () => {
+      const update = createMockUpdate('2.1.2')
+      vi.mocked(check).mockResolvedValue(update as never)
+      await checkForUpdates()
+
+      vi.mocked(update.download).mockImplementation(async () => {})
+      await downloadUpdate()
+
+      vi.mocked(update.install).mockRejectedValue(new Error('install failed'))
+      const result = await installAndRestart()
+
+      expect(relaunch).not.toHaveBeenCalled()
+      expect(result).toEqual({
+        success: false,
+        error: 'install failed',
+        code: 'INSTALL_FAILED'
+      })
     })
 
     it('returns INSTALL_FAILED when relaunch throws', async () => {
@@ -297,7 +326,8 @@ describe('tauri-updater-api', () => {
       vi.mocked(check).mockResolvedValue(update as never)
       await checkForUpdates()
 
-      vi.mocked(update.downloadAndInstall).mockImplementation(async () => {})
+      vi.mocked(update.download).mockImplementation(async () => {})
+      vi.mocked(update.install).mockResolvedValue(undefined)
       await downloadUpdate()
 
       vi.mocked(relaunch).mockRejectedValue(new Error('relaunch failed'))

--- a/src/renderer/lib/tauri-backup-api.ts
+++ b/src/renderer/lib/tauri-backup-api.ts
@@ -50,6 +50,31 @@ const MAX_BACKUPS = 3;
 const METADATA_STORE_FILE = 'backup-metadata.json';
 
 /**
+ * Extract a human-readable message from an unknown thrown value.
+ *
+ * Tauri plugin commands reject with plain strings (not Error instances), so a
+ * bare `err instanceof Error` check would discard the real reason and report
+ * "Unknown error". This normalizes Errors, strings, and serializable objects.
+ */
+function extractErrorMessage(err: unknown, fallback: string): string {
+  if (err instanceof Error && err.message.trim()) {
+    return err.message;
+  }
+  if (typeof err === 'string' && err.trim()) {
+    return err;
+  }
+  try {
+    const serialized = JSON.stringify(err);
+    if (serialized && serialized !== '{}' && serialized !== 'null') {
+      return serialized;
+    }
+  } catch {
+    // fall through to fallback
+  }
+  return fallback;
+}
+
+/**
  * Get the userData directory (source for backups)
  */
 async function getUserDataDir(): Promise<string> {
@@ -319,7 +344,7 @@ export async function createBackup(): Promise<IpcResult<BackupInfo>> {
     return { success: true, data: backupInfo };
   } catch (err) {
     // Check for disk space errors
-    const errorMessage = err instanceof Error ? err.message : 'Unknown error';
+    const errorMessage = extractErrorMessage(err, 'Unknown error');
 
     if (
       errorMessage.includes('ENOSPC') ||
@@ -482,7 +507,7 @@ export async function restoreBackup(backupId: string): Promise<IpcResult<void>> 
 
     return { success: true, data: undefined };
   } catch (err) {
-    const errorMessage = err instanceof Error ? err.message : 'Unknown error';
+    const errorMessage = extractErrorMessage(err, 'Unknown error');
 
     // Attempt rollback: detect actual state and restore original data
     if (oldUserDataPath && tempRestorePath) {

--- a/src/renderer/lib/tauri-backup-api.ts
+++ b/src/renderer/lib/tauri-backup-api.ts
@@ -258,12 +258,15 @@ export async function createBackup(): Promise<IpcResult<BackupInfo>> {
     // Create backup directory
     await mkdir(backupPath, { recursive: true });
 
-    // Copy entire userData directory (except backups folder)
+    // Copy entire userData directory (except backups and versions folders)
     const entries = await readDir(userDataPath);
 
     for (const entry of entries) {
-      // Skip the backups directory itself
-      if (entry.name === 'backups') {
+      // Skip the backups directory itself, and the rollback versions store
+      // (both grow unbounded relative to a single backup and would otherwise
+      // be copied recursively into every new backup, making backups slow and
+      // fragile enough to silently block updates).
+      if (entry.name === 'backups' || entry.name === 'versions') {
         continue;
       }
 

--- a/src/renderer/lib/tauri-updater-api.ts
+++ b/src/renderer/lib/tauri-updater-api.ts
@@ -28,6 +28,7 @@ const UPDATE_MODE: UpdateMode =
  */
 
 let pendingTauriUpdate: Update | null = null
+let downloadedUpdate: Update | null = null
 let pendingAurUpdate: UpdateInfo | null = null
 let manualUpdateInfo: UpdateInfo | null = null
 let autoUpdateEnabled = true
@@ -265,6 +266,13 @@ export async function checkForUpdates(): Promise<UpdateInfo | null> {
     isManualUpdateMode = false
     manualUpdateInfo = null
     downloadedVersion = update && downloadedVersion === update.version ? downloadedVersion : null
+    // Preserve the already-downloaded Update instance (and its in-memory bytes)
+    // when a periodic re-check returns the same version; otherwise drop it so a
+    // newer version is re-downloaded before install.
+    downloadedUpdate =
+      update && downloadedUpdate && downloadedUpdate.version === update.version
+        ? downloadedUpdate
+        : null
     preparedUpdateVersion =
       update && preparedUpdateVersion === update.version ? preparedUpdateVersion : null
     lastCheckedAt = new Date().toISOString()
@@ -390,7 +398,7 @@ export async function downloadUpdate(
       })
     }
 
-    await pendingTauriUpdate.downloadAndInstall((event) => {
+    await pendingTauriUpdate.download((event) => {
       if (!onProgress) return
 
       const mapped = mapDownloadEventToProgress(event, downloadedSoFar, totalBytes)
@@ -399,6 +407,7 @@ export async function downloadUpdate(
       onProgress(mapped.progress)
     })
 
+    downloadedUpdate = pendingTauriUpdate
     downloadedVersion = updateVersion
 
     return { success: true, data: undefined }
@@ -425,7 +434,7 @@ export async function installAndRestart(): Promise<IpcResult<void>> {
     return { success: true, data: undefined }
   }
 
-  if (!pendingTauriUpdate || downloadedVersion !== pendingTauriUpdate.version) {
+  if (!pendingTauriUpdate || downloadedVersion !== pendingTauriUpdate.version || !downloadedUpdate) {
     return {
       success: false,
       error: 'No downloaded update ready to install',
@@ -434,12 +443,15 @@ export async function installAndRestart(): Promise<IpcResult<void>> {
   }
 
   try {
+    // Apply the already-downloaded package, then restart into the new version.
+    // Split from download so the app is never force-restarted during download.
+    await downloadedUpdate.install()
     await relaunch()
     return { success: true, data: undefined }
   } catch (error) {
     return {
       success: false,
-      error: getErrorMessage(error, 'Failed to relaunch after update'),
+      error: getErrorMessage(error, 'Failed to install and restart after update'),
       code: UpdaterErrorCodes.INSTALL_FAILED
     }
   }
@@ -495,6 +507,7 @@ export function registerUpdateEventHandlers(handlers: TauriUpdaterEventHandlers)
 
 export async function clearPendingUpdate(): Promise<void> {
   pendingTauriUpdate = null
+  downloadedUpdate = null
   pendingAurUpdate = null
   manualUpdateInfo = null
   downloadedVersion = null
@@ -504,6 +517,7 @@ export async function clearPendingUpdate(): Promise<void> {
 
 export function _resetUpdaterStateForTesting(): void {
   pendingTauriUpdate = null
+  downloadedUpdate = null
   pendingAurUpdate = null
   manualUpdateInfo = null
   downloadedVersion = null

--- a/src/renderer/lib/tauri-updater-api.ts
+++ b/src/renderer/lib/tauri-updater-api.ts
@@ -375,8 +375,13 @@ export async function downloadUpdate(
     }
   }
 
+  // Capture the handle before any await: a concurrent periodic checkForUpdates()
+  // can reassign the module-scoped pendingTauriUpdate mid-download, which would
+  // otherwise make the post-await assignments point at the wrong Update.
+  const updateHandle = pendingTauriUpdate
+
   try {
-    const updateVersion = pendingTauriUpdate.version
+    const updateVersion = updateHandle.version
 
     if (preparedUpdateVersion !== updateVersion) {
       const preparationResult = await prepareUpdateRecovery()
@@ -398,7 +403,7 @@ export async function downloadUpdate(
       })
     }
 
-    await pendingTauriUpdate.download((event) => {
+    await updateHandle.download((event) => {
       if (!onProgress) return
 
       const mapped = mapDownloadEventToProgress(event, downloadedSoFar, totalBytes)
@@ -407,7 +412,7 @@ export async function downloadUpdate(
       onProgress(mapped.progress)
     })
 
-    downloadedUpdate = pendingTauriUpdate
+    downloadedUpdate = updateHandle
     downloadedVersion = updateVersion
 
     return { success: true, data: undefined }


### PR DESCRIPTION
## Summary

Auto-update was broken in several compounding ways: the update notification appeared, but clicking **Download** did nothing visible. This PR fixes the full chain — silent failures, a missing filesystem permission, a force-close on download, missing updater permissions, and a transparent toast — so the update flow works end to end with an explicit confirmation before the app restarts.

## Related Issue

Closes #
<!-- No tracked issue — surfaced via user report during auto-update testing. -->

## Type of Change

- [ ] feat: new feature
- [x] fix: bug fix
- [ ] docs: documentation only
- [ ] style: formatting or non-functional styling changes
- [ ] refactor: internal cleanup with no behavior change
- [ ] perf: performance improvement
- [ ] test: adds or updates tests
- [ ] build: build or dependency changes
- [ ] ci: CI/CD workflow changes
- [ ] chore: maintenance or tooling
- [ ] revert: reverts a previous change

## What Changed

Root-cause chain, in the order it was uncovered:

1. **Silent download failure surfaced** (`d836e11`) — the toast fired `downloadUpdate()`/`installAndRestart()` without awaiting or inspecting the result, so failures (captured only in `store.error`, rendered only on AppPreferences) produced a silent no-op. Now the toast awaits the action and shows a `toast.error` when `store.error` is set. Also stops copying the unbounded `versions/` rollback store into every backup.

2. **Real root cause — missing `fs:allow-copy-file`** (`cdfe194`) — the capabilities never granted copy-file, so `createBackup()`'s first `copyFile` was rejected by Tauri and threw, silently blocking the pre-download recovery step (every existing backup dir in appData was empty). Added the permission, plus an `extractErrorMessage()` helper so Tauri's plain-string rejections surface real messages instead of "Unknown error".

3. **Download no longer force-closes the app** (`cdfe194`) — Tauri's `downloadAndInstall()` installs and restarts in one call, so "Download" was killing the user's terminal sessions with no warning. Split into `Update.download()` (Download) and `Update.install()` + `relaunch()` (Install), gated behind a native `confirm()` dialog that warns when terminal sessions are active. The downloaded `Update` instance is retained across the periodic re-check so its bytes survive until install.

4. **Missing granular updater permissions** (`18d5b8b`) — the split invokes `plugin:updater|download` and `plugin:updater|install`, which need their own capabilities. Added `updater:allow-download` and `updater:allow-install` (kept `download-and-install` for compatibility).

5. **Transparent toast fixed** (`0d2e83d`) — typed Sonner toasts forced `!bg-transparent`, which beats richColors' own `background: var(--success-bg)` rule (Tailwind emits `!important`), leaving update toasts see-through. Removed the override so richColors paints typed toasts while neutral toasts keep `bg-background`.

Files: `src/renderer/lib/tauri-updater-api.ts`, `src/renderer/lib/tauri-backup-api.ts`, `src/renderer/components/UpdateAvailableToast.tsx`, `src/renderer/components/ui/sonner.tsx`, `src-tauri/capabilities/default.json`, plus updated/added tests.

## How It Was Tested

- [x] `bun run lint`
- [x] `bun run typecheck`
- [x] `bun run test`
- [x] Manual verification completed
- [ ] Not applicable

Manual: built locally with the app version temporarily lowered to 0.3.6 (local-only, **not committed**) and confirmed the full flow against the live v0.3.8 `latest.json` — Download fetches without restarting → "ready to install" toast → Install & Restart → confirmation dialog → installs and restarts. Verified the error toast on a forced failure, and that the toast now renders with a solid background. Automated: 45 updater/backup/toast unit tests pass (`UpdateAvailableToast.test.tsx`, `tauri-updater-api.test.ts`, `tauri-backup-api.test.ts`, `updater-store.test.ts`).

## Screenshots or Recordings

<!-- Required for UI changes when applicable — please attach a recording of the download → confirm → install flow and the solid toast. -->

## Checklist

- [x] My PR title follows the conventional commit format used by this repo
- [x] I linked the related issue or explained why none exists
- [ ] I updated docs when needed
- [x] I added or updated tests when needed
- [x] I verified the change does not introduce unrelated modifications


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added confirmation dialog for update installation with terminal session warnings.
  * Enhanced error reporting for download and installation failures.

* **Bug Fixes**
  * Backup creation now properly excludes the versions directory.
  * Improved error message handling throughout the update process.

* **Tests**
  * Added comprehensive unit tests for update flows and backup functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gnoviawan/termul/pull/191?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->