### PR TITLE
fix(ci): deploy landing from its own dir so Pages bundles functions

### DIFF
--- a/.github/workflows/deploy-landing.yml
+++ b/.github/workflows/deploy-landing.yml
@@ -53,5 +53,6 @@ jobs:
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          command: pages deploy landing/dist --project-name=termul-landing --branch=${{ github.ref_name == 'main' && 'main' || github.head_ref || github.ref_name }} --commit-dirty=true
+          workingDirectory: landing
+          command: pages deploy dist --project-name=termul-landing --branch=${{ github.ref_name == 'main' && 'main' || github.head_ref || github.ref_name }} --commit-dirty=true
           gitHubToken: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

- Fix the landing deploy workflow so Cloudflare Pages bundles the `functions/` directory. CI deploys were shipping static assets only, so the testimonial API fell through to the SPA catch-all (`POST /api/testimonials` returned `405`, unknown `GET /api/*` returned the SPA HTML with `200`).

## Related Issue

Closes #

<!-- No tracked issue; follow-up to PR #221 after observing 405s on deployed testimonial API. -->

## Type of Change

- [x] ci: CI/CD workflow changes

## What Changed

- `cloudflare/wrangler-action` ran from the repo root and deployed `landing/dist`. Cloudflare Pages discovers `functions/` relative to the deploy working directory, and there is no `./functions` at the repo root, so the Functions bundle was never uploaded.
- Set `workingDirectory: landing` and change the command to `pages deploy dist`, so wrangler runs from `landing/` where `./functions` sits next to `./dist`.

## How It Was Tested

- [ ] `bun run lint`
- [ ] `bun run typecheck`
- [ ] `bun run test`
- [x] Manual verification completed

Verified by deploying from `landing/` with the same command shape:
- Deploy output now shows `Uploading Functions bundle`.
- `POST /api/testimonials` performs a real submit (`{"status":"pending"}`) instead of `405`.
- Unknown `GET /api/nope` returns `404` JSON instead of `200` SPA HTML, confirming Function routing is active.
- Test rows cleaned up afterward.

## Screenshots or Recordings

<!-- CI/config change; no UI changes. -->

## Checklist

- [x] My PR title follows the conventional commit format used by this repo
- [x] I linked the related issue or explained why none exists
- [x] I updated docs when needed (n/a)
- [ ] I added or updated tests when needed (CI workflow change; not unit-testable)
- [x] I verified the change does not introduce unrelated modifications


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Corrected deployment configuration to properly reference the build output directory for landing page deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->