### PR TITLE
chore(github): require contributor intent on issue forms

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -8,6 +8,18 @@ body:
       value: |
         Thanks for reporting a bug. Please search existing issues first and include enough detail for someone else to reproduce the problem.
 
+  - type: dropdown
+    id: contributor-intent
+    attributes:
+      label: Will you contribute a fix?
+      description: Helps maintainers prioritize issues and avoid duplicate work.
+      options:
+        - "Yes — I plan to open a pull request"
+        - "No — reporting for maintainers to handle"
+        - "Unsure — open to contributing with guidance"
+    validations:
+      required: true
+
   - type: textarea
     id: summary
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -8,6 +8,18 @@ body:
       value: |
         Thanks for the suggestion. Please check for similar requests first and explain the user problem, not just the solution.
 
+  - type: dropdown
+    id: contributor-intent
+    attributes:
+      label: Will you contribute an implementation?
+      description: Helps maintainers prioritize requests and avoid duplicate work.
+      options:
+        - "Yes — I plan to open a pull request"
+        - "No — reporting for maintainers to handle"
+        - "Unsure — open to contributing with guidance"
+    validations:
+      required: true
+
   - type: textarea
     id: problem
     attributes:


### PR DESCRIPTION
## Summary

- Adds a **required** contributor-intent dropdown to bug and feature issue templates.
- Options: **Yes** (plans to open a PR), **No** (for maintainers), **Unsure** (open to guidance).
- Every new issue will show the choice in the body for clearer triage.

## Test plan

- [ ] Open **New issue → Bug Report** on GitHub and confirm the dropdown appears after the intro, is required, and all three options submit.
- [ ] Open **New issue → Feature Request** and confirm the same field and options.
- [ ] Submit a test issue with each option and verify the rendered issue body includes the selected value.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced issue reporting templates with new required fields: bug reports now ask if reporters will contribute fixes, and feature requests inquire about contributor intent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->