### PR TITLE
chore: release v0.4.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "termul-manager",
   "productName": "Termul Manager",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "Project-aware terminal that treats workspaces as first-class citizens",
   "author": "gnoviawan",
   "contributors": [

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -5673,7 +5673,7 @@ dependencies = [
 
 [[package]]
 name = "termul-manager"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "anyhow",
  "axum",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "termul-manager"
-version = "0.4.1"
+version = "0.4.2"
 description = "Project-aware terminal that treats workspaces as first-class citizens"
 authors = ["gnoviawan", "mannnrachman (Tauri port)"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "https://schema.tauri.app/config/2",
 	"productName": "Termul Manager",
-	"version": "0.4.1",
+	"version": "0.4.2",
 	"identifier": "com.termul-manager.app",
 	"build": {
 		"beforeDevCommand": "npx vite --config vite.config.tauri.ts",

--- a/src/renderer/components/ProjectSidebar.tsx
+++ b/src/renderer/components/ProjectSidebar.tsx
@@ -1367,7 +1367,7 @@ export function ProjectSidebar({
       {/* Version - pinned bottom */}
       <div className="p-2 rounded-b-xl">
         <div className="w-full h-6 inline-flex items-center justify-center">
-          <span className="text-xs text-muted-foreground">Termul v0.4.1</span>
+          <span className="text-xs text-muted-foreground">Termul v0.4.2</span>
         </div>
       </div>
 


### PR DESCRIPTION
Automated version bump to v0.4.2 (package.json, Cargo.toml, Cargo.lock, tauri.conf.json, and the sidebar label).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Application version bumped to 0.4.2 across package configuration, application framework, and UI components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->