### PR TITLE
fix(acp): don't wipe live transcript when reopening chat from history

### DIFF
--- a/src/renderer/stores/acp-store.test.ts
+++ b/src/renderer/stores/acp-store.test.ts
@@ -669,12 +669,25 @@ describe('acp-store', () => {
     expect(useAcpStore.getState().sessions['s-old'].status).toBe('closed')
   })
 
-  it('openHistorySession restores the local transcript if load fails (P5)', async () => {
-    // a connected agent with loadSession -> 'load' strategy
-    seedSession('s-live', 'agent-1', false)
+  it('openHistorySession leaves a live session untouched (P5)', async () => {
+    // The session is already running in a pane with messages in memory; reopening
+    // it from history must not reload or wipe the live transcript.
+    seedSession('s-live', 'agent-1', true)
     useAcpStore.setState((s) => ({
       agents: { ...s.agents, 'agent-1': { id: 'agent-1', capabilities: { loadSession: true } } },
-      agentStatus: { ...s.agentStatus, 'agent-1': 'connected' }
+      agentStatus: { ...s.agentStatus, 'agent-1': 'connected' },
+      messages: {
+        ...s.messages,
+        's-live': [
+          {
+            id: 'live-1',
+            role: 'agent',
+            blocks: [{ type: 'text', text: 'streaming' }],
+            streaming: false,
+            timestamp: 0
+          }
+        ]
+      }
     }))
     const { loadSessionPayload } = await import('@/lib/acp-history-persistence')
     ;(loadSessionPayload as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
@@ -690,6 +703,43 @@ describe('acp-store', () => {
       },
       messages: [
         {
+          id: 'stale',
+          role: 'user',
+          blocks: [{ type: 'text', text: 'stale-persisted' }],
+          streaming: false,
+          timestamp: 0
+        }
+      ]
+    })
+    await useAcpStore.getState().openHistorySession('s-live')
+    // No reload IPC, and the live in-memory transcript is preserved (not the
+    // stale persisted copy).
+    expect(invoke).not.toHaveBeenCalled()
+    expect(useAcpStore.getState().messages['s-live']).toHaveLength(1)
+    expect(useAcpStore.getState().messages['s-live'][0].id).toBe('live-1')
+  })
+
+  it('openHistorySession restores the local transcript if load fails (P5)', async () => {
+    // A non-live session whose agent process is still connected with loadSession
+    // -> 'load' strategy; if the reload fails the local transcript is restored.
+    useAcpStore.setState((s) => ({
+      agents: { ...s.agents, 'agent-1': { id: 'agent-1', capabilities: { loadSession: true } } },
+      agentStatus: { ...s.agentStatus, 'agent-1': 'connected' }
+    }))
+    const { loadSessionPayload } = await import('@/lib/acp-history-persistence')
+    ;(loadSessionPayload as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      metadata: {
+        id: 's-load',
+        agentId: 'agent-1',
+        title: 'Reloadable',
+        cwd: '/w',
+        createdAt: 1,
+        lastActivityAt: 2,
+        messageCount: 1,
+        status: 'closed'
+      },
+      messages: [
+        {
           id: 'm1',
           role: 'user',
           blocks: [{ type: 'text', text: 'prior' }],
@@ -700,10 +750,10 @@ describe('acp-store', () => {
     })
     // acp_load_session rejects
     ;(invoke as ReturnType<typeof vi.fn>).mockRejectedValueOnce('load boom')
-    await expect(useAcpStore.getState().openHistorySession('s-live')).rejects.toBeDefined()
+    await expect(useAcpStore.getState().openHistorySession('s-load')).rejects.toBeDefined()
     // transcript was restored (not left empty) and the error surfaced
-    expect(useAcpStore.getState().messages['s-live']).toHaveLength(1)
-    expect(useAcpStore.getState().sessions['s-live'].lastError).toMatch(/Resume failed/)
+    expect(useAcpStore.getState().messages['s-load']).toHaveLength(1)
+    expect(useAcpStore.getState().sessions['s-load'].lastError).toMatch(/Resume failed/)
   })
 
   it('deleteHistorySession removes the index entry (P5)', async () => {

--- a/src/renderer/stores/acp-store.test.ts
+++ b/src/renderer/stores/acp-store.test.ts
@@ -690,33 +690,67 @@ describe('acp-store', () => {
       }
     }))
     const { loadSessionPayload } = await import('@/lib/acp-history-persistence')
+    await useAcpStore.getState().openHistorySession('s-live')
+    // Fast path: no disk read, no reload IPC; live transcript preserved.
+    expect(loadSessionPayload).not.toHaveBeenCalled()
+    expect(invoke).not.toHaveBeenCalled()
+    expect(useAcpStore.getState().messages['s-live']).toHaveLength(1)
+    expect(useAcpStore.getState().messages['s-live'][0].id).toBe('live-1')
+  })
+
+  it('openHistorySession still reloads when session is cached but closed (P5)', async () => {
+    useAcpStore.setState((s) => ({
+      agents: { ...s.agents, 'agent-1': { id: 'agent-1', capabilities: { loadSession: true } } },
+      agentStatus: { ...s.agentStatus, 'agent-1': 'connected' },
+      sessions: {
+        's-closed': {
+          id: 's-closed',
+          agentId: 'agent-1',
+          cwd: '/w',
+          status: 'closed',
+          title: 'Was open',
+          activeTurn: false,
+          openTurnId: null,
+          modes: null,
+          configOptions: [],
+          lastError: null,
+          createdAt: 1
+        }
+      },
+      messages: { 's-closed': [] }
+    }))
+    const { loadSessionPayload } = await import('@/lib/acp-history-persistence')
     ;(loadSessionPayload as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
       metadata: {
-        id: 's-live',
+        id: 's-closed',
         agentId: 'agent-1',
-        title: 'Live',
+        title: 'Was open',
         cwd: '/w',
         createdAt: 1,
         lastActivityAt: 2,
         messageCount: 1,
-        status: 'active'
+        status: 'closed'
       },
       messages: [
         {
-          id: 'stale',
+          id: 'm1',
           role: 'user',
-          blocks: [{ type: 'text', text: 'stale-persisted' }],
+          blocks: [{ type: 'text', text: 'from disk' }],
           streaming: false,
           timestamp: 0
         }
       ]
     })
-    await useAcpStore.getState().openHistorySession('s-live')
-    // No reload IPC, and the live in-memory transcript is preserved (not the
-    // stale persisted copy).
-    expect(invoke).not.toHaveBeenCalled()
-    expect(useAcpStore.getState().messages['s-live']).toHaveLength(1)
-    expect(useAcpStore.getState().messages['s-live'][0].id).toBe('live-1')
+    ;(invoke as ReturnType<typeof vi.fn>).mockResolvedValueOnce(undefined)
+    await useAcpStore.getState().openHistorySession('s-closed')
+    expect(loadSessionPayload).toHaveBeenCalled()
+    expect(invoke).toHaveBeenCalledWith('acp_load_session', {
+      agentId: 'agent-1',
+      sessionId: 's-closed',
+      cwd: '/w'
+    })
+    // load strategy clears then agent replays; with no replay, messages stay empty
+    expect(useAcpStore.getState().messages['s-closed']).toEqual([])
   })
 
   it('openHistorySession restores the local transcript if load fails (P5)', async () => {

--- a/src/renderer/stores/acp-store.ts
+++ b/src/renderer/stores/acp-store.ts
@@ -622,16 +622,15 @@ export const useAcpStore = create<AcpState>((set, get) => ({
   },
 
   openHistorySession: async (id) => {
+    const cached = get().sessions[id]
+    // Only skip reload for a genuinely live session (active/initializing/error).
+    // A cached `closed` entry (e.g. tab still open after delete) must still open
+    // from persisted history via load/resume/local below.
+    if (cached && cached.status !== 'closed') return
+
     const payload = await loadSessionPayload(id)
     if (!payload) throw new Error(`no persisted history for ${id}`)
     const meta = payload.metadata
-    const live = get().sessions[id]
-
-    // If the session is already live in memory it's running in a pane already; the
-    // in-memory transcript is fresher than the (debounced) persisted copy, so keep
-    // it untouched and just let the caller activate the tab. Reloading here would
-    // wipe the live transcript and leave a blank pane if the agent doesn't replay.
-    if (live) return
 
     const connected = get().agentStatus[meta.agentId] === 'connected'
     const capabilities = get().agents[meta.agentId]?.capabilities ?? null

--- a/src/renderer/stores/acp-store.ts
+++ b/src/renderer/stores/acp-store.ts
@@ -626,16 +626,23 @@ export const useAcpStore = create<AcpState>((set, get) => ({
     if (!payload) throw new Error(`no persisted history for ${id}`)
     const meta = payload.metadata
     const live = get().sessions[id]
-    const connected = !!live && get().agentStatus[live.agentId] === 'connected'
-    const capabilities = live ? (get().agents[live.agentId]?.capabilities ?? null) : null
+
+    // If the session is already live in memory it's running in a pane already; the
+    // in-memory transcript is fresher than the (debounced) persisted copy, so keep
+    // it untouched and just let the caller activate the tab. Reloading here would
+    // wipe the live transcript and leave a blank pane if the agent doesn't replay.
+    if (live) return
+
+    const connected = get().agentStatus[meta.agentId] === 'connected'
+    const capabilities = get().agents[meta.agentId]?.capabilities ?? null
     const strategy = decideResume({ connected, capabilities })
 
-    // Always show the persisted transcript locally first (and register the session
-    // record if it isn't live), so the pane has content regardless of strategy.
+    // Show the persisted transcript locally and register the session record so the
+    // pane has content regardless of strategy.
     set((s) => ({
       sessions: {
         ...s.sessions,
-        [id]: s.sessions[id] ?? {
+        [id]: {
           id,
           agentId: meta.agentId,
           cwd: meta.cwd,
@@ -652,11 +659,11 @@ export const useAcpStore = create<AcpState>((set, get) => ({
       messages: { ...s.messages, [id]: payload.messages }
     }))
 
-    if (strategy === 'load' && live) {
+    if (strategy === 'load') {
       // Agent replays history via session/update; clear local copy to avoid dupes.
       set((s) => ({ messages: { ...s.messages, [id]: [] } }))
       try {
-        await acpApi.loadSession(live.agentId, id, meta.cwd)
+        await acpApi.loadSession(meta.agentId, id, meta.cwd)
       } catch (err) {
         // Load failed — restore the local transcript so the user still sees history.
         set((s) => ({
@@ -670,8 +677,8 @@ export const useAcpStore = create<AcpState>((set, get) => ({
         }))
         throw err
       }
-    } else if (strategy === 'resume' && live) {
-      await acpApi.resumeSession(live.agentId, id, meta.cwd)
+    } else if (strategy === 'resume') {
+      await acpApi.resumeSession(meta.agentId, id, meta.cwd)
     }
     // 'local' → nothing more; the transcript is already shown.
   },


### PR DESCRIPTION
## Summary

Fixes the Chats history sidebar wiping the active conversation when opening the currently running chat: the pane went blank because `openHistorySession` cleared in-memory messages before agent replay.

## Related Issue

Closes #

## Type of Change

- [ ] feat: new feature
- [x] fix: bug fix
- [ ] docs: documentation only
- [ ] style: formatting or non-functional styling changes
- [ ] refactor: internal cleanup with no behavior change
- [ ] perf: performance improvement
- [ ] test: adds or updates tests
- [ ] build: build or dependency changes
- [ ] ci: CI/CD workflow changes
- [ ] chore: maintenance or tooling
- [ ] revert: reverts a previous change

## What Changed

- `openHistorySession` in `acp-store.ts` returns early when the session is already live in memory, so reopening from the Chats tab only activates the tab and preserves the in-memory transcript.
- Non-live sessions still use load/resume/local, keyed off persisted `meta.agentId` (so a connected agent can resume a closed session).
- Tests: live-session guard; load-failure test updated for non-live session.

## How It Was Tested

- [ ] `bun run lint`
- [x] `bun run typecheck`
- [x] `bun run test` (`src/renderer/stores/acp-store.test.ts`, 39 passed)
- [ ] Manual verification completed
- [ ] Not applicable

## Screenshots or Recordings

<!-- Required for UI changes when applicable -->

## Checklist

- [x] My PR title follows the conventional commit format used by this repo
- [x] I linked the related issue or explained why none exists
- [ ] I updated docs when needed
- [x] I added or updated tests when needed
- [x] I verified the change does not introduce unrelated modifications

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an issue where reopening a session from history would unnecessarily reload data while a session was already active, potentially losing transcript information.
  * Improved error handling to better surface issues when session restoration fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->