### PR TITLE
ci: restore macOS Intel release target

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -149,6 +149,11 @@ jobs:
             rust_target: aarch64-apple-darwin
             args: --target aarch64-apple-darwin
 
+          - platform: macos-x64
+            runner: macos-15-intel
+            rust_target: x86_64-apple-darwin
+            args: --target x86_64-apple-darwin
+
     steps:
       - name: Harden runner
         if: matrix.runner == 'ubuntu-22.04'


### PR DESCRIPTION
## Summary

Restores the macOS x64/Intel build matrix entry in the release workflow. It was originally added in #163 but inadvertently removed in #146 (revert to avoid a workflow scope requirement). As a result, every release since then (including v0.4.0) only produces macOS **arm64** artifacts.

## Problem

- v0.4.0 release assets contain `Termul.Manager_0.4.0_aarch64.dmg` but **no Intel/x64 macOS DMG**.
- `latest.json` lists only `darwin-aarch64` / `darwin-aarch64-app` — there is no `darwin-x86_64` entry, so Intel Macs get no compatible build and no updater path.

## Fix

Re-add the `macos-x64` matrix leg:

```yaml
- platform: macos-x64
  runner: macos-15-intel
  rust_target: x86_64-apple-darwin
  args: --target x86_64-apple-darwin
```

`macos-15-intel` is GitHub's supported hosted Intel runner (available through Aug 2027; the last x86_64 macOS image).

## Validation

- YAML parses cleanly.
- Intel ripgrep sidecar already present and confirmed Mach-O x86_64 (`src-tauri/bin/rg-x86_64-apple-darwin`).
- Local build script (`build:tauri:mac-x64`) and deployment docs already list macOS x64/Intel — only the CI matrix entry was missing.

Next release tag will produce the Intel DMG and add `darwin-x86_64` to `latest.json`.