### PR TITLE
fix(terminal): clear sidebar activity indicator on tab unmount (#218)

### DIFF
--- a/src/renderer/components/terminal/ConnectedTerminal.test.tsx
+++ b/src/renderer/components/terminal/ConnectedTerminal.test.tsx
@@ -777,6 +777,41 @@ describe('ConnectedTerminal', () => {
     expect(cleanupFn).toHaveBeenCalled()
   })
 
+  it('should clear terminal activity indicator on unmount', async () => {
+    mockTerminalStoreState.terminals = [
+      { id: 'store-term-1', ptyId: 'terminal-123', healthStatus: 'running' },
+    ]
+    mockTerminalStoreState.findTerminalByPtyId.mockImplementation((ptyId: string) =>
+      ptyId === 'terminal-123'
+        ? { id: 'store-term-1', ptyId: 'terminal-123', healthStatus: 'running' }
+        : undefined,
+    )
+
+    const { unmount } = render(<ConnectedTerminal storeTerminalId="store-term-1" />)
+
+    await vi.waitFor(() => {
+      expect(vi.mocked(terminalApi).spawn).toHaveBeenCalled()
+    })
+
+    expect(capturedDataCallback).toBeTruthy()
+    capturedDataCallback!('terminal-123', new TextEncoder().encode('x'))
+
+    expect(mockTerminalStoreState.updateTerminalActivityBatch).toHaveBeenCalledWith(
+      'store-term-1',
+      true,
+      expect.any(Number),
+    )
+
+    mockTerminalStoreState.updateTerminalActivityBatch.mockClear()
+    unmount()
+
+    expect(mockTerminalStoreState.updateTerminalActivityBatch).toHaveBeenCalledWith(
+      'store-term-1',
+      false,
+      expect.any(Number),
+    )
+  })
+
   it('should set up resize hook on mount', async () => {
     render(<ConnectedTerminal />)
 

--- a/src/renderer/components/terminal/ConnectedTerminal.tsx
+++ b/src/renderer/components/terminal/ConnectedTerminal.tsx
@@ -266,6 +266,30 @@ function ConnectedTerminalComponent({
 	const pendingActivityUpdateRef = useRef<{ id: string } | null>(null);
 	const lastClipboardOpRef = useRef<number>(0);
 
+	/** Clear sidebar activity indicator when this view unmounts (e.g. tab switch). */
+	const clearTerminalActivityOnUnmount = useCallback((): void => {
+		if (activityTimeoutRef.current) {
+			clearTimeout(activityTimeoutRef.current);
+			activityTimeoutRef.current = null;
+		}
+		pendingActivityUpdateRef.current = null;
+		lastActivityUpdateRef.current = 0;
+
+		const store = useTerminalStore.getState();
+		const storeTerminalId =
+			(ptyIdRef.current
+				? store.findTerminalByPtyId(ptyIdRef.current)?.id
+				: undefined) ??
+			(targetId
+				? (store.terminals.find((t) => t.id === targetId)?.id ??
+					store.findTerminalByPtyId(targetId)?.id)
+				: undefined);
+
+		if (storeTerminalId) {
+			store.updateTerminalActivityBatch(storeTerminalId, false, Date.now());
+		}
+	}, [targetId]);
+
 	// Two-stage resize pipeline: 8ms fit debounce + 256ms PTY resize debounce
 	const handlePtyResize = useCallback(
 		async (cols: number, rows: number): Promise<void> => {
@@ -1218,21 +1242,7 @@ function ConnectedTerminalComponent({
 				cleanupExitListenerRef.current = null;
 			}
 
-			// Clean up activity timeout timer
-			if (activityTimeoutRef.current) {
-				clearTimeout(activityTimeoutRef.current);
-			}
-			// Flush pending activity update on unmount
-			if (pendingActivityUpdateRef.current) {
-				useTerminalStore
-					.getState()
-					.updateTerminalActivityBatch(
-						pendingActivityUpdateRef.current.id,
-						true,
-						Date.now(),
-					);
-				pendingActivityUpdateRef.current = null;
-			}
+			clearTerminalActivityOnUnmount();
 			// Cursor cleanup: Disable cursor blink before WebGL disposal to prevent ghost cursors
 			if (terminalRef.current) {
 				terminalRef.current.options.cursorBlink = false;
@@ -1660,11 +1670,11 @@ function ConnectedTerminalComponent({
 			if (cleanupDataListenerRef.current) cleanupDataListenerRef.current();
 			if (cleanupExitListenerRef.current) cleanupExitListenerRef.current();
 
-			if (activityTimeoutRef.current) clearTimeout(activityTimeoutRef.current);
+			clearTerminalActivityOnUnmount();
 			disposeWebglAddon(); terminal.dispose(); terminalRef.current = null; setTerminalInstance(null);
 			didInitRef.current = false; initializedTerminalIdRef.current = undefined;
 		};
-	}, [targetId, autoSpawn, rendererPreference, fontFamily, fontSize, bufferSize, instanceId, externalTerminalId, autoFocus, handleTerminalData, handlePtyResize, setTerminalHealthStatus, disposeWebglAddon]);
+	}, [targetId, autoSpawn, rendererPreference, fontFamily, fontSize, bufferSize, instanceId, externalTerminalId, autoFocus, handleTerminalData, handlePtyResize, setTerminalHealthStatus, disposeWebglAddon, clearTerminalActivityOnUnmount]);
 
 	const isCrashed = healthStatus === "disconnected" || healthStatus === "crashed";
 


### PR DESCRIPTION
## Summary

- Fix project sidebar loading spinner (`Loader2`) staying on when terminals are idle after tab switches or with multiple terminals open.
- Unmount cleanup now clears debounced activity state and sets `hasActivity` to `false` instead of incorrectly flushing pending updates as active.

## Related Issue

Closes #218

## Type of Change

- [ ] feat: new feature
- [x] fix: bug fix
- [ ] docs: documentation only
- [ ] style: formatting or non-functional styling changes
- [ ] refactor: internal cleanup with no behavior change
- [ ] perf: performance improvement
- [x] test: adds or updates tests
- [ ] build: build or dependency changes
- [ ] ci: CI/CD workflow changes
- [ ] chore: maintenance or tooling
- [ ] revert: reverts a previous change

## What Changed

- Added `clearTerminalActivityOnUnmount()` in `ConnectedTerminal.tsx` to cancel activity timers, discard pending debounce, and set `hasActivity` false for the store terminal on unmount.
- Wired the helper into both terminal init `useEffect` cleanup paths (fixes tab-switch leaving the project activity indicator stuck).
- Added regression test: unmount clears activity after simulated PTY output.

## How It Was Tested

- [ ] `bun run lint`
- [ ] `bun run typecheck`
- [ ] `bun run test`
- [ ] Manual verification completed
- [x] Not applicable

## Screenshots or Recordings

<!-- Required for UI changes when applicable -->

N/A — sidebar spinner behavior fix; no visual asset attached.

## Checklist

- [x] My PR title follows the conventional commit format used by this repo
- [x] I linked the related issue or explained why none exists
- [ ] I updated docs when needed
- [x] I added or updated tests when needed
- [x] I verified the change does not introduce unrelated modifications
