### PR TITLE
fix(ui): make file tree icons and semantic colors follow the active theme

### DIFF
--- a/src/renderer/components/CommandHistoryModal.tsx
+++ b/src/renderer/components/CommandHistoryModal.tsx
@@ -244,7 +244,7 @@ export function CommandHistoryModal({
               <button
                 type="button"
                 onClick={() => setShowClearConfirm(true)}
-                className="flex items-center gap-1 px-2 py-1 rounded hover:bg-secondary/50 text-red-400 hover:text-red-300 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                className="flex items-center gap-1 px-2 py-1 rounded hover:bg-secondary/50 text-red-600 dark:text-red-400 hover:text-red-700 dark:hover:text-red-300 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
                 disabled={entries.length === 0 || filterMode !== 'this-project' || isClearing}
                 title={
                   filterMode === 'all-projects'

--- a/src/renderer/components/ConfirmDialog.tsx
+++ b/src/renderer/components/ConfirmDialog.tsx
@@ -110,7 +110,7 @@ export function ConfirmDialog({
                 <button
                   onClick={secondaryAction.onClick}
                   disabled={isLoading}
-                  className="px-3 py-1.5 text-xs font-medium rounded transition-all text-red-400 hover:text-red-300 hover:bg-red-500/10 disabled:opacity-50 disabled:cursor-not-allowed"
+                  className="px-3 py-1.5 text-xs font-medium rounded transition-all text-red-600 dark:text-red-400 hover:text-red-700 dark:hover:text-red-300 hover:bg-red-500/10 disabled:opacity-50 disabled:cursor-not-allowed"
                 >
                   {secondaryAction.label}
                 </button>

--- a/src/renderer/components/ContextMenu.tsx
+++ b/src/renderer/components/ContextMenu.tsx
@@ -111,7 +111,7 @@ export function ContextMenu({ items, x, y, onClose }: ContextMenuProps): React.J
                 'w-full flex items-center px-2 py-1 text-xs transition-colors',
                 item.disabled && 'opacity-50 cursor-not-allowed',
                 item.variant === 'danger'
-                  ? 'text-red-400 hover:bg-red-500/10'
+                  ? 'text-red-600 dark:text-red-400 hover:bg-red-500/10'
                   : 'text-foreground hover:bg-secondary'
               )}
             >

--- a/src/renderer/components/RemoteAccessPopover.tsx
+++ b/src/renderer/components/RemoteAccessPopover.tsx
@@ -75,7 +75,10 @@ export function RemoteAccessPopover(): React.JSX.Element {
           aria-label="Remote terminal access"
           aria-pressed={isRunning}
         >
-          <Monitor size={14} className={cn('mr-0', isRunning ? 'text-green-300' : undefined)} />
+          <Monitor
+            size={14}
+            className={cn('mr-0', isRunning ? 'text-green-600 dark:text-green-300' : undefined)}
+          />
           {isRunning && <span className="sr-only">Remote access enabled</span>}
         </button>
       </PopoverTrigger>

--- a/src/renderer/components/RestoreSnapshotModal.tsx
+++ b/src/renderer/components/RestoreSnapshotModal.tsx
@@ -101,9 +101,12 @@ export function RestoreSnapshotModal({
               </p>
 
               {hasRunningProcesses && (
-                <div className="bg-yellow-900/20 border border-yellow-800/50 rounded p-3 flex items-start gap-2">
-                  <AlertTriangle size={16} className="text-yellow-400 mt-0.5 flex-shrink-0" />
-                  <div className="text-sm text-yellow-400">
+                <div className="bg-yellow-500/10 border border-yellow-500/30 rounded p-3 flex items-start gap-2">
+                  <AlertTriangle
+                    size={16}
+                    className="text-yellow-600 dark:text-yellow-400 mt-0.5 flex-shrink-0"
+                  />
+                  <div className="text-sm text-yellow-700 dark:text-yellow-400">
                     <span className="font-medium">Warning:</span> You have terminals with running
                     processes. Restoring will terminate these processes.
                   </div>

--- a/src/renderer/components/chat/AgentChatPanel.tsx
+++ b/src/renderer/components/chat/AgentChatPanel.tsx
@@ -96,12 +96,12 @@ export function AgentChatPanel({ sessionId }: AgentChatPanelProps): React.JSX.El
     <div className="flex h-full flex-col bg-background">
       <AgentHeader session={session} agentStatus={agentStatus} />
       {session.lastError && (
-        <div className="border-b border-red-500/30 bg-red-500/10 px-3 py-1 text-[11px] text-red-400">
+        <div className="border-b border-red-500/30 bg-red-500/10 px-3 py-1 text-[11px] text-red-600 dark:text-red-400">
           {session.lastError}
         </div>
       )}
       {pendingAuth && pendingAuth.methods.length > 0 && (
-        <div className="flex flex-wrap items-center gap-2 border-b border-amber-500/30 bg-amber-500/10 px-3 py-1.5 text-[11px] text-amber-400">
+        <div className="flex flex-wrap items-center gap-2 border-b border-amber-500/30 bg-amber-500/10 px-3 py-1.5 text-[11px] text-amber-600 dark:text-amber-400">
           <span>{pendingAuth.message ?? 'This agent requires authentication.'}</span>
           {pendingAuth.methods.map((m) => (
             <button

--- a/src/renderer/components/chat/AgentHeader.tsx
+++ b/src/renderer/components/chat/AgentHeader.tsx
@@ -16,7 +16,7 @@ const STATUS_COLOR: Record<string, string> = {
   spawning: 'text-amber-500',
   idle: 'text-muted-foreground',
   error: 'text-red-500',
-  'needs-auth': 'text-amber-400'
+  'needs-auth': 'text-amber-500'
 }
 
 /**

--- a/src/renderer/components/chat/DiffPreview.tsx
+++ b/src/renderer/components/chat/DiffPreview.tsx
@@ -22,11 +22,13 @@ export function DiffPreview({ diff }: DiffPreviewProps): React.JSX.Element {
         <FileDiff size={12} className="text-muted-foreground" />
         <span className="truncate font-mono text-[11px]">{diff.path}</span>
         {isNewFile && (
-          <span className="rounded bg-green-400/10 px-1 text-[10px] text-green-400">new</span>
+          <span className="rounded bg-green-500/10 px-1 text-[10px] text-green-600 dark:text-green-400">
+            new
+          </span>
         )}
         <span className="ml-auto font-mono text-[10px] text-muted-foreground">
-          <span className="text-green-400">+{added}</span>{' '}
-          <span className="text-red-400">−{removed}</span>
+          <span className="text-green-600 dark:text-green-400">+{added}</span>{' '}
+          <span className="text-red-600 dark:text-red-400">−{removed}</span>
         </span>
       </div>
       <div className="max-h-48 overflow-auto p-2 font-mono text-[11px] leading-snug">
@@ -36,8 +38,8 @@ export function DiffPreview({ diff }: DiffPreviewProps): React.JSX.Element {
             className={cn(
               'whitespace-pre-wrap',
               line.type === 'added'
-                ? 'bg-green-400/10 text-green-300'
-                : 'bg-red-400/10 text-red-300'
+                ? 'bg-green-500/10 text-green-700 dark:text-green-300'
+                : 'bg-red-500/10 text-red-700 dark:text-red-300'
             )}
           >
             <span className="select-none opacity-60">{line.type === 'added' ? '+' : '−'} </span>

--- a/src/renderer/components/chat/PlanPanel.tsx
+++ b/src/renderer/components/chat/PlanPanel.tsx
@@ -7,15 +7,21 @@ interface PlanPanelProps {
 }
 
 const PRIORITY_DOT: Record<string, string> = {
-  high: 'bg-red-400',
-  medium: 'bg-amber-400',
+  high: 'bg-red-500',
+  medium: 'bg-amber-500',
   low: 'bg-muted-foreground/50'
 }
 
 function StatusIcon({ status }: { status?: string }): React.JSX.Element {
-  if (status === 'completed') return <CheckCircle2 size={13} className="text-green-400" />
+  if (status === 'completed')
+    return <CheckCircle2 size={13} className="text-green-600 dark:text-green-400" />
   if (status === 'in_progress')
-    return <Loader2 size={13} className="animate-spin text-amber-400 motion-reduce:animate-none" />
+    return (
+      <Loader2
+        size={13}
+        className="animate-spin text-amber-600 dark:text-amber-400 motion-reduce:animate-none"
+      />
+    )
   return <Circle size={13} className="text-muted-foreground/60" />
 }
 

--- a/src/renderer/components/chat/tool-call-format.ts
+++ b/src/renderer/components/chat/tool-call-format.ts
@@ -53,11 +53,23 @@ export interface StatusStyle {
 export function statusStyle(status: ToolCallStatus | undefined): StatusStyle {
   switch (status) {
     case 'in_progress':
-      return { label: 'running', className: 'text-amber-400 bg-amber-400/10', spinning: true }
+      return {
+        label: 'running',
+        className: 'text-amber-600 dark:text-amber-400 bg-amber-500/10',
+        spinning: true
+      }
     case 'completed':
-      return { label: 'done', className: 'text-green-400 bg-green-400/10', spinning: false }
+      return {
+        label: 'done',
+        className: 'text-green-600 dark:text-green-400 bg-green-500/10',
+        spinning: false
+      }
     case 'failed':
-      return { label: 'failed', className: 'text-red-400 bg-red-400/10', spinning: false }
+      return {
+        label: 'failed',
+        className: 'text-red-600 dark:text-red-400 bg-red-500/10',
+        spinning: false
+      }
     case 'pending':
     default:
       return { label: 'pending', className: 'text-muted-foreground bg-muted/40', spinning: false }

--- a/src/renderer/components/file-explorer/FileExplorer.tsx
+++ b/src/renderer/components/file-explorer/FileExplorer.tsx
@@ -877,7 +877,7 @@ export function FileExplorer({ side = 'right' }: FileExplorerProps): React.JSX.E
 
         {rootPath && rootLoadError && (
           <div className="px-3 py-4 space-y-2">
-            <p className="text-sm text-red-400">Failed to load project files.</p>
+            <p className="text-sm text-red-600 dark:text-red-400">Failed to load project files.</p>
             <p className="text-xs text-muted-foreground break-words">{rootLoadError.message}</p>
             <button
               onClick={handleRootRetry}

--- a/src/renderer/components/file-explorer/FileTreeNode.tsx
+++ b/src/renderer/components/file-explorer/FileTreeNode.tsx
@@ -120,7 +120,7 @@ export function FileTreeNode({
         {!isDir && <span className="w-4 mr-0.5 flex-shrink-0" />}
         <Icon
           size={14}
-          className={cn('flex-shrink-0 mr-1.5', isDir ? 'text-blue-400' : 'text-muted-foreground')}
+          className={cn('flex-shrink-0 mr-1.5', isDir ? 'text-primary' : 'text-muted-foreground')}
         />
         <span className="truncate">{entry.name}</span>
 

--- a/src/renderer/components/git/GitDiffView.tsx
+++ b/src/renderer/components/git/GitDiffView.tsx
@@ -16,8 +16,8 @@ interface GitDiffViewProps {
 function lineClass(kind: ParsedDiffLine['kind']): string {
   return cn(
     'px-2 py-0.5 min-h-[1.25rem]',
-    kind === 'addition' && 'bg-green-500/10 text-green-400',
-    kind === 'deletion' && 'bg-red-500/10 text-red-400',
+    kind === 'addition' && 'bg-green-500/10 text-green-700 dark:text-green-400',
+    kind === 'deletion' && 'bg-red-500/10 text-red-700 dark:text-red-400',
     (kind === 'header' || kind === 'meta') && 'text-muted-foreground italic bg-muted/20',
     kind === 'context' && 'text-foreground/90'
   )

--- a/src/renderer/components/git/GitPanel.tsx
+++ b/src/renderer/components/git/GitPanel.tsx
@@ -731,7 +731,7 @@ function SectionAction({
       className={cn(
         'flex h-6 w-6 items-center justify-center rounded transition-colors disabled:opacity-40 disabled:cursor-not-allowed',
         variant === 'danger'
-          ? 'text-muted-foreground hover:bg-red-500/10 hover:text-red-400'
+          ? 'text-muted-foreground hover:bg-red-500/10 hover:text-red-600 dark:hover:text-red-400'
           : 'text-muted-foreground hover:bg-secondary hover:text-foreground'
       )}
     >
@@ -769,7 +769,7 @@ function RowAction({
       className={cn(
         'flex h-6 w-6 items-center justify-center rounded transition-colors disabled:opacity-40 disabled:cursor-not-allowed',
         variant === 'danger'
-          ? 'text-muted-foreground hover:bg-red-500/10 hover:text-red-400'
+          ? 'text-muted-foreground hover:bg-red-500/10 hover:text-red-600 dark:hover:text-red-400'
           : 'text-muted-foreground hover:bg-secondary hover:text-foreground'
       )}
     >

--- a/src/renderer/components/ssh/RemoteFileExplorer.tsx
+++ b/src/renderer/components/ssh/RemoteFileExplorer.tsx
@@ -195,7 +195,7 @@ export function RemoteFileExplorer({
           <Icon
             className={cn(
               'h-3.5 w-3.5 flex-shrink-0',
-              isDir ? 'text-blue-400' : 'text-muted-foreground'
+              isDir ? 'text-primary' : 'text-muted-foreground'
             )}
           />
 

--- a/src/renderer/components/ssh/SSHFileExplorer.tsx
+++ b/src/renderer/components/ssh/SSHFileExplorer.tsx
@@ -139,7 +139,7 @@ export function SSHFileExplorer({
           <Icon
             className={cn(
               'h-3.5 w-3.5 flex-shrink-0',
-              isDir ? 'text-blue-400' : 'text-muted-foreground'
+              isDir ? 'text-primary' : 'text-muted-foreground'
             )}
           />
           <span className="flex-1 truncate">{entry.name}</span>

--- a/src/renderer/pages/ProjectSettings.tsx
+++ b/src/renderer/pages/ProjectSettings.tsx
@@ -458,7 +458,9 @@ export default function ProjectSettings() {
                               placeholder="Value"
                               className={cn(
                                 'w-full bg-transparent border-none text-sm font-mono focus:ring-0 px-2 py-1',
-                                envVar.isSecret ? 'text-muted-foreground' : 'text-green-400'
+                                envVar.isSecret
+                                  ? 'text-muted-foreground'
+                                  : 'text-green-600 dark:text-green-400'
                               )}
                             />
                           </div>

--- a/src/renderer/pages/WorkspaceSnapshots.tsx
+++ b/src/renderer/pages/WorkspaceSnapshots.tsx
@@ -253,7 +253,7 @@ function SnapshotCard({
                 className={cn(
                   'px-2 py-0.5 rounded text-[10px] uppercase font-bold tracking-wider border',
                   snapshot.tag === 'stable'
-                    ? 'bg-green-900/30 text-green-400 border-green-800/50'
+                    ? 'bg-green-500/10 text-green-700 dark:text-green-400 border-green-500/40'
                     : 'bg-primary/10 text-primary border-primary/30'
                 )}
               >


### PR DESCRIPTION
## Summary

Two related fixes that make the file tree and semantic UI colors follow the active color theme instead of using hardcoded values:

1. **File tree folder icons** were always blue (`text-blue-400`) and ignored the active theme. They now use the `text-primary` theme token, so they follow whatever theme is selected (One Dark, Catppuccin, GitHub, Nord, light themes, etc.). File icons remain monochrome.
2. **Semantic status/diff/error/warning colors** used dark-tuned `-300`/`-400` shades with no light-mode variant, so they washed out under light color themes. They now use the codebase's existing `text-{color}-600 dark:text-{color}-400` pattern to stay legible in light themes while keeping the same look in dark themes.

## Related Issue

Tracked in my fork: julianromli/termul#6 (issues are disabled on this upstream repo for me to file against directly).

## Type of Change

- [x] fix: bug fix

## What Changed

**Folder icons (theme-aware) — replaced `text-blue-400` with `text-primary`:**
- `src/renderer/components/file-explorer/FileTreeNode.tsx`
- `src/renderer/components/ssh/RemoteFileExplorer.tsx`
- `src/renderer/components/ssh/SSHFileExplorer.tsx`

**Light-theme contrast (semantic colors on theme-driven surfaces):**
- Chat: `AgentChatPanel`, `AgentHeader`, `DiffPreview`, `PlanPanel`, `tool-call-format`
- Git: `GitDiffView`, `GitPanel` (danger hover)
- `FileExplorer` (load error), `ContextMenu` (danger item), `ConfirmDialog`, `CommandHistoryModal`
- `RestoreSnapshotModal` + `WorkspaceSnapshots` (swapped dark-only `*-900` tints for `*-500/10` that works in both modes)
- `ProjectSettings` (env value), `RemoteAccessPopover` (running indicator)

**Deliberately left unchanged:**
- Always-dark surfaces: terminal output (`TerminalView`), xterm error screen (`TauriTerminal`)
- `StatusBar` — always a saturated colored bar with white text (`--status-bar` is a darkened primary), so `-400` shades are correct there
- `toast` destructive variant — light-on-red is intentional shadcn styling
- True semantic status colors (git status, worktree health, annotation severity) keep their meaning

No new tokens, settings, or APIs. Relies on existing per-theme CSS variables (`--primary`) and the existing Tailwind mappings.

## How It Was Tested

- [x] `bun run lint` (no errors; pre-existing warnings only)
- [x] `bun run typecheck`
- [x] `bun run test` (file-explorer, ssh, chat, git suites pass)
- [x] Manual verification completed

## Screenshots or Recordings

<!-- Folder icons tint with the active theme's primary color; semantic colors stay legible on light themes. -->

## Checklist

- [x] My PR title follows the conventional commit format used by this repo
- [x] I linked the related issue or explained why none exists
- [ ] I updated docs when needed (not needed — no behavior/API docs affected)
- [ ] I added or updated tests when needed (presentational token/shade swaps; existing tests still pass)
- [x] I verified the change does not introduce unrelated modifications
