### PR TITLE
fix(editor): restore Ctrl+S save in markdown preview (#213)

### DIFF
--- a/src/renderer/components/editor/CodeEditor.tsx
+++ b/src/renderer/components/editor/CodeEditor.tsx
@@ -2,6 +2,10 @@ import { useRef, useEffect, useMemo, useState, useCallback } from 'react'
 import { useShallow } from 'zustand/shallow'
 import type { ImperativePanelGroupHandle, PanelOnResize } from 'react-resizable-panels'
 import { useCodeMirror, type VisibleLineRange } from '@/hooks/use-codemirror'
+import {
+  registerEditorContentFlusher,
+  unregisterEditorContentFlusher
+} from '@/lib/editor-content-flush'
 import { TocPanel } from './TocPanel'
 import { ResizablePanelGroup, ResizablePanel, ResizableHandle } from '@/components/ui/resizable'
 import { useTocSettingsStore } from '@/stores/toc-settings-store'
@@ -60,7 +64,8 @@ export function CodeEditor({
     }))
   )
 
-  const { view, setContent, scrollToLine, restoreViewState } = useCodeMirror(containerRef, {
+  const { view, setContent, flushPendingContent, scrollToLine, restoreViewState } = useCodeMirror(containerRef, {
+    filePath,
     content,
     language,
     readOnly,
@@ -99,6 +104,11 @@ export function CodeEditor({
     },
     [getPanelWidth, setTocWidth]
   )
+
+  useEffect(() => {
+    registerEditorContentFlusher(filePath, flushPendingContent)
+    return () => unregisterEditorContentFlusher(filePath)
+  }, [filePath, flushPendingContent])
 
   // Update content when it changes from external source (file reload)
   const prevContentRef = useRef(content)

--- a/src/renderer/components/editor/MarkdownEditor.tsx
+++ b/src/renderer/components/editor/MarkdownEditor.tsx
@@ -2,6 +2,10 @@ import { useState, useEffect, useRef, useCallback, useMemo } from 'react'
 import { useShallow } from 'zustand/shallow'
 import type { ImperativePanelGroupHandle, PanelOnResize } from 'react-resizable-panels'
 import { useBlockNote } from '@/hooks/use-blocknote'
+import {
+  registerEditorContentFlusher,
+  unregisterEditorContentFlusher
+} from '@/lib/editor-content-flush'
 import { BlockNoteViewRaw } from '@blocknote/react'
 import { TocPanel } from './TocPanel'
 import { ResizablePanelGroup, ResizablePanel, ResizableHandle } from '@/components/ui/resizable'
@@ -65,10 +69,17 @@ export function MarkdownEditor({
     [onChange]
   )
 
-  const { editor, replaceContent, getHeadings, scrollToBlock } = useBlockNote({
+  const { editor, replaceContent, flushPendingContent, getHeadings, scrollToBlock } = useBlockNote({
+    filePath,
     initialMarkdown: content,
     onChange: wrappedOnChange
   })
+
+  useEffect(() => {
+    registerEditorContentFlusher(filePath, flushPendingContent)
+    return () => unregisterEditorContentFlusher(filePath)
+  }, [filePath, flushPendingContent])
+
   const isDark = useIsDark()
   const layoutRef = useRef<HTMLDivElement>(null)
   const blockNoteScrollRootRef = useRef<HTMLDivElement>(null)

--- a/src/renderer/components/workspace/EditorTab.tsx
+++ b/src/renderer/components/workspace/EditorTab.tsx
@@ -124,7 +124,7 @@ export function EditorTab({
 							: operationStatus === "reloading"
 								? "Reloading file"
 								: operationStatus === "saved"
-									? "File updated"
+									? `${fileName} saved`
 									: "Close tab"
 					}
 					className={cn(

--- a/src/renderer/hooks/use-blocknote.ts
+++ b/src/renderer/hooks/use-blocknote.ts
@@ -78,7 +78,7 @@ export function useBlockNote(options: UseBlockNoteOptions): UseBlockNoteResult {
 
 	const saveShortcutExtension = useMemo(
 		() =>
-			createExtension({
+			createExtension(() => ({
 				key: "termulSaveShortcut",
 				keyboardShortcuts: {
 					"Mod-s": () => {
@@ -86,7 +86,7 @@ export function useBlockNote(options: UseBlockNoteOptions): UseBlockNoteResult {
 						return true;
 					},
 				},
-			})(),
+			}))(),
 		[],
 	);
 

--- a/src/renderer/hooks/use-blocknote.ts
+++ b/src/renderer/hooks/use-blocknote.ts
@@ -2,9 +2,11 @@ import { useRef, useEffect, useMemo, useCallback } from "react";
 import {
 	BlockNoteEditor,
 	BlockNoteSchema,
+	createExtension,
 	defaultBlockSpecs,
 	createCodeBlockSpec,
 } from "@blocknote/core";
+import { requestSaveEditorFile } from "@/lib/editor-save";
 import { codeBlockOptions } from "@blocknote/code-block";
 import { mermaidBlockSpec } from "@/components/editor/mermaid-block-spec";
 import type { TocHeading } from "@/hooks/use-toc-headings";
@@ -47,6 +49,7 @@ function convertMermaidBlocks(
 }
 
 interface UseBlockNoteOptions {
+	filePath: string;
 	initialMarkdown: string;
 	onChange: (markdown: string) => void;
 }
@@ -55,12 +58,14 @@ interface UseBlockNoteResult {
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	editor: BlockNoteEditor<any, any, any>;
 	replaceContent: (markdown: string) => void;
+	flushPendingContent: () => Promise<void>;
 	getHeadings: () => TocHeading[];
 	scrollToBlock: (blockId: string) => void;
 }
 
 export function useBlockNote(options: UseBlockNoteOptions): UseBlockNoteResult {
 	const onChangeRef = useRef(options.onChange);
+	const filePathRef = useRef(options.filePath);
 	const initialMarkdownRef = useRef(options.initialMarkdown);
 	const debounceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 	// Guard to suppress onChange during programmatic replaceBlocks calls
@@ -69,6 +74,21 @@ export function useBlockNote(options: UseBlockNoteOptions): UseBlockNoteResult {
 	const replaceTokenRef = useRef(0);
 
 	onChangeRef.current = options.onChange;
+	filePathRef.current = options.filePath;
+
+	const saveShortcutExtension = useMemo(
+		() =>
+			createExtension({
+				key: "termulSaveShortcut",
+				keyboardShortcuts: {
+					"Mod-s": () => {
+						void requestSaveEditorFile(filePathRef.current);
+						return true;
+					},
+				},
+			})(),
+		[],
+	);
 
 	const editor = useMemo(() => {
 		const schema = BlockNoteSchema.create({
@@ -78,8 +98,11 @@ export function useBlockNote(options: UseBlockNoteOptions): UseBlockNoteResult {
 				mermaid: mermaidBlockSpec(),
 			},
 		});
-		return BlockNoteEditor.create({ schema });
-	}, []);
+		return BlockNoteEditor.create({
+			schema,
+			extensions: [saveShortcutExtension],
+		});
+	}, [saveShortcutExtension]);
 
 	const runReplace = useCallback(
 		async (markdown: string, token: number): Promise<void> => {
@@ -152,6 +175,20 @@ export function useBlockNote(options: UseBlockNoteOptions): UseBlockNoteResult {
 		[runReplace],
 	);
 
+	const flushPendingContent = useCallback(async (): Promise<void> => {
+		if (debounceTimerRef.current) {
+			clearTimeout(debounceTimerRef.current);
+			debounceTimerRef.current = null;
+		}
+		if (isReplacingRef.current) return;
+		try {
+			const markdown = await editor.blocksToMarkdownLossy(editor.document);
+			onChangeRef.current(markdown);
+		} catch {
+			// Failed to convert to markdown
+		}
+	}, [editor]);
+
 	const getHeadings = useCallback((): TocHeading[] => {
 		return editor.document.flatMap((block) => {
 			if (block.type !== "heading") {
@@ -217,5 +254,5 @@ export function useBlockNote(options: UseBlockNoteOptions): UseBlockNoteResult {
 		[editor],
 	);
 
-	return { editor, replaceContent, getHeadings, scrollToBlock };
+	return { editor, replaceContent, flushPendingContent, getHeadings, scrollToBlock };
 }

--- a/src/renderer/hooks/use-codemirror.ts
+++ b/src/renderer/hooks/use-codemirror.ts
@@ -1,5 +1,5 @@
 import { useRef, useEffect, useCallback, useState } from 'react'
-import { EditorState, Compartment } from '@codemirror/state'
+import { EditorState, Compartment, Prec } from '@codemirror/state'
 import {
   EditorView,
   lineNumbers,
@@ -11,6 +11,7 @@ import { defaultKeymap, indentWithTab, history, historyKeymap } from '@codemirro
 import { bracketMatching, foldGutter, indentOnInput } from '@codemirror/language'
 import { highlightSelectionMatches } from '@codemirror/search'
 import { createTermulTheme } from '@/components/editor/codemirror-theme'
+import { requestSaveEditorFile } from '@/lib/editor-save'
 import type { Extension } from '@codemirror/state'
 
 // Cache loaded language extensions
@@ -88,6 +89,7 @@ export interface VisibleLineRange {
 }
 
 interface UseCodeMirrorOptions {
+  filePath: string
   content: string
   language: string
   readOnly?: boolean
@@ -100,6 +102,7 @@ interface UseCodeMirrorOptions {
 interface UseCodeMirrorResult {
   view: EditorView | null
   setContent: (content: string) => void
+  flushPendingContent: () => void
   scrollToLine: (lineNumber: number, highlightTerm?: string) => void
   restoreViewState: (lineNumber: number, column: number, scrollTop: number) => void
   getVisibleLineRange: () => VisibleLineRange | null
@@ -131,8 +134,10 @@ export function useCodeMirror(
   const visibleRangeDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const themeCompartment = useRef(new Compartment())
   const pendingRestoreTokenRef = useRef<symbol | null>(null)
+  const filePathRef = useRef(options.filePath)
 
   // Keep refs up to date
+  filePathRef.current = options.filePath
   onChangeRef.current = options.onChange
   onCursorChangeRef.current = options.onCursorChange
   onScrollChangeRef.current = options.onScrollChange
@@ -191,6 +196,18 @@ export function useCodeMirror(
       indentOnInput(),
       history(),
       highlightSelectionMatches(),
+      Prec.highest(
+        keymap.of([
+          {
+            key: 'Mod-s',
+            run: () => {
+              void requestSaveEditorFile(filePathRef.current)
+              return true
+            },
+            preventDefault: true
+          }
+        ])
+      ),
       keymap.of([...defaultKeymap, ...historyKeymap, indentWithTab]),
       themeCompartment.current.of(createTermulTheme(isDark)),
       updateListener,
@@ -282,6 +299,17 @@ export function useCodeMirror(
     })
 
     return () => observer.disconnect()
+  }, [])
+
+  const flushPendingContent = useCallback((): void => {
+    if (debounceTimerRef.current) {
+      clearTimeout(debounceTimerRef.current)
+      debounceTimerRef.current = null
+    }
+    const view = viewRef.current
+    if (view) {
+      onChangeRef.current(view.state.doc.toString())
+    }
   }, [])
 
   const setContent = useCallback((content: string) => {
@@ -382,6 +410,7 @@ export function useCodeMirror(
   return {
     view: viewReady ? viewRef.current : null,
     setContent,
+    flushPendingContent,
     scrollToLine,
     restoreViewState,
     getVisibleLineRange

--- a/src/renderer/hooks/use-file-watcher.ts
+++ b/src/renderer/hooks/use-file-watcher.ts
@@ -51,9 +51,6 @@ export function useFileWatcher(): void {
       const fileState = editorState.openFiles.get(path)
       if (fileState) {
         if (consumeEditorSelfSave(path)) {
-          if (!fileState.isDirty) {
-            void editorState.reloadFile(path)
-          }
           return
         }
 

--- a/src/renderer/hooks/use-file-watcher.ts
+++ b/src/renderer/hooks/use-file-watcher.ts
@@ -5,6 +5,7 @@ import { useFileExplorerStore } from '@/stores/file-explorer-store'
 import { useEditorStore } from '@/stores/editor-store'
 import { useWorkspaceStore, editorTabId } from '@/stores/workspace-store'
 import type { FileChangeEvent } from '@shared/types/filesystem.types'
+import { consumeEditorSelfSave } from '@/lib/editor-self-save'
 
 function getDirname(filePath: string): string {
   const normalized = filePath.replace(/\\/g, '/')
@@ -49,20 +50,27 @@ export function useFileWatcher(): void {
       const editorState = useEditorStore.getState()
       const fileState = editorState.openFiles.get(path)
       if (fileState) {
+        if (consumeEditorSelfSave(path)) {
+          if (!fileState.isDirty) {
+            void editorState.reloadFile(path)
+          }
+          return
+        }
+
         // Skip if we just saved this file (within 2 seconds)
         if (Date.now() - fileState.lastModified < 2000) {
           return
         }
 
         if (!fileState.isDirty) {
-          editorState.reloadFile(path)
+          void editorState.reloadFile(path)
         } else {
           toast('File changed externally', {
             description: path.split(/[\\/]/).pop() || path,
             action: {
               label: 'Reload',
               onClick: () => {
-                useEditorStore.getState().reloadFile(path)
+                void useEditorStore.getState().reloadFile(path)
               }
             }
           })

--- a/src/renderer/layouts/WorkspaceLayout.tsx
+++ b/src/renderer/layouts/WorkspaceLayout.tsx
@@ -104,6 +104,7 @@ import { browserTabHide, browserTabShow } from "@/lib/browser-api";
 import type { SFTPEntry } from "@shared/types/ssh.types";
 import { SSHFileExplorer } from "@/components/ssh/SSHFileExplorer";
 import { cn } from "@/lib/utils";
+import { isSaveFileShortcut, requestSaveEditorFile } from "@/lib/editor-save";
 
 function getShortcutTargetContext(target: EventTarget | null): {
 	isInEditor: boolean;
@@ -711,8 +712,30 @@ export default function WorkspaceLayout(): React.JSX.Element {
 		});
 	}, [activeProjectId]);
 
+	// Capture-phase save so WebView/editors cannot block Ctrl+S before it reaches us.
+	useEffect(() => {
+		const handleSaveShortcut = (e: KeyboardEvent): void => {
+			if (!isSaveFileShortcut(e)) return;
+			e.preventDefault();
+			e.stopPropagation();
+			const path =
+				activeTab?.type === "editor"
+					? activeTab.filePath
+					: useEditorStore.getState().activeFilePath;
+			if (path) {
+				void requestSaveEditorFile(path);
+			}
+		};
+
+		window.addEventListener("keydown", handleSaveShortcut, { capture: true });
+		return () =>
+			window.removeEventListener("keydown", handleSaveShortcut, { capture: true });
+	}, [activeTab]);
+
 	useEffect(() => {
 		const handleKeyDown = (e: KeyboardEvent) => {
+			if (isSaveFileShortcut(e)) return;
+
 			// Safety net: skip workspace handling when an earlier handler has already
 			// processed this event by calling preventDefault() — e.g. xterm clipboard
 			// ops or ConnectedTerminal's customKeyEventHandler for terminal-owned keys.
@@ -720,15 +743,6 @@ export default function WorkspaceLayout(): React.JSX.Element {
 
 			const { isInEditor, isInTerminal, isInInput } =
 				getShortcutTargetContext(e.target);
-
-			// Save File (Ctrl+S / ⌘+S) — should work even in editors
-			if (matchesShortcut(e, getActiveKey("saveFile"))) {
-				e.preventDefault();
-				if (activeTab?.type === "editor") {
-					useEditorStore.getState().saveFile(activeTab.filePath);
-				}
-				return;
-			}
 
 			// Close Tab (Ctrl+W / ⌘+W)
 			// On macOS: ⌘+W closes tab, Ctrl+W is forwarded to shell (backward-kill-word)

--- a/src/renderer/lib/editor-content-flush.test.ts
+++ b/src/renderer/lib/editor-content-flush.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import {
+  flushEditorContent,
+  registerEditorContentFlusher,
+  unregisterEditorContentFlusher
+} from './editor-content-flush'
+
+describe('editor-content-flush', () => {
+  const path = '/project/readme.md'
+
+  beforeEach(() => {
+    unregisterEditorContentFlusher(path)
+  })
+
+  it('invokes registered flusher for path', async () => {
+    const flush = vi.fn()
+    registerEditorContentFlusher(path, flush)
+
+    await flushEditorContent(path)
+
+    expect(flush).toHaveBeenCalledOnce()
+  })
+
+  it('awaits async flushers', async () => {
+    const order: string[] = []
+    registerEditorContentFlusher(path, async () => {
+      await Promise.resolve()
+      order.push('flush')
+    })
+
+    await flushEditorContent(path)
+    order.push('after')
+
+    expect(order).toEqual(['flush', 'after'])
+  })
+
+  it('no-ops when no flusher is registered', async () => {
+    await expect(flushEditorContent(path)).resolves.toBeUndefined()
+  })
+})

--- a/src/renderer/lib/editor-content-flush.ts
+++ b/src/renderer/lib/editor-content-flush.ts
@@ -1,0 +1,21 @@
+export type EditorContentFlusher = () => void | Promise<void>
+
+const flushersByPath = new Map<string, EditorContentFlusher>()
+
+export function registerEditorContentFlusher(
+  path: string,
+  flush: EditorContentFlusher,
+): void {
+  flushersByPath.set(path, flush)
+}
+
+export function unregisterEditorContentFlusher(path: string): void {
+  flushersByPath.delete(path)
+}
+
+/** Sync live editor buffer into the store before read-only save paths run. */
+export async function flushEditorContent(path: string): Promise<void> {
+  const flush = flushersByPath.get(path)
+  if (!flush) return
+  await flush()
+}

--- a/src/renderer/lib/editor-save.ts
+++ b/src/renderer/lib/editor-save.ts
@@ -1,0 +1,29 @@
+import { toast } from 'sonner'
+import { useEditorStore } from '@/stores/editor-store'
+import { useKeyboardShortcutsStore, matchesShortcut } from '@/stores/keyboard-shortcuts-store'
+
+export function getEditorFileBaseName(filePath: string): string {
+  const parts = filePath.split(/[\\/]/)
+  return parts[parts.length - 1] || filePath
+}
+
+export function getSaveFileShortcutKey(): string {
+  const shortcut = useKeyboardShortcutsStore.getState().shortcuts.saveFile
+  return shortcut?.customKey ?? shortcut?.defaultKey ?? 'ctrl+s'
+}
+
+export function isSaveFileShortcut(event: KeyboardEvent): boolean {
+  return matchesShortcut(event, getSaveFileShortcutKey())
+}
+
+/** Flush live editor buffer (if mounted) and persist the file. */
+export async function requestSaveEditorFile(filePath: string): Promise<boolean> {
+  const fileName = getEditorFileBaseName(filePath)
+  const saved = await useEditorStore.getState().saveFile(filePath)
+  if (saved) {
+    toast.success(`${fileName} saved`)
+  } else {
+    toast.error(`Failed to save ${fileName}`)
+  }
+  return saved
+}

--- a/src/renderer/lib/editor-save.ts
+++ b/src/renderer/lib/editor-save.ts
@@ -19,11 +19,16 @@ export function isSaveFileShortcut(event: KeyboardEvent): boolean {
 /** Flush live editor buffer (if mounted) and persist the file. */
 export async function requestSaveEditorFile(filePath: string): Promise<boolean> {
   const fileName = getEditorFileBaseName(filePath)
-  const saved = await useEditorStore.getState().saveFile(filePath)
-  if (saved) {
-    toast.success(`${fileName} saved`)
-  } else {
+  try {
+    const saved = await useEditorStore.getState().saveFile(filePath)
+    if (saved) {
+      toast.success(`${fileName} saved`)
+    } else {
+      toast.error(`Failed to save ${fileName}`)
+    }
+    return saved
+  } catch {
     toast.error(`Failed to save ${fileName}`)
+    return false
   }
-  return saved
 }

--- a/src/renderer/lib/editor-self-save.test.ts
+++ b/src/renderer/lib/editor-self-save.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest'
+import {
+  consumeEditorSelfSave,
+  markEditorSelfSave
+} from './editor-self-save'
+
+describe('editor-self-save', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('consumes a recent self-save once', () => {
+    markEditorSelfSave('/project/readme.md')
+    expect(consumeEditorSelfSave('/project/readme.md')).toBe(true)
+    expect(consumeEditorSelfSave('/project/readme.md')).toBe(false)
+  })
+
+  it('does not consume after grace period', () => {
+    markEditorSelfSave('/project/readme.md')
+    vi.advanceTimersByTime(4000)
+    expect(consumeEditorSelfSave('/project/readme.md')).toBe(false)
+  })
+})

--- a/src/renderer/lib/editor-self-save.ts
+++ b/src/renderer/lib/editor-self-save.ts
@@ -1,0 +1,14 @@
+const SELF_SAVE_GRACE_MS = 3000
+const selfSavedAtByPath = new Map<string, number>()
+
+export function markEditorSelfSave(filePath: string): void {
+  selfSavedAtByPath.set(filePath, Date.now())
+}
+
+/** True when the file change event is from our own save (consume one-shot). */
+export function consumeEditorSelfSave(filePath: string): boolean {
+  const savedAt = selfSavedAtByPath.get(filePath)
+  if (savedAt === undefined) return false
+  selfSavedAtByPath.delete(filePath)
+  return Date.now() - savedAt <= SELF_SAVE_GRACE_MS
+}

--- a/src/renderer/stores/editor-store.save-flush.test.ts
+++ b/src/renderer/stores/editor-store.save-flush.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { useEditorStore } from './editor-store'
+
+vi.mock('@/lib/api', () => ({
+  filesystemApi: {
+    getFileInfo: vi.fn(),
+    readFile: vi.fn(),
+    writeFile: vi.fn()
+  }
+}))
+
+vi.mock('@/lib/editor-content-flush', () => ({
+  flushEditorContent: vi.fn()
+}))
+
+import { filesystemApi } from '@/lib/api'
+import { flushEditorContent } from '@/lib/editor-content-flush'
+
+describe('editor-store saveFile', () => {
+  const path = '/project/file.ts'
+
+  beforeEach(() => {
+    vi.mocked(flushEditorContent).mockReset()
+    vi.mocked(flushEditorContent).mockResolvedValue(undefined)
+    vi.mocked(filesystemApi.writeFile).mockReset()
+    vi.mocked(filesystemApi.writeFile).mockResolvedValue({ success: true, data: undefined })
+
+    useEditorStore.setState({
+      openFiles: new Map([
+        [
+          path,
+          {
+            filePath: path,
+            content: 'latest',
+            originalContent: 'original',
+            isDirty: true,
+            language: 'typescript',
+            lastModified: 0,
+            viewMode: 'code',
+            cursorPosition: { line: 1, col: 1 },
+            scrollTop: 0,
+            operationStatus: 'idle'
+          }
+        ]
+      ]),
+      activeFilePath: path
+    })
+  })
+
+  it('flushes editor content before writing to disk', async () => {
+    vi.mocked(flushEditorContent).mockImplementation(async () => {
+      useEditorStore.getState().updateContent(path, 'flushed-latest')
+    })
+
+    const saved = await useEditorStore.getState().saveFile(path)
+
+    expect(flushEditorContent).toHaveBeenCalledWith(path)
+    expect(filesystemApi.writeFile).toHaveBeenCalledWith(path, 'flushed-latest')
+    expect(saved).toBe(true)
+    expect(useEditorStore.getState().openFiles.get(path)?.isDirty).toBe(false)
+  })
+})

--- a/src/renderer/stores/editor-store.save-flush.test.ts
+++ b/src/renderer/stores/editor-store.save-flush.test.ts
@@ -56,6 +56,10 @@ describe('editor-store saveFile', () => {
 
     expect(flushEditorContent).toHaveBeenCalledWith(path)
     expect(filesystemApi.writeFile).toHaveBeenCalledWith(path, 'flushed-latest')
+    expect(filesystemApi.writeFile).toHaveBeenCalledTimes(1)
+    expect(vi.mocked(flushEditorContent).mock.invocationCallOrder[0]).toBeLessThan(
+      vi.mocked(filesystemApi.writeFile).mock.invocationCallOrder[0]
+    )
     expect(saved).toBe(true)
     expect(useEditorStore.getState().openFiles.get(path)?.isDirty).toBe(false)
   })

--- a/src/renderer/stores/editor-store.ts
+++ b/src/renderer/stores/editor-store.ts
@@ -2,6 +2,8 @@ import { create } from 'zustand'
 import { useShallow } from 'zustand/shallow'
 import { toast } from 'sonner'
 import { filesystemApi } from '@/lib/api'
+import { flushEditorContent } from '@/lib/editor-content-flush'
+import { markEditorSelfSave } from '@/lib/editor-self-save'
 
 const EDITOR_TAB_LIMIT = 15
 
@@ -54,7 +56,7 @@ export interface EditorFileState {
   viewMode: 'code' | 'markdown'
   cursorPosition: { line: number; col: number }
   scrollTop: number
-  operationStatus: 'idle' | 'saving' | 'reloading'
+  operationStatus: 'idle' | 'saving' | 'reloading' | 'saved'
 }
 
 export interface EditorState {
@@ -205,6 +207,8 @@ export const useEditorStore = create<EditorState>((set, get) => ({
   },
 
   saveFile: async (path: string): Promise<boolean> => {
+    await flushEditorContent(path)
+
     const { openFiles } = get()
     const file = openFiles.get(path)
     if (!file) return false
@@ -237,9 +241,23 @@ export const useEditorStore = create<EditorState>((set, get) => ({
         originalContent: current.content,
         isDirty: !bufferUnchanged,
         lastModified: Date.now(),
-        operationStatus: 'idle'
+        operationStatus: 'saved'
       })
       set({ openFiles: updatedFiles })
+      markEditorSelfSave(path)
+
+      window.setTimeout(() => {
+        const latest = get().openFiles.get(path)
+        if (latest?.operationStatus === 'saved') {
+          const resetFiles = new Map(get().openFiles)
+          const entry = resetFiles.get(path)
+          if (entry) {
+            resetFiles.set(path, { ...entry, operationStatus: 'idle' })
+            set({ openFiles: resetFiles })
+          }
+        }
+      }, 1500)
+
       return true
     } catch {
       const resetFiles = new Map(get().openFiles)


### PR DESCRIPTION
## Summary

Fixes Ctrl+S not persisting editor changes, especially in markdown WYSIWYG preview. Saves now flush live editor buffers before writing, work from BlockNote and CodeMirror, and show a clear per-file saved toast without prompting to reload after our own save.

## Related Issue

Closes #213

## Type of Change

- [x] fix: bug fix
- [ ] feat: new feature
- [ ] docs: documentation only
- [ ] style: formatting or non-functional styling changes
- [ ] refactor: internal cleanup with no behavior change
- [ ] perf: performance improvement
- [x] test: adds or updates tests
- [ ] build: build or dependency changes
- [ ] ci: CI/CD workflow changes
- [ ] chore: maintenance or tooling
- [ ] revert: reverts a previous change

## What Changed

- Added editor content flush registry so `saveFile` persists the latest CodeMirror/BlockNote buffer (not stale debounced store state).
- Bound `Mod-s` in CodeMirror and BlockNote; workspace save shortcut runs in capture phase.
- Toast shows `{filename} saved` on success; self-save file watcher events reload quietly without the external-change Reload prompt.

## How It Was Tested

- [ ] `bun run lint`
- [ ] `bun run typecheck`
- [x] `bun run test`
- [x] Manual verification completed
- [ ] Not applicable

## Screenshots or Recordings

N/A (keyboard shortcut and toast behavior).

## Checklist

- [x] My PR title follows the conventional commit format used by this repo
- [x] I linked the related issue or explained why none exists
- [ ] I updated docs when needed
- [x] I added or updated tests when needed
- [x] I verified the change does not introduce unrelated modifications

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added keyboard shortcut support (Ctrl+S/⌘+S) to save files
  * File-specific "saved" status indicator displayed when files are saved

* **Bug Fixes**
  * Improved handling of external file changes to prevent overwriting user-initiated saves

<!-- end of auto-generated comment: release notes by coderabbit.ai -->