### PR TITLE
fix(acp): show slash command menu and reactivate history sessions

### DIFF
--- a/src/renderer/components/chat/ChatInputBar.tsx
+++ b/src/renderer/components/chat/ChatInputBar.tsx
@@ -149,82 +149,84 @@ export function ChatInputBar({
 
   return (
     <div className="px-5 pb-3.5 pt-3">
-      <div className="relative mx-auto w-full max-w-3xl overflow-hidden rounded-2xl bg-secondary/40">
+      <div className="relative mx-auto w-full max-w-3xl">
         {menuOpen && <SlashCommandMenu ref={menuRef} sections={sections} onSelect={handleSelect} />}
-        <div className="px-4 pb-1.5 pt-3.5">
-          <textarea
-            ref={textareaRef}
-            value={value}
-            onChange={handleInput}
-            onKeyDown={handleKeyDown}
-            disabled={disabled}
-            rows={1}
-            placeholder={disabled ? 'Session closed' : 'Ask anything… (/ for commands)'}
-            className={cn(
-              'w-full resize-none bg-transparent text-sm leading-relaxed',
-              'placeholder:text-muted-foreground focus:outline-none',
-              'disabled:cursor-not-allowed disabled:opacity-50 max-h-40'
-            )}
-          />
-        </div>
-        <div className="flex items-center justify-between gap-3 px-2.5 pb-2.5">
-          <div className="flex min-w-0 flex-wrap items-center gap-1.5">
-            <span className="flex h-[30px] items-center gap-1.5 rounded-lg bg-foreground/[0.06] px-2.5 text-xs text-foreground/80">
-              <AgentBadge agentId={session.agentId} iconSize={16} className="max-w-[140px]" />
-              <ChevronDown size={11} className="text-muted-foreground" />
-            </span>
-            {hasConfigOptions ? (
-              <>
-                {thoughtLevel && (
-                  <ConfigChip
-                    key={thoughtLevel.id}
-                    option={thoughtLevel}
-                    disabled={disabled}
-                    promoted
-                    onSelect={(valueId) => onSetConfig(thoughtLevel.id, valueId)}
-                  />
-                )}
-                {genericConfigOptions.map((option) => (
-                  <ConfigChip
-                    key={option.id}
-                    option={option}
-                    disabled={disabled}
-                    onSelect={(valueId) => onSetConfig(option.id, valueId)}
-                  />
-                ))}
-              </>
-            ) : (
-              <ModeChip session={session} disabled={disabled} onSelect={onSetMode} />
-            )}
+        <div className="overflow-hidden rounded-2xl bg-secondary/40">
+          <div className="px-4 pb-1.5 pt-3.5">
+            <textarea
+              ref={textareaRef}
+              value={value}
+              onChange={handleInput}
+              onKeyDown={handleKeyDown}
+              disabled={disabled}
+              rows={1}
+              placeholder={disabled ? 'Session closed' : 'Ask anything… (/ for commands)'}
+              className={cn(
+                'w-full resize-none bg-transparent text-sm leading-relaxed',
+                'placeholder:text-muted-foreground focus:outline-none',
+                'disabled:cursor-not-allowed disabled:opacity-50 max-h-40'
+              )}
+            />
           </div>
-          <div className="flex flex-shrink-0 items-center gap-2">
-            {busy ? (
-              <button
-                type="button"
-                onClick={onCancel}
-                title="Cancel turn"
-                aria-label="Cancel turn"
-                className="flex h-[34px] w-[34px] items-center justify-center rounded-full bg-secondary text-foreground hover:bg-secondary/80"
-              >
-                <Square size={14} />
-              </button>
-            ) : (
-              <button
-                type="button"
-                onClick={submit}
-                disabled={!canSend}
-                title="Send"
-                aria-label="Send message"
-                className={cn(
-                  'flex h-[34px] w-[34px] items-center justify-center rounded-full transition-colors',
-                  canSend
-                    ? 'bg-foreground text-background hover:bg-foreground/90'
-                    : 'bg-foreground/20 text-background/70 cursor-not-allowed'
-                )}
-              >
-                <ArrowUp size={16} strokeWidth={2.5} />
-              </button>
-            )}
+          <div className="flex items-center justify-between gap-3 px-2.5 pb-2.5">
+            <div className="flex min-w-0 flex-wrap items-center gap-1.5">
+              <span className="flex h-[30px] items-center gap-1.5 rounded-lg bg-foreground/[0.06] px-2.5 text-xs text-foreground/80">
+                <AgentBadge agentId={session.agentId} iconSize={16} className="max-w-[140px]" />
+                <ChevronDown size={11} className="text-muted-foreground" />
+              </span>
+              {hasConfigOptions ? (
+                <>
+                  {thoughtLevel && (
+                    <ConfigChip
+                      key={thoughtLevel.id}
+                      option={thoughtLevel}
+                      disabled={disabled}
+                      promoted
+                      onSelect={(valueId) => onSetConfig(thoughtLevel.id, valueId)}
+                    />
+                  )}
+                  {genericConfigOptions.map((option) => (
+                    <ConfigChip
+                      key={option.id}
+                      option={option}
+                      disabled={disabled}
+                      onSelect={(valueId) => onSetConfig(option.id, valueId)}
+                    />
+                  ))}
+                </>
+              ) : (
+                <ModeChip session={session} disabled={disabled} onSelect={onSetMode} />
+              )}
+            </div>
+            <div className="flex flex-shrink-0 items-center gap-2">
+              {busy ? (
+                <button
+                  type="button"
+                  onClick={onCancel}
+                  title="Cancel turn"
+                  aria-label="Cancel turn"
+                  className="flex h-[34px] w-[34px] items-center justify-center rounded-full bg-secondary text-foreground hover:bg-secondary/80"
+                >
+                  <Square size={14} />
+                </button>
+              ) : (
+                <button
+                  type="button"
+                  onClick={submit}
+                  disabled={!canSend}
+                  title="Send"
+                  aria-label="Send message"
+                  className={cn(
+                    'flex h-[34px] w-[34px] items-center justify-center rounded-full transition-colors',
+                    canSend
+                      ? 'bg-foreground text-background hover:bg-foreground/90'
+                      : 'bg-foreground/20 text-background/70 cursor-not-allowed'
+                  )}
+                >
+                  <ArrowUp size={16} strokeWidth={2.5} />
+                </button>
+              )}
+            </div>
           </div>
         </div>
       </div>

--- a/src/renderer/stores/acp-store.test.ts
+++ b/src/renderer/stores/acp-store.test.ts
@@ -973,6 +973,7 @@ describe('acp-store', () => {
     })
     // load strategy clears then agent replays; with no replay, messages stay empty
     expect(useAcpStore.getState().messages['s-closed']).toEqual([])
+    expect(useAcpStore.getState().sessions['s-closed'].status).toBe('active')
   })
 
   it('openHistorySession restores the local transcript if load fails (P5)', async () => {

--- a/src/renderer/stores/acp-store.test.ts
+++ b/src/renderer/stores/acp-store.test.ts
@@ -976,6 +976,67 @@ describe('acp-store', () => {
     expect(useAcpStore.getState().sessions['s-closed'].status).toBe('active')
   })
 
+  it('openHistorySession resumes when session is cached but closed (P5)', async () => {
+    useAcpStore.setState((s) => ({
+      agents: {
+        ...s.agents,
+        'agent-1': {
+          id: 'agent-1',
+          capabilities: { loadSession: false, sessionCapabilities: { resume: {} } }
+        }
+      },
+      agentStatus: { ...s.agentStatus, 'agent-1': 'connected' },
+      sessions: {
+        's-closed': {
+          id: 's-closed',
+          agentId: 'agent-1',
+          cwd: '/w',
+          status: 'closed',
+          title: 'Was open',
+          activeTurn: false,
+          openTurnId: null,
+          modes: null,
+          configOptions: [],
+          lastError: null,
+          createdAt: 1
+        }
+      },
+      messages: { 's-closed': [] }
+    }))
+    const { loadSessionPayload } = await import('@/lib/acp-history-persistence')
+    ;(loadSessionPayload as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      metadata: {
+        id: 's-closed',
+        agentId: 'agent-1',
+        title: 'Was open',
+        cwd: '/w',
+        createdAt: 1,
+        lastActivityAt: 2,
+        messageCount: 1,
+        status: 'closed'
+      },
+      messages: [
+        {
+          id: 'm1',
+          role: 'user',
+          blocks: [{ type: 'text', text: 'from disk' }],
+          streaming: false,
+          timestamp: 0
+        }
+      ]
+    })
+    ;(invoke as ReturnType<typeof vi.fn>).mockResolvedValueOnce(undefined)
+    await useAcpStore.getState().openHistorySession('s-closed')
+    expect(loadSessionPayload).toHaveBeenCalled()
+    expect(invoke).toHaveBeenCalledWith('acp_resume_session', {
+      agentId: 'agent-1',
+      sessionId: 's-closed',
+      cwd: '/w'
+    })
+    expect(useAcpStore.getState().messages['s-closed']).toHaveLength(1)
+    expect(useAcpStore.getState().sessions['s-closed'].status).toBe('active')
+  })
+
   it('openHistorySession restores the local transcript if load fails (P5)', async () => {
     // A non-live session whose agent process is still connected with loadSession
     // -> 'load' strategy; if the reload fails the local transcript is restored.

--- a/src/renderer/stores/acp-store.ts
+++ b/src/renderer/stores/acp-store.ts
@@ -301,6 +301,27 @@ function finalizeStreaming(
   return messages
 }
 
+/** Mark a reopened history session live after a successful load/resume IPC call. */
+function withSessionActive(
+  sessions: Record<SessionId, AcpSession>,
+  sessionId: SessionId
+): Record<SessionId, AcpSession> {
+  const session = sessions[sessionId]
+  if (!session) return sessions
+  return { ...sessions, [sessionId]: { ...session, status: 'active', lastError: null } }
+}
+
+/** Surface a failed history load/resume on the session without changing status. */
+function withSessionResumeError(
+  sessions: Record<SessionId, AcpSession>,
+  sessionId: SessionId,
+  err: unknown
+): Record<SessionId, AcpSession> {
+  const session = sessions[sessionId]
+  if (!session) return sessions
+  return { ...sessions, [sessionId]: { ...session, lastError: `Resume failed: ${String(err)}` } }
+}
+
 /** Remove all pending permissions belonging to a session. */
 function dropPermissionsForSession(
   pending: Record<string, PendingPermission>,
@@ -975,35 +996,23 @@ export const useAcpStore = create<AcpState>((set, get) => ({
       set((s) => ({ messages: { ...s.messages, [id]: [] } }))
       try {
         await acpApi.loadSession(meta.agentId, id, meta.cwd)
-        set((s) => {
-          const session = s.sessions[id]
-          if (!session) return {}
-          return {
-            sessions: { ...s.sessions, [id]: { ...session, status: 'active', lastError: null } }
-          }
-        })
+        set((s) => ({ sessions: withSessionActive(s.sessions, id) }))
       } catch (err) {
         // Load failed — restore the local transcript so the user still sees history.
         set((s) => ({
           messages: { ...s.messages, [id]: payload.messages },
-          sessions: s.sessions[id]
-            ? {
-                ...s.sessions,
-                [id]: { ...s.sessions[id], lastError: `Resume failed: ${String(err)}` }
-              }
-            : s.sessions
+          sessions: withSessionResumeError(s.sessions, id, err)
         }))
         throw err
       }
     } else if (strategy === 'resume') {
-      await acpApi.resumeSession(meta.agentId, id, meta.cwd)
-      set((s) => {
-        const session = s.sessions[id]
-        if (!session) return {}
-        return {
-          sessions: { ...s.sessions, [id]: { ...session, status: 'active', lastError: null } }
-        }
-      })
+      try {
+        await acpApi.resumeSession(meta.agentId, id, meta.cwd)
+        set((s) => ({ sessions: withSessionActive(s.sessions, id) }))
+      } catch (err) {
+        set((s) => ({ sessions: withSessionResumeError(s.sessions, id, err) }))
+        throw err
+      }
     }
     // 'local' → nothing more; the transcript is already shown.
   },

--- a/src/renderer/stores/acp-store.ts
+++ b/src/renderer/stores/acp-store.ts
@@ -975,6 +975,13 @@ export const useAcpStore = create<AcpState>((set, get) => ({
       set((s) => ({ messages: { ...s.messages, [id]: [] } }))
       try {
         await acpApi.loadSession(meta.agentId, id, meta.cwd)
+        set((s) => {
+          const session = s.sessions[id]
+          if (!session) return {}
+          return {
+            sessions: { ...s.sessions, [id]: { ...session, status: 'active', lastError: null } }
+          }
+        })
       } catch (err) {
         // Load failed — restore the local transcript so the user still sees history.
         set((s) => ({
@@ -990,6 +997,13 @@ export const useAcpStore = create<AcpState>((set, get) => ({
       }
     } else if (strategy === 'resume') {
       await acpApi.resumeSession(meta.agentId, id, meta.cwd)
+      set((s) => {
+        const session = s.sessions[id]
+        if (!session) return {}
+        return {
+          sessions: { ...s.sessions, [id]: { ...session, status: 'active', lastError: null } }
+        }
+      })
     }
     // 'local' → nothing more; the transcript is already shown.
   },


### PR DESCRIPTION
## Summary

- Fix ACP slash command popover being clipped invisible when typing `/` in agent chat
- Reactivate history sessions after successful `loadSession` / `resumeSession` so the chat input is enabled

## Related Issue

Closes #

## Type of Change

- [ ] feat: new feature
- [x] fix: bug fix
- [ ] docs: documentation only
- [ ] style: formatting or non-functional styling changes
- [ ] refactor: internal cleanup with no behavior change
- [ ] perf: performance improvement
- [x] test: adds or updates tests
- [ ] build: build or dependency changes
- [ ] ci: CI/CD workflow changes
- [ ] chore: maintenance or tooling
- [ ] revert: reverts a previous change

## What Changed

- **`ChatInputBar`**: Move `SlashCommandMenu` outside the `overflow-hidden` rounded input shell so the `absolute bottom-full` popover is not clipped
- **`acp-store`**: Set session `status: 'active'` after successful `loadSession` or `resumeSession` in `openHistorySession` (history tabs previously stayed `closed`, disabling input and the `/` trigger)
- **`acp-store.test`**: Assert closed history session becomes `active` after successful load reload

## How It Was Tested

- [ ] `bun run lint`
- [x] `bun run typecheck`
- [x] `bun run test`
- [ ] Manual verification completed
- [ ] Not applicable

## Screenshots or Recordings

<!-- Required for UI changes when applicable -->

## Checklist

- [x] My PR title follows the conventional commit format used by this repo
- [x] I linked the related issue or explained why none exists
- [ ] I updated docs when needed
- [x] I added or updated tests when needed
- [x] I verified the change does not introduce unrelated modifications


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style / Refactor**
  * Restructured the chat input bar layout so container styling is moved to an inner wrapper while preserving behavior.

* **Bug Fixes**
  * Ensure reopened cached history sessions become active and lingering error states are cleared; transcript restore on resume/load failures improved.

* **Tests**
  * Added coverage for session resume path, asserting messages load and session status becomes active.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->