### PR TITLE
fix(search): cap search query length to prevent resource exhaustion

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1264,6 +1264,10 @@ fn configure_background_command(command: &mut Command) {
 #[cfg(not(target_os = "windows"))]
 fn configure_background_command(_command: &mut Command) {}
 
+/// Maximum allowed search query length to prevent resource exhaustion via
+/// oversized input passed to ripgrep or the file-name walker.
+const MAX_SEARCH_QUERY_LEN: usize = 500;
+
 fn validated_search_root(scope_root: &str, search_root: &str) -> Result<String, String> {
     path_validation::validate_search_path(search_root, scope_root)
         .map(|path| path.to_string_lossy().to_string())
@@ -1339,6 +1343,29 @@ pub async fn search_content_stream(
                 scanned_files: 0,
                 failed_files: 0,
                 error: None,
+            },
+        );
+        return Ok(IpcResult::success(()));
+    }
+
+    if trimmed_query.len() > MAX_SEARCH_QUERY_LEN {
+        log::warn!(
+            "[Security] Search query rejected: length {} exceeds limit of {}",
+            trimmed_query.len(),
+            MAX_SEARCH_QUERY_LEN
+        );
+        let _ = app_handle.emit(
+            "search-content-done",
+            SearchContentDoneEvent {
+                search_id: request.search_id,
+                truncated: false,
+                scanned_files: 0,
+                failed_files: 0,
+                error: Some(format!(
+                    "Search query too long: {} characters (max {})",
+                    trimmed_query.len(),
+                    MAX_SEARCH_QUERY_LEN
+                )),
             },
         );
         return Ok(IpcResult::success(()));
@@ -1565,6 +1592,22 @@ pub async fn search_file_names(
             files: vec![],
             truncated: false,
         }));
+    }
+
+    if trimmed_query.len() > MAX_SEARCH_QUERY_LEN {
+        log::warn!(
+            "[Security] File name search query rejected: length {} exceeds limit of {}",
+            trimmed_query.len(),
+            MAX_SEARCH_QUERY_LEN
+        );
+        return Ok(IpcResult::error(
+            format!(
+                "Search query too long: {} characters (max {})",
+                trimmed_query.len(),
+                MAX_SEARCH_QUERY_LEN
+            ),
+            "QUERY_TOO_LONG",
+        ));
     }
 
     let validated_root = match validated_search_root(&request.scope_root, &request.root_path) {

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1348,10 +1348,11 @@ pub async fn search_content_stream(
         return Ok(IpcResult::success(()));
     }
 
-    if trimmed_query.len() > MAX_SEARCH_QUERY_LEN {
+    let query_char_count = trimmed_query.chars().count();
+    if query_char_count > MAX_SEARCH_QUERY_LEN {
         log::warn!(
-            "[Security] Search query rejected: length {} exceeds limit of {}",
-            trimmed_query.len(),
+            "[Security] Search query rejected: length {} characters exceeds limit of {}",
+            query_char_count,
             MAX_SEARCH_QUERY_LEN
         );
         let _ = app_handle.emit(
@@ -1363,7 +1364,7 @@ pub async fn search_content_stream(
                 failed_files: 0,
                 error: Some(format!(
                     "Search query too long: {} characters (max {})",
-                    trimmed_query.len(),
+                    query_char_count,
                     MAX_SEARCH_QUERY_LEN
                 )),
             },
@@ -1594,16 +1595,17 @@ pub async fn search_file_names(
         }));
     }
 
-    if trimmed_query.len() > MAX_SEARCH_QUERY_LEN {
+    let query_char_count = trimmed_query.chars().count();
+    if query_char_count > MAX_SEARCH_QUERY_LEN {
         log::warn!(
-            "[Security] File name search query rejected: length {} exceeds limit of {}",
-            trimmed_query.len(),
+            "[Security] File name search query rejected: length {} characters exceeds limit of {}",
+            query_char_count,
             MAX_SEARCH_QUERY_LEN
         );
         return Ok(IpcResult::error(
             format!(
                 "Search query too long: {} characters (max {})",
-                trimmed_query.len(),
+                query_char_count,
                 MAX_SEARCH_QUERY_LEN
             ),
             "QUERY_TOO_LONG",


### PR DESCRIPTION
## Summary

Adds a 500-character limit on search queries passed to both `search_content_stream` (ripgrep content search) and `search_file_names` (filesystem walker). Queries exceeding the limit are rejected early with a clear error message before hitting any subprocess or directory traversal.

## Why

The file search feature takes user input and passes it directly to two different execution paths:

1. **`search_content_stream`** pipes the query to `rg` (ripgrep) as a fixed-string argument. The `-F` flag prevents regex injection, but there's no bound on how much data gets passed. An extremely long query string forces ripgrep to scan every file in scope with a massive pattern, consuming CPU and I/O for no practical benefit.

2. **`search_file_names`** runs a synchronous directory walker that compares each filename against the query. A long query triggers string comparison on every file entry across the entire project tree, blocking the thread.

Neither path currently has an upper bound on query length. A 10,000-character query is unusual enough that no real user would type it, but it's easy to send through the IPC layer. This is a straightforward resource exhaustion vector — not a critical vulnerability, but a gap in the input validation that should be closed.

## Implementation

Added a single constant and validation check to both search commands:

**`src-tauri/src/commands.rs:1267`** — new constant:
```rust
const MAX_SEARCH_QUERY_LEN: usize = 500;
```

500 characters is generous enough for any realistic search pattern (file paths, regex fragments, multi-word queries) while blocking abuse. For reference, the longest file path on Windows is 260 characters, and typical search queries are 5-50 characters.

**`search_content_stream` (line 1351)** — after the empty-query check, before path validation:
```rust
if trimmed_query.len() > MAX_SEARCH_QUERY_LEN {
    log::warn!("[Security] Search query rejected: length {} exceeds limit of {}",
        trimmed_query.len(), MAX_SEARCH_QUERY_LEN);
    // emit error event to renderer, then return
}
```

**`search_file_names` (line 1597)** — same pattern, returns an `IpcResult::error` with code `QUERY_TOO_LONG`:
```rust
if trimmed_query.len() > MAX_SEARCH_QUERY_LEN {
    log::warn!("[Security] File name search query rejected: ...");
    return Ok(IpcResult::error(..., "QUERY_TOO_LONG"));
}
```

The validation sits after the empty-query short-circuit and before any path validation or subprocess spawning, so oversized queries are rejected at the cheapest possible point.

## Behavior

| Query length | Before | After |
|-------------|--------|-------|
| 0 (empty) | returns empty result | returns empty result (unchanged) |
| 1-500 | proceeds to search | proceeds to search (unchanged) |
| 501+ | proceeds to search (no limit) | rejected with error message |

The error message includes the actual length and the limit, so if a legitimate use case ever exceeds 500 characters, the user gets a clear signal instead of a silent failure.

## Verification

- `bun run typecheck` passes (both node and web configs)
- `bun run lint` (biome) passes with no new errors
- Commit hook ran both checks automatically
- The `search_content_stream` error path emits a `search-content-done` event with the error message, so the renderer can display it
- The `search_file_names` error path returns an `IpcResult::error` with a specific error code, so the renderer can handle it

## Compatibility

No breaking changes. Existing search behavior is identical for queries under 500 characters. The only difference is that oversized queries are now rejected instead of being processed. No API changes, no new dependencies, no changes to the IPC contract beyond the new error code.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Content and file name searches now reject queries exceeding 500 characters, returning an error instead of proceeding.
  * For oversized content search queries, the search is stopped early and a security warning is logged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->