### PR TITLE
fix(terminal): trap Tab focus navigation for Shift+Tab passthrough

### DIFF
--- a/src/renderer/components/terminal/ConnectedTerminal.test.tsx
+++ b/src/renderer/components/terminal/ConnectedTerminal.test.tsx
@@ -1247,6 +1247,47 @@ describe('ConnectedTerminal', () => {
       expect(result).toBe(true)
     })
 
+    it('should prevent default on Shift+Tab and let xterm handle the key', async () => {
+      render(<ConnectedTerminal />)
+
+      await vi.waitFor(() => {
+        expect(mockTerminalInstance.attachCustomKeyEventHandler).toHaveBeenCalled()
+      })
+
+      const handler = mockTerminalInstance.attachCustomKeyEventHandler.mock.calls[0][0]
+      const event = new KeyboardEvent('keydown', {
+        key: 'Tab',
+        shiftKey: true,
+        bubbles: true
+      })
+      const preventDefaultSpy = vi.spyOn(event, 'preventDefault')
+
+      const result = handler(event)
+
+      expect(result).toBe(true)
+      expect(preventDefaultSpy).toHaveBeenCalled()
+    })
+
+    it('should prevent default on Tab and let xterm handle the key', async () => {
+      render(<ConnectedTerminal />)
+
+      await vi.waitFor(() => {
+        expect(mockTerminalInstance.attachCustomKeyEventHandler).toHaveBeenCalled()
+      })
+
+      const handler = mockTerminalInstance.attachCustomKeyEventHandler.mock.calls[0][0]
+      const event = new KeyboardEvent('keydown', {
+        key: 'Tab',
+        bubbles: true
+      })
+      const preventDefaultSpy = vi.spyOn(event, 'preventDefault')
+
+      const result = handler(event)
+
+      expect(result).toBe(true)
+      expect(preventDefaultSpy).toHaveBeenCalled()
+    })
+
     it('should bubble app-owned shortcuts so the workspace handler can process them', async () => {
       render(<ConnectedTerminal />)
 

--- a/src/renderer/components/terminal/ConnectedTerminal.tsx
+++ b/src/renderer/components/terminal/ConnectedTerminal.tsx
@@ -103,6 +103,15 @@ function isAppOwnedTerminalShortcut(
   return false
 }
 
+/** Prevent browser reverse-tab focus traversal; xterm still handles Tab / Shift+Tab. */
+function trapTerminalTabFocusNavigation(event: KeyboardEvent): boolean {
+  if (event.key !== 'Tab') {
+    return false
+  }
+  event.preventDefault()
+  return true
+}
+
 const MAX_WEBGL_RECOVERY_ATTEMPTS = 3
 const WEBGL_CONTEXT_LOSS_RECOVERY_DELAY_MS = 100
 const VISIBILITY_RECOVERY_DELAY_MS = 150
@@ -630,6 +639,10 @@ function ConnectedTerminalComponent({
             terminal.selectAll()
             return false
         }
+      }
+
+      if (trapTerminalTabFocusNavigation(event)) {
+        return true
       }
 
       return true
@@ -1523,6 +1536,9 @@ function ConnectedTerminalComponent({
             terminal.selectAll()
             return false
         }
+      }
+      if (trapTerminalTabFocusNavigation(event)) {
+        return true
       }
       return true
     })


### PR DESCRIPTION
## Summary

Trap Tab / Shift+Tab in the terminal custom key handler so the WebView does not run reverse-focus navigation when `screenReaderMode` is enabled. xterm still receives the key and sends HT / `\x1b[Z` to the PTY.

## Related Issue

Closes #251

## Type of Change

- [ ] feat: new feature
- [x] fix: bug fix
- [ ] docs: documentation only
- [ ] style: formatting or non-functional styling changes
- [ ] refactor: internal cleanup with no behavior change
- [ ] perf: performance improvement
- [x] test: adds or updates tests
- [ ] build: build or dependency changes
- [ ] ci: CI/CD workflow changes
- [ ] chore: maintenance or tooling
- [ ] revert: reverts a previous change

## What Changed

- Added `trapTerminalTabFocusNavigation()` in `ConnectedTerminal.tsx` to call `preventDefault()` on `Tab` (plain and Shift) while returning `true` so xterm continues handling the sequence.
- Applied the trap in both `attachCustomKeyEventHandler` registration paths (main mount and secondary terminal-init).
- Added Vitest coverage for plain Tab and Shift+Tab (`preventDefault` + handler returns `true`).

## How It Was Tested

- [ ] `bun run lint`
- [x] `bun run typecheck`
- [x] `bun run test`
- [ ] Manual verification completed
- [ ] Not applicable

## Screenshots or Recordings

<!-- Required for UI changes when applicable -->

N/A — keyboard/focus behavior fix; manual check: focus terminal, press Shift+Tab repeatedly; focus should stay in xterm.

## Checklist

- [x] My PR title follows the conventional commit format used by this repo
- [x] I linked the related issue or explained why none exists
- [ ] I updated docs when needed
- [x] I added or updated tests when needed
- [x] I verified the change does not introduce unrelated modifications


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved terminal Tab key navigation to prevent unwanted browser focus traversal.

* **Tests**
  * Added keyboard navigation tests to verify Tab and Shift+Tab handling in the terminal component.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->