### PR TITLE
fix(a11y): add explicit button type attributes to UI components

### DIFF
--- a/src/renderer/components/ActivityRail.tsx
+++ b/src/renderer/components/ActivityRail.tsx
@@ -117,6 +117,7 @@ export function ActivityRail({
       <div className="w-6 h-px bg-border/60 my-1" aria-hidden="true" />
 
       <button
+        type="button"
         onClick={(e) => {
           e.stopPropagation()
           onOpenCommandPalette?.()
@@ -130,6 +131,7 @@ export function ActivityRail({
       </button>
 
       <button
+        type="button"
         onClick={(e) => {
           e.stopPropagation()
           onOpenGitChanges?.()
@@ -146,6 +148,7 @@ export function ActivityRail({
       </button>
 
       <button
+        type="button"
         onClick={(e) => {
           e.stopPropagation()
           onOpenGitHistory?.()
@@ -162,6 +165,7 @@ export function ActivityRail({
       </button>
 
       <button
+        type="button"
         onClick={(e) => {
           void handleToggleSSHPanel(e)
         }}
@@ -178,6 +182,7 @@ export function ActivityRail({
 
       <div className="mt-auto flex flex-col items-center pb-1">
         <button
+          type="button"
           onClick={(e) => {
             void handleToggleSidebar(e)
           }}
@@ -193,6 +198,7 @@ export function ActivityRail({
         </button>
 
         <button
+          type="button"
           onClick={(e) => {
             void handleToggleFileExplorer(e)
           }}
@@ -214,6 +220,7 @@ export function ActivityRail({
         />
 
         <button
+          type="button"
           onClick={(e) => {
             e.stopPropagation()
             navigate('/preferences')

--- a/src/renderer/components/AiPromptDialog.tsx
+++ b/src/renderer/components/AiPromptDialog.tsx
@@ -93,6 +93,7 @@ export function AiPromptDialog({ isOpen, onClose, context }: AiPromptDialogProps
             AI Conflict Resolution Prompts
           </h2>
           <button
+            type="button"
             onClick={onClose}
             className="h-6 w-6 flex items-center justify-center rounded hover:bg-secondary text-muted-foreground"
             aria-label="Close"
@@ -111,6 +112,7 @@ export function AiPromptDialog({ isOpen, onClose, context }: AiPromptDialogProps
               const TplIcon = TOOL_ICONS[tpl.toolName] ?? MessageSquare
               return (
                 <button
+                  type="button"
                   key={tpl.id}
                   onClick={() => setSelectedTemplate(tpl)}
                   className={cn(
@@ -146,6 +148,7 @@ export function AiPromptDialog({ isOpen, onClose, context }: AiPromptDialogProps
             Variables: {selectedTemplate.variables.join(', ')}
           </span>
           <button
+            type="button"
             onClick={handleCopy}
             disabled={!generatedPrompt}
             className={cn(

--- a/src/renderer/components/ColorPickerPopover.tsx
+++ b/src/renderer/components/ColorPickerPopover.tsx
@@ -80,6 +80,7 @@ export function ColorPickerPopover({
           const colors = getColorClasses(color)
           return (
             <button
+              type="button"
               key={color}
               onClick={() => {
                 onSelectColor(color)

--- a/src/renderer/components/CommandHistoryModal.tsx
+++ b/src/renderer/components/CommandHistoryModal.tsx
@@ -242,6 +242,7 @@ export function CommandHistoryModal({
                 </span>
               </div>
               <button
+                type="button"
                 onClick={() => setShowClearConfirm(true)}
                 className="flex items-center gap-1 px-2 py-1 rounded hover:bg-secondary/50 text-red-400 hover:text-red-300 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
                 disabled={entries.length === 0 || filterMode !== 'this-project' || isClearing}


### PR DESCRIPTION
## Problem

Found 12 buttons across the codebase that were missing explicit `type` attributes. This causes a couple of issues:

**The default behavior problem**: When you write `<button onClick={...}>`, browsers assume `type="submit"` by default. That's fine if you're in a form and actually want to submit it, but for UI navigation buttons (opening panels, toggling views, etc.), it can cause unexpected form submissions if the button happens to be inside a form element somewhere up the DOM tree.

**Accessibility compliance**: WCAG 2.1 recommends being explicit about button types. Screen readers and assistive tech work better when the semantic purpose of a button is clear. A `type="button"` signals "this is for interaction, not form submission."

**Code quality**: Biome lint was flagging all of these with `lint/a11y/useButtonType` warnings. Not critical, but cleaning them up makes the codebase healthier.

## What Changed

Added `type="button"` to 12 buttons across 4 component files:

### ActivityRail.tsx (7 buttons)
This is the left-side navigation rail. Fixed:
- Projects button (opens command palette)
- Git Changes button
- Git History button  
- SSH panel toggle
- Sidebar toggle
- File explorer toggle
- Preferences button

All of these are pure navigation/toggle actions, so `type="button"` is the right semantic choice.

### AiPromptDialog.tsx (3 buttons)
- Close button (top-right X)
- Template selector buttons (lets you pick which AI tool template to use)
- Copy prompt button (copies generated prompt to clipboard)

The template selector was particularly important to fix since it's technically inside a form-like layout, even though it doesn't submit anything.

### ColorPickerPopover.tsx (1 button)
The individual color swatches in the color picker. Each one is a button that applies a color on click. No form submission involved.

### CommandHistoryModal.tsx (1 button)
The "Clear History" button. This one opens a confirmation dialog, so definitely not a submit action.

## Why This Matters

### 1. Prevents unexpected form submission
If any of these buttons end up rendered inside a `<form>` tag (either now or in future refactors), they won't accidentally trigger submission. This is a defensive programming practice that prevents subtle bugs.

### 2. Accessibility improvements
- **Screen readers** can better understand button purpose
- **Keyboard navigation** behaves more predictably
- **WCAG 2.1 compliance** - meets Level A success criteria for semantic markup

### 3. Code maintainability
- **Clearer intent**: When you read `<button type="button">`, you immediately know it's not a form control
- **Easier refactoring**: Can move buttons around without worrying about form context
- **No more lint warnings**: Clean biome output

## Technical Details

**Before:**
```tsx
<button
  onClick={(e) => {
    e.stopPropagation()
    onOpenGitChanges?.()
  }}
  className={railButtonClass}
  title="Git changes"
>
```

**After:**
```tsx
<button
  type="button"
  onClick={(e) => {
    e.stopPropagation()
    onOpenGitChanges?.()
  }}
  className={railButtonClass}
  title="Git changes"
>
```

Small change, but it clarifies intent and prevents future issues.

## Validation

### Automated checks
- ✅ `bun run typecheck:node` - passes
- ✅ `bun run typecheck:web` - passes  
- ✅ `bun run check` - **0 useButtonType errors** (previously 12)
- ✅ Pre-commit hooks (husky) - all passed

### Manual testing
Clicked through each affected button to verify:
- ✅ Activity rail buttons all work (projects, git, ssh, panels, preferences)
- ✅ AI prompt dialog buttons work (close, template select, copy)
- ✅ Color picker still applies colors correctly
- ✅ Command history clear button still opens confirmation

No changes to behavior. Everything works exactly as before, just with better semantics.

## Impact

**Files changed**: 4  
**Lines changed**: +12 insertions (just adding `type="button"`)  
**Breaking changes**: None  
**Migration needed**: None

This is a pure improvement with zero risk. The buttons behave identically, they're just more semantically correct and safer for future refactoring.

## Related

This aligns with the broader accessibility improvements being made across the codebase. There are still a few label-without-control issues (separate PR coming for those), but this knocks out all the button type warnings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed buttons across multiple dialogs and interface panels to prevent unintended form submission behavior when interacting with action buttons, template selectors, color options, and control buttons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->