### PR TITLE
fix(pty): refresh terminal PATH from OS at spawn (#275)

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -5911,6 +5911,7 @@ dependencies = [
  "uuid",
  "winapi",
  "windows-sys 0.59.0",
+ "winreg 0.55.0",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -105,6 +105,7 @@ keyring = { version = "3.6", features = ["apple-native"] }
 keyring = { version = "3.6", features = ["sync-secret-service", "crypto-rust"] }
 
 [target.'cfg(windows)'.dependencies]
+winreg = "0.55"
 windows-sys = { version = "0.59", features = ["Win32_UI_WindowsAndMessaging", "Win32_Foundation"] }
 winapi = { version = "0.3", features = [
     "winbase",

--- a/src-tauri/src/pty/env_refresh.rs
+++ b/src-tauri/src/pty/env_refresh.rs
@@ -37,15 +37,19 @@ pub fn merge_path_segments(registry: &str, inherited: &str, delimiter: char) -> 
     let mut seen = std::collections::HashSet::new();
     let mut out: Vec<String> = Vec::new();
 
+    // Semicolon-separated paths follow Windows rules (case-insensitive dedupe).
+    let case_insensitive = delimiter == ';';
+
     let mut push_segment = |seg: &str| {
         let trimmed = seg.trim();
         if trimmed.is_empty() {
             return;
         }
-        #[cfg(target_os = "windows")]
-        let key = trimmed.to_ascii_lowercase();
-        #[cfg(not(target_os = "windows"))]
-        let key = trimmed.to_string();
+        let key = if case_insensitive {
+            trimmed.to_ascii_lowercase()
+        } else {
+            trimmed.to_string()
+        };
         if seen.insert(key) {
             out.push(trimmed.to_string());
         }

--- a/src-tauri/src/pty/env_refresh.rs
+++ b/src-tauri/src/pty/env_refresh.rs
@@ -1,0 +1,256 @@
+//! Refresh `Path` / `PATH` from OS sources before PTY spawn.
+//!
+//! Termul's GUI process keeps a snapshot of the environment from launch time.
+//! Global installs and registry updates are invisible until we re-read PATH here.
+
+use std::collections::HashMap;
+use std::path::Path;
+
+#[cfg(target_os = "windows")]
+fn has_path_key(env: &HashMap<String, String>) -> bool {
+    env.keys().any(|k| k.eq_ignore_ascii_case("path"))
+}
+
+#[cfg(target_os = "windows")]
+fn get_path_from_map(env: &HashMap<String, String>) -> String {
+    env.iter()
+        .find(|(k, _)| k.eq_ignore_ascii_case("path"))
+        .map(|(_, v)| v.clone())
+        .unwrap_or_default()
+}
+
+#[cfg(target_os = "windows")]
+fn set_path_in_map(env: &mut HashMap<String, String>, value: String) {
+    if let Some(existing_key) = env
+        .keys()
+        .find(|k| k.eq_ignore_ascii_case("path"))
+        .cloned()
+    {
+        env.remove(&existing_key);
+    }
+    env.insert("Path".to_string(), value);
+}
+
+/// Merge `registry` and `inherited` PATH segments (platform delimiter), keeping
+/// registry order first then appending inherited segments not already present.
+pub fn merge_path_segments(registry: &str, inherited: &str, delimiter: char) -> String {
+    let mut seen = std::collections::HashSet::new();
+    let mut out: Vec<String> = Vec::new();
+
+    let mut push_segment = |seg: &str| {
+        let trimmed = seg.trim();
+        if trimmed.is_empty() {
+            return;
+        }
+        #[cfg(target_os = "windows")]
+        let key = trimmed.to_ascii_lowercase();
+        #[cfg(not(target_os = "windows"))]
+        let key = trimmed.to_string();
+        if seen.insert(key) {
+            out.push(trimmed.to_string());
+        }
+    };
+
+    for seg in registry.split(delimiter) {
+        push_segment(seg);
+    }
+    for seg in inherited.split(delimiter) {
+        push_segment(seg);
+    }
+
+    out.join(&delimiter.to_string())
+}
+
+#[cfg(target_os = "windows")]
+fn expand_windows_env_value(value: &str) -> String {
+    use std::ffi::OsStr;
+    use std::os::windows::ffi::OsStrExt;
+    use winapi::um::processenv::ExpandEnvironmentStringsW;
+
+    if value.is_empty() {
+        return String::new();
+    }
+
+    let wide: Vec<u16> = OsStr::new(value).encode_wide().chain(Some(0)).collect();
+    let mut buf = vec![0u16; 32_768];
+    unsafe {
+        let needed = ExpandEnvironmentStringsW(wide.as_ptr(), buf.as_mut_ptr(), buf.len() as u32);
+        if needed == 0 || needed as usize > buf.len() {
+            return value.to_string();
+        }
+        let len = needed.saturating_sub(1) as usize;
+        String::from_utf16_lossy(&buf[..len])
+    }
+}
+
+#[cfg(target_os = "windows")]
+fn read_windows_registry_path() -> Option<String> {
+    use winreg::enums::{HKEY_CURRENT_USER, HKEY_LOCAL_MACHINE};
+    use winreg::RegKey;
+
+    let machine = RegKey::predef(HKEY_LOCAL_MACHINE)
+        .open_subkey(r"SYSTEM\CurrentControlSet\Control\Session Manager\Environment")
+        .ok()
+        .and_then(|k| k.get_value::<String, _>("Path").ok())
+        .map(|s| expand_windows_env_value(&s))
+        .filter(|s| !s.is_empty());
+
+    let user = RegKey::predef(HKEY_CURRENT_USER)
+        .open_subkey("Environment")
+        .ok()
+        .and_then(|k| k.get_value::<String, _>("Path").ok())
+        .map(|s| expand_windows_env_value(&s))
+        .filter(|s| !s.is_empty());
+
+    match (machine, user) {
+        (Some(m), Some(u)) => Some(merge_path_segments(&m, &u, ';')),
+        (Some(m), None) => Some(m),
+        (None, Some(u)) => Some(u),
+        (None, None) => None,
+    }
+}
+
+/// PATH string for executable resolution (registry/login probe, else process env).
+pub fn path_for_resolution() -> std::ffi::OsString {
+    fresh_path()
+        .map(std::ffi::OsString::from)
+        .or_else(|| std::env::var_os("PATH"))
+        .unwrap_or_default()
+}
+
+/// Returns the refreshed PATH string for the current platform, if obtainable.
+pub fn fresh_path() -> Option<String> {
+    #[cfg(target_os = "windows")]
+    {
+        return read_windows_registry_path();
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    {
+        probe_unix_login_path()
+    }
+}
+
+#[cfg(not(target_os = "windows"))]
+fn probe_unix_login_path() -> Option<String> {
+    use std::process::Command;
+
+    let shell = std::env::var("SHELL").unwrap_or_else(|_| "/bin/sh".to_string());
+    let shell_name = Path::new(&shell)
+        .file_name()
+        .and_then(|s| s.to_str())
+        .unwrap_or("sh");
+
+    let output = match shell_name {
+        "bash" | "zsh" => Command::new(&shell)
+            .args(["-lc", "printf %s \"$PATH\""])
+            .output()
+            .ok()?,
+        "fish" => Command::new(&shell)
+            .args(["-lc", "printf %s $PATH"])
+            .output()
+            .ok()?,
+        _ => return None,
+    };
+
+    if !output.status.success() {
+        return None;
+    }
+
+    let path = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    if path.is_empty() {
+        None
+    } else {
+        Some(path)
+    }
+}
+
+/// Apply a refreshed PATH to `env`, preserving custom overrides already present.
+pub fn apply_fresh_path(env: &mut HashMap<String, String>) {
+    let delimiter = if cfg!(target_os = "windows") { ';' } else { ':' };
+
+    let inherited = {
+        #[cfg(target_os = "windows")]
+        {
+            if has_path_key(env) {
+                get_path_from_map(env)
+            } else {
+                std::env::var("PATH").unwrap_or_default()
+            }
+        }
+        #[cfg(not(target_os = "windows"))]
+        {
+            env.get("PATH")
+                .cloned()
+                .unwrap_or_else(|| std::env::var("PATH").unwrap_or_default())
+        }
+    };
+
+    let Some(registry_or_probed) = fresh_path() else {
+        return;
+    };
+
+    let merged = merge_path_segments(&registry_or_probed, &inherited, delimiter);
+
+    #[cfg(target_os = "windows")]
+    set_path_in_map(env, merged);
+
+    #[cfg(not(target_os = "windows"))]
+    env.insert("PATH".to_string(), merged);
+}
+
+/// Whether an interactive shell spawn should pass a login-shell flag.
+pub fn shell_wants_login_arg(shell_path: &str) -> Option<&'static str> {
+    let name = Path::new(shell_path)
+        .file_name()
+        .and_then(|s| s.to_str())?
+        .to_ascii_lowercase();
+
+    match name.as_str() {
+        "bash" | "zsh" => Some("-l"),
+        "fish" => Some("-l"),
+        #[cfg(not(target_os = "windows"))]
+        "pwsh" | "powershell" => Some("-Login"),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn merge_dedupes_case_insensitively_on_windows_style() {
+        let merged = merge_path_segments(
+            r"C:\Tools;C:\App",
+            r"C:\tools;C:\Extra",
+            ';',
+        );
+        assert_eq!(merged, r"C:\Tools;C:\App;C:\Extra");
+    }
+
+    #[test]
+    fn merge_unix_colon_delimiter() {
+        let merged = merge_path_segments("/usr/bin", "/bin:/usr/bin", ':');
+        assert_eq!(merged, "/usr/bin:/bin");
+    }
+
+    #[test]
+    fn merge_skips_empty_segments() {
+        let merged = merge_path_segments(";;/a", "/b;;", ';');
+        assert_eq!(merged, "/a;/b");
+    }
+
+    #[test]
+    fn shell_login_arg_for_bash() {
+        assert_eq!(
+            shell_wants_login_arg("/usr/bin/bash"),
+            Some("-l")
+        );
+    }
+
+    #[test]
+    fn shell_login_arg_for_cmd_none() {
+        assert_eq!(shell_wants_login_arg("cmd.exe"), None);
+    }
+}

--- a/src-tauri/src/pty/env_refresh.rs
+++ b/src-tauri/src/pty/env_refresh.rs
@@ -151,7 +151,7 @@ fn probe_unix_login_path() -> Option<String> {
             .output()
             .ok()?,
         "fish" => Command::new(&shell)
-            .args(["-lc", "printf %s $PATH"])
+            .args(["-lc", "string join : $PATH"])
             .output()
             .ok()?,
         _ => return None,

--- a/src-tauri/src/pty/manager.rs
+++ b/src-tauri/src/pty/manager.rs
@@ -1845,28 +1845,6 @@ impl PtyManager {
             }
             None
         }
-
-        #[cfg(not(target_os = "windows"))]
-        {
-            let path_for_which = crate::pty::env_refresh::path_for_resolution();
-            if let Ok(output) = std::process::Command::new("which")
-                .env("PATH", &path_for_which)
-                .arg(shell_path)
-                .output()
-            {
-                if output.status.success() {
-                    let stdout = String::from_utf8_lossy(&output.stdout);
-                    let first_line = stdout.lines().next().unwrap_or("").trim();
-                    if !first_line.is_empty() {
-                        return Some(first_line.to_string());
-                    }
-                }
-            }
-            if Path::new(shell_path).exists() {
-                return Some(shell_path.to_string());
-            }
-            None
-        }
     }
 
     /// Get the home directory

--- a/src-tauri/src/pty/manager.rs
+++ b/src-tauri/src/pty/manager.rs
@@ -32,7 +32,10 @@ fn resolve_executable_from_path(command: &str) -> Option<String> {
         return candidate.exists().then(|| command.to_string());
     }
 
-    let path_var = env::var_os("PATH")?;
+    let path_var = crate::pty::env_refresh::path_for_resolution();
+    if path_var.is_empty() {
+        return None;
+    }
     let pathext_var =
         env::var_os("PATHEXT").unwrap_or_else(|| OsString::from(".COM;.EXE;.BAT;.CMD"));
 
@@ -864,13 +867,13 @@ impl PtyManager {
                     if cfg!(windows)
                         && (shell_path.contains("powershell") || shell_path.contains("pwsh"))
                     {
-                        "-NoLogo"  // Load user profile for custom prompts
+                        "-NoLogo"  // Skip PowerShell banner only (profile still loads)
                     } else {
                         ""
                     }
                 )
             } else if shell_path.contains("powershell") || shell_path.contains("pwsh") {
-                format!("{} -NoLogo", shell_path)  // Load user profile for custom prompts
+                format!("{} -NoLogo", shell_path)  // Skip PowerShell banner only (profile still loads)
             } else {
                 shell_path.clone()
             };
@@ -985,6 +988,13 @@ impl PtyManager {
                 .map_err(|e| format!("Failed to open PTY: {}", e))?;
 
             let mut cmd = CommandBuilder::new(&shell_path);
+            // Interactive shells: login flag so profile-sourced PATH is applied (GH-275).
+            if options.program.is_none() {
+                if let Some(login_arg) = crate::pty::env_refresh::shell_wants_login_arg(&shell_path)
+                {
+                    cmd.arg(login_arg);
+                }
+            }
             // ADR-004.2: In agent mode, append the argv tail as discrete
             // arguments. portable-pty passes argv without a shell, so the prompt
             // is delivered verbatim with no shell interpolation. In shell mode
@@ -1607,7 +1617,12 @@ impl PtyManager {
 
         #[cfg(not(target_os = "windows"))]
         {
-            if let Ok(output) = std::process::Command::new("which").arg(trimmed).output() {
+            let path_for_which = crate::pty::env_refresh::path_for_resolution();
+            if let Ok(output) = std::process::Command::new("which")
+                .env("PATH", &path_for_which)
+                .arg(trimmed)
+                .output()
+            {
                 if output.status.success() {
                     let stdout = String::from_utf8_lossy(&output.stdout);
                     let first_line = stdout.lines().next().unwrap_or("").trim();
@@ -1833,7 +1848,12 @@ impl PtyManager {
 
         #[cfg(not(target_os = "windows"))]
         {
-            if let Ok(output) = std::process::Command::new("which").arg(shell_path).output() {
+            let path_for_which = crate::pty::env_refresh::path_for_resolution();
+            if let Ok(output) = std::process::Command::new("which")
+                .env("PATH", &path_for_which)
+                .arg(shell_path)
+                .output()
+            {
                 if output.status.success() {
                     let stdout = String::from_utf8_lossy(&output.stdout);
                     let first_line = stdout.lines().next().unwrap_or("").trim();
@@ -1870,28 +1890,58 @@ impl PtyManager {
         &self,
         custom_env: Option<HashMap<String, String>>,
     ) -> HashMap<String, String> {
+        let custom_sets_path = custom_env.as_ref().is_some_and(|custom| {
+            custom
+                .keys()
+                .any(|key| key.eq_ignore_ascii_case("path"))
+        });
+
         #[cfg(target_os = "windows")]
         {
-            merge_windows_environment_map(env::vars(), custom_env)
+            let mut env_map = merge_windows_environment_map(env::vars(), None);
+            if !custom_sets_path {
+                crate::pty::env_refresh::apply_fresh_path(&mut env_map);
+            }
+            if let Some(custom) = custom_env {
+                for (key, value) in custom {
+                    upsert_windows_env_var(&mut env_map, &key, value);
+                }
+            }
+            if !has_windows_env_var(&env_map, "Path") {
+                upsert_windows_env_var(
+                    &mut env_map,
+                    "Path",
+                    env::var("PATH").unwrap_or_default(),
+                );
+            }
+            if !has_windows_env_var(&env_map, "PATHEXT") {
+                upsert_windows_env_var(
+                    &mut env_map,
+                    "PATHEXT",
+                    env::var("PATHEXT").unwrap_or_else(|_| ".COM;.EXE;.BAT;.CMD".to_string()),
+                );
+            }
+            env_map
         }
 
         #[cfg(not(target_os = "windows"))]
         {
             let mut env = HashMap::new();
 
-            // Copy current process environment
             for (key, value) in env::vars() {
                 env.insert(key, value);
             }
 
-            // Apply custom environment (overriding existing)
+            if !custom_sets_path {
+                crate::pty::env_refresh::apply_fresh_path(&mut env);
+            }
+
             if let Some(custom) = custom_env {
                 for (key, value) in custom {
                     env.insert(key, value);
                 }
             }
 
-            // Ensure PATH exists
             if !env.contains_key("PATH") {
                 env.insert("PATH".to_string(), "/usr/bin:/bin".to_string());
             }

--- a/src-tauri/src/pty/mod.rs
+++ b/src-tauri/src/pty/mod.rs
@@ -3,6 +3,7 @@
 //! This module handles terminal spawning, data I/O, and lifecycle management.
 
 pub mod da_filter;
+pub mod env_refresh;
 pub mod manager;
 
 #[cfg(target_os = "windows")]


### PR DESCRIPTION
## Summary

Termul terminals now resolve `Path`/`PATH` from authoritative OS sources at spawn time instead of only inheriting the GUI process snapshot, so globally installed CLIs work without restarting the app.

## Related Issue

Closes #275

## Type of Change

- [ ] feat: new feature
- [x] fix: bug fix
- [ ] docs: documentation only
- [ ] style: formatting or non-functional styling changes
- [ ] refactor: internal cleanup with no behavior change
- [ ] perf: performance improvement
- [ ] test: adds or updates tests
- [x] build: build or dependency changes
- [ ] ci: CI/CD workflow changes
- [ ] chore: maintenance or tooling
- [ ] revert: reverts a previous change

## What Changed

- Added `src-tauri/src/pty/env_refresh.rs` to rebuild PATH from Windows registry (HKLM + HKCU, expanded) and Unix login-shell probe
- Updated `merge_environment` to apply refreshed PATH before custom project env overrides
- Updated PATH-based executable resolution (`which`, `resolve_executable_from_path`) to use refreshed PATH
- Unix interactive shells spawn with login flag (`-l`) for bash/zsh/fish so profile-sourced PATH applies
- Fixed misleading PowerShell `-NoLogo` comments in `manager.rs`
- Added `winreg` Windows dependency

## How It Was Tested

- [ ] `bun run lint`
- [ ] `bun run typecheck`
- [ ] `bun run test`
- [x] Manual verification completed
- [ ] Not applicable

**Rust:**
- `cargo test env_refresh` — 5 passed
- `cargo test pty::manager` — 19 passed

## Screenshots or Recordings

N/A (native PTY / env behavior; no UI changes)

## Checklist

- [x] My PR title follows the conventional commit format used by this repo
- [x] I linked the related issue or explained why none exists
- [ ] I updated docs when needed
- [x] I added or updated tests when needed
- [x] I verified the change does not introduce unrelated modifications

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced PATH environment variable refresh using system registry on Windows and login shells on Unix systems for improved executable resolution.
  * Improved shell initialization with automatic login argument detection for interactive shells.

* **Improvements**
  * Updated PowerShell behavior to suppress logo output consistently across configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->