### PR TITLE
feat(file-explorer): show ignored files dimmed instead of hiding them

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1295,15 +1295,12 @@ fn build_search_args(query: &str, root_path: &str, max_matches_per_file: usize) 
         "__pycache__",
         ".pytest_cache",
         "venv",
-        ".env",
         "coverage",
         ".nyc_output",
     ] {
         args.push("-g".to_string());
         args.push(format!("!**/{}/**", ignored));
     }
-    args.push("-g".to_string());
-    args.push("!**/.env".to_string());
 
     args.push("--".to_string());
     args.push(query.to_string());
@@ -1615,7 +1612,6 @@ pub async fn search_file_names(
                 "__pycache__",
                 ".pytest_cache",
                 "venv",
-                ".env",
                 "coverage",
                 ".nyc_output",
             ]

--- a/src/renderer/components/file-explorer/FileTreeNode.tsx
+++ b/src/renderer/components/file-explorer/FileTreeNode.tsx
@@ -31,6 +31,7 @@ export function FileTreeNode({
   onClick
 }: FileTreeNodeProps): React.JSX.Element {
   const isDir = entry.type === 'directory'
+  const isIgnored = entry.ignored === true
   const Icon = getFileIcon(entry.extension, isDir, isExpanded)
   const { startFileDrag } = usePaneDnd()
   const [showTooltip, setShowTooltip] = useState(false)
@@ -89,8 +90,10 @@ export function FileTreeNode({
       <div
         className={cn(
           'group relative flex items-center h-7 cursor-pointer text-sm hover:bg-secondary/50 transition-colors select-none',
+          isIgnored && 'opacity-50',
           isSelected && 'bg-accent text-accent-foreground'
         )}
+        title={isIgnored ? `${entry.name} (git-ignored)` : undefined}
         style={{ paddingLeft: depth * 16 + 4 }}
         onClick={handleClick}
         onContextMenu={(e) => onContextMenu(e, entry)}

--- a/src/renderer/lib/__tests__/tauri-filesystem-api.test.ts
+++ b/src/renderer/lib/__tests__/tauri-filesystem-api.test.ts
@@ -119,7 +119,7 @@ describe('tauriFilesystemApi', () => {
       }
     })
 
-    it('should filter ALWAYS_IGNORE patterns', async () => {
+    it('should flag ALWAYS_IGNORE patterns as ignored but still include them', async () => {
       const mockEntries: DirEntry[] = [
         {
           name: 'file1.txt',
@@ -142,8 +142,16 @@ describe('tauriFilesystemApi', () => {
 
       expect(result.success).toBe(true)
       if (result.success) {
-        expect(result.data).toHaveLength(1)
-        expect(result.data![0].name).toBe('file1.txt')
+        expect(result.data).toHaveLength(4)
+        const byName = Object.fromEntries(result.data!.map((e) => [e.name, e]))
+        // Ignored entries are flagged, not removed
+        expect(byName.node_modules.ignored).toBe(true)
+        expect(byName['.git'].ignored).toBe(true)
+        expect(byName.dist.ignored).toBe(true)
+        // Non-ignored entries are not flagged
+        expect(byName['file1.txt'].ignored).toBe(false)
+        // Non-ignored directories sort before ignored directories
+        expect(result.data![0].name).toBe('.git')
       }
     })
 

--- a/src/renderer/lib/__tests__/tauri-filesystem-api.test.ts
+++ b/src/renderer/lib/__tests__/tauri-filesystem-api.test.ts
@@ -127,6 +127,7 @@ describe('tauriFilesystemApi', () => {
           isFile: true,
           isSymlink: false
         },
+        { name: 'src', isDirectory: true, isFile: false, isSymlink: false },
         {
           name: 'node_modules',
           isDirectory: true,
@@ -142,16 +143,25 @@ describe('tauriFilesystemApi', () => {
 
       expect(result.success).toBe(true)
       if (result.success) {
-        expect(result.data).toHaveLength(4)
+        expect(result.data).toHaveLength(5)
         const byName = Object.fromEntries(result.data!.map((e) => [e.name, e]))
         // Ignored entries are flagged, not removed
         expect(byName.node_modules.ignored).toBe(true)
         expect(byName['.git'].ignored).toBe(true)
         expect(byName.dist.ignored).toBe(true)
         // Non-ignored entries are not flagged
+        expect(byName.src.ignored).toBe(false)
         expect(byName['file1.txt'].ignored).toBe(false)
-        // Non-ignored directories sort before ignored directories
-        expect(result.data![0].name).toBe('.git')
+        // Non-ignored directory sorts before ignored directories
+        expect(result.data![0].name).toBe('src')
+        // Ignored directories still precede files
+        expect(result.data!.map((e) => e.name)).toEqual([
+          'src',
+          '.git',
+          'dist',
+          'node_modules',
+          'file1.txt'
+        ])
       }
     })
 

--- a/src/renderer/lib/tauri-filesystem-api.ts
+++ b/src/renderer/lib/tauri-filesystem-api.ts
@@ -23,6 +23,8 @@ import {
 } from '@tauri-apps/plugin-fs'
 import { cleanupTauriListener, isTauriContext } from './tauri-runtime'
 
+// Names that are commonly git-ignored. Entries matching these are still shown in
+// the file tree but rendered dimmed (and skipped during recursive walks for perf).
 const ALWAYS_IGNORE = [
   'node_modules',
   '.git',
@@ -103,7 +105,11 @@ function sortDirectoryEntries(entries: DirectoryEntry[]): DirectoryEntry[] {
     if (a.type === 'directory' && b.type === 'file') return -1
     if (a.type === 'file' && b.type === 'directory') return 1
 
-    // Within same type, sort alphabetically by name (case-insensitive)
+    // Within same type, non-ignored entries come before ignored ones
+    if (!a.ignored && b.ignored) return -1
+    if (a.ignored && !b.ignored) return 1
+
+    // Within same type/ignored group, sort alphabetically by name (case-insensitive)
     const nameA = a.name.toLowerCase()
     const nameB = b.name.toLowerCase()
     return nameA.localeCompare(nameB)
@@ -188,7 +194,6 @@ export function createTauriFilesystemApi(): FilesystemApi {
         const filtered: DirectoryEntry[] = []
         for (const entry of entries) {
           const name = entry.name
-          if (shouldIgnore(name)) continue
 
           const fullPath = `${normalizedDirPath}/${name}`.replace(/\/+/g, '/')
           let size = 0
@@ -208,7 +213,8 @@ export function createTauriFilesystemApi(): FilesystemApi {
             type: isDir ? 'directory' : 'file',
             extension: isDir ? null : getExtension(name),
             size,
-            modifiedAt: modified
+            modifiedAt: modified,
+            ignored: shouldIgnore(name)
           })
         }
 

--- a/src/shared/types/filesystem.types.ts
+++ b/src/shared/types/filesystem.types.ts
@@ -5,6 +5,8 @@ export interface DirectoryEntry {
   extension: string | null
   size: number
   modifiedAt: number
+  /** True when the entry matches a commonly-ignored name (e.g. node_modules, .env, dist). Shown dimmed but still accessible. */
+  ignored?: boolean
 }
 
 export interface FileContent {


### PR DESCRIPTION
## Summary

- Ignored files/folders (e.g. `node_modules`, `.git`, `dist`, `.env`) were hidden from the file explorer entirely. They are now **shown dimmed but still accessible**, so users can see and open them while knowing they are git-ignored.

## Related Issue

Closes #

## Type of Change

- [x] feat: new feature
- [ ] fix: bug fix
- [ ] docs: documentation only
- [ ] style: formatting or non-functional styling changes
- [ ] refactor: internal cleanup with no behavior change
- [ ] perf: performance improvement
- [ ] test: adds or updates tests
- [ ] build: build or dependency changes
- [ ] ci: CI/CD workflow changes
- [ ] chore: maintenance or tooling
- [ ] revert: reverts a previous change

## What Changed

- Added an optional `ignored` flag to `DirectoryEntry`.
- `readDirectory` now flags commonly-ignored entries instead of skipping them, so they appear in the tree.
- Ignored entries sort to the bottom of their type group (directories/files) to keep the tree tidy.
- `FileTreeNode` renders ignored rows at reduced opacity with a `(git-ignored)` tooltip; they remain clickable/openable.
- Allowed `.env` in ripgrep content and filename search (backend `commands.rs`) so it is accessible there too.
- The recursive file walker still skips ignored directories for performance (not used for tree display).
- Updated the unit test to assert ignored entries are flagged rather than removed.

> Note: dimming is based on a hardcoded common-ignore name list, not per-project `.gitignore` parsing. True `.gitignore`-aware matching is a possible follow-up.

## How It Was Tested

- [ ] `bun run lint`
- [ ] `bun run typecheck`
- [x] `bun run test`
- [x] Manual verification completed
- [ ] Not applicable

`vitest run src/renderer/lib/__tests__/tauri-filesystem-api.test.ts` → 29 passed. Biome check clean on changed files.

## Screenshots or Recordings

<!-- Required for UI changes when applicable -->

## Checklist

- [x] My PR title follows the conventional commit format used by this repo
- [ ] I linked the related issue or explained why none exists
- [ ] I updated docs when needed
- [x] I added or updated tests when needed
- [x] I verified the change does not introduce unrelated modifications


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Git-ignored entries (e.g., node_modules, .env) are now shown in the file explorer with reduced opacity and a "(git-ignored)" label.

* **Bug Fixes**
  * Filename search now correctly considers entries named .env and similar ignored names.
  * Directory listings include ignored entries (marked as ignored) and sort non-ignored items before ignored ones.

* **Tests**
  * Unit tests updated to reflect the new listing/ignored-entry behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->