### PR TITLE
fix(macos): cmd+W closes active tab instead of entire window

### DIFF
--- a/.cora.yaml
+++ b/.cora.yaml
@@ -1,0 +1,43 @@
+# Cora Code Review Configuration
+# See: https://github.com/codecoradev/cora-cli
+
+# Provider settings
+#provider:
+#  provider: openai
+#  model: gpt-4o-mini
+#  base_url: https://api.openai.com/v1
+
+# Review focus areas: security, performance, bugs, best-practice, style
+focus:
+  - security
+  - performance
+  - bugs
+
+# Custom rules / additional instructions for the reviewer
+rules: []
+# rules:
+#   - "Always check for SQL injection vulnerabilities"
+#   - "Ensure all public functions have error handling"
+
+# Ignore patterns
+ignore:
+  files:
+    - "*.lock"
+    - "package-lock.json"
+    - "yarn.lock"
+    - "vendor/"
+    - "node_modules/"
+  rules: []
+#   rules:
+#     - "style"  # ignore style issues
+
+# Hook settings
+hook:
+  mode: warn          # "warn" (print but allow) or "block" (fail commit)
+  min_severity: major # minimum severity to trigger hook action
+  max_diff_size: 50000000 # max diff chars before refusing
+
+# Output settings
+output:
+  format: pretty      # pretty, json, compact, sarif
+  color: true

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -38,6 +38,8 @@ const MENU_ID_ZOOM_OUT: &str = "view-zoom-out";
 const MENU_ID_TOGGLE_FULLSCREEN: &str = "view-toggle-fullscreen";
 const MENU_ID_LEARN_MORE: &str = "help-learn-more";
 const MENU_ID_REVEAL_LOGS: &str = "help-reveal-logs";
+const MENU_ID_CLOSE_TAB: &str = "window-close-tab";
+const MENU_EVENT_CLOSE_TAB: &str = "menu:close-tab";
 const MENU_EVENT_CHECK_FOR_UPDATES_TRIGGERED: &str = "updater:check-for-updates-triggered";
 const LEARN_MORE_URL: &str = "https://github.com/gnoviawan/termul";
 const DEFAULT_ZOOM_FACTOR: f64 = 1.0;
