### PR TITLE
fix(desktop): prevent external file drop from navigating the webview

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -36,6 +36,7 @@ import { useAcpListeners } from './hooks/use-acp-listeners'
 import { useAcpMcp } from './hooks/use-acp-mcp'
 import { useKeyboardShortcutsLoader } from './hooks/use-keyboard-shortcuts'
 import { useMenuUpdaterListener } from './hooks/use-menu-updater-listener'
+import { usePreventFileDropNavigation } from './hooks/use-prevent-file-drop-navigation'
 import { useProjectsAutoSave, useProjectsLoader } from './hooks/use-projects-persistence'
 import { useUpdateCheck } from './hooks/use-updater'
 import { useVisibilityState } from './hooks/use-visibility-state'
@@ -103,6 +104,7 @@ function AppEffects(): null {
   useUpdateCheck()
   useUpdateToast()
   useVisibilityState()
+  usePreventFileDropNavigation()
   return null
 }
 

--- a/src/renderer/TauriApp.tsx
+++ b/src/renderer/TauriApp.tsx
@@ -19,6 +19,7 @@ import { useGitBranch } from './hooks/use-git-branch'
 import { useGitStatus } from './hooks/use-git-status'
 import { useKeyboardShortcutsLoader } from './hooks/use-keyboard-shortcuts'
 import { useMenuUpdaterListener } from './hooks/use-menu-updater-listener'
+import { usePreventFileDropNavigation } from './hooks/use-prevent-file-drop-navigation'
 import { useProjectsAutoSave, useProjectsLoader } from './hooks/use-projects-persistence'
 import { useRemoteProjects } from './hooks/use-remote-projects'
 import { useTerminalDetachedOutput } from './hooks/use-terminal-detached-output'
@@ -60,6 +61,7 @@ function AppEffects(): null {
   useTerminalExitNotification()
   useRemoteProjects()
   useAcpListeners()
+  usePreventFileDropNavigation()
 
   // Initialize desktop notification permissions once at app startup
   // so the OS permission prompt appears early, not on first terminal exit

--- a/src/renderer/hooks/use-prevent-file-drop-navigation.test.ts
+++ b/src/renderer/hooks/use-prevent-file-drop-navigation.test.ts
@@ -1,0 +1,68 @@
+import { renderHook } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { usePreventFileDropNavigation } from './use-prevent-file-drop-navigation'
+
+interface DragEventInit {
+  types?: string[]
+}
+
+function dispatchDragEvent(type: 'dragover' | 'drop', init: DragEventInit = {}): DragEvent {
+  const event = new Event(type, { bubbles: true, cancelable: true }) as DragEvent
+  const dropEffectHolder = { value: 'uninitialized' as DataTransfer['dropEffect'] }
+  Object.defineProperty(event, 'dataTransfer', {
+    value: {
+      types: init.types ?? [],
+      get dropEffect() {
+        return dropEffectHolder.value
+      },
+      set dropEffect(next: DataTransfer['dropEffect']) {
+        dropEffectHolder.value = next
+      }
+    },
+    configurable: true
+  })
+  window.dispatchEvent(event)
+  return event
+}
+
+describe('usePreventFileDropNavigation', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('prevents default navigation when an external file is dropped', () => {
+    renderHook(() => usePreventFileDropNavigation())
+
+    const event = dispatchDragEvent('drop', { types: ['Files'] })
+
+    expect(event.defaultPrevented).toBe(true)
+  })
+
+  it('prevents default and sets dropEffect none on dragover with files', () => {
+    renderHook(() => usePreventFileDropNavigation())
+
+    const event = dispatchDragEvent('dragover', { types: ['Files'] })
+
+    expect(event.defaultPrevented).toBe(true)
+    expect(event.dataTransfer?.dropEffect).toBe('none')
+  })
+
+  it('ignores internal drags that do not carry OS files', () => {
+    renderHook(() => usePreventFileDropNavigation())
+
+    const dragOver = dispatchDragEvent('dragover', { types: ['text/plain'] })
+    const drop = dispatchDragEvent('drop', { types: ['text/plain'] })
+
+    expect(dragOver.defaultPrevented).toBe(false)
+    expect(drop.defaultPrevented).toBe(false)
+  })
+
+  it('removes its listeners on unmount', () => {
+    const { unmount } = renderHook(() => usePreventFileDropNavigation())
+    unmount()
+
+    const event = dispatchDragEvent('drop', { types: ['Files'] })
+
+    expect(event.defaultPrevented).toBe(false)
+  })
+})

