### PR TITLE
feat(sidebar): declutter project list with truncation + search

### DIFF
--- a/src/renderer/components/ProjectSidebar.test.tsx
+++ b/src/renderer/components/ProjectSidebar.test.tsx
@@ -600,3 +600,163 @@ describe('ProjectSidebar Worktree Row', () => {
     expect(mockActivateAndOpenTerminal).not.toHaveBeenCalled()
   })
 })
+
+describe('ProjectSidebar Project Search', () => {
+  // 8 projects crosses the PROJECT_SEARCH_THRESHOLD so the search UI renders.
+  const manyProjects: Project[] = Array.from({ length: 8 }, (_, i) => ({
+    id: String(i + 1),
+    name: `Project ${i + 1}`,
+    color: 'blue' as const,
+    gitBranch: i === 7 ? 'feature/special' : 'main'
+  }))
+
+  const fewProjects: Project[] = [
+    { id: '1', name: 'Alpha', color: 'blue', gitBranch: 'main' },
+    { id: '2', name: 'Beta', color: 'green', gitBranch: 'main' }
+  ]
+
+  it('hides the search box when the project count is below the threshold', () => {
+    renderWithRouter({ projects: fewProjects, activeProjectId: '1' })
+    expect(screen.queryByTestId('project-search-input')).not.toBeInTheDocument()
+  })
+
+  it('shows the search box once the project count reaches the threshold', () => {
+    renderWithRouter({ projects: manyProjects, activeProjectId: '1' })
+    expect(screen.getByTestId('project-search-input')).toBeInTheDocument()
+  })
+
+  it('filters the visible projects by name', () => {
+    renderWithRouter({ projects: manyProjects, activeProjectId: '1' })
+
+    fireEvent.change(screen.getByTestId('project-search-input'), {
+      target: { value: 'Project 8' }
+    })
+
+    expect(screen.getByText('Project 8')).toBeInTheDocument()
+    expect(screen.queryByText('Project 1')).not.toBeInTheDocument()
+    expect(screen.queryByText('Project 2')).not.toBeInTheDocument()
+  })
+
+  it('matches on git branch as well as name', () => {
+    renderWithRouter({ projects: manyProjects, activeProjectId: '1' })
+
+    fireEvent.change(screen.getByTestId('project-search-input'), {
+      target: { value: 'feature/special' }
+    })
+
+    expect(screen.getByText('Project 8')).toBeInTheDocument()
+    expect(screen.queryByText('Project 1')).not.toBeInTheDocument()
+  })
+
+  it('shows an empty state when nothing matches', () => {
+    renderWithRouter({ projects: manyProjects, activeProjectId: '1' })
+
+    fireEvent.change(screen.getByTestId('project-search-input'), {
+      target: { value: 'no-such-project' }
+    })
+
+    expect(screen.getByTestId('project-search-empty')).toBeInTheDocument()
+    expect(screen.getByText('No projects found')).toBeInTheDocument()
+  })
+
+  it('clears the query when the clear button is clicked', () => {
+    renderWithRouter({ projects: manyProjects, activeProjectId: '1' })
+
+    const input = screen.getByTestId('project-search-input') as HTMLInputElement
+    fireEvent.change(input, { target: { value: 'Project 8' } })
+    expect(screen.queryByText('Project 1')).not.toBeInTheDocument()
+
+    fireEvent.click(screen.getByTestId('project-search-clear'))
+
+    expect(input.value).toBe('')
+    expect(screen.getByText('Project 1')).toBeInTheDocument()
+  })
+
+  it('clears the query when Escape is pressed in the search box', () => {
+    renderWithRouter({ projects: manyProjects, activeProjectId: '1' })
+
+    const input = screen.getByTestId('project-search-input') as HTMLInputElement
+    fireEvent.change(input, { target: { value: 'Project 8' } })
+    fireEvent.keyDown(input, { key: 'Escape' })
+
+    expect(input.value).toBe('')
+    expect(screen.getByText('Project 1')).toBeInTheDocument()
+  })
+
+  it('keeps the Ctrl+1 shortcut badge tied to the unfiltered position while searching', () => {
+    renderWithRouter({ projects: manyProjects, activeProjectId: '1' })
+
+    // Project 1 is index 0 -> Ctrl+1. Search for it; the badge must stay Ctrl+1.
+    fireEvent.change(screen.getByTestId('project-search-input'), {
+      target: { value: 'Project 1' }
+    })
+
+    expect(screen.getByText('Project 1')).toBeInTheDocument()
+    expect(screen.getByText('Ctrl+1')).toBeInTheDocument()
+  })
+
+  it('clears a lingering query when the search box drops below the threshold', () => {
+    const { rerender } = render(
+      <MemoryRouter>
+        <ProjectSidebar {...defaultProps} projects={manyProjects} activeProjectId="1" />
+      </MemoryRouter>
+    )
+
+    fireEvent.change(screen.getByTestId('project-search-input'), {
+      target: { value: 'Project 8' }
+    })
+    expect(screen.queryByText('Project 1')).not.toBeInTheDocument()
+
+    // Drop below the threshold so the search box unmounts.
+    rerender(
+      <MemoryRouter>
+        <ProjectSidebar {...defaultProps} projects={fewProjects} activeProjectId="1" />
+      </MemoryRouter>
+    )
+
+    // No stuck filter: the search box is gone and the remaining projects are visible.
+    expect(screen.queryByTestId('project-search-input')).not.toBeInTheDocument()
+    expect(screen.getByText('Alpha')).toBeInTheDocument()
+    expect(screen.getByText('Beta')).toBeInTheDocument()
+  })
+
+  it('clears the search when the active project is not in the filtered results', () => {
+    const { rerender } = render(
+      <MemoryRouter>
+        <ProjectSidebar {...defaultProps} projects={manyProjects} activeProjectId="1" />
+      </MemoryRouter>
+    )
+
+    // Filter to a single project that is NOT the active one.
+    fireEvent.change(screen.getByTestId('project-search-input'), {
+      target: { value: 'Project 8' }
+    })
+    expect(screen.queryByText('Project 2')).not.toBeInTheDocument()
+
+    // Active project switches to one hidden by the query (e.g. Ctrl+2 or a new project).
+    rerender(
+      <MemoryRouter>
+        <ProjectSidebar {...defaultProps} projects={manyProjects} activeProjectId="2" />
+      </MemoryRouter>
+    )
+
+    // Search self-clears so the now-active project is visible again.
+    expect((screen.getByTestId('project-search-input') as HTMLInputElement).value).toBe('')
+    expect(screen.getByText('Project 2')).toBeInTheDocument()
+  })
+
+  it('disables the archived toggle while searching', () => {
+    const withArchived: Project[] = [
+      ...manyProjects,
+      { id: '99', name: 'Old Project', color: 'gray', gitBranch: 'main', isArchived: true }
+    ]
+    renderWithRouter({ projects: withArchived, activeProjectId: '1' })
+
+    fireEvent.change(screen.getByTestId('project-search-input'), {
+      target: { value: 'Project' }
+    })
+
+    const toggle = screen.getByLabelText(/Archived projects/)
+    expect(toggle).toBeDisabled()
+  })
+})

