### PR TITLE
fix(window): restore window geometry in logical pixels to prevent off-screen windows

### DIFF
--- a/src/renderer/hooks/use-window-state.test.ts
+++ b/src/renderer/hooks/use-window-state.test.ts
@@ -1,0 +1,244 @@
+import { act, renderHook, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { Monitor } from '@tauri-apps/api/window'
+import type { WindowState } from '@shared/types/persistence.types'
+import {
+  clampStateToMonitors,
+  getLogicalWorkArea,
+  isPositionOnScreen,
+  useWindowState
+} from './use-window-state'
+
+const { windowMock, persistenceMock, runtimeMock, monitorsMock, primaryMock, LogicalPositionStub, LogicalSizeStub } =
+  vi.hoisted(() => {
+    class LogicalPositionStub {
+      readonly type = 'Logical'
+      constructor(
+        public x: number,
+        public y: number
+      ) {}
+    }
+
+    class LogicalSizeStub {
+      readonly type = 'Logical'
+      constructor(
+        public width: number,
+        public height: number
+      ) {}
+    }
+
+    return {
+      windowMock: {
+        isMaximized: vi.fn(async () => false),
+        scaleFactor: vi.fn(async () => 1),
+        outerPosition: vi.fn(async () => ({ x: 0, y: 0 })),
+        outerSize: vi.fn(async () => ({ width: 1200, height: 800 })),
+        setPosition: vi.fn(async (_position: unknown) => {}),
+        setSize: vi.fn(async (_size: unknown) => {}),
+        maximize: vi.fn(async () => {}),
+        onMoved: vi.fn(async () => vi.fn()),
+        onResized: vi.fn(async () => vi.fn()),
+        onCloseRequested: vi.fn(async () => vi.fn())
+      },
+      persistenceMock: {
+        read: vi.fn(
+          async (): Promise<{ success: boolean; data: WindowState | null }> => ({
+            success: false,
+            data: null
+          })
+        ),
+        write: vi.fn(async (_key: string, _value: unknown) => ({ success: true })),
+        writeDebounced: vi.fn(async (_key: string, _value: unknown) => ({ success: true }))
+      },
+      runtimeMock: { isTauri: true },
+      monitorsMock: vi.fn(async (): Promise<Monitor[]> => []),
+      primaryMock: vi.fn(async (): Promise<Monitor | null> => null),
+      LogicalPositionStub,
+      LogicalSizeStub
+    }
+  })
+
+vi.mock('@tauri-apps/api/window', () => ({
+  getCurrentWindow: () => windowMock,
+  availableMonitors: () => monitorsMock(),
+  primaryMonitor: () => primaryMock(),
+  LogicalPosition: LogicalPositionStub,
+  LogicalSize: LogicalSizeStub
+}))
+
+vi.mock('@/lib/api', () => ({
+  persistenceApi: persistenceMock
+}))
+
+vi.mock('@/lib/tauri-runtime', () => ({
+  isTauriContext: () => runtimeMock.isTauri,
+  cleanupTauriListener: (fn: unknown) => {
+    if (typeof fn === 'function') fn()
+  }
+}))
+
+function makeMonitor(overrides: {
+  x?: number
+  y?: number
+  width: number
+  height: number
+  scaleFactor?: number
+}): Monitor {
+  const { x = 0, y = 0, width, height, scaleFactor = 1 } = overrides
+  return {
+    name: 'mock',
+    size: { type: 'Physical', width, height } as Monitor['size'],
+    position: { type: 'Physical', x, y } as Monitor['position'],
+    workArea: {
+      position: { type: 'Physical', x, y } as Monitor['workArea']['position'],
+      size: { type: 'Physical', width, height } as Monitor['workArea']['size']
+    },
+    scaleFactor
+  }
+}
+
+describe('window-state geometry helpers', () => {
+  it('converts physical work area into logical pixels using the scale factor', () => {
+    const monitor = makeMonitor({ x: 200, y: 100, width: 3840, height: 2160, scaleFactor: 2 })
+    expect(getLogicalWorkArea(monitor)).toEqual({ x: 100, y: 50, width: 1920, height: 1080 })
+  })
+
+  it('treats a window overlapping a scaled monitor as on-screen', () => {
+    // 1080p logical work area on a 4K/200% display.
+    const monitor = makeMonitor({ width: 3840, height: 2160, scaleFactor: 2 })
+    const onScreen: WindowState = {
+      x: 50,
+      y: 50,
+      width: 1200,
+      height: 800,
+      isMaximized: false
+    }
+    expect(isPositionOnScreen(onScreen, [monitor])).toBe(true)
+
+    const offScreen: WindowState = {
+      x: 5000,
+      y: 5000,
+      width: 1200,
+      height: 800,
+      isMaximized: false
+    }
+    expect(isPositionOnScreen(offScreen, [monitor])).toBe(false)
+  })
+
+  it('clamps oversized/off-screen geometry back inside the work area', () => {
+    const monitor = makeMonitor({ width: 1920, height: 1080, scaleFactor: 1 })
+    const bad: WindowState = {
+      x: 4000,
+      y: -500,
+      width: 5000,
+      height: 4000,
+      isMaximized: false
+    }
+    const clamped = clampStateToMonitors(bad, [monitor])
+    expect(clamped.width).toBe(1920)
+    expect(clamped.height).toBe(1080)
+    expect(clamped.x).toBe(0)
+    expect(clamped.y).toBe(0)
+  })
+})
+
+describe('useWindowState restoration', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    runtimeMock.isTauri = true
+    windowMock.isMaximized.mockResolvedValue(false)
+    windowMock.scaleFactor.mockResolvedValue(1)
+    windowMock.outerPosition.mockResolvedValue({ x: 0, y: 0 })
+    windowMock.outerSize.mockResolvedValue({ width: 1200, height: 800 })
+    windowMock.onMoved.mockResolvedValue(vi.fn())
+    windowMock.onResized.mockResolvedValue(vi.fn())
+    windowMock.onCloseRequested.mockResolvedValue(vi.fn())
+    persistenceMock.read.mockResolvedValue({ success: false, data: null })
+    monitorsMock.mockResolvedValue([makeMonitor({ width: 1920, height: 1080, scaleFactor: 1 })])
+    primaryMock.mockResolvedValue(makeMonitor({ width: 1920, height: 1080, scaleFactor: 1 }))
+  })
+
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('restores persisted geometry as logical pixels (no physical/logical drift)', async () => {
+    persistenceMock.read.mockResolvedValue({
+      success: true,
+      data: { x: 120, y: 80, width: 1000, height: 700, isMaximized: false }
+    })
+
+    const { result } = renderHook(() => useWindowState())
+
+    await waitFor(() => expect(result.current).toBe(true))
+
+    expect(windowMock.setPosition).toHaveBeenCalledTimes(1)
+    const positionArg = windowMock.setPosition.mock.calls[0][0] as InstanceType<
+      typeof LogicalPositionStub
+    >
+    expect(positionArg).toBeInstanceOf(LogicalPositionStub)
+    expect(positionArg.x).toBe(120)
+    expect(positionArg.y).toBe(80)
+
+    const sizeArg = windowMock.setSize.mock.calls[0][0] as InstanceType<typeof LogicalSizeStub>
+    expect(sizeArg).toBeInstanceOf(LogicalSizeStub)
+    expect(sizeArg.width).toBe(1000)
+    expect(sizeArg.height).toBe(700)
+
+    expect(windowMock.maximize).not.toHaveBeenCalled()
+  })
+
+  it('recenters when persisted position is fully off-screen', async () => {
+    persistenceMock.read.mockResolvedValue({
+      success: true,
+      data: { x: 9000, y: 9000, width: 1200, height: 800, isMaximized: false }
+    })
+
+    const { result } = renderHook(() => useWindowState())
+    await waitFor(() => expect(result.current).toBe(true))
+
+    const positionArg = windowMock.setPosition.mock.calls[0][0] as InstanceType<
+      typeof LogicalPositionStub
+    >
+    // Centered on the 1920x1080 primary monitor work area.
+    expect(positionArg.x).toBe(Math.round((1920 - 1200) / 2))
+    expect(positionArg.y).toBe(Math.round((1080 - 800) / 2))
+  })
+
+  it('re-maximizes when the persisted state was maximized', async () => {
+    persistenceMock.read.mockResolvedValue({
+      success: true,
+      data: { x: 0, y: 0, width: 1200, height: 800, isMaximized: true }
+    })
+
+    const { result } = renderHook(() => useWindowState())
+    await waitFor(() => expect(result.current).toBe(true))
+
+    expect(windowMock.maximize).toHaveBeenCalledTimes(1)
+  })
+
+  it('persists current geometry converted to logical pixels on a HiDPI display', async () => {
+    windowMock.scaleFactor.mockResolvedValue(2)
+    windowMock.outerPosition.mockResolvedValue({ x: 300, y: 200 })
+    windowMock.outerSize.mockResolvedValue({ width: 2400, height: 1600 })
+
+    const { result, unmount } = renderHook(() => useWindowState())
+    await waitFor(() => expect(result.current).toBe(true))
+
+    await act(async () => {
+      unmount()
+      await Promise.resolve()
+    })
+
+    expect(persistenceMock.write).toHaveBeenCalled()
+    const saved = persistenceMock.write.mock.calls.at(-1)?.[1] as unknown as WindowState
+    expect(saved).toMatchObject({ x: 150, y: 100, width: 1200, height: 800 })
+  })
+
+  it('is immediately ready outside the Tauri context', async () => {
+    runtimeMock.isTauri = false
+    const { result } = renderHook(() => useWindowState())
+    await waitFor(() => expect(result.current).toBe(true))
+    expect(windowMock.setPosition).not.toHaveBeenCalled()
+  })
+})

