### PR TITLE
fix(ui): compact macOS top titlebar strip

### DIFF
--- a/src/renderer/components/ActivityRail.tsx
+++ b/src/renderer/components/ActivityRail.tsx
@@ -49,9 +49,8 @@ interface ActivityRailProps {
  * Vertical activity rail (VSCode-style) that hosts the app's global actions.
  *
  * Layout:
- * - macOS: a top spacer clears the native traffic lights and acts as a drag region.
- *   On macOS there is no separate top title strip, so this rail also carries the
- *   window-drag affordance at the top-left.
+ * - macOS: WorkspaceLayout provides a unified top drag strip for traffic-light
+ *   clearance; the rail brand row remains draggable for top-left window moves.
  * - Brand mark at the top, followed by a separator.
  * - Top group: projects (command palette), git changes, SSH panel toggle.
  * - Bottom group (pinned via `mt-auto`): sidebar toggle, file explorer toggle,
@@ -117,9 +116,6 @@ export function ActivityRail({
       className="w-12 flex flex-col items-center bg-background select-none shrink-0"
       aria-label="Global actions"
     >
-      {/* macOS: top spacer clears native traffic lights and stays draggable */}
-      {isMac && <div className="h-7 w-full shrink-0" data-tauri-drag-region />}
-
       {/* Brand mark. On Windows/Linux it also offsets the actions from the top edge. */}
       <div
         className="w-12 h-11 flex items-center justify-center text-foreground shrink-0"

--- a/src/renderer/components/TitleBar.tsx
+++ b/src/renderer/components/TitleBar.tsx
@@ -13,7 +13,7 @@ const windowControlClass =
  * minimize/maximize/close controls are required. The strip sits at the top of
  * the content column (right of the ActivityRail) and doubles as a window drag
  * region. On macOS this renders nothing — native traffic lights handle window
- * controls, and the ActivityRail carries the drag affordance instead.
+ * controls, and WorkspaceLayout provides a unified top drag strip instead.
  *
  * Global actions (sidebar/explorer toggles, shortcuts, preferences) no longer
  * live here; they moved to the ActivityRail.

--- a/src/renderer/layouts/WorkspaceLayout.tsx
+++ b/src/renderer/layouts/WorkspaceLayout.tsx
@@ -53,7 +53,7 @@ import {
 } from '@/lib/api'
 import { browserTabHide, browserTabShow } from '@/lib/browser-api'
 import { isSaveFileShortcut, requestSaveEditorFile } from '@/lib/editor-save'
-import { isMac } from '@/lib/platform'
+import { isMac, macOsTitlebarStripClass } from '@/lib/platform'
 import { spawnTerminalInPane } from '@/lib/terminal-spawn'
 import { getEffectiveThemeId } from '@/lib/themes'
 import { cn } from '@/lib/utils'
@@ -1378,19 +1378,22 @@ export default function WorkspaceLayout(): React.JSX.Element {
     return (
       <div className="h-screen flex flex-col overflow-hidden bg-background">
         <ResizeEdges />
-        <div className="flex-1 flex overflow-hidden min-h-0 h-full">
-          <ActivityRail
-            isShortcutsOpen={isShortcutMenuOpen}
-            onShortcutsOpenChange={setIsShortcutMenuOpen}
-            onOpenCommandPalette={() => setIsCommandPaletteOpen(true)}
-            canOpenGitChanges={false}
-          />
-          <div className="flex-1 flex flex-col min-w-0">
-            {/* macOS: draggable band clearing native traffic lights over the content column */}
-            {isMac && <div className="h-7 shrink-0" data-tauri-drag-region />}
-            <TitleBar />
-            <div className="flex-1 flex items-center justify-center">
-              <div className="text-muted-foreground text-sm">Loading...</div>
+        <div className="flex-1 flex flex-col overflow-hidden min-h-0 h-full">
+          {isMac && (
+            <div className={macOsTitlebarStripClass} data-tauri-drag-region aria-hidden="true" />
+          )}
+          <div className="flex-1 flex overflow-hidden min-h-0">
+            <ActivityRail
+              isShortcutsOpen={isShortcutMenuOpen}
+              onShortcutsOpenChange={setIsShortcutMenuOpen}
+              onOpenCommandPalette={() => setIsCommandPaletteOpen(true)}
+              canOpenGitChanges={false}
+            />
+            <div className="flex-1 flex flex-col min-w-0">
+              <TitleBar />
+              <div className="flex-1 flex items-center justify-center">
+                <div className="text-muted-foreground text-sm">Loading...</div>
+              </div>
             </div>
           </div>
         </div>
@@ -1401,157 +1404,160 @@ export default function WorkspaceLayout(): React.JSX.Element {
   return (
     <div className="h-screen flex flex-col overflow-hidden bg-background">
       <ResizeEdges />
-      <div className="flex-1 flex overflow-hidden min-h-0 h-full">
-        <ActivityRail
-          isShortcutsOpen={isShortcutMenuOpen}
-          onShortcutsOpenChange={setIsShortcutMenuOpen}
-          onOpenCommandPalette={() => setIsCommandPaletteOpen(true)}
-          onOpenGitChanges={() => handleAddGitTab()}
-          canOpenGitChanges={Boolean(activeProject?.path)}
-          onOpenGitHistory={() => handleAddGitHistoryTab()}
-          canOpenGitHistory={Boolean(activeProject?.path)}
-          isThemePickerOpen={isThemePickerOpen}
-          onToggleThemePicker={handleToggleThemePicker}
-          onOpenAgentChat={handleOpenAgentChat}
-          canOpenAgentChat={Boolean(activeProject?.path)}
-        />
-        <div className="flex-1 flex flex-col min-w-0">
-          {/* macOS: draggable band clearing native traffic lights over the content column */}
-          {isMac && <div className="h-7 shrink-0" data-tauri-drag-region />}
-          <TitleBar />
+      <div className="flex-1 flex flex-col overflow-hidden min-h-0 h-full">
+        {isMac && (
+          <div className={macOsTitlebarStripClass} data-tauri-drag-region aria-hidden="true" />
+        )}
+        <div className="flex-1 flex overflow-hidden min-h-0">
+          <ActivityRail
+            isShortcutsOpen={isShortcutMenuOpen}
+            onShortcutsOpenChange={setIsShortcutMenuOpen}
+            onOpenCommandPalette={() => setIsCommandPaletteOpen(true)}
+            onOpenGitChanges={() => handleAddGitTab()}
+            canOpenGitChanges={Boolean(activeProject?.path)}
+            onOpenGitHistory={() => handleAddGitHistoryTab()}
+            canOpenGitHistory={Boolean(activeProject?.path)}
+            isThemePickerOpen={isThemePickerOpen}
+            onToggleThemePicker={handleToggleThemePicker}
+            onOpenAgentChat={handleOpenAgentChat}
+            canOpenAgentChat={Boolean(activeProject?.path)}
+          />
+          <div className="flex-1 flex flex-col min-w-0">
+            <TitleBar />
 
-          <div className="flex-1 flex overflow-hidden min-h-0 h-full p-2 gap-0">
-            {/* Sidebar */}
-            {isSidebarVisible && (
-              <div className="mr-2">
-                <SidebarTabs
-                  projects={projects}
-                  activeProjectId={activeProjectId}
-                  onSelectProject={handleSelectProject}
-                  onNewProject={() => setIsNewProjectModalOpen(true)}
-                  onUpdateProject={updateProject}
-                  onDeleteProject={deleteProject}
-                  onArchiveProject={archiveProject}
-                  onRestoreProject={restoreProject}
-                  onReorderProjects={reorderProjects}
-                  onSSHConnect={handleSSHConnect}
-                  onSelectSSHProfile={handleSelectSSHProfile}
-                  activeSSHProfileId={activeSSHProfileId}
-                />
-              </div>
-            )}
+            <div className="flex-1 flex overflow-hidden min-h-0 h-full p-2 gap-0">
+              {/* Sidebar */}
+              {isSidebarVisible && (
+                <div className="mr-2">
+                  <SidebarTabs
+                    projects={projects}
+                    activeProjectId={activeProjectId}
+                    onSelectProject={handleSelectProject}
+                    onNewProject={() => setIsNewProjectModalOpen(true)}
+                    onUpdateProject={updateProject}
+                    onDeleteProject={deleteProject}
+                    onArchiveProject={archiveProject}
+                    onRestoreProject={restoreProject}
+                    onReorderProjects={reorderProjects}
+                    onSSHConnect={handleSSHConnect}
+                    onSelectSSHProfile={handleSelectSSHProfile}
+                    activeSSHProfileId={activeSSHProfileId}
+                  />
+                </div>
+              )}
 
-            {/* Main Content and File Explorer Container */}
-            <PaneDndProvider>
-              <div className="flex-1 flex min-h-0 h-full gap-0 overflow-hidden min-w-0">
-                {/* Main Content Area */}
-                <main className="flex-1 flex flex-col min-w-0 rounded-xl bg-card overflow-hidden">
-                  {activeSSHProfile ? (
-                    /* SSH Workspace */
-                    <SSHWorkspace profile={sshProfileWithPassword!} conn={sshConn} />
-                  ) : projects.length === 0 ? (
-                    /* No Projects Empty State */
-                    <div className="flex-1 flex flex-col items-center justify-center bg-background px-6 rounded-xl">
-                      <motion.div
-                        initial={{ opacity: 0, scale: 0.9 }}
-                        animate={{ opacity: 1, scale: 1 }}
-                        transition={{ duration: 0.4, ease: 'easeOut' }}
-                        className="flex flex-col items-center text-center max-w-md"
-                      >
-                        <div className="mb-6">
-                          <FolderKanban className="w-24 h-24 text-muted-foreground/50" />
-                        </div>
-                        <h2 className="text-xl font-semibold text-foreground mb-2">
-                          No Projects Yet
-                        </h2>
-                        <p className="text-muted-foreground text-sm mb-6 leading-relaxed">
-                          Create your first project to organize your terminals, snapshots, and
-                          commands
-                        </p>
-                        <button
-                          onClick={() => setIsNewProjectModalOpen(true)}
-                          className="px-6 py-2.5 bg-primary text-primary-foreground rounded-xl hover:bg-primary/90 transition-colors text-sm font-medium shadow-sm hover:shadow"
-                        >
-                          Create Your First Project
-                        </button>
-                      </motion.div>
-                    </div>
-                  ) : (
-                    <>
-                      {isWorkspaceRoute ? (
+              {/* Main Content and File Explorer Container */}
+              <PaneDndProvider>
+                <div className="flex-1 flex min-h-0 h-full gap-0 overflow-hidden min-w-0">
+                  {/* Main Content Area */}
+                  <main className="flex-1 flex flex-col min-w-0 rounded-xl bg-card overflow-hidden">
+                    {activeSSHProfile ? (
+                      /* SSH Workspace */
+                      <SSHWorkspace profile={sshProfileWithPassword!} conn={sshConn} />
+                    ) : projects.length === 0 ? (
+                      /* No Projects Empty State */
+                      <div className="flex-1 flex flex-col items-center justify-center bg-background px-6 rounded-xl">
                         <motion.div
-                          key={fullscreenPaneId ? 'fullscreen' : 'normal'}
-                          initial={{ opacity: 0.85, scale: 0.97 }}
+                          initial={{ opacity: 0, scale: 0.9 }}
                           animate={{ opacity: 1, scale: 1 }}
-                          transition={{ duration: 0.2, ease: 'easeOut' }}
-                          className="flex-1 min-h-0 h-full overflow-hidden"
+                          transition={{ duration: 0.4, ease: 'easeOut' }}
+                          className="flex flex-col items-center text-center max-w-md"
                         >
-                          <PaneRenderer
-                            node={fullscreenPane ?? paneRoot}
-                            onAddTerminal={handleAddTerminal}
-                            onAddBrowserTab={handleNewBrowserTab}
-                            onCloseTerminal={handleCloseTerminal}
-                            onRenameTerminal={renameTerminal}
-                            onCloseEditorTab={handleCloseEditorTab}
-                            closingTerminalIds={closingTerminalIds}
-                            defaultShell={activeProject?.defaultShell || appDefaultShell}
-                          />
-                        </motion.div>
-                      ) : (
-                        <div className="flex-1 overflow-hidden bg-background relative rounded-xl">
-                          <div className="w-full h-full">
-                            <Outlet />
+                          <div className="mb-6">
+                            <FolderKanban className="w-24 h-24 text-muted-foreground/50" />
                           </div>
+                          <h2 className="text-xl font-semibold text-foreground mb-2">
+                            No Projects Yet
+                          </h2>
+                          <p className="text-muted-foreground text-sm mb-6 leading-relaxed">
+                            Create your first project to organize your terminals, snapshots, and
+                            commands
+                          </p>
+                          <button
+                            onClick={() => setIsNewProjectModalOpen(true)}
+                            className="px-6 py-2.5 bg-primary text-primary-foreground rounded-xl hover:bg-primary/90 transition-colors text-sm font-medium shadow-sm hover:shadow"
+                          >
+                            Create Your First Project
+                          </button>
+                        </motion.div>
+                      </div>
+                    ) : (
+                      <>
+                        {isWorkspaceRoute ? (
+                          <motion.div
+                            key={fullscreenPaneId ? 'fullscreen' : 'normal'}
+                            initial={{ opacity: 0.85, scale: 0.97 }}
+                            animate={{ opacity: 1, scale: 1 }}
+                            transition={{ duration: 0.2, ease: 'easeOut' }}
+                            className="flex-1 min-h-0 h-full overflow-hidden"
+                          >
+                            <PaneRenderer
+                              node={fullscreenPane ?? paneRoot}
+                              onAddTerminal={handleAddTerminal}
+                              onAddBrowserTab={handleNewBrowserTab}
+                              onCloseTerminal={handleCloseTerminal}
+                              onRenameTerminal={renameTerminal}
+                              onCloseEditorTab={handleCloseEditorTab}
+                              closingTerminalIds={closingTerminalIds}
+                              defaultShell={activeProject?.defaultShell || appDefaultShell}
+                            />
+                          </motion.div>
+                        ) : (
+                          <div className="flex-1 overflow-hidden bg-background relative rounded-xl">
+                            <div className="w-full h-full">
+                              <Outlet />
+                            </div>
+                          </div>
+                        )}
+
+                        {/* Status Bar */}
+                        <StatusBar project={activeProject} />
+                      </>
+                    )}
+                  </main>
+
+                  {/* File Explorer - separate floating panel */}
+                  {(isExplorerVisible && activeProject?.path) || activeSSHProfile ? (
+                    <div className="flex-shrink-0 ml-2 flex flex-col gap-2 h-full">
+                      {isExplorerVisible && activeProject?.path && (
+                        <div className={activeSSHProfile ? 'flex-1 min-h-0' : 'h-full'}>
+                          <FileExplorer side="right" />
                         </div>
                       )}
-
-                      {/* Status Bar */}
-                      <StatusBar project={activeProject} />
-                    </>
-                  )}
-                </main>
-
-                {/* File Explorer - separate floating panel */}
-                {(isExplorerVisible && activeProject?.path) || activeSSHProfile ? (
-                  <div className="flex-shrink-0 ml-2 flex flex-col gap-2 h-full">
-                    {isExplorerVisible && activeProject?.path && (
-                      <div className={activeSSHProfile ? 'flex-1 min-h-0' : 'h-full'}>
-                        <FileExplorer side="right" />
-                      </div>
-                    )}
-                    {activeSSHProfile && (
-                      <div
-                        className={cn(
-                          'flex-1 bg-background rounded-xl overflow-hidden min-h-0 flex flex-col border border-border',
-                          !(isExplorerVisible && activeProject?.path) && 'w-64'
-                        )}
-                      >
-                        <SSHFileExplorer
-                          connectionId={sshConn.connectionId ?? ''}
-                          isConnected={sshConn.isConnected}
-                          sftpReady={sshConn.sftpReady}
-                          entries={sshConn.entries}
-                          currentPath={sshConn.currentPath}
-                          expandedDirs={sshConn.expandedDirs}
-                          childEntries={sshConn.childEntries}
-                          loadingDirs={sshConn.loadingDirs}
-                          isLoadingRoot={sshConn.isLoadingRoot}
-                          profileName={activeSSHProfile.name}
-                          onConnect={sshConn.handleConnect}
-                          onBrowseFiles={sshConn.handleBrowseFiles}
-                          onToggleDir={sshConn.toggleDirectory}
-                          onLoadDir={sshConn.loadDirectory}
-                          onMkdir={handleSSHMkdir}
-                          onCreateFile={handleSSHCreateFile}
-                          onDelete={handleSSHDelete}
-                          onRename={handleSSHRename}
-                        />
-                      </div>
-                    )}
-                  </div>
-                ) : null}
-              </div>
-            </PaneDndProvider>
+                      {activeSSHProfile && (
+                        <div
+                          className={cn(
+                            'flex-1 bg-background rounded-xl overflow-hidden min-h-0 flex flex-col border border-border',
+                            !(isExplorerVisible && activeProject?.path) && 'w-64'
+                          )}
+                        >
+                          <SSHFileExplorer
+                            connectionId={sshConn.connectionId ?? ''}
+                            isConnected={sshConn.isConnected}
+                            sftpReady={sshConn.sftpReady}
+                            entries={sshConn.entries}
+                            currentPath={sshConn.currentPath}
+                            expandedDirs={sshConn.expandedDirs}
+                            childEntries={sshConn.childEntries}
+                            loadingDirs={sshConn.loadingDirs}
+                            isLoadingRoot={sshConn.isLoadingRoot}
+                            profileName={activeSSHProfile.name}
+                            onConnect={sshConn.handleConnect}
+                            onBrowseFiles={sshConn.handleBrowseFiles}
+                            onToggleDir={sshConn.toggleDirectory}
+                            onLoadDir={sshConn.loadDirectory}
+                            onMkdir={handleSSHMkdir}
+                            onCreateFile={handleSSHCreateFile}
+                            onDelete={handleSSHDelete}
+                            onRename={handleSSHRename}
+                          />
+                        </div>
+                      )}
+                    </div>
+                  ) : null}
+                </div>
+              </PaneDndProvider>
+            </div>
           </div>
         </div>
       </div>

--- a/src/renderer/lib/platform.ts
+++ b/src/renderer/lib/platform.ts
@@ -11,6 +11,12 @@ const _platform: string = typeof navigator !== 'undefined' ? navigator.platform.
 /** True when running on macOS / Darwin. */
 export const isMac: boolean = _platform.includes('mac')
 
+/**
+ * Slim top inset for macOS overlay title bar / traffic-light clearance.
+ * Used as a single full-width drag strip above the workspace chrome.
+ */
+export const macOsTitlebarStripClass = 'h-6 shrink-0'
+
 /** True when running on Windows. */
 export const isWindows: boolean = _platform.includes('win')
 


### PR DESCRIPTION
## Summary

Compact the macOS overlay title bar by replacing duplicate per-column `h-7` drag spacers with one full-width `h-6` strip above the workspace chrome.

## Related Issue

Closes #313

## Type of Change

- [ ] feat: new feature
- [x] fix: bug fix
- [ ] docs: documentation only
- [ ] style: formatting or non-functional styling changes
- [ ] refactor: internal cleanup with no behavior change
- [ ] perf: performance improvement
- [ ] test: adds or updates tests
- [ ] build: build or dependency changes
- [ ] ci: CI/CD workflow changes
- [ ] chore: maintenance or tooling
- [ ] revert: reverts a previous change

## What Changed

- Added `macOsTitlebarStripClass` (`h-6 shrink-0`) in `src/renderer/lib/platform.ts` for a tunable macOS top inset.
- Restructured `src/renderer/layouts/WorkspaceLayout.tsx` to render a single full-width macOS drag strip above the ActivityRail + content row (loading and loaded states match).
- Removed the redundant macOS top spacer from `src/renderer/components/ActivityRail.tsx`; the brand row remains draggable.
- Updated `src/renderer/components/TitleBar.tsx` comment to reflect unified strip ownership.

## How It Was Tested

- [ ] `bun run lint`
- [ ] `bun run typecheck`
- [x] `bun run test`
- [ ] Manual verification completed
- [ ] Not applicable

Ran targeted Vitest suites in the worktree: `ActivityRail.test.tsx`, `TitleBar.test.tsx`, `WorkspaceLayout.close-persistence.test.tsx` (26 tests passed).

## Screenshots or Recordings

macOS before/after screenshots pending — please verify on a Mac that traffic lights are not clipped and window drag still works from the top strip.

## Checklist

- [x] My PR title follows the conventional commit format used by this repo
- [x] I linked the related issue or explained why none exists
- [x] I updated docs when needed
- [x] I added or updated tests when needed
- [x] I verified the change does not introduce unrelated modifications

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized macOS window drag region handling, centralizing the draggable title strip at the top level of the workspace layout instead of being distributed across multiple components. Updated related styling to use a unified approach across the interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->