### PR TITLE
fix(terminal): disable screenReaderMode to stop duplicate input (#267)

### DIFF
--- a/src/renderer/components/terminal/terminal-config.test.ts
+++ b/src/renderer/components/terminal/terminal-config.test.ts
@@ -49,4 +49,8 @@ describe('DEFAULT_TERMINAL_OPTIONS', () => {
     expect(DEFAULT_TERMINAL_OPTIONS.scrollback).toBe(10000)
     expect(DEFAULT_TERMINAL_OPTIONS.cursorBlink).toBe(true)
   })
+
+  it('should disable screenReaderMode to avoid duplicate PTY input (#267)', () => {
+    expect(DEFAULT_TERMINAL_OPTIONS.screenReaderMode).toBe(false)
+  })
 })

--- a/src/renderer/components/terminal/terminal-config.ts
+++ b/src/renderer/components/terminal/terminal-config.ts
@@ -52,7 +52,10 @@ export const DEFAULT_TERMINAL_OPTIONS: ITerminalOptions = {
   convertEol: false,
   ignoreBracketedPasteMode: false,
   rightClickSelectsWord: true,
-  screenReaderMode: true
+  // xterm screenReaderMode routes keystrokes through the a11y textarea path, which
+  // can emit duplicate bytes to the PTY (see xtermjs/xterm.js#3467). Default off;
+  // re-enable only when we add an explicit user-facing accessibility setting.
+  screenReaderMode: false
 }
 
 /**


### PR DESCRIPTION
## Summary

Fix duplicated keystrokes when typing in terminal-based agents (e.g. pi) on macOS by defaulting xterm `screenReaderMode` to off.

## Related Issue

Closes #267

## Type of Change

- [ ] feat: new feature
- [x] fix: bug fix
- [ ] docs: documentation only
- [ ] style: formatting or non-functional styling changes
- [ ] refactor: internal cleanup with no behavior change
- [ ] perf: performance improvement
- [x] test: adds or updates tests
- [ ] build: build or dependency changes
- [ ] ci: CI/CD workflow changes
- [ ] chore: maintenance or tooling
- [ ] revert: reverts a previous change

## What Changed

- Set `screenReaderMode: false` in `DEFAULT_TERMINAL_OPTIONS` (`terminal-config.ts`) with a comment explaining the xterm duplicate-input behavior.
- Added a regression test asserting the default is `false` (#267).

## How It Was Tested

- [ ] `bun run lint`
- [ ] `bun run typecheck`
- [x] `bun run test`
- [ ] Manual verification completed
- [ ] Not applicable

## Screenshots or Recordings

N/A — terminal input behavior fix; manual macOS verification recommended by reporter.

## Checklist

- [x] My PR title follows the conventional commit format used by this repo
- [x] I linked the related issue or explained why none exists
- [ ] I updated docs when needed
- [x] I added or updated tests when needed
- [x] I verified the change does not introduce unrelated modifications


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved a terminal input duplication issue that was occurring when accessibility features were enabled. This fix ensures reliable and consistent input handling, improving overall user experience and terminal stability.

* **Tests**
  * Added test coverage to verify that default terminal configuration options are correctly set and properly maintained.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->