### PR TITLE
refactor: remove project avatar circle from sidebar list

### DIFF
--- a/src/renderer/components/ProjectSidebar.test.tsx
+++ b/src/renderer/components/ProjectSidebar.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { render, screen, fireEvent, waitFor, within } from '@testing-library/react'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
 import { ProjectSidebar } from './ProjectSidebar'
 import type { Project } from '@/types/project'
@@ -262,16 +262,6 @@ describe('ProjectSidebar', () => {
     expect(screen.getByText('Project Two')).toBeInTheDocument()
   })
 
-  it('should render project avatars with first letter', () => {
-    renderWithRouter()
-
-    const activeProjectsContainer = screen.getByTestId('active-projects-container')
-    const avatars = within(activeProjectsContainer).getAllByTestId('project-avatar-letter')
-    const letters = avatars.map((avatar) => avatar.textContent)
-
-    expect(letters).toStrictEqual(['P', 'P'])
-  })
-
   it('should call onSelectProject when project is clicked', () => {
     const onSelectProject = vi.fn()
     renderWithRouter({ onSelectProject })
@@ -328,31 +318,8 @@ describe('ProjectSidebar', () => {
     ]
     renderWithRouter({ projects: projectsWithEmptyName })
 
-    // Should show fallback character '?' for empty name
-    const avatar = screen.getByTestId('project-avatar-letter')
-    expect(avatar).toHaveTextContent('?')
-  })
-
-  it('should extract first alphabetic character for emoji project names', () => {
-    const projectsWithEmoji: Project[] = [
-      { id: '1', name: '🚀Rocket', color: 'blue', gitBranch: 'main' }
-    ]
-    renderWithRouter({ projects: projectsWithEmoji })
-
-    // Should extract 'R' from Rocket, not the emoji
-    const avatar = screen.getByTestId('project-avatar-letter')
-    expect(avatar).toHaveTextContent('R')
-  })
-
-  it('should preserve emoji-only project names in avatar fallback', () => {
-    const projectsWithEmojiOnlyName: Project[] = [
-      { id: '1', name: '🚀', color: 'blue', gitBranch: 'main' }
-    ]
-    renderWithRouter({ projects: projectsWithEmojiOnlyName })
-
-    // Should keep full emoji grapheme as fallback, not a surrogate fragment
-    const avatar = screen.getByTestId('project-avatar-letter')
-    expect(avatar).toHaveTextContent('🚀')
+    // Empty-named project still renders its row without crashing.
+    expect(screen.getByTestId('active-projects-container')).toBeInTheDocument()
   })
 })
 

--- a/src/renderer/components/ProjectSidebar.tsx
+++ b/src/renderer/components/ProjectSidebar.tsx
@@ -54,13 +54,6 @@ import { groupWorktrees, type WorktreeGroup } from "@/lib/worktree-grouping";
 import { filterWorktrees } from "@/lib/worktree-filter";
 import { filterProjects, shouldShowProjectSearch } from "@/lib/project-filter";
 
