### PR TITLE
fix(git): restore staging controls after editor tab overlay (#217)

### DIFF
--- a/src/renderer/components/git/GitPanel.tsx
+++ b/src/renderer/components/git/GitPanel.tsx
@@ -704,7 +704,7 @@ function SectionHeader({
           </span>
         )}
       </div>
-      <div className="flex items-center gap-0.5 opacity-0 group-hover/section:opacity-100 focus-within:opacity-100 transition-opacity">
+      <div className="flex items-center gap-0.5 opacity-60 group-hover/section:opacity-100 focus-within:opacity-100 transition-opacity">
         {children}
       </div>
     </div>
@@ -823,7 +823,14 @@ function FileItem({ file, isActive, isSelected, onClick, icon, children }: {
         <span className="text-[11px] font-medium truncate leading-tight">{fileName}</span>
         {dirName && <span className="text-[9px] truncate opacity-50 leading-tight">{dirName}</span>}
       </div>
-      <div className="flex items-center gap-0.5 opacity-0 group-hover/row:opacity-100 focus-within:opacity-100 transition-opacity">
+      <div
+        className={cn(
+          "flex items-center gap-0.5 transition-opacity focus-within:opacity-100",
+          isSelected || isActive
+            ? "opacity-100"
+            : "opacity-60 group-hover/row:opacity-100",
+        )}
+      >
         {children}
       </div>
       <div className={cn(

--- a/src/renderer/components/workspace/PaneContent.tsx
+++ b/src/renderer/components/workspace/PaneContent.tsx
@@ -21,6 +21,10 @@ import { shellApi } from "@/lib/api";
 // Import useShallow for selective re-rendering
 import { useShallow } from "zustand/shallow";
 
+/** Inactive tabs stay mounted but must not intercept clicks on the active tab beneath. */
+const INACTIVE_TAB_PANE_CLASS =
+	"w-full h-full absolute inset-0 invisible pointer-events-none";
+
 interface PaneContentProps {
 	pane: LeafNode;
 	onAddTerminal?: (paneId: string, shell?: ShellInfo) => void;
@@ -271,7 +275,7 @@ export function PaneContent({
 										className={cn(
 											isVisible
 												? "w-full h-full"
-												: "w-full h-full absolute inset-0 invisible",
+												: INACTIVE_TAB_PANE_CLASS,
 											// In-app highlight: ring the whole terminal content when its
 											// process finished while unfocused. Distinct amber accent,
 											// inset so it stays inside the pane and clear of the
@@ -310,9 +314,7 @@ export function PaneContent({
 									<div
 										key={tab.id}
 										className={
-											isVisible
-												? "w-full h-full"
-												: "w-full h-full absolute inset-0 invisible"
+											isVisible ? "w-full h-full" : INACTIVE_TAB_PANE_CLASS
 										}
 									>
 										<EditorPanel
@@ -334,9 +336,7 @@ export function PaneContent({
 									<div
 										key={tab.id}
 										className={
-											isVisible
-												? "w-full h-full"
-												: "w-full h-full absolute inset-0 invisible"
+											isVisible ? "w-full h-full" : INACTIVE_TAB_PANE_CLASS
 										}
 									>
 										<BrowserPanel
@@ -358,9 +358,7 @@ export function PaneContent({
 									<div
 										key={tab.id}
 										className={
-											isVisible
-												? "w-full h-full"
-												: "w-full h-full absolute inset-0 invisible"
+											isVisible ? "w-full h-full" : INACTIVE_TAB_PANE_CLASS
 										}
 									>
 										<GitPanel cwd={tab.cwd} isVisible={isVisible} />
@@ -379,9 +377,7 @@ export function PaneContent({
 									<div
 										key={tab.id}
 										className={
-											isVisible
-												? "w-full h-full"
-												: "w-full h-full absolute inset-0 invisible"
+											isVisible ? "w-full h-full" : INACTIVE_TAB_PANE_CLASS
 										}
 									>
 										<GitHistoryPanel cwd={tab.cwd} isVisible={isVisible} />


### PR DESCRIPTION
## Summary

Fixes git panel stage/unstage controls appearing missing or unclickable after staging a file and editing another file in the same pane (issue #217).

## Related Issue

Closes #217

## Type of Change

- [ ] feat: new feature
- [x] fix: bug fix
- [ ] docs: documentation only
- [ ] style: formatting or non-functional styling changes
- [ ] refactor: internal cleanup with no behavior change
- [ ] perf: performance improvement
- [ ] test: adds or updates tests
- [ ] build: build or dependency changes
- [ ] ci: CI/CD workflow changes
- [ ] chore: maintenance or tooling
- [ ] revert: reverts a previous change

## What Changed

- **`PaneContent.tsx`**: Inactive tab shells (terminal, editor, browser, git, git-history) use `pointer-events-none` so hidden absolute overlays cannot block clicks on the active tab below.
- **`GitPanel.tsx`**: Row stage/unstage/discard actions stay visible at reduced opacity (`opacity-60`), full opacity when the row is selected or active; section header actions use the same partial visibility default.

## How It Was Tested

- [x] `bun run lint`
- [ ] `bun run typecheck`
- [ ] `bun run test`
- [x] Manual verification completed
- [ ] Not applicable

## Screenshots or Recordings

<!-- UI change is subtle (controls visible at 60% opacity; pointer-events fix). Manual repro: stage file in Git Changes, edit another file in same pane, return to Git Changes — actions clickable. -->

## Checklist

- [x] My PR title follows the conventional commit format used by this repo
- [x] I linked the related issue or explained why none exists
- [ ] I updated docs when needed
- [ ] I added or updated tests when needed
- [x] I verified the change does not introduce unrelated modifications
