### PR TITLE
fix(pty): conPTY tree kill via Job Object on Windows (#281)

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -108,6 +108,7 @@ keyring = { version = "3.6", features = ["sync-secret-service", "crypto-rust"] }
 winreg = "0.55"
 windows-sys = { version = "0.59", features = ["Win32_UI_WindowsAndMessaging", "Win32_Foundation"] }
 winapi = { version = "0.3", features = [
+    "jobapi2",
     "winbase",
     "winuser",
     "consoleapi",

--- a/src-tauri/src/pty/manager.rs
+++ b/src-tauri/src/pty/manager.rs
@@ -878,13 +878,14 @@ impl PtyManager {
                 shell_path.clone()
             };
 
-            let (reader, writer, pid, process_handle, conpty_handles) =
+            let (reader, writer, pid, process_handle, job_handle, conpty_handles) =
                 spawn_conpty(&shell_escaped, Some(&cwd), cols, rows, &env)
                     .map_err(|e| format!("Failed to spawn ConPTY: {}", e))?;
 
             let child = WindowsConPtyChild {
                 pid,
                 process_handle,
+                job_handle,
             };
 
             // Create terminal instance
@@ -1935,6 +1936,10 @@ impl PtyManager {
 struct WindowsConPtyChild {
     pid: u32,
     process_handle: *mut winapi::ctypes::c_void,
+    // Job Object handle (KILL_ON_JOB_CLOSE) owning the child process tree, or
+    // null if it could not be created. Closing it (on Drop) reaps the whole
+    // tree; TerminateJobObject kills it on demand. See spawn_conpty / #281.
+    job_handle: *mut winapi::ctypes::c_void,
 }
 
 #[cfg(target_os = "windows")]
@@ -1957,6 +1962,12 @@ unsafe impl Sync for WindowsConPtyChild {}
 impl Drop for WindowsConPtyChild {
     fn drop(&mut self) {
         unsafe {
+            // Close the job handle first: with KILL_ON_JOB_CLOSE this reaps the
+            // entire child process tree once the last handle is gone.
+            if !self.job_handle.is_null() {
+                let _ = winapi::um::handleapi::CloseHandle(self.job_handle);
+                self.job_handle = std::ptr::null_mut();
+            }
             if !self.process_handle.is_null() {
                 let _ = winapi::um::handleapi::CloseHandle(self.process_handle);
                 self.process_handle = std::ptr::null_mut();
@@ -1998,10 +2009,37 @@ impl portable_pty::ChildKiller for WindowsPidKiller {
 impl portable_pty::ChildKiller for WindowsConPtyChild {
     fn kill(&mut self) -> std::io::Result<()> {
         unsafe {
+            // Prefer terminating the Job Object: this kills the entire child
+            // process tree (cmd → powershell → node …), which single-PID
+            // TerminateProcess cannot do. See #281.
+            if !self.job_handle.is_null() {
+                if winapi::um::jobapi2::TerminateJobObject(self.job_handle, 1) != 0 {
+                    return Ok(());
+                }
+                // Job termination failed: if the process already exited the job
+                // is effectively empty — treat as success rather than logging an
+                // ERROR_ACCESS_DENIED-style false failure.
+                if self.process_already_exited() {
+                    return Ok(());
+                }
+                let err = std::io::Error::last_os_error();
+                log::warn!(
+                    "[WindowsConPtyChild:{}] TerminateJobObject failed: {}",
+                    self.pid,
+                    err
+                );
+                return Err(err);
+            }
+
             if self.process_handle.is_null() {
                 return Ok(());
             }
             if winapi::um::processthreadsapi::TerminateProcess(self.process_handle, 1) == 0 {
+                // The process may already have exited; that's not a real failure
+                // and avoids the recurring "Access is denied (os error 5)" noise.
+                if self.process_already_exited() {
+                    return Ok(());
+                }
                 let err = std::io::Error::last_os_error();
                 log::warn!(
                     "[WindowsConPtyChild:{}] TerminateProcess failed: {}",
@@ -2034,12 +2072,50 @@ impl portable_pty::ChildKiller for WindowsConPtyChild {
                 );
                 return Box::new(WindowsPidKiller { pid: self.pid });
             }
-        }
 
-        Box::new(WindowsConPtyChild {
-            pid: self.pid,
-            process_handle: dup,
-        })
+            // Duplicate the job handle too so the clone can still tree-kill.
+            // KILL_ON_JOB_CLOSE only fires when the LAST handle closes, so an
+            // extra duplicate is safe and does not terminate the tree early.
+            let mut dup_job: *mut winapi::ctypes::c_void = std::ptr::null_mut();
+            if !self.job_handle.is_null() {
+                if winapi::um::handleapi::DuplicateHandle(
+                    winapi::um::processthreadsapi::GetCurrentProcess(),
+                    self.job_handle,
+                    winapi::um::processthreadsapi::GetCurrentProcess(),
+                    &mut dup_job,
+                    0,
+                    0,
+                    winapi::um::winnt::DUPLICATE_SAME_ACCESS,
+                ) == 0
+                {
+                    log::warn!(
+                        "[WindowsConPtyChild:{}] DuplicateHandle(job) failed, clone loses tree-kill: {}",
+                        self.pid,
+                        std::io::Error::last_os_error()
+                    );
+                    dup_job = std::ptr::null_mut();
+                }
+            }
+
+            Box::new(WindowsConPtyChild {
+                pid: self.pid,
+                process_handle: dup,
+                job_handle: dup_job,
+            })
+        }
+    }
+}
+
+#[cfg(target_os = "windows")]
+impl WindowsConPtyChild {
+    /// Returns true if the underlying process is known to have exited. Used to
+    /// distinguish a benign "already dead" kill from a real termination failure.
+    unsafe fn process_already_exited(&self) -> bool {
+        if self.process_handle.is_null() {
+            return true;
+        }
+        let wait = winapi::um::synchapi::WaitForSingleObject(self.process_handle, 0);
+        wait == winapi::um::winbase::WAIT_OBJECT_0
     }
 }
 

--- a/src-tauri/src/pty/windows.rs
+++ b/src-tauri/src/pty/windows.rs
@@ -127,6 +127,9 @@ type ConPtySpawnResult = (
     Box<dyn std::io::Write + Send>,
     u32,
     *mut c_void,
+    // Job Object handle (KILL_ON_JOB_CLOSE) owning the child process tree, or
+    // null if the Job Object could not be created/assigned. Owned by the caller.
+    *mut c_void,
     ConPtyHandles,
 );
 
@@ -200,13 +203,68 @@ fn env_to_wide_block(env: &std::collections::HashMap<String, String>) -> Vec<u16
     block
 }
 
+/// Create a Job Object with `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE` and assign
+/// `process` to it. When the returned handle is closed, the OS terminates the
+/// process and its entire descendant tree. Returns a null handle (and logs a
+/// warning) if the job could not be created, configured, or assigned, in which
+/// case the caller proceeds with the process running but without tree-kill.
+#[cfg(target_os = "windows")]
+unsafe fn create_kill_on_close_job(process: *mut c_void) -> *mut c_void {
+    use winapi::um::jobapi2::{
+        AssignProcessToJobObject, CreateJobObjectW, SetInformationJobObject,
+    };
+    use winapi::um::winnt::{
+        JobObjectExtendedLimitInformation, JOBOBJECT_EXTENDED_LIMIT_INFORMATION,
+        JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE,
+    };
+
+    let job = CreateJobObjectW(std::ptr::null_mut(), std::ptr::null());
+    if job.is_null() {
+        log::warn!(
+            "[ConPTY] CreateJobObject failed, orphan protection disabled: {}",
+            std::io::Error::last_os_error()
+        );
+        return std::ptr::null_mut();
+    }
+
+    let mut info: JOBOBJECT_EXTENDED_LIMIT_INFORMATION = std::mem::zeroed();
+    info.BasicLimitInformation.LimitFlags = JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE;
+    if SetInformationJobObject(
+        job,
+        JobObjectExtendedLimitInformation,
+        &mut info as *mut _ as *mut c_void,
+        std::mem::size_of::<JOBOBJECT_EXTENDED_LIMIT_INFORMATION>() as u32,
+    ) == 0
+    {
+        log::warn!(
+            "[ConPTY] SetInformationJobObject failed, orphan protection disabled: {}",
+            std::io::Error::last_os_error()
+        );
+        winapi::um::handleapi::CloseHandle(job);
+        return std::ptr::null_mut();
+    }
+
+    // Nested jobs are supported on Win8+/Win10+ (ConPTY requires Win10+), so
+    // assignment is safe even if the child is already in a job.
+    if AssignProcessToJobObject(job, process) == 0 {
+        log::warn!(
+            "[ConPTY] AssignProcessToJobObject failed, orphan protection disabled: {}",
+            std::io::Error::last_os_error()
+        );
+        winapi::um::handleapi::CloseHandle(job);
+        return std::ptr::null_mut();
+    }
+
+    job
+}
+
 /// Spawn a command using Windows ConPTY with proper flags to hide console window
 ///
 /// This function uses the Windows ConPTY API directly to spawn processes
 /// without showing the console window (the main issue with portable-pty 0.9).
 ///
 /// # Returns
-/// A tuple of (reader, writer, pid, process_handle, conpty_handles)
+/// A tuple of (reader, writer, pid, process_handle, job_handle, conpty_handles)
 pub fn spawn_conpty(
     command: &str,
     cwd: Option<&str>,
@@ -363,7 +421,9 @@ pub fn spawn_conpty(
             std::ptr::null_mut(),
             std::ptr::null_mut(),
             0,
-            EXTENDED_STARTUPINFO_PRESENT | winapi::um::winbase::CREATE_UNICODE_ENVIRONMENT,
+            EXTENDED_STARTUPINFO_PRESENT
+                | winapi::um::winbase::CREATE_UNICODE_ENVIRONMENT
+                | winapi::um::winbase::CREATE_SUSPENDED,
             env_block.as_mut_ptr() as *mut _,
             cwd_wide
                 .as_ref()
@@ -384,6 +444,34 @@ pub fn spawn_conpty(
 
         DeleteProcThreadAttributeList(attr_list);
 
+        // 7b. Assign the child to a Job Object configured to kill the whole
+        // process tree when the job handle closes. This is the core fix for the
+        // ConPTY orphan leak (#281): even if app-side cleanup is deferred or the
+        // app exits uncleanly, the OS reaps the entire descendant tree when the
+        // owning handle (held by the terminal instance) is closed. It also kills
+        // grandchildren that single-PID TerminateProcess misses. On any failure
+        // we log and continue with a null job handle — no regression vs. before.
+        let job = create_kill_on_close_job(pi.hProcess);
+
+        // Resume the child only after it is in the job so no grandchild can
+        // escape assignment (#281 spawn race).
+        if winapi::um::processthreadsapi::ResumeThread(pi.hThread) == u32::MAX {
+            let err = std::io::Error::last_os_error();
+            log::warn!("[ConPTY] ResumeThread failed: {}", err);
+            let _ = winapi::um::processthreadsapi::TerminateProcess(pi.hProcess, 1);
+            if !job.is_null() {
+                winapi::um::handleapi::CloseHandle(job);
+            }
+            winapi::um::handleapi::CloseHandle(pi.hProcess);
+            winapi::um::handleapi::CloseHandle(pi.hThread);
+            CloseHandle(input_read);
+            CloseHandle(input_write);
+            CloseHandle(output_read);
+            CloseHandle(output_write);
+            ClosePseudoConsole(hpcon);
+            return Err(err);
+        }
+
         // 8. Close ConPTY's pipe ends (we keep our ends)
         CloseHandle(input_read);
         CloseHandle(output_write);
@@ -399,7 +487,14 @@ pub fn spawn_conpty(
 
         CloseHandle(pi.hThread);
 
-        Ok((reader, writer, pi.dwProcessId, pi.hProcess, conpty_handles))
+        Ok((
+            reader,
+            writer,
+            pi.dwProcessId,
+            pi.hProcess,
+            job,
+            conpty_handles,
+        ))
     }
 }
 
@@ -410,6 +505,71 @@ mod tests {
     fn cmdline(program: &str, args: &[&str]) -> String {
         let owned: Vec<String> = args.iter().map(|s| s.to_string()).collect();
         build_windows_command_line(program, &owned)
+    }
+
+    /// #281: a spawned ConPTY child must be owned by a kill-on-close Job Object,
+    /// and dropping the returned handles must terminate the whole process tree
+    /// (the same mechanism that reaps children when the app process exits).
+    #[cfg(target_os = "windows")]
+    #[test]
+    fn spawn_conpty_assigns_job_and_kills_tree_on_close() {
+        use super::spawn_conpty;
+        use std::collections::HashMap;
+
+        let mut env = HashMap::new();
+        env.insert("Path".to_string(), std::env::var("PATH").unwrap_or_default());
+
+        let (reader, writer, pid, process_handle, job_handle, conpty_handles) =
+            spawn_conpty("cmd.exe", None, 80, 24, &env).expect("spawn_conpty failed");
+
+        assert_ne!(pid, 0, "expected a valid child pid");
+        assert!(!job_handle.is_null(), "child must be assigned to a Job Object");
+        assert!(
+            is_process_alive(pid),
+            "child should be running immediately after spawn"
+        );
+
+        // Drop all owned handles. Closing the last job handle triggers
+        // JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE, terminating the child tree.
+        drop(reader);
+        drop(writer);
+        unsafe {
+            winapi::um::handleapi::CloseHandle(process_handle);
+        }
+        drop(conpty_handles);
+        unsafe {
+            winapi::um::handleapi::CloseHandle(job_handle);
+        }
+
+        // Give the OS a brief moment to reap the tree.
+        let mut alive = true;
+        for _ in 0..50 {
+            if !is_process_alive(pid) {
+                alive = false;
+                break;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(20));
+        }
+        assert!(!alive, "child pid {} leaked after job handle close", pid);
+    }
+
+    #[cfg(target_os = "windows")]
+    fn is_process_alive(pid: u32) -> bool {
+        unsafe {
+            let handle = winapi::um::processthreadsapi::OpenProcess(
+                winapi::um::winnt::PROCESS_QUERY_LIMITED_INFORMATION,
+                0,
+                pid,
+            );
+            if handle.is_null() {
+                return false;
+            }
+            let mut code: u32 = 0;
+            let ok =
+                winapi::um::processthreadsapi::GetExitCodeProcess(handle, &mut code);
+            winapi::um::handleapi::CloseHandle(handle);
+            ok != 0 && code == winapi::um::minwinbase::STILL_ACTIVE
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fix Windows ConPTY orphan process leak (#281) by assigning each spawned shell to a Job Object with `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE`, so the OS terminates the full process tree when the job handle closes (including on app exit). Spawn uses `CREATE_SUSPENDED` → assign to job → `ResumeThread` so grandchildren cannot escape assignment. Explicit kill uses `TerminateJobObject`; already-exited processes are detected via `WaitForSingleObject` to avoid false `Access is denied` warnings.

## Related Issue

Closes #281

## Type of Change

- [ ] feat: new feature
- [x] fix: bug fix
- [ ] docs: documentation only
- [ ] style: formatting or non-functional styling changes
- [ ] refactor: internal cleanup with no behavior change
- [ ] perf: performance improvement
- [x] test: adds or updates tests
- [ ] build: build or dependency changes
- [ ] ci: CI/CD workflow changes
- [ ] chore: maintenance or tooling
- [ ] revert: reverts a previous change

## What Changed

- `src-tauri/Cargo.toml`: enable `winapi` `jobapi2` feature.
- `src-tauri/src/pty/windows.rs`: `create_kill_on_close_job`, job handle in spawn result, `CREATE_SUSPENDED` + resume after assign, unit test `spawn_conpty_assigns_job_and_kills_tree_on_close`.
- `src-tauri/src/pty/manager.rs`: `WindowsConPtyChild.job_handle`, `TerminateJobObject` on kill, job/process handle cleanup in `Drop`, safer `process_already_exited`, warn on failed job handle duplicate in `clone_killer`.

## How It Was Tested

- [ ] `bun run lint`
- [ ] `bun run typecheck`
- [ ] `bun run test`
- [x] Manual verification completed
- [x] Not applicable

`cargo build` and `cargo test pty::` in `src-tauri` (Windows); new spawn/job test passes.

## Screenshots or Recordings

N/A (native PTY lifecycle; no UI change).

## Checklist

- [x] My PR title follows the conventional commit format used by this repo
- [x] I linked the related issue or explained why none exists
- [ ] I updated docs when needed
- [x] I added or updated tests when needed
- [x] I verified the change does not introduce unrelated modifications

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced Windows terminal process management to ensure complete cleanup and termination of all child processes when the terminal is closed, preventing orphaned processes and resource leaks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->