### PR TITLE
feat(git): add commit, amend, and push to the Git panel

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -3,4 +3,4 @@ bun run typecheck
 echo "✅ TypeScript check passed!"
 echo ""
 echo "🔍 Running ESLint on staged files..."
-bunx lint-staged
+bun x lint-staged

--- a/lint-staged.config.js
+++ b/lint-staged.config.js
@@ -1,13 +1,13 @@
 /**
  * lint-staged configuration
  * Runs ESLint on staged files only
- * Uses bunx for consistency with CI (bun-based)
+ * Uses `bun x` for consistency with CI (bun-based)
  * TypeScript typecheck runs separately in pre-commit hook
  */
 export default {
   // TypeScript files - run ESLint with no warnings allowed
-  '*.{ts,tsx}': 'bunx eslint --max-warnings=0',
+  '*.{ts,tsx}': 'bun x eslint --max-warnings=0',
 
   // JavaScript files - run ESLint with no warnings allowed
-  '*.{js,jsx}': 'bunx eslint --max-warnings=0',
+  '*.{js,jsx}': 'bun x eslint --max-warnings=0',
 }

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -2276,19 +2276,28 @@ pub async fn git_commit(
     description: Option<String>,
     amend: Option<bool>,
 ) -> Result<(), String> {
-    crate::trackers::git_tracker::git_commit_file(
-        &cwd,
-        &summary,
-        description.as_deref().unwrap_or(""),
-        amend.unwrap_or(false),
-    )
-    .map_err(|e: String| e)
+    // git_commit_file runs `git commit` (which can block on hooks / GPG prompts
+    // for up to the network timeout), so run it on the blocking thread pool
+    // instead of the async executor.
+    let description = description.unwrap_or_default();
+    let amend = amend.unwrap_or(false);
+    tauri::async_runtime::spawn_blocking(move || {
+        crate::trackers::git_tracker::git_commit_file(&cwd, &summary, &description, amend)
+    })
+    .await
+    .map_err(|e| format!("git commit task failed: {e}"))?
 }
 
 /// Push the current branch to `origin`, setting upstream when none exists.
 #[tauri::command]
 pub async fn git_push(cwd: String) -> Result<(), String> {
-    crate::trackers::git_tracker::git_push_current(&cwd).map_err(|e: String| e)
+    // git_push_current performs a network push (up to the network timeout), so
+    // run it on the blocking thread pool instead of the async executor.
+    tauri::async_runtime::spawn_blocking(move || {
+        crate::trackers::git_tracker::git_push_current(&cwd)
+    })
+    .await
+    .map_err(|e| format!("git push task failed: {e}"))?
 }
 
 /// Get commit-footer context: branch, upstream, ahead/behind, staged count,

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -2267,6 +2267,39 @@ pub async fn git_discard(cwd: String, path: String) -> Result<(), String> {
     crate::trackers::git_tracker::git_discard_file(&cwd, &path).map_err(|e: String| e)
 }
 
