### PR TITLE
feat(git): add read-only Git History graph view

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -4,7 +4,7 @@ use crate::migrations::{
 };
 use crate::pty::{PtyManager, SpawnOptions, TerminalInfo};
 use crate::worktree::{BranchEntry, DirtyStatus, GitWorktreeEntry, RemoveResult, WorktreeManager};
-use crate::trackers::{CwdTracker, ExitCodeTracker, GitStatus, GitTracker, GitStatusDetail};
+use crate::trackers::{CwdTracker, ExitCodeTracker, GitCommit, GitStatus, GitTracker, GitStatusDetail};
 use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, HashMap};
 use std::io::{BufRead, BufReader};
@@ -2265,6 +2265,14 @@ pub async fn git_unstage(cwd: String, path: String) -> Result<(), String> {
 #[tauri::command]
 pub async fn git_discard(cwd: String, path: String) -> Result<(), String> {
     crate::trackers::git_tracker::git_discard_file(&cwd, &path).map_err(|e: String| e)
+}
+
+/// Read commit history for the repository at `cwd` as structured rows for the
+/// history/graph view. `limit` caps the number of commits (clamped backend-side;
+/// defaults to 200). Read-only.
+#[tauri::command]
+pub async fn git_get_log(cwd: String, limit: Option<u32>) -> Result<Vec<GitCommit>, String> {
+    crate::trackers::git_tracker::git_get_log(&cwd, limit).map_err(|e: String| e)
 }
 
 /// Get available shells

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -815,6 +815,7 @@ pub fn run() {
             commands::git_stage,
             commands::git_unstage,
             commands::git_discard,
+            commands::git_get_log,
             // Secure storage commands
             secure_storage::secure_storage_set,
             secure_storage::secure_storage_get,

--- a/src-tauri/src/trackers/git_tracker.rs
+++ b/src-tauri/src/trackers/git_tracker.rs
@@ -176,6 +176,30 @@ pub struct GitStatusDetail {
     pub staged: bool,
 }
 
+/// A single commit row for the history/graph view.
+///
+/// `parents` holds full parent SHAs in order (first parent first); a merge has
+/// two or more. `refs` is the raw `%D` decoration list split on ", " with empty
+/// entries dropped (e.g. `HEAD -> main`, `tag: v1.0`, `origin/main`).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct GitCommit {
+    /// Full 40-char commit hash.
+    pub hash: String,
+    /// Abbreviated commit hash.
+    pub short_hash: String,
+    /// Parent full hashes, first-parent first. Empty for the root commit.
+    pub parents: Vec<String>,
+    /// Ref decorations attached to this commit (branches, tags, HEAD).
+    pub refs: Vec<String>,
+    /// Author name.
+    pub author: String,
+    /// Author date in ISO 8601 / strict format (`%aI`).
+    pub date: String,
+    /// Commit subject (first line of the message).
+    pub subject: String,
+}
+
 impl GitStatus {
     /// Create a new GitStatus with all zeros
     pub fn new() -> Self {
@@ -880,6 +904,107 @@ pub fn git_discard_file(cwd: &str, path: &str) -> Result<(), String> {
     }
 }
 
+/// Default number of commits to read for the history view.
+const GIT_LOG_DEFAULT_LIMIT: u32 = 200;
+/// Upper bound on the history fetch to keep render/parse cost bounded.
+const GIT_LOG_MAX_LIMIT: u32 = 1000;
+
+/// Field separator inside one `git log` record (NUL, `%x00`).
+const LOG_FIELD_SEP: char = '\u{0}';
+/// Record terminator between `git log` entries (`%x1e`, record separator).
+const LOG_RECORD_SEP: char = '\u{1e}';
+
+/// Read commit history for `cwd` as structured [`GitCommit`] rows, newest first.
+///
+/// Uses a NUL-delimited `--pretty` format with a record terminator so commit
+/// subjects containing spaces, pipes, or other punctuation cannot break parsing.
+/// `--parents` yields parent SHAs (for graph topology) and `--decorate=short`
+/// yields ref names. A non-zero exit (empty repo, not a repo) is treated as an
+/// empty history rather than an error, so the UI shows an empty state.
+pub fn git_get_log(cwd: &str, limit: Option<u32>) -> Result<Vec<GitCommit>, String> {
+    let limit = limit
+        .unwrap_or(GIT_LOG_DEFAULT_LIMIT)
+        .clamp(1, GIT_LOG_MAX_LIMIT);
+    let limit_str = limit.to_string();
+
+    let args = [
+        "log",
+        "--no-color",
+        "-n",
+        &limit_str,
+        "--parents",
+        "--decorate=short",
+        "--pretty=format:%H%x00%h%x00%P%x00%D%x00%an%x00%aI%x00%s%x1e",
+    ];
+
+    let output = GitTracker::run_git_command(cwd, &args)
+        .ok_or_else(|| "Failed to run git log".to_string())?;
+
+    // Empty repo / not a repo: surface an empty list, not an error.
+    if !output.status.success() {
+        return Ok(Vec::new());
+    }
+
+    Ok(parse_git_log(&String::from_utf8_lossy(&output.stdout)))
+}
+
+/// Parse the NUL-delimited, record-terminated `git log` output produced by
+/// [`git_get_log`] into [`GitCommit`] rows. Pure function over captured stdout
+/// so it is unit-testable without spawning git.
+fn parse_git_log(stdout: &str) -> Vec<GitCommit> {
+    let mut commits = Vec::new();
+
+    for record in stdout.split(LOG_RECORD_SEP) {
+        // Trim only leading newlines git inserts between records; the fields
+        // themselves are NUL-separated so internal whitespace is preserved.
+        let record = record.trim_start_matches(['\n', '\r']);
+        if record.is_empty() {
+            continue;
+        }
+
+        let fields: Vec<&str> = record.split(LOG_FIELD_SEP).collect();
+        // hash, shortHash, parents, refs, author, date, subject
+        if fields.len() < 7 {
+            continue;
+        }
+
+        let hash = fields[0].trim();
+        if hash.is_empty() {
+            continue;
+        }
+
+        let parents = fields[2]
+            .split_whitespace()
+            .map(str::to_string)
+            .collect::<Vec<_>>();
+
+        // `%D` separates decorations with ", " (comma-space). Split on that exact
+        // separator rather than a bare comma so a ref name containing a comma is
+        // not torn into two chips.
+        let refs = fields[3]
+            .split(", ")
+            .map(str::trim)
+            .filter(|r| !r.is_empty())
+            .map(str::to_string)
+            .collect::<Vec<_>>();
+
+        commits.push(GitCommit {
+            hash: hash.to_string(),
+            short_hash: fields[1].trim().to_string(),
+            parents,
+            refs,
+            author: fields[4].to_string(),
+            date: fields[5].trim().to_string(),
+            // Subject is the final field and may legitimately be empty. Re-join
+            // any trailing fields with the NUL separator so a stray NUL in an
+            // earlier field cannot silently truncate the subject.
+            subject: fields[6..].join("\u{0}"),
+        });
+    }
+
+    commits
+}
+
 fn is_git_ignored(cwd: &str, path: &str) -> Result<bool, String> {
     let output = GitTracker::run_git_command(cwd, &["check-ignore", "--quiet", "--", path])
         .ok_or_else(|| "Failed to run git check-ignore".to_string())?;
@@ -1475,6 +1600,172 @@ mod tests {
         assert!(!details[1].staged);
     }
 
+    // ========== parse_git_log unit tests ==========
+
+    /// Build one NUL-delimited, record-terminated log record matching the
+    /// `git_get_log` pretty format: hash, shortHash, parents, refs, author,
+    /// date, subject.
+    fn log_record(
+        hash: &str,
+        short: &str,
+        parents: &str,
+        refs: &str,
+        author: &str,
+        date: &str,
+        subject: &str,
+    ) -> String {
+        format!(
+            "{hash}\u{0}{short}\u{0}{parents}\u{0}{refs}\u{0}{author}\u{0}{date}\u{0}{subject}\u{1e}"
+        )
+    }
+
+    #[test]
+    fn test_parse_git_log_linear() {
+        let out = format!(
+            "{}\n{}",
+            log_record(
+                "a1b2c3d4e5f6",
+                "a1b2c3d",
+                "00ff11ee22dd",
+                "HEAD -> main",
+                "Ada",
+                "2026-05-30T10:00:00+00:00",
+                "second commit",
+            ),
+            log_record(
+                "00ff11ee22dd",
+                "00ff11e",
+                "",
+                "",
+                "Ada",
+                "2026-05-29T09:00:00+00:00",
+                "first commit",
+            ),
+        );
+        let commits = parse_git_log(&out);
+        assert_eq!(commits.len(), 2);
+        assert_eq!(commits[0].hash, "a1b2c3d4e5f6");
+        assert_eq!(commits[0].short_hash, "a1b2c3d");
+        assert_eq!(commits[0].parents, vec!["00ff11ee22dd".to_string()]);
+        assert_eq!(commits[0].refs, vec!["HEAD -> main".to_string()]);
+        assert_eq!(commits[0].author, "Ada");
+        assert_eq!(commits[0].subject, "second commit");
+        // Root commit has no parents.
+        assert!(commits[1].parents.is_empty());
+        assert!(commits[1].refs.is_empty());
+    }
+
+    #[test]
+    fn test_parse_git_log_merge_multiple_parents() {
+        let out = log_record(
+            "merge00",
+            "merge00",
+            "parentA1 parentB2",
+            "",
+            "Ada",
+            "2026-05-30T12:00:00+00:00",
+            "Merge branch 'feature'",
+        );
+        let commits = parse_git_log(&out);
+        assert_eq!(commits.len(), 1);
+        assert_eq!(
+            commits[0].parents,
+            vec!["parentA1".to_string(), "parentB2".to_string()]
+        );
+    }
+
+    #[test]
+    fn test_parse_git_log_decorations() {
+        let out = log_record(
+            "dec00",
+            "dec00",
+            "p0",
+            "HEAD -> main, tag: v1.0, origin/main",
+            "Ada",
+            "2026-05-30T12:00:00+00:00",
+            "release",
+        );
+        let commits = parse_git_log(&out);
+        assert_eq!(
+            commits[0].refs,
+            vec![
+                "HEAD -> main".to_string(),
+                "tag: v1.0".to_string(),
+                "origin/main".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn test_parse_git_log_special_char_subject() {
+        // Subject with pipes, spaces, and unicode must survive verbatim because
+        // fields are NUL-delimited, not whitespace/pipe-delimited.
+        let subject = "fix: a | b  with  spaces — café 🚀";
+        let out = log_record(
+            "sp00", "sp00", "p0", "", "Ada", "2026-05-30T12:00:00+00:00", subject,
+        );
+        let commits = parse_git_log(&out);
+        assert_eq!(commits[0].subject, subject);
+    }
+
+    #[test]
+    fn test_parse_git_log_empty_input() {
+        assert!(parse_git_log("").is_empty());
+        assert!(parse_git_log("\n\n").is_empty());
+    }
+
+    #[test]
+    fn test_parse_git_log_skips_malformed_record() {
+        // A record with too few fields is dropped; a valid one is kept.
+        let out = format!(
+            "not\u{0}enough\u{1e}{}",
+            log_record("ok00", "ok00", "", "", "Ada", "2026-05-30T12:00:00+00:00", "ok")
+        );
+        let commits = parse_git_log(&out);
+        assert_eq!(commits.len(), 1);
+        assert_eq!(commits[0].hash, "ok00");
+    }
+
+    #[test]
+    fn test_parse_git_log_empty_subject_is_kept() {
+        let out = log_record("es00", "es00", "p0", "", "Ada", "2026-05-30T12:00:00+00:00", "");
+        let commits = parse_git_log(&out);
+        assert_eq!(commits.len(), 1);
+        assert_eq!(commits[0].subject, "");
+    }
+
+    #[test]
+    fn test_parse_git_log_ref_name_with_comma_is_one_chip() {
+        // `%D` joins decorations with ", "; a ref whose name contains a comma
+        // must stay one chip. Splitting on ", " (not bare ',') keeps it intact.
+        let out = log_record(
+            "rc00",
+            "rc00",
+            "p0",
+            "HEAD -> main, tag: v1,2",
+            "Ada",
+            "2026-05-30T12:00:00+00:00",
+            "x",
+        );
+        let commits = parse_git_log(&out);
+        assert_eq!(
+            commits[0].refs,
+            vec!["HEAD -> main".to_string(), "tag: v1,2".to_string()]
+        );
+    }
+
+    #[test]
+    fn test_parse_git_log_subject_with_embedded_nul_is_preserved() {
+        // A stray NUL in the subject would create an 8th field; re-joining the
+        // trailing fields keeps the subject whole instead of truncating it.
+        let record = format!(
+            "h00\u{0}h00\u{0}p0\u{0}\u{0}Ada\u{0}2026-05-30T12:00:00+00:00\u{0}before\u{0}after\u{1e}"
+        );
+        let commits = parse_git_log(&record);
+        assert_eq!(commits.len(), 1);
+        assert_eq!(commits[0].subject, "before\u{0}after");
+    }
+
     // ========== Windows-specific tests for CWD dedupe and throttling ==========
 
     #[cfg(target_os = "windows")]
@@ -1769,6 +2060,98 @@ mod tests {
         let repo = init_repo("discard-missing");
         // No such file; classified clean -> Noop, must not error.
         git_discard_file(repo.to_str().unwrap(), "ghost.txt").unwrap();
+        std::fs::remove_dir_all(&repo).ok();
+    }
+
+    #[test]
+    fn it_git_get_log_empty_repo_is_empty() {
+        if git_missing() {
+            return;
+        }
+        // A freshly-init'd repo has no commits; git log exits non-zero and we
+        // must surface an empty list instead of an error.
+        let repo = init_repo("log-empty");
+        let commits = git_get_log(repo.to_str().unwrap(), None).unwrap();
+        assert!(commits.is_empty());
+        std::fs::remove_dir_all(&repo).ok();
+    }
+
+    #[test]
+    fn it_git_get_log_reads_linear_history_newest_first() {
+        if git_missing() {
+            return;
+        }
+        let repo = init_repo("log-linear");
+        std::fs::write(repo.join("a.txt"), "1\n").unwrap();
+        git(&repo, &["add", "-A"]);
+        git(&repo, &["commit", "-qm", "first commit"]);
+        std::fs::write(repo.join("a.txt"), "2\n").unwrap();
+        git(&repo, &["add", "-A"]);
+        git(&repo, &["commit", "-qm", "second | commit"]);
+
+        let commits = git_get_log(repo.to_str().unwrap(), None).unwrap();
+        assert_eq!(commits.len(), 2);
+        // Newest first; subject with a pipe survives intact.
+        assert_eq!(commits[0].subject, "second | commit");
+        assert_eq!(commits[1].subject, "first commit");
+        // The newer commit's first parent is the older commit.
+        assert_eq!(commits[0].parents, vec![commits[1].hash.clone()]);
+        // Root commit has no parents.
+        assert!(commits[1].parents.is_empty());
+        // HEAD decoration is present somewhere on the tip.
+        assert!(commits[0].refs.iter().any(|r| r.contains("HEAD")));
+        std::fs::remove_dir_all(&repo).ok();
+    }
+
+    #[test]
+    fn it_git_get_log_captures_merge_parents() {
+        if git_missing() {
+            return;
+        }
+        let repo = init_repo("log-merge");
+        let cwd = repo.to_str().unwrap();
+        std::fs::write(repo.join("a.txt"), "base\n").unwrap();
+        git(&repo, &["add", "-A"]);
+        git(&repo, &["commit", "-qm", "base"]);
+        // Create a feature branch with its own commit.
+        git(&repo, &["checkout", "-q", "-b", "feature"]);
+        std::fs::write(repo.join("b.txt"), "feat\n").unwrap();
+        git(&repo, &["add", "-A"]);
+        git(&repo, &["commit", "-qm", "feature work"]);
+        // Diverge main.
+        git(&repo, &["checkout", "-q", "-"]); // back to default branch
+        std::fs::write(repo.join("c.txt"), "main\n").unwrap();
+        git(&repo, &["add", "-A"]);
+        git(&repo, &["commit", "-qm", "main work"]);
+        // Force a merge commit (no fast-forward).
+        git(&repo, &["merge", "--no-ff", "-q", "-m", "Merge feature", "feature"]);
+
+        let commits = git_get_log(cwd, None).unwrap();
+        let merge = commits
+            .iter()
+            .find(|c| c.subject == "Merge feature")
+            .expect("merge commit present");
+        assert!(
+            merge.parents.len() >= 2,
+            "merge should have >= 2 parents, got {:?}",
+            merge.parents
+        );
+        std::fs::remove_dir_all(&repo).ok();
+    }
+
+    #[test]
+    fn it_git_get_log_respects_limit() {
+        if git_missing() {
+            return;
+        }
+        let repo = init_repo("log-limit");
+        for i in 0..5 {
+            std::fs::write(repo.join("a.txt"), format!("{i}\n")).unwrap();
+            git(&repo, &["add", "-A"]);
+            git(&repo, &["commit", "-qm", &format!("commit {i}")]);
+        }
+        let commits = git_get_log(repo.to_str().unwrap(), Some(3)).unwrap();
+        assert_eq!(commits.len(), 3);
         std::fs::remove_dir_all(&repo).ok();
     }
 }

--- a/src-tauri/src/trackers/git_tracker.rs
+++ b/src-tauri/src/trackers/git_tracker.rs
@@ -918,7 +918,7 @@ const LOG_RECORD_SEP: char = '\u{1e}';
 ///
 /// Uses a NUL-delimited `--pretty` format with a record terminator so commit
 /// subjects containing spaces, pipes, or other punctuation cannot break parsing.
-/// `--parents` yields parent SHAs (for graph topology), `--decorate=short`
+/// `--parents` yields parent SHAs (for graph topology), `--decorate=full`
 /// yields ref names, and `--topo-order` emits commits child-before-parent so the
 /// renderer's lane layout never sees a parent before its child.
 ///

--- a/src-tauri/src/trackers/git_tracker.rs
+++ b/src-tauri/src/trackers/git_tracker.rs
@@ -918,9 +918,14 @@ const LOG_RECORD_SEP: char = '\u{1e}';
 ///
 /// Uses a NUL-delimited `--pretty` format with a record terminator so commit
 /// subjects containing spaces, pipes, or other punctuation cannot break parsing.
-/// `--parents` yields parent SHAs (for graph topology) and `--decorate=short`
-/// yields ref names. A non-zero exit (empty repo, not a repo) is treated as an
-/// empty history rather than an error, so the UI shows an empty state.
+/// `--parents` yields parent SHAs (for graph topology), `--decorate=short`
+/// yields ref names, and `--topo-order` emits commits child-before-parent so the
+/// renderer's lane layout never sees a parent before its child.
+///
+/// A *benign* failure (a repo with no commits yet, or a path that is not a git
+/// repository) is reported as an empty history so the UI shows an empty state.
+/// Any other non-zero exit (corrupt `.git`, unreadable objects, permission
+/// errors) is propagated as an error so real failures are surfaced.
 pub fn git_get_log(cwd: &str, limit: Option<u32>) -> Result<Vec<GitCommit>, String> {
     let limit = limit
         .unwrap_or(GIT_LOG_DEFAULT_LIMIT)
@@ -930,22 +935,40 @@ pub fn git_get_log(cwd: &str, limit: Option<u32>) -> Result<Vec<GitCommit>, Stri
     let args = [
         "log",
         "--no-color",
+        "--topo-order",
         "-n",
         &limit_str,
         "--parents",
-        "--decorate=short",
+        "--decorate=full",
         "--pretty=format:%H%x00%h%x00%P%x00%D%x00%an%x00%aI%x00%s%x1e",
     ];
 
     let output = GitTracker::run_git_command(cwd, &args)
         .ok_or_else(|| "Failed to run git log".to_string())?;
 
-    // Empty repo / not a repo: surface an empty list, not an error.
     if !output.status.success() {
-        return Ok(Vec::new());
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        // A repo with no commits yet, or a non-repo path, is an expected empty
+        // state — not an error. Everything else (corrupt objects, permission
+        // problems) is surfaced so it is not silently swallowed.
+        if is_benign_log_failure(&stderr) {
+            return Ok(Vec::new());
+        }
+        return Err(stderr.trim().to_string());
     }
 
     Ok(parse_git_log(&String::from_utf8_lossy(&output.stdout)))
+}
+
+/// Whether a failing `git log` stderr represents an expected empty-history
+/// state (no commits yet, or not a git repository) rather than a real error.
+fn is_benign_log_failure(stderr: &str) -> bool {
+    let s = stderr.to_lowercase();
+    s.contains("does not have any commits yet")
+        || s.contains("not a git repository")
+        || s.contains("bad default revision")
+        // Fresh repo with an unborn HEAD: `ambiguous argument 'HEAD'`.
+        || (s.contains("ambiguous argument") && s.contains("head"))
 }
 
 /// Parse the NUL-delimited, record-terminated `git log` output produced by
@@ -1676,11 +1699,13 @@ mod tests {
 
     #[test]
     fn test_parse_git_log_decorations() {
+        // With --decorate=full the parser receives canonical ref names; it only
+        // splits on ", " and leaves classification to the renderer.
         let out = log_record(
             "dec00",
             "dec00",
             "p0",
-            "HEAD -> main, tag: v1.0, origin/main",
+            "HEAD -> refs/heads/main, tag: refs/tags/v1.0, refs/remotes/origin/main",
             "Ada",
             "2026-05-30T12:00:00+00:00",
             "release",
@@ -1689,9 +1714,9 @@ mod tests {
         assert_eq!(
             commits[0].refs,
             vec![
-                "HEAD -> main".to_string(),
-                "tag: v1.0".to_string(),
-                "origin/main".to_string(),
+                "HEAD -> refs/heads/main".to_string(),
+                "tag: refs/tags/v1.0".to_string(),
+                "refs/remotes/origin/main".to_string(),
             ]
         );
     }
@@ -1712,6 +1737,29 @@ mod tests {
     fn test_parse_git_log_empty_input() {
         assert!(parse_git_log("").is_empty());
         assert!(parse_git_log("\n\n").is_empty());
+    }
+
+    #[test]
+    fn test_is_benign_log_failure() {
+        // Expected empty-history states are benign.
+        assert!(is_benign_log_failure(
+            "fatal: your current branch 'main' does not have any commits yet"
+        ));
+        assert!(is_benign_log_failure(
+            "fatal: not a git repository (or any of the parent directories): .git"
+        ));
+        assert!(is_benign_log_failure(
+            "fatal: bad default revision 'HEAD'"
+        ));
+        assert!(is_benign_log_failure(
+            "fatal: ambiguous argument 'HEAD': unknown revision or path not in the working tree."
+        ));
+        // Real failures must NOT be swallowed.
+        assert!(!is_benign_log_failure(
+            "error: object file .git/objects/ab/cd is empty"
+        ));
+        assert!(!is_benign_log_failure("fatal: unable to read tree"));
+        assert!(!is_benign_log_failure(""));
     }
 
     #[test]
@@ -1758,10 +1806,9 @@ mod tests {
     fn test_parse_git_log_subject_with_embedded_nul_is_preserved() {
         // A stray NUL in the subject would create an 8th field; re-joining the
         // trailing fields keeps the subject whole instead of truncating it.
-        let record = format!(
-            "h00\u{0}h00\u{0}p0\u{0}\u{0}Ada\u{0}2026-05-30T12:00:00+00:00\u{0}before\u{0}after\u{1e}"
-        );
-        let commits = parse_git_log(&record);
+        let record =
+            "h00\u{0}h00\u{0}p0\u{0}\u{0}Ada\u{0}2026-05-30T12:00:00+00:00\u{0}before\u{0}after\u{1e}";
+        let commits = parse_git_log(record);
         assert_eq!(commits.len(), 1);
         assert_eq!(commits[0].subject, "before\u{0}after");
     }

--- a/src-tauri/src/trackers/mod.rs
+++ b/src-tauri/src/trackers/mod.rs
@@ -11,4 +11,4 @@ pub mod git_tracker;
 
 pub use cwd_tracker::CwdTracker;
 pub use exit_code_tracker::ExitCodeTracker;
-pub use git_tracker::{GitStatus, GitTracker, GitStatusDetail};
+pub use git_tracker::{GitCommit, GitStatus, GitStatusDetail, GitTracker};

--- a/src/renderer/components/ActivityRail.tsx
+++ b/src/renderer/components/ActivityRail.tsx
@@ -1,4 +1,4 @@
-import { PanelLeft, PanelRight, SlidersHorizontal, FolderKanban, GitBranch, Network } from 'lucide-react'
+import { PanelLeft, PanelRight, SlidersHorizontal, FolderKanban, GitBranch, History, Network } from 'lucide-react'
 import { TitleBarShortcutsPopover } from '@/components/TitleBarShortcutsPopover'
 import { TermulMark } from '@/components/TermulMark'
 import { useNavigate, useLocation } from 'react-router-dom'
@@ -21,6 +21,10 @@ interface ActivityRailProps {
   onOpenGitChanges?: () => void
   /** Whether a git changes tab can currently be opened (active project has a path). */
   canOpenGitChanges?: boolean
+  /** Opens a git history (commit graph) tab in the active pane. */
+  onOpenGitHistory?: () => void
+  /** Whether a git history tab can currently be opened (active project has a path). */
+  canOpenGitHistory?: boolean
 }
 
 /**
@@ -44,7 +48,9 @@ export function ActivityRail({
   onShortcutsOpenChange,
   onOpenCommandPalette,
   onOpenGitChanges,
-  canOpenGitChanges = false
+  canOpenGitChanges = false,
+  onOpenGitHistory,
+  canOpenGitHistory = false
 }: ActivityRailProps = {}): React.JSX.Element {
   const isSidebarVisible = useSidebarVisible()
   const isExplorerVisible = useFileExplorerVisible()
@@ -124,6 +130,22 @@ export function ActivityRail({
         <GitBranch
           size={18}
           className={canOpenGitChanges ? 'text-muted-foreground' : 'text-muted-foreground/40'}
+        />
+      </button>
+
+      <button
+        onClick={(e) => {
+          e.stopPropagation()
+          onOpenGitHistory?.()
+        }}
+        className={railButtonClass}
+        title={canOpenGitHistory ? 'Git history' : 'Git history (open a project first)'}
+        aria-label="Open git history"
+        disabled={!onOpenGitHistory || !canOpenGitHistory}
+      >
+        <History
+          size={18}
+          className={canOpenGitHistory ? 'text-muted-foreground' : 'text-muted-foreground/40'}
         />
       </button>
 

--- a/src/renderer/components/git/GitHistoryPanel.tsx
+++ b/src/renderer/components/git/GitHistoryPanel.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useMemo, useState } from "react";
 import { useGitHistoryStore } from "@/stores/git-history-store";
 import { computeGraphLayout, type GraphLayout } from "@/lib/git-graph-layout";
 import { formatRelativeTime } from "@/lib/git-time";
+import { describeRef } from "@/lib/git-ref";
 import { cn } from "@/lib/utils";
 import { GitBranch, RefreshCw, History, Tag, Search } from "lucide-react";
 import { ScrollArea } from "@/components/ui/scroll-area";
@@ -44,21 +45,6 @@ function rowY(row: number): number {
 }
 
 /** Parse a raw `%D` decoration into a display label + kind for chip styling. */
-function describeRef(ref: string): { label: string; kind: "head" | "tag" | "remote" | "branch" } {
-  if (ref.startsWith("tag: ")) {
-    return { label: ref.slice(5), kind: "tag" };
-  }
-  if (ref.startsWith("HEAD -> ")) {
-    return { label: ref.slice(8), kind: "head" };
-  }
-  if (ref === "HEAD") {
-    return { label: "HEAD", kind: "head" };
-  }
-  if (ref.includes("/")) {
-    return { label: ref, kind: "remote" };
-  }
-  return { label: ref, kind: "branch" };
-}
 
 export function GitHistoryPanel({ cwd, isVisible }: GitHistoryPanelProps): React.JSX.Element {
   const commits = useGitHistoryStore((state) => state.commits[cwd]);
@@ -120,6 +106,7 @@ export function GitHistoryPanel({ cwd, isVisible }: GitHistoryPanelProps): React
             <input
               type="text"
               placeholder="Filter commits..."
+              aria-label="Filter commits"
               className="w-44 bg-secondary/50 border-none rounded-md py-1.5 pl-8 pr-3 text-xs focus:ring-1 focus:ring-primary outline-none"
               value={searchQuery}
               onChange={(e) => setSearchQuery(e.target.value)}
@@ -132,6 +119,7 @@ export function GitHistoryPanel({ cwd, isVisible }: GitHistoryPanelProps): React
             onClick={() => refreshLog(cwd)}
             disabled={isLoading}
             title="Refresh history"
+            aria-label="Refresh history"
           >
             <RefreshCw className={cn("h-4 w-4", isLoading && "animate-spin")} />
           </Button>

--- a/src/renderer/components/git/GitHistoryPanel.tsx
+++ b/src/renderer/components/git/GitHistoryPanel.tsx
@@ -1,0 +1,281 @@
+import React, { useEffect, useMemo, useState } from "react";
+import { useGitHistoryStore } from "@/stores/git-history-store";
+import { computeGraphLayout, type GraphLayout } from "@/lib/git-graph-layout";
+import { formatRelativeTime } from "@/lib/git-time";
+import { cn } from "@/lib/utils";
+import { GitBranch, RefreshCw, History, Tag, Search } from "lucide-react";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import { Button } from "@/components/ui/button";
+import type { GitCommit } from "@shared/types/ipc.types";
+
+interface GitHistoryPanelProps {
+  cwd: string;
+  isVisible: boolean;
+}
+
+// Fixed row geometry so the SVG graph and the HTML rows line up exactly.
+const ROW_HEIGHT = 30;
+const LANE_WIDTH = 16;
+const NODE_RADIUS = 4;
+const GRAPH_PADDING = 10;
+
+// Lane colors cycle through the project palette tokens (see index.css).
+const LANE_COLORS = [
+  "hsl(var(--project-blue))",
+  "hsl(var(--project-green))",
+  "hsl(var(--project-purple))",
+  "hsl(var(--project-orange))",
+  "hsl(var(--project-cyan))",
+  "hsl(var(--project-pink))",
+  "hsl(var(--project-yellow))",
+  "hsl(var(--project-red))",
+];
+
+function laneColor(lane: number): string {
+  return LANE_COLORS[lane % LANE_COLORS.length];
+}
+
+function laneX(lane: number): number {
+  return GRAPH_PADDING + lane * LANE_WIDTH;
+}
+
+function rowY(row: number): number {
+  return row * ROW_HEIGHT + ROW_HEIGHT / 2;
+}
+
+/** Parse a raw `%D` decoration into a display label + kind for chip styling. */
+function describeRef(ref: string): { label: string; kind: "head" | "tag" | "remote" | "branch" } {
+  if (ref.startsWith("tag: ")) {
+    return { label: ref.slice(5), kind: "tag" };
+  }
+  if (ref.startsWith("HEAD -> ")) {
+    return { label: ref.slice(8), kind: "head" };
+  }
+  if (ref === "HEAD") {
+    return { label: "HEAD", kind: "head" };
+  }
+  if (ref.includes("/")) {
+    return { label: ref, kind: "remote" };
+  }
+  return { label: ref, kind: "branch" };
+}
+
+export function GitHistoryPanel({ cwd, isVisible }: GitHistoryPanelProps): React.JSX.Element {
+  const commits = useGitHistoryStore((state) => state.commits[cwd]);
+  const isLoading = useGitHistoryStore((state) => state.loading[cwd] ?? false);
+  const error = useGitHistoryStore((state) => state.error[cwd] ?? null);
+  const refreshLog = useGitHistoryStore((state) => state.refreshLog);
+
+  const [searchQuery, setSearchQuery] = useState("");
+
+  useEffect(() => {
+    // Fetch on first reveal (or when no data yet) and on cwd change.
+    if (isVisible && commits === undefined) {
+      void refreshLog(cwd);
+    }
+  }, [isVisible, cwd, commits, refreshLog]);
+
+  const filteredCommits = useMemo(() => {
+    const list = commits ?? [];
+    if (!searchQuery.trim()) return list;
+    const q = searchQuery.toLowerCase();
+    return list.filter(
+      (c) =>
+        c.subject.toLowerCase().includes(q) ||
+        c.author.toLowerCase().includes(q) ||
+        c.shortHash.toLowerCase().includes(q) ||
+        c.hash.toLowerCase().includes(q) ||
+        c.refs.some((r) => r.toLowerCase().includes(q)),
+    );
+  }, [commits, searchQuery]);
+
+  // The lane graph reflects true topology, so it is computed from the full
+  // commit list, not the filtered view. Filtering only affects the row list.
+  const layout: GraphLayout = useMemo(
+    () => computeGraphLayout(commits ?? []),
+    [commits],
+  );
+  // Hash -> row index, so parent-edge endpoints are an O(1) lookup instead of
+  // an O(n) scan per edge inside the render loop.
+  const rowByHash = useMemo(() => {
+    const map = new Map<string, number>();
+    for (const row of layout.rows) map.set(row.commit.hash, row.row);
+    return map;
+  }, [layout]);
+
+  const graphWidth = GRAPH_PADDING * 2 + Math.max(1, layout.laneCount) * LANE_WIDTH;
+  const graphHeight = Math.max(1, layout.rows.length) * ROW_HEIGHT;
+  const isFiltering = searchQuery.trim().length > 0;
+
+  return (
+    <div className="flex h-full w-full flex-col bg-background overflow-hidden">
+      <div className="p-3 border-b border-border flex items-center justify-between gap-2 shrink-0">
+        <div className="flex items-center gap-2 text-sm font-medium text-foreground">
+          <History size={15} className="text-primary" />
+          Git History
+        </div>
+        <div className="flex items-center gap-2">
+          <div className="relative">
+            <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 text-muted-foreground" size={14} />
+            <input
+              type="text"
+              placeholder="Filter commits..."
+              className="w-44 bg-secondary/50 border-none rounded-md py-1.5 pl-8 pr-3 text-xs focus:ring-1 focus:ring-primary outline-none"
+              value={searchQuery}
+              onChange={(e) => setSearchQuery(e.target.value)}
+            />
+          </div>
+          <Button
+            variant="ghost"
+            size="icon"
+            className="h-8 w-8"
+            onClick={() => refreshLog(cwd)}
+            disabled={isLoading}
+            title="Refresh history"
+          >
+            <RefreshCw className={cn("h-4 w-4", isLoading && "animate-spin")} />
+          </Button>
+        </div>
+      </div>
+
+      {commits === undefined && isLoading ? (
+        <div className="flex-1 flex items-center justify-center text-muted-foreground">
+          <RefreshCw className="animate-spin mr-2" size={16} />
+          Loading history...
+        </div>
+      ) : (commits?.length ?? 0) === 0 ? (
+        <EmptyState error={error} />
+      ) : (
+        <ScrollArea className="flex-1">
+          <div className="relative" style={{ minHeight: isFiltering ? undefined : graphHeight }}>
+            {/* SVG lane graph, pinned to the left, aligned row-for-row. The
+               graph reflects the full contiguous topology, so it is only drawn
+               in the unfiltered view; a filtered subset cannot show meaningful
+               branch/merge lanes. */}
+            {!isFiltering && (
+              <svg
+                width={graphWidth}
+                height={graphHeight}
+                className="absolute left-0 top-0 pointer-events-none"
+                aria-hidden="true"
+              >
+                {layout.rows.map((row) =>
+                  row.parentEdges.map((edge) => {
+                    const x1 = laneX(row.lane);
+                    const y1 = rowY(row.row);
+                    const x2 = laneX(edge.toLane);
+                    // Parent row index drives the edge end; if the parent is
+                    // outside the window, run the edge to the bottom edge.
+                    const parentRow = rowByHash.get(edge.parentHash);
+                    const y2 = parentRow !== undefined ? rowY(parentRow) : graphHeight;
+                    const color = laneColor(x1 === x2 ? row.lane : edge.toLane);
+                    // Straight segment for same-lane; gentle bend for lane changes.
+                    const d =
+                      x1 === x2
+                        ? `M ${x1} ${y1} L ${x2} ${y2}`
+                        : `M ${x1} ${y1} C ${x1} ${(y1 + y2) / 2}, ${x2} ${(y1 + y2) / 2}, ${x2} ${y2}`;
+                    return (
+                      <path
+                        key={`${row.commit.hash}-${edge.parentHash}-${edge.toLane}`}
+                        d={d}
+                        fill="none"
+                        stroke={color}
+                        strokeWidth={1.5}
+                      />
+                    );
+                  }),
+                )}
+                {layout.rows.map((row) => (
+                  <circle
+                    key={row.commit.hash}
+                    cx={laneX(row.lane)}
+                    cy={rowY(row.row)}
+                    r={NODE_RADIUS}
+                    fill={laneColor(row.lane)}
+                    stroke="hsl(var(--background))"
+                    strokeWidth={1.5}
+                  />
+                ))}
+              </svg>
+            )}
+
+            {/* Commit rows. In the unfiltered view they are offset right to
+               clear the graph column; while filtering, the graph is hidden so
+               rows use the full width. */}
+            <div style={{ paddingLeft: isFiltering ? undefined : graphWidth }}>
+              {isFiltering && filteredCommits.length === 0 ? (
+                <div className="px-4 py-8 text-center text-xs text-muted-foreground">
+                  No commits match "{searchQuery}"
+                </div>
+              ) : (
+                (isFiltering ? filteredCommits : layout.rows.map((r) => r.commit)).map(
+                  (commit) => <CommitRow key={commit.hash} commit={commit} />,
+                )
+              )}
+            </div>
+          </div>
+        </ScrollArea>
+      )}
+    </div>
+  );
+}
+
+function CommitRow({ commit }: { commit: GitCommit }): React.JSX.Element {
+  return (
+    <div
+      className="flex items-center gap-3 pr-3 border-b border-border/40 hover:bg-secondary/40 transition-colors"
+      style={{ height: ROW_HEIGHT }}
+      title={`${commit.shortHash} — ${commit.subject}`}
+    >
+      <div className="flex items-center gap-1.5 shrink-0">
+        {commit.refs.map((ref) => (
+          <RefChip key={ref} raw={ref} />
+        ))}
+      </div>
+      <span className="text-xs text-foreground truncate flex-1 min-w-0">{commit.subject}</span>
+      <span className="text-[10px] text-muted-foreground truncate max-w-[120px] shrink-0">
+        {commit.author}
+      </span>
+      <span className="text-[10px] text-muted-foreground/70 shrink-0 w-10 text-right">
+        {formatRelativeTime(commit.date)}
+      </span>
+      <span className="font-mono text-[10px] text-muted-foreground/60 shrink-0 w-14">
+        {commit.shortHash}
+      </span>
+    </div>
+  );
+}
+
+function RefChip({ raw }: { raw: string }): React.JSX.Element {
+  const { label, kind } = describeRef(raw);
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center gap-1 px-1.5 h-4 rounded text-[9px] font-medium leading-none",
+        kind === "head" && "bg-primary/15 text-primary",
+        kind === "tag" && "bg-amber-500/15 text-amber-500",
+        kind === "remote" && "bg-muted-foreground/15 text-muted-foreground",
+        kind === "branch" && "bg-green-500/15 text-green-500",
+      )}
+    >
+      {kind === "tag" ? <Tag size={9} /> : <GitBranch size={9} />}
+      {label}
+    </span>
+  );
+}
+
+function EmptyState({ error }: { error: string | null }): React.JSX.Element {
+  return (
+    <div className="flex-1 flex flex-col items-center justify-center text-muted-foreground p-8 text-center">
+      <div className="w-12 h-12 rounded-full bg-secondary flex items-center justify-center mb-4 text-muted-foreground/50">
+        <History size={24} />
+      </div>
+      <h3 className="text-sm font-medium text-foreground mb-1">No commit history</h3>
+      <p className="text-xs max-w-[260px]">
+        {error
+          ? "This folder may not be a Git repository, or git is unavailable."
+          : "There are no commits to show yet. Make your first commit to see it here."}
+      </p>
+    </div>
+  );
+}

--- a/src/renderer/components/workspace/PaneContent.tsx
+++ b/src/renderer/components/workspace/PaneContent.tsx
@@ -6,6 +6,7 @@ import { ConnectedTerminal } from "@/components/terminal/ConnectedTerminal";
 import { EditorPanel } from "@/components/editor/EditorPanel";
 import { BrowserPanel } from "@/components/browser/BrowserPanel";
 import { GitPanel } from "@/components/git/GitPanel";
+import { GitHistoryPanel } from "@/components/git/GitHistoryPanel";
 import { useWorkspaceStore, getAllLeafPanes } from "@/stores/workspace-store";
 import { useTerminalStore, useTerminalActions } from "@/stores/terminal-store";
 import { useProjectStore } from "@/stores/project-store";
@@ -363,6 +364,27 @@ export function PaneContent({
 										}
 									>
 										<GitPanel cwd={tab.cwd} isVisible={isVisible} />
+									</div>
+								);
+							})}
+
+						{pane.tabs
+							.filter(
+								(t): t is WorkspaceTab & { type: "git-history" } =>
+									t.type === "git-history",
+							)
+							.map((tab) => {
+								const isVisible = activeTab?.id === tab.id;
+								return (
+									<div
+										key={tab.id}
+										className={
+											isVisible
+												? "w-full h-full"
+												: "w-full h-full absolute inset-0 invisible"
+										}
+									>
+										<GitHistoryPanel cwd={tab.cwd} isVisible={isVisible} />
 									</div>
 								);
 							})}

--- a/src/renderer/components/workspace/WorkspaceTabBar.tsx
+++ b/src/renderer/components/workspace/WorkspaceTabBar.tsx
@@ -11,6 +11,7 @@ import {
 	Minimize2,
 	GitBranch,
 	GitPullRequest,
+	History,
 } from "lucide-react";
 import { useGitStatusStore, type GitStatusState } from "@/stores/git-status-store";
 import type { GitStatusDetail } from "@shared/types/ipc.types";
@@ -533,6 +534,96 @@ function GitTabInline({
 	);
 }
 
+function GitHistoryTabInline({
+	tab: _tab,
+	isActive,
+	isDragging,
+	isDropTarget,
+	dropPosition,
+	onSelect,
+	onClose,
+	onDragStart,
+	onDragOver,
+	onDragLeave,
+	onDrop,
+}: {
+	tab: { type: "git-history"; id: string; cwd: string };
+	isActive: boolean;
+	isDragging: boolean;
+	isDropTarget: boolean;
+	dropPosition: TabReorderPosition | null;
+	onSelect: () => void;
+	onClose: () => void;
+	onDragStart: (e: React.DragEvent) => void;
+	onDragOver: (e: React.DragEvent) => void;
+	onDragLeave: () => void;
+	onDrop: (e: React.DragEvent) => void;
+}) {
+	const [contextMenu, setContextMenu] = useState<{
+		x: number;
+		y: number;
+	} | null>(null);
+
+	return (
+		<>
+			<div
+				draggable
+				onDragStart={onDragStart}
+				onDragOver={onDragOver}
+				onDragLeave={onDragLeave}
+				onDrop={onDrop}
+				onClick={onSelect}
+				onContextMenu={(e) => {
+					e.preventDefault();
+					setContextMenu({ x: e.clientX, y: e.clientY });
+				}}
+				className={cn(
+					"group relative h-full px-3 flex items-center min-w-[120px] max-w-[200px] gap-2 cursor-pointer select-none border-r border-border transition-all duration-150 ease-out border-b-2 border-b-transparent",
+					isActive
+						? "bg-background border-b-primary text-foreground"
+						: "text-muted-foreground hover:bg-secondary/50 hover:text-foreground",
+					isDragging && "opacity-50 scale-[0.98]",
+					isDropTarget &&
+						dropPosition === "before" &&
+						"border-l-2 border-l-primary",
+					isDropTarget &&
+						dropPosition === "after" &&
+						"border-r-2 border-r-primary",
+				)}
+			>
+				<History size={12} className={isActive ? "text-primary" : ""} />
+				<span className="truncate text-[11px] font-medium flex-1">
+					Git History
+				</span>
+				<button
+					onClick={(e) => {
+						e.stopPropagation();
+						onClose();
+					}}
+					className="opacity-0 group-hover:opacity-100 p-0.5 rounded hover:bg-background/50 transition-opacity"
+				>
+					<XIcon size={10} />
+				</button>
+			</div>
+
+			{contextMenu && (
+				<ContextMenu
+					items={[
+						{
+							label: "Close",
+							icon: <XIcon size={12} />,
+							onClick: onClose,
+						},
+					]}
+					x={contextMenu.x}
+					y={contextMenu.y}
+					onClose={() => setContextMenu(null)}
+				/>
+			)}
+		</>
+	);
+}
+
 interface WorkspaceTabBarProps {
 	paneId: string;
 	tabs: WorkspaceTab[];
@@ -901,6 +992,25 @@ export function WorkspaceTabBar({
 									) : tab.type === "git" ? (
 										<GitTabInline
 											tab={tab as { type: "git"; id: string; cwd: string }}
+											isActive={tab.id === activeTabId}
+											isDragging={dragging}
+											isDropTarget={isTarget}
+											dropPosition={position}
+											onSelect={() => {
+												setActiveTab(paneId, tab.id);
+												setActivePane(paneId);
+											}}
+											onClose={() => {
+												useWorkspaceStore.getState().removeTab(tab.id);
+											}}
+											onDragStart={(e) => handleTabDragStart(tab.id, e)}
+											onDragOver={(e) => handleTabDragOver(tab.id, e)}
+											onDragLeave={handleTabDragLeave}
+											onDrop={(e) => handleTabDrop(tab.id, e)}
+										/>
+									) : tab.type === "git-history" ? (
+										<GitHistoryTabInline
+											tab={tab as { type: "git-history"; id: string; cwd: string }}
 											isActive={tab.id === activeTabId}
 											isDragging={dragging}
 											isDropTarget={isTarget}

--- a/src/renderer/hooks/use-editor-persistence.ts
+++ b/src/renderer/hooks/use-editor-persistence.ts
@@ -53,7 +53,13 @@ interface PersistedGitTabRef {
   cwd: string
 }
 
-type PersistedTabRef = PersistedEditorTabRef | PersistedTerminalTabRef | PersistedBrowserTabRef | PersistedGitTabRef
+interface PersistedGitHistoryTabRef {
+  type: 'git-history'
+  id: string
+  cwd: string
+}
+
+type PersistedTabRef = PersistedEditorTabRef | PersistedTerminalTabRef | PersistedBrowserTabRef | PersistedGitTabRef | PersistedGitHistoryTabRef
 
 interface PersistedLeafNode {
   type: 'leaf'
@@ -129,6 +135,10 @@ function serializePaneTree(node: PaneNode): PersistedPaneNode {
 
       if (tab.type === 'git') {
         return [{ type: 'git', id: tab.id, cwd: tab.cwd }]
+      }
+
+      if (tab.type === 'git-history') {
+        return [{ type: 'git-history', id: tab.id, cwd: tab.cwd }]
       }
 
       return []
@@ -295,6 +305,10 @@ function reconcileTerminalTabs(
           return [tab]
         }
 
+        if (tab.type === 'git-history') {
+          return [tab]
+        }
+
         if (shouldKeepPersistedTerminalTabs) {
           return [tab]
         }
@@ -372,6 +386,16 @@ export function deserializePaneTree(persisted: PersistedPaneNodeInput): PaneNode
           return [
             {
               type: 'git',
+              id: tab.id,
+              cwd: tab.cwd
+            }
+          ]
+        }
+
+        if (tab.type === 'git-history') {
+          return [
+            {
+              type: 'git-history',
               id: tab.id,
               cwd: tab.cwd
             }

--- a/src/renderer/layouts/WorkspaceLayout.tsx
+++ b/src/renderer/layouts/WorkspaceLayout.tsx
@@ -684,14 +684,17 @@ export default function WorkspaceLayout(): React.JSX.Element {
 
 	const handleAddGitHistoryTab = useCallback((paneId?: string) => {
 		const resolvedPaneId = paneId ?? useWorkspaceStore.getState().activePaneId;
-		if (resolvedPaneId && activeProject?.path) {
-			useWorkspaceStore.getState().addTabToPane(resolvedPaneId, {
-				type: "git-history",
-				id: `git-history-${crypto.randomUUID()}`,
-				cwd: activeProject.path,
-			});
-		}
-	}, [activeProject?.path]);
+		if (!resolvedPaneId) return;
+		// Resolve the worktree-aware cwd (same helper terminal creation uses) so
+		// the history reflects the active worktree, not just the project root.
+		const resolvedCwd = getDefaultCwdForProject(activeProjectId);
+		if (!resolvedCwd) return;
+		useWorkspaceStore.getState().addTabToPane(resolvedPaneId, {
+			type: "git-history",
+			id: `git-history-${crypto.randomUUID()}`,
+			cwd: resolvedCwd,
+		});
+	}, [activeProjectId]);
 
 	useEffect(() => {
 		const handleKeyDown = (e: KeyboardEvent) => {

--- a/src/renderer/layouts/WorkspaceLayout.tsx
+++ b/src/renderer/layouts/WorkspaceLayout.tsx
@@ -682,6 +682,17 @@ export default function WorkspaceLayout(): React.JSX.Element {
 		}
 	}, [activeProject?.path]);
 
+	const handleAddGitHistoryTab = useCallback((paneId?: string) => {
+		const resolvedPaneId = paneId ?? useWorkspaceStore.getState().activePaneId;
+		if (resolvedPaneId && activeProject?.path) {
+			useWorkspaceStore.getState().addTabToPane(resolvedPaneId, {
+				type: "git-history",
+				id: `git-history-${crypto.randomUUID()}`,
+				cwd: activeProject.path,
+			});
+		}
+	}, [activeProject?.path]);
+
 	useEffect(() => {
 		const handleKeyDown = (e: KeyboardEvent) => {
 			// Safety net: skip workspace handling when an earlier handler has already
@@ -720,6 +731,8 @@ export default function WorkspaceLayout(): React.JSX.Element {
 						}
 					}
 				} else if (activeTab?.type === "git") {
+					useWorkspaceStore.getState().removeTab(activeTab.id);
+				} else if (activeTab?.type === "git-history") {
 					useWorkspaceStore.getState().removeTab(activeTab.id);
 				} else if (activeTab?.type === "terminal") {
 					handleCloseTerminalRef.current?.(activeTab.terminalId, activeTab.id);
@@ -1230,6 +1243,8 @@ export default function WorkspaceLayout(): React.JSX.Element {
 					onOpenCommandPalette={() => setIsCommandPaletteOpen(true)}
 					onOpenGitChanges={() => handleAddGitTab()}
 					canOpenGitChanges={Boolean(activeProject?.path)}
+					onOpenGitHistory={() => handleAddGitHistoryTab()}
+					canOpenGitHistory={Boolean(activeProject?.path)}
 				/>
 				<div className="flex-1 flex flex-col min-w-0">
 					{/* macOS: draggable band clearing native traffic lights over the content column */}

--- a/src/renderer/lib/git-api.ts
+++ b/src/renderer/lib/git-api.ts
@@ -1,5 +1,5 @@
 import { invoke } from "@tauri-apps/api/core";
-import { GitStatusDetail } from "@shared/types/ipc.types";
+import { GitCommit, GitStatusDetail } from "@shared/types/ipc.types";
 
 export const gitApi = {
   getStatus: (cwd: string) =>
@@ -16,4 +16,7 @@ export const gitApi = {
 
   discard: (cwd: string, path: string) =>
     invoke<void>("git_discard", { cwd, path }),
+
+  getLog: (cwd: string, limit?: number) =>
+    invoke<GitCommit[]>("git_get_log", { cwd, limit }),
 };

--- a/src/renderer/lib/git-graph-layout.test.ts
+++ b/src/renderer/lib/git-graph-layout.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect } from "vitest";
+import { computeGraphLayout } from "./git-graph-layout";
+import type { GitCommit } from "@shared/types/ipc.types";
+
+function commit(hash: string, parents: string[], extra: Partial<GitCommit> = {}): GitCommit {
+  return {
+    hash,
+    shortHash: hash.slice(0, 7),
+    parents,
+    refs: [],
+    author: "Test",
+    date: "2026-05-30T12:00:00+00:00",
+    subject: `commit ${hash}`,
+    ...extra,
+  };
+}
+
+describe("computeGraphLayout", () => {
+  it("returns an empty layout for no commits", () => {
+    const layout = computeGraphLayout([]);
+    expect(layout.rows).toEqual([]);
+    expect(layout.laneCount).toBe(0);
+  });
+
+  it("places linear history in a single lane", () => {
+    // Newest first: B -> A (root).
+    const commits = [commit("B", ["A"]), commit("A", [])];
+    const layout = computeGraphLayout(commits);
+
+    expect(layout.laneCount).toBe(1);
+    expect(layout.rows.map((r) => r.lane)).toEqual([0, 0]);
+    // B has one edge down to A's lane (0).
+    expect(layout.rows[0].parentEdges).toEqual([{ parentHash: "A", toLane: 0 }]);
+    // Root commit has no edges.
+    expect(layout.rows[1].parentEdges).toEqual([]);
+    expect(layout.rows[1].row).toBe(1);
+  });
+
+  it("fans out a merge commit into both parent lanes", () => {
+    // M merges feature(P2) into main(P1); both descend from Base.
+    const commits = [
+      commit("M", ["P1", "P2"]),
+      commit("P1", ["Base"]),
+      commit("P2", ["Base"]),
+      commit("Base", []),
+    ];
+    const layout = computeGraphLayout(commits);
+
+    expect(layout.laneCount).toBe(2);
+
+    const merge = layout.rows[0];
+    expect(merge.commit.hash).toBe("M");
+    expect(merge.lane).toBe(0);
+    // First parent continues the merge's lane (0); second parent branches to 1.
+    expect(merge.parentEdges).toEqual([
+      { parentHash: "P1", toLane: 0 },
+      { parentHash: "P2", toLane: 1 },
+    ]);
+
+    // The feature commit sits in lane 1 and converges back to Base in lane 0.
+    const feat = layout.rows.find((r) => r.commit.hash === "P2");
+    expect(feat?.lane).toBe(1);
+    expect(feat?.parentEdges).toEqual([{ parentHash: "Base", toLane: 0 }]);
+  });
+
+  it("assigns distinct lanes to diverging branch tips", () => {
+    // Two tips both pointing at the same Base, no merge in the window.
+    const commits = [
+      commit("TipA", ["Base"]),
+      commit("TipB", ["Base"]),
+      commit("Base", []),
+    ];
+    const layout = computeGraphLayout(commits);
+
+    expect(layout.laneCount).toBe(2);
+    expect(layout.rows[0].lane).toBe(0); // TipA
+    expect(layout.rows[1].lane).toBe(1); // TipB
+    // Both converge onto Base's lane (0).
+    expect(layout.rows[0].parentEdges).toEqual([{ parentHash: "Base", toLane: 0 }]);
+    expect(layout.rows[1].parentEdges).toEqual([{ parentHash: "Base", toLane: 0 }]);
+    expect(layout.rows[2].lane).toBe(0); // Base
+  });
+
+  it("reclaims a freed lane for an unrelated later tip", () => {
+    // TipA closes out (root) before an unrelated TipB appears; TipB should
+    // reuse lane 0 rather than allocating a third lane.
+    const commits = [
+      commit("TipA", []),
+      commit("TipB", ["Base"]),
+      commit("Base", []),
+    ];
+    const layout = computeGraphLayout(commits);
+    expect(layout.laneCount).toBe(1);
+    expect(layout.rows.map((r) => r.lane)).toEqual([0, 0, 0]);
+  });
+
+  it("frees the lane of a parent that lies outside the fetched window", () => {
+    // 'Older' is referenced as a parent but not present in the window (it is
+    // beyond the fetch limit). Its reserved lane must be reclaimed so the
+    // following independent tip reuses lane 0 instead of inflating laneCount.
+    const commits = [
+      commit("Tip", ["Older"]), // Older is NOT in the list
+      commit("Other", []),
+    ];
+    const layout = computeGraphLayout(commits);
+    expect(layout.laneCount).toBe(1);
+    expect(layout.rows.map((r) => r.lane)).toEqual([0, 0]);
+    // The edge to the out-of-window parent is still emitted for rendering.
+    expect(layout.rows[0].parentEdges).toEqual([{ parentHash: "Older", toLane: 0 }]);
+  });
+
+  it("handles an octopus merge with three parents", () => {
+    const commits = [
+      commit("M", ["P1", "P2", "P3"]),
+      commit("P1", ["Base"]),
+      commit("P2", ["Base"]),
+      commit("P3", ["Base"]),
+      commit("Base", []),
+    ];
+    const layout = computeGraphLayout(commits);
+    // Three distinct parent lanes off the merge node.
+    expect(layout.rows[0].parentEdges).toEqual([
+      { parentHash: "P1", toLane: 0 },
+      { parentHash: "P2", toLane: 1 },
+      { parentHash: "P3", toLane: 2 },
+    ]);
+    expect(layout.laneCount).toBe(3);
+  });
+});

--- a/src/renderer/lib/git-graph-layout.test.ts
+++ b/src/renderer/lib/git-graph-layout.test.ts
@@ -126,4 +126,22 @@ describe("computeGraphLayout", () => {
     ]);
     expect(layout.laneCount).toBe(3);
   });
+
+  it("keeps a visible parent in its own lane when an earlier merge parent is out-of-window", () => {
+    // M's first parent 'Older' is beyond the fetch limit (omitted). The visible
+    // second parent 'P2' must NOT collapse onto the out-of-window parent's lane;
+    // releasing the Older lane is deferred until all parents are placed.
+    const commits = [
+      commit("M", ["Older", "P2"]), // Older is NOT in the list
+      commit("P2", ["Base"]),
+      commit("Base", []),
+    ];
+    const layout = computeGraphLayout(commits);
+    expect(layout.rows[0].parentEdges).toEqual([
+      { parentHash: "Older", toLane: 0 },
+      { parentHash: "P2", toLane: 1 },
+    ]);
+    expect(layout.rows.find((r) => r.commit.hash === "P2")?.lane).toBe(1);
+    expect(layout.laneCount).toBe(2);
+  });
 });

--- a/src/renderer/lib/git-graph-layout.ts
+++ b/src/renderer/lib/git-graph-layout.ts
@@ -82,6 +82,11 @@ export function computeGraphLayout(commits: GitCommit[]): GraphLayout {
     }
 
     const parentEdges: GraphEdge[] = [];
+    // Lanes for out-of-window parents are released only after every parent of
+    // this commit has been assigned. Releasing mid-iteration would let a later
+    // parent's firstFreeLane() reclaim a lane still needed by an earlier
+    // parent, collapsing two distinct parent edges onto one lane.
+    const lanesToRelease: number[] = [];
     commit.parents.forEach((parentHash, parentIdx) => {
       let parentLane: number;
       const existing = active.indexOf(parentHash);
@@ -99,13 +104,17 @@ export function computeGraphLayout(commits: GitCommit[]): GraphLayout {
       }
       parentEdges.push({ parentHash, toLane: parentLane });
       maxLaneIndex = Math.max(maxLaneIndex, parentLane);
-      // Parent outside the fetched window: it will never be drawn, so free its
-      // lane now for reuse by older commits. The edge is still emitted (the
-      // renderer runs it to the bottom edge).
+      // Parent outside the fetched window: it will never be drawn, so its lane
+      // can be reused by older commits. The edge is still emitted (the renderer
+      // runs it to the bottom edge). Defer the actual release until all parents
+      // of this commit are placed.
       if (!known.has(parentHash)) {
-        active[parentLane] = null;
+        lanesToRelease.push(parentLane);
       }
     });
+    for (const releaseLane of lanesToRelease) {
+      active[releaseLane] = null;
+    }
 
     // Root commit (no parents): free this lane for reuse below.
     if (commit.parents.length === 0) {

--- a/src/renderer/lib/git-graph-layout.ts
+++ b/src/renderer/lib/git-graph-layout.ts
@@ -1,0 +1,120 @@
+import type { GitCommit } from "@shared/types/ipc.types";
+
+/**
+ * A commit positioned for SVG rendering.
+ *
+ * `lane` is the horizontal column index for the commit node. `row` is its
+ * vertical position (0 = newest, matching the input order). `parentEdges`
+ * describes one line segment per parent, from this commit's lane to the lane
+ * the parent occupies once it is drawn.
+ */
+export interface GraphRow {
+  commit: GitCommit;
+  row: number;
+  lane: number;
+  /** Edges from this commit down to each parent's lane. */
+  parentEdges: GraphEdge[];
+}
+
+export interface GraphEdge {
+  /** Parent commit hash this edge connects to. */
+  parentHash: string;
+  /** Lane the parent will be drawn in (or continues through). */
+  toLane: number;
+}
+
+export interface GraphLayout {
+  rows: GraphRow[];
+  /** Total number of lanes used; drives the SVG graph column width. */
+  laneCount: number;
+}
+
+/**
+ * Assign lanes and parent edges to a newest-first commit list for a self-rendered
+ * SVG lane graph.
+ *
+ * Algorithm (single pass, newest -> oldest):
+ * - Keep an array of "active lanes". Each slot holds the SHA that lane is
+ *   currently waiting to draw next, or `null` if the lane is free.
+ * - For each commit, its lane is the first active lane already waiting for its
+ *   hash; if none, it takes the first free lane (or a new one appended).
+ * - After placing the commit, that lane is reassigned to the commit's FIRST
+ *   parent. Additional parents (a merge) reuse a lane already waiting for them
+ *   or claim a new lane — producing the merge fan-out.
+ * - Edges connect the commit to the lane each parent occupies, so the renderer
+ *   can draw converging/diverging lines.
+ *
+ * Lanes freed by a commit whose hash no lane is waiting for (e.g. a branch tip
+ * with no children in the window) are reclaimed for later commits, keeping the
+ * lane count tight.
+ */
+export function computeGraphLayout(commits: GitCommit[]): GraphLayout {
+  // active[i] = hash the lane at column i is waiting to render next, or null.
+  const active: (string | null)[] = [];
+  const rows: GraphRow[] = [];
+  // All hashes present in the fetched window. A parent not in this set lives
+  // beyond the fetch limit and will never be drawn, so its lane must not stay
+  // reserved (that would inflate the lane count and block reuse).
+  const known = new Set(commits.map((c) => c.hash));
+  let maxLaneIndex = -1;
+
+  const firstFreeLane = (): number => {
+    const idx = active.indexOf(null);
+    if (idx !== -1) return idx;
+    active.push(null);
+    return active.length - 1;
+  };
+
+  for (let row = 0; row < commits.length; row++) {
+    const commit = commits[row];
+
+    // Find a lane already expecting this commit (its child reserved it).
+    let lane = active.indexOf(commit.hash);
+    if (lane === -1) {
+      // No child in view reserved a lane — this is a tip; take a free lane.
+      lane = firstFreeLane();
+    } else {
+      // Clear every lane that was waiting for this same commit so duplicate
+      // reservations (two children sharing a parent) collapse into one node.
+      for (let i = 0; i < active.length; i++) {
+        if (active[i] === commit.hash) active[i] = null;
+      }
+    }
+
+    const parentEdges: GraphEdge[] = [];
+    commit.parents.forEach((parentHash, parentIdx) => {
+      let parentLane: number;
+      const existing = active.indexOf(parentHash);
+      if (existing !== -1) {
+        // Another lane already expects this parent: edge merges into it.
+        parentLane = existing;
+      } else if (parentIdx === 0) {
+        // First parent continues this commit's lane.
+        parentLane = lane;
+        active[lane] = parentHash;
+      } else {
+        // Extra merge parent: branch off into a fresh lane.
+        parentLane = firstFreeLane();
+        active[parentLane] = parentHash;
+      }
+      parentEdges.push({ parentHash, toLane: parentLane });
+      maxLaneIndex = Math.max(maxLaneIndex, parentLane);
+      // Parent outside the fetched window: it will never be drawn, so free its
+      // lane now for reuse by older commits. The edge is still emitted (the
+      // renderer runs it to the bottom edge).
+      if (!known.has(parentHash)) {
+        active[parentLane] = null;
+      }
+    });
+
+    // Root commit (no parents): free this lane for reuse below.
+    if (commit.parents.length === 0) {
+      active[lane] = null;
+    }
+
+    rows.push({ commit, row, lane, parentEdges });
+    maxLaneIndex = Math.max(maxLaneIndex, lane);
+  }
+
+  return { rows, laneCount: maxLaneIndex + 1 };
+}

--- a/src/renderer/lib/git-ref.test.ts
+++ b/src/renderer/lib/git-ref.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from "vitest";
+import { describeRef } from "./git-ref";
+
+describe("describeRef", () => {
+  it("classifies the current branch from HEAD ->", () => {
+    expect(describeRef("HEAD -> refs/heads/main")).toEqual({
+      label: "main",
+      kind: "head",
+    });
+  });
+
+  it("classifies detached HEAD", () => {
+    expect(describeRef("HEAD")).toEqual({ label: "HEAD", kind: "head" });
+  });
+
+  it("classifies a local branch and preserves a slash in the name", () => {
+    // The key case: a local slashed branch must NOT be mistaken for a remote.
+    expect(describeRef("refs/heads/feature/login")).toEqual({
+      label: "feature/login",
+      kind: "branch",
+    });
+  });
+
+  it("classifies a remote-tracking ref", () => {
+    expect(describeRef("refs/remotes/origin/main")).toEqual({
+      label: "origin/main",
+      kind: "remote",
+    });
+  });
+
+  it("classifies tags from both decoration forms", () => {
+    expect(describeRef("tag: refs/tags/v1.0")).toEqual({
+      label: "v1.0",
+      kind: "tag",
+    });
+    expect(describeRef("refs/tags/v2.0")).toEqual({
+      label: "v2.0",
+      kind: "tag",
+    });
+  });
+
+  it("classifies HEAD -> a slashed local branch as head, label keeps the slash", () => {
+    expect(describeRef("HEAD -> refs/heads/feature/x")).toEqual({
+      label: "feature/x",
+      kind: "head",
+    });
+  });
+
+  it("treats an unknown decoration as a branch, not a remote", () => {
+    expect(describeRef("weird/thing")).toEqual({
+      label: "weird/thing",
+      kind: "branch",
+    });
+  });
+});

--- a/src/renderer/lib/git-ref.ts
+++ b/src/renderer/lib/git-ref.ts
@@ -1,0 +1,66 @@
+/** The classified kind of a git ref decoration, used for chip styling. */
+export type GitRefKind = "head" | "tag" | "remote" | "branch";
+
+export interface DescribedRef {
+  label: string;
+  kind: GitRefKind;
+}
+
+/**
+ * Parse one raw `%D` decoration entry from `git log --decorate=full` into a
+ * display label + kind.
+ *
+ * Full decoration yields canonical, unambiguous ref names:
+ * - `HEAD -> refs/heads/main`     → head, label "main"
+ * - `HEAD`                        → head (detached), label "HEAD"
+ * - `refs/heads/feature/login`    → branch, label "feature/login"
+ * - `refs/remotes/origin/main`    → remote, label "origin/main"
+ * - `tag: refs/tags/v1.0`         → tag, label "v1.0"
+ *
+ * Using full names (not `--decorate=short`) is what lets a local branch with a
+ * slash (`feature/login`) be told apart from a remote ref (`origin/main`),
+ * which short names cannot distinguish.
+ */
+export function describeRef(ref: string): DescribedRef {
+  const trimmed = ref.trim();
+
+  // `HEAD -> <ref>`: the current branch. Classify by the target ref.
+  if (trimmed.startsWith("HEAD -> ")) {
+    const target = trimmed.slice("HEAD -> ".length).trim();
+    return { label: stripRefPrefix(target), kind: "head" };
+  }
+
+  if (trimmed === "HEAD") {
+    return { label: "HEAD", kind: "head" };
+  }
+
+  // Annotated/lightweight tags are decorated as `tag: refs/tags/<name>`.
+  if (trimmed.startsWith("tag: ")) {
+    const target = trimmed.slice("tag: ".length).trim();
+    return { label: stripRefPrefix(target), kind: "tag" };
+  }
+
+  if (trimmed.startsWith("refs/tags/")) {
+    return { label: trimmed.slice("refs/tags/".length), kind: "tag" };
+  }
+
+  if (trimmed.startsWith("refs/remotes/")) {
+    return { label: trimmed.slice("refs/remotes/".length), kind: "remote" };
+  }
+
+  if (trimmed.startsWith("refs/heads/")) {
+    return { label: trimmed.slice("refs/heads/".length), kind: "branch" };
+  }
+
+  // Unknown/odd decoration: show it verbatim and treat it as a branch rather
+  // than guessing "remote" from a slash (which mislabels local slashed names).
+  return { label: stripRefPrefix(trimmed), kind: "branch" };
+}
+
+/** Strip a known canonical ref prefix for display, leaving the human name. */
+function stripRefPrefix(ref: string): string {
+  if (ref.startsWith("refs/heads/")) return ref.slice("refs/heads/".length);
+  if (ref.startsWith("refs/remotes/")) return ref.slice("refs/remotes/".length);
+  if (ref.startsWith("refs/tags/")) return ref.slice("refs/tags/".length);
+  return ref;
+}

--- a/src/renderer/lib/git-time.test.ts
+++ b/src/renderer/lib/git-time.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from "vitest";
+import { formatRelativeTime } from "./git-time";
+
+describe("formatRelativeTime", () => {
+  const now = Date.parse("2026-05-30T12:00:00Z");
+
+  it("returns empty string for invalid input", () => {
+    expect(formatRelativeTime("not-a-date", now)).toBe("");
+    expect(formatRelativeTime("", now)).toBe("");
+  });
+
+  it("formats sub-minute as 'now'", () => {
+    expect(formatRelativeTime("2026-05-30T11:59:30Z", now)).toBe("now");
+  });
+
+  it("formats minutes, hours, days, and weeks", () => {
+    expect(formatRelativeTime("2026-05-30T11:55:00Z", now)).toBe("5m");
+    expect(formatRelativeTime("2026-05-30T09:00:00Z", now)).toBe("3h");
+    expect(formatRelativeTime("2026-05-28T12:00:00Z", now)).toBe("2d");
+    expect(formatRelativeTime("2026-05-16T12:00:00Z", now)).toBe("2w");
+  });
+
+  it("clamps future timestamps to 'now'", () => {
+    expect(formatRelativeTime("2026-05-30T12:05:00Z", now)).toBe("now");
+  });
+
+  it("falls back to a date for old timestamps", () => {
+    // ~12 weeks earlier: beyond the 8-week relative window.
+    const result = formatRelativeTime("2026-03-01T12:00:00Z", now);
+    expect(result).not.toBe("");
+    expect(result).not.toMatch(/^\d+[mhdw]$/);
+  });
+});

--- a/src/renderer/lib/git-time.ts
+++ b/src/renderer/lib/git-time.ts
@@ -1,0 +1,32 @@
+/**
+ * Format an ISO 8601 timestamp as a compact relative time for commit rows,
+ * e.g. "now", "5m", "3h", "2d", "5w". Falls back to a short localized date for
+ * anything older than ~8 weeks. Invalid input yields an empty string so the UI
+ * can render nothing rather than "Invalid Date".
+ *
+ * `now` is injectable for deterministic tests.
+ */
+export function formatRelativeTime(iso: string, now: number = Date.now()): string {
+  const then = Date.parse(iso);
+  if (Number.isNaN(then)) return "";
+
+  const diffMs = now - then;
+  // Future timestamps (clock skew) clamp to "now" rather than negative values.
+  const seconds = Math.max(0, Math.floor(diffMs / 1000));
+
+  if (seconds < 60) return "now";
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}m`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h`;
+  const days = Math.floor(hours / 24);
+  if (days < 7) return `${days}d`;
+  const weeks = Math.floor(days / 7);
+  if (weeks < 8) return `${weeks}w`;
+
+  return new Date(then).toLocaleDateString(undefined, {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+  });
+}

--- a/src/renderer/stores/git-history-store.ts
+++ b/src/renderer/stores/git-history-store.ts
@@ -1,0 +1,57 @@
+import { create } from "zustand";
+import { toast } from "sonner";
+import { gitApi } from "@/lib/git-api";
+import type { GitCommit } from "@shared/types/ipc.types";
+
+export interface GitHistoryState {
+  // commits[cwd] = GitCommit[] (newest first)
+  commits: Record<string, GitCommit[]>;
+  // loading[cwd] = boolean
+  loading: Record<string, boolean>;
+  // error[cwd] = string | null
+  error: Record<string, string | null>;
+
+  refreshLog: (cwd: string, limit?: number) => Promise<void>;
+}
+
+export const useGitHistoryStore = create<GitHistoryState>((set) => ({
+  commits: {},
+  loading: {},
+  error: {},
+
+  refreshLog: async (cwd, limit) => {
+    // Capture a per-cwd request token before awaiting so a later refresh that
+    // resolves first cannot be overwritten by an earlier, slower response.
+    const token = (logRequestVersions[cwd] ?? 0) + 1;
+    logRequestVersions[cwd] = token;
+    const isCurrent = () => logRequestVersions[cwd] === token;
+
+    set((state) => ({
+      loading: { ...state.loading, [cwd]: true },
+      error: { ...state.error, [cwd]: null },
+    }));
+
+    try {
+      const commits = await gitApi.getLog(cwd, limit);
+      if (!isCurrent()) return;
+      set((state) => ({
+        commits: { ...state.commits, [cwd]: commits },
+        loading: { ...state.loading, [cwd]: false },
+      }));
+    } catch (err) {
+      if (!isCurrent()) return;
+      const message = String(err);
+      set((state) => ({
+        // Keep any previously-loaded commits so a transient refresh failure
+        // does not wipe the displayed history; only surface the error.
+        loading: { ...state.loading, [cwd]: false },
+        error: { ...state.error, [cwd]: message },
+      }));
+      toast.error(`Failed to load git history: ${message}`);
+    }
+  },
+}));
+
+/** Monotonic request token per cwd, kept outside React state because it is
+ * control metadata for discarding superseded in-flight fetches. */
+const logRequestVersions: Record<string, number> = {};

--- a/src/renderer/stores/workspace-store.ts
+++ b/src/renderer/stores/workspace-store.ts
@@ -13,6 +13,7 @@ export type WorkspaceTab =
   | { type: 'editor'; id: string; filePath: string }
   | { type: 'browser'; id: string; browserTabId: string }
   | { type: 'git'; id: string; cwd: string }
+  | { type: 'git-history'; id: string; cwd: string }
 
 // CRITICAL: Global lock to prevent syncTerminalTabs from running multiple times concurrently
 // This prevents duplicate tab creation during rapid state changes

--- a/src/shared/types/ipc.types.ts
+++ b/src/shared/types/ipc.types.ts
@@ -77,12 +77,31 @@ export interface GitStatusDetail {
 	staged: boolean;
 }
 
+// A single commit row for the history/graph view.
+export interface GitCommit {
+	/** Full 40-char commit hash. */
+	hash: string;
+	/** Abbreviated commit hash. */
+	shortHash: string;
+	/** Parent full hashes, first-parent first. Empty for the root commit. */
+	parents: string[];
+	/** Ref decorations (branches, tags, HEAD) attached to this commit. */
+	refs: string[];
+	/** Author name. */
+	author: string;
+	/** Author date in ISO 8601 strict format. */
+	date: string;
+	/** Commit subject (first line of the message). */
+	subject: string;
+}
+
 export interface GitApi {
 	getStatus: (cwd: string) => Promise<GitStatusDetail[]>;
 	getDiff: (cwd: string, path: string, staged?: boolean) => Promise<string>;
 	stage: (cwd: string, path: string) => Promise<void>;
 	unstage: (cwd: string, path: string) => Promise<void>;
 	discard: (cwd: string, path: string) => Promise<void>;
+	getLog: (cwd: string, limit?: number) => Promise<GitCommit[]>;
 }
 
 // Terminal API exposed via preload


### PR DESCRIPTION
## Summary

- Adds a read-only **Git History** pane that lists recent commits with a self-rendered SVG lane graph (branch/merge topology), commit metadata (short SHA, author, relative date, subject), and ref decorations (HEAD/branch/tag chips).
- Fills the gap where the existing Git integration only showed working-tree status and per-file diffs — previously you had to drop to a terminal to run `git log`.

## Related Issue

Closes #
<!-- No tracked issue. Implements the "Git History Graph view" item from _bmad-output/implementation-artifacts/deferred-work.md (split from the git commit-UI work on 2026-05-30). -->

## Type of Change

- [x] feat: new feature

## What Changed

**Backend (Rust)**
- `git_get_log` / `parse_git_log` in `src-tauri/src/trackers/git_tracker.rs` read `git log` through the existing `GitTracker::run_git_command` argument vector (no shell). Uses a NUL-delimited, record-terminated `--pretty` format with `--parents` and `--decorate` so subjects containing spaces/pipes/unicode cannot break parsing. Limit clamped to `1..=1000` (default 200). A non-zero exit (empty repo / not a repo) surfaces an empty list rather than an error.
- Registered the `git_get_log` Tauri command.

**Renderer**
- `gitApi.getLog` facade + `GitCommit` shared type.
- `git-history-store` (Zustand) with a superseded-request guard; keeps already-displayed commits on a transient refresh error.
- `git-graph-layout.ts`: pure lane-assignment + edge computation (frees out-of-window parent lanes, handles octopus merges) — no charting dependency, React 18 safe.
- `git-time.ts`: compact relative-time helper ("5m", "3h", "2d", "2w", else short date).
- `GitHistoryPanel`: SVG lane graph + commit rows, loading/empty/error states, filter (matches subject/author/full+short hash/refs), refresh. The graph is hidden while filtering so rows stay aligned.
- New `git-history` workspace tab type wired end-to-end: `workspace-store`, `PaneContent`, `WorkspaceTabBar`, `use-editor-persistence` (persistence round-trip), `WorkspaceLayout` (launch + Ctrl+W close), and `ActivityRail` (new rail button).

**Scope notes:** read-only — no checkout/revert/cherry-pick, no per-commit diff/file-tree, no pagination beyond the 200-commit cap (deferred as future enhancements).

## How It Was Tested

- [x] `bun run lint`
- [x] `bun run typecheck`
- [x] `bun run test`
- [x] Manual verification completed
<!-- Rust: cargo test (parse_git_log unit tests: linear, merge, decorations, comma-in-ref, embedded-NUL subject, special chars, empty/malformed; integration: empty repo, linear newest-first, merge parents, limit). Renderer: git-graph-layout + git-time vitest suites, plus ActivityRail and use-editor-persistence regression suites. Both tsconfig.web and tsconfig.node typecheck clean; ESLint clean on new files. -->

## Screenshots or Recordings

<!-- UI feature — screenshots/recording to be added. The pane opens from the new History button in the Activity Rail (enabled when a project with a path is active). -->

## Checklist

- [x] My PR title follows the conventional commit format used by this repo
- [x] I linked the related issue or explained why none exists
- [x] I updated docs when needed
- [x] I added or updated tests when needed
- [x] I verified the change does not introduce unrelated modifications

---

### Adversarial review

Ran an edge-case-hunter review pass; fixed 5 surfaced findings (comma-in-ref splitting, NUL-truncated subject, lane-count inflation from out-of-window parents, history wiped on transient refresh error, full-hash search) plus a self-caught filter/graph misalignment and an O(n²)→O(1) edge lookup. Verified no command injection (argument vector + `current_dir`, no shell; `limit` is a clamped `u32`). The general adversarial agent repeatedly crashed on an environmental startup error, so its angles (security, React keys/deps, persistence-restore) were verified manually.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * View Git commit history with a visual lane graph, search/filter by subject/author/hash/ref, and compact relative times.
  * Open Git History from the activity rail or workspace tabs (including drag‑drop, context menu, and close shortcut).
  * Persistent Git History tabs that restore across sessions, handle empty/non-repo projects, and show clear loading/empty/error states.

* **Tests**
  * Added unit and integration tests for graph layout, time formatting, ref parsing, and commit parsing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gnoviawan/termul/pull/202?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->