### PR TITLE
feat(acp): promote thought_level config option to a dedicated selector chip

### DIFF
--- a/src/renderer/components/chat/AgentHeader.tsx
+++ b/src/renderer/components/chat/AgentHeader.tsx
@@ -20,6 +20,16 @@ const STATUS_COLOR: Record<string, string> = {
 }
 
 /**
+ * Resolve the display label for a config chip. Promoted chips (e.g.
+ * `thought_level`) use the shared category heading; generic chips keep their
+ * original `option.name` fallback unchanged.
+ */
+function getLabelForConfigChip(option: SessionConfigOption, promoted: boolean): string {
+  if (!promoted || !option.category) return option.name
+  return KNOWN_CATEGORY_HEADINGS[option.category] ?? option.name
+}
+
+/**
  * A popover selector for one config option. When `promoted` is set (e.g. a
  * `thought_level` reasoning-level option, issue #286), the chip gains a leading
  * icon and uses the shared category heading for its popover title, giving it
@@ -37,11 +47,7 @@ export function ConfigChip({
   promoted?: boolean
 }): React.JSX.Element {
   const current = option.options.find((o) => o.value === option.currentValue)
-  // Promoted chips (e.g. thought_level) use the shared category heading; generic
-  // chips keep their original `option.name` fallback unchanged.
-  const fallbackLabel = promoted
-    ? (option.category && KNOWN_CATEGORY_HEADINGS[option.category]) || option.name
-    : option.name
+  const fallbackLabel = getLabelForConfigChip(option, promoted)
   return (
     <Popover>
       <PopoverTrigger asChild disabled={disabled}>

--- a/src/renderer/components/chat/AgentHeader.tsx
+++ b/src/renderer/components/chat/AgentHeader.tsx
@@ -1,9 +1,10 @@
-import { ChevronDown, Circle } from 'lucide-react'
+import { Brain, ChevronDown, Circle } from 'lucide-react'
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
 import type { SessionConfigOption } from '@/lib/acp-api'
 import { cn } from '@/lib/utils'
 import type { AcpSession, AgentStatus } from '@/stores/acp-store'
 import { AgentBadge } from './AgentBadge'
+import { KNOWN_CATEGORY_HEADINGS } from './slash-menu-model'
 
 interface AgentHeaderProps {
   session: AcpSession
@@ -18,17 +19,29 @@ const STATUS_COLOR: Record<string, string> = {
   'needs-auth': 'text-amber-400'
 }
 
-/** A popover selector for one config option. */
+/**
+ * A popover selector for one config option. When `promoted` is set (e.g. a
+ * `thought_level` reasoning-level option, issue #286), the chip gains a leading
+ * icon and uses the shared category heading for its popover title, giving it
+ * visual priority over generic `other` options.
+ */
 export function ConfigChip({
   option,
   disabled,
-  onSelect
+  onSelect,
+  promoted = false
 }: {
   option: SessionConfigOption
   disabled: boolean
   onSelect: (valueId: string) => void
+  promoted?: boolean
 }): React.JSX.Element {
   const current = option.options.find((o) => o.value === option.currentValue)
+  // Promoted chips (e.g. thought_level) use the shared category heading; generic
+  // chips keep their original `option.name` fallback unchanged.
+  const fallbackLabel = promoted
+    ? (option.category && KNOWN_CATEGORY_HEADINGS[option.category]) || option.name
+    : option.name
   return (
     <Popover>
       <PopoverTrigger asChild disabled={disabled}>
@@ -37,13 +50,14 @@ export function ConfigChip({
           disabled={disabled}
           className="flex h-[30px] items-center gap-1 rounded-lg bg-foreground/[0.06] px-2.5 text-xs text-foreground/80 hover:bg-foreground/[0.09] disabled:cursor-not-allowed disabled:opacity-50"
         >
-          {current?.name ?? option.name}
+          {promoted && <Brain size={13} className="text-muted-foreground" />}
+          {current?.name ?? fallbackLabel}
           <ChevronDown size={11} className="text-muted-foreground" />
         </button>
       </PopoverTrigger>
       <PopoverContent align="start" side="top" className="w-56 p-1">
         <div className="px-2 py-1 text-[10px] font-semibold uppercase tracking-wide text-muted-foreground/70">
-          {option.name}
+          {promoted ? fallbackLabel : option.name}
         </div>
         {option.options.map((v) => (
           <button

--- a/src/renderer/components/chat/ChatInputBar.tsx
+++ b/src/renderer/components/chat/ChatInputBar.tsx
@@ -5,6 +5,7 @@ import { cn } from '@/lib/utils'
 import type { AcpSession } from '@/stores/acp-store'
 import { AgentBadge } from './AgentBadge'
 import { ConfigChip, ModeChip } from './AgentHeader'
+import { partitionConfigOptions } from './chat-input-bar-config'
 import { SlashCommandMenu, type SlashMenuHandle } from './SlashCommandMenu'
 import {
   applyCommandToInput,
@@ -47,6 +48,7 @@ export function ChatInputBar({
 }: ChatInputBarProps): React.JSX.Element {
   const usableConfigOptions = configOptions.filter((o) => o.options.length > 0)
   const hasConfigOptions = usableConfigOptions.length > 0
+  const { thoughtLevel, rest: genericConfigOptions } = partitionConfigOptions(usableConfigOptions)
   const [value, setValue] = useState('')
   const textareaRef = useRef<HTMLTextAreaElement>(null)
   const menuRef = useRef<SlashMenuHandle>(null)
@@ -172,14 +174,25 @@ export function ChatInputBar({
               <ChevronDown size={11} className="text-muted-foreground" />
             </span>
             {hasConfigOptions ? (
-              usableConfigOptions.map((option) => (
-                <ConfigChip
-                  key={option.id}
-                  option={option}
-                  disabled={disabled}
-                  onSelect={(valueId) => onSetConfig(option.id, valueId)}
-                />
-              ))
+              <>
+                {thoughtLevel && (
+                  <ConfigChip
+                    key={thoughtLevel.id}
+                    option={thoughtLevel}
+                    disabled={disabled}
+                    promoted
+                    onSelect={(valueId) => onSetConfig(thoughtLevel.id, valueId)}
+                  />
+                )}
+                {genericConfigOptions.map((option) => (
+                  <ConfigChip
+                    key={option.id}
+                    option={option}
+                    disabled={disabled}
+                    onSelect={(valueId) => onSetConfig(option.id, valueId)}
+                  />
+                ))}
+              </>
             ) : (
               <ModeChip session={session} disabled={disabled} onSelect={onSetMode} />
             )}

--- a/src/renderer/components/chat/chat-input-bar-config.test.ts
+++ b/src/renderer/components/chat/chat-input-bar-config.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest'
+import type { SessionConfigOption } from '@/lib/acp-api'
+import { partitionConfigOptions } from './chat-input-bar-config'
+
+function opt(id: string, category: string | null): SessionConfigOption {
+  return {
+    id,
+    name: id,
+    category,
+    type: 'select',
+    currentValue: 'a',
+    description: null,
+    options: [
+      { value: 'a', name: 'A', description: null },
+      { value: 'b', name: 'B', description: null }
+    ]
+  }
+}
+
+describe('partitionConfigOptions', () => {
+  it('returns null thoughtLevel and empty rest for no options', () => {
+    expect(partitionConfigOptions([])).toEqual({ thoughtLevel: null, rest: [] })
+  })
+
+  it('promotes a thought_level option and leaves rest empty', () => {
+    const tl = opt('reasoning', 'thought_level')
+    const result = partitionConfigOptions([tl])
+    expect(result.thoughtLevel).toBe(tl)
+    expect(result.rest).toEqual([])
+  })
+
+  it('keeps generic options in rest when no thought_level present', () => {
+    const mode = opt('mode', 'mode')
+    const model = opt('model', 'model')
+    const result = partitionConfigOptions([mode, model])
+    expect(result.thoughtLevel).toBeNull()
+    expect(result.rest).toEqual([mode, model])
+  })
+
+  it('partitions mixed options, preserving rest order', () => {
+    const mode = opt('mode', 'mode')
+    const tl = opt('reasoning', 'thought_level')
+    const model = opt('model', 'model')
+    const result = partitionConfigOptions([mode, tl, model])
+    expect(result.thoughtLevel).toBe(tl)
+    expect(result.rest).toEqual([mode, model])
+  })
+
+  it('treats unknown categories as generic rest', () => {
+    const custom = opt('custom', 'something-new')
+    const result = partitionConfigOptions([custom])
+    expect(result.thoughtLevel).toBeNull()
+    expect(result.rest).toEqual([custom])
+  })
+
+  it('promotes only the first thought_level option, rest keeps the others', () => {
+    const tl1 = opt('reasoning1', 'thought_level')
+    const tl2 = opt('reasoning2', 'thought_level')
+    const result = partitionConfigOptions([tl1, tl2])
+    expect(result.thoughtLevel).toBe(tl1)
+    expect(result.rest).toEqual([tl2])
+  })
+})

--- a/src/renderer/components/chat/chat-input-bar-config.ts
+++ b/src/renderer/components/chat/chat-input-bar-config.ts
@@ -1,0 +1,36 @@
+/**
+ * Pure helpers for the input-bar config-option chip row. Kept free of
+ * React/store so they can be unit-tested directly. Partitions agent-advertised
+ * config options so the `thought_level` reasoning-level control can be promoted
+ * to a dedicated, distinctly-styled chip rendered ahead of generic options
+ * (issue #286).
+ */
+import type { SessionConfigOption } from '@/lib/acp-api'
+
+/** ACP semantic category for reasoning/thinking-depth config options. */
+export const THOUGHT_LEVEL_CATEGORY = 'thought_level'
+
+export interface PartitionedConfigOptions {
+  /** The first `thought_level` option, if the agent advertises one. */
+  thoughtLevel: SessionConfigOption | null
+  /** All remaining options, in their original relative order. */
+  rest: SessionConfigOption[]
+}
+
+/**
+ * Split usable config options into the promoted `thought_level` option (first
+ * match wins) and the rest, preserving the rest's original order. Options with
+ * an unknown/other category fall through to `rest` and render as plain chips.
+ */
+export function partitionConfigOptions(options: SessionConfigOption[]): PartitionedConfigOptions {
+  let thoughtLevel: SessionConfigOption | null = null
+  const rest: SessionConfigOption[] = []
+  for (const option of options) {
+    if (thoughtLevel === null && option.category === THOUGHT_LEVEL_CATEGORY) {
+      thoughtLevel = option
+    } else {
+      rest.push(option)
+    }
+  }
+  return { thoughtLevel, rest }
+}

--- a/src/renderer/components/chat/slash-menu-model.ts
+++ b/src/renderer/components/chat/slash-menu-model.ts
@@ -58,7 +58,7 @@ function matches(filter: string, ...fields: (string | null | undefined)[]): bool
   return fields.some((x) => (x ?? '').toLowerCase().includes(f))
 }
 
-const KNOWN_CATEGORY_HEADINGS: Record<string, string> = {
+export const KNOWN_CATEGORY_HEADINGS: Record<string, string> = {
   mode: 'Mode',
   model: 'Model',
   thought_level: 'Thinking Level'


### PR DESCRIPTION
## Summary

- Promote ACP `thought_level` config options to a dedicated reasoning-level selector chip in the chat input bar, separate from generic config options (issue #286).

## Related Issue

Closes #286

## Type of Change

- [x] feat: new feature

## What Changed

- Added a pure `partitionConfigOptions` helper that splits agent-advertised config options into the first `thought_level` option and the rest (preserving order).
- `ChatInputBar` now renders the `thought_level` chip first (when advertised), followed by generic config chips unchanged; legacy `ModeChip` fallback and ADR-003.4 precedence preserved.
- `ConfigChip` gained an optional `promoted` prop that adds a `Brain` icon and uses the shared "Thinking Level" category heading; generic chips render exactly as before.
- Exported `KNOWN_CATEGORY_HEADINGS` from `slash-menu-model.ts` as the single source of category labels.
- No backend, store, or protocol changes — purely consumes data the ACP core already emits. Selector is hidden when no `thought_level` option is advertised (graceful absence).

## How It Was Tested

- [x] `bun run lint`
- [x] `bun run typecheck`
- [x] `bun run test`
- [x] Manual verification completed

Notes: 17 unit tests pass (6 new covering empty/promote/generic-only/mixed-order/unknown-category/first-match-only). Verified end-to-end against a live `cursor-agent acp` session — it advertises `modes`+`models` only (no `thought_level` category), so the selector correctly stays hidden; it will render automatically for agents that advertise a `thought_level` config option.

## Screenshots or Recordings

<!-- Selector is data-gated; cursor-agent does not advertise thought_level so no visible chip in that setup. -->

## Checklist

- [x] My PR title follows the conventional commit format used by this repo
- [x] I linked the related issue or explained why none exists
- [ ] I updated docs when needed
- [x] I added or updated tests when needed
- [x] I verified the change does not introduce unrelated modifications


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Configuration options now display with improved visual hierarchy; a special "thought level" option is now visually promoted with a distinct icon and consistent category labeling.

* **Tests**
  * Added comprehensive test coverage for configuration option partitioning logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->