### PR TITLE
fix(worktree): strip verbatim \?\ path prefix so git accepts worktree paths (Windows)

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -41,7 +41,7 @@ fn validate_browser_tab_caller(webview: &Webview, expected_tab_id: &str) -> Resu
 /// Returns the canonicalized path or an error if the path is invalid or inaccessible.
 fn validate_project_path(path: &str) -> Result<PathBuf, String> {
     let path_buf = PathBuf::from(path);
-    
+
     // Canonicalize to resolve symlinks and relative paths
     let canonical = path_buf.canonicalize().map_err(|e| {
         log::warn!(
@@ -51,9 +51,16 @@ fn validate_project_path(path: &str) -> Result<PathBuf, String> {
         );
         format!("Invalid or inaccessible path: {}", e)
     })?;
-    
-    log::debug!("[Security] Path validated: {} -> {:?}", path, canonical);
-    Ok(canonical)
+
+    // On Windows, `canonicalize()` returns a verbatim (`\\?\…`) path. That prefix
+    // defeats external tools such as `git.exe` (e.g. `git worktree add` fails with
+    // "could not create leading directories …: Invalid argument"). Strip it so the
+    // validated path stays tool-friendly while keeping the canonicalization benefits.
+    let canonical_str = canonical.to_string_lossy();
+    let simplified = path_validation::strip_verbatim_prefix(&canonical_str);
+
+    log::debug!("[Security] Path validated: {} -> {}", path, simplified);
+    Ok(PathBuf::from(simplified))
 }
 
 /// Macro to validate a path and convert it to a String, returning early with an IpcResult error if validation fails.

--- a/src-tauri/src/path_validation.rs
+++ b/src-tauri/src/path_validation.rs
@@ -6,6 +6,32 @@ fn path_has_parent_dir(path: &str) -> bool {
         .any(|component| matches!(component, Component::ParentDir))
 }
 
+/// Strip the Windows verbatim (extended-length) path prefixes that
+/// `std::fs::canonicalize` prepends on Windows: `\\?\C:\…` and `\\?\UNC\…`.
+///
+/// Those prefixes defeat external tools such as `git.exe`, which aborts with
+/// `fatal: could not create leading directories of …: Invalid argument` when it
+/// receives one. Canonicalization is still performed by the caller for security
+/// (symlink resolution + existence checks); this only rewrites the *string*
+/// representation back to a normal, tool-friendly path.
+///
+/// This is pure string rewriting, so the verbatim prefixes (which never occur on
+/// Unix) are simply left untouched there.
+pub fn strip_verbatim_prefix(path: &str) -> String {
+    const VERBATIM: &str = r"\\?\";
+    const VERBATIM_UNC: &str = r"\\?\UNC\";
+
+    let trimmed = path.trim_start();
+    // Order matters: the longer UNC prefix must be checked first.
+    if let Some(rest) = trimmed.strip_prefix(VERBATIM_UNC) {
+        return format!(r"\\{}", rest);
+    }
+    if let Some(rest) = trimmed.strip_prefix(VERBATIM) {
+        return rest.to_string();
+    }
+    path.to_string()
+}
+
 /// Validates that a search path is within the allowed project boundary.
 /// Returns the canonicalized path if valid, or an error if the path
 /// attempts to escape the project root or contains path traversal.
@@ -245,5 +271,37 @@ mod tests {
         assert!(result.unwrap_err().contains("does not exist"));
 
         cleanup_test_dir(&project_root);
+    }
+
+    #[test]
+    fn test_strip_verbatim_disk_prefix() {
+        assert_eq!(strip_verbatim_prefix(r"\\?\C:\Users\foo"), r"C:\Users\foo");
+    }
+
+    #[test]
+    fn test_strip_verbatim_unc_prefix() {
+        assert_eq!(
+            strip_verbatim_prefix(r"\\?\UNC\server\share\foo"),
+            r"\\server\share\foo"
+        );
+    }
+
+    #[test]
+    fn test_strip_verbatim_leaves_normal_path_unchanged() {
+        assert_eq!(
+            strip_verbatim_prefix(r"C:\Users\foo\bar"),
+            r"C:\Users\foo\bar"
+        );
+        // No verbatim prefix -> returned verbatim (string).
+        assert_eq!(strip_verbatim_prefix("/home/user/project"), "/home/user/project");
+    }
+
+    #[test]
+    fn test_strip_verbatim_disk_prefix_chosen_over_unc_match() {
+        // A path like \\?\UNC... must collapse to \\server, never to just "UNC...".
+        assert!(
+            strip_verbatim_prefix(r"\\?\UNC\server\share").starts_with(r"\\server"),
+            "UNC verbatim prefix must map to a UNC share path"
+        );
     }
 }


### PR DESCRIPTION
## Problem

Creating a worktree on **Windows** fails for every project with:

```
Git error: Preparing worktree (new branch '…')
fatal: could not create leading directories of
'/?/C:/Users/.../.termul/worktrees/<name>/.git': Invalid argument
```

The malformed `/?/C:/...` path is what `git.exe` makes of a **verbatim (extended-length) path** it was handed.

## Root cause

`validate_project_path` (`src-tauri/src/commands.rs`) canonicalizes the project path with `std::fs::canonicalize()`. On Windows this **always** returns a path with the `\?\` prefix, e.g.:

```
\?\C:\Users\willy\Documents\OpenMontage
```

That prefix is then passed straight through to `git.exe` as a `git worktree add` argument. Git (MSYS2) cannot parse `\?\…` and aborts — hence every worktree creation breaks on Windows.

This is a **regression from #197** (`fix(security): add path validation to worktree commands`), which introduced the canonicalize for path-traversal protection.

> Unrelated to PR #346 (`fix(worktree): self-heal stale git-repo detection`) — different root cause, kept as a separate PR.

## Fix

Canonicalization is kept for security (symlink resolution + existence check), but the `\?\` prefix is stripped from the resulting string before it reaches external tools:

- **`path_validation::strip_verbatim_prefix`** — pure-string rewriter:
  - `\?\C:\…` → `C:\…`
  - `\?\UNC\server\share` → `\server\share`
  - normal paths: unchanged (no-op on Unix)
- **`validate_project_path`** applies it, so every validated path (worktree create/list/remove, PTY cwd, …) stays tool-friendly while preserving the canonicalization benefits.

## Verification

- Rust toolchain is not available in my local environment, so I could not run `cargo test`/`cargo check` locally. The change is minimal and reviewed by hand.
- Unit tests added for both prefix shapes + the no-op case (cross-platform string tests).
- **Relying on CI** (`pr-validation.yml`) which runs `cargo check --all-targets`, `cargo test`, `cargo clippy -- -D warnings`, plus a dedicated `rust-windows-check` job — directly relevant since this is a Windows-only bug. I'll address anything CI flags.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Windows paths are now normalized to remove extended-length prefixes, improving tool compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->