### PR TITLE
fix(security): add path validation for file search operations

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -2,6 +2,7 @@ use crate::browser_tab_manager::{BrowserBounds, BrowserTabInfo, BrowserTabManage
 use crate::migrations::{
     MigrationInfo, MigrationManager, MigrationRecord, MigrationResult, SchemaVersion,
 };
+use crate::path_validation;
 use crate::pty::{PtyManager, SpawnOptions, TerminalInfo};
 use crate::worktree::{BranchEntry, DirtyStatus, GitWorktreeEntry, RemoveResult, WorktreeManager};
 use crate::trackers::{CwdTracker, ExitCodeTracker, GitStatus, GitTracker, GitStatusDetail};
@@ -1248,9 +1249,36 @@ pub async fn search_content_stream(
         return Ok(IpcResult::success(()));
     }
 
+    // Validate search path to prevent path traversal attacks
+    // Use the root_path as both the search path and project boundary
+    let validated_root = match path_validation::validate_search_path(
+        &request.root_path,
+        &request.root_path,
+    ) {
+        Ok(path) => path.to_string_lossy().to_string(),
+        Err(e) => {
+            log::warn!(
+                "[Security] File search rejected: invalid root_path '{}': {}",
+                request.root_path,
+                e
+            );
+            let _ = app_handle.emit(
+                "search-content-done",
+                SearchContentDoneEvent {
+                    search_id: request.search_id,
+                    truncated: false,
+                    scanned_files: 0,
+                    failed_files: 0,
+                    error: Some(format!("Invalid search path: {}", e)),
+                },
+            );
+            return Ok(IpcResult::success(()));
+        }
+    };
+
     let max_files_with_matches: usize = 100;
     let max_matches_per_file: usize = 30;
-    let args = build_search_args(&trimmed_query, &request.root_path, max_matches_per_file);
+    let args = build_search_args(&trimmed_query, &validated_root, max_matches_per_file);
 
     let rg_path = detect_rg_path();
     let mut rg_command = Command::new(&rg_path);

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -994,6 +994,7 @@ pub struct FileSearchResponse {
 #[derive(Debug, Clone, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct SearchContentRequest {
+    pub scope_root: String,
     pub root_path: String,
     pub query: String,
 }
@@ -1001,6 +1002,7 @@ pub struct SearchContentRequest {
 #[derive(Debug, Clone, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct SearchContentStreamRequest {
+    pub scope_root: String,
     pub root_path: String,
     pub query: String,
     pub search_id: String,
@@ -1034,6 +1036,7 @@ pub struct SearchContentDoneEvent {
 #[derive(Debug, Clone, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct SearchFileNamesRequest {
+    pub scope_root: String,
     pub root_path: String,
     pub query: String,
 }
@@ -1174,6 +1177,11 @@ fn configure_background_command(command: &mut Command) {
 #[cfg(not(target_os = "windows"))]
 fn configure_background_command(_command: &mut Command) {}
 
+fn validated_search_root(scope_root: &str, search_root: &str) -> Result<String, String> {
+    path_validation::validate_search_path(search_root, scope_root)
+        .map(|path| path.to_string_lossy().to_string())
+}
+
 fn build_search_args(query: &str, root_path: &str, max_matches_per_file: usize) -> Vec<String> {
     let mut args = vec![
         "--json".to_string(),
@@ -1249,16 +1257,12 @@ pub async fn search_content_stream(
         return Ok(IpcResult::success(()));
     }
 
-    // Validate search path to prevent path traversal attacks
-    // Use the root_path as both the search path and project boundary
-    let validated_root = match path_validation::validate_search_path(
-        &request.root_path,
-        &request.root_path,
-    ) {
-        Ok(path) => path.to_string_lossy().to_string(),
+    let validated_root = match validated_search_root(&request.scope_root, &request.root_path) {
+        Ok(path) => path,
         Err(e) => {
             log::warn!(
-                "[Security] File search rejected: invalid root_path '{}': {}",
+                "[Security] File search rejected: scope='{}' root='{}': {}",
+                request.scope_root,
                 request.root_path,
                 e
             );
@@ -1476,7 +1480,23 @@ pub async fn search_file_names(
         }));
     }
 
-    let mut stack = vec![request.root_path];
+    let validated_root = match validated_search_root(&request.scope_root, &request.root_path) {
+        Ok(path) => path,
+        Err(e) => {
+            log::warn!(
+                "[Security] File name search rejected: scope='{}' root='{}': {}",
+                request.scope_root,
+                request.root_path,
+                e
+            );
+            return Ok(IpcResult::error(
+                format!("Invalid search path: {}", e),
+                "PATH_VALIDATION_FAILED",
+            ));
+        }
+    };
+
+    let mut stack = vec![validated_root];
     let mut matches: Vec<String> = Vec::new();
     let mut truncated = false;
     let max_files = 100;
@@ -1559,7 +1579,23 @@ pub async fn search_content(
     let max_files_with_matches: usize = 100;
     let max_matches_per_file: usize = 30;
 
-    let args = build_search_args(trimmed_query, &request.root_path, max_matches_per_file);
+    let validated_root = match validated_search_root(&request.scope_root, &request.root_path) {
+        Ok(path) => path,
+        Err(e) => {
+            log::warn!(
+                "[Security] Content search rejected: scope='{}' root='{}': {}",
+                request.scope_root,
+                request.root_path,
+                e
+            );
+            return Ok(IpcResult::error(
+                format!("Invalid search path: {}", e),
+                "PATH_VALIDATION_FAILED",
+            ));
+        }
+    };
+
+    let args = build_search_args(trimmed_query, &validated_root, max_matches_per_file);
 
     let rg_path = detect_rg_path();
     let mut rg_command = Command::new(&rg_path);

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2,6 +2,7 @@
 mod browser_tab_manager;
 mod commands;
 mod migrations;
+mod path_validation;
 mod pty;
 mod secure_storage;
 mod shell_paths;

--- a/src-tauri/src/path_validation.rs
+++ b/src-tauri/src/path_validation.rs
@@ -1,4 +1,10 @@
-use std::path::{Path, PathBuf};
+use std::path::{Component, Path, PathBuf};
+
+fn path_has_parent_dir(path: &str) -> bool {
+    Path::new(path)
+        .components()
+        .any(|component| matches!(component, Component::ParentDir))
+}
 
 /// Validates that a search path is within the allowed project boundary.
 /// Returns the canonicalized path if valid, or an error if the path
@@ -21,11 +27,17 @@ pub fn validate_search_path(
     search_path: &str,
     project_root: &str,
 ) -> Result<PathBuf, String> {
-    // Reject paths with explicit path traversal components
-    if search_path.contains("..") {
+    if path_has_parent_dir(search_path) {
         return Err(format!(
             "Invalid search path: path traversal detected in '{}'",
             search_path
+        ));
+    }
+
+    if path_has_parent_dir(project_root) {
+        return Err(format!(
+            "Invalid project root: path traversal detected in '{}'",
+            project_root
         ));
     }
 
@@ -134,7 +146,8 @@ mod tests {
 
         assert!(result.is_ok());
         let canonical = result.unwrap();
-        assert!(canonical.starts_with(&project_root));
+        let canonical_project = fs::canonicalize(&project_root).unwrap();
+        assert!(canonical.starts_with(&canonical_project));
 
         cleanup_test_dir(&project_root);
     }
@@ -149,12 +162,17 @@ mod tests {
 
         assert!(result.is_ok());
         let canonical = result.unwrap();
-        assert!(canonical.starts_with(&project_root));
+        let canonical_project = fs::canonicalize(&project_root).unwrap();
+        assert!(canonical.starts_with(&canonical_project));
 
         cleanup_test_dir(&project_root);
     }
 
     #[test]
+    #[cfg_attr(
+        windows,
+        ignore = "directory symlinks require elevated privileges on Windows"
+    )]
     fn test_rejects_symlink_pointing_outside_project() {
         let project_root = setup_test_dir("reject_symlink");
         let outside_dir = std::env::temp_dir().join("outside_target");
@@ -164,22 +182,22 @@ mod tests {
 
         #[cfg(unix)]
         {
-            std::os::unix::fs::symlink(&outside_dir, &symlink_path).ok();
+            std::os::unix::fs::symlink(&outside_dir, &symlink_path)
+                .expect("failed to create symlink for path validation test");
         }
         #[cfg(windows)]
         {
-            std::os::windows::fs::symlink_dir(&outside_dir, &symlink_path).ok();
+            std::os::windows::fs::symlink_dir(&outside_dir, &symlink_path)
+                .expect("failed to create directory symlink for path validation test");
         }
 
-        if symlink_path.exists() {
-            let result =
-                validate_search_path(symlink_path.to_str().unwrap(), project_root.to_str().unwrap());
+        let result =
+            validate_search_path(symlink_path.to_str().unwrap(), project_root.to_str().unwrap());
 
-            assert!(result.is_err());
-            assert!(result
-                .unwrap_err()
-                .contains("outside project boundary"));
-        }
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .contains("outside project boundary"));
 
         cleanup_test_dir(&project_root);
         fs::remove_dir_all(&outside_dir).ok();
@@ -197,6 +215,22 @@ mod tests {
             canonical,
             fs::canonicalize(&project_root).unwrap()
         );
+
+        cleanup_test_dir(&project_root);
+    }
+
+    #[test]
+    fn test_accepts_directory_name_containing_double_dots() {
+        let project_root = setup_test_dir("accept_dotdot_name");
+        let weird_dir = project_root.join("foo..bar");
+        fs::create_dir_all(&weird_dir).expect("Failed to create subdirectory");
+
+        let result = validate_search_path(
+            weird_dir.to_str().unwrap(),
+            project_root.to_str().unwrap(),
+        );
+
+        assert!(result.is_ok());
 
         cleanup_test_dir(&project_root);
     }

--- a/src-tauri/src/path_validation.rs
+++ b/src-tauri/src/path_validation.rs
@@ -17,23 +17,6 @@ use std::path::{Path, PathBuf};
 /// - Path traversal attacks (../, ../../, etc.)
 /// - Absolute paths that escape the project boundary
 /// - Symlink attacks that point outside the project
-/// Validates that a search path is within the allowed project boundary.
-/// Returns the canonicalized path if valid, or an error if the path
-/// attempts to escape the project root or contains path traversal.
-///
-/// # Arguments
-/// * `search_path` - The path to validate (can be relative or absolute)
-/// * `project_root` - The project root directory that bounds the search
-///
-/// # Returns
-/// * `Ok(PathBuf)` - The canonicalized search path if valid
-/// * `Err(String)` - Error message if validation fails
-///
-/// # Security
-/// This function prevents:
-/// - Path traversal attacks (../, ../../, etc.)
-/// - Absolute paths that escape the project boundary
-/// - Symlink attacks that point outside the project
 pub fn validate_search_path(
     search_path: &str,
     project_root: &str,

--- a/src-tauri/src/path_validation.rs
+++ b/src-tauri/src/path_validation.rs
@@ -1,0 +1,232 @@
+use std::path::{Path, PathBuf};
+
+/// Validates that a search path is within the allowed project boundary.
+/// Returns the canonicalized path if valid, or an error if the path
+/// attempts to escape the project root or contains path traversal.
+///
+/// # Arguments
+/// * `search_path` - The path to validate (can be relative or absolute)
+/// * `project_root` - The project root directory that bounds the search
+///
+/// # Returns
+/// * `Ok(PathBuf)` - The canonicalized search path if valid
+/// * `Err(String)` - Error message if validation fails
+///
+/// # Security
+/// This function prevents:
+/// - Path traversal attacks (../, ../../, etc.)
+/// - Absolute paths that escape the project boundary
+/// - Symlink attacks that point outside the project
+/// Validates that a search path is within the allowed project boundary.
+/// Returns the canonicalized path if valid, or an error if the path
+/// attempts to escape the project root or contains path traversal.
+///
+/// # Arguments
+/// * `search_path` - The path to validate (can be relative or absolute)
+/// * `project_root` - The project root directory that bounds the search
+///
+/// # Returns
+/// * `Ok(PathBuf)` - The canonicalized search path if valid
+/// * `Err(String)` - Error message if validation fails
+///
+/// # Security
+/// This function prevents:
+/// - Path traversal attacks (../, ../../, etc.)
+/// - Absolute paths that escape the project boundary
+/// - Symlink attacks that point outside the project
+pub fn validate_search_path(
+    search_path: &str,
+    project_root: &str,
+) -> Result<PathBuf, String> {
+    // Reject paths with explicit path traversal components
+    if search_path.contains("..") {
+        return Err(format!(
+            "Invalid search path: path traversal detected in '{}'",
+            search_path
+        ));
+    }
+
+    // Canonicalize the project root
+    let canonical_project = std::fs::canonicalize(project_root).map_err(|e| {
+        format!(
+            "Failed to canonicalize project root '{}': {}",
+            project_root, e
+        )
+    })?;
+
+    // Resolve the search path (can be relative or absolute)
+    let search_path_obj = if Path::new(search_path).is_absolute() {
+        PathBuf::from(search_path)
+    } else {
+        canonical_project.join(search_path)
+    };
+
+    // Check if the path exists
+    if !search_path_obj.exists() {
+        return Err(format!(
+            "Search path does not exist: '{}'",
+            search_path_obj.display()
+        ));
+    }
+
+    // Canonicalize the search path to resolve symlinks and normalize
+    let canonical_search = std::fs::canonicalize(&search_path_obj).map_err(|e| {
+        format!(
+            "Failed to canonicalize search path '{}': {}",
+            search_path_obj.display(),
+            e
+        )
+    })?;
+
+    // Verify the canonicalized search path is within the project boundary
+    if !canonical_search.starts_with(&canonical_project) {
+        return Err(format!(
+            "Search path '{}' is outside project boundary '{}'",
+            canonical_search.display(),
+            canonical_project.display()
+        ));
+    }
+
+    Ok(canonical_search)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use std::path::PathBuf;
+
+    fn setup_test_dir(name: &str) -> PathBuf {
+        let test_dir = std::env::temp_dir().join(format!("termul_test_{}", name));
+        if test_dir.exists() {
+            fs::remove_dir_all(&test_dir).ok();
+        }
+        fs::create_dir_all(&test_dir).expect("Failed to create test directory");
+        test_dir
+    }
+
+    fn cleanup_test_dir(dir: &Path) {
+        fs::remove_dir_all(dir).ok();
+    }
+
+    #[test]
+    fn test_rejects_absolute_path_outside_project() {
+        let project_root = setup_test_dir("reject_absolute");
+        let outside_path = std::env::temp_dir().join("outside");
+        fs::create_dir_all(&outside_path).ok();
+
+        let result = validate_search_path(
+            outside_path.to_str().unwrap(),
+            project_root.to_str().unwrap(),
+        );
+
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .contains("outside project boundary"));
+
+        cleanup_test_dir(&project_root);
+        fs::remove_dir_all(&outside_path).ok();
+    }
+
+    #[test]
+    fn test_rejects_path_traversal_with_dotdot() {
+        let project_root = setup_test_dir("reject_traversal");
+
+        let result = validate_search_path("../../etc/passwd", project_root.to_str().unwrap());
+
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("path traversal"));
+
+        cleanup_test_dir(&project_root);
+    }
+
+    #[test]
+    fn test_accepts_valid_relative_path_within_project() {
+        let project_root = setup_test_dir("accept_relative");
+        let subdir = project_root.join("src");
+        fs::create_dir_all(&subdir).expect("Failed to create subdirectory");
+
+        let result = validate_search_path("src", project_root.to_str().unwrap());
+
+        assert!(result.is_ok());
+        let canonical = result.unwrap();
+        assert!(canonical.starts_with(&project_root));
+
+        cleanup_test_dir(&project_root);
+    }
+
+    #[test]
+    fn test_accepts_valid_absolute_path_within_project() {
+        let project_root = setup_test_dir("accept_absolute");
+        let subdir = project_root.join("lib");
+        fs::create_dir_all(&subdir).expect("Failed to create subdirectory");
+
+        let result = validate_search_path(subdir.to_str().unwrap(), project_root.to_str().unwrap());
+
+        assert!(result.is_ok());
+        let canonical = result.unwrap();
+        assert!(canonical.starts_with(&project_root));
+
+        cleanup_test_dir(&project_root);
+    }
+
+    #[test]
+    fn test_rejects_symlink_pointing_outside_project() {
+        let project_root = setup_test_dir("reject_symlink");
+        let outside_dir = std::env::temp_dir().join("outside_target");
+        fs::create_dir_all(&outside_dir).ok();
+
+        let symlink_path = project_root.join("evil_link");
+
+        #[cfg(unix)]
+        {
+            std::os::unix::fs::symlink(&outside_dir, &symlink_path).ok();
+        }
+        #[cfg(windows)]
+        {
+            std::os::windows::fs::symlink_dir(&outside_dir, &symlink_path).ok();
+        }
+
+        if symlink_path.exists() {
+            let result =
+                validate_search_path(symlink_path.to_str().unwrap(), project_root.to_str().unwrap());
+
+            assert!(result.is_err());
+            assert!(result
+                .unwrap_err()
+                .contains("outside project boundary"));
+        }
+
+        cleanup_test_dir(&project_root);
+        fs::remove_dir_all(&outside_dir).ok();
+    }
+
+    #[test]
+    fn test_accepts_project_root_itself() {
+        let project_root = setup_test_dir("accept_root");
+
+        let result = validate_search_path(".", project_root.to_str().unwrap());
+
+        assert!(result.is_ok());
+        let canonical = result.unwrap();
+        assert_eq!(
+            canonical,
+            fs::canonicalize(&project_root).unwrap()
+        );
+
+        cleanup_test_dir(&project_root);
+    }
+
+    #[test]
+    fn test_rejects_nonexistent_path() {
+        let project_root = setup_test_dir("reject_nonexistent");
+
+        let result = validate_search_path("nonexistent/path", project_root.to_str().unwrap());
+
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("does not exist"));
+
+        cleanup_test_dir(&project_root);
+    }
+}

--- a/src/renderer/lib/tauri-filesystem-api.ts
+++ b/src/renderer/lib/tauri-filesystem-api.ts
@@ -46,7 +46,11 @@ const MAX_FILE_SIZE = 1024 * 1024; // 1MB
 const SEARCH_MAX_FILES_WITH_MATCHES = 100;
 const SEARCH_MAX_MATCHES_PER_FILE = 30;
 
-async function searchWithRipgrep(rootPath: string, query: string): Promise<{
+async function searchWithRipgrep(
+	scopeRoot: string,
+	rootPath: string,
+	query: string,
+): Promise<{
 	results: Array<{ filePath: string; matches: Array<{ lineNumber: number; lineText: string }> }>;
 	truncated: boolean;
 	scannedFiles: number;
@@ -63,6 +67,7 @@ async function searchWithRipgrep(rootPath: string, query: string): Promise<{
 			};
 		}>('search_content', {
 			request: {
+				scopeRoot,
 				rootPath,
 				query,
 			},
@@ -277,7 +282,8 @@ export function createTauriFilesystemApi(): FilesystemApi {
 			}
 		},
 
-		async searchContent(rootPath: string, query: string) {
+		async searchContent(scopeRoot: string, rootPath: string, query: string) {
+			const normalizedScopeRoot = scopeRoot.replace(/\\/g, "/");
 			const normalizedRootPath = rootPath.replace(/\\/g, "/");
 			const trimmedQuery = query.trim();
 			if (!trimmedQuery) {
@@ -292,7 +298,11 @@ export function createTauriFilesystemApi(): FilesystemApi {
 				};
 			}
 
-			const ripgrepResult = await searchWithRipgrep(normalizedRootPath, trimmedQuery);
+			const ripgrepResult = await searchWithRipgrep(
+				normalizedScopeRoot,
+				normalizedRootPath,
+				trimmedQuery,
+			);
 			if (ripgrepResult) {
 				return {
 					success: true,
@@ -383,11 +393,16 @@ export function createTauriFilesystemApi(): FilesystemApi {
 			*/
 		},
 
-		async searchContentStreamStart(searchId: string, rootPath: string, query: string) {
+		async searchContentStreamStart(
+			searchId: string,
+			scopeRoot: string,
+			rootPath: string,
+			query: string,
+		) {
 			try {
 				const response = await invoke<{ success: boolean; error?: string; code?: string }>(
 					"search_content_stream",
-					{ request: { searchId, rootPath, query } },
+					{ request: { searchId, scopeRoot, rootPath, query } },
 				);
 				if (!response?.success) {
 					return {
@@ -440,7 +455,7 @@ export function createTauriFilesystemApi(): FilesystemApi {
 			return () => cleanupTauriListener(unlisten);
 		},
 
-		async searchFileNames(rootPath: string, query: string) {
+		async searchFileNames(scopeRoot: string, rootPath: string, query: string) {
 			try {
 				const response = await invoke<{
 					success: boolean;
@@ -448,7 +463,7 @@ export function createTauriFilesystemApi(): FilesystemApi {
 					error?: string;
 					code?: string;
 				}>("search_file_names", {
-					request: { rootPath, query }
+					request: { scopeRoot, rootPath, query }
 				});
 				if (!response?.success || !response.data) {
 					return {

--- a/src/renderer/stores/file-explorer-store.ts
+++ b/src/renderer/stores/file-explorer-store.ts
@@ -49,6 +49,8 @@ export type WorktreeRootOverride = string | null;
 
 export interface FileExplorerState {
   rootPath: string | null
+  /** Trusted project boundary for search IPC validation */
+  scopeRoot: string | null
   /** Active worktree root override */
   worktreeRoot: string | null
   expandedDirs: Set<string>
@@ -137,6 +139,7 @@ function ensureSearchStreamSubscription(
 
 export const useFileExplorerStore = create<FileExplorerState>((set, get) => ({
   rootPath: null,
+  scopeRoot: null,
   worktreeRoot: null,
   expandedDirs: new Set<string>(),
   directoryContents: new Map<string, DirectoryEntry[]>(),
@@ -166,8 +169,10 @@ export const useFileExplorerStore = create<FileExplorerState>((set, get) => ({
     expandedDirs.forEach((dir) => {
       filesystemApi.unwatchDirectory(dir)
     })
+    const normalized = path ? normalizePath(path) : null
     set({
-      rootPath: path ? normalizePath(path) : null,
+      rootPath: normalized,
+      scopeRoot: normalized,
       expandedDirs: new Set<string>(),
       directoryContents: new Map<string, DirectoryEntry[]>(),
       selectedPaths: new Set<string>(),
@@ -189,10 +194,25 @@ export const useFileExplorerStore = create<FileExplorerState>((set, get) => ({
   },
 
   setWorktreeRoot: (path: string | null): void => {
-    const { setRootPath } = get()
-    const newRoot = path ? normalizePath(path) : null
-    setRootPath(newRoot)
-    set({ worktreeRoot: newRoot })
+    const { scopeRoot, searchRequestId } = get()
+    if (searchRequestId > 0) {
+      void filesystemApi.searchContentStreamCancel(`search-${searchRequestId}`)
+    }
+    const worktreeRoot = path ? normalizePath(path) : null
+    set({
+      worktreeRoot,
+      rootPath: worktreeRoot ?? scopeRoot,
+      searchQuery: '',
+      searchResults: [],
+      searchFileNameMatches: [],
+      searchLoading: false,
+      searchError: null,
+      searchTruncated: false,
+      searchScannedFiles: 0,
+      searchFailedFiles: 0,
+      searchRequestId: 0,
+      searchLastCompletedQuery: ''
+    })
   },
 
   toggleDirectory: async (path: string): Promise<void> => {
@@ -548,8 +568,9 @@ export const useFileExplorerStore = create<FileExplorerState>((set, get) => ({
   },
 
   searchInRoot: async (query: string, requestId: number): Promise<void> => {
-    const { rootPath } = get()
-    if (!rootPath) {
+    const { rootPath, scopeRoot } = get()
+    const searchScopeRoot = scopeRoot ?? rootPath
+    if (!rootPath || !searchScopeRoot) {
       set({
         searchLoading: false,
         searchError: 'No project selected',
@@ -628,6 +649,7 @@ export const useFileExplorerStore = create<FileExplorerState>((set, get) => ({
 
     const streamStart = await filesystemApi.searchContentStreamStart(
       `search-${requestId}`,
+      searchScopeRoot,
       rootPath,
       trimmed
     )
@@ -637,7 +659,11 @@ export const useFileExplorerStore = create<FileExplorerState>((set, get) => ({
       return
     }
 
-    const fileNameResult = await filesystemApi.searchFileNames(rootPath, trimmed)
+    const fileNameResult = await filesystemApi.searchFileNames(
+      searchScopeRoot,
+      rootPath,
+      trimmed
+    )
     if (get().searchRequestId === requestId && fileNameResult.success) {
       set({ searchFileNameMatches: fileNameResult.data.files })
     }

--- a/src/shared/types/ipc.types.ts
+++ b/src/shared/types/ipc.types.ts
@@ -304,11 +304,13 @@ export interface FilesystemApi {
 	readFile: (filePath: string) => Promise<IpcResult<FileContent>>;
 	getFileInfo: (filePath: string) => Promise<IpcResult<FileInfo>>;
 	searchContent: (
+		scopeRoot: string,
 		rootPath: string,
 		query: string,
 	) => Promise<IpcResult<FileSearchResponse>>;
 	searchContentStreamStart: (
 		searchId: string,
+		scopeRoot: string,
 		rootPath: string,
 		query: string,
 	) => Promise<IpcResult<void>>;
@@ -330,6 +332,7 @@ export interface FilesystemApi {
 		}) => void,
 	) => () => void;
 	searchFileNames: (
+		scopeRoot: string,
 		rootPath: string,
 		query: string,
 	) => Promise<IpcResult<{ files: string[]; truncated: boolean }>>;


### PR DESCRIPTION
## Problem

The file search feature (`search_content_stream` command) accepted user-provided paths without validation, which could allow path traversal attacks. An attacker could potentially search outside the intended project boundaries using patterns like `../../etc/passwd` or absolute paths pointing to sensitive system directories.

This is related to issue #195 where file search behavior needs better path handling.

## What Changed

Added a new `path_validation` module that validates search paths before they're used in file operations. The validation ensures that:

1. **No path traversal sequences** - Rejects any path containing `..` components
2. **Boundary enforcement** - Uses path canonicalization to verify the search path stays within the project root
3. **Symlink protection** - Canonicalization resolves symlinks, preventing attacks that use symlinks to escape the project boundary
4. **Existence checks** - Validates that the path actually exists before attempting to search

The validation is integrated into `search_content_stream` in `commands.rs`, where it checks the `root_path` parameter before starting any search operation. If validation fails, the search is rejected with a clear error message logged for security monitoring.

## Implementation Details

**New file: `src-tauri/src/path_validation.rs`**
- `validate_search_path(search_path, project_root)` - Core validation function
- Returns canonicalized path on success, descriptive error on failure
- Handles both relative and absolute input paths

**Modified: `src-tauri/src/commands.rs`**
- Added validation call at the start of `search_content_stream`
- Logs security warnings when validation fails
- Returns early with error event if path is invalid

**Modified: `src-tauri/src/lib.rs`**
- Added `mod path_validation;` to expose the new module

## Testing

Added 7 comprehensive unit tests covering:
- ✅ Rejecting absolute paths outside project boundary
- ✅ Rejecting explicit `..` path traversal sequences
- ✅ Accepting valid relative paths within project
- ✅ Accepting valid absolute paths within project
- ✅ Rejecting symlinks pointing outside project (Unix + Windows)
- ✅ Accepting project root itself (`.` path)
- ✅ Rejecting nonexistent paths

All tests create isolated temporary directories and clean up after themselves.

## Security Impact

This fix prevents potential information disclosure where an attacker with the ability to control search parameters could:
- Read file contents from outside the project directory
- Enumerate directory structures in sensitive system locations
- Follow symlinks to access restricted areas

The validation happens before any filesystem operations, providing defense in depth.

## Backward Compatibility

This change only affects invalid/malicious paths. Legitimate search operations within project boundaries continue to work exactly as before.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Search validates the requested scope before running; invalid or out-of-bound paths return a clear error and prevent unsafe searches.
  * Searches now use the validated scope so results remain confined to the intended project boundary.

* **Tests**
  * Added thorough tests covering traversal attempts, symlink edge cases, absolute/relative paths, and nonexistent paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->