### PR TITLE
fix(ssh): repair SSH connection status, DNS connect, keychain persistence, and host-key verification

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -86,6 +86,7 @@ jobs:
             libwebkit2gtk-4.1-dev \
             libappindicator3-dev \
             librsvg2-dev \
+            libdbus-1-dev \
             patchelf
 
       - name: Setup Rust

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -170,6 +170,7 @@ jobs:
             libwebkit2gtk-4.1-dev \
             libappindicator3-dev \
             librsvg2-dev \
+            libdbus-1-dev \
             patchelf
 
       - name: Setup Bun

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -9,6 +9,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "aes"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -280,6 +291,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-padding"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8894febbff9f758034a5b8e12d87918f56dfc64a8e1fe757d65e29041538d93"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "block2"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -432,6 +452,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cbc"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26b52a9543ae338f279b96b0b9fed9c8093744685043739079ce85cd58f289a6"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -501,6 +530,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common",
+ "inout",
+]
+
+[[package]]
 name = "clipboard-win"
 version = "5.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -546,6 +585,16 @@ dependencies = [
 
 [[package]]
 name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
@@ -567,7 +616,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa95a34622365fa5bbf40b20b75dba8dfa8c94c734aea8ac9a5ca38af14316f1"
 dependencies = [
  "bitflags 2.11.0",
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-graphics-types",
  "foreign-types",
  "libc",
@@ -580,7 +629,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d44a101f213f6c4cdc1853d4b78aef6db6bdfa3468798cc1d9912f4735013eb"
 dependencies = [
  "bitflags 2.11.0",
- "core-foundation",
+ "core-foundation 0.10.1",
  "libc",
 ]
 
@@ -712,6 +761,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
 
 [[package]]
+name = "dbus"
+version = "0.9.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b942602992bb7acfd1f51c49811c58a610ef9181b6e66f3e519d79b540a3bf73"
+dependencies = [
+ "libc",
+ "libdbus-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "dbus-secret-service"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "708b509edf7889e53d7efb0ffadd994cc6c2345ccb62f55cfd6b0682165e4fa6"
+dependencies = [
+ "aes",
+ "block-padding",
+ "cbc",
+ "dbus",
+ "fastrand",
+ "hkdf",
+ "num",
+ "once_cell",
+ "sha2",
+ "zeroize",
+]
+
+[[package]]
 name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -753,6 +831,7 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -1628,6 +1707,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "hkdf"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
+dependencies = [
+ "hmac",
+]
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
+
+[[package]]
 name = "html5ever"
 version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1955,6 +2052,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "block-padding",
+ "generic-array",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2089,7 +2196,13 @@ version = "3.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eebcc3aff044e5944a8fbaf69eb277d11986064cba30c468730e8b9909fb551c"
 dependencies = [
+ "byteorder",
+ "dbus-secret-service",
  "log",
+ "secret-service",
+ "security-framework 2.11.1",
+ "security-framework 3.7.0",
+ "windows-sys 0.60.2",
  "zeroize",
 ]
 
@@ -2166,6 +2279,15 @@ name = "libc"
 version = "0.2.182"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
+
+[[package]]
+name = "libdbus-sys"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "328c4789d42200f1eeec05bd86c9c13c7f091d2ba9a6ea35acdf51f31bc0f043"
+dependencies = [
+ "pkg-config",
+]
 
 [[package]]
 name = "libloading"
@@ -2421,6 +2543,19 @@ dependencies = [
 
 [[package]]
 name = "nix"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
+dependencies = [
+ "bitflags 2.11.0",
+ "cfg-if",
+ "cfg_aliases 0.2.1",
+ "libc",
+ "memoffset",
+]
+
+[[package]]
+name = "nix"
 version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
@@ -2488,7 +2623,7 @@ dependencies = [
  "mac-notification-sys",
  "serde",
  "tauri-winrt-notification",
- "zbus",
+ "zbus 5.14.0",
 ]
 
 [[package]]
@@ -2502,10 +2637,74 @@ dependencies = [
 ]
 
 [[package]]
+name = "num"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
+dependencies = [
+ "num-bigint",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+]
 
 [[package]]
 name = "num-traits"
@@ -3884,7 +4083,7 @@ dependencies = [
  "openssl-probe",
  "rustls-pki-types",
  "schannel",
- "security-framework",
+ "security-framework 3.7.0",
 ]
 
 [[package]]
@@ -3902,7 +4101,7 @@ version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784"
 dependencies = [
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-foundation-sys",
  "jni",
  "log",
@@ -3911,7 +4110,7 @@ dependencies = [
  "rustls-native-certs",
  "rustls-platform-verifier-android",
  "rustls-webpki",
- "security-framework",
+ "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
  "windows-sys 0.61.2",
@@ -4016,13 +4215,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
+name = "secret-service"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4d35ad99a181be0a60ffcbe85d680d98f87bdc4d7644ade319b87076b9dbfd4"
+dependencies = [
+ "aes",
+ "cbc",
+ "futures-util",
+ "generic-array",
+ "hkdf",
+ "num",
+ "once_cell",
+ "rand 0.8.5",
+ "serde",
+ "sha2",
+ "zbus 4.4.0",
+]
+
+[[package]]
+name = "security-framework"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
+dependencies = [
+ "bitflags 2.11.0",
+ "core-foundation 0.9.4",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
 name = "security-framework"
 version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
  "bitflags 2.11.0",
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
  "security-framework-sys",
@@ -4428,6 +4659,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
 name = "string_cache"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4547,7 +4784,7 @@ checksum = "f3a753bdc39c07b192151523a3f77cd0394aa75413802c883a0f6f6a0e5ee2e7"
 dependencies = [
  "bitflags 2.11.0",
  "block2 0.6.2",
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-graphics",
  "crossbeam-channel",
  "dispatch",
@@ -4862,7 +5099,7 @@ dependencies = [
  "thiserror 2.0.18",
  "url",
  "windows",
- "zbus",
+ "zbus 5.14.0",
 ]
 
 [[package]]
@@ -6703,6 +6940,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "xdg-home"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec1cdab258fb55c0da61328dc52c8764709b249011b2cad0454c72f0bf10a1f6"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "yoke"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6723,6 +6970,38 @@ dependencies = [
  "quote",
  "syn 2.0.117",
  "synstructure",
+]
+
+[[package]]
+name = "zbus"
+version = "4.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb97012beadd29e654708a0fdb4c84bc046f537aecfde2c3ee0a9e4b4d48c725"
+dependencies = [
+ "async-broadcast",
+ "async-process",
+ "async-recursion",
+ "async-trait",
+ "enumflags2",
+ "event-listener",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "hex",
+ "nix 0.29.0",
+ "ordered-stream",
+ "rand 0.8.5",
+ "serde",
+ "serde_repr",
+ "sha1",
+ "static_assertions",
+ "tracing",
+ "uds_windows",
+ "windows-sys 0.52.0",
+ "xdg-home",
+ "zbus_macros 4.4.0",
+ "zbus_names 3.0.0",
+ "zvariant 4.2.0",
 ]
 
 [[package]]
@@ -6755,9 +7034,22 @@ dependencies = [
  "uuid",
  "windows-sys 0.61.2",
  "winnow 0.7.14",
- "zbus_macros",
- "zbus_names",
- "zvariant",
+ "zbus_macros 5.14.0",
+ "zbus_names 4.3.1",
+ "zvariant 5.10.0",
+]
+
+[[package]]
+name = "zbus_macros"
+version = "4.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "267db9407081e90bbfa46d841d3cbc60f59c0351838c4bc65199ecd79ab1983e"
+dependencies = [
+ "proc-macro-crate 3.4.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "zvariant_utils 2.1.0",
 ]
 
 [[package]]
@@ -6770,9 +7062,20 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
- "zbus_names",
- "zvariant",
- "zvariant_utils",
+ "zbus_names 4.3.1",
+ "zvariant 5.10.0",
+ "zvariant_utils 3.3.0",
+]
+
+[[package]]
+name = "zbus_names"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b9b1fef7d021261cc16cba64c351d291b715febe0fa10dc3a443ac5a5022e6c"
+dependencies = [
+ "serde",
+ "static_assertions",
+ "zvariant 4.2.0",
 ]
 
 [[package]]
@@ -6783,7 +7086,7 @@ checksum = "ffd8af6d5b78619bab301ff3c560a5bd22426150253db278f164d6cf3b72c50f"
 dependencies = [
  "serde",
  "winnow 0.7.14",
- "zvariant",
+ "zvariant 5.10.0",
 ]
 
 [[package]]
@@ -6832,6 +7135,20 @@ name = "zeroize"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "zerotrie"
@@ -6916,6 +7233,19 @@ dependencies = [
 
 [[package]]
 name = "zvariant"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2084290ab9a1c471c38fc524945837734fbf124487e105daec2bb57fd48c81fe"
+dependencies = [
+ "endi",
+ "enumflags2",
+ "serde",
+ "static_assertions",
+ "zvariant_derive 4.2.0",
+]
+
+[[package]]
+name = "zvariant"
 version = "5.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5708299b21903bbe348e94729f22c49c55d04720a004aa350f1f9c122fd2540b"
@@ -6924,8 +7254,21 @@ dependencies = [
  "enumflags2",
  "serde",
  "winnow 0.7.14",
- "zvariant_derive",
- "zvariant_utils",
+ "zvariant_derive 5.10.0",
+ "zvariant_utils 3.3.0",
+]
+
+[[package]]
+name = "zvariant_derive"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73e2ba546bda683a90652bac4a279bc146adad1386f25379cf73200d2002c449"
+dependencies = [
+ "proc-macro-crate 3.4.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "zvariant_utils 2.1.0",
 ]
 
 [[package]]
@@ -6938,7 +7281,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
- "zvariant_utils",
+ "zvariant_utils 3.3.0",
+]
+
+[[package]]
+name = "zvariant_utils"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c51bcff7cc3dbb5055396bcf774748c3dab426b4b8659046963523cee4808340"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -50,7 +50,11 @@ uuid = { version = "1", features = ["v4", "serde"] }
 # without a full Perl module setup; see README SSH development notes.
 ssh2 = "0.9"
 
-# Secure storage (OS keychain for secure credential storage)
+# Secure storage (OS keychain for secure credential storage).
+# IMPORTANT: keyring selects its backend at COMPILE TIME via cargo features.
+# Without an OS-backend feature it silently falls back to an in-memory mock
+# store, so set_password "succeeds" but get_password always returns NoEntry
+# (credentials never persist). Enable the native backend per OS below.
 keyring = "3.6"
 
 # Logging
@@ -59,6 +63,20 @@ env_logger = { version = "0.11", default-features = false }
 
 [dev-dependencies]
 tauri = { version = "2.0", features = ["test"] }
+
+# --- OS keychain backends for `keyring` (see note on the keyring dep above) ---
+# Windows Credential Manager
+[target.'cfg(target_os = "windows")'.dependencies]
+keyring = { version = "3.6", features = ["windows-native"] }
+
+# macOS Keychain
+[target.'cfg(target_os = "macos")'.dependencies]
+keyring = { version = "3.6", features = ["apple-native"] }
+
+# Linux Secret Service (persistent across reboots) with pure-Rust crypto so we
+# don't require a system OpenSSL/Perl build toolchain.
+[target.'cfg(target_os = "linux")'.dependencies]
+keyring = { version = "3.6", features = ["sync-secret-service", "crypto-rust"] }
 
 [target.'cfg(windows)'.dependencies]
 windows-sys = { version = "0.59", features = ["Win32_UI_WindowsAndMessaging", "Win32_Foundation"] }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -670,6 +670,17 @@ pub fn run() {
             let ssh_manager = Arc::new(ssh::SSHManager::new(handle.clone()));
             app.manage(ssh_manager);
 
+            // Verify the OS keychain backend actually persists secrets. If this
+            // fails, stored SSH passwords/passphrases silently vanish (mock
+            // store), so surface it loudly in logs.
+            match ssh::credential_store::self_test() {
+                Ok(()) => log::info!("[SSH] Credential keychain self-test passed"),
+                Err(e) => log::error!(
+                    "[SSH] Credential keychain self-test FAILED: {} -- stored SSH credentials will not persist",
+                    e
+                ),
+            }
+
             // Create Migration Manager
             let migration_manager = Arc::new(MigrationManager::new(handle.clone()));
             app.manage(migration_manager.clone());

--- a/src-tauri/src/ssh/connection.rs
+++ b/src-tauri/src/ssh/connection.rs
@@ -6,7 +6,7 @@
 use crate::ssh::profile_manager::SSHProfile;
 use parking_lot::RwLock;
 use serde::{Deserialize, Serialize};
-use ssh2::{CheckResult, KnownHostFileKind, KnownHostKeyFormat, Session};
+use ssh2::{CheckResult, KnownHostFileKind, Session};
 use std::collections::HashMap;
 use std::io::Read;
 use std::net::{TcpStream, ToSocketAddrs};
@@ -21,6 +21,33 @@ const MAX_RECONNECT_ATTEMPTS: u32 = 5;
 const INITIAL_BACKOFF_MS: u64 = 1000;
 const MAX_BACKOFF_MS: u64 = 30000;
 const TCP_CONNECT_TIMEOUT_SECS: u64 = 10;
+
+/// Minimal standard-base64 encoder (RFC 4648) for serializing host-key blobs
+/// into OpenSSH `known_hosts` lines. Avoids pulling in a base64 dependency for
+/// this single use site.
+fn base64_encode(input: &[u8]) -> String {
+    const TABLE: &[u8; 64] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+    let mut out = String::with_capacity(input.len().div_ceil(3) * 4);
+    for chunk in input.chunks(3) {
+        let b0 = chunk[0] as u32;
+        let b1 = *chunk.get(1).unwrap_or(&0) as u32;
+        let b2 = *chunk.get(2).unwrap_or(&0) as u32;
+        let n = (b0 << 16) | (b1 << 8) | b2;
+        out.push(TABLE[((n >> 18) & 0x3f) as usize] as char);
+        out.push(TABLE[((n >> 12) & 0x3f) as usize] as char);
+        out.push(if chunk.len() > 1 {
+            TABLE[((n >> 6) & 0x3f) as usize] as char
+        } else {
+            '='
+        });
+        out.push(if chunk.len() > 2 {
+            TABLE[(n & 0x3f) as usize] as char
+        } else {
+            '='
+        });
+    }
+    out
+}
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -131,18 +158,39 @@ impl SSHConnectionManager {
     /// `TcpStream::connect_timeout` requires a `SocketAddr`, which only parses
     /// numeric IPs. Resolving via `ToSocketAddrs` first lets us connect to
     /// hostnames (e.g. `example.com`) as well as IPs.
+    ///
+    /// The total connect time is bounded by `TCP_CONNECT_TIMEOUT_SECS` across
+    /// ALL resolved addresses (a shared deadline), so a dual-stack host whose
+    /// IPv6 route black-holes cannot stall for `N * timeout` before falling
+    /// back to IPv4.
     fn connect_tcp(host: &str, port: u16) -> Result<TcpStream, String> {
         let addr = format!("{}:{}", host, port);
-        let resolved = addr
+        let resolved: Vec<_> = addr
             .to_socket_addrs()
-            .map_err(|e| format!("Failed to resolve {}: {}", addr, e))?;
+            .map_err(|e| format!("Failed to resolve {}: {}", addr, e))?
+            .collect();
+
+        if resolved.is_empty() {
+            return Err(format!("Failed to resolve {}: no addresses returned", addr));
+        }
+
+        let total = Duration::from_secs(TCP_CONNECT_TIMEOUT_SECS);
+        let deadline = std::time::Instant::now() + total;
+        // Divide the budget across addresses, with a sensible floor so each
+        // address still gets a fair attempt.
+        let per_attempt = std::cmp::max(
+            total / resolved.len() as u32,
+            Duration::from_secs(2),
+        );
 
         let mut last_err: Option<String> = None;
         for socket_addr in resolved {
-            match TcpStream::connect_timeout(
-                &socket_addr,
-                Duration::from_secs(TCP_CONNECT_TIMEOUT_SECS),
-            ) {
+            let remaining = deadline.saturating_duration_since(std::time::Instant::now());
+            if remaining.is_zero() {
+                break;
+            }
+            let attempt_timeout = std::cmp::min(per_attempt, remaining);
+            match TcpStream::connect_timeout(&socket_addr, attempt_timeout) {
                 Ok(stream) => return Ok(stream),
                 Err(e) => last_err = Some(e.to_string()),
             }
@@ -151,7 +199,7 @@ impl SSHConnectionManager {
         Err(format!(
             "TCP connection to {} failed: {}",
             addr,
-            last_err.unwrap_or_else(|| "no addresses resolved".to_string())
+            last_err.unwrap_or_else(|| "connection timed out".to_string())
         ))
     }
 
@@ -184,18 +232,36 @@ impl SSHConnectionManager {
         Ok(session)
     }
 
-    /// Path to the user's `~/.ssh/known_hosts` file.
-    fn known_hosts_path() -> Option<std::path::PathBuf> {
+    /// Path to the user's `~/.ssh` directory.
+    fn ssh_dir() -> Option<std::path::PathBuf> {
         let home = std::env::var_os("HOME")
             .or_else(|| std::env::var_os("USERPROFILE"))
             .map(std::path::PathBuf::from)?;
-        Some(home.join(".ssh").join("known_hosts"))
+        Some(home.join(".ssh"))
     }
 
-    /// Verify the server host key against the user's `known_hosts`, applying
-    /// `accept-new` behavior: unknown hosts are added and persisted, changed
-    /// keys are rejected (potential MITM). This mirrors the interactive terminal
-    /// path which uses `StrictHostKeyChecking=accept-new`.
+    /// Path to the user's `~/.ssh/known_hosts` file (read-only, for verification).
+    fn known_hosts_path() -> Option<std::path::PathBuf> {
+        Self::ssh_dir().map(|d| d.join("known_hosts"))
+    }
+
+    /// Path to the app-managed known_hosts file. New accept-new entries are
+    /// persisted here (appended) instead of rewriting the user's shared
+    /// `~/.ssh/known_hosts`, whose format (markers like `@cert-authority` /
+    /// `@revoked`, unsupported key types, comments) libssh2's writer would drop.
+    fn app_known_hosts_path() -> Option<std::path::PathBuf> {
+        Self::ssh_dir().map(|d| d.join("known_hosts_termul"))
+    }
+
+    /// Verify the server host key against the user's `known_hosts` plus the
+    /// app-managed store, applying `accept-new` behavior: unknown hosts are
+    /// recorded and persisted, changed keys are rejected (potential MITM). This
+    /// mirrors the interactive terminal path's `StrictHostKeyChecking=accept-new`.
+    ///
+    /// To avoid corrupting the user's shared `~/.ssh/known_hosts` (libssh2's
+    /// `write_file` truncates and re-serializes only what it could parse), both
+    /// files are loaded read-only for the check, and newly accepted keys are
+    /// appended to the app-managed file only.
     fn verify_host_key(session: &Session, host: &str, port: u16) -> Result<(), String> {
         let (key, key_type) = session
             .host_key()
@@ -205,11 +271,21 @@ impl SSHConnectionManager {
             .known_hosts()
             .map_err(|e| format!("Failed to access known_hosts: {}", e))?;
 
-        let kh_path = Self::known_hosts_path();
-        if let Some(ref path) = kh_path {
+        // Load the user's shared known_hosts (read-only) and the app-managed
+        // file. If a file exists but cannot be read, fail closed rather than
+        // silently downgrading a populated store to accept-new.
+        for path in [Self::known_hosts_path(), Self::app_known_hosts_path()]
+            .into_iter()
+            .flatten()
+        {
             if path.exists() {
-                // A read error is non-fatal: we treat it as an empty store.
-                let _ = known_hosts.read_file(path, KnownHostFileKind::OpenSSH);
+                if let Err(e) = known_hosts.read_file(&path, KnownHostFileKind::OpenSSH) {
+                    // A genuinely empty file reads as Ok; an error here means the
+                    // file is present but unreadable/partially parseable. Treat
+                    // the user's file leniently (system ssh remains source of
+                    // truth) but log; only the app file is ours to trust.
+                    log::warn!("[SSH] Could not fully read known_hosts {:?}: {}", path, e);
+                }
             }
         }
 
@@ -220,38 +296,73 @@ impl SSHConnectionManager {
                 host, port
             )),
             CheckResult::NotFound => {
-                // accept-new: remember this host for next time.
-                let key_format = match key_type {
-                    ssh2::HostKeyType::Rsa => KnownHostKeyFormat::SshRsa,
-                    ssh2::HostKeyType::Dss => KnownHostKeyFormat::SshDss,
-                    ssh2::HostKeyType::Ecdsa256 => KnownHostKeyFormat::Ecdsa256,
-                    ssh2::HostKeyType::Ecdsa384 => KnownHostKeyFormat::Ecdsa384,
-                    ssh2::HostKeyType::Ecdsa521 => KnownHostKeyFormat::Ecdsa521,
-                    ssh2::HostKeyType::Ed25519 => KnownHostKeyFormat::Ed25519,
-                    ssh2::HostKeyType::Unknown => KnownHostKeyFormat::Unknown,
-                };
-                let host_entry = if port == 22 {
-                    host.to_string()
-                } else {
-                    format!("[{}]:{}", host, port)
-                };
-                if let Err(e) = known_hosts.add(&host_entry, key, "", key_format) {
-                    log::warn!("[SSH] Failed to record new host key for {}: {}", host_entry, e);
-                    return Ok(());
-                }
-                if let Some(ref path) = kh_path {
-                    if let Some(parent) = path.parent() {
-                        let _ = std::fs::create_dir_all(parent);
-                    }
-                    if let Err(e) = known_hosts.write_file(path, KnownHostFileKind::OpenSSH) {
-                        log::warn!("[SSH] Failed to persist known_hosts at {:?}: {}", path, e);
-                    }
-                }
+                // accept-new: remember this host by appending a single OpenSSH
+                // line to the app-managed file (never rewriting the user's).
+                Self::append_known_host(host, port, key, key_type);
                 Ok(())
             }
             CheckResult::Failure => {
                 Err("Host key verification failed: unable to check known_hosts".to_string())
             }
+        }
+    }
+
+    /// Append a single OpenSSH-format known_hosts line to the app-managed file.
+    /// Best-effort: failures are logged, not fatal (the host was still accepted
+    /// for this session under TOFU).
+    fn append_known_host(host: &str, port: u16, key: &[u8], key_type: ssh2::HostKeyType) {
+        use std::io::Write;
+
+        let key_type_str = match key_type {
+            ssh2::HostKeyType::Rsa => "ssh-rsa",
+            ssh2::HostKeyType::Dss => "ssh-dss",
+            ssh2::HostKeyType::Ecdsa256 => "ecdsa-sha2-nistp256",
+            ssh2::HostKeyType::Ecdsa384 => "ecdsa-sha2-nistp384",
+            ssh2::HostKeyType::Ecdsa521 => "ecdsa-sha2-nistp521",
+            ssh2::HostKeyType::Ed25519 => "ssh-ed25519",
+            ssh2::HostKeyType::Unknown => {
+                log::warn!("[SSH] Not persisting host key for {}: unknown key type", host);
+                return;
+            }
+        };
+
+        let host_entry = if port == 22 {
+            host.to_string()
+        } else {
+            format!("[{}]:{}", host, port)
+        };
+        // base64-encode the raw key blob (OpenSSH known_hosts format).
+        let key_b64 = base64_encode(key);
+        let line = format!("{} {} {}\n", host_entry, key_type_str, key_b64);
+
+        let path = match Self::app_known_hosts_path() {
+            Some(p) => p,
+            None => return,
+        };
+        if let Some(parent) = path.parent() {
+            if let Err(e) = std::fs::create_dir_all(parent) {
+                log::warn!("[SSH] Failed to create {:?}: {}", parent, e);
+                return;
+            }
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::PermissionsExt;
+                let _ = std::fs::set_permissions(parent, std::fs::Permissions::from_mode(0o700));
+            }
+        }
+
+        match std::fs::OpenOptions::new().create(true).append(true).open(&path) {
+            Ok(mut file) => {
+                #[cfg(unix)]
+                {
+                    use std::os::unix::fs::PermissionsExt;
+                    let _ = file.set_permissions(std::fs::Permissions::from_mode(0o600));
+                }
+                if let Err(e) = file.write_all(line.as_bytes()) {
+                    log::warn!("[SSH] Failed to persist host key for {}: {}", host_entry, e);
+                }
+            }
+            Err(e) => log::warn!("[SSH] Failed to open {:?}: {}", path, e),
         }
     }
 
@@ -380,13 +491,24 @@ impl SSHConnectionManager {
                     if let Ok(tcp) = tcp_result {
                         if let Ok(mut new_session) = Session::new() {
                             new_session.set_tcp_stream(tcp);
-                            if new_session.handshake().is_ok()
-                                && Self::verify_host_key(
-                                    &new_session,
-                                    &profile.host,
-                                    profile.port,
-                                )
-                                .is_ok()
+                            let handshake_ok = new_session.handshake().is_ok();
+                            let verify_result = if handshake_ok {
+                                Self::verify_host_key(&new_session, &profile.host, profile.port)
+                            } else {
+                                Ok(())
+                            };
+                            if let Err(e) = &verify_result {
+                                // A rotated/changed host key turns a transient
+                                // reconnect into a hard failure; log the cause so
+                                // it is diagnosable rather than a generic retry.
+                                log::warn!(
+                                    "[SSH] Host key verification failed during reconnect of {}: {}",
+                                    connection_id,
+                                    e
+                                );
+                            }
+                            if handshake_ok
+                                && verify_result.is_ok()
                                 && Self::authenticate_session(
                                     &new_session,
                                     &profile,
@@ -659,15 +781,28 @@ mod tests {
     fn connect_tcp_accepts_hostname_syntax() {
         // Regression for the IP-only bug: an address must reach DNS resolution
         // (and then a connection attempt) rather than failing with "invalid
-        // socket address syntax". Localhost on a closed high port refuses
-        // immediately, so this proves the host:port was parsed/resolved.
-        let err = SSHConnectionManager::connect_tcp("localhost", 1)
+        // socket address syntax". 127.0.0.1 on a closed low port refuses
+        // immediately and avoids resolver/dual-stack dependence.
+        let err = SSHConnectionManager::connect_tcp("127.0.0.1", 1)
             .expect_err("closed port should not connect");
         assert!(
             !err.contains("invalid socket address"),
-            "hostname should resolve, got: {}",
+            "address should resolve, got: {}",
             err
         );
         assert!(err.contains("TCP connection"), "unexpected error: {}", err);
+    }
+
+    #[test]
+    fn base64_encode_matches_known_vectors() {
+        // RFC 4648 test vectors, ensuring correct padding for the known_hosts
+        // serializer.
+        assert_eq!(base64_encode(b""), "");
+        assert_eq!(base64_encode(b"f"), "Zg==");
+        assert_eq!(base64_encode(b"fo"), "Zm8=");
+        assert_eq!(base64_encode(b"foo"), "Zm9v");
+        assert_eq!(base64_encode(b"foob"), "Zm9vYg==");
+        assert_eq!(base64_encode(b"fooba"), "Zm9vYmE=");
+        assert_eq!(base64_encode(b"foobar"), "Zm9vYmFy");
     }
 }

--- a/src-tauri/src/ssh/connection.rs
+++ b/src-tauri/src/ssh/connection.rs
@@ -6,10 +6,10 @@
 use crate::ssh::profile_manager::SSHProfile;
 use parking_lot::RwLock;
 use serde::{Deserialize, Serialize};
-use ssh2::Session;
+use ssh2::{CheckResult, KnownHostFileKind, KnownHostKeyFormat, Session};
 use std::collections::HashMap;
 use std::io::Read;
-use std::net::TcpStream;
+use std::net::{TcpStream, ToSocketAddrs};
 use std::path::Path;
 use std::sync::Arc;
 use std::time::Duration;
@@ -125,21 +125,43 @@ impl SSHConnectionManager {
         Ok(connected_info)
     }
 
+    /// Resolve `host:port` (DNS name or literal IP) and open a TCP connection to
+    /// the first address that accepts within the timeout.
+    ///
+    /// `TcpStream::connect_timeout` requires a `SocketAddr`, which only parses
+    /// numeric IPs. Resolving via `ToSocketAddrs` first lets us connect to
+    /// hostnames (e.g. `example.com`) as well as IPs.
+    fn connect_tcp(host: &str, port: u16) -> Result<TcpStream, String> {
+        let addr = format!("{}:{}", host, port);
+        let resolved = addr
+            .to_socket_addrs()
+            .map_err(|e| format!("Failed to resolve {}: {}", addr, e))?;
+
+        let mut last_err: Option<String> = None;
+        for socket_addr in resolved {
+            match TcpStream::connect_timeout(
+                &socket_addr,
+                Duration::from_secs(TCP_CONNECT_TIMEOUT_SECS),
+            ) {
+                Ok(stream) => return Ok(stream),
+                Err(e) => last_err = Some(e.to_string()),
+            }
+        }
+
+        Err(format!(
+            "TCP connection to {} failed: {}",
+            addr,
+            last_err.unwrap_or_else(|| "no addresses resolved".to_string())
+        ))
+    }
+
     /// Create an SSH session to the given profile
     fn create_session(
         &self,
         profile: &SSHProfile,
         password: Option<&str>,
     ) -> Result<Session, String> {
-        let addr = format!("{}:{}", profile.host, profile.port);
-
-        let tcp = TcpStream::connect_timeout(
-            &addr
-                .parse()
-                .map_err(|e| format!("Invalid address {}: {}", addr, e))?,
-            Duration::from_secs(TCP_CONNECT_TIMEOUT_SECS),
-        )
-        .map_err(|e| format!("TCP connection to {} failed: {}", addr, e))?;
+        let tcp = Self::connect_tcp(&profile.host, profile.port)?;
 
         let mut session =
             Session::new().map_err(|e| format!("Failed to create SSH session: {}", e))?;
@@ -148,6 +170,11 @@ impl SSHConnectionManager {
             .handshake()
             .map_err(|e| format!("SSH handshake failed: {}", e))?;
 
+        // Verify the server host key against ~/.ssh/known_hosts (TOFU /
+        // accept-new semantics) before authenticating, so the SFTP/port-forward
+        // channel is not silently exposed to MITM.
+        Self::verify_host_key(&session, &profile.host, profile.port)?;
+
         // Authenticate
         Self::authenticate_session(&session, profile, password)?;
 
@@ -155,6 +182,77 @@ impl SSHConnectionManager {
         session.set_keepalive(true, HEARTBEAT_INTERVAL_SECS as u32);
 
         Ok(session)
+    }
+
+    /// Path to the user's `~/.ssh/known_hosts` file.
+    fn known_hosts_path() -> Option<std::path::PathBuf> {
+        let home = std::env::var_os("HOME")
+            .or_else(|| std::env::var_os("USERPROFILE"))
+            .map(std::path::PathBuf::from)?;
+        Some(home.join(".ssh").join("known_hosts"))
+    }
+
+    /// Verify the server host key against the user's `known_hosts`, applying
+    /// `accept-new` behavior: unknown hosts are added and persisted, changed
+    /// keys are rejected (potential MITM). This mirrors the interactive terminal
+    /// path which uses `StrictHostKeyChecking=accept-new`.
+    fn verify_host_key(session: &Session, host: &str, port: u16) -> Result<(), String> {
+        let (key, key_type) = session
+            .host_key()
+            .ok_or_else(|| "Server did not present a host key".to_string())?;
+
+        let mut known_hosts = session
+            .known_hosts()
+            .map_err(|e| format!("Failed to access known_hosts: {}", e))?;
+
+        let kh_path = Self::known_hosts_path();
+        if let Some(ref path) = kh_path {
+            if path.exists() {
+                // A read error is non-fatal: we treat it as an empty store.
+                let _ = known_hosts.read_file(path, KnownHostFileKind::OpenSSH);
+            }
+        }
+
+        match known_hosts.check_port(host, port, key) {
+            CheckResult::Match => Ok(()),
+            CheckResult::Mismatch => Err(format!(
+                "Host key verification failed for {}:{}: the server key does not match the known_hosts entry (possible man-in-the-middle). Remove the stale entry to reconnect.",
+                host, port
+            )),
+            CheckResult::NotFound => {
+                // accept-new: remember this host for next time.
+                let key_format = match key_type {
+                    ssh2::HostKeyType::Rsa => KnownHostKeyFormat::SshRsa,
+                    ssh2::HostKeyType::Dss => KnownHostKeyFormat::SshDss,
+                    ssh2::HostKeyType::Ecdsa256 => KnownHostKeyFormat::Ecdsa256,
+                    ssh2::HostKeyType::Ecdsa384 => KnownHostKeyFormat::Ecdsa384,
+                    ssh2::HostKeyType::Ecdsa521 => KnownHostKeyFormat::Ecdsa521,
+                    ssh2::HostKeyType::Ed25519 => KnownHostKeyFormat::Ed25519,
+                    ssh2::HostKeyType::Unknown => KnownHostKeyFormat::Unknown,
+                };
+                let host_entry = if port == 22 {
+                    host.to_string()
+                } else {
+                    format!("[{}]:{}", host, port)
+                };
+                if let Err(e) = known_hosts.add(&host_entry, key, "", key_format) {
+                    log::warn!("[SSH] Failed to record new host key for {}: {}", host_entry, e);
+                    return Ok(());
+                }
+                if let Some(ref path) = kh_path {
+                    if let Some(parent) = path.parent() {
+                        let _ = std::fs::create_dir_all(parent);
+                    }
+                    if let Err(e) = known_hosts.write_file(path, KnownHostFileKind::OpenSSH) {
+                        log::warn!("[SSH] Failed to persist known_hosts at {:?}: {}", path, e);
+                    }
+                }
+                Ok(())
+            }
+            CheckResult::Failure => {
+                Err("Host key verification failed: unable to check known_hosts".to_string())
+            }
+        }
     }
 
     fn authenticate_session(
@@ -276,20 +374,19 @@ impl SSHConnectionManager {
 
                     tokio::time::sleep(Duration::from_millis(backoff)).await;
 
-                    // Try to create new session
-                    let addr = format!("{}:{}", profile.host, profile.port);
-                    let tcp_result = TcpStream::connect_timeout(
-                        &match addr.parse() {
-                            Ok(a) => a,
-                            Err(_) => continue,
-                        },
-                        Duration::from_secs(TCP_CONNECT_TIMEOUT_SECS),
-                    );
+                    // Try to create new session (resolves DNS names, not just IPs)
+                    let tcp_result = Self::connect_tcp(&profile.host, profile.port);
 
                     if let Ok(tcp) = tcp_result {
                         if let Ok(mut new_session) = Session::new() {
                             new_session.set_tcp_stream(tcp);
                             if new_session.handshake().is_ok()
+                                && Self::verify_host_key(
+                                    &new_session,
+                                    &profile.host,
+                                    profile.port,
+                                )
+                                .is_ok()
                                 && Self::authenticate_session(
                                     &new_session,
                                     &profile,
@@ -540,5 +637,37 @@ mod tests {
                 .expect_err("unknown auth method must fail before network authentication");
 
         assert_eq!(error, "Unknown auth method: webauthn");
+    }
+
+    #[test]
+    fn connect_tcp_rejects_unresolvable_host_without_panicking() {
+        // A syntactically valid but non-resolvable host must produce a
+        // descriptive error rather than the old IP-only parse failure.
+        let err = SSHConnectionManager::connect_tcp(
+            "nonexistent.invalid.example.test.",
+            22,
+        )
+        .expect_err("unresolvable host should error");
+        assert!(
+            err.contains("resolve") || err.contains("TCP connection"),
+            "unexpected error message: {}",
+            err
+        );
+    }
+
+    #[test]
+    fn connect_tcp_accepts_hostname_syntax() {
+        // Regression for the IP-only bug: an address must reach DNS resolution
+        // (and then a connection attempt) rather than failing with "invalid
+        // socket address syntax". Localhost on a closed high port refuses
+        // immediately, so this proves the host:port was parsed/resolved.
+        let err = SSHConnectionManager::connect_tcp("localhost", 1)
+            .expect_err("closed port should not connect");
+        assert!(
+            !err.contains("invalid socket address"),
+            "hostname should resolve, got: {}",
+            err
+        );
+        assert!(err.contains("TCP connection"), "unexpected error: {}", err);
     }
 }

--- a/src-tauri/src/ssh/connection.rs
+++ b/src-tauri/src/ssh/connection.rs
@@ -165,7 +165,10 @@ impl SSHConnectionManager {
     /// back to IPv4.
     fn connect_tcp(host: &str, port: u16) -> Result<TcpStream, String> {
         let addr = format!("{}:{}", host, port);
-        let resolved: Vec<_> = addr
+        // Resolve via the (host, port) tuple rather than the formatted string so
+        // bare IPv6 literals (which as a string would need bracket form
+        // `[::1]:22`) resolve correctly. The `addr` string is kept for messages.
+        let resolved: Vec<_> = (host, port)
             .to_socket_addrs()
             .map_err(|e| format!("Failed to resolve {}: {}", addr, e))?
             .collect();
@@ -272,18 +275,32 @@ impl SSHConnectionManager {
             .map_err(|e| format!("Failed to access known_hosts: {}", e))?;
 
         // Load the user's shared known_hosts (read-only) and the app-managed
-        // file. If a file exists but cannot be read, fail closed rather than
-        // silently downgrading a populated store to accept-new.
-        for path in [Self::known_hosts_path(), Self::app_known_hosts_path()]
+        // file. The user's file is treated leniently (system ssh remains its
+        // source of truth); the app-managed file is ours, so if it exists but
+        // cannot be read we fail closed rather than silently downgrading a
+        // populated store to accept-new.
+        let app_path = Self::app_known_hosts_path();
+        for path in [Self::known_hosts_path(), app_path.clone()]
             .into_iter()
             .flatten()
         {
             if path.exists() {
                 if let Err(e) = known_hosts.read_file(&path, KnownHostFileKind::OpenSSH) {
-                    // A genuinely empty file reads as Ok; an error here means the
-                    // file is present but unreadable/partially parseable. Treat
-                    // the user's file leniently (system ssh remains source of
-                    // truth) but log; only the app file is ours to trust.
+                    let is_app_file = app_path.as_deref() == Some(path.as_path());
+                    if is_app_file {
+                        log::error!(
+                            "[SSH] Failed to read app known_hosts {:?}: {}",
+                            path,
+                            e
+                        );
+                        return Err(format!(
+                            "Failed to read app known_hosts {:?}: {}",
+                            path, e
+                        ));
+                    }
+                    // A genuinely empty file reads as Ok; an error on the user's
+                    // file means it is present but unreadable/partially
+                    // parseable. Log and continue (system ssh owns that file).
                     log::warn!("[SSH] Could not fully read known_hosts {:?}: {}", path, e);
                 }
             }
@@ -467,6 +484,10 @@ impl SSHConnectionManager {
                 // Attempt reconnect with exponential backoff
                 let mut attempts = 0u32;
                 let mut reconnected = false;
+                // Set when reconnect aborts due to a host-key verification
+                // failure, so the generic "Reconnect failed" message below does
+                // not clobber the precise error already stored.
+                let mut host_key_failed = false;
 
                 while attempts < MAX_RECONNECT_ATTEMPTS
                     && !should_stop.load(std::sync::atomic::Ordering::Relaxed)
@@ -497,18 +518,25 @@ impl SSHConnectionManager {
                             } else {
                                 Ok(())
                             };
-                            if let Err(e) = &verify_result {
-                                // A rotated/changed host key turns a transient
-                                // reconnect into a hard failure; log the cause so
-                                // it is diagnosable rather than a generic retry.
-                                log::warn!(
+                            // A changed/rotated host key is not a transient
+                            // failure: retrying cannot fix it and continuing to
+                            // retry hides the cause. Fail fast and surface the
+                            // exact verification error to the UI.
+                            if let Err(e) = verify_result {
+                                let mut state_guard = state.lock().await;
+                                state_guard.info.status = "failed".to_string();
+                                state_guard.info.error = Some(e.clone());
+                                state_guard.session = None;
+                                Self::emit_status_static(&app_handle, &state_guard.info);
+                                log::error!(
                                     "[SSH] Host key verification failed during reconnect of {}: {}",
                                     connection_id,
                                     e
                                 );
+                                host_key_failed = true;
+                                break;
                             }
                             if handshake_ok
-                                && verify_result.is_ok()
                                 && Self::authenticate_session(
                                     &new_session,
                                     &profile,
@@ -544,7 +572,7 @@ impl SSHConnectionManager {
                     }
                 }
 
-                if !reconnected {
+                if !reconnected && !host_key_failed {
                     let mut state_guard = state.lock().await;
                     state_guard.info.status = "failed".to_string();
                     state_guard.info.error =
@@ -557,6 +585,12 @@ impl SSHConnectionManager {
                         connection_id,
                         attempts
                     );
+                    break;
+                }
+
+                // A host-key failure already set a precise error and status;
+                // stop the heartbeat loop without overwriting it.
+                if host_key_failed {
                     break;
                 }
             }
@@ -804,5 +838,22 @@ mod tests {
         assert_eq!(base64_encode(b"foob"), "Zm9vYg==");
         assert_eq!(base64_encode(b"fooba"), "Zm9vYmE=");
         assert_eq!(base64_encode(b"foobar"), "Zm9vYmFy");
+    }
+
+    #[test]
+    fn connect_tcp_accepts_ipv6_literal() {
+        // Regression: resolving via the (host, port) tuple (not a formatted
+        // string) lets bare IPv6 literals resolve without bracket form.
+        // `::1` port 1 should reach a connection attempt, not a resolve/parse
+        // error. If the host has no IPv6 loopback it still must not be an
+        // "invalid socket address" failure.
+        let err = SSHConnectionManager::connect_tcp("::1", 1)
+            .expect_err("closed port should not connect");
+        assert!(
+            !err.contains("invalid socket address"),
+            "IPv6 literal should resolve via tuple, got: {}",
+            err
+        );
+        assert!(err.contains("TCP connection"), "unexpected error: {}", err);
     }
 }

--- a/src-tauri/src/ssh/credential_store.rs
+++ b/src-tauri/src/ssh/credential_store.rs
@@ -98,3 +98,35 @@ pub fn delete_credentials(profile_id: &str) -> Result<(), String> {
         Err(format!("Failed to delete credentials: {}", errors.join("; ")))
     }
 }
+
+/// Verify that the configured keyring backend actually persists secrets.
+///
+/// `keyring` selects its backend at compile time; without an OS-backend cargo
+/// feature it silently uses an in-memory mock where `set_password` succeeds but
+/// `get_password` returns `NoEntry`. This round-trips a throwaway entry and
+/// returns an error if the store is non-functional, so misconfiguration is
+/// caught at startup instead of silently losing every credential.
+pub fn self_test() -> Result<(), String> {
+    let key = format!("__selftest-{}", uuid::Uuid::new_v4());
+    let probe = "ok";
+    let entry = Entry::new(SERVICE_NAME, &key)
+        .map_err(|e| format!("keyring unavailable: {}", e))?;
+    entry
+        .set_password(probe)
+        .map_err(|e| format!("keyring write failed: {}", e))?;
+    let read_back = match entry.get_password() {
+        Ok(v) => v,
+        Err(e) => {
+            let _ = entry.delete_credential();
+            return Err(format!(
+                "keyring read-back failed (likely no OS backend compiled in): {}",
+                e
+            ));
+        }
+    };
+    let _ = entry.delete_credential();
+    if read_back != probe {
+        return Err("keyring read-back mismatch (mock/in-memory store active)".to_string());
+    }
+    Ok(())
+}

--- a/src-tauri/src/ssh/credential_store.rs
+++ b/src-tauri/src/ssh/credential_store.rs
@@ -117,16 +117,26 @@ pub fn self_test() -> Result<(), String> {
     let read_back = match entry.get_password() {
         Ok(v) => v,
         Err(e) => {
-            let _ = entry.delete_credential();
+            if let Err(del_err) = entry.delete_credential() {
+                return Err(format!(
+                    "keyring read-back failed ({}) and probe cleanup also failed: {}",
+                    e, del_err
+                ));
+            }
             return Err(format!(
                 "keyring read-back failed (likely no OS backend compiled in): {}",
                 e
             ));
         }
     };
-    let _ = entry.delete_credential();
+    // Clean up the probe; a cleanup failure indicates a partially-working
+    // backend and is itself worth surfacing.
+    let delete_result = entry.delete_credential();
     if read_back != probe {
         return Err("keyring read-back mismatch (mock/in-memory store active)".to_string());
+    }
+    if let Err(del_err) = delete_result {
+        return Err(format!("keyring probe cleanup failed: {}", del_err));
     }
     Ok(())
 }

--- a/src/renderer/components/ssh/SSHWorkspace.tsx
+++ b/src/renderer/components/ssh/SSHWorkspace.tsx
@@ -37,7 +37,7 @@ export function SSHWorkspace({ profile, conn }: SSHWorkspaceProps): React.JSX.El
             )}
           </div>
           <div className="flex items-center gap-1">
-            {conn.isConnected ? (
+            {conn.isConnected || conn.localTerminalPtyId ? (
               <button onClick={conn.handleDisconnect}
                 className="px-2 py-0.5 text-[10px] rounded border border-border hover:bg-destructive/10 hover:text-destructive flex items-center gap-1">
                 <WifiOff className="h-3 w-3" />Disconnect
@@ -64,7 +64,7 @@ export function SSHWorkspace({ profile, conn }: SSHWorkspaceProps): React.JSX.El
                 <Terminal className="h-3.5 w-3.5" />{conn.isConnecting ? 'Connecting...' : 'Reconnect'}
               </button>
             </div>
-          ) : conn.isConnected && conn.localTerminalPtyId ? (
+          ) : conn.localTerminalPtyId ? (
             <div className="absolute inset-0 overflow-hidden">
               <ConnectedTerminal terminalId={conn.localTerminalPtyId} autoSpawn={false} isVisible={true} onExit={conn.handleSSHProcessExit} />
             </div>

--- a/src/renderer/components/ssh/SSHWorkspace.tsx
+++ b/src/renderer/components/ssh/SSHWorkspace.tsx
@@ -26,6 +26,10 @@ export function SSHWorkspace({ profile, conn }: SSHWorkspaceProps): React.JSX.El
               <span className="flex items-center gap-1 text-[10px] text-green-500">
                 <span className="h-1.5 w-1.5 rounded-full bg-green-500" />Connected
               </span>
+            ) : conn.isConnectingStatus || conn.isConnecting ? (
+              <span className="flex items-center gap-1 text-[10px] text-yellow-500">
+                <span className="h-1.5 w-1.5 rounded-full bg-yellow-500 animate-pulse" />Connecting
+              </span>
             ) : (
               <span className="flex items-center gap-1 text-[10px] text-muted-foreground">
                 <span className="h-1.5 w-1.5 rounded-full bg-muted-foreground/40" />Disconnected
@@ -62,7 +66,7 @@ export function SSHWorkspace({ profile, conn }: SSHWorkspaceProps): React.JSX.El
             </div>
           ) : conn.isConnected && conn.localTerminalPtyId ? (
             <div className="absolute inset-0 overflow-hidden">
-              <ConnectedTerminal terminalId={conn.localTerminalPtyId} autoSpawn={false} isVisible={true} />
+              <ConnectedTerminal terminalId={conn.localTerminalPtyId} autoSpawn={false} isVisible={true} onExit={conn.handleSSHProcessExit} />
             </div>
           ) : (
             <div className="flex-1 flex flex-col items-center justify-center gap-3 text-center px-6">

--- a/src/renderer/hooks/use-ssh-connection.test.ts
+++ b/src/renderer/hooks/use-ssh-connection.test.ts
@@ -21,7 +21,7 @@ vi.mock('@/lib/api', () => ({
   },
   sshApi: {
     connect: mocks.connect,
-    sftpListDir: vi.fn(),
+    sftpListDir: vi.fn().mockResolvedValue({ success: true, data: [] }),
   },
   createAskpassScript: mocks.createAskpassScript,
 }))
@@ -104,5 +104,59 @@ describe('useSSHConnection', () => {
       'pty-1',
       expect.not.stringContaining('UserKnownHostsFile')
     )
+  })
+
+  it('marks connected and readies SFTP only after the backend connect succeeds', async () => {
+    const { result } = renderHook(() => useSSHConnection(baseProfile))
+
+    await act(async () => {
+      await result.current.handleConnect()
+    })
+
+    const conn = useSSHStore.getState().connections.find((c) => c.profileId === 'profile-1')
+    expect(conn?.status).toBe('connected')
+    expect(conn?.id).toBe('conn-1') // swapped to the backend id
+    expect(result.current.sftpReady).toBe(true)
+  })
+
+  it('does NOT report connected when the backend SSH connect fails', async () => {
+    mocks.connect.mockResolvedValueOnce({
+      success: false,
+      error: 'Password authentication failed',
+      code: 'SSH_CONNECT_ERROR',
+    })
+
+    const { result } = renderHook(() => useSSHConnection(baseProfile))
+
+    await act(async () => {
+      await result.current.handleConnect()
+    })
+
+    const conn = useSSHStore.getState().connections.find((c) => c.profileId === 'profile-1')
+    expect(conn?.status).toBe('failed')
+    expect(conn?.error).toBe('Password authentication failed')
+    expect(result.current.isConnected).toBe(false)
+    expect(result.current.sftpReady).toBe(false)
+  })
+
+  it('downgrades to failed when the interactive ssh process exits before connecting', async () => {
+    mocks.connect.mockResolvedValueOnce({
+      success: false,
+      error: 'timed out',
+      code: 'SSH_CONNECT_ERROR',
+    })
+
+    const { result } = renderHook(() => useSSHConnection(baseProfile))
+
+    await act(async () => {
+      await result.current.handleConnect()
+    })
+    act(() => {
+      result.current.handleSSHProcessExit()
+    })
+
+    const conn = useSSHStore.getState().connections.find((c) => c.profileId === 'profile-1')
+    expect(conn?.status).toBe('failed')
+    expect(result.current.isConnected).toBe(false)
   })
 })

--- a/src/renderer/hooks/use-ssh-connection.test.ts
+++ b/src/renderer/hooks/use-ssh-connection.test.ts
@@ -159,4 +159,72 @@ describe('useSSHConnection', () => {
     expect(conn?.status).toBe('failed')
     expect(result.current.isConnected).toBe(false)
   })
+
+  it('keeps the interactive terminal reachable after a backend connect failure (no orphan)', async () => {
+    mocks.connect.mockResolvedValueOnce({
+      success: false,
+      error: 'auth failed',
+      code: 'SSH_CONNECT_ERROR',
+    })
+
+    const { result } = renderHook(() => useSSHConnection(baseProfile))
+
+    await act(async () => {
+      await result.current.handleConnect()
+    })
+
+    // The PTY is NOT killed on failure: the terminal stays visible (SSHWorkspace
+    // renders on localTerminalPtyId) with a Disconnect control, so the ssh
+    // process is never an unreachable orphan.
+    expect(mocks.kill).not.toHaveBeenCalled()
+    expect(result.current.localTerminalPtyId).toBe('pty-1')
+    const conn = useSSHStore.getState().connections.find((c) => c.profileId === 'profile-1')
+    expect(conn?.status).toBe('failed')
+  })
+
+  it('kills the previous PTY when retrying connect (prevents orphan leak)', async () => {
+    mocks.connect.mockResolvedValueOnce({
+      success: false,
+      error: 'auth failed',
+      code: 'SSH_CONNECT_ERROR',
+    })
+    mocks.spawn
+      .mockResolvedValueOnce({ success: true, data: { id: 'pty-1', shell: 'ssh', cwd: '/' } })
+      .mockResolvedValueOnce({ success: true, data: { id: 'pty-2', shell: 'ssh', cwd: '/' } })
+
+    const { result } = renderHook(() => useSSHConnection(baseProfile))
+
+    await act(async () => {
+      await result.current.handleConnect()
+    })
+    // Retry: the first (failed) PTY must be killed before the new spawn.
+    await act(async () => {
+      await result.current.handleConnect()
+    })
+
+    expect(mocks.kill).toHaveBeenCalledWith('pty-1')
+    expect(result.current.localTerminalPtyId).toBe('pty-2')
+  })
+
+  it('does not blank SFTP or downgrade when the shell exits on a healthy connection', async () => {
+    const { result } = renderHook(() => useSSHConnection(baseProfile))
+
+    await act(async () => {
+      await result.current.handleConnect()
+    })
+    // Sanity: connected with SFTP ready.
+    expect(result.current.isConnected).toBe(true)
+    expect(result.current.sftpReady).toBe(true)
+
+    // User types `exit` in the interactive shell; the ssh2/SFTP backend is
+    // independent and still connected, so SFTP must stay ready and the badge
+    // must remain connected.
+    act(() => {
+      result.current.handleSSHProcessExit()
+    })
+
+    const conn = useSSHStore.getState().connections.find((c) => c.profileId === 'profile-1')
+    expect(conn?.status).toBe('connected')
+    expect(result.current.sftpReady).toBe(true)
+  })
 })

--- a/src/renderer/hooks/use-ssh-connection.test.ts
+++ b/src/renderer/hooks/use-ssh-connection.test.ts
@@ -96,14 +96,44 @@ describe('useSSHConnection', () => {
       await vi.advanceTimersByTimeAsync(500)
     })
 
+    // Args are individually quoted for the shell. On non-Windows (jsdom test
+    // env) that means single-quote wrapping, so the option appears quoted.
     expect(mocks.write).toHaveBeenCalledWith(
       'pty-1',
-      expect.stringContaining('-o StrictHostKeyChecking=accept-new')
+      expect.stringContaining("'StrictHostKeyChecking=accept-new'")
     )
     expect(mocks.write).toHaveBeenCalledWith(
       'pty-1',
       expect.not.stringContaining('UserKnownHostsFile')
     )
+  })
+
+  it('neutralizes shell metacharacters and backslashes in profile fields (no injection)', async () => {
+    // A key path with a shell-injection payload and backslashes must be fully
+    // quoted so the shell cannot execute the payload. (jsdom => POSIX quoting.)
+    const malicious: SSHProfile = {
+      ...baseProfile,
+      authMethod: 'key',
+      privateKeyPath: "/tmp/key'; rm -rf $HOME #",
+    }
+    const { result } = renderHook(() => useSSHConnection(malicious))
+
+    await act(async () => {
+      await result.current.handleConnect()
+    })
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(500)
+    })
+
+    const written = mocks.write.mock.calls.find((c) => c[0] === 'pty-1')?.[1] as string
+    expect(written).toBeDefined()
+    // The payload is fully contained in a single-quoted span: the inner single
+    // quote is closed/escaped/reopened ('\''), so the shell sees the whole
+    // thing as one literal -i argument and cannot execute `rm`.
+    expect(written).toContain("'/tmp/key'\\''; rm -rf $HOME #'")
+    // The command must remain a single `ssh` invocation: there is no unquoted
+    // command separator that would start a second command.
+    expect(written.startsWith("'ssh' ")).toBe(true)
   })
 
   it('marks connected and readies SFTP only after the backend connect succeeds', async () => {

--- a/src/renderer/hooks/use-ssh-connection.ts
+++ b/src/renderer/hooks/use-ssh-connection.ts
@@ -209,6 +209,8 @@ export function useSSHConnection(profile: SSHProfile | null) {
     // If SFTP never came up (id still the local placeholder), retry the backend connect.
     if (connectionId.startsWith('ssh-conn-')) {
       if (!profile) return
+      // sshApi.connect never rejects (invokeIpc catches and returns an
+      // IpcResult), so a failure surfaces as !success rather than a throw.
       const sftpResult = await sshApi.connect(profile.id, profile.password)
       if (sftpResult.success && sftpResult.data?.id) {
         const backendId = sftpResult.data.id
@@ -217,7 +219,11 @@ export function useSSHConnection(profile: SSHProfile | null) {
         setSftpReady(true)
         void loadDirectory('/', backendId)
       } else {
+        // Don't leave the placeholder connection stuck: reflect the failure so
+        // the badge and SFTP state are accurate.
         const errMsg = sftpResult.success ? 'connection not established' : sftpResult.error
+        updateConnectionStatusByProfile(profile.id, 'failed', errMsg)
+        setSftpReady(false)
         toast.error(`SFTP unavailable: ${errMsg ?? 'connection not established'}`)
       }
       return

--- a/src/renderer/hooks/use-ssh-connection.ts
+++ b/src/renderer/hooks/use-ssh-connection.ts
@@ -209,22 +209,31 @@ export function useSSHConnection(profile: SSHProfile | null) {
     // If SFTP never came up (id still the local placeholder), retry the backend connect.
     if (connectionId.startsWith('ssh-conn-')) {
       if (!profile) return
-      // sshApi.connect never rejects (invokeIpc catches and returns an
-      // IpcResult), so a failure surfaces as !success rather than a throw.
-      const sftpResult = await sshApi.connect(profile.id, profile.password)
-      if (sftpResult.success && sftpResult.data?.id) {
-        const backendId = sftpResult.data.id
-        updateConnectionId(profile.id, backendId)
-        updateConnectionStatusByProfile(profile.id, 'connected')
-        setSftpReady(true)
-        void loadDirectory('/', backendId)
-      } else {
-        // Don't leave the placeholder connection stuck: reflect the failure so
-        // the badge and SFTP state are accurate.
-        const errMsg = sftpResult.success ? 'connection not established' : sftpResult.error
+      // sshApi.connect resolves to an IpcResult (invokeIpc catches rejections),
+      // so failures normally surface as !success. The try/catch is defensive
+      // only: it guarantees the placeholder connection can never stay wedged if
+      // the call unexpectedly throws (e.g. a future refactor).
+      try {
+        const sftpResult = await sshApi.connect(profile.id, profile.password)
+        if (sftpResult.success && sftpResult.data?.id) {
+          const backendId = sftpResult.data.id
+          updateConnectionId(profile.id, backendId)
+          updateConnectionStatusByProfile(profile.id, 'connected')
+          setSftpReady(true)
+          void loadDirectory('/', backendId)
+        } else {
+          // Don't leave the placeholder connection stuck: reflect the failure so
+          // the badge and SFTP state are accurate.
+          const errMsg = sftpResult.success ? 'connection not established' : sftpResult.error
+          updateConnectionStatusByProfile(profile.id, 'failed', errMsg)
+          setSftpReady(false)
+          toast.error(`SFTP unavailable: ${errMsg ?? 'connection not established'}`)
+        }
+      } catch (error) {
+        const errMsg = error instanceof Error ? error.message : String(error)
         updateConnectionStatusByProfile(profile.id, 'failed', errMsg)
         setSftpReady(false)
-        toast.error(`SFTP unavailable: ${errMsg ?? 'connection not established'}`)
+        toast.error(`SFTP unavailable: ${errMsg}`)
       }
       return
     }

--- a/src/renderer/hooks/use-ssh-connection.ts
+++ b/src/renderer/hooks/use-ssh-connection.ts
@@ -84,10 +84,26 @@ export function useSSHConnection(profile: SSHProfile | null) {
     }
 
     try {
-      // Build SSH command as a quoted string. Each argument is wrapped so that
-      // Windows key paths / usernames containing spaces survive being written
-      // into the shell (e.g. -i "C:\Users\John Doe\.ssh\id_rsa").
-      const quoteArg = (arg: string): string => (/[\s"]/.test(arg) ? `"${arg.replace(/"/g, '\\"')}"` : arg)
+      // Build the SSH command as a quoted string written into the interactive
+      // shell. Quoting rules differ per shell, so quote per platform and fully
+      // escape metacharacters (including backslashes) to avoid both breakage
+      // and injection from profile fields.
+      //
+      // - POSIX shells (bash/zsh on macOS/Linux): single-quote wrapping makes
+      //   the contents fully literal (backslashes, $, backticks, spaces). An
+      //   embedded single quote is closed, escaped, and reopened: '\'' .
+      // - Windows (cmd.exe / PowerShell): wrap in double quotes. Windows file
+      //   paths, usernames and hostnames cannot contain a double quote, so any
+      //   stray quote (or control char) is stripped defensively rather than
+      //   risking a broken/injectable command.
+      const quoteArg = (arg: string): string => {
+        if (isWindows) {
+          // eslint-disable-next-line no-control-regex -- strip control chars defensively
+          const safe = arg.replace(/["\u0000-\u001f]/g, '')
+          return `"${safe}"`
+        }
+        return `'${arg.replace(/'/g, "'\\''")}'`
+      }
       const sshArgs: string[] = ['ssh']
       sshArgs.push(`${profile.username}@${profile.host}`)
       if (profile.port !== 22) {

--- a/src/renderer/hooks/use-ssh-connection.ts
+++ b/src/renderer/hooks/use-ssh-connection.ts
@@ -76,6 +76,13 @@ export function useSSHConnection(profile: SSHProfile | null) {
     if (isConnecting || isConnected) return
     setIsConnecting(true)
 
+    // If a previous attempt left a local PTY (e.g. a failed connect the user is
+    // retrying), kill it first so we don't orphan a running ssh process.
+    if (localTerminalPtyId) {
+      void terminalApi.kill(localTerminalPtyId)
+      setLocalTerminalPtyId(null)
+    }
+
     try {
       // Build SSH command as a quoted string. Each argument is wrapped so that
       // Windows key paths / usernames containing spaces survive being written
@@ -140,8 +147,11 @@ export function useSSHConnection(profile: SSHProfile | null) {
         void loadDirectory('/', backendId)
         toast.success(`Connected: ${profile.name}`)
       } else {
-        // SSH did not authenticate. Keep the terminal open (the user can still
-        // type a password manually) but tell the truth in the badge.
+        // SSH did not authenticate over the ssh2 backend. Keep the interactive
+        // terminal visible (it stays mounted via localTerminalPtyId, so the user
+        // can still type a password / read the error and a Disconnect control is
+        // shown), but tell the truth in the badge. Cancel the queued command
+        // write so it doesn't fire into a terminal the user may be using.
         const errMsg = sftpResult.success ? 'connection not established' : sftpResult.error
         updateConnectionStatusByProfile(profile.id, 'failed', errMsg)
         toast.error(`SSH connection failed: ${errMsg ?? 'unknown error'}`)
@@ -152,17 +162,21 @@ export function useSSHConnection(profile: SSHProfile | null) {
     } finally {
       setIsConnecting(false)
     }
-  }, [profile, isConnecting, isConnected, markConnecting, updateConnectionId, updateConnectionStatusByProfile, loadDirectory])
+  }, [profile, isConnecting, isConnected, localTerminalPtyId, markConnecting, updateConnectionId, updateConnectionStatusByProfile, loadDirectory])
 
-  // Called when the interactive ssh process in the PTY exits. An immediate exit
-  // typically means ssh failed to connect (bad key, refused auth, ssh client
-  // missing). Clear SFTP state; only downgrade the badge if we are not already
-  // in a real connected state driven by the ssh2 backend.
+  // Called when the interactive ssh process in the PTY exits (e.g. the user
+  // typed `exit`, or ssh failed and quit). The terminal PTY is now dead, so
+  // drop our reference to it (the workspace will show the reconnect prompt).
+  // The ssh2/SFTP backend connection is independent: only tear that down /
+  // downgrade the badge if it was never actually connected. Typing `exit` on a
+  // healthy connection must NOT blank the file browser.
   const handleSSHProcessExit = useCallback(() => {
     if (!profile) return
-    setSftpReady(false)
-    setEntries([])
+    if (writeTimerRef.current) { clearTimeout(writeTimerRef.current); writeTimerRef.current = null }
+    setLocalTerminalPtyId(null)
     if (!isConnected) {
+      setSftpReady(false)
+      setEntries([])
       updateConnectionStatusByProfile(profile.id, 'failed', 'SSH session ended')
     }
   }, [profile, isConnected, updateConnectionStatusByProfile])

--- a/src/renderer/hooks/use-ssh-connection.ts
+++ b/src/renderer/hooks/use-ssh-connection.ts
@@ -1,6 +1,7 @@
 import { useState, useCallback, useEffect, useRef } from 'react'
 import { toast } from 'sonner'
 import { sshApi, terminalApi, createAskpassScript } from '@/lib/api'
+import { isWindows } from '@/lib/platform'
 import { useSSHConnections, useSSHActions } from '@/stores/ssh-store'
 import { useTerminalStore } from '@/stores/terminal-store'
 import type { SSHProfile, SFTPEntry } from '@shared/types/ssh.types'
@@ -9,9 +10,15 @@ export function useSSHConnection(profile: SSHProfile | null) {
   const connections = useSSHConnections()
   const connection = profile ? connections.find((c) => c.profileId === profile.id) : undefined
   const isConnected = connection?.status === 'connected'
+  const isConnectingStatus = connection?.status === 'connecting'
   const connectionId = connection?.id
   const terminalStoreId = connection?.terminalId
-  const { markConnected, markDisconnected, updateConnectionId } = useSSHActions()
+  const {
+    markConnecting,
+    markDisconnected,
+    updateConnectionId,
+    updateConnectionStatusByProfile,
+  } = useSSHActions()
 
   const [localTerminalPtyId, setLocalTerminalPtyId] = useState<string | null>(null)
   const [isConnecting, setIsConnecting] = useState(false)
@@ -23,11 +30,12 @@ export function useSSHConnection(profile: SSHProfile | null) {
   const [loadingDirs, setLoadingDirs] = useState<Set<string>>(new Set())
   const [isLoadingRoot, setIsLoadingRoot] = useState(false)
 
-  const loadDirectory = useCallback(async (path: string) => {
-    if (!connectionId) return
+  const loadDirectory = useCallback(async (path: string, overrideConnectionId?: string) => {
+    const id = overrideConnectionId ?? connectionId
+    if (!id) return
     setIsLoadingRoot(true)
     try {
-      const result = await sshApi.sftpListDir(connectionId, path)
+      const result = await sshApi.sftpListDir(id, path)
       if (result.success) { setEntries(result.data); setCurrentPath(path) }
       else toast.error(`Failed to load: ${result.error}`)
     } catch (error) {
@@ -41,6 +49,14 @@ export function useSSHConnection(profile: SSHProfile | null) {
   const loadDirRef = useRef(loadDirectory)
   loadDirRef.current = loadDirectory
 
+  // Pending timers so we can cancel writes/loads on disconnect/unmount
+  const writeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const restoreTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  useEffect(() => () => {
+    if (writeTimerRef.current) clearTimeout(writeTimerRef.current)
+    if (restoreTimerRef.current) clearTimeout(restoreTimerRef.current)
+  }, [])
+
   // Restore terminal + SFTP when connection state becomes available (e.g. on workspace switch-back)
   useEffect(() => {
     if (!isConnected || !terminalStoreId || localTerminalPtyId) return
@@ -49,7 +65,8 @@ export function useSSHConnection(profile: SSHProfile | null) {
       setLocalTerminalPtyId(term.ptyId)
       if (connectionId && !connectionId.startsWith('ssh-conn-')) {
         setSftpReady(true)
-        setTimeout(() => loadDirRef.current('/'), 300)
+        if (restoreTimerRef.current) clearTimeout(restoreTimerRef.current)
+        restoreTimerRef.current = setTimeout(() => loadDirRef.current('/'), 300)
       }
     }
   }, [isConnected, terminalStoreId, localTerminalPtyId, connectionId])
@@ -60,7 +77,10 @@ export function useSSHConnection(profile: SSHProfile | null) {
     setIsConnecting(true)
 
     try {
-      // Build SSH command as array to prevent shell injection
+      // Build SSH command as a quoted string. Each argument is wrapped so that
+      // Windows key paths / usernames containing spaces survive being written
+      // into the shell (e.g. -i "C:\Users\John Doe\.ssh\id_rsa").
+      const quoteArg = (arg: string): string => (/[\s"]/.test(arg) ? `"${arg.replace(/"/g, '\\"')}"` : arg)
       const sshArgs: string[] = ['ssh']
       sshArgs.push(`${profile.username}@${profile.host}`)
       if (profile.port !== 22) {
@@ -73,13 +93,21 @@ export function useSSHConnection(profile: SSHProfile | null) {
       if (profile.authMethod === 'password') {
         sshArgs.push('-o', 'PreferredAuthentications=password')
       }
-      const sshCmd = sshArgs.join(' ')
+      const sshCmd = sshArgs.map(quoteArg).join(' ')
 
       let spawnEnv: Record<string, string> | undefined
       if (profile.authMethod === 'password' && profile.password) {
-        const result = await createAskpassScript(profile.password)
-        if (result.success) spawnEnv = { SSH_ASKPASS: result.data, SSH_ASKPASS_REQUIRE: 'force' }
-        else toast.warning(`Password helper unavailable: ${result.error}`)
+        if (isWindows) {
+          // Win32-OpenSSH ignores SSH_ASKPASS for the server password prompt and
+          // cannot launch a .bat helper, so auto-feeding the password into the
+          // terminal does not work. The in-app SFTP/file browser (ssh2 backend)
+          // still authenticates with the password; the terminal will prompt.
+          toast.info('On Windows, type your password in the terminal when prompted. File browsing connects automatically.')
+        } else {
+          const result = await createAskpassScript(profile.password)
+          if (result.success) spawnEnv = { SSH_ASKPASS: result.data, SSH_ASKPASS_REQUIRE: 'force' }
+          else toast.warning(`Password helper unavailable: ${result.error}`)
+        }
       }
 
       const spawnResult = await terminalApi.spawn({ env: spawnEnv })
@@ -91,28 +119,62 @@ export function useSSHConnection(profile: SSHProfile | null) {
       const terminalStore = useTerminalStore.getState()
       const terminal = terminalStore.addTerminal(`SSH: ${profile.name}`, `ssh-${profile.id}`, spawnResult.data.shell, spawnResult.data.cwd)
       terminalStore.setTerminalPtyId(terminal.id, ptyId)
-      markConnected(profile.id, terminal.id)
 
-      setTimeout(() => { void terminalApi.write(ptyId, sshCmd + '\r') }, 500)
+      // Reflect the in-progress state honestly: 'connecting' until we have a
+      // real success signal. The green 'connected' badge is no longer set just
+      // because a local shell was spawned.
+      markConnecting(profile.id, terminal.id)
 
+      if (writeTimerRef.current) clearTimeout(writeTimerRef.current)
+      writeTimerRef.current = setTimeout(() => { void terminalApi.write(ptyId, sshCmd + '\r') }, 500)
+
+      // The ssh2/SFTP backend connection is the authoritative source of truth
+      // for whether SSH actually authenticated.
       const sftpResult = await sshApi.connect(profile.id, profile.password)
       if (sftpResult.success && sftpResult.data?.id) {
-        updateConnectionId(profile.id, sftpResult.data.id)
+        const backendId = sftpResult.data.id
+        updateConnectionId(profile.id, backendId)
+        updateConnectionStatusByProfile(profile.id, 'connected')
+        setSftpReady(true)
+        // connectionId state may not have updated within this tick; pass the id explicitly.
+        void loadDirectory('/', backendId)
         toast.success(`Connected: ${profile.name}`)
-      } else if (!sftpResult.success) {
-        toast.warning(`Terminal opened, but SFTP failed: ${sftpResult.error}`)
+      } else {
+        // SSH did not authenticate. Keep the terminal open (the user can still
+        // type a password manually) but tell the truth in the badge.
+        const errMsg = sftpResult.success ? 'connection not established' : sftpResult.error
+        updateConnectionStatusByProfile(profile.id, 'failed', errMsg)
+        toast.error(`SSH connection failed: ${errMsg ?? 'unknown error'}`)
       }
     } catch (error) {
+      if (profile) updateConnectionStatusByProfile(profile.id, 'failed', error instanceof Error ? error.message : String(error))
       toast.error(`Connection failed: ${error instanceof Error ? error.message : String(error)}`)
     } finally {
       setIsConnecting(false)
     }
-  }, [profile, isConnecting, isConnected, markConnected, updateConnectionId])
+  }, [profile, isConnecting, isConnected, markConnecting, updateConnectionId, updateConnectionStatusByProfile, loadDirectory])
+
+  // Called when the interactive ssh process in the PTY exits. An immediate exit
+  // typically means ssh failed to connect (bad key, refused auth, ssh client
+  // missing). Clear SFTP state; only downgrade the badge if we are not already
+  // in a real connected state driven by the ssh2 backend.
+  const handleSSHProcessExit = useCallback(() => {
+    if (!profile) return
+    setSftpReady(false)
+    setEntries([])
+    if (!isConnected) {
+      updateConnectionStatusByProfile(profile.id, 'failed', 'SSH session ended')
+    }
+  }, [profile, isConnected, updateConnectionStatusByProfile])
 
   const handleDisconnect = useCallback(async () => {
     if (!profile) return
-    // Call backend disconnect first to clean up SSH session, SFTP channels, and port forwards
-    if (connection) {
+    if (writeTimerRef.current) { clearTimeout(writeTimerRef.current); writeTimerRef.current = null }
+    if (restoreTimerRef.current) { clearTimeout(restoreTimerRef.current); restoreTimerRef.current = null }
+    // Call backend disconnect first to clean up SSH session, SFTP channels, and
+    // port forwards. Skip backend call for purely local (never-authenticated)
+    // connections whose id is still the temporary 'ssh-conn-' placeholder.
+    if (connection && !connection.id.startsWith('ssh-conn-')) {
       try {
         await sshApi.disconnect(connection.id)
       } catch (error) {
@@ -125,13 +187,29 @@ export function useSSHConnection(profile: SSHProfile | null) {
     setSftpReady(false)
     setEntries([])
     toast.info(`Disconnected: ${profile.name}`)
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- profile?.id and profile?.name cover the only fields used
   }, [localTerminalPtyId, connection, profile?.id, profile?.name, markDisconnected])
 
-  const handleBrowseFiles = useCallback(() => {
+  const handleBrowseFiles = useCallback(async () => {
     if (!connectionId) { toast.error('Not connected — open a terminal first'); return }
-    if (connectionId.startsWith('ssh-conn-')) { toast.info('SFTP connecting... please wait'); return }
+    // If SFTP never came up (id still the local placeholder), retry the backend connect.
+    if (connectionId.startsWith('ssh-conn-')) {
+      if (!profile) return
+      const sftpResult = await sshApi.connect(profile.id, profile.password)
+      if (sftpResult.success && sftpResult.data?.id) {
+        const backendId = sftpResult.data.id
+        updateConnectionId(profile.id, backendId)
+        updateConnectionStatusByProfile(profile.id, 'connected')
+        setSftpReady(true)
+        void loadDirectory('/', backendId)
+      } else {
+        const errMsg = sftpResult.success ? 'connection not established' : sftpResult.error
+        toast.error(`SFTP unavailable: ${errMsg ?? 'connection not established'}`)
+      }
+      return
+    }
     setSftpReady(true); void loadDirectory('/')
-  }, [connectionId, loadDirectory])
+  }, [connectionId, loadDirectory, profile, updateConnectionId, updateConnectionStatusByProfile])
 
   const toggleDirectory = useCallback(async (dirPath: string) => {
     if (!connectionId) return
@@ -149,9 +227,9 @@ export function useSSHConnection(profile: SSHProfile | null) {
   }, [connectionId, expandedDirs])
 
   return {
-    isConnected, connectionId, localTerminalPtyId, isConnecting,
+    isConnected, isConnectingStatus, connectionId, localTerminalPtyId, isConnecting,
     sftpReady, entries, currentPath, expandedDirs, childEntries, loadingDirs, isLoadingRoot,
     setLocalTerminalPtyId, setSftpReady, setEntries,
-    handleConnect, handleDisconnect, loadDirectory, handleBrowseFiles, toggleDirectory,
+    handleConnect, handleDisconnect, handleSSHProcessExit, loadDirectory, handleBrowseFiles, toggleDirectory,
   }
 }

--- a/src/renderer/layouts/WorkspaceLayout.close-persistence.test.tsx
+++ b/src/renderer/layouts/WorkspaceLayout.close-persistence.test.tsx
@@ -290,6 +290,9 @@ vi.mock('@/lib/api', () => ({
     save: vi.fn(),
     clear: vi.fn(),
     flush: vi.fn()
+  },
+  sshApi: {
+    onConnectionStatusChanged: vi.fn(() => vi.fn())
   }
 }))
 

--- a/src/renderer/layouts/WorkspaceLayout.test.tsx
+++ b/src/renderer/layouts/WorkspaceLayout.test.tsx
@@ -290,6 +290,7 @@ vi.mock('@/lib/api', () => ({
   addRendererRef: mockApi.addRendererRef,
   removeRendererRef: mockApi.removeRendererRef,
   hasActiveTerminalSessions: mockApi.hasActiveTerminalSessions,
+  sshApi: { onConnectionStatusChanged: vi.fn(() => vi.fn()) },
   tauriUpdaterApi: {},
   tauriVersionSkipService: {}
 }))

--- a/src/renderer/layouts/WorkspaceLayout.tsx
+++ b/src/renderer/layouts/WorkspaceLayout.tsx
@@ -38,7 +38,7 @@ import {
 	useFileExplorerVisible,
 } from "@/stores/file-explorer-store";
 import { useSidebarVisible } from "@/stores/sidebar-store";
-import { useSSHProfiles, useSSHActions, useActiveSSHProfileId, useActiveSSHProfile } from "@/stores/ssh-store";
+import { useSSHProfiles, useSSHActions, useActiveSSHProfileId, useActiveSSHProfile, useSSHStore } from "@/stores/ssh-store";
 import { useEditorStore } from "@/stores/editor-store";
 import { useCommandHistoryStore } from "@/stores/command-history-store";
 import {
@@ -203,6 +203,7 @@ export default function WorkspaceLayout(): React.JSX.Element {
 		} catch (error) {
 			toast.error(`Failed: ${error instanceof Error ? error.message : String(error)}`);
 		}
+		// eslint-disable-next-line react-hooks/exhaustive-deps -- specific sshConn fields cover all usage
 	}, [sshConn.connectionId, sshConn.currentPath, sshConn.loadDirectory]);
 
 	const handleSSHCreateFile = useCallback(async () => {
@@ -217,6 +218,7 @@ export default function WorkspaceLayout(): React.JSX.Element {
 		} catch (error) {
 			toast.error(`Failed: ${error instanceof Error ? error.message : String(error)}`);
 		}
+		// eslint-disable-next-line react-hooks/exhaustive-deps -- specific sshConn fields cover all usage
 	}, [sshConn.connectionId, sshConn.currentPath, sshConn.loadDirectory]);
 
 	const handleSSHDelete = useCallback(async (entry: SFTPEntry) => {
@@ -229,6 +231,7 @@ export default function WorkspaceLayout(): React.JSX.Element {
 		} catch (error) {
 			toast.error(`Delete failed: ${error instanceof Error ? error.message : String(error)}`);
 		}
+		// eslint-disable-next-line react-hooks/exhaustive-deps -- specific sshConn fields cover all usage
 	}, [sshConn.connectionId, sshConn.currentPath, sshConn.loadDirectory]);
 
 	const handleSSHRename = useCallback(async (entry: SFTPEntry) => {
@@ -243,12 +246,24 @@ export default function WorkspaceLayout(): React.JSX.Element {
 		} catch (error) {
 			toast.error(`Rename failed: ${error instanceof Error ? error.message : String(error)}`);
 		}
+		// eslint-disable-next-line react-hooks/exhaustive-deps -- specific sshConn fields cover all usage
 	}, [sshConn.connectionId, sshConn.currentPath, sshConn.loadDirectory]);
 
 	// Load SSH profiles on mount
 	useEffect(() => {
 		loadSSHProfiles();
 	}, [loadSSHProfiles]);
+
+	// Reconcile real SSH connection status from the backend (heartbeat,
+	// reconnect, failure). Without this the badge can only ever show the
+	// optimistic state set at connect time.
+	useEffect(() => {
+		if (typeof sshApi?.onConnectionStatusChanged !== 'function') return;
+		const unlisten = sshApi.onConnectionStatusChanged((connectionId, status, error) => {
+			useSSHStore.getState().updateConnectionStatus(connectionId, status, error);
+		});
+		return () => { unlisten?.(); };
+	}, []);
 
 	const handleSelectSSHProfile = useCallback((profileId: string) => {
 		selectSSHProfile(profileId);

--- a/src/renderer/stores/ssh-store.ts
+++ b/src/renderer/stores/ssh-store.ts
@@ -39,9 +39,11 @@ export interface SSHState {
   setEditingContent: (content: string) => void
 
   // Manual connection tracking (for terminal-based SSH)
+  markConnecting: (profileId: string, terminalId: string) => void
   markConnected: (profileId: string, terminalId: string) => void
   markDisconnected: (profileId: string) => void
   updateConnectionId: (profileId: string, backendConnectionId: string) => void
+  updateConnectionStatusByProfile: (profileId: string, status: SSHConnectionStatus, error?: string) => void
 
   // Port forward actions
   startPortForward: (connectionId: string, config: PortForwardConfig) => Promise<boolean>
@@ -145,7 +147,12 @@ export const useSSHStore = create<SSHState>((set, get) => ({
   },
 
   disconnect: async (connectionId: string) => {
-    const result = await sshApi.disconnect(connectionId)
+    // Connections whose id still starts with 'ssh-conn-' were never registered
+    // with the backend (SFTP/ssh2 never connected), so calling the backend
+    // would fail with an unknown id. Treat those as local-only and just clear
+    // local state.
+    const isLocalOnly = connectionId.startsWith('ssh-conn-')
+    const result = isLocalOnly ? { success: true as const } : await sshApi.disconnect(connectionId)
     if (result.success) {
       set((state) => ({
         connections: state.connections.filter((c) => c.id !== connectionId),
@@ -169,6 +176,22 @@ export const useSSHStore = create<SSHState>((set, get) => ({
 
   setEditingFile: (file) => set({ editingFile: file }),
   setEditingContent: (content) => set({ editingContent: content }),
+
+  markConnecting: (profileId: string, terminalId: string) => {
+    set((state) => {
+      // Remove any existing connection for this profile
+      const filtered = state.connections.filter((c) => c.profileId !== profileId)
+      const newConn: SSHConnection = {
+        id: `ssh-conn-${Date.now()}`,
+        profileId,
+        status: 'connecting',
+        terminalId,
+        activeForwards: [],
+        reconnectAttempts: 0,
+      }
+      return { connections: [...filtered, newConn] }
+    })
+  },
 
   markConnected: (profileId: string, terminalId: string) => {
     set((state) => {
@@ -197,6 +220,24 @@ export const useSSHStore = create<SSHState>((set, get) => ({
     set((state) => ({
       connections: state.connections.map((c) =>
         c.profileId === profileId ? { ...c, id: backendConnectionId } : c
+      ),
+    }))
+  },
+
+  updateConnectionStatusByProfile: (profileId: string, status: SSHConnectionStatus, error?: string) => {
+    set((state) => ({
+      connections: state.connections.map((c) =>
+        c.profileId === profileId
+          ? {
+              ...c,
+              status,
+              error,
+              connectedAt:
+                status === 'connected' && !c.connectedAt
+                  ? new Date().toISOString()
+                  : c.connectedAt,
+            }
+          : c
       ),
     }))
   },
@@ -295,9 +336,11 @@ export const useSSHActions = () =>
       stopPortForward: state.stopPortForward,
       clearCompletedTransfers: state.clearCompletedTransfers,
       selectProfile: state.selectProfile,
+      markConnecting: state.markConnecting,
       markConnected: state.markConnected,
       markDisconnected: state.markDisconnected,
       updateConnectionId: state.updateConnectionId,
+      updateConnectionStatusByProfile: state.updateConnectionStatusByProfile,
       setEditingFile: state.setEditingFile,
       setEditingContent: state.setEditingContent,
     }))

--- a/src/renderer/stores/ssh-store.ts
+++ b/src/renderer/stores/ssh-store.ts
@@ -40,7 +40,6 @@ export interface SSHState {
 
   // Manual connection tracking (for terminal-based SSH)
   markConnecting: (profileId: string, terminalId: string) => void
-  markConnected: (profileId: string, terminalId: string) => void
   markDisconnected: (profileId: string) => void
   updateConnectionId: (profileId: string, backendConnectionId: string) => void
   updateConnectionStatusByProfile: (profileId: string, status: SSHConnectionStatus, error?: string) => void
@@ -193,23 +192,6 @@ export const useSSHStore = create<SSHState>((set, get) => ({
     })
   },
 
-  markConnected: (profileId: string, terminalId: string) => {
-    set((state) => {
-      // Remove any existing connection for this profile
-      const filtered = state.connections.filter((c) => c.profileId !== profileId)
-      const newConn: SSHConnection = {
-        id: `ssh-conn-${Date.now()}`,
-        profileId,
-        status: 'connected',
-        terminalId,
-        activeForwards: [],
-        reconnectAttempts: 0,
-        connectedAt: new Date().toISOString(),
-      }
-      return { connections: [...filtered, newConn] }
-    })
-  },
-
   markDisconnected: (profileId: string) => {
     set((state) => ({
       connections: state.connections.filter((c) => c.profileId !== profileId),
@@ -337,7 +319,6 @@ export const useSSHActions = () =>
       clearCompletedTransfers: state.clearCompletedTransfers,
       selectProfile: state.selectProfile,
       markConnecting: state.markConnecting,
-      markConnected: state.markConnected,
       markDisconnected: state.markDisconnected,
       updateConnectionId: state.updateConnectionId,
       updateConnectionStatusByProfile: state.updateConnectionStatusByProfile,


### PR DESCRIPTION
## Summary

Fixes the SSH & Remote Connection feature, which reported a green **"Connected"** badge while the actual `ssh` session had failed and SFTP never started (reproduced on Windows). Root cause: the feature runs **two independent paths** that never reconciled — an interactive terminal that writes a literal `ssh ...` string into a spawned shell (relying on the OS client), and a separate `ssh2`/libssh2 session for SFTP/port-forwarding.

## What was wrong

- **False "Connected" status** — the UI marked a profile connected the instant a local shell spawned, regardless of whether `ssh` authenticated.
- **DNS hostnames never connected (SFTP)** — the `ssh2` path used IP-only `addr.parse()`, so any hostname (e.g. `biznet…`) failed before the handshake.
- **Credentials never persisted** — `keyring` was compiled with no OS-backend feature, silently falling back to an in-memory mock; saved passwords/passphrases were lost.
- **No host-key verification** on the `ssh2` SFTP/port-forward channel (MITM exposure).
- **"SFTP not started" stuck** — `sftpReady` was never set on success and a failed SFTP left the connection id in a state that dead-ended the "Browse Files" button.
- **Windows password auth** relied on `SSH_ASKPASS` + a `.bat` helper, which Win32-OpenSSH ignores.

## Changes

**Backend (Rust)**
- `connection.rs`: resolve `host:port` via `to_socket_addrs()` (DNS + IP) with a **shared connect deadline** across resolved addresses; applied to initial connect and the reconnect loop.
- `connection.rs`: add **host-key verification** (TOFU / `accept-new`) before auth, matching the terminal path's `StrictHostKeyChecking=accept-new`. New keys are **appended** to an app-managed `~/.ssh/known_hosts_termul` (0600 under a 0700 `~/.ssh`) — the user's shared `~/.ssh/known_hosts` is only ever read, never rewritten (libssh2's writer would drop `@cert-authority`/`@revoked`/unknown-key lines).
- `Cargo.toml`: enable per-OS `keyring` backends (`windows-native`, `apple-native`, Linux `sync-secret-service` + `crypto-rust`). Add a **startup keychain self-test** that logs loudly on regression. CI: add `libdbus-1-dev` to the Linux build steps.

**Frontend (React/TS)**
- `use-ssh-connection.ts` / `ssh-store.ts`: real state machine — `connecting` → `connected` only when the `ssh2` backend authenticates; `failed` (with the real error) otherwise. The interactive terminal renders whenever a PTY exists and a Disconnect control is always available, so the session is visible and never orphaned; retry kills any prior PTY.
- `WorkspaceLayout.tsx`: subscribe to the backend `ssh-connection-status-changed` event so heartbeat/reconnect/failure reconcile the badge.
- Set `sftpReady` + auto-load the directory on SFTP success; "Browse Files" retries the backend connect instead of dead-ending.
- Skip the non-functional `SSH_ASKPASS` `.bat` on Windows and inform the user; quote `ssh` args so key paths with spaces work; cancel pending timers on disconnect; `exit` in the shell no longer blanks a healthy SFTP browser.

## Testing

- Backend: 112 lib tests pass; added DNS-resolution and base64 (RFC 4648) regression tests. `cargo check --all-targets` clean.
- Frontend: 1250 tests pass; added status-machine regression tests (no false-positive connected, `sftpReady` on success, failed on ssh exit, no orphan PTY on failure, retry kills old PTY, healthy SFTP survives shell exit). Typecheck + ESLint (`--max-warnings=0`) clean.
- Two code-review passes (correctness + security); findings fixed in the second commit.

## Notes / follow-ups (out of scope, pre-existing)

- Shell-injection hardening: profile fields are typed into a shell; validation on import + a robust per-shell quoter should be a separate change.
- Linux/macOS askpass still writes the password to a temp file (0600, auto-deleted) — unchanged residual.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * SSH host-key verification with accept-new semantics and persistent known‑hosts.
  * OS-native credential storage enabled; startup logs if persistent keychain isn't available.
  * Connection status now shows Connecting, Connected, and Disconnected; improved PTY exit handling.

* **Bug Fixes**
  * More reliable SSH connections and reconnects with stronger host-key checks and safer TCP/timeouts.
  * Improved PTY lifecycle, terminal write cancellation, and SFTP/directory handling.

* **Tests**
  * Expanded unit and integration tests for SSH, encoding, and connection behaviors.

* **Chores**
  * CI: ensure libdbus-1-dev is installed on Linux build jobs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gnoviawan/termul/pull/198?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->