### PR TITLE
fix(landing): add more domain to CSP whitelist

### DIFF
--- a/landing/scripts/_headers.yaml
+++ b/landing/scripts/_headers.yaml
@@ -2,9 +2,9 @@
   headers:
     Content-Security-Policy:
       default-src: ["'self'"]
-      script-src: ["'self'", "{{CSP_SCRIPT_HASHES}}", "https://www.googletagmanager.com"]
+      script-src: ["'self'", "{{CSP_SCRIPT_HASHES}}", "https://www.googletagmanager.com", "https://static.cloudflareinsights.com"]
       style-src: ["'self'", "'unsafe-inline'", "https://fonts.googleapis.com"]
-      img-src: ["'self'", "data:", "https://www.googletagmanager.com", "*.google-analytics.com", "*.analytics.google.com", "*.github.com", "*.unavatar.io", "*.cloudflareinsights.com"]
+      img-src: ["'self'", "data:", "https://www.googletagmanager.com", "*.google-analytics.com", "*.analytics.google.com", "github.com", "githubusercontent.com",  "*.githubusercontent.com",  "*.github.com", "*.unavatar.io", "unavatar.io", "api.dicebear.com", "*.cloudflareinsights.com"]
       media-src: ["'self'", "https://d8j0ntlcm91z4.cloudfront.net"]
       font-src: ["'self'", "https://fonts.gstatic.com"]
       frame-src: ["'self'", "https://www.googletagmanager.com"]

--- a/landing/scripts/_headers.yaml
+++ b/landing/scripts/_headers.yaml
@@ -2,13 +2,40 @@
   headers:
     Content-Security-Policy:
       default-src: ["'self'"]
-      script-src: ["'self'", "{{CSP_SCRIPT_HASHES}}", "https://www.googletagmanager.com", "https://static.cloudflareinsights.com"]
+      script-src:
+        [
+          "'self'",
+          "{{CSP_SCRIPT_HASHES}}",
+          "https://www.googletagmanager.com",
+          "https://static.cloudflareinsights.com",
+        ]
       style-src: ["'self'", "'unsafe-inline'", "https://fonts.googleapis.com"]
-      img-src: ["'self'", "data:", "https://www.googletagmanager.com", "*.google-analytics.com", "*.analytics.google.com", "github.com", "githubusercontent.com",  "*.githubusercontent.com",  "*.github.com", "*.unavatar.io", "unavatar.io", "api.dicebear.com", "*.cloudflareinsights.com"]
+      img-src:
+        [
+          "'self'",
+          "data:",
+          "https://www.googletagmanager.com",
+          "*.google-analytics.com",
+          "*.analytics.google.com",
+          "github.com",
+          "githubusercontent.com",
+          "*.githubusercontent.com",
+          "*.github.com",
+          "*.unavatar.io",
+          "unavatar.io",
+          "api.dicebear.com",
+          "*.cloudflareinsights.com",
+        ]
       media-src: ["'self'", "https://d8j0ntlcm91z4.cloudfront.net"]
       font-src: ["'self'", "https://fonts.gstatic.com"]
       frame-src: ["'self'", "https://www.googletagmanager.com"]
-      connect-src: ["'self'", "*.google-analytics.com", "*.analytics.google.com", "https://www.googletagmanager.com"]
+      connect-src:
+        [
+          "'self'",
+          "*.google-analytics.com",
+          "*.analytics.google.com",
+          "https://www.googletagmanager.com",
+        ]
       base-uri: ["'none'"]
       form-action: ["'self'"]
       frame-ancestors: ["'none'"]

--- a/landing/scripts/_headers.yaml
+++ b/landing/scripts/_headers.yaml
@@ -32,9 +32,12 @@
       connect-src:
         [
           "'self'",
+          "google-analytics.com",
           "*.google-analytics.com",
           "*.analytics.google.com",
+          "analytics.google.com",
           "https://www.googletagmanager.com",
+          "https://cloudflareinsights.com"
         ]
       base-uri: ["'none'"]
       form-action: ["'self'"]


### PR DESCRIPTION
## Summary

fix(csp): whitelist more domain to CSP
    
    - github.com
    - unavatar.io
    - static.cloudflareinsights.com
    - api.dicebear.com

## Related Issue

Closes #

## Type of Change

- [ ] feat: new feature
- [x] fix: bug fix
- [ ] docs: documentation only
- [ ] style: formatting or non-functional styling changes
- [ ] refactor: internal cleanup with no behavior change
- [ ] perf: performance improvement
- [ ] test: adds or updates tests
- [ ] build: build or dependency changes
- [ ] ci: CI/CD workflow changes
- [ ] chore: maintenance or tooling
- [ ] revert: reverts a previous change

## What Changed

-

## How It Was Tested

- [ ] `bun run lint`
- [ ] `bun run typecheck`
- [ ] `bun run test`
- [ ] Manual verification completed
- [ ] Not applicable

## Screenshots or Recordings

<!-- Required for UI changes when applicable -->

## Checklist

- [ ] My PR title follows the conventional commit format used by this repo
- [ ] I linked the related issue or explained why none exists
- [ ] I updated docs when needed
- [ ] I added or updated tests when needed
- [ ] I verified the change does not introduce unrelated modifications


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Content Security Policy to allow additional script, image, and connection sources (including Cloudflare Insights, Google Analytics hosts, GitHub and avatar/image providers) for improved third‑party content and analytics.
  * Adjusted placement of the Cross‑Origin‑Resource‑Policy header to ensure correct header ordering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->