### PR TITLE
fix(pty): strip verbatim \?\ CWD prefix so cmd.exe starts in project

### DIFF
--- a/src-tauri/src/pty/manager.rs
+++ b/src-tauri/src/pty/manager.rs
@@ -949,11 +949,15 @@ impl PtyManager {
             self.get_home_directory()
         };
 
-        // Verify CWD exists and canonicalize to resolve symlinks and path traversal
+        // Verify CWD exists and canonicalize to resolve symlinks and path traversal.
+        // On Windows, canonicalize returns a verbatim device-namespace path (the
+        // extended-length prefix) that cmd.exe/ConPTY and other external tools reject
+        // as "UNC paths are not supported", making the shell fall back to the Windows
+        // directory. Normalize it to a tool-friendly form (no-op off Windows),
+        // mirroring the #347 fix for git worktree paths. See `strip_verbatim_prefix`.
         let cwd = std::fs::canonicalize(&cwd)
-            .map_err(|e| format!("Invalid working directory '{}': {}", cwd, e))?
-            .to_string_lossy()
-            .to_string();
+            .map_err(|e| format!("Invalid working directory '{}': {}", cwd, e))?;
+        let cwd = crate::path_validation::strip_verbatim_prefix(&cwd.to_string_lossy());
 
         // Get terminal size
         let cols = options.cols.unwrap_or(80);


### PR DESCRIPTION
## Problem

After **v0.4.6**, opening a terminal whose shell resolves to `cmd.exe` prints:

```
'\?\E:\open-source\PecutAPP\termul'
CMD.EXE was started with the above path as the current directory.
UNC paths are not supported.  Defaulting to Windows directory.
```

…and the shell lands in `C:\` instead of the project. Regression first released in v0.4.6.

## Root cause

PR **#295** (`6a498a6e`) replaced the pty CWD existence check with `std::fs::canonicalize(&cwd)` in `PtyManager::spawn`:

```rust
let cwd = std::fs::canonicalize(&cwd)
    .map_err(|e| format!("Invalid working directory '{}': {}", cwd, e))?
    .to_string_lossy()
    .to_string();
```

On Windows, `canonicalize()` returns a **verbatim `\?\`-prefixed** (device-namespace) path, e.g. `\?\E:\open-source\…\termul`. That string was passed unmodified to `cmd.exe` via ConPTY; `cmd.exe` cannot operate in the device namespace and bails to the Windows directory. (PowerShell tolerates `\?\`, which is why the symptom is cmd.exe-specific.)

The codebase already documents this exact trap in several places and has shipped the identical-class fix once before (git worktree paths, **#347** / `63e68fc7`).

## Fix

Apply the existing `path_validation::strip_verbatim_prefix` right after canonicalize — the exact remedy from #347:

```rust
let cwd = std::fs::canonicalize(&cwd)
    .map_err(|e| format!("Invalid working directory '{}': {}", cwd, e))?;
let cwd = crate::path_validation::strip_verbatim_prefix(&cwd.to_string_lossy());
```

Canonicalize still runs, so **#295's symlink/traversal protections are preserved**; only the string representation handed to external tools is normalized back to `C:\…` (pure string rewrite, **no-op off Windows**). The cleaned path flows to all five downstream consumers: ConPTY spawn cwd, `TerminalInstance.cwd`, the cwd tracker, the git tracker, and the returned `TerminalInfo`.

## Why this approach

- **Minimal & proven**: one call to an existing, already-tested util (`strip_verbatim_prefix` has 4 unit tests covering disk/UNC/no-op cases). Mirrors #347 verbatim.
- **No behavior change off Windows**: the util is a documented no-op on Unix.
- **No security regression**: `canonicalize` (existence check + symlink resolution) is untouched; only the prefix is stripped from the resulting string.

## Verification

- ✅ `cargo check` — clean compile (only the pre-existing `shell_wants_login_arg` dead-code warning in an untouched file)
- ✅ `cargo test path_validation` — 11 passed, 1 ignored (locks the rewrite contract the fix depends on)
- ✅ `bun run typecheck` + Biome — green (pre-commit hooks)
- ✅ Debug build (`build:tauri:debug`) produces a runnable `termul-manager.exe`
- ⏭️ Manual: launch a `cmd.exe` terminal in a real-disk-path project → prompt starts in the project, no UNC banner, no `C:\` fallback

## References

- Introducing change: #295 (`6a498a6e`) — `fix(pty): canonicalize CWD to resolve symlinks and reject invalid paths`
- Precedent fix: #347 (`63e68fc7`) — `fix(worktree): strip verbatim \?\ path prefix so git accepts worktree paths`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved working directory path resolution, particularly for Windows systems, to ensure proper handling of path normalization and directory navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->