### PR TITLE
fix(pty): canonicalize CWD to resolve symlinks and reject invalid paths

### DIFF
--- a/src-tauri/src/pty/manager.rs
+++ b/src-tauri/src/pty/manager.rs
@@ -841,10 +841,11 @@ impl PtyManager {
             self.get_home_directory()
         };
 
-        // Verify CWD exists
-        if !Path::new(&cwd).exists() {
-            return Err(format!("Directory does not exist: {}", cwd));
-        }
+        // Verify CWD exists and canonicalize to resolve symlinks and path traversal
+        let cwd = std::fs::canonicalize(&cwd)
+            .map_err(|e| format!("Invalid working directory '{}': {}", cwd, e))?
+            .to_string_lossy()
+            .to_string();
 
         // Get terminal size
         let cols = options.cols.unwrap_or(80);


### PR DESCRIPTION
## What

The `terminal_spawn` method was checking whether the requested working directory exists, but it passed the raw path as-is to the PTY child process. That means symlinks, `..` traversal, relative paths, and other ambiguities went through without normalisation.

The old check only verified existence:

```rust
if !Path::new(&cwd).exists() {
    return Err("Directory does not exist: {}", cwd);
}
```

If the path exists but is a dangling symlink, a relative path like `../../etc`, or contains redundant components like `/tmp/../home/user`, nothing was resolved before handing it to the shell. The PTY would still start, but the actual working directory might not be what the caller expected.

### What changed

```rust
let cwd = std::fs::canonicalize(&cwd)
    .map_err(|e| format!("Invalid working directory '{}': {}", cwd, e))?
    .to_string_lossy()
    .to_string();
```

One call replaces the existence check:

- **`canonicalize` fails for non-existent paths** — same guard as before, just implicit
- **Resolves symlinks** — a `cwd` pointing to a symlink now expands to the real directory. This matters for cross-drive mounts, WSL interop paths, and container mounts where the symlink target is what the shell actually lands in
- **Collapses `..` and `.`** — no more `/home/user/projects/../downloads` making it through to the shell
- **Produces an absolute path** — relative CWDs are resolved against the daemon's own working directory instead of being passed raw to the PTY

This is a one-line swap in `src-tauri/src/pty/manager.rs` around line 844. No new tests were added because the function is deeply wired through the spawn pipeline, but the behaviour is entirely in the standard library — `canonicalize` is well-specified and the error message preserves the original path for debugging.

### Validation

- `bun run typecheck` passes
- Rust `cargo check` would need the MSVC linker on this machine, but the logic is a single `std::fs` call with no conditional branches
- The existing `.exists()` check would have returned `Ok` for valid paths; `canonicalize` returns `Ok` for exactly the same paths plus normalisation
- Invalid paths that previously returned a generic "does not exist" now return a specific error with the original path and the OS error message

### Risk

Low. The canonicalized path replaces the raw one in a single code path — the `cwd` variable that gets passed to `PtySession::new` and eventually to the OS process spawn. If canonicalization fails, the spawn returns early with an error (same as the old behaviour, but with more detail). No existing valid workflow is affected because `canonicalize` succeeds for any valid path that `exists()` would return true for.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced working directory validation with improved symlink resolution and clearer error reporting when invalid paths are specified during terminal spawning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->