--- a/src/renderer/hooks/use-prevent-file-drop-navigation.ts
+++ b/src/renderer/hooks/use-prevent-file-drop-navigation.ts
@@ -1,0 +1,53 @@
+import { useEffect } from 'react'
+
+/**
+ * Guard against the WebView navigating away when an external OS file is dropped
+ * onto the window.
+ *
+ * The Tauri window runs with `dragDropEnabled: false` (see
+ * `src-tauri/tauri.conf.json`), so native drag/drop events are forwarded
+ * straight to the WebView. The WebView's default behavior for a dropped file is
+ * to navigate to it — e.g. dropping a PDF makes WKWebView render the PDF
+ * full-screen, replacing the entire React app with no way back (issue: dropping
+ * a file locks the UI and forces a restart).
+ *
+ * Internal drag-and-drop (tab/file reordering via `use-pane-dnd`) uses custom
+ * JSON payloads on `dataTransfer`, not OS files, so it never sets the `Files`
+ * type. We only swallow drags that carry OS files, leaving internal DnD intact.
+ */
+function hasExternalFiles(event: DragEvent): boolean {
+  const types = event.dataTransfer?.types
+  if (!types) return false
+  // `types` is a DOMStringList in some engines and a string[] in others;
+  // both support iteration via Array.from.
+  return Array.from(types).includes('Files')
+}
+
+export function usePreventFileDropNavigation(): void {
+  useEffect(() => {
+    const handleDragOver = (event: DragEvent): void => {
+      if (!hasExternalFiles(event)) return
+      // Required so the subsequent `drop` event fires and so the cursor shows
+      // a "no drop" affordance instead of the default "open" behavior.
+      event.preventDefault()
+      if (event.dataTransfer) {
+        event.dataTransfer.dropEffect = 'none'
+      }
+    }
+
+    const handleDrop = (event: DragEvent): void => {
+      if (!hasExternalFiles(event)) return
+      // Stop the WebView from navigating to / rendering the dropped file.
+      event.preventDefault()
+      event.stopPropagation()
+    }
+
+    window.addEventListener('dragover', handleDragOver, { capture: true })
+    window.addEventListener('drop', handleDrop, { capture: true })
+
+    return () => {
+      window.removeEventListener('dragover', handleDragOver, { capture: true })
+      window.removeEventListener('drop', handleDrop, { capture: true })
+    }
+  }, [])
+}


### PR DESCRIPTION
## Summary

Fixes a bug where dragging an external file (e.g. a PDF) onto the app window replaces the entire React UI with the WebView's built-in file viewer — full-screen, with no close button and no way back to the terminal. The only escape is to force-quit the app.

## Root cause

The main window runs with `dragDropEnabled: false` in `src-tauri/tauri.conf.json`. With Tauri's native drag/drop interception disabled, drop events are forwarded straight to the WebView. The WebView's default action for a dropped file is to navigate to it, so on macOS WKWebView renders the dropped PDF full-screen, unmounting the app.

There was no handler anywhere swallowing external file drops — internal drag-and-drop (`use-pane-dnd`) only deals with custom JSON tab/file payloads, never OS files.

## Fix

Add a small adapter hook, `usePreventFileDropNavigation`, that installs capture-phase `dragover`/`drop` listeners on `window` and calls `preventDefault()` **only** for drags carrying OS files (`dataTransfer.types` includes `'Files'`). Internal tab/file drags use custom JSON payloads and never set the `Files` type, so they are unaffected.

Wired into both `TauriApp` (desktop runtime) and `App` (dev/browser fallback) for parity.

## Testing

- Added colocated `use-prevent-file-drop-navigation.test.ts` (4 cases: drop prevented, dragover prevented + `dropEffect = none`, internal drags ignored, listener cleanup on unmount).
- `bun run typecheck` — passes
- `bun x biome check` on changed files — passes
- `bun x vitest run` for the new test + `App.test.tsx` — 13 passed

## Notes

This PR only stops the destructive navigation. Turning dropped files into terminal attachments would be a separate feature (it would likely require `dragDropEnabled: true` plus a Tauri `onDragDropEvent` handler to forward file paths into the active PTY).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced drag-and-drop handling to prevent unintended file navigation. When dragging files from external sources over the application window, the browser's default file-drop behavior is now prevented. Visual feedback via a "no drop" cursor indicator clarifies interaction boundaries. This improvement ensures a smoother and more predictable user experience throughout the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->