### PR TITLE
fix(security): resolve CodeQL alerts for v0.4.0 release

### DIFF
--- a/.github/workflows/deploy-landing.yml
+++ b/.github/workflows/deploy-landing.yml
@@ -31,7 +31,7 @@ jobs:
           persist-credentials: false
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version: 1.3.x
 
@@ -49,7 +49,7 @@ jobs:
 
       - name: Deploy to Cloudflare Pages
         if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
-        uses: cloudflare/wrangler-action@v3
+        uses: cloudflare/wrangler-action@9acf94ace14e7dc412b076f2c5c20b8ce93c79cd # v3.15.0
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/.github/workflows/fork-monitor.yml
+++ b/.github/workflows/fork-monitor.yml
@@ -33,7 +33,7 @@ jobs:
           persist-credentials: false
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version: 1.3.x
 
@@ -131,7 +131,7 @@ jobs:
           persist-credentials: false
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version: 1.3.x
 

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -90,7 +90,7 @@ jobs:
             patchelf
 
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           components: clippy
 
@@ -123,7 +123,7 @@ jobs:
           persist-credentials: false
 
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           components: clippy
 
@@ -149,7 +149,7 @@ jobs:
           persist-credentials: false
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v2 # v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version: 1.3.x
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -174,7 +174,7 @@ jobs:
             patchelf
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v2 # v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version: 1.3.x
 

--- a/src/renderer/hooks/use-terminal-restore.ts
+++ b/src/renderer/hooks/use-terminal-restore.ts
@@ -844,7 +844,7 @@ async function restoreFromLayout(
         spawnCount: SPAWN_TRACKER.get(terminalCallId)
       })
 
-      const newId = Date.now().toString() + crypto.randomUUID().slice(0, 3)
+      const newId = crypto.randomUUID()
       TERMINALS_PENDING_PTY_ASSIGNMENT.add(newId)
 
       try {

--- a/src/renderer/hooks/use-terminal-restore.ts
+++ b/src/renderer/hooks/use-terminal-restore.ts
@@ -288,7 +288,7 @@ export function useTerminalRestore(): void {
   const [visibilityRetry, setVisibilityRetry] = useState(0)
 
   useEffect(() => {
-    const callId = Math.random().toString(36).slice(2, 9)
+    const callId = crypto.randomUUID().slice(0, 7)
     RESTORE_CALL_STACK.push(callId)
 
     debugLog('useTerminalRestore', `EFFECT RUN [callId: ${callId}]`, {
@@ -768,7 +768,7 @@ async function restoreFromLayout(
   layout: PersistedTerminalLayout,
   isCancelled: () => boolean
 ): Promise<RestoreExecutionResult> {
-  const restoreId = `restore-${Math.random().toString(36).slice(2, 7)}`
+  const restoreId = `restore-${crypto.randomUUID().slice(0, 5)}`
 
   // FIX #2: Use proper lock acquire/release with owner tracking
   if (!acquireGlobalSpawnLock(restoreId)) {
@@ -833,7 +833,7 @@ async function restoreFromLayout(
         return { status: 'cancelled', path: 'persisted-replay' }
       }
 
-      const terminalCallId = `${restoreId}-${persistedTerminal.name}-${Math.random().toString(36).slice(2, 5)}`
+      const terminalCallId = `${restoreId}-${persistedTerminal.name}-${crypto.randomUUID().slice(0, 3)}`
       SPAWN_TRACKER.set(terminalCallId, (SPAWN_TRACKER.get(terminalCallId) || 0) + 1)
       let spawnTimeout: ReturnType<typeof setTimeout> | null = null
 
@@ -844,7 +844,7 @@ async function restoreFromLayout(
         spawnCount: SPAWN_TRACKER.get(terminalCallId)
       })
 
-      const newId = Date.now().toString() + Math.random().toString(36).slice(2, 5)
+      const newId = Date.now().toString() + crypto.randomUUID().slice(0, 3)
       TERMINALS_PENDING_PTY_ASSIGNMENT.add(newId)
 
       try {
@@ -1018,7 +1018,7 @@ async function createDefaultTerminal(
   projectId: string,
   isCancelled: () => boolean
 ): Promise<RestoreExecutionResult> {
-  const defaultId = `default-${Math.random().toString(36).slice(2, 7)}`
+  const defaultId = `default-${crypto.randomUUID().slice(0, 5)}`
 
   // FIX #2: Use proper lock acquire/release with owner tracking
   if (!acquireGlobalSpawnLock(defaultId)) {


### PR DESCRIPTION
## Summary
Resolves the 9 CodeQL code-scanning alerts blocking the v0.4.0 release PR (#210).

### High severity (1)
- **`js/insecure-randomness`** in `src/renderer/hooks/use-terminal-restore.ts` — Replaced all `Math.random()`-based ID generation (restore IDs, lock owner IDs, call IDs, pending PTY IDs) with `crypto.randomUUID()`. These IDs feed the global spawn-lock owner/session tracking, which CodeQL treats as a security context. Short readable IDs are preserved via `.slice()` on the UUID.

### Medium severity (8)
- **`actions/unpinned-tag`** — Pinned GitHub Actions to commit SHAs across `pr-validation.yml`, `fork-monitor.yml`, `release.yml`, and `deploy-landing.yml`:
  - `oven-sh/setup-bun@v2` → `@0c5077e…` # v2
  - `dtolnay/rust-toolchain@stable` → `@29eef33…` # stable
  - `cloudflare/wrangler-action@v3` → `@9acf94a…` # v3.15.0

  SHAs reuse the exact pins already established elsewhere in the repo's workflows.

## Testing
- Pre-commit hooks passed: TypeScript typecheck (node + web) and ESLint (`--max-warnings=0`)
- All four modified workflow YAML files validated as parseable

## Notes
Merging this into `dev` clears the code-scanning gate on the dev → main release PR (#210).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Pinned third-party CI actions to fixed commit references to improve workflow stability and security.
  * Replaced weaker random ID generation with stronger, more reliable unique IDs for terminal restoration and session handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->