### PR TITLE
fix(worktree): self-heal stale git-repo detection in reconciler

### DIFF
--- a/src/renderer/hooks/use-projects-persistence.ts
+++ b/src/renderer/hooks/use-projects-persistence.ts
@@ -363,39 +363,6 @@ async function reconcileProjectWorktrees(project: Project): Promise<void> {
 }
 
 /**
- * Hook that reconciles worktrees for the active project.
- * Runs on project selection and periodically (every 60s).
- * Also reconciles all projects on initial load.
- */
-export function useWorktreeReconciler(): void {
-  const activeProjectId = useProjectStore((state) => state.activeProjectId)
-  // Use a stable selector that returns only what we need to avoid retriggers on store writes
-  const projectRef = useRef<Project | null>(null)
-
-  useEffect(() => {
-    const project = useProjectStore.getState().projects.find((p) => p.id === activeProjectId)
-    if (!project?.path) return
-
-    projectRef.current = project
-
-    // Reconcile on project selection
-    reconcileProjectWorktrees(project)
-
-    // Periodic reconciliation every 60s for active project
-    const interval = setInterval(() => {
-      const currentProject = useProjectStore
-        .getState()
-        .projects.find((p) => p.id === activeProjectId)
-      if (currentProject?.path) {
-        reconcileProjectWorktrees(currentProject)
-      }
-    }, 60_000)
-
-    return () => clearInterval(interval)
-  }, [activeProjectId])
-}
-
-/**
  * Force-reconcile worktrees for a specific project after create/remove operations.
  * Always re-lists from git to ensure consistency.
  */

--- a/src/renderer/hooks/use-worktree-reconciler.test.ts
+++ b/src/renderer/hooks/use-worktree-reconciler.test.ts
@@ -2,6 +2,20 @@ import { renderHook } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { useWorktreeReconciler } from './use-worktree-reconciler'
 
