### PR TITLE
fix(sidebar): restore project drag-to-reorder (#242)

### DIFF
--- a/src/renderer/components/ProjectSidebar.tsx
+++ b/src/renderer/components/ProjectSidebar.tsx
@@ -1086,7 +1086,7 @@ export function ProjectSidebar({
                     <Reorder.Item
                       key={group.id}
                       value={groupEntry}
-                      drag={isSearching ? false : "y"}
+                      drag={isSearching ? false : 'y'}
                       layout="position"
                       className="list-none"
                     >
@@ -1170,7 +1170,7 @@ export function ProjectSidebar({
                                 <Reorder.Item
                                   key={project.id}
                                   value={project}
-                                  drag={isSearching ? false : "y"}
+                                  drag={isSearching ? false : 'y'}
                                   layout="position"
                                   className="list-none"
                                   whileDrag={{
@@ -1257,7 +1257,7 @@ export function ProjectSidebar({
                       <Reorder.Item
                         key={project.id}
                         value={project}
-                        drag={isSearching ? false : "y"}
+                        drag={isSearching ? false : 'y'}
                         layout="position"
                         className="list-none"
                         whileDrag={{

--- a/src/renderer/components/ProjectSidebar.tsx
+++ b/src/renderer/components/ProjectSidebar.tsx
@@ -1706,7 +1706,7 @@ const ProjectItem = memo(function ProjectItem({
           }
         }}
         className={cn(
-          'w-full flex items-center px-0 py-1 transition-colors group text-left border-l-2 cursor-pointer',
+          'w-full flex items-center px-0 py-1 transition-colors group text-left border-l-2 cursor-pointer select-none',
           isActive
             ? `${colors.border} bg-sidebar-accent`
             : `${colors.borderMuted} hover:bg-sidebar-accent/50`

--- a/src/renderer/components/ProjectSidebar.tsx
+++ b/src/renderer/components/ProjectSidebar.tsx
@@ -1086,7 +1086,7 @@ export function ProjectSidebar({
                     <Reorder.Item
                       key={group.id}
                       value={groupEntry}
-                      drag={isSearching ? false : undefined}
+                      drag={isSearching ? false : "y"}
                       layout="position"
                       className="list-none"
                     >
@@ -1170,7 +1170,7 @@ export function ProjectSidebar({
                                 <Reorder.Item
                                   key={project.id}
                                   value={project}
-                                  drag={isSearching ? false : undefined}
+                                  drag={isSearching ? false : "y"}
                                   layout="position"
                                   className="list-none"
                                   whileDrag={{
@@ -1257,7 +1257,7 @@ export function ProjectSidebar({
                       <Reorder.Item
                         key={project.id}
                         value={project}
-                        drag={isSearching ? false : undefined}
+                        drag={isSearching ? false : "y"}
                         layout="position"
                         className="list-none"
                         whileDrag={{

--- a/src/renderer/components/ProjectSidebar.tsx
+++ b/src/renderer/components/ProjectSidebar.tsx
@@ -1079,12 +1079,13 @@ export function ProjectSidebar({
                 className="flex flex-col gap-1"
                 data-testid="grouped-projects-container"
               >
-                {visibleGroups.map(({ group, projects: gpProjects }) => {
+                {visibleGroups.map((groupEntry) => {
+                  const { group, projects: gpProjects } = groupEntry
                   const isCollapsed = group.isCollapsed
                   return (
                     <Reorder.Item
                       key={group.id}
-                      value={{ group, projects: gpProjects }}
+                      value={groupEntry}
                       drag={isSearching ? false : undefined}
                       layout="position"
                       className="list-none"


### PR DESCRIPTION
## Summary

- Fixes project sidebar drag-to-reorder, which was completely broken: dragging a project row selected the name text instead of moving it, and no row or group folder could be reordered.

## Related Issue

Closes #242

## Type of Change

- [x] fix: bug fix

## What Changed

Three layered defects, fixed in order of discovery:

1. **`drag` prop disabled by spread order (the dominant blocker).** `Reorder.Item` passed `drag={isSearching ? false : undefined}`. In framer-motion `12.26.2`, `Reorder/Item.mjs` renders `<Component drag={axis} {...props} ...>` — spreading `props` *after* the default `drag: axis`. When not searching, `props.drag === undefined` overwrote the library default, leaving `drag={undefined}` and disabling dragging on **every** project row and group folder. Now passes `drag="y"` (matching `axis`) so the explicit prop no longer clobbers the default; `drag={false}` while searching still disables reorder. This is the version-bump regression, not a code change in #227.
2. **Grouped `Reorder.Item` value identity.** The grouped item received a freshly built object literal (`value={{ group, projects }}`) every render, which never reference-matched the entries in the group's `values` array. Framer tracks items by reference identity, so group-folder reorder silently no-opped. Now passes the actual `visibleGroups` array entry (`value={groupEntry}`).
3. **Missing `select-none`.** The project row container lacked `select-none` (unlike the group folder header), so press-drag triggered native text selection. Added `select-none` to the row.

**Files:** `src/renderer/components/ProjectSidebar.tsx`

## How It Was Tested

- [x] `bun run typecheck`
- [x] `bun run test` (52/52 `ProjectSidebar.test.tsx` pass)
- [ ] Manual verification completed
- [x] Not applicable

> Note: lint shows only pre-existing warnings unrelated to this change. Manual drag verification in a dev build is recommended before merge.

## Screenshots or Recordings

<!-- Required for UI changes when applicable -->

## Checklist

- [x] My PR title follows the conventional commit format used by this repo
- [x] I linked the related issue or explained why none exists
- [ ] I updated docs when needed
- [x] I added or updated tests when needed
- [x] I verified the change does not introduce unrelated modifications


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Enhanced drag-and-drop responsiveness for project lists when not searching.
  * More consistent grouped-project behavior for smoother reordering and display.
  * Improved project-item interaction styling to prevent accidental text selection and provide clearer hover/click feedback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->