### PR TITLE
fix(sidebar): only expand worktrees via chevron

### DIFF
--- a/src/renderer/components/ProjectSidebar.test.tsx
+++ b/src/renderer/components/ProjectSidebar.test.tsx
@@ -95,6 +95,12 @@ const renderWithRouter = (props = {}) => {
   )
 }
 
+// Worktrees are collapsed by default and only expand via the chevron, so tests
+// that assert on worktree rows must open the section first.
+const expandWorktrees = () => {
+  fireEvent.click(screen.getByLabelText('Expand worktrees'))
+}
+
 describe('ProjectSidebar Context Menu', () => {
   it('should open context menu on right-click', () => {
     renderWithRouter()
@@ -554,6 +560,7 @@ describe('ProjectSidebar Worktree Row', () => {
 
   it('shows the worktree name but not the branch chip on the row face', () => {
     renderWithRouter({ projects: projectWithWorktree, activeProjectId: '1' })
+    expandWorktrees()
 
     // Name is shown
     expect(screen.getByText('try-new-hero')).toBeInTheDocument()
@@ -563,6 +570,7 @@ describe('ProjectSidebar Worktree Row', () => {
 
   it('keeps the branch available via the row tooltip', () => {
     renderWithRouter({ projects: projectWithWorktree, activeProjectId: '1' })
+    expandWorktrees()
 
     const row = screen.getByLabelText('Worktree try-new-hero on feature/try-new-hero')
     expect(row).toHaveAttribute('title', expect.stringContaining('feature/try-new-hero'))
@@ -570,6 +578,7 @@ describe('ProjectSidebar Worktree Row', () => {
 
   it('exposes an accessible "Open terminal" button on the worktree row', () => {
     renderWithRouter({ projects: projectWithWorktree, activeProjectId: '1' })
+    expandWorktrees()
 
     expect(
       screen.getByLabelText('Open terminal in try-new-hero')
@@ -579,6 +588,7 @@ describe('ProjectSidebar Worktree Row', () => {
   it('opens a terminal in the worktree when the terminal button is clicked, without triggering row select', async () => {
     const onSelectProject = vi.fn()
     renderWithRouter({ projects: projectWithWorktree, activeProjectId: '1', onSelectProject })
+    expandWorktrees()
 
     fireEvent.click(screen.getByLabelText('Open terminal in try-new-hero'))
 
@@ -591,6 +601,7 @@ describe('ProjectSidebar Worktree Row', () => {
 
   it('does not trigger row select when activating the terminal button via keyboard', () => {
     renderWithRouter({ projects: projectWithWorktree, activeProjectId: '1' })
+    expandWorktrees()
 
     const termButton = screen.getByLabelText('Open terminal in try-new-hero')
     // Enter on the nested terminal button must not bubble to the row's onKeyDown select
@@ -782,11 +793,13 @@ describe('ProjectSidebar Worktree Search', () => {
 
   it('shows a worktree search box with an icon once there are 10+ worktrees', () => {
     renderWithRouter({ projects: projectWithManyWorktrees, activeProjectId: '1' })
+    expandWorktrees()
     expect(screen.getByLabelText('Search worktrees')).toBeInTheDocument()
   })
 
   it('shows a clear button only after typing, and clears on click', () => {
     renderWithRouter({ projects: projectWithManyWorktrees, activeProjectId: '1' })
+    expandWorktrees()
 
     const input = screen.getByLabelText('Search worktrees') as HTMLInputElement
     expect(screen.queryByLabelText('Clear worktree search')).not.toBeInTheDocument()
@@ -800,6 +813,7 @@ describe('ProjectSidebar Worktree Search', () => {
 
   it('clears the worktree query on Escape', () => {
     renderWithRouter({ projects: projectWithManyWorktrees, activeProjectId: '1' })
+    expandWorktrees()
 
     const input = screen.getByLabelText('Search worktrees') as HTMLInputElement
     fireEvent.change(input, { target: { value: 'worktree-3' } })

--- a/src/renderer/components/ProjectSidebar.tsx
+++ b/src/renderer/components/ProjectSidebar.tsx
@@ -151,21 +151,11 @@ export function ProjectSidebar({
 	const [searchQuery, setSearchQuery] = useState("");
 	const searchInputRef = useRef<HTMLInputElement>(null);
 
-	// Expanded worktree projects — active project auto-expands
-	const [expandedProjects, setExpandedProjects] = useState<Set<string>>(() => {
-		const set = new Set<string>();
-		if (activeProjectId) set.add(activeProjectId);
-		return set;
-	});
-
-	// Auto-expand/contract active project
-	useEffect(() => {
-		setExpandedProjects((prev) => {
-			const next = new Set(prev);
-			next.add(activeProjectId);
-			return next;
-		});
-	}, [activeProjectId]);
+	// Expanded worktree projects — expansion is controlled solely by the chevron.
+	// Selecting a project no longer auto-expands its worktrees, keeping the list uncluttered.
+	const [expandedProjects, setExpandedProjects] = useState<Set<string>>(
+		() => new Set<string>(),
+	);
 
 	// Context menu state
 	const [contextMenu, setContextMenu] = useState<ContextMenuState>({

--- a/src/renderer/components/ProjectSidebar.tsx
+++ b/src/renderer/components/ProjectSidebar.tsx
@@ -1,5 +1,5 @@
 import { useState, useCallback, useRef, useEffect, memo, KeyboardEvent, useMemo } from "react";
-import { Reorder, AnimatePresence, motion } from "framer-motion";
+import { Reorder, AnimatePresence, motion, LayoutGroup } from "framer-motion";
 import {
 	Plus,
 	Archive,
@@ -851,6 +851,11 @@ export function ProjectSidebar({
 					</div>
 				) : (
 					<>
+						{/* LayoutGroup keeps Reorder layout measurements in sync when an item's
+						    own height changes (e.g. expanding/collapsing worktrees via the
+						    chevron). Without it, the group caches stale item boxes after a
+						    height change and drag-to-reorder stops working. */}
+						<LayoutGroup>
 						<Reorder.Group
 							axis="y"
 							values={filteredActiveProjects}
@@ -873,6 +878,10 @@ export function ProjectSidebar({
 										key={project.id}
 										value={project}
 										drag={isSearching ? false : undefined}
+										// layout="position" lets framer-motion remeasure the item when
+										// its height changes (worktree expand/collapse) so the group's
+										// order calculations stay accurate and drag keeps working.
+										layout="position"
 										className="list-none"
 										whileDrag={{
 											scale: 1.02,
@@ -913,6 +922,7 @@ export function ProjectSidebar({
 								);
 							})}
 						</Reorder.Group>
+						</LayoutGroup>
 
 						{/* Archived Projects Section */}
 						{filteredArchivedProjects.length > 0 && (


### PR DESCRIPTION
## Summary
Selecting a project in the sidebar no longer auto-expands its worktree list. Expansion/collapse is now controlled solely by the chevron toggle, keeping the projects list uncluttered.

## Problem
Clicking a project row called `onSelectProject`, which updated `activeProjectId`. An auto-expand `useEffect` re-ran on every `activeProjectId` change and forced the clicked project's worktrees open, cluttering the list.

## Change
- Removed the auto-expand `useEffect` that added the active project to `expandedProjects`.
- Removed the initial seeding of the active project into `expandedProjects` on mount.
- Worktrees now start collapsed; the chevron is the only control for expand/collapse. Clicking a project row still selects it and navigates.

## Testing
- `bun run typecheck:web` passes
- `eslint src/renderer/components/ProjectSidebar.tsx` passes
- pre-commit hooks (typecheck + lint-staged) passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Worktrees no longer automatically expand when a project becomes active; users must manually toggle expansion to view worktree details.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gnoviawan/termul/pull/203?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->