+// Mock variables are hoisted so they are available inside vi.mock() factories
+// (vitest hoists vi.mock above all imports and top-level declarations).
+const mocks = vi.hoisted(() => ({
+  removeWorktree: vi.fn(),
+  updateProject: vi.fn(),
+  addWorktree: vi.fn(),
+  reconcileNow: vi.fn(),
+  // Mutable per-scenario state, read live inside the mocked store's getState().
+  state: {
+    activeWorktreeId: null as string | null,
+    isGitRepo: true
+  }
+}))
+
 // Mock the worktree API
 vi.mock('@/lib/api', () => ({
   worktreeApi: {
@@ -14,14 +28,13 @@ vi.mock('@/lib/api', () => ({
   }
 }))
 
+// Shared reconciler (re-checks `git worktree list` and flips isGitRepo). Mocked so
+// tests can assert it is invoked and simulate the heal side-effect.
+vi.mock('@/hooks/use-projects-persistence', () => ({
+  reconcileProjectWorktreesNow: mocks.reconcileNow
+}))
+
 // Mock the project store
-const mockRemoveWorktree = vi.fn()
-const mockUpdateProject = vi.fn()
-const mockAddWorktree = vi.fn()
-
-// Mutable activeWorktreeId — tests can override this per-scenario
-let mockActiveWorktreeId: string | null = null
-
 vi.mock('@/stores/project-store', () => ({
   useProjectStore: {
     getState: () => ({
@@ -30,7 +43,7 @@ vi.mock('@/stores/project-store', () => ({
           id: 'proj-1',
           name: 'Test',
           path: '/test/project',
-          isGitRepo: true,
+          isGitRepo: mocks.state.isGitRepo,
           worktrees: [
             {
               id: 'wt-1',
@@ -47,17 +60,17 @@ vi.mock('@/stores/project-store', () => ({
               createdAt: '2026-01-01'
             }
           ],
-          activeWorktreeId: mockActiveWorktreeId
+          activeWorktreeId: mocks.state.activeWorktreeId
         }
       ],
-      addWorktree: mockAddWorktree,
-      removeWorktree: mockRemoveWorktree,
-      updateProject: mockUpdateProject
+      addWorktree: mocks.addWorktree,
+      removeWorktree: mocks.removeWorktree,
+      updateProject: mocks.updateProject
     })
   },
   useProjectActions: () => ({
-    removeWorktree: mockRemoveWorktree,
-    updateProject: mockUpdateProject
+    removeWorktree: mocks.removeWorktree,
+    updateProject: mocks.updateProject
   })
 }))
 
@@ -66,7 +79,8 @@ import { worktreeApi } from '@/lib/api'
 describe('useWorktreeReconciler', () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    mockActiveWorktreeId = null
+    mocks.state.activeWorktreeId = null
+    mocks.state.isGitRepo = true
   })
 
   it('removes orphaned worktrees that no longer exist in git', async () => {
@@ -87,7 +101,7 @@ describe('useWorktreeReconciler', () => {
 
     // Wait for async reconciliation
     await vi.waitFor(() => {
-      expect(mockRemoveWorktree).toHaveBeenCalledWith('proj-1', 'wt-2')
+      expect(mocks.removeWorktree).toHaveBeenCalledWith('proj-1', 'wt-2')
     })
   })
 
@@ -114,7 +128,7 @@ describe('useWorktreeReconciler', () => {
     renderHook(() => useWorktreeReconciler('proj-1'))
 
     await vi.waitFor(() => {
-      expect(mockAddWorktree).toHaveBeenCalledWith(
+      expect(mocks.addWorktree).toHaveBeenCalledWith(
         'proj-1',
         expect.objectContaining({
           name: 'feat-3',
@@ -127,7 +141,7 @@ describe('useWorktreeReconciler', () => {
 
   it('resets active worktree if it becomes orphaned', async () => {
     // Set active worktree to the one that will be orphaned by git (only feat-1 remains)
-    mockActiveWorktreeId = 'wt-2'
+    mocks.state.activeWorktreeId = 'wt-2'
 
     vi.mocked(worktreeApi.list).mockResolvedValue({
       success: true,
@@ -144,8 +158,8 @@ describe('useWorktreeReconciler', () => {
     renderHook(() => useWorktreeReconciler('proj-1'))
 
     await vi.waitFor(() => {
-      expect(mockRemoveWorktree).toHaveBeenCalledWith('proj-1', 'wt-2')
-      expect(mockUpdateProject).toHaveBeenCalledWith('proj-1', { activeWorktreeId: null })
+      expect(mocks.removeWorktree).toHaveBeenCalledWith('proj-1', 'wt-2')
+      expect(mocks.updateProject).toHaveBeenCalledWith('proj-1', { activeWorktreeId: null })
     })
   })
 
@@ -160,8 +174,39 @@ describe('useWorktreeReconciler', () => {
 
     // Wait for async operations
     await vi.waitFor(() => {
-      expect(mockRemoveWorktree).not.toHaveBeenCalled()
-      expect(mockAddWorktree).not.toHaveBeenCalled()
+      expect(mocks.removeWorktree).not.toHaveBeenCalled()
+      expect(mocks.addWorktree).not.toHaveBeenCalled()
+    })
+  })
+
+  it('self-heals a project wrongly marked as non-git (re-runs git detection)', async () => {
+    // A project can be flagged non-git when git was not available at first detection
+    // (e.g. GUI app PATH differs from the shell at startup).
+    mocks.state.isGitRepo = false
+    // The shared reconciler re-runs `git worktree list`; simulate the heal side-effect.
+    mocks.reconcileNow.mockImplementation(async () => {
+      mocks.state.isGitRepo = true
+    })
+
+    renderHook(() => useWorktreeReconciler('proj-1'))
+
+    await vi.waitFor(() => {
+      expect(mocks.reconcileNow).toHaveBeenCalledWith('proj-1')
+    })
+  })
+
+  it('heals a project flagged as a git repo after .git is removed', async () => {
+    // Project is marked a repo, but git now reports it is not a repository anymore.
+    vi.mocked(worktreeApi.list).mockResolvedValue({
+      success: false,
+      error: 'Not a git repo',
+      code: 'NOT_A_GIT_REPO'
+    })
+
+    renderHook(() => useWorktreeReconciler('proj-1'))
+
+    await vi.waitFor(() => {
+      expect(mocks.updateProject).toHaveBeenCalledWith('proj-1', { isGitRepo: false })
     })
   })
 })

--- a/src/renderer/hooks/use-worktree-reconciler.ts
+++ b/src/renderer/hooks/use-worktree-reconciler.ts
@@ -9,6 +9,7 @@
  */
 
 import { useCallback, useEffect, useRef } from 'react'
+import { reconcileProjectWorktreesNow } from '@/hooks/use-projects-persistence'
 import { worktreeApi } from '@/lib/api'
 import { useProjectActions, useProjectStore } from '@/stores/project-store'
 import type { Worktree } from '@/types/project'
@@ -26,13 +27,33 @@ export function useWorktreeReconciler(projectId: string) {
   const { removeWorktree, updateProject } = useProjectActions()
 
   const reconcile = useCallback(async () => {
+    const initial = useProjectStore.getState().projects.find((p) => p.id === projectId)
+    if (!initial?.path) return
+
+    // Self-heal stale git-repo detection. A project can be marked non-git if git
+    // was not available when it was first detected (e.g. the GUI app's PATH differs
+    // from the shell at startup, or the repo was initialised afterwards). Re-run the
+    // shared reconciler, which executes `git worktree list` and flips `isGitRepo`.
+    if (!initial.isGitRepo) {
+      await reconcileProjectWorktreesNow(projectId)
+    }
+
+    // Re-read the latest state (covers the heal above and any concurrent store writes).
     const project = useProjectStore.getState().projects.find((p) => p.id === projectId)
+    if (!project?.isGitRepo || !project.path) return
     // Allow empty worktrees array (still reconcile to discover newly created worktrees)
-    if (!project?.path || !project.isGitRepo || project.worktrees === undefined) return
+    if (project.worktrees === undefined) return
 
     try {
       const result = await worktreeApi.list(project.path)
-      if (!result.success || !result.data) return
+      if (!result.success) {
+        // Heal the reverse case: `.git` was removed after the project was marked a repo.
+        if (result.code === 'NOT_A_GIT_REPO' || result.code === 'GIT_NOT_FOUND') {
+          updateProject(projectId, { isGitRepo: false })
+        }
+        return
+      }
+      if (!result.data) return
 
       // Build set of actual worktree paths from git
       const actualPaths = new Set(result.data.map((w) => w.path))


### PR DESCRIPTION
## Problem

A project that is a valid git repository can be permanently misdetected as **"no git repo"** in the project context menu (the entry reads `New Worktree (no git repo)` and is disabled), even though the repo is perfectly valid:

```
git worktree list --porcelain   # works, exit 0
```

## Root cause

The **live** `useWorktreeReconciler` hook (`use-worktree-reconciler.ts`) reconciled worktrees with this guard:

```ts
if (!project?.path || !project.isGitRepo || project.worktrees === undefined) return
```

Once `isGitRepo` was ever set to `false`, the periodic (60s) reconciler **short-circuited and never re-checked**, so a stale flag could never be corrected — a detection deadlock.

A project gets flagged `isGitRepo: false` at startup when `git worktree list` fails transiently — most commonly because **a GUI app's PATH differs from the shell**, so `git` isn't found at first detection (or the repo was initialised after the project was added).

There was also a **second `useWorktreeReconciler`** export in `use-projects-persistence.ts` (same name, no guard, *could* self-heal) that was **dead code — never mounted** — which masked the bug and made the duplication confusing.

## Fix

- **Self-heal `false → true`:** when a project is marked non-git, re-run `reconcileProjectWorktreesNow` (which executes `git worktree list` and flips `isGitRepo`) before skipping reconciliation.
- **Self-heal `true → false`:** flip to `false` when `worktree_list` now returns `NOT_A_GIT_REPO` / `GIT_NOT_FOUND` (e.g. `.git` was removed).
- **Removed the dead-code duplicate** `useWorktreeReconciler` in `use-projects-persistence.ts`.
- **Added tests** for both self-heal directions.

## Verification

- `bun run typecheck` ✅ (node + web)
- `bun run vitest run use-worktree-reconciler` → **6/6 pass** (incl. 2 new self-heal tests)
- `bun run vitest run use-projects-persistence` → **7/7 pass**
- `biome check` ✅ on changed files
- Pre-commit hooks (husky: typecheck + biome) passed.

## Behaviour change

After this change, a project that was wrongly flagged non-git will correct itself on the next reconciliation tick (≤60s) or when it becomes the active project, instead of being stuck forever.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved automatic detection and recovery when a project's git repository becomes unavailable (e.g., directory deleted or moved)
  * Enhanced project state management to properly synchronize status when repository conditions change

<!-- end of auto-generated comment: release notes by coderabbit.ai -->