### PR TITLE
feat(acp): inject Agent Skills from slash menu in chat and launcher

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -11,6 +11,7 @@ mod pty;
 mod remote;
 mod secure_storage;
 mod shell_paths;
+mod skills;
 mod ssh;
 mod trackers;
 mod worktree;
@@ -926,6 +927,9 @@ pub fn run() {
             acp::commands::acp_respond_permission,
             acp::commands::acp_authenticate,
             acp_binary_install::acp_install_registry_binary,
+            // Agent Skills (Zed-compatible SKILL.md packages)
+            skills::commands::list_agent_skills_cmd,
+            skills::commands::read_agent_skill_cmd,
             // Remote server commands
             commands::remote_server_start,
             commands::remote_server_stop,

--- a/src-tauri/src/skills/commands.rs
+++ b/src-tauri/src/skills/commands.rs
@@ -1,0 +1,18 @@
+//! Tauri IPC for Agent Skills discovery.
+
+use super::{list_agent_skills, read_agent_skill, AgentSkillContent, AgentSkillSummary};
+
+#[tauri::command]
+pub fn list_agent_skills_cmd(
+    project_root: Option<String>,
+) -> Result<Vec<AgentSkillSummary>, String> {
+    list_agent_skills(project_root.as_deref())
+}
+
+#[tauri::command]
+pub fn read_agent_skill_cmd(
+    name: String,
+    project_root: Option<String>,
+) -> Result<AgentSkillContent, String> {
+    read_agent_skill(&name, project_root.as_deref())
+}

--- a/src-tauri/src/skills/mod.rs
+++ b/src-tauri/src/skills/mod.rs
@@ -27,20 +27,34 @@ pub struct AgentSkillContent {
     pub body: String,
 }
 
-fn home_skills_root() -> PathBuf {
-    #[cfg(target_os = "windows")]
-    {
-        if let Ok(home) = std::env::var("USERPROFILE").or_else(|_| std::env::var("HOME")) {
-            return PathBuf::from(home).join(".agents").join("skills");
-        }
+fn home_skills_root() -> Result<PathBuf, String> {
+    let home = std::env::var("HOME")
+        .or_else(|_| std::env::var("USERPROFILE"))
+        .map_err(|_| "could not resolve user home directory".to_string())?;
+    Ok(PathBuf::from(home).join(".agents").join("skills"))
+}
+
+/// Zed-compatible skill names: lowercase letters, digits, hyphens; no traversal.
+fn validate_skill_name(name: &str) -> Result<(), String> {
+    if name.is_empty() {
+        return Err("skill name must not be empty".to_string());
     }
-    #[cfg(not(target_os = "windows"))]
-    {
-        if let Ok(home) = std::env::var("HOME") {
-            return PathBuf::from(home).join(".agents").join("skills");
-        }
+    if name.contains('/') || name.contains('\\') {
+        return Err("invalid skill name".to_string());
     }
-    PathBuf::from(".agents/skills")
+    if name == "." || name == ".." {
+        return Err("invalid skill name".to_string());
+    }
+    if name.starts_with('-') || name.ends_with('-') || name.contains("--") {
+        return Err("invalid skill name".to_string());
+    }
+    if !name
+        .bytes()
+        .all(|b| b.is_ascii_lowercase() || b.is_ascii_digit() || b == b'-')
+    {
+        return Err("invalid skill name".to_string());
+    }
+    Ok(())
 }
 
 /// Split `SKILL.md` into frontmatter key/value pairs and the markdown body.
@@ -106,6 +120,9 @@ fn scan_skills_dir(
             .cloned()
             .filter(|n| !n.is_empty())
             .unwrap_or(folder_name);
+        if validate_skill_name(&name).is_err() {
+            continue;
+        }
         let description = frontmatter.get("description").cloned().unwrap_or_default();
 
         out.insert(
@@ -125,7 +142,7 @@ fn scan_skills_dir(
 pub fn list_agent_skills(project_root: Option<&str>) -> Result<Vec<AgentSkillSummary>, String> {
     let mut by_name: HashMap<String, AgentSkillSummary> = HashMap::new();
 
-    scan_skills_dir(&home_skills_root(), "global", &mut by_name)?;
+    scan_skills_dir(&home_skills_root()?, "global", &mut by_name)?;
 
     if let Some(root) = project_root.filter(|s| !s.is_empty()) {
         let project_skills = PathBuf::from(root)
@@ -140,9 +157,7 @@ pub fn list_agent_skills(project_root: Option<&str>) -> Result<Vec<AgentSkillSum
 }
 
 fn resolve_skill_path(name: &str, project_root: Option<&str>) -> Result<(PathBuf, String), String> {
-    if name.is_empty() {
-        return Err("skill name must not be empty".to_string());
-    }
+    validate_skill_name(name)?;
 
     if let Some(root) = project_root.filter(|s| !s.is_empty()) {
         let project_skill = PathBuf::from(root)
@@ -155,7 +170,7 @@ fn resolve_skill_path(name: &str, project_root: Option<&str>) -> Result<(PathBuf
         }
     }
 
-    let global_skill = home_skills_root().join(name).join("SKILL.md");
+    let global_skill = home_skills_root()?.join(name).join("SKILL.md");
     if global_skill.is_file() {
         return Ok((global_skill, "global".to_string()));
     }
@@ -215,6 +230,57 @@ mod tests {
         let content = read_agent_skill("demo-skill", Some(&root)).unwrap();
         assert_eq!(content.name, "demo-skill");
         assert_eq!(content.body.trim(), "Run the demo.");
+
+        let _ = fs::remove_dir_all(temp);
+    }
+
+    #[test]
+    fn read_agent_skill_rejects_path_traversal_names() {
+        let temp = std::env::temp_dir().join(format!("termul-skill-sec-{}", std::process::id()));
+        let skill_dir = temp.join(".agents").join("skills").join("safe-skill");
+        fs::create_dir_all(&skill_dir).unwrap();
+        fs::write(skill_dir.join("SKILL.md"), "---\nname: safe-skill\n---\n\nok\n").unwrap();
+        let root = temp.to_string_lossy().to_string();
+
+        for malicious in [
+            "../../../etc/passwd",
+            "foo/../bar",
+            "..",
+            ".",
+            "bad/name",
+            "bad\\name",
+        ] {
+            let err = read_agent_skill(malicious, Some(&root)).unwrap_err();
+            assert!(
+                err.contains("invalid skill name") || err.contains("not found"),
+                "expected rejection for {malicious}, got: {err}"
+            );
+        }
+
+        let _ = fs::remove_dir_all(temp);
+    }
+
+    #[test]
+    fn list_agent_skills_ignores_invalid_directory_names() {
+        let temp = std::env::temp_dir().join(format!("termul-skill-list-sec-{}", std::process::id()));
+        let skills_root = temp.join(".agents").join("skills");
+        fs::create_dir_all(skills_root.join("valid-skill")).unwrap();
+        fs::write(
+            skills_root.join("valid-skill").join("SKILL.md"),
+            "---\nname: valid-skill\n---\n\nok\n",
+        )
+        .unwrap();
+        fs::create_dir_all(skills_root.join("Invalid")).unwrap();
+        fs::write(
+            skills_root.join("Invalid").join("SKILL.md"),
+            "---\nname: Invalid\n---\n\nno\n",
+        )
+        .unwrap();
+
+        let root = temp.to_string_lossy().to_string();
+        let listed = list_agent_skills(Some(&root)).unwrap();
+        assert!(listed.iter().any(|s| s.name == "valid-skill"));
+        assert!(!listed.iter().any(|s| s.name == "Invalid"));
 
         let _ = fs::remove_dir_all(temp);
     }

--- a/src-tauri/src/skills/mod.rs
+++ b/src-tauri/src/skills/mod.rs
@@ -1,0 +1,221 @@
+//! Agent Skills discovery — Zed-compatible `SKILL.md` packages under
+//! `~/.agents/skills/` (global) and `{project}/.agents/skills/` (project-local).
+
+pub mod commands;
+
+use serde::Serialize;
+use std::collections::HashMap;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct AgentSkillSummary {
+    pub name: String,
+    pub description: String,
+    /// `"global"` or `"project"`.
+    pub scope: String,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct AgentSkillContent {
+    pub name: String,
+    pub description: String,
+    pub scope: String,
+    /// Markdown body after YAML frontmatter.
+    pub body: String,
+}
+
+fn home_skills_root() -> PathBuf {
+    #[cfg(target_os = "windows")]
+    {
+        if let Ok(home) = std::env::var("USERPROFILE").or_else(|_| std::env::var("HOME")) {
+            return PathBuf::from(home).join(".agents").join("skills");
+        }
+    }
+    #[cfg(not(target_os = "windows"))]
+    {
+        if let Ok(home) = std::env::var("HOME") {
+            return PathBuf::from(home).join(".agents").join("skills");
+        }
+    }
+    PathBuf::from(".agents/skills")
+}
+
+/// Split `SKILL.md` into frontmatter key/value pairs and the markdown body.
+pub fn parse_skill_md(content: &str) -> Result<(HashMap<String, String>, String), String> {
+    let trimmed = content.trim_start();
+    if !trimmed.starts_with("---") {
+        return Ok((HashMap::new(), content.trim().to_string()));
+    }
+
+    let rest = trimmed.strip_prefix("---").unwrap_or(trimmed).trim_start();
+    let end = rest
+        .find("\n---")
+        .ok_or_else(|| "SKILL.md frontmatter is not closed with '---'".to_string())?;
+    let frontmatter = &rest[..end];
+    let body = rest[end + 4..].trim_start_matches('\r').trim_start();
+
+    let mut map = HashMap::new();
+    for line in frontmatter.lines() {
+        let line = line.trim();
+        if line.is_empty() || line.starts_with('#') {
+            continue;
+        }
+        let Some((key, value)) = line.split_once(':') else {
+            continue;
+        };
+        let key = key.trim().to_string();
+        let value = value.trim().trim_matches('"').trim_matches('\'').to_string();
+        if !key.is_empty() {
+            map.insert(key, value);
+        }
+    }
+
+    Ok((map, body.to_string()))
+}
+
+fn scan_skills_dir(
+    dir: &Path,
+    scope: &str,
+    out: &mut HashMap<String, AgentSkillSummary>,
+) -> Result<(), String> {
+    if !dir.is_dir() {
+        return Ok(());
+    }
+
+    for entry in fs::read_dir(dir).map_err(|e| format!("read skills dir {}: {e}", dir.display()))? {
+        let entry = entry.map_err(|e| e.to_string())?;
+        let file_type = entry.file_type().map_err(|e| e.to_string())?;
+        if !file_type.is_dir() {
+            continue;
+        }
+
+        let folder_name = entry.file_name().to_string_lossy().to_string();
+        let skill_md = entry.path().join("SKILL.md");
+        if !skill_md.is_file() {
+            continue;
+        }
+
+        let raw = fs::read_to_string(&skill_md)
+            .map_err(|e| format!("read {}: {e}", skill_md.display()))?;
+        let (frontmatter, _) = parse_skill_md(&raw)?;
+        let name = frontmatter
+            .get("name")
+            .cloned()
+            .filter(|n| !n.is_empty())
+            .unwrap_or(folder_name);
+        let description = frontmatter.get("description").cloned().unwrap_or_default();
+
+        out.insert(
+            name.clone(),
+            AgentSkillSummary {
+                name,
+                description,
+                scope: scope.to_string(),
+            },
+        );
+    }
+
+    Ok(())
+}
+
+/// List installed skills. Project-local entries override global names.
+pub fn list_agent_skills(project_root: Option<&str>) -> Result<Vec<AgentSkillSummary>, String> {
+    let mut by_name: HashMap<String, AgentSkillSummary> = HashMap::new();
+
+    scan_skills_dir(&home_skills_root(), "global", &mut by_name)?;
+
+    if let Some(root) = project_root.filter(|s| !s.is_empty()) {
+        let project_skills = PathBuf::from(root)
+            .join(".agents")
+            .join("skills");
+        scan_skills_dir(&project_skills, "project", &mut by_name)?;
+    }
+
+    let mut skills: Vec<AgentSkillSummary> = by_name.into_values().collect();
+    skills.sort_by(|a, b| a.name.cmp(&b.name));
+    Ok(skills)
+}
+
+fn resolve_skill_path(name: &str, project_root: Option<&str>) -> Result<(PathBuf, String), String> {
+    if name.is_empty() {
+        return Err("skill name must not be empty".to_string());
+    }
+
+    if let Some(root) = project_root.filter(|s| !s.is_empty()) {
+        let project_skill = PathBuf::from(root)
+            .join(".agents")
+            .join("skills")
+            .join(name)
+            .join("SKILL.md");
+        if project_skill.is_file() {
+            return Ok((project_skill, "project".to_string()));
+        }
+    }
+
+    let global_skill = home_skills_root().join(name).join("SKILL.md");
+    if global_skill.is_file() {
+        return Ok((global_skill, "global".to_string()));
+    }
+
+    Err(format!("skill '{name}' not found"))
+}
+
+/// Read a skill's markdown body. Project-local overrides global.
+pub fn read_agent_skill(name: &str, project_root: Option<&str>) -> Result<AgentSkillContent, String> {
+    let (path, scope) = resolve_skill_path(name, project_root)?;
+    let raw = fs::read_to_string(&path).map_err(|e| format!("read {}: {e}", path.display()))?;
+    let (frontmatter, body) = parse_skill_md(&raw)?;
+    let skill_name = frontmatter
+        .get("name")
+        .cloned()
+        .filter(|n| !n.is_empty())
+        .unwrap_or_else(|| name.to_string());
+    let description = frontmatter.get("description").cloned().unwrap_or_default();
+
+    Ok(AgentSkillContent {
+        name: skill_name,
+        description,
+        scope,
+        body,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    #[test]
+    fn parse_skill_md_splits_frontmatter() {
+        let raw = "---\nname: demo\ndescription: A demo skill\n---\n\n## Steps\n\nDo things.\n";
+        let (fm, body) = parse_skill_md(raw).unwrap();
+        assert_eq!(fm.get("name").map(String::as_str), Some("demo"));
+        assert_eq!(fm.get("description").map(String::as_str), Some("A demo skill"));
+        assert!(body.contains("## Steps"));
+    }
+
+    #[test]
+    fn list_and_read_project_skill() {
+        let temp = std::env::temp_dir().join(format!("termul-skill-test-{}", std::process::id()));
+        let skill_dir = temp.join(".agents").join("skills").join("demo-skill");
+        fs::create_dir_all(&skill_dir).unwrap();
+        fs::write(
+            skill_dir.join("SKILL.md"),
+            "---\nname: demo-skill\ndescription: Demo\n---\n\nRun the demo.\n",
+        )
+        .unwrap();
+
+        let root = temp.to_string_lossy().to_string();
+        let listed = list_agent_skills(Some(&root)).unwrap();
+        assert!(listed.iter().any(|s| s.name == "demo-skill" && s.scope == "project"));
+
+        let content = read_agent_skill("demo-skill", Some(&root)).unwrap();
+        assert_eq!(content.name, "demo-skill");
+        assert_eq!(content.body.trim(), "Run the demo.");
+
+        let _ = fs::remove_dir_all(temp);
+    }
+}

--- a/src-tauri/src/skills/mod.rs
+++ b/src-tauri/src/skills/mod.rs
@@ -81,7 +81,11 @@ pub fn parse_skill_md(content: &str) -> Result<(HashMap<String, String>, String)
             continue;
         };
         let key = key.trim().to_string();
-        let value = value.trim().trim_matches('"').trim_matches('\'').to_string();
+        let value = value
+            .trim()
+            .trim_matches('"')
+            .trim_matches('\'')
+            .to_string();
         if !key.is_empty() {
             map.insert(key, value);
         }
@@ -145,9 +149,7 @@ pub fn list_agent_skills(project_root: Option<&str>) -> Result<Vec<AgentSkillSum
     scan_skills_dir(&home_skills_root()?, "global", &mut by_name)?;
 
     if let Some(root) = project_root.filter(|s| !s.is_empty()) {
-        let project_skills = PathBuf::from(root)
-            .join(".agents")
-            .join("skills");
+        let project_skills = PathBuf::from(root).join(".agents").join("skills");
         scan_skills_dir(&project_skills, "project", &mut by_name)?;
     }
 
@@ -179,7 +181,10 @@ fn resolve_skill_path(name: &str, project_root: Option<&str>) -> Result<(PathBuf
 }
 
 /// Read a skill's markdown body. Project-local overrides global.
-pub fn read_agent_skill(name: &str, project_root: Option<&str>) -> Result<AgentSkillContent, String> {
+pub fn read_agent_skill(
+    name: &str,
+    project_root: Option<&str>,
+) -> Result<AgentSkillContent, String> {
     let (path, scope) = resolve_skill_path(name, project_root)?;
     let raw = fs::read_to_string(&path).map_err(|e| format!("read {}: {e}", path.display()))?;
     let (frontmatter, body) = parse_skill_md(&raw)?;
@@ -208,7 +213,10 @@ mod tests {
         let raw = "---\nname: demo\ndescription: A demo skill\n---\n\n## Steps\n\nDo things.\n";
         let (fm, body) = parse_skill_md(raw).unwrap();
         assert_eq!(fm.get("name").map(String::as_str), Some("demo"));
-        assert_eq!(fm.get("description").map(String::as_str), Some("A demo skill"));
+        assert_eq!(
+            fm.get("description").map(String::as_str),
+            Some("A demo skill")
+        );
         assert!(body.contains("## Steps"));
     }
 
@@ -225,7 +233,9 @@ mod tests {
 
         let root = temp.to_string_lossy().to_string();
         let listed = list_agent_skills(Some(&root)).unwrap();
-        assert!(listed.iter().any(|s| s.name == "demo-skill" && s.scope == "project"));
+        assert!(listed
+            .iter()
+            .any(|s| s.name == "demo-skill" && s.scope == "project"));
 
         let content = read_agent_skill("demo-skill", Some(&root)).unwrap();
         assert_eq!(content.name, "demo-skill");
@@ -239,7 +249,11 @@ mod tests {
         let temp = std::env::temp_dir().join(format!("termul-skill-sec-{}", std::process::id()));
         let skill_dir = temp.join(".agents").join("skills").join("safe-skill");
         fs::create_dir_all(&skill_dir).unwrap();
-        fs::write(skill_dir.join("SKILL.md"), "---\nname: safe-skill\n---\n\nok\n").unwrap();
+        fs::write(
+            skill_dir.join("SKILL.md"),
+            "---\nname: safe-skill\n---\n\nok\n",
+        )
+        .unwrap();
         let root = temp.to_string_lossy().to_string();
 
         for malicious in [
@@ -262,7 +276,8 @@ mod tests {
 
     #[test]
     fn list_agent_skills_ignores_invalid_directory_names() {
-        let temp = std::env::temp_dir().join(format!("termul-skill-list-sec-{}", std::process::id()));
+        let temp =
+            std::env::temp_dir().join(format!("termul-skill-list-sec-{}", std::process::id()));
         let skills_root = temp.join(".agents").join("skills");
         fs::create_dir_all(skills_root.join("valid-skill")).unwrap();
         fs::write(

--- a/src/renderer/components/agents/AgentLauncher.tsx
+++ b/src/renderer/components/agents/AgentLauncher.tsx
@@ -1,7 +1,7 @@
 import type { DetectedShells, ShellInfo } from '@shared/types/ipc.types'
 import { type LastSelectedAgent, PersistenceKeys } from '@shared/types/persistence.types'
-import { ArrowUp, Loader2, Plus, Settings2, Terminal as TerminalIcon } from 'lucide-react'
-import { memo, useCallback, useEffect, useMemo, useState } from 'react'
+import { ArrowUp, Loader2, Plus, Settings2, Terminal as TerminalIcon, X } from 'lucide-react'
+import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { toast } from 'sonner'
 import { Button } from '@/components/ui/button'
@@ -33,6 +33,18 @@ import { prepareChatKey, useAcpStore } from '@/stores/acp-store'
 import { useDefaultShell, useMaxTerminalsPerProject } from '@/stores/app-settings-store'
 import { useProjectStore } from '@/stores/project-store'
 import { useWorkspaceStore } from '@/stores/workspace-store'
+import {
+  buildPromptWithLoadedSkill,
+  type LoadedAgentSkill,
+  useAgentSkills
+} from '@/hooks/use-agent-skills'
+import { SlashCommandMenu, type SlashMenuHandle } from '@/components/chat/SlashCommandMenu'
+import {
+  buildSlashSections,
+  isSlashTrigger,
+  type SlashItem,
+  slashFilter
+} from '@/components/chat/slash-menu-model'
 import { CustomAgentDialog } from './CustomAgentDialog'
 
 /**
@@ -65,6 +77,9 @@ export function AgentLauncher({
 }: AgentLauncherProps): React.JSX.Element {
   const navigate = useNavigate()
   const [prompt, setPrompt] = useState('')
+  const [loadedSkill, setLoadedSkill] = useState<LoadedAgentSkill | null>(null)
+  const menuRef = useRef<SlashMenuHandle>(null)
+  const textareaRef = useRef<HTMLTextAreaElement>(null)
   const [loadedAgents, setLoadedAgents] =
     useState<readonly TerminalAgentDefinition[]>(BUILT_IN_AGENTS)
   const cliAgents = agentsProp ?? loadedAgents
@@ -134,6 +149,7 @@ export function AgentLauncher({
   }, [entries])
 
   const activeProjectId = useProjectStore((s) => s.activeProjectId)
+  const projectRoot = activeProjectId ? getDefaultCwdForProject(activeProjectId) : undefined
   const maxTerminals = useMaxTerminalsPerProject()
   const appDefaultShell = useDefaultShell()
 
@@ -180,6 +196,33 @@ export function AgentLauncher({
     if (!selectedEntry) return 'cli'
     return selectedEntry.modes.includes(selectedMode) ? selectedMode : selectedEntry.modes[0]
   }, [selectedEntry, selectedMode])
+
+  const { skills } = useAgentSkills(effectiveMode === 'acp' ? projectRoot : undefined)
+  const menuOpen = effectiveMode === 'acp' && isSlashTrigger(prompt)
+  const slashSections = useMemo(
+    () =>
+      menuOpen
+        ? buildSlashSections({
+            commands: [],
+            configOptions: [],
+            modes: null,
+            skills,
+            filter: slashFilter(prompt)
+          })
+        : [],
+    [menuOpen, skills, prompt]
+  )
+
+  useEffect(() => {
+    if (effectiveMode !== 'acp') setLoadedSkill(null)
+  }, [effectiveMode])
+
+  const handleSlashSelect = useCallback((item: SlashItem) => {
+    if (item.kind !== 'skill') return
+    setLoadedSkill({ name: item.name, description: item.description ?? '' })
+    setPrompt('')
+    textareaRef.current?.focus()
+  }, [])
 
   // When an ACP agent is selected with a resolvable cwd, prepare a session in
   // the background (best-effort, deduped by the store) so the eventual send
@@ -234,12 +277,14 @@ export function AgentLauncher({
       const cwd = getDefaultCwdForProject(activeProjectId as string)
       const sessionId = await useAcpStore.getState().startChat(configId, cwd)
       useWorkspaceStore.getState().addAgentChatTab(sessionId, paneId)
-      if (prompt.trim().length > 0) {
-        void useAcpStore.getState().sendPrompt(sessionId, prompt.trim())
+      const text = await buildPromptWithLoadedSkill(loadedSkill, prompt, projectRoot)
+      if (text.trim().length > 0) {
+        void useAcpStore.getState().sendPrompt(sessionId, text.trim())
       }
+      setLoadedSkill(null)
       useWorkspaceStore.getState().hideAgentLauncher()
     },
-    [activeProjectId, paneId, prompt]
+    [activeProjectId, paneId, prompt, loadedSkill, projectRoot]
   )
 
   const launch = useCallback(
@@ -275,19 +320,42 @@ export function AgentLauncher({
 
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+      if (menuOpen && slashSections.length > 0) {
+        if (e.key === 'ArrowDown') {
+          e.preventDefault()
+          menuRef.current?.move(1)
+          return
+        }
+        if (e.key === 'ArrowUp') {
+          e.preventDefault()
+          menuRef.current?.move(-1)
+          return
+        }
+        if (e.key === 'Enter' && !e.shiftKey && !e.nativeEvent.isComposing) {
+          e.preventDefault()
+          menuRef.current?.selectHighlighted()
+          return
+        }
+        if (e.key === 'Escape') {
+          e.preventDefault()
+          setPrompt('')
+          return
+        }
+      }
+
       if ((e.metaKey || e.ctrlKey) && e.key === 'Enter') {
         e.preventDefault()
         void launch(selectedEntry, effectiveMode)
       }
-      if (e.key === 'Enter' && !e.shiftKey && !e.metaKey && !e.ctrlKey) {
+      if (e.key === 'Enter' && !e.shiftKey && !e.metaKey && !e.ctrlKey && !menuOpen) {
         e.preventDefault()
         void launch(selectedEntry, effectiveMode)
       }
-      if (e.key === 'Escape') {
+      if (e.key === 'Escape' && !menuOpen) {
         useWorkspaceStore.getState().hideAgentLauncher()
       }
     },
-    [launch, selectedEntry, effectiveMode]
+    [launch, selectedEntry, effectiveMode, menuOpen, slashSections.length]
   )
 
   const handleSelectChange = useCallback(
@@ -377,13 +445,41 @@ export function AgentLauncher({
     }
   }, [])
 
-  const canLaunch = Boolean(selectedEntry) && !isLaunching
+  const canLaunch =
+    Boolean(selectedEntry) &&
+    !isLaunching &&
+    (effectiveMode !== 'acp' || prompt.trim().length > 0 || loadedSkill !== null)
 
   return (
     <div
       className={cn('absolute inset-0 flex flex-col items-center justify-center p-8', className)}
     >
       <div className="flex w-full max-w-xl flex-col gap-3">
+        <div className="relative">
+          {menuOpen && (
+            <SlashCommandMenu
+              ref={menuRef}
+              sections={slashSections}
+              onSelect={handleSlashSelect}
+            />
+          )}
+          {loadedSkill && effectiveMode === 'acp' && (
+            <div className="mb-1 flex items-start gap-2 rounded-lg border border-border/60 bg-muted/20 px-3 py-1.5">
+              <span className="min-w-0 flex-1 text-xs text-muted-foreground">
+                Skill:{' '}
+                <span className="font-medium text-foreground break-words">{loadedSkill.name}</span>
+              </span>
+              <button
+                type="button"
+                onClick={() => setLoadedSkill(null)}
+                className="ml-auto shrink-0 rounded p-0.5 text-muted-foreground hover:bg-muted/60 hover:text-foreground"
+                aria-label="Remove loaded skill"
+                title="Remove skill"
+              >
+                <X size={12} />
+              </button>
+            </div>
+          )}
         {/* Chat-style input bar — grid layout for clean alignment */}
         <div className="grid grid-cols-[auto_auto_auto_1fr_auto] items-center overflow-hidden rounded-xl border border-border bg-card shadow-sm transition-colors hover:bg-muted/35 focus-within:border-border/80 focus-within:bg-muted/20 focus-within:ring-1 focus-within:ring-border/50 focus-within:ring-offset-0">
           {/* Agent selector — column 1 */}
@@ -474,10 +570,17 @@ export function AgentLauncher({
 
           {/* Textarea — column 2 (flex-1 via 1fr) */}
           <textarea
+            ref={textareaRef}
             value={prompt}
             onChange={(e) => setPrompt(e.target.value)}
             onKeyDown={handleKeyDown}
-            placeholder="Describe what you want…"
+            placeholder={
+              effectiveMode === 'acp'
+                ? loadedSkill
+                  ? 'Add a message (optional)…'
+                  : 'Describe what you want… (/ for skills)'
+                : 'Describe what you want…'
+            }
             rows={1}
             aria-label="Agent prompt"
             autoFocus
@@ -506,6 +609,7 @@ export function AgentLauncher({
           >
             {isLaunching ? <Loader2 size={16} className="animate-spin" /> : <ArrowUp size={16} />}
           </button>
+        </div>
         </div>
 
         {/* Hint */}

--- a/src/renderer/components/agents/AgentLauncher.tsx
+++ b/src/renderer/components/agents/AgentLauncher.tsx
@@ -4,6 +4,13 @@ import { ArrowUp, Loader2, Plus, Settings2, Terminal as TerminalIcon, X } from '
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { toast } from 'sonner'
+import { SlashCommandMenu, type SlashMenuHandle } from '@/components/chat/SlashCommandMenu'
+import {
+  buildSlashSections,
+  isSlashTrigger,
+  type SlashItem,
+  slashFilter
+} from '@/components/chat/slash-menu-model'
 import { Button } from '@/components/ui/button'
 import {
   Select,
@@ -13,6 +20,11 @@ import {
   SelectTrigger,
   SelectValue
 } from '@/components/ui/select'
+import {
+  buildPromptWithLoadedSkill,
+  type LoadedAgentSkill,
+  useAgentSkills
+} from '@/hooks/use-agent-skills'
 import { launchAgentInPane } from '@/lib/agent-launch'
 import { BUILT_IN_AGENTS, type TerminalAgentDefinition } from '@/lib/agents/agent-registry'
 import { loadAllAgents, upsertCustomAgent } from '@/lib/agents/custom-agents'
@@ -33,18 +45,6 @@ import { prepareChatKey, useAcpStore } from '@/stores/acp-store'
 import { useDefaultShell, useMaxTerminalsPerProject } from '@/stores/app-settings-store'
 import { useProjectStore } from '@/stores/project-store'
 import { useWorkspaceStore } from '@/stores/workspace-store'
-import {
-  buildPromptWithLoadedSkill,
-  type LoadedAgentSkill,
-  useAgentSkills
-} from '@/hooks/use-agent-skills'
-import { SlashCommandMenu, type SlashMenuHandle } from '@/components/chat/SlashCommandMenu'
-import {
-  buildSlashSections,
-  isSlashTrigger,
-  type SlashItem,
-  slashFilter
-} from '@/components/chat/slash-menu-model'
 import { CustomAgentDialog } from './CustomAgentDialog'
 
 /**
@@ -457,11 +457,7 @@ export function AgentLauncher({
       <div className="flex w-full max-w-xl flex-col gap-3">
         <div className="relative">
           {menuOpen && (
-            <SlashCommandMenu
-              ref={menuRef}
-              sections={slashSections}
-              onSelect={handleSlashSelect}
-            />
+            <SlashCommandMenu ref={menuRef} sections={slashSections} onSelect={handleSlashSelect} />
           )}
           {loadedSkill && effectiveMode === 'acp' && (
             <div className="mb-1 flex items-start gap-2 rounded-lg border border-border/60 bg-muted/20 px-3 py-1.5">
@@ -480,136 +476,136 @@ export function AgentLauncher({
               </button>
             </div>
           )}
-        {/* Chat-style input bar — grid layout for clean alignment */}
-        <div className="grid grid-cols-[auto_auto_auto_1fr_auto] items-center overflow-hidden rounded-xl border border-border bg-card shadow-sm transition-colors hover:bg-muted/35 focus-within:border-border/80 focus-within:bg-muted/20 focus-within:ring-1 focus-within:ring-border/50 focus-within:ring-offset-0">
-          {/* Agent selector — column 1 */}
-          <Select value={selectedKey} onValueChange={handleSelectChange}>
-            <SelectTrigger className="h-11 w-auto gap-1.5 border-0 bg-transparent pl-3 pr-1 shadow-none hover:bg-muted/40 focus:ring-0 focus:ring-offset-0 [&>svg]:opacity-60">
-              <SelectValue>
-                <span className="flex items-center gap-1.5">
-                  <EntryGlyph entry={selectedEntry} />
-                  <span className="max-w-[100px] truncate text-xs font-medium">
-                    {selectedEntry?.name ?? 'Agent'}
-                  </span>
-                </span>
-              </SelectValue>
-            </SelectTrigger>
-            <SelectContent>
-              {entries.length === 0 ? (
-                <button
-                  type="button"
-                  onClick={openAgentSettings}
-                  className="flex w-full items-center gap-2 px-2 py-1.5 text-xs text-primary hover:bg-muted/40"
-                >
-                  <Settings2 size={12} />
-                  Enable an agent in Settings…
-                </button>
-              ) : (
-                <>
-                  {entries
-                    .filter((e) => e.isBuiltIn)
-                    .map((entry) => (
-                      <SelectItem key={entry.key} value={entry.key}>
-                        <EntryRow entry={entry} />
-                      </SelectItem>
-                    ))}
-                  {entries.some((e) => e.isBuiltIn) && entries.some((e) => !e.isBuiltIn) && (
-                    <SelectSeparator />
-                  )}
-                  {entries
-                    .filter((e) => !e.isBuiltIn)
-                    .map((entry) => (
-                      <SelectItem key={entry.key} value={entry.key}>
-                        <EntryRow entry={entry} />
-                      </SelectItem>
-                    ))}
-                  <SelectSeparator />
-                  <SelectItem value={AGENT_SELECT_NEW}>
-                    <span className="flex items-center gap-2 text-primary">
-                      <Plus size={12} />
-                      New custom agent…
+          {/* Chat-style input bar — grid layout for clean alignment */}
+          <div className="grid grid-cols-[auto_auto_auto_1fr_auto] items-center overflow-hidden rounded-xl border border-border bg-card shadow-sm transition-colors hover:bg-muted/35 focus-within:border-border/80 focus-within:bg-muted/20 focus-within:ring-1 focus-within:ring-border/50 focus-within:ring-offset-0">
+            {/* Agent selector — column 1 */}
+            <Select value={selectedKey} onValueChange={handleSelectChange}>
+              <SelectTrigger className="h-11 w-auto gap-1.5 border-0 bg-transparent pl-3 pr-1 shadow-none hover:bg-muted/40 focus:ring-0 focus:ring-offset-0 [&>svg]:opacity-60">
+                <SelectValue>
+                  <span className="flex items-center gap-1.5">
+                    <EntryGlyph entry={selectedEntry} />
+                    <span className="max-w-[100px] truncate text-xs font-medium">
+                      {selectedEntry?.name ?? 'Agent'}
                     </span>
-                  </SelectItem>
-                </>
-              )}
-            </SelectContent>
-          </Select>
+                  </span>
+                </SelectValue>
+              </SelectTrigger>
+              <SelectContent>
+                {entries.length === 0 ? (
+                  <button
+                    type="button"
+                    onClick={openAgentSettings}
+                    className="flex w-full items-center gap-2 px-2 py-1.5 text-xs text-primary hover:bg-muted/40"
+                  >
+                    <Settings2 size={12} />
+                    Enable an agent in Settings…
+                  </button>
+                ) : (
+                  <>
+                    {entries
+                      .filter((e) => e.isBuiltIn)
+                      .map((entry) => (
+                        <SelectItem key={entry.key} value={entry.key}>
+                          <EntryRow entry={entry} />
+                        </SelectItem>
+                      ))}
+                    {entries.some((e) => e.isBuiltIn) && entries.some((e) => !e.isBuiltIn) && (
+                      <SelectSeparator />
+                    )}
+                    {entries
+                      .filter((e) => !e.isBuiltIn)
+                      .map((entry) => (
+                        <SelectItem key={entry.key} value={entry.key}>
+                          <EntryRow entry={entry} />
+                        </SelectItem>
+                      ))}
+                    <SelectSeparator />
+                    <SelectItem value={AGENT_SELECT_NEW}>
+                      <span className="flex items-center gap-2 text-primary">
+                        <Plus size={12} />
+                        New custom agent…
+                      </span>
+                    </SelectItem>
+                  </>
+                )}
+              </SelectContent>
+            </Select>
 
-          {/* CLI/ACP mode toggle — column 2 (only for dual-mode agents) */}
-          {selectedEntry && selectedEntry.modes.length > 1 ? (
-            <div className="flex items-center gap-0.5 rounded-md bg-muted/40 p-0.5">
-              {(['cli', 'acp'] as const).map((mode) => (
-                <button
-                  key={mode}
-                  type="button"
-                  onClick={() => handleModeChange(mode)}
-                  className={cn(
-                    'rounded px-1.5 py-0.5 text-[10px] font-medium uppercase transition-colors',
-                    effectiveMode === mode
-                      ? 'bg-background text-foreground shadow-sm'
-                      : 'text-muted-foreground hover:text-foreground'
-                  )}
-                  aria-pressed={effectiveMode === mode}
-                  aria-label={`Run as ${mode.toUpperCase()}`}
-                >
-                  {mode}
-                </button>
-              ))}
-            </div>
-          ) : (
-            <span
-              className="rounded bg-muted/40 px-1.5 py-0.5 text-[10px] font-medium uppercase text-muted-foreground"
-              title={`This agent runs as ${effectiveMode.toUpperCase()}`}
-            >
-              {effectiveMode}
-            </span>
-          )}
-
-          {/* Divider */}
-          <div className="h-6 w-px bg-border/50 justify-self-center" />
-
-          {/* Textarea — column 2 (flex-1 via 1fr) */}
-          <textarea
-            ref={textareaRef}
-            value={prompt}
-            onChange={(e) => setPrompt(e.target.value)}
-            onKeyDown={handleKeyDown}
-            placeholder={
-              effectiveMode === 'acp'
-                ? loadedSkill
-                  ? 'Add a message (optional)…'
-                  : 'Describe what you want… (/ for skills)'
-                : 'Describe what you want…'
-            }
-            rows={1}
-            aria-label="Agent prompt"
-            autoFocus
-            className="min-w-0 resize-none bg-transparent px-3 py-2.5 text-sm outline-none placeholder:text-muted-foreground/60"
-            style={{ minHeight: '44px', maxHeight: '120px' }}
-            onInput={(e) => {
-              const el = e.currentTarget
-              el.style.height = 'auto'
-              el.style.height = `${Math.min(el.scrollHeight, 120)}px`
-            }}
-          />
-
-          {/* Launch button — column 3 */}
-          <button
-            type="button"
-            onClick={handleSubmit}
-            disabled={!canLaunch}
-            className={cn(
-              'mr-2 flex h-8 w-8 shrink-0 items-center justify-center rounded-md bg-transparent transition-colors',
-              canLaunch
-                ? 'text-muted-foreground hover:bg-muted/50 hover:text-foreground'
-                : 'text-muted-foreground/35'
+            {/* CLI/ACP mode toggle — column 2 (only for dual-mode agents) */}
+            {selectedEntry && selectedEntry.modes.length > 1 ? (
+              <div className="flex items-center gap-0.5 rounded-md bg-muted/40 p-0.5">
+                {(['cli', 'acp'] as const).map((mode) => (
+                  <button
+                    key={mode}
+                    type="button"
+                    onClick={() => handleModeChange(mode)}
+                    className={cn(
+                      'rounded px-1.5 py-0.5 text-[10px] font-medium uppercase transition-colors',
+                      effectiveMode === mode
+                        ? 'bg-background text-foreground shadow-sm'
+                        : 'text-muted-foreground hover:text-foreground'
+                    )}
+                    aria-pressed={effectiveMode === mode}
+                    aria-label={`Run as ${mode.toUpperCase()}`}
+                  >
+                    {mode}
+                  </button>
+                ))}
+              </div>
+            ) : (
+              <span
+                className="rounded bg-muted/40 px-1.5 py-0.5 text-[10px] font-medium uppercase text-muted-foreground"
+                title={`This agent runs as ${effectiveMode.toUpperCase()}`}
+              >
+                {effectiveMode}
+              </span>
             )}
-            aria-label={`Launch ${selectedEntry?.name ?? 'agent'}`}
-            title={isLaunching ? 'Launching…' : `Launch ${selectedEntry?.name ?? 'agent'}`}
-          >
-            {isLaunching ? <Loader2 size={16} className="animate-spin" /> : <ArrowUp size={16} />}
-          </button>
-        </div>
+
+            {/* Divider */}
+            <div className="h-6 w-px bg-border/50 justify-self-center" />
+
+            {/* Textarea — column 2 (flex-1 via 1fr) */}
+            <textarea
+              ref={textareaRef}
+              value={prompt}
+              onChange={(e) => setPrompt(e.target.value)}
+              onKeyDown={handleKeyDown}
+              placeholder={
+                effectiveMode === 'acp'
+                  ? loadedSkill
+                    ? 'Add a message (optional)…'
+                    : 'Describe what you want… (/ for skills)'
+                  : 'Describe what you want…'
+              }
+              rows={1}
+              aria-label="Agent prompt"
+              autoFocus
+              className="min-w-0 resize-none bg-transparent px-3 py-2.5 text-sm outline-none placeholder:text-muted-foreground/60"
+              style={{ minHeight: '44px', maxHeight: '120px' }}
+              onInput={(e) => {
+                const el = e.currentTarget
+                el.style.height = 'auto'
+                el.style.height = `${Math.min(el.scrollHeight, 120)}px`
+              }}
+            />
+
+            {/* Launch button — column 3 */}
+            <button
+              type="button"
+              onClick={handleSubmit}
+              disabled={!canLaunch}
+              className={cn(
+                'mr-2 flex h-8 w-8 shrink-0 items-center justify-center rounded-md bg-transparent transition-colors',
+                canLaunch
+                  ? 'text-muted-foreground hover:bg-muted/50 hover:text-foreground'
+                  : 'text-muted-foreground/35'
+              )}
+              aria-label={`Launch ${selectedEntry?.name ?? 'agent'}`}
+              title={isLaunching ? 'Launching…' : `Launch ${selectedEntry?.name ?? 'agent'}`}
+            >
+              {isLaunching ? <Loader2 size={16} className="animate-spin" /> : <ArrowUp size={16} />}
+            </button>
+          </div>
         </div>
 
         {/* Hint */}

--- a/src/renderer/components/agents/AgentLauncher.tsx
+++ b/src/renderer/components/agents/AgentLauncher.tsx
@@ -1,10 +1,12 @@
 import type { DetectedShells, ShellInfo } from '@shared/types/ipc.types'
 import { type LastSelectedAgent, PersistenceKeys } from '@shared/types/persistence.types'
-import { ArrowUp, Loader2, Plus, Settings2, Terminal as TerminalIcon, X } from 'lucide-react'
+import { ArrowUp, Loader2, Plus, Settings2, Terminal as TerminalIcon } from 'lucide-react'
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { toast } from 'sonner'
+import { LoadedSkillChip } from '@/components/chat/LoadedSkillChip'
 import { SlashCommandMenu, type SlashMenuHandle } from '@/components/chat/SlashCommandMenu'
+import { tryHandleSlashMenuKeyDown } from '@/components/chat/slash-menu-keyboard'
 import {
   buildSlashSections,
   isSlashTrigger,
@@ -197,8 +199,8 @@ export function AgentLauncher({
     return selectedEntry.modes.includes(selectedMode) ? selectedMode : selectedEntry.modes[0]
   }, [selectedEntry, selectedMode])
 
-  const { skills } = useAgentSkills(effectiveMode === 'acp' ? projectRoot : undefined)
-  const menuOpen = effectiveMode === 'acp' && isSlashTrigger(prompt)
+  const { skills } = useAgentSkills(projectRoot)
+  const menuOpen = isSlashTrigger(prompt)
   const slashSections = useMemo(
     () =>
       menuOpen
@@ -212,10 +214,6 @@ export function AgentLauncher({
         : [],
     [menuOpen, skills, prompt]
   )
-
-  useEffect(() => {
-    if (effectiveMode !== 'acp') setLoadedSkill(null)
-  }, [effectiveMode])
 
   const handleSlashSelect = useCallback((item: SlashItem) => {
     if (item.kind !== 'skill') return
@@ -252,12 +250,13 @@ export function AgentLauncher({
     async (agent: TerminalAgentDefinition): Promise<void> => {
       const project = useProjectStore.getState().projects.find((p) => p.id === activeProjectId)
       const cwd = getDefaultCwdForProject(activeProjectId as string)
+      const launchPrompt = await buildPromptWithLoadedSkill(loadedSkill, prompt, projectRoot)
       const result = await launchAgentInPane(
         paneId,
         activeProjectId as string,
         cwd,
         agent,
-        prompt,
+        launchPrompt,
         {
           envVars: project?.envVars,
           maxTerminalsPerProject: maxTerminals
@@ -267,9 +266,10 @@ export function AgentLauncher({
         toast.error(result.error || 'Failed to launch agent')
         return
       }
+      setLoadedSkill(null)
       useWorkspaceStore.getState().hideAgentLauncher()
     },
-    [activeProjectId, maxTerminals, paneId, prompt]
+    [activeProjectId, maxTerminals, paneId, prompt, loadedSkill, projectRoot]
   )
 
   const launchAcp = useCallback(
@@ -320,27 +320,15 @@ export function AgentLauncher({
 
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
-      if (menuOpen && slashSections.length > 0) {
-        if (e.key === 'ArrowDown') {
-          e.preventDefault()
-          menuRef.current?.move(1)
-          return
-        }
-        if (e.key === 'ArrowUp') {
-          e.preventDefault()
-          menuRef.current?.move(-1)
-          return
-        }
-        if (e.key === 'Enter' && !e.shiftKey && !e.nativeEvent.isComposing) {
-          e.preventDefault()
-          menuRef.current?.selectHighlighted()
-          return
-        }
-        if (e.key === 'Escape') {
-          e.preventDefault()
-          setPrompt('')
-          return
-        }
+      if (
+        tryHandleSlashMenuKeyDown(e, {
+          menuOpen,
+          sectionsLength: slashSections.length,
+          menuRef,
+          onClearInput: () => setPrompt('')
+        })
+      ) {
+        return
       }
 
       if ((e.metaKey || e.ctrlKey) && e.key === 'Enter') {
@@ -459,158 +447,147 @@ export function AgentLauncher({
           {menuOpen && (
             <SlashCommandMenu ref={menuRef} sections={slashSections} onSelect={handleSlashSelect} />
           )}
-          {loadedSkill && effectiveMode === 'acp' && (
-            <div className="mb-1 flex items-start gap-2 rounded-lg border border-border/60 bg-muted/20 px-3 py-1.5">
-              <span className="min-w-0 flex-1 text-xs text-muted-foreground">
-                Skill:{' '}
-                <span className="font-medium text-foreground break-words">{loadedSkill.name}</span>
-              </span>
-              <button
-                type="button"
-                onClick={() => setLoadedSkill(null)}
-                className="ml-auto shrink-0 rounded p-0.5 text-muted-foreground hover:bg-muted/60 hover:text-foreground"
-                aria-label="Remove loaded skill"
-                title="Remove skill"
-              >
-                <X size={12} />
-              </button>
-            </div>
-          )}
-          {/* Chat-style input bar — grid layout for clean alignment */}
-          <div className="grid grid-cols-[auto_auto_auto_1fr_auto] items-center overflow-hidden rounded-xl border border-border bg-card shadow-sm transition-colors hover:bg-muted/35 focus-within:border-border/80 focus-within:bg-muted/20 focus-within:ring-1 focus-within:ring-border/50 focus-within:ring-offset-0">
-            {/* Agent selector — column 1 */}
-            <Select value={selectedKey} onValueChange={handleSelectChange}>
-              <SelectTrigger className="h-11 w-auto gap-1.5 border-0 bg-transparent pl-3 pr-1 shadow-none hover:bg-muted/40 focus:ring-0 focus:ring-offset-0 [&>svg]:opacity-60">
-                <SelectValue>
-                  <span className="flex items-center gap-1.5">
-                    <EntryGlyph entry={selectedEntry} />
-                    <span className="max-w-[100px] truncate text-xs font-medium">
-                      {selectedEntry?.name ?? 'Agent'}
-                    </span>
-                  </span>
-                </SelectValue>
-              </SelectTrigger>
-              <SelectContent>
-                {entries.length === 0 ? (
-                  <button
-                    type="button"
-                    onClick={openAgentSettings}
-                    className="flex w-full items-center gap-2 px-2 py-1.5 text-xs text-primary hover:bg-muted/40"
-                  >
-                    <Settings2 size={12} />
-                    Enable an agent in Settings…
-                  </button>
-                ) : (
-                  <>
-                    {entries
-                      .filter((e) => e.isBuiltIn)
-                      .map((entry) => (
-                        <SelectItem key={entry.key} value={entry.key}>
-                          <EntryRow entry={entry} />
-                        </SelectItem>
-                      ))}
-                    {entries.some((e) => e.isBuiltIn) && entries.some((e) => !e.isBuiltIn) && (
-                      <SelectSeparator />
-                    )}
-                    {entries
-                      .filter((e) => !e.isBuiltIn)
-                      .map((entry) => (
-                        <SelectItem key={entry.key} value={entry.key}>
-                          <EntryRow entry={entry} />
-                        </SelectItem>
-                      ))}
-                    <SelectSeparator />
-                    <SelectItem value={AGENT_SELECT_NEW}>
-                      <span className="flex items-center gap-2 text-primary">
-                        <Plus size={12} />
-                        New custom agent…
-                      </span>
-                    </SelectItem>
-                  </>
-                )}
-              </SelectContent>
-            </Select>
-
-            {/* CLI/ACP mode toggle — column 2 (only for dual-mode agents) */}
-            {selectedEntry && selectedEntry.modes.length > 1 ? (
-              <div className="flex items-center gap-0.5 rounded-md bg-muted/40 p-0.5">
-                {(['cli', 'acp'] as const).map((mode) => (
-                  <button
-                    key={mode}
-                    type="button"
-                    onClick={() => handleModeChange(mode)}
-                    className={cn(
-                      'rounded px-1.5 py-0.5 text-[10px] font-medium uppercase transition-colors',
-                      effectiveMode === mode
-                        ? 'bg-background text-foreground shadow-sm'
-                        : 'text-muted-foreground hover:text-foreground'
-                    )}
-                    aria-pressed={effectiveMode === mode}
-                    aria-label={`Run as ${mode.toUpperCase()}`}
-                  >
-                    {mode}
-                  </button>
-                ))}
-              </div>
-            ) : (
-              <span
-                className="rounded bg-muted/40 px-1.5 py-0.5 text-[10px] font-medium uppercase text-muted-foreground"
-                title={`This agent runs as ${effectiveMode.toUpperCase()}`}
-              >
-                {effectiveMode}
-              </span>
+          <div className="overflow-hidden rounded-xl border border-border bg-card shadow-sm transition-colors hover:bg-muted/35 focus-within:border-border/80 focus-within:bg-muted/20 focus-within:ring-1 focus-within:ring-border/50 focus-within:ring-offset-0">
+            {loadedSkill && (
+              <LoadedSkillChip skill={loadedSkill} onRemove={() => setLoadedSkill(null)} />
             )}
+            <div className="grid grid-cols-[auto_auto_auto_1fr_auto] items-center">
+              {/* Agent selector — column 1 */}
+              <Select value={selectedKey} onValueChange={handleSelectChange}>
+                <SelectTrigger className="h-11 w-auto gap-1.5 border-0 bg-transparent pl-3 pr-1 shadow-none hover:bg-muted/40 focus:ring-0 focus:ring-offset-0 [&>svg]:opacity-60">
+                  <SelectValue>
+                    <span className="flex items-center gap-1.5">
+                      <EntryGlyph entry={selectedEntry} />
+                      <span className="max-w-[100px] truncate text-xs font-medium">
+                        {selectedEntry?.name ?? 'Agent'}
+                      </span>
+                    </span>
+                  </SelectValue>
+                </SelectTrigger>
+                <SelectContent>
+                  {entries.length === 0 ? (
+                    <button
+                      type="button"
+                      onClick={openAgentSettings}
+                      className="flex w-full items-center gap-2 px-2 py-1.5 text-xs text-primary hover:bg-muted/40"
+                    >
+                      <Settings2 size={12} />
+                      Enable an agent in Settings…
+                    </button>
+                  ) : (
+                    <>
+                      {entries
+                        .filter((e) => e.isBuiltIn)
+                        .map((entry) => (
+                          <SelectItem key={entry.key} value={entry.key}>
+                            <EntryRow entry={entry} />
+                          </SelectItem>
+                        ))}
+                      {entries.some((e) => e.isBuiltIn) && entries.some((e) => !e.isBuiltIn) && (
+                        <SelectSeparator />
+                      )}
+                      {entries
+                        .filter((e) => !e.isBuiltIn)
+                        .map((entry) => (
+                          <SelectItem key={entry.key} value={entry.key}>
+                            <EntryRow entry={entry} />
+                          </SelectItem>
+                        ))}
+                      <SelectSeparator />
+                      <SelectItem value={AGENT_SELECT_NEW}>
+                        <span className="flex items-center gap-2 text-primary">
+                          <Plus size={12} />
+                          New custom agent…
+                        </span>
+                      </SelectItem>
+                    </>
+                  )}
+                </SelectContent>
+              </Select>
 
-            {/* Divider */}
-            <div className="h-6 w-px bg-border/50 justify-self-center" />
+              {/* CLI/ACP mode toggle — column 2 (only for dual-mode agents) */}
+              {selectedEntry && selectedEntry.modes.length > 1 ? (
+                <div className="flex items-center gap-0.5 rounded-md bg-muted/40 p-0.5">
+                  {(['cli', 'acp'] as const).map((mode) => (
+                    <button
+                      key={mode}
+                      type="button"
+                      onClick={() => handleModeChange(mode)}
+                      className={cn(
+                        'rounded px-1.5 py-0.5 text-[10px] font-medium uppercase transition-colors',
+                        effectiveMode === mode
+                          ? 'bg-background text-foreground shadow-sm'
+                          : 'text-muted-foreground hover:text-foreground'
+                      )}
+                      aria-pressed={effectiveMode === mode}
+                      aria-label={`Run as ${mode.toUpperCase()}`}
+                    >
+                      {mode}
+                    </button>
+                  ))}
+                </div>
+              ) : (
+                <span
+                  className="rounded bg-muted/40 px-1.5 py-0.5 text-[10px] font-medium uppercase text-muted-foreground"
+                  title={`This agent runs as ${effectiveMode.toUpperCase()}`}
+                >
+                  {effectiveMode}
+                </span>
+              )}
 
-            {/* Textarea — column 2 (flex-1 via 1fr) */}
-            <textarea
-              ref={textareaRef}
-              value={prompt}
-              onChange={(e) => setPrompt(e.target.value)}
-              onKeyDown={handleKeyDown}
-              placeholder={
-                effectiveMode === 'acp'
-                  ? loadedSkill
+              {/* Divider */}
+              <div className="h-6 w-px bg-border/50 justify-self-center" />
+
+              {/* Textarea — column 2 (flex-1 via 1fr) */}
+              <textarea
+                ref={textareaRef}
+                value={prompt}
+                onChange={(e) => setPrompt(e.target.value)}
+                onKeyDown={handleKeyDown}
+                placeholder={
+                  loadedSkill
                     ? 'Add a message (optional)…'
                     : 'Describe what you want… (/ for skills)'
-                  : 'Describe what you want…'
-              }
-              rows={1}
-              aria-label="Agent prompt"
-              autoFocus
-              className="min-w-0 resize-none bg-transparent px-3 py-2.5 text-sm outline-none placeholder:text-muted-foreground/60"
-              style={{ minHeight: '44px', maxHeight: '120px' }}
-              onInput={(e) => {
-                const el = e.currentTarget
-                el.style.height = 'auto'
-                el.style.height = `${Math.min(el.scrollHeight, 120)}px`
-              }}
-            />
+                }
+                rows={1}
+                aria-label="Agent prompt"
+                autoFocus
+                className="min-w-0 resize-none bg-transparent px-3 py-2.5 text-sm outline-none placeholder:text-muted-foreground/60"
+                style={{ minHeight: '44px', maxHeight: '120px' }}
+                onInput={(e) => {
+                  const el = e.currentTarget
+                  el.style.height = 'auto'
+                  el.style.height = `${Math.min(el.scrollHeight, 120)}px`
+                }}
+              />
 
-            {/* Launch button — column 3 */}
-            <button
-              type="button"
-              onClick={handleSubmit}
-              disabled={!canLaunch}
-              className={cn(
-                'mr-2 flex h-8 w-8 shrink-0 items-center justify-center rounded-md bg-transparent transition-colors',
-                canLaunch
-                  ? 'text-muted-foreground hover:bg-muted/50 hover:text-foreground'
-                  : 'text-muted-foreground/35'
-              )}
-              aria-label={`Launch ${selectedEntry?.name ?? 'agent'}`}
-              title={isLaunching ? 'Launching…' : `Launch ${selectedEntry?.name ?? 'agent'}`}
-            >
-              {isLaunching ? <Loader2 size={16} className="animate-spin" /> : <ArrowUp size={16} />}
-            </button>
+              {/* Launch button — column 3 */}
+              <button
+                type="button"
+                onClick={handleSubmit}
+                disabled={!canLaunch}
+                className={cn(
+                  'mr-2 flex h-8 w-8 shrink-0 items-center justify-center rounded-md bg-transparent transition-colors',
+                  canLaunch
+                    ? 'text-muted-foreground hover:bg-muted/50 hover:text-foreground'
+                    : 'text-muted-foreground/35'
+                )}
+                aria-label={`Launch ${selectedEntry?.name ?? 'agent'}`}
+                title={isLaunching ? 'Launching…' : `Launch ${selectedEntry?.name ?? 'agent'}`}
+              >
+                {isLaunching ? (
+                  <Loader2 size={16} className="animate-spin" />
+                ) : (
+                  <ArrowUp size={16} />
+                )}
+              </button>
+            </div>
           </div>
         </div>
 
         {/* Hint */}
         <span className="text-center text-[11px] text-muted-foreground/50">
-          Enter to launch · Shift+Enter for newline · Esc to dismiss
+          Tab to complete · Enter to launch · Shift+Enter for newline · Esc to dismiss
         </span>
 
         {/* Plain terminal */}

--- a/src/renderer/components/chat/ChatInputBar.tsx
+++ b/src/renderer/components/chat/ChatInputBar.tsx
@@ -1,6 +1,12 @@
-import { ArrowUp, ChevronDown, Square } from 'lucide-react'
+import { ArrowUp, ChevronDown, Square, X } from 'lucide-react'
 import { type KeyboardEvent, useCallback, useMemo, useRef, useState } from 'react'
+import { toast } from 'sonner'
 import type { AvailableCommand, SessionConfigOption, SessionModeState } from '@/lib/acp-api'
+import {
+  buildPromptWithLoadedSkill,
+  type LoadedAgentSkill,
+  useAgentSkills
+} from '@/hooks/use-agent-skills'
 import { cn } from '@/lib/utils'
 import type { AcpSession } from '@/stores/acp-store'
 import { AgentBadge } from './AgentBadge'
@@ -18,6 +24,8 @@ import {
 interface ChatInputBarProps {
   /** Active session — drives the agent icon and selector chips. */
   session: AcpSession
+  /** Project/worktree root used to discover project-local skills. */
+  projectRoot?: string
   /** Whether a prompt turn is currently active (disables send, enables cancel). */
   busy: boolean
   /** Whether the session is closed/disconnected (fully disables input). */
@@ -36,6 +44,7 @@ interface ChatInputBarProps {
 
 export function ChatInputBar({
   session,
+  projectRoot,
   busy,
   disabled,
   onSend,
@@ -49,7 +58,10 @@ export function ChatInputBar({
   const usableConfigOptions = configOptions.filter((o) => o.options.length > 0)
   const hasConfigOptions = usableConfigOptions.length > 0
   const { thoughtLevel, rest: genericConfigOptions } = partitionConfigOptions(usableConfigOptions)
+  const { skills } = useAgentSkills(projectRoot ?? session.cwd)
   const [value, setValue] = useState('')
+  const [loadedSkill, setLoadedSkill] = useState<LoadedAgentSkill | null>(null)
+  const [sending, setSending] = useState(false)
   const textareaRef = useRef<HTMLTextAreaElement>(null)
   const menuRef = useRef<SlashMenuHandle>(null)
 
@@ -57,8 +69,11 @@ export function ChatInputBar({
   const filter = slashFilter(value)
 
   const sections = useMemo(
-    () => (menuOpen ? buildSlashSections({ commands, configOptions, modes, filter }) : []),
-    [menuOpen, commands, configOptions, modes, filter]
+    () =>
+      menuOpen
+        ? buildSlashSections({ commands, configOptions, modes, skills, filter })
+        : [],
+    [menuOpen, commands, configOptions, modes, skills, filter]
   )
 
   const resetHeight = useCallback(() => {
@@ -67,16 +82,48 @@ export function ChatInputBar({
     }
   }, [])
 
-  const submit = useCallback(() => {
-    const text = value.trim()
-    if (!text || busy || disabled) return
-    onSend(text)
-    setValue('')
-    resetHeight()
-  }, [value, busy, disabled, onSend, resetHeight])
+  const submit = useCallback(async () => {
+    const userText = value.trim()
+    if ((!userText && !loadedSkill) || busy || disabled || sending) return
+
+    setSending(true)
+    try {
+      const text = await buildPromptWithLoadedSkill(
+        loadedSkill,
+        userText,
+        projectRoot ?? session.cwd
+      )
+      if (!text.trim()) return
+      onSend(text)
+      setValue('')
+      setLoadedSkill(null)
+      resetHeight()
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : 'Failed to load skill')
+    } finally {
+      setSending(false)
+    }
+  }, [
+    value,
+    loadedSkill,
+    busy,
+    disabled,
+    sending,
+    onSend,
+    resetHeight,
+    projectRoot,
+    session.cwd
+  ])
 
   const handleSelect = useCallback(
     (item: SlashItem) => {
+      if (item.kind === 'skill') {
+        setLoadedSkill({ name: item.name, description: item.description ?? '' })
+        setValue('')
+        resetHeight()
+        textareaRef.current?.focus()
+        return
+      }
       if (item.kind === 'command') {
         setValue(applyCommandToInput(value, item.name))
         textareaRef.current?.focus()
@@ -87,7 +134,6 @@ export function ChatInputBar({
       } else {
         onSetMode(item.modeId)
       }
-      // config/mode selections do not touch the input; close the menu by clearing the slash token
       setValue('')
       resetHeight()
     },
@@ -96,7 +142,6 @@ export function ChatInputBar({
 
   const handleKeyDown = useCallback(
     (e: KeyboardEvent<HTMLTextAreaElement>) => {
-      // When the slash menu is open with items, route navigation/selection to it.
       if (menuOpen && sections.length > 0) {
         if (e.key === 'ArrowDown') {
           e.preventDefault()
@@ -109,7 +154,6 @@ export function ChatInputBar({
           return
         }
         if (e.key === 'Enter' && !e.shiftKey && !e.nativeEvent.isComposing && sections.length > 0) {
-          // Enter selects the highlighted item; it must NOT send the prompt.
           e.preventDefault()
           menuRef.current?.selectHighlighted()
           return
@@ -120,19 +164,16 @@ export function ChatInputBar({
           resetHeight()
           return
         }
-        // fall through for typing/Backspace so the filter updates
       }
 
-      // Esc cancels an in-flight turn (when the menu isn't open).
       if (e.key === 'Escape' && busy) {
         e.preventDefault()
         onCancel()
         return
       }
-      // Enter sends; Shift+Enter newline; ignore during IME composition.
       if (e.key === 'Enter' && !e.shiftKey && !e.nativeEvent.isComposing) {
         e.preventDefault()
-        submit()
+        void submit()
       }
     },
     [menuOpen, sections.length, busy, onCancel, submit, resetHeight]
@@ -145,22 +186,45 @@ export function ChatInputBar({
     el.style.height = `${Math.min(el.scrollHeight, 160)}px`
   }, [])
 
-  const canSend = !disabled && value.trim().length > 0
+  const canSend = !disabled && !sending && (value.trim().length > 0 || loadedSkill !== null)
 
   return (
     <div className="px-5 pb-3.5 pt-3">
       <div className="relative mx-auto w-full max-w-3xl">
         {menuOpen && <SlashCommandMenu ref={menuRef} sections={sections} onSelect={handleSelect} />}
         <div className="overflow-hidden rounded-2xl bg-secondary/40">
+          {loadedSkill && (
+            <div className="flex items-start gap-2 border-b border-border/40 px-4 py-1.5">
+              <span className="min-w-0 flex-1 text-xs text-muted-foreground">
+                Skill:{' '}
+                <span className="font-medium text-foreground break-words">{loadedSkill.name}</span>
+              </span>
+              <button
+                type="button"
+                onClick={() => setLoadedSkill(null)}
+                className="ml-auto shrink-0 rounded p-0.5 text-muted-foreground hover:bg-muted/60 hover:text-foreground"
+                aria-label="Remove loaded skill"
+                title="Remove skill"
+              >
+                <X size={12} />
+              </button>
+            </div>
+          )}
           <div className="px-4 pb-1.5 pt-3.5">
             <textarea
               ref={textareaRef}
               value={value}
               onChange={handleInput}
               onKeyDown={handleKeyDown}
-              disabled={disabled}
+              disabled={disabled || sending}
               rows={1}
-              placeholder={disabled ? 'Session closed' : 'Ask anything… (/ for commands)'}
+              placeholder={
+                disabled
+                  ? 'Session closed'
+                  : loadedSkill
+                    ? 'Add a message (optional)…'
+                    : 'Ask anything… (/ for commands & skills)'
+              }
               className={cn(
                 'w-full resize-none bg-transparent text-sm leading-relaxed',
                 'placeholder:text-muted-foreground focus:outline-none',
@@ -212,7 +276,7 @@ export function ChatInputBar({
               ) : (
                 <button
                   type="button"
-                  onClick={submit}
+                  onClick={() => void submit()}
                   disabled={!canSend}
                   title="Send"
                   aria-label="Send message"

--- a/src/renderer/components/chat/ChatInputBar.tsx
+++ b/src/renderer/components/chat/ChatInputBar.tsx
@@ -1,12 +1,12 @@
-import { ArrowUp, ChevronDown, Square, X } from 'lucide-react'
 import { type KeyboardEvent, useCallback, useMemo, useRef, useState } from 'react'
+import { ArrowUp, ChevronDown, Square, X } from 'lucide-react'
 import { toast } from 'sonner'
-import type { AvailableCommand, SessionConfigOption, SessionModeState } from '@/lib/acp-api'
 import {
   buildPromptWithLoadedSkill,
   type LoadedAgentSkill,
   useAgentSkills
 } from '@/hooks/use-agent-skills'
+import type { AvailableCommand, SessionConfigOption, SessionModeState } from '@/lib/acp-api'
 import { cn } from '@/lib/utils'
 import type { AcpSession } from '@/stores/acp-store'
 import { AgentBadge } from './AgentBadge'

--- a/src/renderer/components/chat/ChatInputBar.tsx
+++ b/src/renderer/components/chat/ChatInputBar.tsx
@@ -1,5 +1,5 @@
-import { type KeyboardEvent, useCallback, useMemo, useRef, useState } from 'react'
 import { ArrowUp, ChevronDown, Square, X } from 'lucide-react'
+import { type KeyboardEvent, useCallback, useMemo, useRef, useState } from 'react'
 import { toast } from 'sonner'
 import {
   buildPromptWithLoadedSkill,
@@ -69,10 +69,7 @@ export function ChatInputBar({
   const filter = slashFilter(value)
 
   const sections = useMemo(
-    () =>
-      menuOpen
-        ? buildSlashSections({ commands, configOptions, modes, skills, filter })
-        : [],
+    () => (menuOpen ? buildSlashSections({ commands, configOptions, modes, skills, filter }) : []),
     [menuOpen, commands, configOptions, modes, skills, filter]
   )
 
@@ -103,17 +100,7 @@ export function ChatInputBar({
     } finally {
       setSending(false)
     }
-  }, [
-    value,
-    loadedSkill,
-    busy,
-    disabled,
-    sending,
-    onSend,
-    resetHeight,
-    projectRoot,
-    session.cwd
-  ])
+  }, [value, loadedSkill, busy, disabled, sending, onSend, resetHeight, projectRoot, session.cwd])
 
   const handleSelect = useCallback(
     (item: SlashItem) => {

--- a/src/renderer/components/chat/ChatInputBar.tsx
+++ b/src/renderer/components/chat/ChatInputBar.tsx
@@ -1,4 +1,4 @@
-import { ArrowUp, ChevronDown, Square, X } from 'lucide-react'
+import { ArrowUp, ChevronDown, Square } from 'lucide-react'
 import { type KeyboardEvent, useCallback, useMemo, useRef, useState } from 'react'
 import { toast } from 'sonner'
 import {
@@ -12,7 +12,9 @@ import type { AcpSession } from '@/stores/acp-store'
 import { AgentBadge } from './AgentBadge'
 import { ConfigChip, ModeChip } from './AgentHeader'
 import { partitionConfigOptions } from './chat-input-bar-config'
+import { LoadedSkillChip } from './LoadedSkillChip'
 import { SlashCommandMenu, type SlashMenuHandle } from './SlashCommandMenu'
+import { tryHandleSlashMenuKeyDown } from './slash-menu-keyboard'
 import {
   applyCommandToInput,
   buildSlashSections,
@@ -129,28 +131,18 @@ export function ChatInputBar({
 
   const handleKeyDown = useCallback(
     (e: KeyboardEvent<HTMLTextAreaElement>) => {
-      if (menuOpen && sections.length > 0) {
-        if (e.key === 'ArrowDown') {
-          e.preventDefault()
-          menuRef.current?.move(1)
-          return
-        }
-        if (e.key === 'ArrowUp') {
-          e.preventDefault()
-          menuRef.current?.move(-1)
-          return
-        }
-        if (e.key === 'Enter' && !e.shiftKey && !e.nativeEvent.isComposing && sections.length > 0) {
-          e.preventDefault()
-          menuRef.current?.selectHighlighted()
-          return
-        }
-        if (e.key === 'Escape') {
-          e.preventDefault()
-          setValue('')
-          resetHeight()
-          return
-        }
+      if (
+        tryHandleSlashMenuKeyDown(e, {
+          menuOpen,
+          sectionsLength: sections.length,
+          menuRef,
+          onClearInput: () => {
+            setValue('')
+            resetHeight()
+          }
+        })
+      ) {
+        return
       }
 
       if (e.key === 'Escape' && busy) {
@@ -181,21 +173,7 @@ export function ChatInputBar({
         {menuOpen && <SlashCommandMenu ref={menuRef} sections={sections} onSelect={handleSelect} />}
         <div className="overflow-hidden rounded-2xl bg-secondary/40">
           {loadedSkill && (
-            <div className="flex items-start gap-2 border-b border-border/40 px-4 py-1.5">
-              <span className="min-w-0 flex-1 text-xs text-muted-foreground">
-                Skill:{' '}
-                <span className="font-medium text-foreground break-words">{loadedSkill.name}</span>
-              </span>
-              <button
-                type="button"
-                onClick={() => setLoadedSkill(null)}
-                className="ml-auto shrink-0 rounded p-0.5 text-muted-foreground hover:bg-muted/60 hover:text-foreground"
-                aria-label="Remove loaded skill"
-                title="Remove skill"
-              >
-                <X size={12} />
-              </button>
-            </div>
+            <LoadedSkillChip skill={loadedSkill} onRemove={() => setLoadedSkill(null)} />
           )}
           <div className="px-4 pb-1.5 pt-3.5">
             <textarea

--- a/src/renderer/components/chat/LoadedSkillChip.tsx
+++ b/src/renderer/components/chat/LoadedSkillChip.tsx
@@ -1,0 +1,33 @@
+import { X } from 'lucide-react'
+import type { LoadedAgentSkill } from '@/hooks/use-agent-skills'
+import { cn } from '@/lib/utils'
+
+interface LoadedSkillChipProps {
+  skill: LoadedAgentSkill
+  onRemove: () => void
+  className?: string
+}
+
+/** Shows the active Agent Skill above a prompt input (chat or launcher). */
+export function LoadedSkillChip({
+  skill,
+  onRemove,
+  className
+}: LoadedSkillChipProps): React.JSX.Element {
+  return (
+    <div className={cn('flex items-start gap-2 border-b border-border/40 px-4 py-1.5', className)}>
+      <span className="min-w-0 flex-1 text-xs text-muted-foreground">
+        Skill: <span className="font-medium text-foreground break-words">{skill.name}</span>
+      </span>
+      <button
+        type="button"
+        onClick={onRemove}
+        className="ml-auto shrink-0 rounded p-0.5 text-muted-foreground hover:bg-muted/60 hover:text-foreground"
+        aria-label="Remove loaded skill"
+        title="Remove skill"
+      >
+        <X size={12} />
+      </button>
+    </div>
+  )
+}

--- a/src/renderer/components/chat/SlashCommandMenu.tsx
+++ b/src/renderer/components/chat/SlashCommandMenu.tsx
@@ -1,4 +1,4 @@
-import { Check, SlidersHorizontal, TerminalSquare } from 'lucide-react'
+import { Check, SlidersHorizontal, Sparkles, TerminalSquare } from 'lucide-react'
 import { forwardRef, useEffect, useImperativeHandle, useMemo, useRef, useState } from 'react'
 import { cn } from '@/lib/utils'
 import type { SlashItem, SlashSection } from './slash-menu-model'
@@ -28,6 +28,8 @@ function itemKey(item: SlashItem): string {
       return `config:${item.configId}:${item.valueId}`
     case 'mode':
       return `mode:${item.modeId}`
+    case 'skill':
+      return `skill:${item.name}`
   }
 }
 
@@ -95,9 +97,19 @@ export const SlashCommandMenu = forwardRef<SlashMenuHandle, SlashCommandMenuProp
               flatIndex += 1
               const isHighlighted = flatIndex === highlight
               const idx = flatIndex
-              const Icon = item.kind === 'command' ? TerminalSquare : SlidersHorizontal
-              const selected = item.kind !== 'command' && item.selected
-              const label = item.kind === 'command' ? `/${item.name}` : item.label
+              const Icon =
+                item.kind === 'command'
+                  ? TerminalSquare
+                  : item.kind === 'skill'
+                    ? Sparkles
+                    : SlidersHorizontal
+              const selected = item.kind !== 'command' && item.kind !== 'skill' && item.selected
+              const label =
+                item.kind === 'command'
+                  ? `/${item.name}`
+                  : item.kind === 'skill'
+                    ? `/${item.name}`
+                    : item.label
               const description = item.description
               return (
                 <button
@@ -111,14 +123,24 @@ export const SlashCommandMenu = forwardRef<SlashMenuHandle, SlashCommandMenuProp
                   }}
                   onMouseEnter={() => setHighlight(idx)}
                   className={cn(
-                    'flex w-full items-center gap-2 px-3 py-1.5 text-left text-sm',
+                    'flex w-full gap-2 px-3 py-1.5 text-left text-sm',
+                    item.kind === 'skill' ? 'flex-wrap items-start' : 'items-center',
                     isHighlighted ? 'bg-accent text-accent-foreground' : 'text-foreground'
                   )}
                 >
                   <Icon size={13} className="shrink-0 text-muted-foreground" />
-                  <span className="truncate font-medium">{label}</span>
+                  <span
+                    className={cn(
+                      'font-medium',
+                      item.kind === 'skill' ? 'break-words' : 'min-w-0 truncate'
+                    )}
+                  >
+                    {label}
+                  </span>
                   {description && (
-                    <span className="truncate text-xs text-muted-foreground">{description}</span>
+                    <span className="min-w-0 flex-1 truncate text-xs text-muted-foreground">
+                      {description}
+                    </span>
                   )}
                   {selected && <Check size={13} className="ml-auto shrink-0 text-primary" />}
                 </button>

--- a/src/renderer/components/chat/slash-menu-keyboard.test.ts
+++ b/src/renderer/components/chat/slash-menu-keyboard.test.ts
@@ -1,0 +1,43 @@
+import { createRef } from 'react'
+import { describe, expect, it, vi } from 'vitest'
+import type { SlashMenuHandle } from './SlashCommandMenu'
+import { tryHandleSlashMenuKeyDown } from './slash-menu-keyboard'
+
+function keyEvent(key: string, extra: Partial<KeyboardEvent> = {}): KeyboardEvent {
+  return {
+    key,
+    shiftKey: false,
+    preventDefault: vi.fn(),
+    nativeEvent: { isComposing: false },
+    ...extra
+  } as unknown as KeyboardEvent
+}
+
+describe('tryHandleSlashMenuKeyDown', () => {
+  it('returns false when the menu is closed', () => {
+    const menuRef = createRef<SlashMenuHandle>()
+    const handled = tryHandleSlashMenuKeyDown(keyEvent('Tab'), {
+      menuOpen: false,
+      sectionsLength: 2,
+      menuRef,
+      onClearInput: vi.fn()
+    })
+    expect(handled).toBe(false)
+  })
+
+  it('selects the highlighted item on Tab', () => {
+    const menuRef = createRef<SlashMenuHandle>()
+    const selectHighlighted = vi.fn(() => true)
+    menuRef.current = { move: vi.fn(), selectHighlighted }
+
+    const handled = tryHandleSlashMenuKeyDown(keyEvent('Tab'), {
+      menuOpen: true,
+      sectionsLength: 2,
+      menuRef,
+      onClearInput: vi.fn()
+    })
+
+    expect(handled).toBe(true)
+    expect(selectHighlighted).toHaveBeenCalledOnce()
+  })
+})

--- a/src/renderer/components/chat/slash-menu-keyboard.test.ts
+++ b/src/renderer/components/chat/slash-menu-keyboard.test.ts
@@ -1,4 +1,4 @@
-import { createRef } from 'react'
+import type { KeyboardEvent, RefObject } from 'react'
 import { describe, expect, it, vi } from 'vitest'
 import type { SlashMenuHandle } from './SlashCommandMenu'
 import { tryHandleSlashMenuKeyDown } from './slash-menu-keyboard'
@@ -15,7 +15,7 @@ function keyEvent(key: string, extra: Partial<KeyboardEvent> = {}): KeyboardEven
 
 describe('tryHandleSlashMenuKeyDown', () => {
   it('returns false when the menu is closed', () => {
-    const menuRef = createRef<SlashMenuHandle>()
+    const menuRef: RefObject<SlashMenuHandle | null> = { current: null }
     const handled = tryHandleSlashMenuKeyDown(keyEvent('Tab'), {
       menuOpen: false,
       sectionsLength: 2,
@@ -26,9 +26,10 @@ describe('tryHandleSlashMenuKeyDown', () => {
   })
 
   it('selects the highlighted item on Tab', () => {
-    const menuRef = createRef<SlashMenuHandle>()
     const selectHighlighted = vi.fn(() => true)
-    menuRef.current = { move: vi.fn(), selectHighlighted }
+    const menuRef: RefObject<SlashMenuHandle | null> = {
+      current: { move: vi.fn(), selectHighlighted }
+    }
 
     const handled = tryHandleSlashMenuKeyDown(keyEvent('Tab'), {
       menuOpen: true,

--- a/src/renderer/components/chat/slash-menu-keyboard.ts
+++ b/src/renderer/components/chat/slash-menu-keyboard.ts
@@ -1,0 +1,46 @@
+import type { KeyboardEvent, RefObject } from 'react'
+import type { SlashMenuHandle } from './SlashCommandMenu'
+
+export interface SlashMenuKeyboardOptions {
+  menuOpen: boolean
+  sectionsLength: number
+  menuRef: RefObject<SlashMenuHandle | null>
+  onClearInput: () => void
+}
+
+/** Route ↑/↓/Tab/Enter/Escape to the slash menu when it is open. Returns true if handled. */
+export function tryHandleSlashMenuKeyDown(
+  e: KeyboardEvent,
+  options: SlashMenuKeyboardOptions
+): boolean {
+  const { menuOpen, sectionsLength, menuRef, onClearInput } = options
+  if (!menuOpen || sectionsLength === 0) return false
+
+  if (e.key === 'ArrowDown') {
+    e.preventDefault()
+    menuRef.current?.move(1)
+    return true
+  }
+  if (e.key === 'ArrowUp') {
+    e.preventDefault()
+    menuRef.current?.move(-1)
+    return true
+  }
+  if (e.key === 'Tab' && !e.shiftKey) {
+    e.preventDefault()
+    menuRef.current?.selectHighlighted()
+    return true
+  }
+  if (e.key === 'Enter' && !e.shiftKey && !e.nativeEvent.isComposing) {
+    e.preventDefault()
+    menuRef.current?.selectHighlighted()
+    return true
+  }
+  if (e.key === 'Escape') {
+    e.preventDefault()
+    onClearInput()
+    return true
+  }
+
+  return false
+}

--- a/src/renderer/components/chat/slash-menu-model.test.ts
+++ b/src/renderer/components/chat/slash-menu-model.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import type { AvailableCommand, SessionConfigOption, SessionModeState } from '@/lib/acp-api'
+import type { AgentSkillSummary } from '@/lib/skills-api'
 import {
   applyCommandToInput,
   buildSlashSections,
@@ -49,6 +50,11 @@ const modes: SessionModeState = {
   ]
 }
 
+const skills: AgentSkillSummary[] = [
+  { name: 'investigate', description: 'Run an investigation', scope: 'project' },
+  { name: 'review', description: 'Review code', scope: 'global' }
+]
+
 describe('slash trigger detection', () => {
   it('opens on a lone slash and a leading slash token', () => {
     expect(isSlashTrigger('/')).toBe(true)
@@ -71,7 +77,19 @@ describe('slash trigger detection', () => {
 })
 
 describe('buildSlashSections', () => {
-  it('lists commands first', () => {
+  it('lists skills before commands', () => {
+    const sections = buildSlashSections({
+      commands,
+      configOptions: [],
+      modes: null,
+      skills,
+      filter: ''
+    })
+    expect(sections[0].id).toBe('skills')
+    expect(sections[1].id).toBe('commands')
+  })
+
+  it('lists commands first when no skills', () => {
     const sections = buildSlashSections({ commands, configOptions: [], modes: null, filter: '' })
     expect(sections[0].id).toBe('commands')
     expect(sections[0].items).toHaveLength(2)

--- a/src/renderer/components/chat/slash-menu-model.ts
+++ b/src/renderer/components/chat/slash-menu-model.ts
@@ -10,6 +10,7 @@ import type {
   SessionMode,
   SessionModeState
 } from '@/lib/acp-api'
+import type { AgentSkillSummary } from '@/lib/skills-api'
 
 export interface SlashCommandItem {
   kind: 'command'
@@ -34,7 +35,14 @@ export interface SlashModeItem {
   selected: boolean
 }
 
-export type SlashItem = SlashCommandItem | SlashConfigItem | SlashModeItem
+export interface SlashSkillItem {
+  kind: 'skill'
+  name: string
+  description: string | null
+  scope: string
+}
+
+export type SlashItem = SlashCommandItem | SlashConfigItem | SlashModeItem | SlashSkillItem
 
 export interface SlashSection {
   /** Stable key for the section. */
@@ -48,6 +56,7 @@ export interface SlashMenuInput {
   commands: AvailableCommand[]
   configOptions: SessionConfigOption[]
   modes: SessionModeState | null
+  skills?: AgentSkillSummary[]
   /** The text after the leading `/`, used to filter. */
   filter: string
 }
@@ -79,8 +88,20 @@ function headingForCategory(category: string | null | undefined, fallbackName: s
  * legacy Modes section is emitted if modes exist.
  */
 export function buildSlashSections(input: SlashMenuInput): SlashSection[] {
-  const { commands, configOptions, modes, filter } = input
+  const { commands, configOptions, modes, skills = [], filter } = input
   const sections: SlashSection[] = []
+
+  const skillItems: SlashItem[] = skills
+    .filter((s) => matches(filter, s.name, s.description))
+    .map((s) => ({
+      kind: 'skill',
+      name: s.name,
+      description: s.description || null,
+      scope: s.scope
+    }))
+  if (skillItems.length > 0) {
+    sections.push({ id: 'skills', heading: 'Skills', items: skillItems })
+  }
 
   const commandItems: SlashItem[] = commands
     .filter((c) => matches(filter, c.name, c.description))

--- a/src/renderer/hooks/use-agent-skills.ts
+++ b/src/renderer/hooks/use-agent-skills.ts
@@ -48,7 +48,12 @@ export async function buildPromptWithLoadedSkill(
   const trimmed = userText.trim()
   if (!loadedSkill) return trimmed
 
-  const skill = await skillsApi.readSkill(loadedSkill.name, projectRoot)
-  const { formatPromptWithSkill } = await import('@/lib/skills-prompt')
-  return formatPromptWithSkill(skill.body, trimmed)
+  try {
+    const skill = await skillsApi.readSkill(loadedSkill.name, projectRoot)
+    const { formatPromptWithSkill } = await import('@/lib/skills-prompt')
+    return formatPromptWithSkill(skill.body, trimmed)
+  } catch (err) {
+    const detail = err instanceof Error ? err.message : String(err)
+    throw new Error(`Failed to load skill '${loadedSkill.name}': ${detail}`)
+  }
 }

--- a/src/renderer/hooks/use-agent-skills.ts
+++ b/src/renderer/hooks/use-agent-skills.ts
@@ -20,6 +20,7 @@ export function useAgentSkills(projectRoot: string | undefined): {
   }, [])
 
   useEffect(() => {
+    void reloadToken
     let cancelled = false
     setLoading(true)
     void (async () => {

--- a/src/renderer/hooks/use-agent-skills.ts
+++ b/src/renderer/hooks/use-agent-skills.ts
@@ -1,0 +1,54 @@
+import { useCallback, useEffect, useState } from 'react'
+import { type AgentSkillSummary, skillsApi } from '@/lib/skills-api'
+
+export interface LoadedAgentSkill {
+  name: string
+  description: string
+}
+
+export function useAgentSkills(projectRoot: string | undefined): {
+  skills: AgentSkillSummary[]
+  loading: boolean
+  reload: () => void
+} {
+  const [skills, setSkills] = useState<AgentSkillSummary[]>([])
+  const [loading, setLoading] = useState(false)
+  const [reloadToken, setReloadToken] = useState(0)
+
+  const reload = useCallback(() => {
+    setReloadToken((t) => t + 1)
+  }, [])
+
+  useEffect(() => {
+    let cancelled = false
+    setLoading(true)
+    void (async () => {
+      try {
+        const listed = await skillsApi.listSkills(projectRoot)
+        if (!cancelled) setSkills(listed)
+      } catch {
+        if (!cancelled) setSkills([])
+      } finally {
+        if (!cancelled) setLoading(false)
+      }
+    })()
+    return () => {
+      cancelled = true
+    }
+  }, [projectRoot, reloadToken])
+
+  return { skills, loading, reload }
+}
+
+export async function buildPromptWithLoadedSkill(
+  loadedSkill: LoadedAgentSkill | null,
+  userText: string,
+  projectRoot: string | undefined
+): Promise<string> {
+  const trimmed = userText.trim()
+  if (!loadedSkill) return trimmed
+
+  const skill = await skillsApi.readSkill(loadedSkill.name, projectRoot)
+  const { formatPromptWithSkill } = await import('@/lib/skills-prompt')
+  return formatPromptWithSkill(skill.body, trimmed)
+}

--- a/src/renderer/lib/skills-api.ts
+++ b/src/renderer/lib/skills-api.ts
@@ -1,0 +1,33 @@
+/**
+ * Agent Skills IPC facade — lists and reads Zed-compatible SKILL.md packages.
+ */
+import { invoke } from '@tauri-apps/api/core'
+
+export interface AgentSkillSummary {
+  name: string
+  description: string
+  /** `'global'` or `'project'`. */
+  scope: string
+}
+
+export interface AgentSkillContent {
+  name: string
+  description: string
+  scope: string
+  body: string
+}
+
+export const skillsApi = {
+  listSkills(projectRoot?: string): Promise<AgentSkillSummary[]> {
+    return invoke<AgentSkillSummary[]>('list_agent_skills_cmd', {
+      projectRoot: projectRoot || null
+    })
+  },
+
+  readSkill(name: string, projectRoot?: string): Promise<AgentSkillContent> {
+    return invoke<AgentSkillContent>('read_agent_skill_cmd', {
+      name,
+      projectRoot: projectRoot || null
+    })
+  }
+}

--- a/src/renderer/lib/skills-prompt.test.ts
+++ b/src/renderer/lib/skills-prompt.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest'
+import { formatPromptWithSkill } from '@/lib/skills-prompt'
+
+describe('formatPromptWithSkill', () => {
+  it('returns user text when skill body is empty', () => {
+    expect(formatPromptWithSkill('', 'hello')).toBe('hello')
+  })
+
+  it('returns skill body when user text is empty', () => {
+    expect(formatPromptWithSkill('## Do work', '')).toBe('## Do work')
+  })
+
+  it('joins skill and user text with a separator', () => {
+    expect(formatPromptWithSkill('## Skill', 'hello')).toBe('## Skill\n\n---\n\nhello')
+  })
+})

--- a/src/renderer/lib/skills-prompt.test.ts
+++ b/src/renderer/lib/skills-prompt.test.ts
@@ -13,4 +13,16 @@ describe('formatPromptWithSkill', () => {
   it('joins skill and user text with a separator', () => {
     expect(formatPromptWithSkill('## Skill', 'hello')).toBe('## Skill\n\n---\n\nhello')
   })
+
+  it('trims leading and trailing whitespace from both parts', () => {
+    expect(formatPromptWithSkill('  ## Skill  ', '  hello  ')).toBe('## Skill\n\n---\n\nhello')
+  })
+
+  it('returns user text when skill body is whitespace-only', () => {
+    expect(formatPromptWithSkill('   ', 'hello')).toBe('hello')
+  })
+
+  it('returns skill body when user text is whitespace-only', () => {
+    expect(formatPromptWithSkill('## Skill', '   ')).toBe('## Skill')
+  })
 })

--- a/src/renderer/lib/skills-prompt.ts
+++ b/src/renderer/lib/skills-prompt.ts
@@ -1,0 +1,12 @@
+/**
+ * Wrap skill instructions and optional user text into a single prompt string.
+ */
+export function formatPromptWithSkill(skillBody: string, userText: string): string {
+  const instructions = skillBody.trim()
+  const user = userText.trim()
+
+  if (!instructions) return user
+  if (!user) return instructions
+
+  return `${instructions}\n\n---\n\n${user}`
+}


### PR DESCRIPTION
## Summary

Add minimal Zed-compatible Agent Skills support to ACP chat and the agent launcher: discover `SKILL.md` packages from global and project-local paths, pick them via `/`, and inject skill instructions into the agent prompt on send or launch.

## Related Issue

No linked issue — greenfield UX follow-up to ACP chat integration.

## Type of Change

- [x] feat: new feature
- [ ] fix: bug fix
- [ ] docs: documentation only
- [ ] style: formatting or non-functional styling changes
- [ ] refactor: internal cleanup with no behavior change
- [ ] perf: performance improvement
- [ ] test: adds or updates tests
- [ ] build: build or dependency changes
- [ ] ci: CI/CD workflow changes
- [ ] chore: maintenance or tooling
- [ ] revert: reverts a previous change

## What Changed

- **Rust:** new `skills` module with `list_agent_skills_cmd` and `read_agent_skill_cmd` Tauri commands; scans `~/.agents/skills/` and `{projectRoot}/.agents/skills/` (project overrides global on name collision).
- **ACP chat:** slash menu gains a **Skills** section; selecting a skill shows a chip and injects the skill body into the prompt (optional user message appended after a separator).
- **Agent launcher (ACP mode):** same `/` skills menu and injection on launch; skill-only launches are allowed.
- **UI:** skill names are not truncated in the menu or loaded-skill chip.

## How It Was Tested

- [ ] `bun run lint`
- [ ] `bun run typecheck`
- [x] `bun run test` — `skills-prompt.test.ts`, `slash-menu-model.test.ts`
- [x] Manual verification completed — Rust `cargo test skills`
- [ ] Not applicable

## Screenshots or Recordings

<!-- Required for UI changes when applicable -->

## Checklist

- [x] My PR title follows the conventional commit format used by this repo
- [x] I linked the related issue or explained why none exists
- [ ] I updated docs when needed
- [x] I added or updated tests when needed
- [x] I verified the change does not introduce unrelated modifications


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Agent Skills: browse, select, and load skills via slash commands (/) in chat and agent launcher
  * Shows active skill as a visible badge with dismiss option
  * Loaded skills integrated into outgoing prompts with formatted merging
  * Supports project-local and global skills with project-local override
  * Slash menu lists skills, supports keyboard navigation, Tab/Enter selection, and updated UI/typography
  * Async send flow with error reporting and cancel support

* **Tests**
  * Added tests for skill parsing, listing/override behavior, keyboard handling, and prompt formatting
<!-- end of auto-generated comment: release notes by coderabbit.ai -->