--- a/src/renderer/hooks/use-window-state.ts
+++ b/src/renderer/hooks/use-window-state.ts
@@ -15,19 +15,52 @@ const DEFAULT_WIDTH = 1200
 const DEFAULT_HEIGHT = 800
 const MIN_VISIBLE_PIXELS = 100
 
-function createDefaultWindowState(monitor: Monitor | null): WindowState {
-  const workArea = monitor?.workArea
+interface LogicalRect {
+  x: number
+  y: number
+  width: number
+  height: number
+}
 
-  const originX = workArea?.position.x ?? 0
-  const originY = workArea?.position.y ?? 0
-  const workWidth = workArea?.size.width ?? DEFAULT_WIDTH
-  const workHeight = workArea?.size.height ?? DEFAULT_HEIGHT
+/**
+ * Tauri reports window geometry (`outerPosition`/`outerSize`) and monitor work
+ * areas in *physical* pixels, but `setPosition`/`setSize` here apply *logical*
+ * pixels. On HiDPI displays the two differ by the monitor scale factor, so we
+ * normalize everything to logical pixels. Persisting and restoring in the same
+ * unit keeps the window where the user left it instead of drifting off-screen
+ * (e.g. after sleep/wake when the active monitor or its scale factor changes).
+ */
+function normalizeScaleFactor(scaleFactor: number | undefined): number {
+  return typeof scaleFactor === 'number' && scaleFactor > 0 ? scaleFactor : 1
+}
+
+/** Convert a monitor's physical work area into logical coordinates. */
+export function getLogicalWorkArea(monitor: Monitor | null): LogicalRect {
+  if (!monitor?.workArea) {
+    return { x: 0, y: 0, width: DEFAULT_WIDTH, height: DEFAULT_HEIGHT }
+  }
+
+  const scale = normalizeScaleFactor(monitor.scaleFactor)
+  const { position, size } = monitor.workArea
 
   return {
-    x: Math.round(originX + (workWidth - DEFAULT_WIDTH) / 2),
-    y: Math.round(originY + (workHeight - DEFAULT_HEIGHT) / 2),
-    width: DEFAULT_WIDTH,
-    height: DEFAULT_HEIGHT,
+    x: Math.round(position.x / scale),
+    y: Math.round(position.y / scale),
+    width: Math.round(size.width / scale),
+    height: Math.round(size.height / scale)
+  }
+}
+
+function createDefaultWindowState(monitor: Monitor | null): WindowState {
+  const area = getLogicalWorkArea(monitor)
+  const width = Math.min(DEFAULT_WIDTH, area.width)
+  const height = Math.min(DEFAULT_HEIGHT, area.height)
+
+  return {
+    x: Math.round(area.x + (area.width - width) / 2),
+    y: Math.round(area.y + (area.height - height) / 2),
+    width,
+    height,
     isMaximized: false
   }
 }
@@ -37,44 +70,89 @@ async function getDefaultWindowState(): Promise<WindowState> {
   return createDefaultWindowState(monitor)
 }
 
-function isPositionOnScreen(state: WindowState, monitors: Monitor[]): boolean {
+function overlapArea(state: WindowState, area: LogicalRect): { x: number; y: number } {
+  const overlapX = Math.max(
+    0,
+    Math.min(state.x + state.width, area.x + area.width) - Math.max(state.x, area.x)
+  )
+  const overlapY = Math.max(
+    0,
+    Math.min(state.y + state.height, area.y + area.height) - Math.max(state.y, area.y)
+  )
+
+  return { x: overlapX, y: overlapY }
+}
+
+export function isPositionOnScreen(state: WindowState, monitors: Monitor[]): boolean {
   if (monitors.length === 0) return true
 
   return monitors.some((monitor) => {
-    const area = monitor.workArea
-    const dx = area.position.x
-    const dy = area.position.y
-    const dw = area.size.width
-    const dh = area.size.height
-
-    const overlapX = Math.max(0, Math.min(state.x + state.width, dx + dw) - Math.max(state.x, dx))
-    const overlapY = Math.max(0, Math.min(state.y + state.height, dy + dh) - Math.max(state.y, dy))
-
+    const area = getLogicalWorkArea(monitor)
+    const { x: overlapX, y: overlapY } = overlapArea(state, area)
     return overlapX >= MIN_VISIBLE_PIXELS && overlapY >= MIN_VISIBLE_PIXELS
   })
 }
 
+/**
+ * Guarantee the restored window fits within, and sits fully inside, the monitor
+ * it overlaps most. This protects against corrupt or stale persisted geometry
+ * (the root cause of the window opening off-screen with an unreachable maximize
+ * control). The window is never sized larger than the target work area and is
+ * nudged back on-screen when its origin falls outside the visible bounds.
+ */
+export function clampStateToMonitors(state: WindowState, monitors: Monitor[]): WindowState {
+  if (monitors.length === 0) return state
+
+  let target = getLogicalWorkArea(monitors[0])
+  let bestOverlap = -1
+
+  for (const monitor of monitors) {
+    const area = getLogicalWorkArea(monitor)
+    const { x: overlapX, y: overlapY } = overlapArea(state, area)
+    const overlap = overlapX * overlapY
+
+    if (overlap > bestOverlap) {
+      bestOverlap = overlap
+      target = area
+    }
+  }
+
+  const width = Math.min(state.width, target.width)
+  const height = Math.min(state.height, target.height)
+  const maxX = target.x + target.width - width
+  const maxY = target.y + target.height - height
+  const x = Math.min(Math.max(state.x, target.x), maxX)
+  const y = Math.min(Math.max(state.y, target.y), maxY)
+
+  return { ...state, x, y, width, height }
+}
+
 async function loadWindowState(): Promise<WindowState> {
   const result = await persistenceApi.read<WindowState>(PersistenceKeys.windowState)
+  const monitors = await availableMonitors()
 
   if (!result.success || !result.data) {
-    return getDefaultWindowState()
+    return clampStateToMonitors(await getDefaultWindowState(), monitors)
   }
 
   const persistedState = result.data
-  const monitors = await availableMonitors()
 
   if (isPositionOnScreen(persistedState, monitors)) {
-    return persistedState
+    return clampStateToMonitors(persistedState, monitors)
   }
 
+  // Persisted position is no longer visible (monitor removed, resolution or
+  // scale changed). Recenter on the primary monitor but keep the saved size.
   const defaultState = await getDefaultWindowState()
-  return {
-    ...defaultState,
-    width: persistedState.width,
-    height: persistedState.height,
-    isMaximized: persistedState.isMaximized
-  }
+  return clampStateToMonitors(
+    {
+      ...defaultState,
+      width: persistedState.width,
+      height: persistedState.height,
+      isMaximized: persistedState.isMaximized
+    },
+    monitors
+  )
 }
 
 export function useWindowState(): boolean {
@@ -101,13 +179,14 @@ export function useWindowState(): boolean {
         }
       }
 
+      const scale = normalizeScaleFactor(await window.scaleFactor())
       const position = await window.outerPosition()
       const size = await window.outerSize()
       const state: WindowState = {
-        x: position.x,
-        y: position.y,
-        width: size.width,
-        height: size.height,
+        x: Math.round(position.x / scale),
+        y: Math.round(position.y / scale),
+        width: Math.round(size.width / scale),
+        height: Math.round(size.height / scale),
         isMaximized: false
       }
 


### PR DESCRIPTION
## Summary

Fixes #205 — window could open in a broken state (maximize unreachable / not auto-maximized) after sleep/wake on Windows.

## Root cause

In `src/renderer/hooks/use-window-state.ts`, window geometry was **saved in physical pixels** (`outerPosition()` / `outerSize()` and the monitor work area both report physical pixels) but **restored as logical pixels** (`LogicalPosition` / `LogicalSize`).

On HiDPI displays the two differ by the monitor scale factor, so the window drifts on restore. After sleep/wake — when Windows can change the active monitor or its scale factor — the window could land mostly or fully off-screen, leaving the maximize control unreachable.

## Changes

- Normalize all geometry to **logical pixels** using the monitor/window `scaleFactor`, so save and restore use the same unit.
- Add `clampStateToMonitors()` safeguard: a restored window is never sized larger than its target monitor's work area and is nudged back on-screen if its origin falls outside visible bounds — a hard guarantee against an unreachable window from stale/corrupt geometry.
- Clamp the default state to the work area so small monitors aren't given an oversized default.
- New `getLogicalWorkArea()` / `isPositionOnScreen()` helpers operate in logical space.

## Tests

- Added `src/renderer/hooks/use-window-state.test.ts` (8 tests): scale-factor conversion, on-screen detection on scaled monitors, off-screen recenter, clamping, HiDPI persist round-trip, re-maximize, and non-Tauri no-op.

## Verification

- `npm run typecheck:web` ✅
- ESLint clean on changed files ✅
- Full suite: 1273 passed / 42 skipped ✅

## Screenshots
<img width="375" height="350" alt="image" src="https://github.com/user-attachments/assets/3b7405e9-cc96-44eb-8e10-fdc603919f78" />
<img width="241" height="73" alt="image" src="https://github.com/user-attachments/assets/d377cd53-e8da-41c5-9d1e-a88b69b81fa1" />



## Notes

This is a renderer-side restore path, so it primarily helps users with valid persisted geometry. For windows never positioned (or persisted maximized), the clamp + default-state changes still keep the initial window on-screen and within the work area.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved window position and size restoration on high-DPI displays, ensuring windows are properly restored to their intended locations and remain visible on screen.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->