@@ -455,7 +457,7 @@ fn build_app_menu<R: tauri::Runtime>(
 ) -> tauri::Result<tauri::menu::Menu<R>> {
     let file_menu = {
         #[cfg(target_os = "macos")]
-        let builder = SubmenuBuilder::new(app, "File").close_window();
+        let builder = SubmenuBuilder::new(app, "File");
 
         #[cfg(not(target_os = "macos"))]
         let builder = SubmenuBuilder::new(app, "File").quit();
@@ -510,6 +512,20 @@ fn build_app_menu<R: tauri::Runtime>(
             .build()?
     };
 
+    #[cfg(target_os = "macos")]
+    let window_menu = {
+        let close_tab = MenuItemBuilder::with_id(MENU_ID_CLOSE_TAB, "Close Tab")
+            .accelerator("Cmd+W")
+            .build(app)?;
+        SubmenuBuilder::new(app, "Window")
+            .minimize()
+            .maximize()
+            .separator()
+            .item(&close_tab)
+            .build()?
+    };
+
+    #[cfg(not(target_os = "macos"))]
     let window_menu = SubmenuBuilder::new(app, "Window")
         .minimize()
         .maximize()
@@ -596,6 +612,10 @@ fn handle_menu_event<R: tauri::Runtime>(app: &tauri::AppHandle<R>, event: tauri:
     } else if event.id() == MENU_ID_REVEAL_LOGS {
         if let Err(error) = reveal_log_dir(app) {
             log::error!("Failed to reveal log directory from menu: {}", error);
+        }
+    } else if event.id() == MENU_ID_CLOSE_TAB {
+        if let Err(error) = app.emit(MENU_EVENT_CLOSE_TAB, ()) {
+            log::error!("Failed to emit close-tab menu event: {}", error);
         }
     }
 }

--- a/src/renderer/layouts/WorkspaceLayout.tsx
+++ b/src/renderer/layouts/WorkspaceLayout.tsx
@@ -1,5 +1,6 @@
 import type { ShellInfo } from '@shared/types/ipc.types'
 import type { SFTPEntry } from '@shared/types/ssh.types'
+import { listen, type UnlistenFn } from '@tauri-apps/api/event'
 import { motion } from 'framer-motion'
 import { FolderKanban } from 'lucide-react'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
@@ -324,6 +325,31 @@ export default function WorkspaceLayout(): React.JSX.Element {
   // declaration-order dependency. The ref is updated each render.
   const handleCloseTerminalRef = useRef<((id: string, tabId: string) => void) | null>(null)
 
+  /** Close the active tab (reused by keyboard shortcut and native menu event). */
+  const closeActiveTab = useCallback(() => {
+    if (!activeTab) return
+    if (activeTab.type === 'editor') {
+      const fileState = useEditorStore.getState().openFiles.get(activeTab.filePath)
+      if (fileState?.isDirty) {
+        setDirtyCloseFilePath(activeTab.filePath)
+      } else {
+        const didClose = useEditorStore.getState().closeFileIfIdle(activeTab.filePath)
+        if (didClose) {
+          useWorkspaceStore.getState().removeTab(activeTab.id)
+        }
+      }
+    } else if (activeTab.type === 'git' || activeTab.type === 'git-history') {
+      useWorkspaceStore.getState().removeTab(activeTab.id)
+    } else if (activeTab.type === 'terminal') {
+      handleCloseTerminalRef.current?.(activeTab.terminalId, activeTab.id)
+    } else if (activeTab.type === 'browser') {
+      useBrowserSessionStore.getState().removeTab(activeTab.browserTabId)
+      useWorkspaceStore.getState().removeTab(activeTab.id)
+    } else if (activeTab.type === 'agent-chat') {
+      useWorkspaceStore.getState().removeTab(activeTab.id)
+    }
+  }, [activeTab])
+
   // File watcher hook
   useFileWatcher()
 
@@ -564,6 +590,23 @@ export default function WorkspaceLayout(): React.JSX.Element {
       return Promise.resolve(false)
     })
   }, [closeAppWithPersistenceFlush])
+
+  // Listen for native menu "Close Tab" event (macOS Cmd+W intercepted by menu bar)
+  useEffect(() => {
+    let unlisten: UnlistenFn | undefined
+    listen<void>('menu:close-tab', () => {
+      closeActiveTab()
+    })
+      .then((fn) => {
+        unlisten = fn
+      })
+      .catch(() => {
+        // Not in Tauri context — ignore
+      })
+    return () => {
+      unlisten?.()
+    }
+  }, [closeActiveTab])
 
   // Load snapshots when project changes
   useSnapshotLoader()