+/// Create a commit from the staged index. `amend` rewrites HEAD instead of
+/// adding a new commit. The message is passed via a temp file, not `-m`.
+#[tauri::command]
+pub async fn git_commit(
+    cwd: String,
+    summary: String,
+    description: Option<String>,
+    amend: Option<bool>,
+) -> Result<(), String> {
+    crate::trackers::git_tracker::git_commit_file(
+        &cwd,
+        &summary,
+        description.as_deref().unwrap_or(""),
+        amend.unwrap_or(false),
+    )
+    .map_err(|e: String| e)
+}
+
+/// Push the current branch to `origin`, setting upstream when none exists.
+#[tauri::command]
+pub async fn git_push(cwd: String) -> Result<(), String> {
+    crate::trackers::git_tracker::git_push_current(&cwd).map_err(|e: String| e)
+}
+
+/// Get commit-footer context: branch, upstream, ahead/behind, staged count,
+/// and the last commit's subject/body (for prefilling an amend).
+#[tauri::command]
+pub async fn git_get_commit_context(
+    cwd: String,
+) -> Result<crate::trackers::git_tracker::GitCommitContext, String> {
+    crate::trackers::git_tracker::git_get_commit_context(&cwd).map_err(|e: String| e)
+}
+
 /// Get available shells
 #[cfg(test)]
 mod tests {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -815,6 +815,9 @@ pub fn run() {
             commands::git_stage,
             commands::git_unstage,
             commands::git_discard,
+            commands::git_commit,
+            commands::git_push,
+            commands::git_get_commit_context,
             // Secure storage commands
             secure_storage::secure_storage_set,
             secure_storage::secure_storage_get,

--- a/src-tauri/src/trackers/git_tracker.rs
+++ b/src-tauri/src/trackers/git_tracker.rs
@@ -601,15 +601,54 @@ impl GitTracker {
     }
 
     pub fn run_git_command(cwd: &str, args: &[&str]) -> Option<std::process::Output> {
-        let mut child = backend_command(resolve_git_binary())
-            .args(args)
+        Self::run_git_command_with_timeout(cwd, args, GIT_COMMAND_TIMEOUT_MS)
+    }
+
+    /// Run a git command with an explicit timeout (ms). Network-bound commands
+    /// such as `git push` must use a generous timeout instead of the short
+    /// status-poll default, which would otherwise kill the process mid-transfer.
+    /// Generic over `AsRef<OsStr>` so callers can pass non-UTF-8 paths (e.g. a
+    /// commit message file path) without a lossy conversion.
+    pub fn run_git_command_with_timeout<S: AsRef<std::ffi::OsStr>>(
+        cwd: &str,
+        args: &[S],
+        timeout_ms: u64,
+    ) -> Option<std::process::Output> {
+        let mut command = backend_command(resolve_git_binary());
+        command
+            .args(args.iter().map(|a| a.as_ref()))
             .current_dir(cwd)
             .stdout(Stdio::piped())
-            .stderr(Stdio::piped())
-            .spawn()
-            .ok()?;
+            .stderr(Stdio::piped());
+        Self::spawn_and_wait(command, args, cwd, timeout_ms)
+    }
 
-        let deadline = Instant::now() + Duration::from_millis(GIT_COMMAND_TIMEOUT_MS);
+    /// Run `git push <args>` with the network timeout and `GIT_TERMINAL_PROMPT=0`
+    /// so a remote that requires credentials fails fast ("could not read
+    /// Username") instead of blocking on a terminal prompt until the timeout.
+    pub fn run_git_push(cwd: &str, args: &[&str], timeout_ms: u64) -> Option<std::process::Output> {
+        let mut command = backend_command(resolve_git_binary());
+        command
+            .args(args)
+            .current_dir(cwd)
+            .env("GIT_TERMINAL_PROMPT", "0")
+            .stdin(Stdio::null())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped());
+        Self::spawn_and_wait(command, args, cwd, timeout_ms)
+    }
+
+    /// Spawn a prepared git `Command` and wait up to `timeout_ms`, killing the
+    /// child on timeout. `args`/`cwd` are used only for the timeout log line.
+    fn spawn_and_wait<S: AsRef<std::ffi::OsStr>>(
+        mut command: Command,
+        args: &[S],
+        cwd: &str,
+        timeout_ms: u64,
+    ) -> Option<std::process::Output> {
+        let mut child = command.spawn().ok()?;
+
+        let deadline = Instant::now() + Duration::from_millis(timeout_ms);
 
         loop {
             match child.try_wait() {
@@ -618,9 +657,13 @@ impl GitTracker {
                     if Instant::now() >= deadline {
                         let _ = child.kill();
                         let _ = child.wait();
+                        let rendered: Vec<String> = args
+                            .iter()
+                            .map(|a| a.as_ref().to_string_lossy().into_owned())
+                            .collect();
                         log::warn!(
                             "[GitTracker] Timed out running git {} in {}",
-                            args.join(" "),
+                            rendered.join(" "),
                             cwd
                         );
                         return None;
@@ -879,6 +922,231 @@ pub fn git_discard_file(cwd: &str, path: &str) -> Result<(), String> {
         DiscardAction::Noop => Ok(()),
     }
 }
+
+/// Network-bound git operations (push/fetch) get a generous timeout instead of
+/// the 2s status-poll default. 120s comfortably covers most pushes.
+const GIT_NETWORK_TIMEOUT_MS: u64 = 120_000;
+
+/// Context the commit footer needs to render: current branch, whether an
+/// upstream is configured, ahead/behind counts, how many entries are staged,
+/// and the last commit's subject/body (used to prefill an amend).
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct GitCommitContext {
+    /// Current branch name, or `None` in a detached HEAD / no-branch state.
+    pub branch: Option<String>,
+    /// Whether the current branch has a configured upstream.
+    pub has_upstream: bool,
+    /// Commits the local branch is ahead of its upstream.
+    pub ahead: u32,
+    /// Commits the local branch is behind its upstream.
+    pub behind: u32,
+    /// Number of staged index entries (`git diff --cached --name-only`).
+    pub staged_count: u32,
+    /// Whether the repo has at least one commit (HEAD resolves).
+    pub has_head: bool,
+    /// Last commit subject (first line), empty when no HEAD.
+    pub last_subject: String,
+    /// Last commit body (everything after the subject + blank line), empty when none.
+    pub last_body: String,
+}
+
+/// Build the commit message body from a summary and optional description.
+/// Format: `summary`, a blank line, then the trimmed description. The blank
+/// line and body are omitted when the description is empty.
+fn build_commit_message(summary: &str, description: &str) -> String {
+    let summary = summary.trim();
+    let description = description.trim();
+    if description.is_empty() {
+        summary.to_string()
+    } else {
+        format!("{summary}\n\n{description}")
+    }
+}
+
+/// Number of staged entries via `git diff --cached --name-only`.
+/// Returns `None` when the git invocation itself fails, so callers can
+/// distinguish "genuinely nothing staged" (`Some(0)`) from "could not tell".
+fn staged_entry_count(cwd: &str) -> Option<u32> {
+    GitTracker::run_git_command(cwd, &["diff", "--cached", "--name-only"])
+        .filter(|o| o.status.success())
+        .map(|o| {
+            String::from_utf8_lossy(&o.stdout)
+                .lines()
+                .filter(|l| !l.trim().is_empty())
+                .count() as u32
+        })
+}
+
+/// Create a commit from the currently-staged index.
+///
+/// The message is written to a temp file and passed via `git commit -F <file>`
+/// so arbitrary user text is never interpolated into a shell or `-m` argument;
+/// this also preserves multi-line bodies. The temp file is created with an
+/// exclusive, uniquely-named handle (no symlink-following clobber, no collision
+/// between near-simultaneous commits) and deleted after the commit attempt.
+///
+/// `amend` rewrites HEAD instead of creating a new commit. A plain commit with
+/// nothing staged is rejected; an amend requires an existing HEAD. Uses the
+/// network-length timeout so pre-commit hooks / GPG passphrase prompts are not
+/// killed mid-run (which could leave a stale `.git/index.lock`).
+pub fn git_commit_file(
+    cwd: &str,
+    summary: &str,
+    description: &str,
+    amend: bool,
+) -> Result<(), String> {
+    if summary.trim().is_empty() {
+        return Err("Commit summary cannot be empty".to_string());
+    }
+    if amend {
+        if !repo_has_head(cwd) {
+            return Err("No commit to amend".to_string());
+        }
+    } else {
+        match staged_entry_count(cwd) {
+            Some(0) => return Err("Nothing staged to commit".to_string()),
+            None => return Err("Failed to read the staged index".to_string()),
+            Some(_) => {}
+        }
+    }
+
+    let message = build_commit_message(summary, description);
+    let msg_path = create_commit_message_file(message.as_bytes())?;
+
+    // Pass the real OS path (not a lossy String) so a non-UTF-8 temp dir still
+    // resolves to the file we actually wrote.
+    use std::ffi::OsStr;
+    let mut args: Vec<&OsStr> =
+        vec![OsStr::new("commit"), OsStr::new("-F"), msg_path.as_os_str()];
+    if amend {
+        args.push(OsStr::new("--amend"));
+    }
+
+    let result = match GitTracker::run_git_command_with_timeout(cwd, &args, GIT_NETWORK_TIMEOUT_MS) {
+        Some(output) if output.status.success() => Ok(()),
+        Some(output) => Err(String::from_utf8_lossy(&output.stderr).trim().to_string()),
+        None => Err("git commit timed out or failed to start".to_string()),
+    };
+    // Always clean up the temp message file, regardless of commit outcome.
+    let _ = std::fs::remove_file(&msg_path);
+    result
+}
+
+/// Write `bytes` to a freshly-created, uniquely-named temp file using an
+/// exclusive create (`create_new`), which fails rather than following a symlink
+/// or truncating an existing file (CWE-59/CWE-377). Returns the path on success.
+fn create_commit_message_file(bytes: &[u8]) -> Result<std::path::PathBuf, String> {
+    use std::io::Write;
+    let pid = std::process::id();
+    for attempt in 0..8u32 {
+        let nanos = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_nanos())
+            .unwrap_or(0);
+        let path = std::env::temp_dir()
+            .join(format!("termul-commitmsg-{pid}-{nanos}-{attempt}.txt"));
+        match std::fs::OpenOptions::new()
+            .write(true)
+            .create_new(true) // O_EXCL: fail if the path already exists
+            .open(&path)
+        {
+            Ok(mut f) => {
+                f.write_all(bytes).and_then(|_| f.flush()).map_err(|e| {
+                    let _ = std::fs::remove_file(&path);
+                    format!("Failed to write commit message: {e}")
+                })?;
+                return Ok(path);
+            }
+            Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => continue,
+            Err(e) => return Err(format!("Failed to create commit message file: {e}")),
+        }
+    }
+    Err("Failed to create a unique commit message file".to_string())
+}
+
+/// Push the current branch to `origin`. When the branch has no upstream, it is
+/// published with `--set-upstream origin <branch>`. Uses the network timeout.
+/// Rejects in a detached-HEAD / no-branch state.
+pub fn git_push_current(cwd: &str) -> Result<(), String> {
+    let branch = GitTracker::check_branch_internal(cwd)
+        .ok_or_else(|| "Not on a branch (detached HEAD); cannot push".to_string())?;
+
+    let has_upstream = GitTracker::run_git_command(cwd, &["rev-parse", "--verify", "--quiet", "@{u}"])
+        .map(|o| o.status.success())
+        .unwrap_or(false);
+
+    let args: Vec<&str> = if has_upstream {
+        vec!["push"]
+    } else {
+        vec!["push", "--set-upstream", "origin", &branch]
+    };
+
+    let output = GitTracker::run_git_push(cwd, &args, GIT_NETWORK_TIMEOUT_MS)
+        .ok_or_else(|| {
+            "git push did not complete (it timed out, could not start, or the \
+             remote required interactive credentials)"
+                .to_string()
+        })?;
+    if output.status.success() {
+        Ok(())
+    } else {
+        Err(String::from_utf8_lossy(&output.stderr).trim().to_string())
+    }
+}
+
+/// Gather the commit-footer context for a repo. Tolerant of no-HEAD and
+/// no-upstream repos: missing values come back as zeros / empty / false.
+pub fn git_get_commit_context(cwd: &str) -> Result<GitCommitContext, String> {
+    let branch = GitTracker::check_branch_internal(cwd);
+    let has_head = repo_has_head(cwd);
+
+    let has_upstream = GitTracker::run_git_command(cwd, &["rev-parse", "--verify", "--quiet", "@{u}"])
+        .map(|o| o.status.success())
+        .unwrap_or(false);
+
+    let (mut ahead, mut behind) = (0u32, 0u32);
+    if has_upstream {
+        if let Some(o) =
+            GitTracker::run_git_command(cwd, &["rev-list", "--left-right", "--count", "HEAD...@{u}"])
+        {
+            if o.status.success() {
+                let counts = String::from_utf8_lossy(&o.stdout);
+                let parts: Vec<&str> = counts.split_whitespace().collect();
+                if parts.len() == 2 {
+                    ahead = parts[0].parse().unwrap_or(0);
+                    behind = parts[1].parse().unwrap_or(0);
+                }
+            }
+        }
+    }
+
+    let (last_subject, last_body) = if has_head {
+        let subject = GitTracker::run_git_command(cwd, &["log", "-1", "--pretty=%s"])
+            .filter(|o| o.status.success())
+            .map(|o| String::from_utf8_lossy(&o.stdout).trim_end().to_string())
+            .unwrap_or_default();
+        let body = GitTracker::run_git_command(cwd, &["log", "-1", "--pretty=%b"])
+            .filter(|o| o.status.success())
+            .map(|o| String::from_utf8_lossy(&o.stdout).trim_end().to_string())
+            .unwrap_or_default();
+        (subject, body)
+    } else {
+        (String::new(), String::new())
+    };
+
+    Ok(GitCommitContext {
+        branch,
+        has_upstream,
+        ahead,
+        behind,
+        staged_count: staged_entry_count(cwd).unwrap_or(0),
+        has_head,
+        last_subject,
+        last_body,
+    })
+}
+
 
 fn is_git_ignored(cwd: &str, path: &str) -> Result<bool, String> {
     let output = GitTracker::run_git_command(cwd, &["check-ignore", "--quiet", "--", path])
@@ -1769,6 +2037,234 @@ mod tests {
         let repo = init_repo("discard-missing");
         // No such file; classified clean -> Noop, must not error.
         git_discard_file(repo.to_str().unwrap(), "ghost.txt").unwrap();
+        std::fs::remove_dir_all(&repo).ok();
+    }
+
+    // ---- commit / amend / push / context ----
+
+    fn last_subject(repo: &std::path::Path) -> String {
+        let out = git(repo, &["log", "-1", "--pretty=%s"]);
+        String::from_utf8_lossy(&out.stdout).trim().to_string()
+    }
+
+    fn last_body(repo: &std::path::Path) -> String {
+        let out = git(repo, &["log", "-1", "--pretty=%b"]);
+        String::from_utf8_lossy(&out.stdout).trim().to_string()
+    }
+
+    fn count_commits(repo: &std::path::Path) -> usize {
+        let out = git(repo, &["rev-list", "--count", "HEAD"]);
+        String::from_utf8_lossy(&out.stdout).trim().parse().unwrap_or(0)
+    }
+
+    #[test]
+    fn it_build_commit_message_formats_body() {
+        assert_eq!(build_commit_message("hello", ""), "hello");
+        assert_eq!(build_commit_message("  hello  ", "  "), "hello");
+        assert_eq!(
+            build_commit_message("summary", "more detail"),
+            "summary\n\nmore detail"
+        );
+    }
+
+    #[test]
+    fn it_commit_creates_commit_and_clears_index() {
+        if git_missing() {
+            return;
+        }
+        let repo = init_repo("commit-basic");
+        std::fs::write(repo.join("a.txt"), "one\n").unwrap();
+        git(&repo, &["add", "-A"]);
+        git(&repo, &["commit", "-qm", "init"]);
+        std::fs::write(repo.join("a.txt"), "two\n").unwrap();
+        git(&repo, &["add", "--", "a.txt"]);
+
+        let cwd = repo.to_str().unwrap();
+        git_commit_file(cwd, "second commit", "", false).unwrap();
+
+        assert_eq!(count_commits(&repo), 2);
+        assert_eq!(last_subject(&repo), "second commit");
+        assert_eq!(staged_entry_count(cwd), Some(0), "index cleared after commit");
+        std::fs::remove_dir_all(&repo).ok();
+    }
+
+    #[test]
+    fn it_commit_writes_multiline_body() {
+        if git_missing() {
+            return;
+        }
+        let repo = init_repo("commit-body");
+        std::fs::write(repo.join("a.txt"), "x\n").unwrap();
+        git(&repo, &["add", "--", "a.txt"]);
+
+        git_commit_file(repo.to_str().unwrap(), "sum", "line one\nline two", false).unwrap();
+        assert_eq!(last_subject(&repo), "sum");
+        assert_eq!(last_body(&repo), "line one\nline two");
+        std::fs::remove_dir_all(&repo).ok();
+    }
+
+    #[test]
+    fn it_commit_rejects_empty_summary() {
+        if git_missing() {
+            return;
+        }
+        let repo = init_repo("commit-emptysum");
+        std::fs::write(repo.join("a.txt"), "x\n").unwrap();
+        git(&repo, &["add", "--", "a.txt"]);
+        let err = git_commit_file(repo.to_str().unwrap(), "   ", "", false).unwrap_err();
+        assert!(err.to_lowercase().contains("summary"));
+        std::fs::remove_dir_all(&repo).ok();
+    }
+
+    #[test]
+    fn it_commit_rejects_nothing_staged() {
+        if git_missing() {
+            return;
+        }
+        let repo = init_repo("commit-nostage");
+        std::fs::write(repo.join("a.txt"), "x\n").unwrap();
+        git(&repo, &["add", "-A"]);
+        git(&repo, &["commit", "-qm", "init"]);
+        // Clean index now.
+        let err = git_commit_file(repo.to_str().unwrap(), "noop", "", false).unwrap_err();
+        assert!(err.to_lowercase().contains("nothing staged"));
+        std::fs::remove_dir_all(&repo).ok();
+    }
+
+    #[test]
+    fn it_amend_rewords_subject_without_new_commit() {
+        if git_missing() {
+            return;
+        }
+        let repo = init_repo("amend-reword");
+        std::fs::write(repo.join("a.txt"), "x\n").unwrap();
+        git(&repo, &["add", "-A"]);
+        git(&repo, &["commit", "-qm", "original"]);
+        assert_eq!(count_commits(&repo), 1);
+
+        git_commit_file(repo.to_str().unwrap(), "reworded", "", true).unwrap();
+        assert_eq!(count_commits(&repo), 1, "amend must not add a commit");
+        assert_eq!(last_subject(&repo), "reworded");
+        std::fs::remove_dir_all(&repo).ok();
+    }
+
+    #[test]
+    fn it_amend_folds_staged_changes() {
+        if git_missing() {
+            return;
+        }
+        let repo = init_repo("amend-fold");
+        std::fs::write(repo.join("a.txt"), "one\n").unwrap();
+        git(&repo, &["add", "-A"]);
+        git(&repo, &["commit", "-qm", "init"]);
+        std::fs::write(repo.join("b.txt"), "new\n").unwrap();
+        git(&repo, &["add", "--", "b.txt"]);
+
+        let cwd = repo.to_str().unwrap();
+        git_commit_file(cwd, "init+b", "", true).unwrap();
+        assert_eq!(count_commits(&repo), 1);
+        // b.txt is now part of HEAD; nothing left staged.
+        assert_eq!(staged_entry_count(cwd), Some(0));
+        let tree = git(&repo, &["ls-tree", "--name-only", "HEAD"]);
+        let names = String::from_utf8_lossy(&tree.stdout);
+        assert!(names.contains("b.txt"));
+        std::fs::remove_dir_all(&repo).ok();
+    }
+
+    #[test]
+    fn it_amend_rejects_no_head() {
+        if git_missing() {
+            return;
+        }
+        let repo = init_repo("amend-nohead");
+        std::fs::write(repo.join("a.txt"), "x\n").unwrap();
+        git(&repo, &["add", "--", "a.txt"]); // staged, but no commit yet
+        let err = git_commit_file(repo.to_str().unwrap(), "x", "", true).unwrap_err();
+        assert!(err.to_lowercase().contains("no commit to amend"));
+        std::fs::remove_dir_all(&repo).ok();
+    }
+
+    #[test]
+    fn it_push_sets_upstream_and_resets_ahead() {
+        if git_missing() {
+            return;
+        }
+        let repo = init_repo("push-upstream");
+        std::fs::write(repo.join("a.txt"), "x\n").unwrap();
+        git(&repo, &["add", "-A"]);
+        git(&repo, &["commit", "-qm", "init"]);
+
+        // Local bare remote -> no network.
+        let bare = unique_temp_dir("push-bare");
+        git(&bare, &["init", "--bare", "-q"]);
+        let bare_str = bare.to_str().unwrap();
+        git(&repo, &["remote", "add", "origin", bare_str]);
+
+        let cwd = repo.to_str().unwrap();
+        // No upstream yet -> push must set it.
+        git_push_current(cwd).unwrap();
+
+        let ctx = git_get_commit_context(cwd).unwrap();
+        assert!(ctx.has_upstream, "upstream should be set after publish");
+        assert_eq!(ctx.ahead, 0, "ahead resets after push");
+
+        // A further commit is ahead; push again brings it back to 0.
+        std::fs::write(repo.join("a.txt"), "y\n").unwrap();
+        git(&repo, &["add", "-A"]);
+        git(&repo, &["commit", "-qm", "second"]);
+        assert_eq!(git_get_commit_context(cwd).unwrap().ahead, 1);
+        git_push_current(cwd).unwrap();
+        assert_eq!(git_get_commit_context(cwd).unwrap().ahead, 0);
+
+        std::fs::remove_dir_all(&repo).ok();
+        std::fs::remove_dir_all(&bare).ok();
+    }
+
+    #[test]
+    fn it_push_rejects_detached_head() {
+        if git_missing() {
+            return;
+        }
+        let repo = init_repo("push-detached");
+        std::fs::write(repo.join("a.txt"), "x\n").unwrap();
+        git(&repo, &["add", "-A"]);
+        git(&repo, &["commit", "-qm", "init"]);
+        let head = git(&repo, &["rev-parse", "HEAD"]);
+        let sha = String::from_utf8_lossy(&head.stdout).trim().to_string();
+        git(&repo, &["checkout", "-q", &sha]); // detach
+
+        let err = git_push_current(repo.to_str().unwrap()).unwrap_err();
+        assert!(err.to_lowercase().contains("branch"));
+        std::fs::remove_dir_all(&repo).ok();
+    }
+
+    #[test]
+    fn it_commit_context_reports_fields() {
+        if git_missing() {
+            return;
+        }
+        let repo = init_repo("ctx-basic");
+        let cwd = repo.to_str().unwrap();
+
+        // No HEAD yet.
+        let empty = git_get_commit_context(cwd).unwrap();
+        assert!(!empty.has_head);
+        assert_eq!(empty.staged_count, 0);
+        assert!(empty.last_subject.is_empty());
+
+        std::fs::write(repo.join("a.txt"), "x\n").unwrap();
+        git(&repo, &["add", "-A"]);
+        git(&repo, &["commit", "-qm", "first\n\nbody text"]);
+        std::fs::write(repo.join("b.txt"), "y\n").unwrap();
+        git(&repo, &["add", "--", "b.txt"]);
+
+        let ctx = git_get_commit_context(cwd).unwrap();
+        assert!(ctx.has_head);
+        assert!(ctx.branch.is_some());
+        assert!(!ctx.has_upstream);
+        assert_eq!(ctx.staged_count, 1);
+        assert_eq!(ctx.last_subject, "first");
+        assert_eq!(ctx.last_body, "body text");
         std::fs::remove_dir_all(&repo).ok();
     }
 }

--- a/src/renderer/components/git/GitPanel.tsx
+++ b/src/renderer/components/git/GitPanel.tsx
@@ -801,7 +801,6 @@ function FileItem({ file, isActive, isSelected, onClick, icon, children }: {
       onClick(e);
     }
   };
-  };
 
   return (
     <div

--- a/src/renderer/components/git/GitPanel.tsx
+++ b/src/renderer/components/git/GitPanel.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState, useMemo } from "react";
+import React, { useEffect, useState, useMemo, useCallback } from "react";
 import { useGitStatusStore, diffKey } from "@/stores/git-status-store";
 import { cn } from "@/lib/utils";
 import { 
@@ -7,13 +7,10 @@ import {
   Plus, 
   Minus, 
   RotateCcw,
-  Check,
-  ChevronRight,
   ChevronDown,
   GitBranch,
   RefreshCw,
   Search,
-  Undo2,
   GitCommit,
   ArrowUp
 } from "lucide-react";
@@ -28,6 +25,8 @@ interface GitPanelProps {
   isVisible: boolean;
 }
 
+type Section = "staged" | "unstaged";
+
 export function GitPanel({ cwd, isVisible }: GitPanelProps) {
   const statuses = useGitStatusStore((state) => state.statuses);
   const diffs = useGitStatusStore((state) => state.diffs);
@@ -35,9 +34,9 @@ export function GitPanel({ cwd, isVisible }: GitPanelProps) {
   const setSelectedFile = useGitStatusStore((state) => state.setSelectedFile);
   const refreshStatus = useGitStatusStore((state) => state.refreshStatus);
   const fetchDiff = useGitStatusStore((state) => state.fetchDiff);
-  const stageFile = useGitStatusStore((state) => state.stageFile);
-  const unstageFile = useGitStatusStore((state) => state.unstageFile);
-  const discardFile = useGitStatusStore((state) => state.discardFile);
+  const stageFiles = useGitStatusStore((state) => state.stageFiles);
+  const unstageFiles = useGitStatusStore((state) => state.unstageFiles);
+  const discardFiles = useGitStatusStore((state) => state.discardFiles);
   const isFetchingStatus = useGitStatusStore((state) => state.isFetchingStatus);
   const commitContexts = useGitStatusStore((state) => state.commitContexts);
   const fetchCommitContext = useGitStatusStore((state) => state.fetchCommitContext);
@@ -51,7 +50,17 @@ export function GitPanel({ cwd, isVisible }: GitPanelProps) {
   // an `MM` file appears in both sections under the same path.
   const [selectedStaged, setSelectedStaged] = useState(false);
   const [isMutating, setIsMutating] = useState(false);
+
+  // Multi-selection model. Selection is scoped to a single section (staged or
+  // unstaged), since the same path can exist in both and they are staged /
+  // unstaged independently. `anchorPath` is the pivot for shift-range selects.
+  const [selectedPaths, setSelectedPaths] = useState<Set<string>>(new Set());
+  const [selectionSection, setSelectionSection] = useState<Section | null>(null);
+  const [anchorPath, setAnchorPath] = useState<string | null>(null);
+
+  // Discard is confirmed through the app dialog; remember what it targets.
   const [confirmDiscardOpen, setConfirmDiscardOpen] = useState(false);
+  const [discardTargets, setDiscardTargets] = useState<string[]>([]);
 
   // Commit footer state.
   const [summary, setSummary] = useState("");
@@ -75,13 +84,16 @@ export function GitPanel({ cwd, isVisible }: GitPanelProps) {
     }
   }, [isVisible, cwd, refreshStatus, fetchCommitContext]);
 
-  // Reset the commit footer when the repo (cwd) changes so a half-typed message
-  // or an Amend toggle from one repo never carries over into another.
+  // Reset the commit footer and any multi-selection when the repo (cwd) changes
+  // so half-typed messages or stale selections never carry over between repos.
   useEffect(() => {
     setSummary("");
     setDescription("");
     setAmend(false);
     setConfirmAmendOpen(false);
+    setSelectedPaths(new Set());
+    setSelectionSection(null);
+    setAnchorPath(null);
   }, [cwd]);
 
   useEffect(() => {
@@ -109,63 +121,140 @@ export function GitPanel({ cwd, isVisible }: GitPanelProps) {
     return { stagedFiles: staged, unstagedFiles: unstaged };
   }, [filteredStatuses]);
 
-  const handleFileClick = (path: string, staged: boolean) => {
-    // Only update selection; the effect below is the single source of truth for
-    // fetching the diff, which avoids a duplicate request on click.
-    setSelectedFile(path);
-    setSelectedStaged(staged);
-  };
+  const clearSelection = useCallback(() => {
+    setSelectedPaths(new Set());
+    setSelectionSection(null);
+    setAnchorPath(null);
+  }, []);
 
-  const handleStage = async () => {
-    if (!selectedFile) return;
-    setIsMutating(true);
-    try {
-      await stageFile(cwd, selectedFile);
-      setSelectedStaged(true);
-    } catch (error) {
-      toast.error(`Failed to stage file: ${String(error)}`);
-    } finally {
-      setIsMutating(false);
-    }
-  };
+  // Click selection with VSCode-style modifiers:
+  // - plain click  → select only this row
+  // - ctrl/cmd     → toggle this row in the selection
+  // - shift        → select the contiguous range from the anchor
+  // Selection is always scoped to the clicked row's section.
+  const handleFileClick = useCallback(
+    (
+      e: React.MouseEvent | React.KeyboardEvent,
+      path: string,
+      staged: boolean,
+      sectionFiles: GitStatusDetail[],
+    ) => {
+      const section: Section = staged ? "staged" : "unstaged";
+      const sameSection = selectionSection === section;
 
-  const handleUnstage = async () => {
-    if (!selectedFile) return;
-    setIsMutating(true);
-    try {
-      await unstageFile(cwd, selectedFile);
-      setSelectedStaged(false);
-    } catch (error) {
-      toast.error(`Failed to unstage file: ${String(error)}`);
-    } finally {
-      setIsMutating(false);
-    }
-  };
+      if (e.shiftKey && sameSection && anchorPath) {
+        const paths = sectionFiles.map((f) => f.path);
+        const a = paths.indexOf(anchorPath);
+        const b = paths.indexOf(path);
+        if (a !== -1 && b !== -1) {
+          const [lo, hi] = a < b ? [a, b] : [b, a];
+          setSelectedPaths(new Set(paths.slice(lo, hi + 1)));
+          setSelectionSection(section);
+        }
+      } else if (e.ctrlKey || e.metaKey) {
+        const next = new Set(sameSection ? selectedPaths : []);
+        if (next.has(path)) {
+          next.delete(path);
+        } else {
+          next.add(path);
+        }
+        setSelectedPaths(next);
+        setSelectionSection(next.size > 0 ? section : null);
+        setAnchorPath(path);
+      } else {
+        setSelectedPaths(new Set([path]));
+        setSelectionSection(section);
+        setAnchorPath(path);
+      }
 
-  const handleDiscard = () => {
-    if (!selectedFile) return;
-    // Discard only reverts unstaged (working-tree) changes via `git checkout`.
-    // Staged content is not affected, so block the action on staged rows.
-    if (selectedStaged) return;
-    // Use the app's ConfirmDialog rather than window.confirm, which is
-    // unreliable inside the Tauri webview and bypasses the app's styling.
+      // The diff view always follows the most-recently clicked row.
+      setSelectedFile(path);
+      setSelectedStaged(staged);
+    },
+    [selectionSection, selectedPaths, anchorPath, setSelectedFile],
+  );
+
+  // Resolve the paths an inline row action should affect: when the row is part
+  // of an active multi-selection in its section, act on the whole selection;
+  // otherwise act on just that row.
+  const targetsFor = useCallback(
+    (path: string, section: Section): string[] => {
+      if (
+        selectionSection === section &&
+        selectedPaths.size > 0 &&
+        selectedPaths.has(path)
+      ) {
+        return [...selectedPaths];
+      }
+      return [path];
+    },
+    [selectionSection, selectedPaths],
+  );
+
+  const runStage = useCallback(
+    async (paths: string[]) => {
+      if (paths.length === 0) return;
+      setIsMutating(true);
+      try {
+        await stageFiles(cwd, paths);
+        clearSelection();
+        if (selectedFile && paths.includes(selectedFile)) {
+          setSelectedStaged(true);
+        }
+      } catch (error) {
+        toast.error(`Failed to stage: ${String(error)}`);
+      } finally {
+        setIsMutating(false);
+      }
+    },
+    [cwd, stageFiles, clearSelection, selectedFile],
+  );
+
+  const runUnstage = useCallback(
+    async (paths: string[]) => {
+      if (paths.length === 0) return;
+      setIsMutating(true);
+      try {
+        await unstageFiles(cwd, paths);
+        clearSelection();
+        if (selectedFile && paths.includes(selectedFile)) {
+          setSelectedStaged(false);
+        }
+      } catch (error) {
+        toast.error(`Failed to unstage: ${String(error)}`);
+      } finally {
+        setIsMutating(false);
+      }
+    },
+    [cwd, unstageFiles, clearSelection, selectedFile],
+  );
+
+  // Discard only reverts unstaged (working-tree) changes, so it is only ever
+  // offered for unstaged rows. Confirm before destroying work.
+  const requestDiscard = useCallback((paths: string[]) => {
+    if (paths.length === 0) return;
+    setDiscardTargets(paths);
     setConfirmDiscardOpen(true);
-  };
+  }, []);
 
-  const confirmDiscard = async () => {
-    if (!selectedFile) return;
+  const confirmDiscard = useCallback(async () => {
+    if (discardTargets.length === 0) return;
     setIsMutating(true);
     try {
-      await discardFile(cwd, selectedFile);
-      setSelectedFile(null);
-      setSelectedStaged(false);
+      await discardFiles(cwd, discardTargets);
+      if (selectedFile && discardTargets.includes(selectedFile)) {
+        setSelectedFile(null);
+        setSelectedStaged(false);
+      }
+      clearSelection();
     } catch (error) {
       toast.error(`Failed to discard changes: ${String(error)}`);
     } finally {
       setIsMutating(false);
       setConfirmDiscardOpen(false);
+      setDiscardTargets([]);
     }
-  };
+  }, [cwd, discardTargets, discardFiles, selectedFile, setSelectedFile, clearSelection]);
 
   // Toggling amend on prefills the message from the last commit so the user can
   // reword it — but only when the inputs are empty, so we never clobber text the
@@ -264,6 +353,11 @@ export function GitPanel({ cwd, isVisible }: GitPanelProps) {
     }
   };
 
+  const stagedSelectionCount =
+    selectionSection === "staged" ? selectedPaths.size : 0;
+  const unstagedSelectionCount =
+    selectionSection === "unstaged" ? selectedPaths.size : 0;
+
   return (
     <div className="flex h-full w-full bg-background overflow-hidden">
       {/* File List Sidebar */}
@@ -297,41 +391,99 @@ export function GitPanel({ cwd, isVisible }: GitPanelProps) {
           <div className="p-2 space-y-4">
             {stagedFiles.length > 0 && (
               <div className="space-y-1">
-                <div className="px-2 py-1 text-[10px] font-bold text-muted-foreground uppercase tracking-wider flex items-center gap-2">
-                  <ChevronDown size={12} />
-                  Staged Changes
-                </div>
-                {stagedFiles.map((file: GitStatusDetail) => (
-                  <FileItem 
-                    key={file.path} 
-                    file={file} 
-                    isSelected={selectedFile === file.path && selectedStaged}
-                    onClick={() => handleFileClick(file.path, true)}
-                    icon={getFileIcon(file.status)}
+                <SectionHeader
+                  label="Staged Changes"
+                  count={stagedFiles.length}
+                  selectionCount={stagedSelectionCount}
+                >
+                  <SectionAction
+                    icon={<Minus size={13} />}
+                    label="Unstage all changes"
+                    disabled={isMutating}
+                    onClick={() => runUnstage(stagedFiles.map((f) => f.path))}
                   />
-                ))}
+                </SectionHeader>
+                {stagedFiles.map((file: GitStatusDetail) => {
+                  const inSelection =
+                    selectionSection === "staged" && selectedPaths.has(file.path);
+                  return (
+                    <FileItem
+                      key={file.path}
+                      file={file}
+                      isActive={selectedFile === file.path && selectedStaged}
+                      isSelected={inSelection}
+                      onClick={(e) => handleFileClick(e, file.path, true, stagedFiles)}
+                      icon={getFileIcon(file.status)}
+                    >
+                      <RowAction
+                        icon={<Minus size={13} />}
+                        label="Unstage changes"
+                        disabled={isMutating}
+                        onClick={() => runUnstage(targetsFor(file.path, "staged"))}
+                      />
+                    </FileItem>
+                  );
+                })}
               </div>
             )}
 
             <div className="space-y-1">
-              <div className="px-2 py-1 text-[10px] font-bold text-muted-foreground uppercase tracking-wider flex items-center gap-2">
-                <ChevronDown size={12} />
-                Changes ({unstagedFiles.length})
-              </div>
+              <SectionHeader
+                label="Changes"
+                count={unstagedFiles.length}
+                selectionCount={unstagedSelectionCount}
+              >
+                {unstagedFiles.length > 0 && (
+                  <>
+                    <SectionAction
+                      icon={<RotateCcw size={13} />}
+                      label="Discard all changes"
+                      variant="danger"
+                      disabled={isMutating}
+                      onClick={() => requestDiscard(unstagedFiles.map((f) => f.path))}
+                    />
+                    <SectionAction
+                      icon={<Plus size={13} />}
+                      label="Stage all changes"
+                      disabled={isMutating}
+                      onClick={() => runStage(unstagedFiles.map((f) => f.path))}
+                    />
+                  </>
+                )}
+              </SectionHeader>
               {unstagedFiles.length === 0 ? (
                 <div className="px-4 py-8 text-center">
                   <p className="text-xs text-muted-foreground">No changes detected</p>
                 </div>
               ) : (
-                unstagedFiles.map((file: GitStatusDetail) => (
-                  <FileItem 
-                    key={file.path} 
-                    file={file} 
-                    isSelected={selectedFile === file.path && !selectedStaged}
-                    onClick={() => handleFileClick(file.path, false)}
-                    icon={getFileIcon(file.status)}
-                  />
-                ))
+                unstagedFiles.map((file: GitStatusDetail) => {
+                  const inSelection =
+                    selectionSection === "unstaged" && selectedPaths.has(file.path);
+                  return (
+                    <FileItem
+                      key={file.path}
+                      file={file}
+                      isActive={selectedFile === file.path && !selectedStaged}
+                      isSelected={inSelection}
+                      onClick={(e) => handleFileClick(e, file.path, false, unstagedFiles)}
+                      icon={getFileIcon(file.status)}
+                    >
+                      <RowAction
+                        icon={<RotateCcw size={13} />}
+                        label="Discard changes"
+                        variant="danger"
+                        disabled={isMutating}
+                        onClick={() => requestDiscard(targetsFor(file.path, "unstaged"))}
+                      />
+                      <RowAction
+                        icon={<Plus size={13} />}
+                        label="Stage changes"
+                        disabled={isMutating}
+                        onClick={() => runStage(targetsFor(file.path, "unstaged"))}
+                      />
+                    </FileItem>
+                  );
+                })
               )}
             </div>
           </div>
@@ -436,48 +588,9 @@ export function GitPanel({ cwd, isVisible }: GitPanelProps) {
                 <FileCode size={16} className="text-primary shrink-0" />
                 <span className="text-sm font-medium truncate">{selectedFile}</span>
               </div>
-              <div className="flex items-center gap-2">
-                <Button
-                  variant="outline"
-                  size="sm"
-                  className="h-8 text-xs gap-2"
-                  onClick={handleDiscard}
-                  disabled={isMutating || selectedStaged}
-                  title={
-                    selectedStaged
-                      ? "Unstage first to discard — Discard only reverts unstaged (working-tree) changes"
-                      : "Discard unstaged changes to this file"
-                  }
-                >
-                  <RotateCcw size={14} />
-                  Discard
-                </Button>
-                {selectedStaged ? (
-                  <Button
-                    variant="default"
-                    size="sm"
-                    className="h-8 text-xs gap-2"
-                    onClick={handleUnstage}
-                    disabled={isMutating}
-                    title="Unstage this file"
-                  >
-                    <Undo2 size={14} />
-                    Unstage
-                  </Button>
-                ) : (
-                  <Button
-                    variant="default"
-                    size="sm"
-                    className="h-8 text-xs gap-2"
-                    onClick={handleStage}
-                    disabled={isMutating}
-                    title="Stage this file"
-                  >
-                    <Check size={14} />
-                    Stage
-                  </Button>
-                )}
-              </div>
+              <span className="text-[10px] uppercase tracking-wider text-muted-foreground shrink-0">
+                {selectedStaged ? "Staged" : "Working tree"}
+              </span>
             </div>
             <ScrollArea className="flex-1 font-mono text-xs">
               {currentDiff === undefined || currentDiff === null ? (
@@ -538,14 +651,19 @@ export function GitPanel({ cwd, isVisible }: GitPanelProps) {
         variant="danger"
         title="Discard changes"
         message={
-          selectedFile
-            ? `Discard changes to "${selectedFile}"? This cannot be undone.`
-            : ""
+          discardTargets.length > 1
+            ? `Discard changes to ${discardTargets.length} files? This cannot be undone.`
+            : discardTargets[0]
+              ? `Discard changes to "${discardTargets[0]}"? This cannot be undone.`
+              : ""
         }
         confirmLabel="Discard"
         isLoading={isMutating}
         onConfirm={confirmDiscard}
-        onCancel={() => setConfirmDiscardOpen(false)}
+        onCancel={() => {
+          setConfirmDiscardOpen(false);
+          setDiscardTargets([]);
+        }}
       />
 
       <ConfirmDialog
@@ -562,25 +680,137 @@ export function GitPanel({ cwd, isVisible }: GitPanelProps) {
   );
 }
 
-function FileItem({ file, isSelected, onClick, icon }: {
+function SectionHeader({
+  label,
+  count,
+  selectionCount,
+  children,
+}: {
+  label: string;
+  count: number;
+  selectionCount: number;
+  children?: React.ReactNode;
+}) {
+  return (
+    <div className="group/section flex items-center justify-between px-2 py-1">
+      <div className="text-[10px] font-bold text-muted-foreground uppercase tracking-wider flex items-center gap-2">
+        <ChevronDown size={12} />
+        {label} ({count})
+        {selectionCount > 1 && (
+          <span className="text-primary normal-case font-medium">
+            · {selectionCount} selected
+          </span>
+        )}
+      </div>
+      <div className="flex items-center gap-0.5 opacity-0 group-hover/section:opacity-100 focus-within:opacity-100 transition-opacity">
+        {children}
+      </div>
+    </div>
+  );
+}
+
+function SectionAction({
+  icon,
+  label,
+  onClick,
+  disabled,
+  variant,
+}: {
+  icon: React.ReactNode;
+  label: string;
+  onClick: () => void;
+  disabled?: boolean;
+  variant?: "danger";
+}) {
+  return (
+    <button
+      type="button"
+      aria-label={label}
+      title={label}
+      disabled={disabled}
+      onClick={onClick}
+      className={cn(
+        "flex h-6 w-6 items-center justify-center rounded transition-colors disabled:opacity-40 disabled:cursor-not-allowed",
+        variant === "danger"
+          ? "text-muted-foreground hover:bg-red-500/10 hover:text-red-400"
+          : "text-muted-foreground hover:bg-secondary hover:text-foreground",
+      )}
+    >
+      {icon}
+    </button>
+  );
+}
+
+function RowAction({
+  icon,
+  label,
+  onClick,
+  disabled,
+  variant,
+}: {
+  icon: React.ReactNode;
+  label: string;
+  onClick: () => void;
+  disabled?: boolean;
+  variant?: "danger";
+}) {
+  // Stop the click from bubbling to the row, which would otherwise change the
+  // selection / diff target instead of running the action.
+  const handleClick = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    onClick();
+  };
+  return (
+    <button
+      type="button"
+      aria-label={label}
+      title={label}
+      disabled={disabled}
+      onClick={handleClick}
+      className={cn(
+        "flex h-6 w-6 items-center justify-center rounded transition-colors disabled:opacity-40 disabled:cursor-not-allowed",
+        variant === "danger"
+          ? "text-muted-foreground hover:bg-red-500/10 hover:text-red-400"
+          : "text-muted-foreground hover:bg-secondary hover:text-foreground",
+      )}
+    >
+      {icon}
+    </button>
+  );
+}
+
+function FileItem({ file, isActive, isSelected, onClick, icon, children }: {
   file: { path: string, status: GitFileStatus },
+  isActive: boolean,
   isSelected: boolean,
-  onClick: () => void,
-  icon: React.ReactNode
+  onClick: (e: React.MouseEvent | React.KeyboardEvent) => void,
+  icon: React.ReactNode,
+  children?: React.ReactNode,
 }) {
   const fileName = file.path.split('/').pop() || file.path;
   const dirName = file.path.includes('/') ? file.path.substring(0, file.path.lastIndexOf('/')) : '';
 
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === "Enter" || e.key === " ") {
+      e.preventDefault();
+      onClick(e);
+    }
+  };
+
   return (
-    <button
-      type="button"
+    <div
+      role="option"
+      tabIndex={0}
       onClick={onClick}
-      aria-pressed={isSelected}
+      onKeyDown={handleKeyDown}
+      aria-selected={isSelected || isActive}
       className={cn(
-        "flex w-full items-center gap-3 px-3 py-2 rounded-md border-0 bg-transparent text-left cursor-pointer transition-colors group focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/60",
-        isSelected 
-          ? "bg-primary/10 text-primary" 
-          : "hover:bg-secondary/80 text-muted-foreground hover:text-foreground"
+        "group/row flex w-full items-center gap-3 px-3 py-2 rounded-md text-left cursor-pointer transition-colors select-none focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/60",
+        isSelected
+          ? "bg-primary/15 text-foreground"
+          : isActive
+            ? "bg-primary/10 text-primary"
+            : "hover:bg-secondary/80 text-muted-foreground hover:text-foreground",
       )}
     >
       <div className="shrink-0">{icon}</div>
@@ -588,8 +818,11 @@ function FileItem({ file, isSelected, onClick, icon }: {
         <span className="text-[11px] font-medium truncate leading-tight">{fileName}</span>
         {dirName && <span className="text-[9px] truncate opacity-50 leading-tight">{dirName}</span>}
       </div>
+      <div className="flex items-center gap-0.5 opacity-0 group-hover/row:opacity-100 focus-within:opacity-100 transition-opacity">
+        {children}
+      </div>
       <div className={cn(
-        "text-[10px] uppercase font-bold px-1 rounded",
+        "text-[10px] uppercase font-bold px-1 rounded shrink-0",
         file.status === 'added' && "text-green-500",
         file.status === 'modified' && "text-amber-500",
         file.status === 'deleted' && "text-red-500",
@@ -597,6 +830,6 @@ function FileItem({ file, isSelected, onClick, icon }: {
       )}>
         {file.status === 'modified' ? 'M' : file.status.charAt(0).toUpperCase()}
       </div>
-    </button>
+    </div>
   );
 }

--- a/src/renderer/components/git/GitPanel.tsx
+++ b/src/renderer/components/git/GitPanel.tsx
@@ -13,7 +13,9 @@ import {
   GitBranch,
   RefreshCw,
   Search,
-  Undo2
+  Undo2,
+  GitCommit,
+  ArrowUp
 } from "lucide-react";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { Button } from "@/components/ui/button";
@@ -37,6 +39,12 @@ export function GitPanel({ cwd, isVisible }: GitPanelProps) {
   const unstageFile = useGitStatusStore((state) => state.unstageFile);
   const discardFile = useGitStatusStore((state) => state.discardFile);
   const isFetchingStatus = useGitStatusStore((state) => state.isFetchingStatus);
+  const commitContexts = useGitStatusStore((state) => state.commitContexts);
+  const fetchCommitContext = useGitStatusStore((state) => state.fetchCommitContext);
+  const commit = useGitStatusStore((state) => state.commit);
+  const push = useGitStatusStore((state) => state.push);
+
+  const commitContext = commitContexts[cwd] ?? null;
 
   const [searchQuery, setSearchQuery] = useState("");
   // Track which side (staged vs unstaged) of the selected path is shown, since
@@ -45,6 +53,17 @@ export function GitPanel({ cwd, isVisible }: GitPanelProps) {
   const [isMutating, setIsMutating] = useState(false);
   const [confirmDiscardOpen, setConfirmDiscardOpen] = useState(false);
 
+  // Commit footer state.
+  const [summary, setSummary] = useState("");
+  const [description, setDescription] = useState("");
+  const [amend, setAmend] = useState(false);
+  const [isCommitting, setIsCommitting] = useState(false);
+  const [isPushing, setIsPushing] = useState(false);
+  const [confirmAmendOpen, setConfirmAmendOpen] = useState(false);
+  // Synchronous in-flight guard so a same-tick double-click cannot dispatch two
+  // commits before the isCommitting state has re-rendered.
+  const commitInFlight = React.useRef(false);
+
   const currentDiff = selectedFile
     ? diffs[diffKey(cwd, selectedFile, selectedStaged)]
     : null;
@@ -52,8 +71,18 @@ export function GitPanel({ cwd, isVisible }: GitPanelProps) {
   useEffect(() => {
     if (isVisible) {
       refreshStatus(cwd);
+      fetchCommitContext(cwd);
     }
-  }, [isVisible, cwd, refreshStatus]);
+  }, [isVisible, cwd, refreshStatus, fetchCommitContext]);
+
+  // Reset the commit footer when the repo (cwd) changes so a half-typed message
+  // or an Amend toggle from one repo never carries over into another.
+  useEffect(() => {
+    setSummary("");
+    setDescription("");
+    setAmend(false);
+    setConfirmAmendOpen(false);
+  }, [cwd]);
 
   useEffect(() => {
     if (!isVisible || !selectedFile) {
@@ -138,6 +167,93 @@ export function GitPanel({ cwd, isVisible }: GitPanelProps) {
     }
   };
 
+  // Toggling amend on prefills the message from the last commit so the user can
+  // reword it — but only when the inputs are empty, so we never clobber text the
+  // user already typed. Toggling off clears a prefill that the user did not edit.
+  const handleToggleAmend = () => {
+    const next = !amend;
+    setAmend(next);
+    if (next && commitContext?.hasHead) {
+      if (summary.trim() === "" && description.trim() === "") {
+        setSummary(commitContext.lastSubject);
+        setDescription(commitContext.lastBody);
+      }
+    } else if (!next) {
+      // Only auto-clear if the inputs still match the prefilled last commit
+      // (i.e. the user did not type their own message over it).
+      if (
+        summary === (commitContext?.lastSubject ?? "") &&
+        description === (commitContext?.lastBody ?? "")
+      ) {
+        setSummary("");
+        setDescription("");
+      }
+    }
+  };
+
+  const stagedCount = commitContext?.stagedCount ?? 0;
+  const canCommit =
+    summary.trim().length > 0 &&
+    !isCommitting &&
+    !isPushing &&
+    (amend ? !!commitContext?.hasHead : stagedCount > 0);
+
+  const runCommit = async () => {
+    if (commitInFlight.current) return;
+    commitInFlight.current = true;
+    setIsCommitting(true);
+    try {
+      await commit(cwd, summary, description, amend);
+      setSummary("");
+      setDescription("");
+      setAmend(false);
+      toast.success(amend ? "Commit amended" : "Changes committed");
+    } catch (error) {
+      toast.error(`Failed to commit: ${String(error)}`);
+    } finally {
+      setIsCommitting(false);
+      setConfirmAmendOpen(false);
+      commitInFlight.current = false;
+    }
+  };
+
+  const handleCommit = () => {
+    if (!canCommit || commitInFlight.current) return;
+    // Amending a commit that already matches the upstream rewrites published
+    // history; gate it behind a confirmation.
+    if (amend && commitContext?.hasUpstream && commitContext.ahead === 0) {
+      setConfirmAmendOpen(true);
+      return;
+    }
+    void runCommit();
+  };
+
+  const handlePush = async () => {
+    if (isPushing || isCommitting) return;
+    setIsPushing(true);
+    try {
+      await push(cwd);
+      toast.success("Pushed to remote");
+    } catch (error) {
+      toast.error(`Failed to push: ${String(error)}`);
+    } finally {
+      setIsPushing(false);
+    }
+  };
+
+  const onBranch = !!commitContext?.branch;
+  const ahead = commitContext?.ahead ?? 0;
+  const behind = commitContext?.behind ?? 0;
+  // Once an upstream exists, there is nothing to push when we are not ahead.
+  // Before an upstream exists, publishing is always meaningful.
+  const hasSomethingToPush = !commitContext?.hasUpstream || ahead > 0;
+  const canPush = onBranch && hasSomethingToPush && !isPushing && !isCommitting;
+  const pushLabel = !commitContext?.hasUpstream
+    ? "Publish branch"
+    : ahead > 0
+      ? `Push ${ahead}`
+      : "Up to date";
+
   const getFileIcon = (status: GitFileStatus) => {
     switch (status) {
       case "added": return <Plus className="text-green-500" size={14} />;
@@ -217,6 +333,93 @@ export function GitPanel({ cwd, isVisible }: GitPanelProps) {
             </div>
           </div>
         </ScrollArea>
+
+        {/* Commit footer (GitHub Desktop style) */}
+        <div className="border-t border-border p-3 space-y-2 bg-background/60">
+          <input
+            type="text"
+            placeholder={amend ? "Update commit message" : "Summary (required)"}
+            className="w-full bg-secondary/50 border-none rounded-md py-1.5 px-3 text-xs focus:ring-1 focus:ring-primary outline-none"
+            value={summary}
+            onChange={(e) => setSummary(e.target.value)}
+            disabled={isCommitting}
+          />
+          <textarea
+            placeholder="Description (optional)"
+            rows={3}
+            className="w-full resize-none bg-secondary/50 border-none rounded-md py-1.5 px-3 text-xs focus:ring-1 focus:ring-primary outline-none"
+            value={description}
+            onChange={(e) => setDescription(e.target.value)}
+            disabled={isCommitting}
+          />
+          <label
+            className={cn(
+              "flex items-center gap-2 text-[11px] select-none",
+              commitContext?.hasHead
+                ? "text-muted-foreground cursor-pointer"
+                : "text-muted-foreground/40 cursor-not-allowed",
+            )}
+            title={
+              commitContext?.hasHead
+                ? "Amend the last commit instead of creating a new one"
+                : "No commit to amend yet"
+            }
+          >
+            <input
+              type="checkbox"
+              className="h-3 w-3 accent-primary"
+              checked={amend}
+              onChange={handleToggleAmend}
+              disabled={!commitContext?.hasHead || isCommitting}
+            />
+            Amend last commit
+          </label>
+          <Button
+            variant="default"
+            size="sm"
+            className="w-full h-8 text-xs gap-2"
+            onClick={handleCommit}
+            disabled={!canCommit}
+            title={
+              amend
+                ? "Amend the last commit"
+                : stagedCount === 0
+                  ? "Stage files to commit"
+                  : "Commit staged changes"
+            }
+          >
+            <GitCommit size={14} />
+            {isCommitting
+              ? "Committing..."
+              : amend
+                ? "Amend commit"
+                : commitContext?.branch
+                  ? `Commit to ${commitContext.branch}`
+                  : "Commit"}
+          </Button>
+          <Button
+            variant="outline"
+            size="sm"
+            className="w-full h-8 text-xs gap-2"
+            onClick={handlePush}
+            disabled={!canPush}
+            title={
+              !onBranch
+                ? "Not on a branch (detached HEAD)"
+                : !commitContext?.hasUpstream
+                  ? "Publish this branch to origin"
+                  : ahead > 0
+                    ? "Push commits to the remote"
+                    : "Nothing to push — up to date with the remote"
+            }
+          >
+            <ArrowUp size={14} className={cn(isPushing && "animate-pulse")} />
+            {isPushing ? "Pushing..." : pushLabel}
+            {behind > 0 && (
+              <span className="text-[10px] text-amber-500">↓{behind}</span>
+            )}
+          </Button>
+        </div>
       </div>
 
       {/* Diff View */}
@@ -338,6 +541,17 @@ export function GitPanel({ cwd, isVisible }: GitPanelProps) {
         isLoading={isMutating}
         onConfirm={confirmDiscard}
         onCancel={() => setConfirmDiscardOpen(false)}
+      />
+
+      <ConfirmDialog
+        isOpen={confirmAmendOpen}
+        variant="danger"
+        title="Amend pushed commit"
+        message="The last commit appears to already be pushed. Amending rewrites published history and will require a force-push to update the remote. Continue?"
+        confirmLabel="Amend anyway"
+        isLoading={isCommitting}
+        onConfirm={runCommit}
+        onCancel={() => setConfirmAmendOpen(false)}
       />
     </div>
   );

--- a/src/renderer/components/git/GitPanel.tsx
+++ b/src/renderer/components/git/GitPanel.tsx
@@ -791,10 +791,14 @@ function FileItem({ file, isActive, isSelected, onClick, icon, children }: {
   const dirName = file.path.includes('/') ? file.path.substring(0, file.path.lastIndexOf('/')) : '';
 
   const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.currentTarget !== e.target) {
+      return;
+    }
     if (e.key === "Enter" || e.key === " ") {
       e.preventDefault();
       onClick(e);
     }
+  };
   };
 
   return (

--- a/src/renderer/components/git/GitPanel.tsx
+++ b/src/renderer/components/git/GitPanel.tsx
@@ -283,7 +283,10 @@ export function GitPanel({ cwd, isVisible }: GitPanelProps) {
             variant="ghost" 
             size="icon" 
             className="h-8 w-8" 
-            onClick={() => refreshStatus(cwd)}
+            onClick={() => {
+              refreshStatus(cwd);
+              fetchCommitContext(cwd);
+            }}
             disabled={isFetchingStatus}
           >
             <RefreshCw className={cn("h-4 w-4", isFetchingStatus && "animate-spin")} />
@@ -338,6 +341,7 @@ export function GitPanel({ cwd, isVisible }: GitPanelProps) {
         <div className="border-t border-border p-3 space-y-2 bg-background/60">
           <input
             type="text"
+            aria-label="Commit summary"
             placeholder={amend ? "Update commit message" : "Summary (required)"}
             className="w-full bg-secondary/50 border-none rounded-md py-1.5 px-3 text-xs focus:ring-1 focus:ring-primary outline-none"
             value={summary}
@@ -345,6 +349,7 @@ export function GitPanel({ cwd, isVisible }: GitPanelProps) {
             disabled={isCommitting}
           />
           <textarea
+            aria-label="Commit description"
             placeholder="Description (optional)"
             rows={3}
             className="w-full resize-none bg-secondary/50 border-none rounded-md py-1.5 px-3 text-xs focus:ring-1 focus:ring-primary outline-none"

--- a/src/renderer/components/git/GitPanel.tsx
+++ b/src/renderer/components/git/GitPanel.tsx
@@ -87,6 +87,8 @@ export function GitPanel({ cwd, isVisible }: GitPanelProps) {
   // Reset the commit footer and any multi-selection when the repo (cwd) changes
   // so half-typed messages or stale selections never carry over between repos.
   useEffect(() => {
+    setSelectedFile(null);
+    setSelectedStaged(false);
     setSummary("");
     setDescription("");
     setAmend(false);
@@ -94,7 +96,7 @@ export function GitPanel({ cwd, isVisible }: GitPanelProps) {
     setSelectedPaths(new Set());
     setSelectionSection(null);
     setAnchorPath(null);
-  }, [cwd]);
+  }, [cwd, setSelectedFile]);
 
   useEffect(() => {
     if (!isVisible || !selectedFile) {

--- a/src/renderer/lib/git-api.ts
+++ b/src/renderer/lib/git-api.ts
@@ -1,5 +1,5 @@
 import { invoke } from "@tauri-apps/api/core";
-import { GitStatusDetail } from "@shared/types/ipc.types";
+import { GitCommitContext, GitStatusDetail } from "@shared/types/ipc.types";
 
 export const gitApi = {
   getStatus: (cwd: string) =>
@@ -16,4 +16,12 @@ export const gitApi = {
 
   discard: (cwd: string, path: string) =>
     invoke<void>("git_discard", { cwd, path }),
+
+  commit: (cwd: string, summary: string, description = "", amend = false) =>
+    invoke<void>("git_commit", { cwd, summary, description, amend }),
+
+  push: (cwd: string) => invoke<void>("git_push", { cwd }),
+
+  getCommitContext: (cwd: string) =>
+    invoke<GitCommitContext>("git_get_commit_context", { cwd }),
 };

--- a/src/renderer/stores/git-status-store.test.ts
+++ b/src/renderer/stores/git-status-store.test.ts
@@ -1,0 +1,138 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useGitStatusStore, diffKey } from "./git-status-store";
+import * as gitApiModule from "@/lib/git-api";
+import type { GitCommitContext, GitStatusDetail } from "@shared/types/ipc.types";
+
+vi.mock("@/lib/git-api", () => ({
+  gitApi: {
+    getStatus: vi.fn(),
+    getDiff: vi.fn(),
+    stage: vi.fn(),
+    unstage: vi.fn(),
+    discard: vi.fn(),
+    commit: vi.fn(),
+    push: vi.fn(),
+    getCommitContext: vi.fn(),
+  },
+}));
+
+vi.mock("sonner", () => ({
+  toast: { error: vi.fn(), success: vi.fn() },
+}));
+
+const { gitApi } = gitApiModule as unknown as {
+  gitApi: {
+    getStatus: ReturnType<typeof vi.fn>;
+    getDiff: ReturnType<typeof vi.fn>;
+    stage: ReturnType<typeof vi.fn>;
+    unstage: ReturnType<typeof vi.fn>;
+    discard: ReturnType<typeof vi.fn>;
+    commit: ReturnType<typeof vi.fn>;
+    push: ReturnType<typeof vi.fn>;
+    getCommitContext: ReturnType<typeof vi.fn>;
+  };
+};
+
+const CWD = "/repo";
+
+const makeContext = (over: Partial<GitCommitContext> = {}): GitCommitContext => ({
+  branch: "main",
+  hasUpstream: true,
+  ahead: 0,
+  behind: 0,
+  stagedCount: 1,
+  hasHead: true,
+  lastSubject: "last",
+  lastBody: "",
+  ...over,
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  useGitStatusStore.setState({
+    statuses: {},
+    diffs: {},
+    commitContexts: {},
+    selectedFile: null,
+    isFetchingStatus: false,
+    statusFetchCount: 0,
+  });
+  gitApi.getStatus.mockResolvedValue([] as GitStatusDetail[]);
+  gitApi.getCommitContext.mockResolvedValue(makeContext());
+});
+
+describe("git-status-store commit footer", () => {
+  it("fetchCommitContext stores context per cwd", async () => {
+    gitApi.getCommitContext.mockResolvedValue(makeContext({ ahead: 3 }));
+    await useGitStatusStore.getState().fetchCommitContext(CWD);
+    expect(useGitStatusStore.getState().commitContexts[CWD].ahead).toBe(3);
+  });
+
+  it("fetchCommitContext swallows errors (no throw)", async () => {
+    gitApi.getCommitContext.mockRejectedValue(new Error("boom"));
+    await expect(
+      useGitStatusStore.getState().fetchCommitContext(CWD),
+    ).resolves.toBeUndefined();
+    expect(useGitStatusStore.getState().commitContexts[CWD]).toBeUndefined();
+  });
+
+  it("fetchCommitContext drops stale context when the fetch fails", async () => {
+    // Seed a context, then make the next fetch fail.
+    await useGitStatusStore.getState().fetchCommitContext(CWD);
+    expect(useGitStatusStore.getState().commitContexts[CWD]).toBeDefined();
+    gitApi.getCommitContext.mockRejectedValue(new Error("locked"));
+    await useGitStatusStore.getState().fetchCommitContext(CWD);
+    expect(useGitStatusStore.getState().commitContexts[CWD]).toBeUndefined();
+  });
+
+  it("commit invokes gitApi.commit then refreshes status and context", async () => {
+    await useGitStatusStore.getState().commit(CWD, "summary", "body", false);
+    expect(gitApi.commit).toHaveBeenCalledWith(CWD, "summary", "body", false);
+    expect(gitApi.getStatus).toHaveBeenCalledWith(CWD);
+    expect(gitApi.getCommitContext).toHaveBeenCalledWith(CWD);
+  });
+
+  it("commit passes amend flag through", async () => {
+    await useGitStatusStore.getState().commit(CWD, "reword", "", true);
+    expect(gitApi.commit).toHaveBeenCalledWith(CWD, "reword", "", true);
+  });
+
+  it("commit propagates errors to the caller", async () => {
+    gitApi.commit.mockRejectedValue(new Error("commit failed"));
+    await expect(
+      useGitStatusStore.getState().commit(CWD, "x", "", false),
+    ).rejects.toThrow("commit failed");
+    // Status/context refresh should not run when the mutation failed.
+    expect(gitApi.getStatus).not.toHaveBeenCalled();
+  });
+
+  it("commit still resolves when the post-commit refresh fails", async () => {
+    // The commit itself succeeded; a transient refresh failure must not be
+    // reported to the caller as a failed commit.
+    gitApi.commit.mockResolvedValue(undefined);
+    gitApi.getStatus.mockRejectedValue(new Error("transient lock"));
+    await expect(
+      useGitStatusStore.getState().commit(CWD, "summary", "", false),
+    ).resolves.toBeUndefined();
+    expect(gitApi.commit).toHaveBeenCalledOnce();
+  });
+
+  it("push invokes gitApi.push then refreshes status and context", async () => {
+    await useGitStatusStore.getState().push(CWD);
+    expect(gitApi.push).toHaveBeenCalledWith(CWD);
+    expect(gitApi.getStatus).toHaveBeenCalledWith(CWD);
+    expect(gitApi.getCommitContext).toHaveBeenCalledWith(CWD);
+  });
+
+  it("push propagates errors to the caller", async () => {
+    gitApi.push.mockRejectedValue(new Error("auth failed"));
+    await expect(useGitStatusStore.getState().push(CWD)).rejects.toThrow(
+      "auth failed",
+    );
+    expect(gitApi.getStatus).not.toHaveBeenCalled();
+  });
+
+  it("diffKey disambiguates staged vs unstaged rows", () => {
+    expect(diffKey(CWD, "a.txt", true)).not.toBe(diffKey(CWD, "a.txt", false));
+  });
+});

--- a/src/renderer/stores/git-status-store.test.ts
+++ b/src/renderer/stores/git-status-store.test.ts
@@ -156,3 +156,55 @@ describe("git-status-store commit footer", () => {
     expect(diffKey(CWD, "a.txt", true)).not.toBe(diffKey(CWD, "a.txt", false));
   });
 });
+
+describe("git-status-store batch staging", () => {
+  it("stageFile delegates to a single-path stage", async () => {
+    await useGitStatusStore.getState().stageFile(CWD, "a.txt");
+    expect(gitApi.stage).toHaveBeenCalledWith(CWD, "a.txt");
+    expect(gitApi.stage).toHaveBeenCalledOnce();
+  });
+
+  it("stageFiles stages every path then refreshes once", async () => {
+    await useGitStatusStore.getState().stageFiles(CWD, ["a.txt", "b.txt", "c.txt"]);
+    expect(gitApi.stage).toHaveBeenCalledTimes(3);
+    expect(gitApi.stage).toHaveBeenNthCalledWith(1, CWD, "a.txt");
+    expect(gitApi.stage).toHaveBeenNthCalledWith(2, CWD, "b.txt");
+    expect(gitApi.stage).toHaveBeenNthCalledWith(3, CWD, "c.txt");
+    // Status + context refresh run exactly once for the whole batch.
+    expect(gitApi.getStatus).toHaveBeenCalledOnce();
+    expect(gitApi.getCommitContext).toHaveBeenCalledOnce();
+  });
+
+  it("unstageFiles unstages every path then refreshes once", async () => {
+    await useGitStatusStore.getState().unstageFiles(CWD, ["a.txt", "b.txt"]);
+    expect(gitApi.unstage).toHaveBeenCalledTimes(2);
+    expect(gitApi.getStatus).toHaveBeenCalledOnce();
+    expect(gitApi.getCommitContext).toHaveBeenCalledOnce();
+  });
+
+  it("discardFiles discards every path then refreshes once", async () => {
+    await useGitStatusStore.getState().discardFiles(CWD, ["a.txt", "b.txt"]);
+    expect(gitApi.discard).toHaveBeenCalledTimes(2);
+    expect(gitApi.getStatus).toHaveBeenCalledOnce();
+    expect(gitApi.getCommitContext).toHaveBeenCalledOnce();
+  });
+
+  it("empty batch is a no-op (no git calls, no refresh)", async () => {
+    await useGitStatusStore.getState().stageFiles(CWD, []);
+    expect(gitApi.stage).not.toHaveBeenCalled();
+    expect(gitApi.getStatus).not.toHaveBeenCalled();
+  });
+
+  it("stageFiles still refreshes when a mid-batch stage fails", async () => {
+    gitApi.stage
+      .mockResolvedValueOnce(undefined)
+      .mockRejectedValueOnce(new Error("add failed"));
+    await expect(
+      useGitStatusStore.getState().stageFiles(CWD, ["a.txt", "b.txt"]),
+    ).rejects.toThrow("add failed");
+    // The second file aborts the loop, but a refresh still runs so the UI
+    // reflects the first file that did stage.
+    expect(gitApi.stage).toHaveBeenCalledTimes(2);
+    expect(gitApi.getStatus).toHaveBeenCalledOnce();
+  });
+});

--- a/src/renderer/stores/git-status-store.test.ts
+++ b/src/renderer/stores/git-status-store.test.ts
@@ -76,6 +76,26 @@ describe("git-status-store commit footer", () => {
     expect(useGitStatusStore.getState().commitContexts[CWD]).toBeUndefined();
   });
 
+  it("fetchCommitContext ignores a stale (out-of-order) response", async () => {
+    // First call resolves slowly with stale data; second call resolves fast
+    // with fresh data. The slow one must not overwrite the fresh result.
+    let resolveSlow: (v: GitCommitContext) => void = () => {};
+    const slow = new Promise<GitCommitContext>((r) => {
+      resolveSlow = r;
+    });
+    gitApi.getCommitContext.mockReturnValueOnce(slow);
+    gitApi.getCommitContext.mockResolvedValueOnce(makeContext({ ahead: 9 }));
+
+    const first = useGitStatusStore.getState().fetchCommitContext(CWD);
+    const second = useGitStatusStore.getState().fetchCommitContext(CWD);
+    await second;
+    // Now let the older request resolve with stale data.
+    resolveSlow(makeContext({ ahead: 1 }));
+    await first;
+
+    expect(useGitStatusStore.getState().commitContexts[CWD].ahead).toBe(9);
+  });
+
   it("fetchCommitContext drops stale context when the fetch fails", async () => {
     // Seed a context, then make the next fetch fail.
     await useGitStatusStore.getState().fetchCommitContext(CWD);

--- a/src/renderer/stores/git-status-store.ts
+++ b/src/renderer/stores/git-status-store.ts
@@ -67,13 +67,19 @@ export const useGitStatusStore = create<GitStatusState>((set, get) => ({
   },
 
   fetchCommitContext: async (cwd) => {
+    // Guard against out-of-order responses: a slow earlier fetch must not
+    // overwrite or delete a fresher result. Mirror the fetchDiff token pattern.
+    const token = (commitContextRequests[cwd] = (commitContextRequests[cwd] ?? 0) + 1);
+    const isCurrent = () => commitContextRequests[cwd] === token;
     try {
       const context = await gitApi.getCommitContext(cwd);
+      if (!isCurrent()) return;
       set((state) => ({
         commitContexts: { ...state.commitContexts, [cwd]: context },
       }));
     } catch (error) {
       console.error("Failed to fetch commit context:", error);
+      if (!isCurrent()) return;
       // Drop any stale context so the footer disables its actions rather than
       // acting on out-of-date ahead/staged/HEAD data.
       set((state) => {
@@ -166,6 +172,12 @@ async function refreshAfterMutation(
  * so an in-flight `fetchDiff` can detect it has been superseded. Kept outside
  * React state because it is control metadata, not render data. */
 const diffRequestVersions: Record<string, number> = {};
+
+/** Monotonic request token per cwd for `fetchCommitContext`. Lets a late
+ * response detect it has been superseded by a newer fetch, so out-of-order
+ * responses cannot overwrite or delete fresher context. Control metadata, not
+ * render data, so it lives outside React state (same rationale as above). */
+const commitContextRequests: Record<string, number> = {};
 
 function bumpDiffVersion(key: string) {
   diffRequestVersions[key] = (diffRequestVersions[key] ?? 0) + 1;

--- a/src/renderer/stores/git-status-store.ts
+++ b/src/renderer/stores/git-status-store.ts
@@ -26,6 +26,9 @@ export interface GitStatusState {
   stageFile: (cwd: string, path: string) => Promise<void>;
   unstageFile: (cwd: string, path: string) => Promise<void>;
   discardFile: (cwd: string, path: string) => Promise<void>;
+  stageFiles: (cwd: string, paths: string[]) => Promise<void>;
+  unstageFiles: (cwd: string, paths: string[]) => Promise<void>;
+  discardFiles: (cwd: string, paths: string[]) => Promise<void>;
   commit: (
     cwd: string,
     summary: string,
@@ -116,27 +119,56 @@ export const useGitStatusStore = create<GitStatusState>((set, get) => ({
     }
   },
 
-  stageFile: async (cwd, path) => {
-    await gitApi.stage(cwd, path);
-    invalidateFileDiffs(set, cwd, path);
-    await get().refreshStatus(cwd);
-    // Keep the commit footer's staged count in sync so Commit enables/disables
-    // correctly right after a stage toggle.
-    await get().fetchCommitContext(cwd);
+  // Single-file mutations delegate to the batch variants so the post-mutation
+  // refresh logic lives in exactly one place. The commit footer's staged count
+  // is refreshed afterwards so Commit enables/disables correctly.
+  stageFile: async (cwd, path) => get().stageFiles(cwd, [path]),
+
+  unstageFile: async (cwd, path) => get().unstageFiles(cwd, [path]),
+
+  discardFile: async (cwd, path) => get().discardFiles(cwd, [path]),
+
+  // Batch mutations apply the per-file git operation to every path, then
+  // refresh status + commit context once at the end rather than after each
+  // file. The first failing path aborts the run (subsequent files are left
+  // untouched) but a refresh still runs so the UI reflects what did change.
+  stageFiles: async (cwd, paths) => {
+    if (paths.length === 0) return;
+    try {
+      for (const path of paths) {
+        await gitApi.stage(cwd, path);
+        invalidateFileDiffs(set, cwd, path);
+      }
+    } finally {
+      await get().refreshStatus(cwd);
+      await get().fetchCommitContext(cwd);
+    }
   },
 
-  unstageFile: async (cwd, path) => {
-    await gitApi.unstage(cwd, path);
-    invalidateFileDiffs(set, cwd, path);
-    await get().refreshStatus(cwd);
-    await get().fetchCommitContext(cwd);
+  unstageFiles: async (cwd, paths) => {
+    if (paths.length === 0) return;
+    try {
+      for (const path of paths) {
+        await gitApi.unstage(cwd, path);
+        invalidateFileDiffs(set, cwd, path);
+      }
+    } finally {
+      await get().refreshStatus(cwd);
+      await get().fetchCommitContext(cwd);
+    }
   },
 
-  discardFile: async (cwd, path) => {
-    await gitApi.discard(cwd, path);
-    invalidateFileDiffs(set, cwd, path);
-    await get().refreshStatus(cwd);
-    await get().fetchCommitContext(cwd);
+  discardFiles: async (cwd, paths) => {
+    if (paths.length === 0) return;
+    try {
+      for (const path of paths) {
+        await gitApi.discard(cwd, path);
+        invalidateFileDiffs(set, cwd, path);
+      }
+    } finally {
+      await get().refreshStatus(cwd);
+      await get().fetchCommitContext(cwd);
+    }
   },
 
   commit: async (cwd, summary, description, amend) => {

--- a/src/renderer/stores/git-status-store.ts
+++ b/src/renderer/stores/git-status-store.ts
@@ -1,7 +1,7 @@
 import { create } from "zustand";
 import { toast } from "sonner";
 import { gitApi } from "@/lib/git-api";
-import { GitStatusDetail } from "@shared/types/ipc.types";
+import { GitCommitContext, GitStatusDetail } from "@shared/types/ipc.types";
 
 /** Build the staged-aware diff cache key so the staged and unstaged rows of the
  * same file (porcelain `MM`) do not collide. */
@@ -13,6 +13,8 @@ export interface GitStatusState {
   statuses: Record<string, GitStatusDetail[]>;
   // diffs["cwd:path:staged"] = string
   diffs: Record<string, string>;
+  // commitContexts[cwd] = GitCommitContext
+  commitContexts: Record<string, GitCommitContext>;
   selectedFile: string | null;
   isFetchingStatus: boolean;
   statusFetchCount: number;
@@ -20,14 +22,23 @@ export interface GitStatusState {
   setSelectedFile: (path: string | null) => void;
   refreshStatus: (cwd: string) => Promise<void>;
   fetchDiff: (cwd: string, path: string, staged: boolean) => Promise<void>;
+  fetchCommitContext: (cwd: string) => Promise<void>;
   stageFile: (cwd: string, path: string) => Promise<void>;
   unstageFile: (cwd: string, path: string) => Promise<void>;
   discardFile: (cwd: string, path: string) => Promise<void>;
+  commit: (
+    cwd: string,
+    summary: string,
+    description: string,
+    amend: boolean,
+  ) => Promise<void>;
+  push: (cwd: string) => Promise<void>;
 }
 
 export const useGitStatusStore = create<GitStatusState>((set, get) => ({
   statuses: {},
   diffs: {},
+  commitContexts: {},
   selectedFile: null,
   isFetchingStatus: false,
   statusFetchCount: 0,
@@ -51,6 +62,25 @@ export const useGitStatusStore = create<GitStatusState>((set, get) => ({
           statusFetchCount,
           isFetchingStatus: statusFetchCount > 0
         };
+      });
+    }
+  },
+
+  fetchCommitContext: async (cwd) => {
+    try {
+      const context = await gitApi.getCommitContext(cwd);
+      set((state) => ({
+        commitContexts: { ...state.commitContexts, [cwd]: context },
+      }));
+    } catch (error) {
+      console.error("Failed to fetch commit context:", error);
+      // Drop any stale context so the footer disables its actions rather than
+      // acting on out-of-date ahead/staged/HEAD data.
+      set((state) => {
+        if (!(cwd in state.commitContexts)) return {};
+        const commitContexts = { ...state.commitContexts };
+        delete commitContexts[cwd];
+        return { commitContexts };
       });
     }
   },
@@ -84,20 +114,53 @@ export const useGitStatusStore = create<GitStatusState>((set, get) => ({
     await gitApi.stage(cwd, path);
     invalidateFileDiffs(set, cwd, path);
     await get().refreshStatus(cwd);
+    // Keep the commit footer's staged count in sync so Commit enables/disables
+    // correctly right after a stage toggle.
+    await get().fetchCommitContext(cwd);
   },
 
   unstageFile: async (cwd, path) => {
     await gitApi.unstage(cwd, path);
     invalidateFileDiffs(set, cwd, path);
     await get().refreshStatus(cwd);
+    await get().fetchCommitContext(cwd);
   },
 
   discardFile: async (cwd, path) => {
     await gitApi.discard(cwd, path);
     invalidateFileDiffs(set, cwd, path);
     await get().refreshStatus(cwd);
+    await get().fetchCommitContext(cwd);
+  },
+
+  commit: async (cwd, summary, description, amend) => {
+    await gitApi.commit(cwd, summary, description, amend);
+    // The mutation succeeded. Refresh status/context to reflect the new HEAD,
+    // but never let a refresh failure surface as a commit failure (the commit
+    // already happened) — swallow refresh errors here.
+    await refreshAfterMutation(get, cwd);
+  },
+
+  push: async (cwd) => {
+    await gitApi.push(cwd);
+    await refreshAfterMutation(get, cwd);
   },
 }));
+
+/** Refresh status + commit context after a successful mutation. Errors here are
+ * logged but never rethrown, so a transient read failure does not get reported
+ * to the user as a failed commit/push that actually succeeded. */
+async function refreshAfterMutation(
+  get: () => GitStatusState,
+  cwd: string,
+): Promise<void> {
+  try {
+    await get().refreshStatus(cwd);
+  } catch (error) {
+    console.error("Post-mutation status refresh failed:", error);
+  }
+  await get().fetchCommitContext(cwd);
+}
 
 /** Monotonic request token per diff key. Bumped whenever a key is invalidated
  * so an in-flight `fetchDiff` can detect it has been superseded. Kept outside

--- a/src/shared/types/ipc.types.ts
+++ b/src/shared/types/ipc.types.ts
@@ -77,12 +77,32 @@ export interface GitStatusDetail {
 	staged: boolean;
 }
 
+// Context for the commit footer (branch, upstream, ahead/behind, last commit).
+export interface GitCommitContext {
+	branch: string | null;
+	hasUpstream: boolean;
+	ahead: number;
+	behind: number;
+	stagedCount: number;
+	hasHead: boolean;
+	lastSubject: string;
+	lastBody: string;
+}
+
 export interface GitApi {
 	getStatus: (cwd: string) => Promise<GitStatusDetail[]>;
 	getDiff: (cwd: string, path: string, staged?: boolean) => Promise<string>;
 	stage: (cwd: string, path: string) => Promise<void>;
 	unstage: (cwd: string, path: string) => Promise<void>;
 	discard: (cwd: string, path: string) => Promise<void>;
+	commit: (
+		cwd: string,
+		summary: string,
+		description?: string,
+		amend?: boolean,
+	) => Promise<void>;
+	push: (cwd: string) => Promise<void>;
+	getCommitContext: (cwd: string) => Promise<GitCommitContext>;
 }
 
 // Terminal API exposed via preload


### PR DESCRIPTION
## Summary

- Add a GitHub-Desktop-style commit footer to the Git panel: commit, amend, and push, building on the existing stage/unstage/discard/diff surface.

## Related Issue

Closes #

<!-- No tracked issue; this extends the Git panel (commit/amend/push) per request. -->

## Type of Change

- [x] feat: new feature
- [x] fix: bug fix
- [ ] docs: documentation only
- [ ] style: formatting or non-functional styling changes
- [ ] refactor: internal cleanup with no behavior change
- [ ] perf: performance improvement
- [x] test: adds or updates tests
- [ ] build: build or dependency changes
- [ ] ci: CI/CD workflow changes
- [ ] chore: maintenance or tooling
- [ ] revert: reverts a previous change

## What Changed

**Feature — commit, amend, push (`feat(git)`)**
- Commit footer in `GitPanel`: summary + optional description, Commit button (gated on a non-empty summary and staged content), an "Amend last commit" toggle that prefills from the last commit, and a Push button reflecting ahead/behind / publish state.
- Three new argument-vector Tauri commands: `git_commit` (with `amend`), `git_push`, `git_get_commit_context` (branch / upstream / ahead-behind / staged count / last commit subject+body).
- Renderer: `git-api` invokers, `GitCommitContext` type, and `git-status-store` actions (`commit`, `push`, `fetchCommitContext`) that refresh status + context after a mutation.

**Safety / correctness details**
- Commit message is written to an exclusive (`O_EXCL`) temp file and passed via `git commit -F` — never `-m` of user text (no shell interpolation, preserves multi-line bodies); the real `OsStr` path is used and the file is cleaned up.
- Commit/amend run on a long timeout so pre-commit hooks / GPG prompts are not killed mid-run (which could leave a stale `index.lock`).
- Push uses a 120s network timeout and sets `GIT_TERMINAL_PROMPT=0` to fail fast on missing credentials instead of hanging; auto-`--set-upstream origin <branch>` when no upstream exists.
- Amending an already-pushed commit is gated behind the app `ConfirmDialog`. No force-push, `reset --hard`, `rebase`, `commit -a`, or hook bypass.
- Post-mutation status refresh is decoupled from the success path; stale commit context is dropped on fetch failure; footer state resets on `cwd` change; amend toggle never clobbers typed text; synchronous double-submit guard.

**Fix — husky pre-commit (`fix(husky)`)**
- Pre-commit hook and `lint-staged.config.js` called `bunx`, which does not exist where Bun ships as a single binary (modern Bun uses `bun x`); the hook crashed with exit 127 and dumped the PATH, blocking commits from the in-app button. Switched both call sites to `bun x`.

## How It Was Tested

- [x] `bun run lint`
- [x] `bun run typecheck`
- [x] `bun run test`
- [x] Manual verification completed
- [ ] Not applicable

Additional: `cd src-tauri && cargo test git` → 61 passed (incl. 9 new commit/amend/push/context integration tests against temp repos + a local bare remote); `cargo build` clean (no warnings). Renderer store suite: 296 passed. A real `git commit` was run to confirm the husky hook now passes end-to-end.

## Screenshots or Recordings

<!-- Commit footer added to the Git panel (summary, description, amend toggle, Commit, Push). UI follows existing Radix/Tailwind patterns. -->

## Checklist

- [x] My PR title follows the conventional commit format used by this repo
- [x] I linked the related issue or explained why none exists
- [ ] I updated docs when needed
- [x] I added or updated tests when needed
- [x] I verified the change does not introduce unrelated modifications


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Commit and push UI with message/description, amend flow (confirmation for amending pushed commits), commit footer showing branch/upstream/ahead-behind/staged info.
  * Multi-select staging with bulk stage/unstage/discard and clear staged vs working-tree diffs.
  * Commit/push actions available via app IPC.

* **Bug Fixes / Reliability**
  * Safer commit-context caching to avoid stale or out-of-order updates.
  * Network-aware push with enforced timeouts and detached‑HEAD push rejection.

* **Tests**
  * New integration/unit tests covering commit, amend, push, context, and batch staging flows.

* **Chores**
  * Updated lint pre-commit runner commands.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->