### PR TITLE
chore: release v0.4.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "termul-manager",
   "productName": "Termul Manager",
-  "version": "0.4.5",
+  "version": "0.4.6",
   "description": "Project-aware terminal that treats workspaces as first-class citizens",
   "author": "gnoviawan",
   "contributors": [

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -5946,7 +5946,7 @@ dependencies = [
 
 [[package]]
 name = "termul-manager"
-version = "0.4.5"
+version = "0.4.6"
 dependencies = [
  "agent-client-protocol",
  "anyhow",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "termul-manager"
-version = "0.4.5"
+version = "0.4.6"
 description = "Project-aware terminal that treats workspaces as first-class citizens"
 authors = ["gnoviawan", "mannnrachman (Tauri port)"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "https://schema.tauri.app/config/2",
 	"productName": "Termul Manager",
-	"version": "0.4.5",
+	"version": "0.4.6",
 	"identifier": "com.termul-manager.app",
 	"build": {
 		"beforeDevCommand": "npx vite --config vite.config.tauri.ts",

--- a/src/renderer/components/ProjectSidebar.tsx
+++ b/src/renderer/components/ProjectSidebar.tsx
@@ -1533,7 +1533,7 @@ export function ProjectSidebar({
       {/* Version - pinned bottom */}
       <div className="p-2 rounded-b-xl">
         <div className="w-full h-6 inline-flex items-center justify-center">
-          <span className="text-xs text-muted-foreground">Termul v0.4.5</span>
+          <span className="text-xs text-muted-foreground">Termul v0.4.6</span>
         </div>
       </div>
 


### PR DESCRIPTION
Automated version bump to v0.4.6 (package.json, Cargo.toml, Cargo.lock, tauri.conf.json, and the sidebar label).