@@ -865,28 +908,7 @@ export default function WorkspaceLayout(): React.JSX.Element {
       // On Windows/Linux: Ctrl+W closes tab
       if (matchesShortcut(e, getActiveKey('closeTab'))) {
         e.preventDefault()
-        if (activeTab?.type === 'editor') {
-          const fileState = useEditorStore.getState().openFiles.get(activeTab.filePath)
-          if (fileState?.isDirty) {
-            setDirtyCloseFilePath(activeTab.filePath)
-          } else {
-            const didClose = useEditorStore.getState().closeFileIfIdle(activeTab.filePath)
-            if (didClose) {
-              useWorkspaceStore.getState().removeTab(activeTab.id)
-            }
-          }
-        } else if (activeTab?.type === 'git') {
-          useWorkspaceStore.getState().removeTab(activeTab.id)
-        } else if (activeTab?.type === 'git-history') {
-          useWorkspaceStore.getState().removeTab(activeTab.id)
-        } else if (activeTab?.type === 'terminal') {
-          handleCloseTerminalRef.current?.(activeTab.terminalId, activeTab.id)
-        } else if (activeTab?.type === 'browser') {
-          useBrowserSessionStore.getState().removeTab(activeTab.browserTabId)
-          useWorkspaceStore.getState().removeTab(activeTab.id)
-        } else if (activeTab?.type === 'agent-chat') {
-          useWorkspaceStore.getState().removeTab(activeTab.id)
-        }
+        closeActiveTab()
         return
       }
 
@@ -1077,7 +1099,8 @@ export default function WorkspaceLayout(): React.JSX.Element {
     updatePanelVisibility,
     isExplorerVisible,
     isSidebarVisible,
-    handleOpenThemePicker
+    handleOpenThemePicker,
+    closeActiveTab
   ])
 
   useEffect(() => {

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -29,7 +29,7 @@ vi.mock('@tauri-apps/api/core', () => ({
 }))
 
 vi.mock('@tauri-apps/api/event', () => ({
-  listen: vi.fn()
+  listen: vi.fn(() => Promise.resolve(() => {}))
 }))
 
 vi.mock('@tauri-apps/plugin-fs', () => ({


### PR DESCRIPTION
## Summary

Fixes #234

On macOS, pressing `Cmd+W` closed the entire app window instead of just the active tab. This happened because the native macOS menu bar (`Window → Close Window`) intercepted `Cmd+W` before the JavaScript keyboard handler could process it.

## Root Cause

Two native `.close_window()` menu items in `src-tauri/src/lib.rs` both bound `Cmd+W` at the OS level:
1. **File menu** (macOS): `.close_window()` — intercepts Cmd+W
2. **Window menu**: `.close_window()` — also intercepts Cmd+W

Since AppKit `NSMenu` processes keystrokes before the webview, the JS `keydown` handler never received the event.

## Changes

### Rust (`src-tauri/src/lib.rs`)
- **File menu (macOS)**: Removed `.close_window()` — File menu is now empty on macOS (no longer binds Cmd+W)
- **Window menu (macOS only)**: Replaced `.close_window()` with a custom `"Close Tab"` menu item (`MENU_ID_CLOSE_TAB`) that emits `"menu:close-tab"` event to the frontend
- **Window menu (Windows)**: Keeps `.close_window()` unchanged — not affected
- Added `handle_menu_event` branch to emit the event

### Frontend (`src/renderer/layouts/WorkspaceLayout.tsx`)
- Extracted `closeActiveTab()` as a reusable `useCallback` (handles editor/terminal/browser/git/agent-chat tabs)
- Keyboard `keydown` handler now calls `closeActiveTab()` instead of inline logic
- Added `useEffect` listener for `"menu:close-tab"` Tauri event → calls `closeActiveTab()`

## Platform Impact

| Platform | Before | After |
|----------|--------|-------|
| **macOS** | Cmd+W → closes window/app | Cmd+W → closes active tab |
| **Windows** | Ctrl+W → closes tab (JS) | Ctrl+W → closes tab (JS, unchanged) |
| **Linux** | Ctrl+W → closes tab (JS) | Ctrl+W → closes tab (JS, unchanged) |

## Test Plan

- [x] macOS: Open 2+ terminal tabs → Cmd+W closes active tab, app stays open
- [x] macOS: Cmd+W on last tab → no-op, app stays open
- [x] macOS: Window menu shows "Close Tab ⌘W" instead of "Close Window"
- [x] TypeScript typecheck passes
- [x] Biome lint passes
- [ ] Windows: Ctrl+W still closes active tab (no native menu intercept)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a macOS "Close Tab" menu item with Cmd+W support.

* **Improvements**
  * Unified Close Tab behavior across all tab types.
  * Menu action and keyboard shortcut (Ctrl/⌘+W) now trigger the same close operation.

* **Tests**
  * Updated event mocking so menu event listeners behave correctly in tests.

* **Chores**
  * Added project code-review configuration (.cora) for automated checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->