### PR TITLE
fix(browser): restrict URL schemes to http, https, and about only

### DIFF
--- a/src-tauri/src/browser_tab_manager.rs
+++ b/src-tauri/src/browser_tab_manager.rs
@@ -2,6 +2,27 @@ use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 use tauri::{AppHandle, Manager};
 
+/// Allowed URL schemes for browser tabs
+const ALLOWED_SCHEMES: [&str; 3] = ["http", "https", "about"];
+
+/// Validates that a URL uses an allowed scheme (http, https, or about).
+/// Returns the parsed URL if valid, or a descriptive error message if invalid.
+fn validate_browser_url(url: &str) -> Result<tauri::Url, String> {
+    let parsed: tauri::Url = url
+        .parse()
+        .map_err(|e| format!("Invalid URL: {}", e))?;
+
+    let scheme = parsed.scheme();
+    if !ALLOWED_SCHEMES.contains(&scheme) {
+        return Err(format!(
+            "URL scheme '{}' is not allowed. Only http, https, and about schemes are permitted.",
+            scheme
+        ));
+    }
+
+    Ok(parsed)
+}
+
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct BrowserTabInfo {
@@ -180,9 +201,7 @@ impl BrowserTabManager {
         bounds: BrowserBounds,
     ) -> Result<BrowserTabInfo, String> {
         let window = self.get_window()?;
-        let parsed_url: tauri::Url = url
-            .parse()
-            .map_err(|e| format!("Invalid URL: {}", e))?;
+        let parsed_url = validate_browser_url(&url)?;
 
         let builder = tauri::webview::WebviewBuilder::new(
             tab_id.clone(),
@@ -395,9 +414,7 @@ impl BrowserTabManager {
     pub fn navigate(&self, tab_id: &str, url: String) -> Result<(), String> {
         self.invalidate_annotation_injected(tab_id);
         let webview = self.get_webview(tab_id)?;
-        let parsed_url: tauri::Url = url
-            .parse()
-            .map_err(|e| format!("Invalid URL: {}", e))?;
+        let parsed_url = validate_browser_url(&url)?;
         webview
             .navigate(parsed_url)
             .map_err(|e| format!("Navigation failed: {}", e))?;
@@ -499,5 +516,81 @@ impl BrowserTabManager {
 impl Drop for BrowserTabManager {
     fn drop(&mut self) {
         self.destroy_all();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_validate_browser_url_accepts_http() {
+        let result = validate_browser_url("http://example.com");
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap().scheme(), "http");
+    }
+
+    #[test]
+    fn test_validate_browser_url_accepts_https() {
+        let result = validate_browser_url("https://example.com");
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap().scheme(), "https");
+    }
+
+    #[test]
+    fn test_validate_browser_url_accepts_about_blank() {
+        let result = validate_browser_url("about:blank");
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap().scheme(), "about");
+    }
+
+    #[test]
+    fn test_validate_browser_url_rejects_file_scheme() {
+        let result = validate_browser_url("file:///etc/passwd");
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(err.contains("file"));
+        assert!(err.contains("not allowed"));
+    }
+
+    #[test]
+    fn test_validate_browser_url_rejects_javascript_scheme() {
+        let result = validate_browser_url("javascript:alert('xss')");
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(err.contains("javascript"));
+        assert!(err.contains("not allowed"));
+    }
+
+    #[test]
+    fn test_validate_browser_url_rejects_data_scheme() {
+        let result = validate_browser_url("data:text/html,<script>alert('xss')</script>");
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(err.contains("data"));
+        assert!(err.contains("not allowed"));
+    }
+
+    #[test]
+    fn test_validate_browser_url_rejects_vbscript_scheme() {
+        let result = validate_browser_url("vbscript:msgbox('xss')");
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(err.contains("vbscript"));
+        assert!(err.contains("not allowed"));
+    }
+
+    #[test]
+    fn test_validate_browser_url_rejects_invalid_url() {
+        let result = validate_browser_url("not a valid url");
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(err.contains("Invalid URL"));
+    }
+
+    #[test]
+    fn test_validate_browser_url_rejects_empty_string() {
+        let result = validate_browser_url("");
+        assert!(result.is_err());
     }
 }


### PR DESCRIPTION
## Problem

Browser tabs in Termul accept arbitrary URLs without protocol validation. This creates a security risk: if someone navigates to a `file://` URL, the browser webview can load local filesystem content. Combined with the annotation feature (which captures screenshots and element data), this could expose sensitive files.

The same issue affects other dangerous URL schemes:
- `javascript:` - script execution in the webview context
- `data:` - inline content that bypasses CSP
- `vbscript:` - legacy script execution on Windows

The current code just parses URLs and assumes Tauri's webview security is enough:

```rust
let parsed_url: tauri::Url = url
    .parse()
    .map_err(|e| format!("Invalid URL: {}", e))?;
```

This happens in two places: `BrowserTabManager::create()` (when creating tabs) and `BrowserTabManager::navigate()` (when navigating to new URLs). Neither checks the scheme.

## What Changed

Added a `validate_browser_url()` helper that enforces an allowlist of safe schemes: `http`, `https`, and `about`. The function:
- Parses the URL
- Checks the scheme against the allowlist
- Returns the parsed URL if valid
- Returns a clear error message if blocked

Applied this validation in both entry points:
- `create()` - blocks dangerous URLs when creating browser tabs
- `navigate()` - blocks dangerous URLs when navigating

The error message tells users exactly what went wrong:
```
URL scheme 'file' is not allowed. Only http, https, and about schemes are permitted.
```

## Why These Three Schemes?

**`http` and `https`** - Standard web protocols. The entire point of browser tabs is loading web content.

**`about:`** - Browser built-ins like `about:blank`. Needed for empty tab initialization and internal pages. Doesn't expose local content.

Everything else gets blocked. The annotation feature makes this stricter than it would be for a normal browser: we're not just displaying content, we're programmatically extracting element data and bounding boxes. That extraction shouldn't run on local files.

## Testing

Added 9 unit tests in a `#[cfg(test)]` module:

**Valid URLs (should pass):**
- `test_validate_browser_url_accepts_http` - verifies http:// works
- `test_validate_browser_url_accepts_https` - verifies https:// works  
- `test_validate_browser_url_accepts_about_blank` - verifies about:blank works

**Invalid URLs (should fail with clear errors):**
- `test_validate_browser_url_rejects_file_scheme` - blocks file:///etc/passwd
- `test_validate_browser_url_rejects_javascript_scheme` - blocks javascript:alert('xss')
- `test_validate_browser_url_rejects_data_scheme` - blocks data:text/html,...
- `test_validate_browser_url_rejects_vbscript_scheme` - blocks vbscript:msgbox('xss')
- `test_validate_browser_url_rejects_invalid_url` - handles malformed URLs
- `test_validate_browser_url_rejects_empty_string` - handles empty input

Tests verify both that invalid schemes are blocked and that error messages contain the scheme name and "not allowed".

## Security Impact

**Before:** Browser tabs could load `file://` URLs and expose local filesystem content through the annotation feature.

**After:** Only http, https, and about schemes are allowed. File access, script injection, and other dangerous protocols are blocked at the API boundary.

This doesn't prevent all browser security issues (the webview still has its own attack surface), but it does prevent the most obvious filesystem exposure vector. If an agent or compromised component tries to screenshot `/etc/passwd` or `C:\Windows\System32\config\SAM` by opening it in a browser tab, the request fails before the webview is created.

## Verification Note

Could not run `cargo check` or `cargo test` on this machine due to a Visual Studio linker environment issue (not related to the code). The changes follow the existing patterns in the file:
- Same `Result<T, String>` error handling
- Same function signature style
- Same test structure as other Rust test modules in the project

Pre-commit hooks (TypeScript typecheck + Biome lint) passed successfully.

## Related Work

This complements existing security fixes in the codebase:
- `path_validation.rs` - prevents path traversal in filesystem operations
- Previous PR #273 - escapes JS string literals in browser injection
- Previous PR #274 - caps search query length to prevent resource exhaustion
- Previous PR #294 - escapes script tags and Unicode separators in annotation JS

All of these share the same principle: validate at the boundary, fail fast, give clear errors.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced URL validation for browser tab creation and navigation, restricting schemes to http, https, and about to prevent invalid URLs with clearer error messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->