-function getFirstLetter(name: string): string {
-	if (!name) return "?";
-	const match = name.match(/[a-zA-Z]/);
-	const first = Array.from(name)[0];
-	return match ? match[0].toUpperCase() : first ? first.toUpperCase() : "?";
-}
-
 interface ContextMenuState {
 	isOpen: boolean;
 	x: number;
@@ -1237,7 +1230,6 @@ const ProjectItem = memo(function ProjectItem({
 		}
 	};
 
-	const firstLetter = getFirstLetter(project.name);
 	const hasWorktrees = (project.worktrees?.length ?? 0) > 0 || project.isGitRepo;
 	const worktrees = project.worktrees ?? [];
 
@@ -1288,21 +1280,6 @@ const ProjectItem = memo(function ProjectItem({
 					<div className="w-5 flex-shrink-0" />
 				)}
 
-				{/* Circular avatar with first letter */}
-				<div
-					className={cn(
-						"w-4 h-4 rounded-full flex items-center justify-center ml-1 mr-2 flex-shrink-0",
-						colors.bg,
-					)}
-					aria-hidden="true"
-				>
-					<span
-						className="text-[10px] leading-none text-white"
-						data-testid="project-avatar-letter"
-					>
-						{firstLetter}
-					</span>
-				</div>
 				{isEditing ? (
 					<input
 						ref={inputRef}
@@ -1311,13 +1288,13 @@ const ProjectItem = memo(function ProjectItem({
 						onChange={(e) => onEditNameChange(e.target.value)}
 						onKeyDown={handleKeyDown}
 						onBlur={onSaveRename}
-						className="flex-1 min-w-0 bg-sidebar-accent border border-border rounded-md px-2 py-0.5 text-sm text-foreground outline-none focus:ring-1 focus:ring-primary mr-2"
+						className="flex-1 min-w-0 bg-sidebar-accent border border-border rounded-md px-2 py-0.5 text-sm text-foreground outline-none focus:ring-1 focus:ring-primary ml-2 mr-2"
 						onClick={(e) => e.stopPropagation()}
 					/>
 				) : (
 					<span
 						className={cn(
-							"text-sm transition-colors flex-1 min-w-0 truncate mr-2",
+							"text-sm transition-colors flex-1 min-w-0 truncate ml-2 mr-2",
 							// flex-1 min-w-0 is required for truncate to clip inside a flex row
 							isActive
 								? "text-foreground"
@@ -1615,7 +1592,6 @@ function ArchivedProjectItem({
 	onContextMenu,
 }: ArchivedProjectItemProps): React.JSX.Element {
 	const colors = getColorClasses(project.color);
-	const firstLetter = getFirstLetter(project.name);
 
 	return (
 		<button
@@ -1628,23 +1604,8 @@ function ArchivedProjectItem({
 			aria-label={`Archived project: ${project.name}`}
 			data-testid={`archived-project-item-${project.id}`}
 		>
-			{/* Circular avatar with first letter */}
-			<div
-				className={cn(
-					"w-4 h-4 rounded-full flex items-center justify-center ml-2 mr-2 flex-shrink-0",
-					colors.bg,
-				)}
-				aria-hidden="true"
-			>
-				<span
-					className="text-[10px] leading-none text-white"
-					data-testid="project-avatar-letter"
-				>
-					{firstLetter}
-				</span>
-			</div>
 			<span
-				className="text-sm text-muted-foreground group-hover:text-foreground flex-1 min-w-0 truncate mr-2"
+				className="text-sm text-muted-foreground group-hover:text-foreground flex-1 min-w-0 truncate ml-2 mr-2"
 				title={project.name}
 			>
 				{project.name}


### PR DESCRIPTION
## Summary

- Remove the circular project avatar (colored circle with the first letter) from the project list in the sidebar, for both active and archived project rows. The project name now sits with proper left indentation where the circle used to be.

## Related Issue

Closes #

No tracked issue; this is a small UI cleanup of the sidebar project list.

## Type of Change

- [x] refactor: internal cleanup with no behavior change

## What Changed

- Removed the `rounded-full` avatar element (and its `project-avatar-letter` testid) from the active project row and the archived project row in `ProjectSidebar.tsx`.
- Adjusted the project name/edit-input left margin so rows stay aligned without the avatar.
- Dropped the now-unused `getFirstLetter` helper.
- Removed the obsolete avatar-related tests and the now-unused `within` import in `ProjectSidebar.test.tsx`.

## How It Was Tested

- [x] `bun run typecheck`
- [x] `bun run test` (ProjectSidebar suite: 50 passed)
- [x] Manual verification completed

## Screenshots or Recordings

<!-- UI change: project list rows no longer show the leading colored circle. -->

## Checklist

- [x] My PR title follows the conventional commit format used by this repo
- [x] I linked the related issue or explained why none exists
- [ ] I updated docs when needed
- [x] I added or updated tests when needed
- [x] I verified the change does not introduce unrelated modifications


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Removed circular avatar letters from project items in the sidebar. Projects in both active and archived sections now display only text names, providing a cleaner interface. Updated layout spacing and styling accordingly.

* **Tests**
  * Updated project sidebar test suite to remove avatar-related validations and align assertions with the new display behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->