### PR TITLE
fix(pty): protect open-project terminals from orphan reaping

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -125,6 +125,14 @@ pub struct RendererRefRequest {
     pub renderer_id: String,
 }
 
+/// Request to update a terminal's orphan-reaping protection.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SetTerminalProtectedRequest {
+    pub terminal_id: String,
+    pub protected: bool,
+}
+
 // ==================== Terminal Commands ====================
 
 /// Spawn a new terminal with binary data channel
@@ -255,6 +263,23 @@ pub async fn terminal_remove_renderer_ref(
     pty_manager: State<'_, Arc<PtyManager>>,
 ) -> Result<IpcResult<()>, String> {
     match pty_manager.remove_renderer_ref(&request.terminal_id, &request.renderer_id) {
+        Ok(()) => Ok(IpcResult::success(())),
+        Err(e) => Ok(IpcResult::error(e, "TERMINAL_NOT_FOUND")),
+    }
+}
+
+/// Update a terminal's orphan-reaping protection.
+///
+/// Protection is enabled automatically at spawn. The renderer calls this with
+/// `protected = false` only when a terminal is genuinely released (its project
+/// is closed or its tab is closed), so orphan detection may reclaim it. This
+/// keeps live background-project terminals from being killed mid-task.
+#[tauri::command]
+pub async fn terminal_set_protected(
+    request: SetTerminalProtectedRequest,
+    pty_manager: State<'_, Arc<PtyManager>>,
+) -> Result<IpcResult<()>, String> {
+    match pty_manager.set_protected(&request.terminal_id, request.protected) {
         Ok(()) => Ok(IpcResult::success(())),
         Err(e) => Ok(IpcResult::error(e, "TERMINAL_NOT_FOUND")),
     }

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -279,10 +279,10 @@ pub async fn terminal_set_protected(
     request: SetTerminalProtectedRequest,
     pty_manager: State<'_, Arc<PtyManager>>,
 ) -> Result<IpcResult<()>, String> {
-    match pty_manager.set_protected(&request.terminal_id, request.protected) {
-        Ok(()) => Ok(IpcResult::success(())),
-        Err(e) => Ok(IpcResult::error(e, "TERMINAL_NOT_FOUND")),
-    }
+    // `set_protected` is intentionally idempotent and infallible (it is a no-op
+    // when the terminal is already gone), so there is no error case to map.
+    pty_manager.set_protected(&request.terminal_id, request.protected);
+    Ok(IpcResult::success(()))
 }
 
 /// Set visibility state (affects polling behavior and PTY kill deferral)

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -821,6 +821,7 @@ pub fn run() {
             commands::terminal_update_orphan_detection,
             commands::terminal_add_renderer_ref,
             commands::terminal_remove_renderer_ref,
+            commands::terminal_set_protected,
             commands::terminal_set_visibility,
             // Agent registry (ADR-004.6: identity/discovery, opt-in, read-only)
             commands::agent_registry_fetch,

--- a/src-tauri/src/pty/manager.rs
+++ b/src-tauri/src/pty/manager.rs
@@ -536,6 +536,14 @@ pub struct TerminalInstance {
     pub last_activity: Arc<RwLock<Instant>>,
     pub orphan_since: Arc<RwLock<Option<Instant>>>,
     pub renderer_refs: Arc<RwLock<HashSet<String>>>,
+    /// When true, this terminal is still owned by an open project/tab and must
+    /// NOT be reaped by orphan detection — even if it currently has zero
+    /// renderer refs (e.g. its project is switched to the background, so the
+    /// `ConnectedTerminal` component unmounted). It is set true at spawn and
+    /// cleared only when the terminal is explicitly released (project closed or
+    /// terminal tab closed). This prevents busy background-project terminals
+    /// from being killed mid-task — the cause of the "Terminal not found"/hang.
+    pub protected: Arc<AtomicBool>,
     pub cols: Arc<RwLock<u16>>,
     pub rows: Arc<RwLock<u16>>,
     /// Broadcast channel for fan-out of raw PTY output to remote WebSocket clients.
@@ -587,9 +595,39 @@ impl TerminalInstance {
         self.renderer_refs.read().is_empty()
     }
 
+    /// Whether this terminal is eligible for orphan reaping right now.
+    ///
+    /// A terminal is reapable only when it is NOT protected (its project/tab is
+    /// genuinely closed), has no renderer refs, and has exceeded the timeout —
+    /// measured from when it became orphaned, or by inactivity if it never had
+    /// a renderer ref. Protected terminals (e.g. a backgrounded project's live
+    /// terminals) are never reaped, even with zero renderer refs.
+    pub fn is_orphan_reapable(&self, timeout: Duration) -> bool {
+        should_reap_orphan(
+            self.is_protected(),
+            self.is_orphan(),
+            self.orphan_since().map(|since| since.elapsed()),
+            self.inactive_duration(),
+            timeout,
+        )
+    }
+
     /// Returns when the terminal became orphaned, if ever.
     pub fn orphan_since(&self) -> Option<Instant> {
         *self.orphan_since.read()
+    }
+
+    /// Whether this terminal is protected from orphan reaping (still owned by an
+    /// open project/tab). See the `protected` field docs.
+    pub fn is_protected(&self) -> bool {
+        self.protected.load(Ordering::Relaxed)
+    }
+
+    /// Update the protection flag. Set false only when the terminal is genuinely
+    /// released (project closed / terminal tab closed), making it eligible for
+    /// orphan reaping once it also has no renderer refs.
+    pub fn set_protected(&self, protected: bool) {
+        self.protected.store(protected, Ordering::Relaxed);
     }
 
     /// Subscribe to live PTY output. Returns a receiver that yields raw byte batches.
@@ -613,6 +651,31 @@ impl TerminalInstance {
         let rx = self.broadcast_tx.subscribe();
         let snapshot: Vec<u8> = guard.iter().copied().collect();
         (snapshot, rx)
+    }
+}
+
+/// Pure decision for whether an orphaned terminal should be reaped.
+///
+/// Kept free-standing (no PTY handles) so it can be unit-tested in isolation.
+///
+/// * `protected` — terminal is still owned by an open project/tab; never reap.
+/// * `is_orphan` — terminal currently has zero renderer refs.
+/// * `orphaned_for` — elapsed time since it became orphaned, if it ever was.
+/// * `inactive_for` — elapsed time since last PTY activity.
+/// * `timeout` — configured orphan timeout.
+fn should_reap_orphan(
+    protected: bool,
+    is_orphan: bool,
+    orphaned_for: Option<Duration>,
+    inactive_for: Duration,
+    timeout: Duration,
+) -> bool {
+    if protected || !is_orphan {
+        return false;
+    }
+    match orphaned_for {
+        Some(elapsed) => elapsed > timeout,
+        None => inactive_for > timeout,
     }
 }
 
@@ -799,11 +862,12 @@ impl PtyManager {
                     .read()
                     .iter()
                     .filter(|(_, instance)| {
-                        instance.is_orphan()
-                            && instance
-                                .orphan_since()
-                                .map(|since| since.elapsed() > timeout)
-                                .unwrap_or_else(|| instance.inactive_duration() > timeout)
+                        // Never reap terminals that are still owned by an open
+                        // project/tab. A backgrounded project's terminals lose
+                        // their renderer refs (component unmount) but remain
+                        // live and may be running tasks — reaping them caused
+                        // the "Terminal not found"/hang bug.
+                        instance.is_orphan_reapable(timeout)
                     })
                     .map(|(id, _)| id.clone())
                     .collect();
@@ -946,6 +1010,7 @@ impl PtyManager {
                 last_activity: Arc::new(RwLock::new(Instant::now())),
                 orphan_since: Arc::new(RwLock::new(None)),
                 renderer_refs: Arc::new(RwLock::new(HashSet::new())),
+                protected: Arc::new(AtomicBool::new(true)),
                 cols: Arc::new(RwLock::new(cols)),
                 rows: Arc::new(RwLock::new(rows)),
                 broadcast_tx: Arc::new(tokio::sync::broadcast::channel(TERM_BROADCAST_CAPACITY).0),
@@ -1083,6 +1148,7 @@ impl PtyManager {
                 last_activity: Arc::new(RwLock::new(Instant::now())),
                 orphan_since: Arc::new(RwLock::new(None)),
                 renderer_refs: Arc::new(RwLock::new(HashSet::new())),
+                protected: Arc::new(AtomicBool::new(true)),
                 cols: Arc::new(RwLock::new(cols)),
                 rows: Arc::new(RwLock::new(rows)),
                 broadcast_tx: Arc::new(tokio::sync::broadcast::channel(TERM_BROADCAST_CAPACITY).0),
@@ -1475,6 +1541,20 @@ impl PtyManager {
             .get(id)
             .ok_or_else(|| format!("Terminal not found: {}", id))
             .map(|instance| instance.remove_renderer_ref(renderer_id))
+    }
+
+    /// Update a terminal's orphan-reaping protection.
+    ///
+    /// Protection is enabled at spawn and should be disabled only when the
+    /// terminal is genuinely released by the renderer (its project is closed or
+    /// the terminal tab is closed). Once unprotected AND lacking renderer refs,
+    /// the terminal becomes eligible for orphan reaping again. Returns Ok even
+    /// if the terminal is already gone, so callers can release idempotently.
+    pub fn set_protected(&self, id: &str, protected: bool) -> Result<(), String> {
+        if let Some(instance) = self.terminals.read().get(id) {
+            instance.set_protected(protected);
+        }
+        Ok(())
     }
 
     /// Get terminal by ID
@@ -2582,6 +2662,79 @@ mod tests {
         let resolved = resolve_spawn_program("gemini").expect("unix passthrough");
         assert_eq!(resolved.program, "gemini");
         assert!(resolved.prepend_args.is_empty());
+    }
+
+    #[test]
+    fn test_should_reap_orphan_protected_never_reaped() {
+        let long_ago = Duration::from_secs(10_000);
+        let timeout = Duration::from_secs(600);
+        // Protected + orphaned + long past timeout => still not reapable.
+        assert!(!should_reap_orphan(
+            true,
+            true,
+            Some(long_ago),
+            long_ago,
+            timeout
+        ));
+    }
+
+    #[test]
+    fn test_should_reap_orphan_attached_never_reaped() {
+        let long_ago = Duration::from_secs(10_000);
+        let timeout = Duration::from_secs(600);
+        // Not protected but still has a renderer ref (is_orphan == false).
+        assert!(!should_reap_orphan(
+            false,
+            false,
+            Some(long_ago),
+            long_ago,
+            timeout
+        ));
+    }
+
+    #[test]
+    fn test_should_reap_orphan_orphaned_past_timeout_reaped() {
+        let timeout = Duration::from_secs(600);
+        // Unprotected, orphaned, past timeout => reapable.
+        assert!(should_reap_orphan(
+            false,
+            true,
+            Some(Duration::from_secs(601)),
+            Duration::from_secs(0),
+            timeout
+        ));
+    }
+
+    #[test]
+    fn test_should_reap_orphan_orphaned_within_timeout_not_reaped() {
+        let timeout = Duration::from_secs(600);
+        assert!(!should_reap_orphan(
+            false,
+            true,
+            Some(Duration::from_secs(59)),
+            Duration::from_secs(0),
+            timeout
+        ));
+    }
+
+    #[test]
+    fn test_should_reap_orphan_uses_inactivity_when_never_orphaned() {
+        let timeout = Duration::from_secs(600);
+        // Never had a renderer ref (orphaned_for None) => fall back to inactivity.
+        assert!(should_reap_orphan(
+            false,
+            true,
+            None,
+            Duration::from_secs(601),
+            timeout
+        ));
+        assert!(!should_reap_orphan(
+            false,
+            true,
+            None,
+            Duration::from_secs(59),
+            timeout
+        ));
     }
 
     #[test]

--- a/src-tauri/src/pty/manager.rs
+++ b/src-tauri/src/pty/manager.rs
@@ -1548,13 +1548,13 @@ impl PtyManager {
     /// Protection is enabled at spawn and should be disabled only when the
     /// terminal is genuinely released by the renderer (its project is closed or
     /// the terminal tab is closed). Once unprotected AND lacking renderer refs,
-    /// the terminal becomes eligible for orphan reaping again. Returns Ok even
-    /// if the terminal is already gone, so callers can release idempotently.
-    pub fn set_protected(&self, id: &str, protected: bool) -> Result<(), String> {
+    /// the terminal becomes eligible for orphan reaping again. This is a no-op
+    /// (rather than an error) when the terminal is already gone, so callers can
+    /// release idempotently.
+    pub fn set_protected(&self, id: &str, protected: bool) {
         if let Some(instance) = self.terminals.read().get(id) {
             instance.set_protected(protected);
         }
-        Ok(())
     }
 
     /// Get terminal by ID

--- a/src/renderer/hooks/use-projects-persistence.ts
+++ b/src/renderer/hooks/use-projects-persistence.ts
@@ -537,7 +537,15 @@ export function useDeleteProjectWithCascade(): (id: string) => Promise<void> {
     for (const terminal of projectTerminals) {
       if (terminal.ptyId) {
         try {
-          await terminalApi.kill(terminal.ptyId)
+          // kill() returns an IpcResult; a soft failure does not throw. The
+          // project is being deleted regardless, so we always proceed to drop
+          // the renderer record below — we just surface a failed kill in logs
+          // (e.g. the backend deferring a kill while the window is hidden still
+          // reports success, so this only logs genuine failures).
+          const result = await terminalApi.kill(terminal.ptyId)
+          if (!result.success) {
+            console.warn('Failed to kill PTY during project delete:', result.error)
+          }
         } catch (error) {
           console.warn('Failed to kill PTY during project delete:', error)
         }

--- a/src/renderer/hooks/use-projects-persistence.ts
+++ b/src/renderer/hooks/use-projects-persistence.ts
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useRef } from 'react'
-import { persistenceApi, secureStorageApi, worktreeApi } from '@/lib/api'
+import { persistenceApi, secureStorageApi, terminalApi, worktreeApi } from '@/lib/api'
 import { useProjectStore } from '@/stores/project-store'
+import { useTerminalStore } from '@/stores/terminal-store'
 import type { EnvVariable, Project, ProjectColor, ProjectGroup, Worktree } from '@/types/project'
 import type {
   PersistedProject,
@@ -526,6 +527,22 @@ export function useDeleteProjectWithCascade(): (id: string) => Promise<void> {
     // Delete secrets from secure storage
     if (project) {
       await deleteSecrets(project.id, project.envVars)
+    }
+
+    // Kill the project's live PTYs so the backend reclaims them. The terminals
+    // are genuinely released here (the project is being deleted), so they must
+    // not stay alive/protected and leak. kill() removes them from the backend
+    // terminal map; we also drop them from the renderer store.
+    const projectTerminals = useTerminalStore.getState().terminals.filter((t) => t.projectId === id)
+    for (const terminal of projectTerminals) {
+      if (terminal.ptyId) {
+        try {
+          await terminalApi.kill(terminal.ptyId)
+        } catch (error) {
+          console.warn('Failed to kill PTY during project delete:', error)
+        }
+      }
+      useTerminalStore.getState().closeTerminal(terminal.id, id)
     }
 
     // Delete the project from the store

--- a/src/renderer/hooks/use-projects-persistence.ts
+++ b/src/renderer/hooks/use-projects-persistence.ts
@@ -544,7 +544,14 @@ export function useDeleteProjectWithCascade(): (id: string) => Promise<void> {
           // reports success, so this only logs genuine failures).
           const result = await terminalApi.kill(terminal.ptyId)
           if (!result.success) {
-            console.warn('Failed to kill PTY during project delete:', result.error)
+        try {
+          const killResult = await terminalApi.kill(terminal.ptyId)
+          if (!killResult.success) {
+            console.warn('Failed to kill PTY during project delete:', killResult.error)
+            // Best-effort fallback: allow orphan cleanup if PTY still exists
+            await terminalApi.setProtected(terminal.ptyId, false).catch((error) => {
+              console.warn('Failed to clear PTY protection during project delete:', error)
+            })
           }
         } catch (error) {
           console.warn('Failed to kill PTY during project delete:', error)

--- a/src/renderer/hooks/use-projects-persistence.ts
+++ b/src/renderer/hooks/use-projects-persistence.ts
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useRef } from 'react'
 import { persistenceApi, secureStorageApi, terminalApi, worktreeApi } from '@/lib/api'
+import { setTerminalProtected } from '@/lib/terminal-api'
 import { useProjectStore } from '@/stores/project-store'
 import { useTerminalStore } from '@/stores/terminal-store'
 import type { EnvVariable, Project, ProjectColor, ProjectGroup, Worktree } from '@/types/project'
@@ -544,12 +545,9 @@ export function useDeleteProjectWithCascade(): (id: string) => Promise<void> {
           // reports success, so this only logs genuine failures).
           const result = await terminalApi.kill(terminal.ptyId)
           if (!result.success) {
-        try {
-          const killResult = await terminalApi.kill(terminal.ptyId)
-          if (!killResult.success) {
-            console.warn('Failed to kill PTY during project delete:', killResult.error)
+            console.warn('Failed to kill PTY during project delete:', result.error)
             // Best-effort fallback: allow orphan cleanup if PTY still exists
-            await terminalApi.setProtected(terminal.ptyId, false).catch((error) => {
+            await setTerminalProtected(terminal.ptyId, false).catch((error) => {
               console.warn('Failed to clear PTY protection during project delete:', error)
             })
           }

--- a/src/renderer/lib/tauri-terminal-api.ts
+++ b/src/renderer/lib/tauri-terminal-api.ts
@@ -57,7 +57,8 @@ const IPC_COMMANDS = {
   GET_EXIT_CODE: 'terminal_get_exit_code',
   UPDATE_ORPHAN_DETECTION: 'terminal_update_orphan_detection',
   ADD_RENDERER_REF: 'terminal_add_renderer_ref',
-  REMOVE_RENDERER_REF: 'terminal_remove_renderer_ref'
+  REMOVE_RENDERER_REF: 'terminal_remove_renderer_ref',
+  SET_PROTECTED: 'terminal_set_protected'
 } as const
 
 /**
@@ -537,6 +538,25 @@ export async function removeRendererRef(
   // Rust expects argument `request: RendererRefRequest { terminal_id, renderer_id }`
   const request = { terminalId: ptyId, rendererId }
   return invokeIpc<void>(IPC_COMMANDS.REMOVE_RENDERER_REF, { request })
+}
+
+/**
+ * Internal method to set a terminal's orphan-reaping protection (not part of
+ * the TerminalApi interface).
+ *
+ * Protection is enabled automatically at spawn. Call with `protected = false`
+ * ONLY when a terminal is genuinely released — its project is closed or its tab
+ * is closed. Do NOT call this on a project switch or component unmount: a
+ * backgrounded project's terminals must stay protected so orphan detection does
+ * not kill them mid-task (the "Terminal not found"/hang bug).
+ */
+export async function setTerminalProtected(
+  ptyId: string,
+  protectedState: boolean
+): Promise<IpcResult<void>> {
+  // Rust expects argument `request: SetTerminalProtectedRequest { terminal_id, protected }`
+  const request = { terminalId: ptyId, protected: protectedState }
+  return invokeIpc<void>(IPC_COMMANDS.SET_PROTECTED, { request })
 }
 
 /**

--- a/src/renderer/lib/terminal-api.ts
+++ b/src/renderer/lib/terminal-api.ts
@@ -22,4 +22,4 @@ import { createTauriTerminalApi } from './tauri-terminal-api'
 export const terminalApi: TerminalApi = createTauriTerminalApi()
 
 // Re-export internal renderer ref methods for ConnectedTerminal component
-export { addRendererRef, removeRendererRef } from './tauri-terminal-api'
+export { addRendererRef, removeRendererRef, setTerminalProtected } from './tauri-terminal-api'


### PR DESCRIPTION
## Summary

- Fixes background-project terminals dying with `Terminal not found` / hang while another project is focused.

## Related Issue

Closes #308

## Type of Change

- [x] fix: bug fix

## What Changed

Root cause: on project switch, the backgrounded project's `ConnectedTerminal` components unmount and call `removeRendererRef`, setting `orphan_since`. Orphan detection in `manager.rs` then reaped these still-alive (possibly busy) terminals after the timeout, bypassing the activity-based safety net. The killed PTY id no longer exists in the backend map, so writes/resizes return `Terminal not found`.

Fix (backend protection flag):

- `src-tauri/src/pty/manager.rs`
  - Added `protected: Arc<AtomicBool>` to `TerminalInstance`, enabled at spawn (Windows ConPTY + non-Windows paths).
  - Added `is_protected()` / `set_protected()` and extracted the reap decision into a pure `should_reap_orphan(...)` + `is_orphan_reapable(timeout)`. Orphan detection now skips protected terminals.
  - Added `PtyManager::set_protected(id, protected)` (idempotent).
- `src-tauri/src/commands.rs` + `src-tauri/src/lib.rs`: new `terminal_set_protected` command (with `SetTerminalProtectedRequest`), registered in the invoke handler.
- `src/renderer/lib/tauri-terminal-api.ts` / `terminal-api.ts`: `setTerminalProtected(ptyId, protected)` adapter + `SET_PROTECTED` command name.
- `src/renderer/hooks/use-projects-persistence.ts`: deleting a project now kills its live PTYs (and removes them from the store) so protected terminals don't leak after their owning project is gone.

Project switching and component unmount are unchanged (still only `removeRendererRef`), so backgrounded-project terminals stay protected and alive. Explicit terminal close (`WorkspaceLayout.handleCloseTerminal` -> `terminalApi.kill`) still reclaims terminals normally.

## How It Was Tested

- [x] `bun run typecheck`
- [x] `bun run test` (use-terminal-restore, use-projects-persistence, tauri-terminal-api, api-bridge, terminal-store)
- [x] `cargo test` (added 5 unit tests for `should_reap_orphan`)
- [ ] Manual verification completed

## Checklist

- [x] My PR title follows the conventional commit format used by this repo
- [x] I linked the related issue or explained why none exists
- [ ] I updated docs when needed
- [x] I added or updated tests when needed
- [x] I verified the change does not introduce unrelated modifications

## Notes

- `cargo clippy -D warnings` reports 3 pre-existing errors in files this PR does not touch (`env_refresh.rs`, Windows ConPTY block at `manager.rs:2204`), triggered by a newer clippy. Not addressed here.
- Behavior change: deleting a project now actively kills its terminal PTYs (previously they leaked).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add ability to mark terminals as protected to prevent automatic termination when orphaned; protection can be toggled from the renderer.
  * Expose a renderer API to set terminal protected state.

* **Bug Fixes**
  * Project deletion now better cleans up live terminals by attempting to terminate PTYs and closing renderer-side terminal records.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->