### PR TITLE
fix(ui): integrate macOS overlay titlebar with workspace chrome

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -910,18 +910,23 @@ pub fn run() {
             // channel, session id, and resolved log path on a single line.
             logging::log_startup_banner(&handle);
 
-            // macOS: Enable overlay title bar for native traffic lights.
-            // Window starts hidden (visible: false), so we set this before show().
-            // On Windows/Linux: set_decorations(false) removes native frame
-            // so the custom HTML titlebar is used instead.
+            // Window chrome is configured before show(). macOS overlay settings
+            // live in tauri.conf.json — avoid set_decorations(true) there because
+            // it resets hiddenTitle/full-size content view. Win/Linux drop native
+            // frame so the HTML titlebar owns window controls.
             #[cfg(target_os = "macos")]
             {
                 if let Some(window) = app.get_webview_window("main") {
-                    if let Err(e) = window.set_decorations(true) {
-                        log::warn!("[macOS] Failed to enable window decorations: {}", e);
-                    }
                     if let Err(e) = window.set_title_bar_style(tauri::TitleBarStyle::Overlay) {
                         log::warn!("[macOS] Failed to set overlay title bar style: {}", e);
+                    }
+                }
+            }
+            #[cfg(not(target_os = "macos"))]
+            {
+                if let Some(window) = app.get_webview_window("main") {
+                    if let Err(e) = window.set_decorations(false) {
+                        log::warn!("Failed to disable native window decorations: {}", e);
                     }
                 }
             }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -20,7 +20,13 @@
 				"height": 800,
 				"minWidth": 800,
 				"minHeight": 600,
-				"decorations": false,
+				"decorations": true,
+				"titleBarStyle": "Overlay",
+				"hiddenTitle": true,
+				"trafficLightPosition": {
+					"x": 14,
+					"y": 16
+				},
 				"visible": false,
 				"transparent": false,
 				"dragDropEnabled": false

--- a/src/renderer/components/ActivityRail.test.tsx
+++ b/src/renderer/components/ActivityRail.test.tsx
@@ -146,6 +146,16 @@ describe('ActivityRail', () => {
     expect(screen.getByRole('img', { name: 'Termul' })).toBeInTheDocument()
   })
 
+  it('keeps the brand row draggable on macOS for top-left window moves', () => {
+    platformState.isMac = true
+
+    renderRail()
+
+    const rail = screen.getByRole('navigation', { name: 'Global actions' })
+    expect(rail.className).not.toContain('pt-[32px]')
+    expect(rail.querySelector('[data-tauri-drag-region="true"]')).not.toBeNull()
+  })
+
   it('opens the command palette via the projects action', () => {
     const onOpenCommandPalette = vi.fn()
     render(

--- a/src/renderer/components/ActivityRail.tsx
+++ b/src/renderer/components/ActivityRail.tsx
@@ -49,8 +49,8 @@ interface ActivityRailProps {
  * Vertical activity rail (VSCode-style) that hosts the app's global actions.
  *
  * Layout:
- * - macOS: WorkspaceLayout provides a unified top drag strip for traffic-light
- *   clearance; the rail brand row remains draggable for top-left window moves.
+ * - macOS: WorkspaceLayout renders a full-width titlebar zone above this rail;
+ *   the brand row stays draggable for top-left window moves.
  * - Brand mark at the top, followed by a separator.
  * - Top group: projects (command palette), git changes, SSH panel toggle.
  * - Bottom group (pinned via `mt-auto`): sidebar toggle, file explorer toggle,
@@ -116,7 +116,7 @@ export function ActivityRail({
       className="w-12 flex flex-col items-center bg-background select-none shrink-0"
       aria-label="Global actions"
     >
-      {/* Brand mark. On Windows/Linux it also offsets the actions from the top edge. */}
+      {/* Brand mark */}
       <div
         className="w-12 h-11 flex items-center justify-center text-foreground shrink-0"
         data-tauri-drag-region={isMac ? true : undefined}
@@ -175,6 +175,7 @@ export function ActivityRail({
       </button>
 
       <button
+        type="button"
         onClick={(e) => {
           e.stopPropagation()
           onOpenGitHistory?.()

--- a/src/renderer/layouts/WorkspaceLayout.test.tsx
+++ b/src/renderer/layouts/WorkspaceLayout.test.tsx
@@ -7,6 +7,20 @@ import { useSidebarStore } from '@/stores/sidebar-store'
 import type { Project, ProjectColor, Terminal } from '@/types/project'
 import WorkspaceLayout from './WorkspaceLayout'
 
+const { platformState } = vi.hoisted(() => ({
+  platformState: { isMac: false }
+}))
+
+vi.mock('@/lib/platform', async () => {
+  const actual = await vi.importActual<typeof import('@/lib/platform')>('@/lib/platform')
+  return {
+    ...actual,
+    get isMac() {
+      return platformState.isMac
+    }
+  }
+})
+
 function createProject(id: string, path: string, color: ProjectColor): Project {
   return {
     id,
@@ -337,6 +351,7 @@ vi.mock('@/lib/api', () => ({
 }))
 
 beforeEach(() => {
+  platformState.isMac = false
   vi.stubGlobal('api', mockApi)
   if (!HTMLElement.prototype.scrollIntoView) {
     HTMLElement.prototype.scrollIntoView = vi.fn()
@@ -382,6 +397,16 @@ const renderWithRouter = (initialEntries = ['/']) => {
 }
 
 describe('WorkspaceLayout - Empty States', () => {
+  it('renders a full-width macOS titlebar zone above workspace chrome', () => {
+    platformState.isMac = true
+
+    renderWithRouter()
+
+    const strip = document.querySelector('[data-tauri-drag-region][aria-hidden="true"]')
+    expect(strip).not.toBeNull()
+    expect(strip?.className).toContain('h-8')
+  })
+
   it('persists terminal layout before unload when a project is active', async () => {
     mockUseActiveProjectId.mockReturnValue('project-1')
     mockUseActiveProject.mockReturnValue(createProject('project-1', '/workspace/project-1', 'blue'))

--- a/src/renderer/layouts/WorkspaceLayout.tsx
+++ b/src/renderer/layouts/WorkspaceLayout.tsx
@@ -125,6 +125,12 @@ function getShortcutTargetContext(target: EventTarget | null): {
   return { isInEditor, isInTerminal, isInInput }
 }
 
+function MacOsTitlebarStrip(): React.JSX.Element | null {
+  if (!isMac) return null
+
+  return <div className={macOsTitlebarStripClass} data-tauri-drag-region aria-hidden="true" />
+}
+
 export default function WorkspaceLayout(): React.JSX.Element {
   const location = useLocation()
   const navigate = useNavigate()
@@ -1379,9 +1385,7 @@ export default function WorkspaceLayout(): React.JSX.Element {
       <div className="h-screen flex flex-col overflow-hidden bg-background">
         <ResizeEdges />
         <div className="flex-1 flex flex-col overflow-hidden min-h-0 h-full">
-          {isMac && (
-            <div className={macOsTitlebarStripClass} data-tauri-drag-region aria-hidden="true" />
-          )}
+          <MacOsTitlebarStrip />
           <div className="flex-1 flex overflow-hidden min-h-0">
             <ActivityRail
               isShortcutsOpen={isShortcutMenuOpen}
@@ -1405,9 +1409,7 @@ export default function WorkspaceLayout(): React.JSX.Element {
     <div className="h-screen flex flex-col overflow-hidden bg-background">
       <ResizeEdges />
       <div className="flex-1 flex flex-col overflow-hidden min-h-0 h-full">
-        {isMac && (
-          <div className={macOsTitlebarStripClass} data-tauri-drag-region aria-hidden="true" />
-        )}
+        <MacOsTitlebarStrip />
         <div className="flex-1 flex overflow-hidden min-h-0">
           <ActivityRail
             isShortcutsOpen={isShortcutMenuOpen}

--- a/src/renderer/lib/platform.ts
+++ b/src/renderer/lib/platform.ts
@@ -12,10 +12,11 @@ const _platform: string = typeof navigator !== 'undefined' ? navigator.platform.
 export const isMac: boolean = _platform.includes('mac')
 
 /**
- * Slim top inset for macOS overlay title bar / traffic-light clearance.
- * Used as a single full-width drag strip above the workspace chrome.
+ * Full-width macOS titlebar clearance strip above workspace chrome.
+ * Height matches Windows `TitleBar` (`h-8`) so content starts at the same
+ * vertical offset on both platforms.
  */
-export const macOsTitlebarStripClass = 'h-6 shrink-0'
+export const macOsTitlebarStripClass = 'h-8 shrink-0 bg-background'
 
 /** True when running on Windows. */
 export const isWindows: boolean = _platform.includes('win')


### PR DESCRIPTION
## Summary

- Configure macOS overlay titlebar in `tauri.conf.json` (`titleBarStyle`, `hiddenTitle`, `trafficLightPosition`) so traffic lights share the app background instead of leaving a disjoint gap below the system title area.
- Stop calling `set_decorations(true)` at runtime on macOS; apply `set_decorations(false)` at runtime on Windows/Linux now that config defaults to `decorations: true`.
- Raise the global macOS drag strip from `h-6` to `h-8` (matching Windows `TitleBar`) and extract `MacOsTitlebarStrip()` in `WorkspaceLayout`.

Fixes #343

## Problem

On macOS v0.4.5, the native titlebar and workspace chrome feel disconnected — visible empty band between traffic lights and sidebar tabs (Projects/Chats). PR #317 added an `h-6` strip but overlay config was incomplete.

## Test plan

- [x] macOS: traffic lights sit in overlay titlebar with no disjoint gap above Projects/Chats
- [x] macOS: window draggable from full-width top strip and ActivityRail brand row
- [x] macOS: sidebar tabs and activity rail align below a single `h-8` zone
- [ ] Windows: custom HTML titlebar still works (`set_decorations(false)` at runtime)
- [ ] Linux: same as Windows
- [x] `bun run test -- WorkspaceLayout.test ActivityRail.test` passes

## Screenshots

 Before (v0.4.5) 

<img width="1624" height="1007" alt="Screenshot 2026-06-09 at 22 02 26" src="https://github.com/user-attachments/assets/a283a804-1bd2-492f-9d88-1e3e4d65a755" />

After:
<img width="1624" height="1007" alt="Screenshot 2026-06-11 at 21 54 10" src="https://github.com/user-attachments/assets/46715e71-36df-41d4-99a1-79cb639b4df3" />