--- a/src/renderer/components/ProjectSidebar.test.tsx
+++ b/src/renderer/components/ProjectSidebar.test.tsx
@@ -350,6 +350,41 @@ describe('ProjectSidebar', () => {
   })
 })
 
+describe('ProjectSidebar Name Truncation', () => {
+  const longName =
+    'A Very Long Project Name That Would Otherwise Wrap Onto A Second Line In The Narrow Sidebar'
+
+  it('truncates a long active project name instead of wrapping', () => {
+    renderWithRouter({
+      projects: [{ id: '1', name: longName, color: 'blue', gitBranch: 'main' }],
+      activeProjectId: '1'
+    })
+
+    const nameEl = screen.getByText(longName)
+    // truncate => overflow-hidden + text-ellipsis + whitespace-nowrap;
+    // min-w-0 lets the flex child shrink below its content width so clipping kicks in.
+    expect(nameEl).toHaveClass('truncate', 'min-w-0', 'flex-1')
+    // Full name remains discoverable on hover.
+    expect(nameEl).toHaveAttribute('title', longName)
+  })
+
+  it('truncates a long archived project name and exposes the full name via title', () => {
+    renderWithRouter({
+      projects: [
+        { id: '1', name: 'Active Project', color: 'blue', gitBranch: 'main' },
+        { id: '2', name: longName, color: 'green', gitBranch: 'develop', isArchived: true }
+      ]
+    })
+
+    // Expand the archived section.
+    fireEvent.click(screen.getByText(/Archived \(1\)/))
+
+    const nameEl = screen.getByText(longName)
+    expect(nameEl).toHaveClass('truncate', 'min-w-0', 'flex-1')
+    expect(nameEl).toHaveAttribute('title', longName)
+  })
+})
+
 describe('ProjectSidebar Archived Projects', () => {
   const projectsWithArchived: Project[] = [
     { id: '1', name: 'Active Project', color: 'blue', gitBranch: 'main' },

--- a/src/renderer/components/ProjectSidebar.test.tsx
+++ b/src/renderer/components/ProjectSidebar.test.tsx
@@ -760,3 +760,51 @@ describe('ProjectSidebar Project Search', () => {
     expect(toggle).toBeDisabled()
   })
 })
+
+describe('ProjectSidebar Worktree Search', () => {
+  // 10+ worktrees crosses the worktree-search threshold.
+  const projectWithManyWorktrees: Project[] = [
+    {
+      id: '1',
+      name: 'Big Repo',
+      color: 'blue',
+      gitBranch: 'main',
+      isGitRepo: true,
+      worktrees: Array.from({ length: 11 }, (_, i) => ({
+        id: `wt-${i}`,
+        name: `worktree-${i}`,
+        branch: `feature/branch-${i}`,
+        path: `/repo/.termul/worktrees/worktree-${i}`,
+        createdAt: new Date().toISOString()
+      }))
+    }
+  ]
+
+  it('shows a worktree search box with an icon once there are 10+ worktrees', () => {
+    renderWithRouter({ projects: projectWithManyWorktrees, activeProjectId: '1' })
+    expect(screen.getByLabelText('Search worktrees')).toBeInTheDocument()
+  })
+
+  it('shows a clear button only after typing, and clears on click', () => {
+    renderWithRouter({ projects: projectWithManyWorktrees, activeProjectId: '1' })
+
+    const input = screen.getByLabelText('Search worktrees') as HTMLInputElement
+    expect(screen.queryByLabelText('Clear worktree search')).not.toBeInTheDocument()
+
+    fireEvent.change(input, { target: { value: 'worktree-3' } })
+    expect(screen.getByLabelText('Clear worktree search')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByLabelText('Clear worktree search'))
+    expect(input.value).toBe('')
+  })
+
+  it('clears the worktree query on Escape', () => {
+    renderWithRouter({ projects: projectWithManyWorktrees, activeProjectId: '1' })
+
+    const input = screen.getByLabelText('Search worktrees') as HTMLInputElement
+    fireEvent.change(input, { target: { value: 'worktree-3' } })
+    fireEvent.keyDown(input, { key: 'Escape' })
+
+    expect(input.value).toBe('')
+  })
+})

--- a/src/renderer/components/ProjectSidebar.tsx
+++ b/src/renderer/components/ProjectSidebar.tsx
@@ -11,6 +11,7 @@ import {
 	RotateCcw,
 	ChevronDown,
 	ChevronRight,
+	Search,
 	Loader2,
 	AlertTriangle,
 	Settings,
@@ -50,6 +51,7 @@ import { useWorktreeStatus } from "@/hooks/use-worktree-status";
 import { useWorktreeReconciler } from "@/hooks/use-worktree-reconciler";
 import { groupWorktrees, type WorktreeGroup } from "@/lib/worktree-grouping";
 import { filterWorktrees } from "@/lib/worktree-filter";
+import { filterProjects, shouldShowProjectSearch } from "@/lib/project-filter";
 
 function getFirstLetter(name: string): string {
 	if (!name) return "?";
@@ -137,6 +139,10 @@ export function ProjectSidebar({
 
 	// Show archived toggle state
 	const [showArchived, setShowArchived] = useState(false);
+
+	// Project search/filter query
+	const [searchQuery, setSearchQuery] = useState("");
+	const searchInputRef = useRef<HTMLInputElement>(null);
 
 	// Expanded worktree projects — active project auto-expands
 	const [expandedProjects, setExpandedProjects] = useState<Set<string>>(() => {
@@ -677,9 +683,59 @@ export function ProjectSidebar({
 		(p) => p.id === colorPicker.projectId,
 	);
 
-	// Filter active and archived projects
-	const activeProjects = projects.filter((p) => !p.isArchived);
-	const archivedProjects = projects.filter((p) => p.isArchived);
+	// Split active and archived projects
+	const activeProjects = useMemo(() => projects.filter((p) => !p.isArchived), [projects]);
+	const archivedProjects = useMemo(() => projects.filter((p) => p.isArchived), [projects]);
+
+	// The search box only renders once the list is long enough to be worth filtering.
+	const showSearch = shouldShowProjectSearch(projects.length);
+
+	// Apply the search query to each group. Filtering is gated on `showSearch` so a
+	// lingering query can never keep the list filtered after the search box unmounts
+	// (e.g. project count drops below the threshold). The unfiltered `activeProjects`
+	// is kept for shortcut-index math below.
+	const trimmedQuery = showSearch ? searchQuery.trim() : "";
+	const isSearching = trimmedQuery.length > 0;
+	const filteredActiveProjects = useMemo(
+		() => filterProjects(activeProjects, { searchQuery: trimmedQuery }),
+		[activeProjects, trimmedQuery],
+	);
+	const filteredArchivedProjects = useMemo(
+		() => filterProjects(archivedProjects, { searchQuery: trimmedQuery }),
+		[archivedProjects, trimmedQuery],
+	);
+
+	// Map each active project id to its position in the UNFILTERED active list.
+	// The badge reflects this position (not the filtered render index) so the
+	// number a user sees doesn't shift around as they type a search query.
+	const activeIndexById = useMemo(() => {
+		const map = new Map<string, number>();
+		activeProjects.forEach((p, i) => map.set(p.id, i));
+		return map;
+	}, [activeProjects]);
+
+	// Reset a lingering query if the search box is no longer shown.
+	useEffect(() => {
+		if (!showSearch && searchQuery) setSearchQuery("");
+	}, [showSearch, searchQuery]);
+
+	// When the active project CHANGES to one that the current query hides (e.g. a
+	// project was just created, or a Ctrl+1..9 shortcut selected a hidden project),
+	// clear the search so the now-active project becomes visible instead of silently
+	// vanishing. Keyed on a change of `activeProjectId` only — searching for OTHER
+	// projects while the active one stays put must NOT wipe the query.
+	const prevActiveProjectId = useRef(activeProjectId);
+	useEffect(() => {
+		const changed = prevActiveProjectId.current !== activeProjectId;
+		prevActiveProjectId.current = activeProjectId;
+		if (!changed || !isSearching || !activeProjectId) return;
+		const visible =
+			filteredActiveProjects.some((p) => p.id === activeProjectId) ||
+			filteredArchivedProjects.some((p) => p.id === activeProjectId);
+		if (!visible) setSearchQuery("");
+	}, [activeProjectId, isSearching, filteredActiveProjects, filteredArchivedProjects]);
+	const hasNoSearchResults =
+		isSearching && filteredActiveProjects.length === 0 && filteredArchivedProjects.length === 0;
 
 	// Determine which menu items to show based on project archived status
 	const getMenuItems = useCallback(
@@ -714,32 +770,96 @@ export function ProjectSidebar({
 				</button>
 			</div>
 
+			{/* Project search — appears once the list is long enough to be worth filtering */}
+			{showSearch && (
+				<div className="px-2 py-1.5 border-b border-sidebar-border">
+					<div className="relative">
+						<Search
+							size={12}
+							className="absolute left-2 top-1/2 -translate-y-1/2 text-muted-foreground pointer-events-none"
+							aria-hidden="true"
+						/>
+						<input
+							ref={searchInputRef}
+							type="search"
+							placeholder="Search projects..."
+							value={searchQuery}
+							onChange={(e) => setSearchQuery(e.target.value)}
+							onKeyDown={(e) => {
+								if (e.key === "Escape" && searchQuery) {
+									e.preventDefault();
+									e.stopPropagation();
+									setSearchQuery("");
+								}
+							}}
+							className="w-full text-xs bg-sidebar-accent border border-border rounded pl-7 pr-7 py-1 text-foreground placeholder-muted-foreground outline-none focus:ring-1 focus:ring-primary [&::-webkit-search-cancel-button]:hidden"
+							aria-label="Search projects"
+							data-testid="project-search-input"
+						/>
+						{searchQuery && (
+							<button
+								onClick={() => {
+									setSearchQuery("");
+									// Clearing unmounts this button; return focus to the input.
+									searchInputRef.current?.focus();
+								}}
+								className="absolute right-1.5 top-1/2 -translate-y-1/2 h-4 w-4 inline-flex items-center justify-center rounded hover:bg-sidebar-accent text-muted-foreground hover:text-foreground transition-colors focus:outline-none focus-visible:ring-1 focus-visible:ring-primary"
+								title="Clear search"
+								aria-label="Clear project search"
+								data-testid="project-search-clear"
+							>
+								<X size={12} />
+							</button>
+						)}
+					</div>
+				</div>
+			)}
+
 			{/* Project List */}
 			<div className="flex-1 overflow-y-auto py-1">
-				{activeProjects.length === 0 && archivedProjects.length === 0 ? (
+				{projects.length === 0 ? (
 					<div className="flex flex-col items-center justify-center p-6 text-center opacity-60">
 						<p className="text-sm text-muted-foreground">No projects yet</p>
 						<p className="text-xs text-muted-foreground mt-1">
 							Create your first project to get started
 						</p>
 					</div>
+				) : hasNoSearchResults ? (
+					<div
+						className="flex flex-col items-center justify-center p-6 text-center opacity-60"
+						data-testid="project-search-empty"
+						role="status"
+						aria-live="polite"
+					>
+						<p className="text-sm text-muted-foreground">No projects found</p>
+						<p className="text-xs text-muted-foreground mt-1 break-words">
+							Nothing matches “{trimmedQuery}”
+						</p>
+					</div>
 				) : (
 					<>
 						<Reorder.Group
 							axis="y"
-							values={activeProjects}
-							onReorder={(reordered) =>
-								onReorderProjects(reordered.map((p) => p.id))
-							}
+							values={filteredActiveProjects}
+							onReorder={(reordered) => {
+								// Reordering a filtered subset would drop the hidden projects,
+								// so only persist a new order when the full list is visible.
+								if (isSearching) return;
+								onReorderProjects(reordered.map((p) => p.id));
+							}}
 							className="flex flex-col"
 							data-testid="active-projects-container"
 						>
-							{activeProjects.map((project, index) => {
+							{filteredActiveProjects.map((project) => {
 								const hasActivity = projectActivityIds.includes(project.id);
+								// Shortcut badge reflects the project's position in the UNFILTERED
+								// active list to stay in sync with the global Ctrl+1..9 handler.
+								const shortcutIndex = activeIndexById.get(project.id) ?? -1;
 								return (
 									<Reorder.Item
 										key={project.id}
 										value={project}
+										drag={isSearching ? false : undefined}
 										className="list-none"
 										whileDrag={{
 											scale: 1.02,
@@ -753,7 +873,7 @@ export function ProjectSidebar({
 											onToggleExpand={() => toggleProjectExpanded(project.id)}
 											isEditing={editingId === project.id}
 											editName={editName}
-											shortcut={index < 9 ? `Ctrl+${index + 1}` : undefined}
+											shortcut={shortcutIndex >= 0 && shortcutIndex < 9 ? `Ctrl+${shortcutIndex + 1}` : undefined}
 											hasActivity={hasActivity}
 											hasError={projectErrorIds.has(project.id)}
 											onClick={() => {
@@ -782,23 +902,24 @@ export function ProjectSidebar({
 						</Reorder.Group>
 
 						{/* Archived Projects Section */}
-						{archivedProjects.length > 0 && (
+						{filteredArchivedProjects.length > 0 && (
 							<div className="mt-2">
 								<button
 									onClick={() => setShowArchived(!showArchived)}
-									className="w-full flex items-center px-3 py-1.5 text-xs tracking-wider text-sidebar-foreground uppercase hover:bg-sidebar-accent/50 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-primary"
-									aria-expanded={showArchived}
-									aria-label={`Archived projects (${archivedProjects.length})`}
+									disabled={isSearching}
+									className="w-full flex items-center px-3 py-1.5 text-xs tracking-wider text-sidebar-foreground uppercase hover:bg-sidebar-accent/50 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-primary disabled:cursor-default disabled:hover:bg-transparent"
+									aria-expanded={showArchived || isSearching}
+									aria-label={`Archived projects (${filteredArchivedProjects.length})`}
 								>
-									{showArchived ? (
+									{showArchived || isSearching ? (
 										<ChevronDown size={14} className="mr-2" />
 									) : (
 										<ChevronRight size={14} className="mr-2" />
 									)}
-									Archived ({archivedProjects.length})
+									Archived ({filteredArchivedProjects.length})
 								</button>
-								{showArchived &&
-									archivedProjects.map((project) => {
+								{(showArchived || isSearching) &&
+									filteredArchivedProjects.map((project) => {
 										const hasActivity = projectActivityIds.includes(project.id);
 										return (
 											<ArchivedProjectItem

--- a/src/renderer/components/ProjectSidebar.tsx
+++ b/src/renderer/components/ProjectSidebar.tsx
@@ -770,19 +770,19 @@ export function ProjectSidebar({
 				</button>
 			</div>
 
-			{/* Project search — appears once the list is long enough to be worth filtering */}
+			{/* Project search — flat style matching the file explorer search */}
 			{showSearch && (
-				<div className="px-2 py-1.5 border-b border-sidebar-border">
+				<div className="px-3 py-1.5 border-b border-sidebar-border">
 					<div className="relative">
 						<Search
-							size={12}
-							className="absolute left-2 top-1/2 -translate-y-1/2 text-muted-foreground pointer-events-none"
+							size={13}
+							className="pointer-events-none absolute left-2 top-1/2 -translate-y-1/2 text-muted-foreground"
 							aria-hidden="true"
 						/>
 						<input
 							ref={searchInputRef}
 							type="search"
-							placeholder="Search projects..."
+							placeholder="Search projects…"
 							value={searchQuery}
 							onChange={(e) => setSearchQuery(e.target.value)}
 							onKeyDown={(e) => {
@@ -792,7 +792,7 @@ export function ProjectSidebar({
 									setSearchQuery("");
 								}
 							}}
-							className="w-full text-xs bg-sidebar-accent border border-border rounded pl-7 pr-7 py-1 text-foreground placeholder-muted-foreground outline-none focus:ring-1 focus:ring-primary [&::-webkit-search-cancel-button]:hidden"
+							className="w-full rounded-none border-0 bg-transparent py-1 pl-7 pr-7 text-xs text-foreground outline-none placeholder:text-muted-foreground/60 focus:ring-0 [&::-webkit-search-cancel-button]:hidden"
 							aria-label="Search projects"
 							data-testid="project-search-input"
 						/>
@@ -803,12 +803,12 @@ export function ProjectSidebar({
 									// Clearing unmounts this button; return focus to the input.
 									searchInputRef.current?.focus();
 								}}
-								className="absolute right-1.5 top-1/2 -translate-y-1/2 h-4 w-4 inline-flex items-center justify-center rounded hover:bg-sidebar-accent text-muted-foreground hover:text-foreground transition-colors focus:outline-none focus-visible:ring-1 focus-visible:ring-primary"
+								className="absolute right-0 top-1/2 inline-flex h-5 w-5 -translate-y-1/2 items-center justify-center rounded-md text-muted-foreground transition-colors hover:text-foreground focus:outline-none"
 								title="Clear search"
 								aria-label="Clear project search"
 								data-testid="project-search-clear"
 							>
-								<X size={12} />
+								<X size={11} />
 							</button>
 						)}
 					</div>
@@ -1350,16 +1350,41 @@ const ProjectItem = memo(function ProjectItem({
 						transition={{ duration: 0.15, ease: "easeInOut" }}
 						className="ml-5 border-l border-sidebar-border overflow-hidden"
 					>
-						{/* Worktree search bar - visible at 10+ worktrees */}
+						{/* Worktree search bar - visible at 10+ worktrees, flat style matching the file explorer */}
 					{worktrees.length >= 10 && (
 						<div className="px-2 py-1">
-							<input
-								type="text"
-								placeholder="Search worktrees..."
-								value={worktreeSearchQuery}
-								onChange={(e) => setWorktreeSearchQuery(e.target.value)}
-								className="w-full text-xs bg-sidebar-accent border border-border rounded px-2 py-1 text-foreground placeholder-muted-foreground outline-none focus:ring-1 focus:ring-primary"
-							/>
+							<div className="relative">
+								<Search
+									size={12}
+									className="pointer-events-none absolute left-2 top-1/2 -translate-y-1/2 text-muted-foreground"
+									aria-hidden="true"
+								/>
+								<input
+									type="search"
+									placeholder="Search worktrees…"
+									value={worktreeSearchQuery}
+									onChange={(e) => setWorktreeSearchQuery(e.target.value)}
+									onKeyDown={(e) => {
+										if (e.key === "Escape" && worktreeSearchQuery) {
+											e.preventDefault();
+											e.stopPropagation();
+											setWorktreeSearchQuery("");
+										}
+									}}
+									className="w-full rounded-none border-0 bg-transparent py-1 pl-7 pr-7 text-xs text-foreground outline-none placeholder:text-muted-foreground/60 focus:ring-0 [&::-webkit-search-cancel-button]:hidden"
+									aria-label="Search worktrees"
+								/>
+								{worktreeSearchQuery && (
+									<button
+										onClick={() => setWorktreeSearchQuery("")}
+										className="absolute right-0 top-1/2 inline-flex h-5 w-5 -translate-y-1/2 items-center justify-center rounded-md text-muted-foreground transition-colors hover:text-foreground focus:outline-none"
+										title="Clear search"
+										aria-label="Clear worktree search"
+									>
+										<X size={11} />
+									</button>
+								)}
+							</div>
 						</div>
 					)}
 					{/* Root item */}

--- a/src/renderer/components/ProjectSidebar.tsx
+++ b/src/renderer/components/ProjectSidebar.tsx
@@ -1164,17 +1164,19 @@ const ProjectItem = memo(function ProjectItem({
 						onChange={(e) => onEditNameChange(e.target.value)}
 						onKeyDown={handleKeyDown}
 						onBlur={onSaveRename}
-						className="flex-1 bg-sidebar-accent border border-border rounded-md px-2 py-0.5 text-sm text-foreground outline-none focus:ring-1 focus:ring-primary mr-2"
+						className="flex-1 min-w-0 bg-sidebar-accent border border-border rounded-md px-2 py-0.5 text-sm text-foreground outline-none focus:ring-1 focus:ring-primary mr-2"
 						onClick={(e) => e.stopPropagation()}
 					/>
 				) : (
 					<span
 						className={cn(
-							"text-sm transition-colors flex-1 mr-2",
+							"text-sm transition-colors flex-1 min-w-0 truncate mr-2",
+							// flex-1 min-w-0 is required for truncate to clip inside a flex row
 							isActive
 								? "text-foreground"
 								: "text-muted-foreground group-hover:text-foreground",
 						)}
+						title={project.name}
 					>
 						{project.name}
 					</span>
@@ -1469,7 +1471,10 @@ function ArchivedProjectItem({
 					{firstLetter}
 				</span>
 			</div>
-			<span className="text-sm text-muted-foreground group-hover:text-foreground flex-1">
+			<span
+				className="text-sm text-muted-foreground group-hover:text-foreground flex-1 min-w-0 truncate mr-2"
+				title={project.name}
+			>
 				{project.name}
 			</span>
 			{hasActivity && (

--- a/src/renderer/lib/project-filter.test.ts
+++ b/src/renderer/lib/project-filter.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from 'vitest'
+import { filterProjects, shouldShowProjectSearch, PROJECT_SEARCH_THRESHOLD } from './project-filter'
+import type { Project } from '@/types/project'
+
+const projects: Project[] = [
+	{ id: '1', name: 'Termul Desktop', color: 'blue', path: '/home/me/code/termul', gitBranch: 'main' },
+	{ id: '2', name: 'Landing Site', color: 'green', path: '/home/me/code/landing', gitBranch: 'feature/hero' },
+	{ id: '3', name: 'API Server', color: 'red', path: '/srv/api', gitBranch: 'develop' },
+	{ id: '4', name: 'Docs', color: 'gray' },
+]
+
+describe('filterProjects', () => {
+	it('returns all projects when query is empty', () => {
+		expect(filterProjects(projects, { searchQuery: '' })).toHaveLength(4)
+	})
+
+	it('returns all projects when query is only whitespace', () => {
+		expect(filterProjects(projects, { searchQuery: '   ' })).toHaveLength(4)
+	})
+
+	it('returns all projects when searchQuery is undefined', () => {
+		expect(filterProjects(projects, {})).toHaveLength(4)
+	})
+
+	it('matches on project name (case-insensitive)', () => {
+		const result = filterProjects(projects, { searchQuery: 'termul' })
+		expect(result).toHaveLength(1)
+		expect(result[0].id).toBe('1')
+	})
+
+	it('matches on path', () => {
+		const result = filterProjects(projects, { searchQuery: '/srv/api' })
+		expect(result.map((p) => p.id)).toEqual(['3'])
+	})
+
+	it('matches on git branch', () => {
+		const result = filterProjects(projects, { searchQuery: 'feature/' })
+		expect(result.map((p) => p.id)).toEqual(['2'])
+	})
+
+	it('trims surrounding whitespace before matching', () => {
+		const result = filterProjects(projects, { searchQuery: '  docs  ' })
+		expect(result.map((p) => p.id)).toEqual(['4'])
+	})
+
+	it('returns an empty array when nothing matches', () => {
+		expect(filterProjects(projects, { searchQuery: 'zzz-nope' })).toHaveLength(0)
+	})
+
+	it('does not throw for projects missing optional path/branch', () => {
+		const result = filterProjects(projects, { searchQuery: 'docs' })
+		expect(result.map((p) => p.id)).toEqual(['4'])
+	})
+})
+
+describe('shouldShowProjectSearch', () => {
+	it('hides search below the threshold', () => {
+		expect(shouldShowProjectSearch(PROJECT_SEARCH_THRESHOLD - 1)).toBe(false)
+	})
+
+	it('shows search at the threshold', () => {
+		expect(shouldShowProjectSearch(PROJECT_SEARCH_THRESHOLD)).toBe(true)
+	})
+
+	it('shows search above the threshold', () => {
+		expect(shouldShowProjectSearch(PROJECT_SEARCH_THRESHOLD + 5)).toBe(true)
+	})
+})

--- a/src/renderer/lib/project-filter.ts
+++ b/src/renderer/lib/project-filter.ts
@@ -1,0 +1,46 @@
+/**
+ * Project search and filter utilities.
+ *
+ * Provides name/path/branch search for managing large project collections
+ * in the sidebar. Mirrors the worktree-filter convention.
+ */
+
+import type { Project } from '@/types/project'
+
+export interface ProjectFilterOptions {
+	/** Search query matched against name, path, and git branch */
+	searchQuery?: string
+}
+
+/**
+ * Filter projects based on a search query.
+ * Matches (case-insensitive) against project name, path, and git branch.
+ * Returns the input unchanged when the query is empty/whitespace.
+ */
+export function filterProjects(
+	projects: Project[],
+	options: ProjectFilterOptions,
+): Project[] {
+	const query = options.searchQuery?.trim().toLowerCase()
+	if (!query) return projects
+
+	return projects.filter((p) => {
+		if (p.name.toLowerCase().includes(query)) return true
+		if (p.path?.toLowerCase().includes(query)) return true
+		if (p.gitBranch?.toLowerCase().includes(query)) return true
+		return false
+	})
+}
+
+/**
+ * Threshold at which the project search UI becomes worthwhile.
+ * Below this, the list is short enough that a search box is just clutter.
+ */
+export const PROJECT_SEARCH_THRESHOLD = 8
+
+/**
+ * Check if the project search UI should be shown.
+ */
+export function shouldShowProjectSearch(projectCount: number): boolean {
+	return projectCount >= PROJECT_SEARCH_THRESHOLD
+}


### PR DESCRIPTION
## Summary

Declutter the projects sidebar when there are many projects: stop long names from wrapping, add a project search/filter, and align both the project and worktree search bars with the file-explorer search styling.

## Related Issue

No tracked issue — UX cleanup raised during sidebar review.

## Type of Change

- [x] feat: new feature
- [x] fix: bug fix
- [x] style: formatting or non-functional styling changes

## What Changed

- **Truncate long names** — active and archived project name spans (and the rename input) now use `min-w-0 truncate` so long names clip with an ellipsis instead of wrapping to a second line, with a `title` for the full name on hover.
- **Project search** — a search box appears once the sidebar has 8+ projects, filtering active + archived projects by name/path/git branch (case-insensitive). Includes a clear (X) button, Escape-to-clear, and a "No projects found" empty state with an `aria-live` region.
  - Safety: drag-reorder is disabled while searching (a filtered subset can't be persisted without dropping hidden projects); a lingering query resets when the search box unmounts below threshold; the search self-clears when the active project changes to one the query hides (new project / Ctrl+1..9), so nothing silently vanishes. The shortcut badge stays tied to each project's position in the unfiltered active list.
- **Consistent search styling** — both the project search and worktree search now use the flat, borderless file-explorer look (transparent background, left search icon, right clear button). The worktree search also gained a clear button + Escape-to-clear, which it previously lacked.

## How It Was Tested

- [x] `bun run lint`
- [x] `bun run typecheck`
- [x] `bun run test`
- [x] Manual verification completed
- [ ] Not applicable

`bun run lint` reports 0 errors (4 pre-existing warnings in untouched files). `bun run typecheck` (node + web) clean. New unit tests for `filterProjects`/`shouldShowProjectSearch` plus component tests for truncation, project search behavior, and worktree search; full ProjectSidebar + project-filter suites pass (65 tests).

## Screenshots or Recordings

<!-- UI change — screenshots to be added before merge if needed -->

## Checklist

- [x] My PR title follows the conventional commit format used by this repo
- [x] I linked the related issue or explained why none exists
- [ ] I updated docs when needed
- [x] I added or updated tests when needed
- [x] I verified the change does not introduce unrelated modifications


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added project search functionality to the sidebar for easier navigation
  * Enhanced worktree search UI with improved styling and clear button

* **Improvements**
  * Long project names now display with truncation and full-name tooltips
  * Search UI automatically appears when you have 8+ projects

* **Tests**
  * Added comprehensive test coverage for project sidebar search and filtering behavior

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gnoviawan/termul/pull/192?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->