### PR TITLE
fix(file-explorer): stream filename search via rg --files to fix 0-count regression

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -57,7 +57,7 @@ fn validate_project_path(path: &str) -> Result<PathBuf, String> {
     // "could not create leading directories …: Invalid argument"). Strip it so the
     // validated path stays tool-friendly while keeping the canonicalization benefits.
     let canonical_str = canonical.to_string_lossy();
-    let simplified = path_validation::strip_verbatim_prefix(&canonical_str);
+    let simplified = path_validation::strip_verbatim_prefix(&canonical_str).into_owned();
 
     log::debug!("[Security] Path validated: {} -> {}", path, simplified);
     Ok(PathBuf::from(simplified))
@@ -1133,6 +1133,12 @@ pub struct SearchContentCancelRequest {
     pub search_id: String,
 }
 
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SearchFileNamesCancelRequest {
+    pub search_id: String,
+}
+
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct SearchContentBatchEvent {
@@ -1148,6 +1154,10 @@ pub struct SearchContentDoneEvent {
     pub truncated: bool,
     pub scanned_files: usize,
     pub failed_files: usize,
+    /// Programmatic error code (e.g. `QUERY_TOO_LONG`). Mirrors the field on
+    /// `SearchFileNamesDoneEvent` so the renderer can branch on it.
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub code: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub error: Option<String>,
 }
@@ -1166,7 +1176,12 @@ pub struct SearchFileNamesStreamRequest {
 pub struct SearchFileNamesBatchEvent {
     pub search_id: String,
     pub files: Vec<String>,
-    pub truncated: bool,
+    /// `None` on mid-stream batches (final truncation state is not yet known).
+    /// `Some(true)` is set on the trailing batch if the result was capped, and
+    /// `Some(false)` otherwise. `serde` skips `None` so the field is omitted
+    /// on the wire when not set.
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub truncated: Option<bool>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -1175,6 +1190,10 @@ pub struct SearchFileNamesDoneEvent {
     pub search_id: String,
     pub truncated: bool,
     pub total_files: usize,
+    /// Programmatic error code (e.g. `QUERY_TOO_LONG`, `PATH_VALIDATION_FAILED`,
+    /// `RG_SPAWN_FAILED`). Set when `error` is set; otherwise `None`.
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub code: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub error: Option<String>,
 }
@@ -1464,7 +1483,37 @@ pub async fn search_content_stream(
                 truncated: false,
                 scanned_files: 0,
                 failed_files: 0,
+                code: None,
                 error: None,
+            },
+        );
+        return Ok(IpcResult::success(()));
+    }
+
+    // Mirror the filename-search guard: queries longer than the cap are
+    // rejected before spawning rg so an unbounded string cannot be piped to
+    // a child process. The spec says the cap should be "consistent with the
+    // existing content search cap"; since no such cap existed, the filename
+    // constant is now applied here too.
+    if trimmed_query.chars().count() > MAX_SEARCH_QUERY_LEN {
+        log::warn!(
+            "[Security] Content search query rejected: length {} exceeds limit of {}",
+            trimmed_query.chars().count(),
+            MAX_SEARCH_QUERY_LEN
+        );
+        let _ = app_handle.emit(
+            "search-content-done",
+            SearchContentDoneEvent {
+                search_id: request.search_id,
+                truncated: false,
+                scanned_files: 0,
+                failed_files: 0,
+                code: Some("QUERY_TOO_LONG".to_string()),
+                error: Some(format!(
+                    "Search query too long: {} characters (max {})",
+                    trimmed_query.chars().count(),
+                    MAX_SEARCH_QUERY_LEN
+                )),
             },
         );
         return Ok(IpcResult::success(()));
@@ -1486,6 +1535,7 @@ pub async fn search_content_stream(
                     truncated: false,
                     scanned_files: 0,
                     failed_files: 0,
+                    code: Some("PATH_VALIDATION_FAILED".to_string()),
                     error: Some(format!("Invalid search path: {}", e)),
                 },
             );
@@ -1511,6 +1561,7 @@ pub async fn search_content_stream(
                     truncated: false,
                     scanned_files: 0,
                     failed_files: 0,
+                    code: Some("RG_SPAWN_FAILED".to_string()),
                     error: Some(format!("rg spawn failed (path: {}): {}", rg_path, e)),
                 },
             );
@@ -1528,6 +1579,10 @@ pub async fn search_content_stream(
                     truncated: false,
                     scanned_files: 0,
                     failed_files: 1,
+                    // Distinct from `RG_SPAWN_FAILED` (rg binary never
+                    // started). Here rg did start, but its pipe was
+                    // already closed when we tried to take it.
+                    code: Some("RG_STDOUT_CAPTURE_FAILED".to_string()),
                     error: Some("failed to capture rg stdout".to_string()),
                 },
             );
@@ -1547,6 +1602,7 @@ pub async fn search_content_stream(
         let mut grouped: BTreeMap<String, Vec<FileSearchMatch>> = BTreeMap::new();
         let mut pending_matches: BTreeMap<String, Vec<FileSearchMatch>> = BTreeMap::new();
         let mut truncated = false;
+        let mut stream_error: Option<String> = None;
 
         let flush_batch = |pending: &mut BTreeMap<String, Vec<FileSearchMatch>>,
                            truncated: bool| {
@@ -1571,10 +1627,18 @@ pub async fn search_content_stream(
             pending.clear();
         };
 
-        for line in reader.lines() {
-            let line = match line {
-                Ok(v) => v,
-                Err(_) => continue,
+        // Manual loop so we can record the first I/O error instead of
+        // silently dropping it (which `for line in reader.lines()` would
+        // do via its `Err(_) => continue` swallow).
+        let mut iter = reader.lines();
+        loop {
+            let line = match iter.next() {
+                Some(Ok(v)) => v,
+                Some(Err(e)) => {
+                    stream_error = Some(format!("stdout read error: {}", e));
+                    break;
+                }
+                None => break,
             };
 
             let parsed: serde_json::Value = match serde_json::from_str(&line) {
@@ -1645,12 +1709,40 @@ pub async fn search_content_stream(
 
         flush_batch(&mut pending_matches, truncated);
 
-        if let Ok(mut child) = child_handle.lock() {
-            let _ = child.try_wait().or_else(|_| child.wait().map(Some));
-        }
+        // Reap the child and propagate non-zero exit status (other than 1,
+        // which rg uses for "no matches") as a surfaced error. Mirrors the
+        // pattern from `search_file_names_stream` so the renderer can
+        // distinguish a clean run from a runtime rg failure.
+        let exit_status = {
+            let mut child = match child_handle.lock() {
+                Ok(c) => c,
+                Err(_) => {
+                    stream_error.get_or_insert("child handle poisoned".to_string());
+                    return;
+                }
+            };
+            child.wait().ok()
+        };
         if let Ok(mut guard) = search_processes().lock() {
             guard.remove(&search_id);
         }
+
+        let final_error = stream_error.or_else(|| {
+            exit_status
+                .as_ref()
+                .filter(|s| !s.success() && s.code() != Some(1))
+                .map(|s| format!("rg exited with status: {:?}", s))
+        });
+
+        // `RG_STREAM_FAILED` is the catch-all code for any error that
+        // surfaces mid-walk (stdout I/O error or non-zero exit other than
+        // rg's "no matches" code 1). Mirrors the filename stream's
+        // semantic.
+        let final_code = if final_error.is_some() {
+            Some("RG_STREAM_FAILED".to_string())
+        } else {
+            None
+        };
 
         let _ = app_handle.emit(
             "search-content-done",
@@ -1659,7 +1751,8 @@ pub async fn search_content_stream(
                 truncated,
                 scanned_files: 0,
                 failed_files: 0,
-                error: None,
+                code: final_code,
+                error: final_error,
             },
         );
     });
@@ -1675,7 +1768,7 @@ pub async fn search_content_cancel(
     if let Some(child_handle) = guard.remove(&request.search_id) {
         if let Ok(mut child) = child_handle.lock() {
             let _ = child.kill();
-            let _ = child.try_wait().or_else(|_| child.wait().map(Some));
+            let _ = child.wait();
         }
     }
     Ok(IpcResult::success(()))
@@ -1696,6 +1789,7 @@ pub async fn search_file_names_stream(
                 search_id,
                 truncated: false,
                 total_files: 0,
+                code: None,
                 error: None,
             },
         );
@@ -1714,6 +1808,7 @@ pub async fn search_file_names_stream(
                 search_id,
                 truncated: false,
                 total_files: 0,
+                code: Some("QUERY_TOO_LONG".to_string()),
                 error: Some(format!(
                     "Search query too long: {} characters (max {})",
                     trimmed_query.chars().count(),
@@ -1739,6 +1834,7 @@ pub async fn search_file_names_stream(
                     search_id,
                     truncated: false,
                     total_files: 0,
+                    code: Some("PATH_VALIDATION_FAILED".to_string()),
                     error: Some(format!("Invalid search path: {}", e)),
                 },
             );
@@ -1765,6 +1861,7 @@ pub async fn search_file_names_stream(
                     search_id,
                     truncated: false,
                     total_files: 0,
+                    code: Some("RG_SPAWN_FAILED".to_string()),
                     error: Some(format!("rg spawn failed (path: {}): {}", rg_path, e)),
                 },
             );
@@ -1782,6 +1879,10 @@ pub async fn search_file_names_stream(
                     search_id,
                     truncated: false,
                     total_files: 0,
+                    // Distinct from `RG_SPAWN_FAILED` (which means the rg
+                    // binary never started). Here rg DID start, but the
+                    // pipe was already closed when we tried to take it.
+                    code: Some("RG_STDOUT_CAPTURE_FAILED".to_string()),
                     error: Some("failed to capture rg stdout".to_string()),
                 },
             );
@@ -1817,18 +1918,28 @@ pub async fn search_file_names_stream(
                         truncated = true;
                         break;
                     }
-                    files.push(line.replace('\\', "/"));
+                    // ripgrep on Windows may emit verbatim paths
+                    // (e.g. `\\?\C:\...`) when the root is canonicalized.
+                    // Strip the prefix before the slash-normalization so the
+                    // renderer never sees a `\\?\` blob in click paths.
+                    let normalized =
+                        path_validation::strip_verbatim_prefix(&line).replace('\\', "/");
+                    files.push(normalized);
 
                     // Emit a mid-stream batch when we cross a batch
                     // boundary, but skip the trailing batch below if we
                     // already published this exact count.
                     if files.len() % batch_size == 0 {
+                        // Mid-stream batch — final truncation state is not
+                        // known yet, so the field is `None` (serde omits it
+                        // from the wire). The trailing batch below carries
+                        // the authoritative value.
                         let _ = app_handle.emit(
                             "search-file-names-batch",
                             SearchFileNamesBatchEvent {
                                 search_id: search_id.clone(),
                                 files: files.clone(),
-                                truncated: false,
+                                truncated: None,
                             },
                         );
                         last_batch_count = files.len();
@@ -1851,7 +1962,7 @@ pub async fn search_file_names_stream(
                 SearchFileNamesBatchEvent {
                     search_id: search_id.clone(),
                     files: files.clone(),
-                    truncated,
+                    truncated: Some(truncated),
                 },
             );
         }
@@ -1881,12 +1992,26 @@ pub async fn search_file_names_stream(
                 .map(|s| format!("rg exited with status: {:?}", s))
         });
 
+        // `RG_STREAM_FAILED` is the catch-all code for any error that
+        // surfaces mid-walk (stdout I/O error or non-zero exit other than
+        // rg's "no matches" code 1). Distinct from `RG_SPAWN_FAILED`,
+        // which is reserved for the rg binary failing to start in the
+        // first place. The renderer can branch on it alongside the inline
+        // `QUERY_TOO_LONG` / `PATH_VALIDATION_FAILED` / `RG_STDOUT_CAPTURE_FAILED`
+        // codes emitted earlier in the command.
+        let final_code = if final_error.is_some() {
+            Some("RG_STREAM_FAILED".to_string())
+        } else {
+            None
+        };
+
         let _ = app_handle.emit(
             "search-file-names-done",
             SearchFileNamesDoneEvent {
                 search_id,
                 truncated,
                 total_files: files.len(),
+                code: final_code,
                 error: final_error,
             },
         );
@@ -1897,7 +2022,7 @@ pub async fn search_file_names_stream(
 
 #[tauri::command]
 pub async fn search_file_names_cancel(
-    request: SearchContentCancelRequest,
+    request: SearchFileNamesCancelRequest,
 ) -> Result<IpcResult<()>, String> {
     let mut guard = filename_search_processes()
         .lock()
@@ -1905,7 +2030,7 @@ pub async fn search_file_names_cancel(
     if let Some(child_handle) = guard.remove(&request.search_id) {
         if let Ok(mut child) = child_handle.lock() {
             let _ = child.kill();
-            let _ = child.try_wait().or_else(|_| child.wait().map(Some));
+            let _ = child.wait();
         }
     }
     Ok(IpcResult::success(()))
@@ -3123,5 +3248,123 @@ mod tests {
         let cleaned = sanitize_log_field(&huge);
         assert!(cleaned.ends_with("…[truncated]"));
         assert!(cleaned.chars().count() <= MAX_FRONTEND_FIELD_LEN + "…[truncated]".chars().count());
+    }
+
+    // ===== filename search streaming (gh-195) =====
+    //
+    // Coverage for `build_file_name_search_args` and the per-stream event
+    // contracts. The end-to-end rg spawn path is exercised in a real
+    // workspace by manual smoke; these tests pin the argv and serde shapes
+    // so a future refactor cannot silently regress them.
+
+    #[test]
+    fn build_file_name_search_args_escapes_glob_metacharacters() {
+        // A query containing `*`, `?`, `[`, `]`, `\` must not be interpreted
+        // as a glob wildcard. Each metacharacter should be prefixed with a
+        // backslash so rg treats it as a literal substring match.
+        let args = build_file_name_search_args("foo*bar?baz[qux]\\z", "/tmp");
+        let iglob_idx = args
+            .iter()
+            .position(|a| a == "--iglob")
+            .expect("--iglob present");
+        let pattern = &args[iglob_idx + 1];
+        assert_eq!(pattern, r"**/*foo\*bar\?baz\[qux\]\\z*");
+        // The query should still be matched at any directory depth.
+        assert!(pattern.starts_with("**/*"));
+    }
+
+    #[test]
+    fn build_file_name_search_args_includes_ignore_list_and_excludes() {
+        let args = build_file_name_search_args("foo", "/tmp");
+        // The hardcoded ignore list must show up as bare-basename `-g !<name>`
+        // entries so rg actually skips those directories in `--files` mode.
+        for ignored in [
+            "node_modules",
+            ".git",
+            ".env",
+            "Thumbs.db",
+            "desktop.ini",
+            ".DS_Store",
+        ] {
+            let needle = format!("!{}", ignored);
+            let has = args.windows(2).any(|w| w[0] == "-g" && w[1] == needle);
+            assert!(has, "missing `-g {}` in {:?}", ignored, args);
+        }
+        // The root path is the trailing argv entry.
+        assert_eq!(args.last().map(String::as_str), Some("/tmp"));
+    }
+
+    #[test]
+    fn build_file_name_search_args_appends_root_path() {
+        let args = build_file_name_search_args("term", "/some/root path");
+        // Root paths with spaces should appear verbatim, not split.
+        assert_eq!(args.last().map(String::as_str), Some("/some/root path"));
+    }
+
+    #[test]
+    fn build_file_name_search_args_starts_with_files_and_case_insensitive() {
+        let args = build_file_name_search_args("foo", "/tmp");
+        assert_eq!(args[0], "--files");
+        assert_eq!(args[1], "-i");
+    }
+
+    #[test]
+    fn search_file_names_done_event_serializes_code_field() {
+        // The `code` field is optional and skipped on the wire when `None`.
+        let with_code = SearchFileNamesDoneEvent {
+            search_id: "search-1".to_string(),
+            truncated: false,
+            total_files: 0,
+            code: Some("QUERY_TOO_LONG".to_string()),
+            error: Some("too long".to_string()),
+        };
+        let json = serde_json::to_string(&with_code).unwrap();
+        assert!(json.contains("\"code\":\"QUERY_TOO_LONG\""));
+        assert!(json.contains("\"error\":\"too long\""));
+
+        let without_code = SearchFileNamesDoneEvent {
+            search_id: "search-1".to_string(),
+            truncated: false,
+            total_files: 0,
+            code: None,
+            error: None,
+        };
+        let json = serde_json::to_string(&without_code).unwrap();
+        assert!(!json.contains("code"));
+        assert!(!json.contains("error"));
+    }
+
+    #[test]
+    fn search_file_names_batch_event_omits_truncated_when_none() {
+        // Mid-stream batches carry `None` so the renderer knows the value is
+        // unknown; serde should drop the field from the wire.
+        let mid_stream = SearchFileNamesBatchEvent {
+            search_id: "search-1".to_string(),
+            files: vec!["a".to_string()],
+            truncated: None,
+        };
+        let json = serde_json::to_string(&mid_stream).unwrap();
+        assert!(!json.contains("truncated"));
+
+        let final_batch = SearchFileNamesBatchEvent {
+            search_id: "search-1".to_string(),
+            files: vec!["a".to_string()],
+            truncated: Some(true),
+        };
+        let json = serde_json::to_string(&final_batch).unwrap();
+        assert!(json.contains("\"truncated\":true"));
+    }
+
+    #[test]
+    fn search_file_names_cancel_request_is_a_dto_not_aliased_to_content() {
+        // The two cancel commands must accept distinct types so a future
+        // shape change to `SearchContentCancelRequest` cannot silently
+        // affect the filename path. This pins the type identity at compile
+        // time (the two structs are distinct) and verifies the field shape
+        // by exercising the constructor.
+        let req = SearchFileNamesCancelRequest {
+            search_id: "search-1".to_string(),
+        };
+        assert_eq!(req.search_id, "search-1");
     }
 }

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1154,17 +1154,29 @@ pub struct SearchContentDoneEvent {
 
 #[derive(Debug, Clone, Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub struct SearchFileNamesRequest {
+pub struct SearchFileNamesStreamRequest {
     pub scope_root: String,
     pub root_path: String,
     pub query: String,
+    pub search_id: String,
 }
 
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
-pub struct SearchFileNamesResponse {
+pub struct SearchFileNamesBatchEvent {
+    pub search_id: String,
     pub files: Vec<String>,
     pub truncated: bool,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SearchFileNamesDoneEvent {
+    pub search_id: String,
+    pub truncated: bool,
+    pub total_files: usize,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -1177,10 +1189,16 @@ pub struct RgInfoResponse {
 }
 
 static SEARCH_PROCESSES: OnceLock<Mutex<HashMap<String, Arc<Mutex<Child>>>>> = OnceLock::new();
+static FILENAME_SEARCH_PROCESSES: OnceLock<Mutex<HashMap<String, Arc<Mutex<Child>>>>> =
+    OnceLock::new();
 static RG_PATH_CACHE: OnceLock<String> = OnceLock::new();
 
 fn search_processes() -> &'static Mutex<HashMap<String, Arc<Mutex<Child>>>> {
     SEARCH_PROCESSES.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+fn filename_search_processes() -> &'static Mutex<HashMap<String, Arc<Mutex<Child>>>> {
+    FILENAME_SEARCH_PROCESSES.get_or_init(|| Mutex::new(HashMap::new()))
 }
 
 #[cfg(target_os = "windows")]
@@ -1296,6 +1314,13 @@ fn configure_background_command(command: &mut Command) {
 #[cfg(not(target_os = "windows"))]
 fn configure_background_command(_command: &mut Command) {}
 
+/// Maximum number of characters allowed in a search query.
+///
+/// Generous enough for any realistic file path, regex fragment, or multi-word
+/// query, but small enough to block trivially abusive inputs from being piped
+/// to ripgrep (file name and content) or the synchronous filename walker.
+const MAX_SEARCH_QUERY_LEN: usize = 500;
+
 fn validated_search_root(scope_root: &str, search_root: &str) -> Result<String, String> {
     path_validation::validate_search_path(search_root, scope_root)
         .map(|path| path.to_string_lossy().to_string())
@@ -1336,6 +1361,78 @@ fn build_search_args(query: &str, root_path: &str, max_matches_per_file: usize) 
 
     args.push("--".to_string());
     args.push(query.to_string());
+    args.push(root_path.to_string());
+    args
+}
+
+/// Build the ripgrep argv for a streaming filename search.
+///
+/// We rely on `rg --files --iglob` so we get the same multi-threaded tree walk
+/// that powers content search. The glob form is `**/*{escaped_query}*` to
+/// match the previous "filename contains query" behavior at any directory
+/// depth. `-i` keeps the match case-insensitive on every platform (ripgrep's
+/// default is already case-insensitive on Windows, but Linux/macOS would
+/// otherwise be sensitive). Glob metacharacters in the query are escaped so
+/// they match literally, mirroring the old `contains` semantics.
+fn build_file_name_search_args(query: &str, root_path: &str) -> Vec<String> {
+    // Escape glob metacharacters that ripgrep would otherwise interpret as
+    // wildcards (`*`, `?`, `[`, `]`, `\`) so the query is matched as a
+    // substring of the basename.
+    let mut escaped = String::with_capacity(query.len());
+    for ch in query.chars() {
+        match ch {
+            '*' | '?' | '[' | ']' | '\\' => {
+                escaped.push('\\');
+                escaped.push(ch);
+            }
+            _ => escaped.push(ch),
+        }
+    }
+
+    let mut args = vec![
+        "--files".to_string(),
+        "-i".to_string(),
+        "--iglob".to_string(),
+        format!("**/*{}*", escaped),
+    ];
+
+    // NB: In `--files` + `--iglob` mode, ripgrep only honors `-g` ignore
+    // patterns written as bare basenames (e.g. `-g '!node_modules'`). The
+    // `!**/name/**` form that `build_search_args` uses for content search
+    // is silently dropped here, so we explicitly use the basename form.
+    for ignored in [
+        "node_modules",
+        ".git",
+        ".next",
+        ".cache",
+        ".turbo",
+        "dist",
+        "build",
+        ".output",
+        ".nuxt",
+        ".svelte-kit",
+        "__pycache__",
+        ".pytest_cache",
+        "venv",
+        "coverage",
+        ".nyc_output",
+    ] {
+        args.push("-g".to_string());
+        args.push(format!("!{}", ignored));
+    }
+    // Exclude platform cruft and common dotenv secrets. The exact `.env`
+    // exclusion matches the spec; `.env.local` / `.env.production` are
+    // deliberately left to `.gitignore` so a project's own ignore list is
+    // honored.
+    args.push("-g".to_string());
+    args.push("!.env".to_string());
+    args.push("-g".to_string());
+    args.push("!Thumbs.db".to_string());
+    args.push("-g".to_string());
+    args.push("!desktop.ini".to_string());
+    args.push("-g".to_string());
+    args.push("!.DS_Store".to_string());
+
     args.push(root_path.to_string());
     args
 }
@@ -1585,15 +1682,46 @@ pub async fn search_content_cancel(
 }
 
 #[tauri::command]
-pub async fn search_file_names(
-    request: SearchFileNamesRequest,
-) -> Result<IpcResult<SearchFileNamesResponse>, String> {
-    let trimmed_query = request.query.trim().to_lowercase();
+pub async fn search_file_names_stream(
+    request: SearchFileNamesStreamRequest,
+    app_handle: AppHandle,
+) -> Result<IpcResult<()>, String> {
+    let trimmed_query = request.query.trim().to_string();
+    let search_id = request.search_id.clone();
+
     if trimmed_query.is_empty() {
-        return Ok(IpcResult::success(SearchFileNamesResponse {
-            files: vec![],
-            truncated: false,
-        }));
+        let _ = app_handle.emit(
+            "search-file-names-done",
+            SearchFileNamesDoneEvent {
+                search_id,
+                truncated: false,
+                total_files: 0,
+                error: None,
+            },
+        );
+        return Ok(IpcResult::success(()));
+    }
+
+    if trimmed_query.chars().count() > MAX_SEARCH_QUERY_LEN {
+        log::warn!(
+            "[Security] File name search query rejected: length {} exceeds limit of {}",
+            trimmed_query.chars().count(),
+            MAX_SEARCH_QUERY_LEN
+        );
+        let _ = app_handle.emit(
+            "search-file-names-done",
+            SearchFileNamesDoneEvent {
+                search_id,
+                truncated: false,
+                total_files: 0,
+                error: Some(format!(
+                    "Search query too long: {} characters (max {})",
+                    trimmed_query.chars().count(),
+                    MAX_SEARCH_QUERY_LEN
+                )),
+            },
+        );
+        return Ok(IpcResult::success(()));
     }
 
     let validated_root = match validated_search_root(&request.scope_root, &request.root_path) {
@@ -1605,76 +1733,182 @@ pub async fn search_file_names(
                 request.root_path,
                 e
             );
-            return Ok(IpcResult::error(
-                format!("Invalid search path: {}", e),
-                "PATH_VALIDATION_FAILED",
-            ));
+            let _ = app_handle.emit(
+                "search-file-names-done",
+                SearchFileNamesDoneEvent {
+                    search_id,
+                    truncated: false,
+                    total_files: 0,
+                    error: Some(format!("Invalid search path: {}", e)),
+                },
+            );
+            return Ok(IpcResult::success(()));
         }
     };
 
-    let mut stack = vec![validated_root];
-    let mut matches: Vec<String> = Vec::new();
-    let mut truncated = false;
-    let max_files = 100;
+    let args = build_file_name_search_args(&trimmed_query, &validated_root);
 
-    while let Some(dir) = stack.pop() {
-        let entries = match std::fs::read_dir(&dir) {
-            Ok(entries) => entries,
-            Err(_) => continue,
-        };
+    let rg_path = detect_rg_path();
+    let mut rg_command = Command::new(&rg_path);
+    rg_command
+        .args(&args)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null());
+    configure_background_command(&mut rg_command);
 
-        for entry in entries.flatten() {
-            let path = entry.path();
-            let file_name = match path.file_name().and_then(|n| n.to_str()) {
-                Some(name) => name,
-                None => continue,
-            };
-
-            if [
-                "node_modules",
-                ".git",
-                ".next",
-                ".cache",
-                ".turbo",
-                "dist",
-                "build",
-                ".output",
-                ".nuxt",
-                ".svelte-kit",
-                "__pycache__",
-                ".pytest_cache",
-                "venv",
-                "coverage",
-                ".nyc_output",
-            ]
-            .contains(&file_name)
-            {
-                continue;
-            }
-
-            if path.is_dir() {
-                stack.push(path.to_string_lossy().to_string());
-                continue;
-            }
-
-            if file_name.to_lowercase().contains(&trimmed_query) {
-                matches.push(path.to_string_lossy().replace('\\', "/"));
-                if matches.len() >= max_files {
-                    truncated = true;
-                    break;
-                }
-            }
+    let mut child = match rg_command.spawn() {
+        Ok(c) => c,
+        Err(e) => {
+            let _ = app_handle.emit(
+                "search-file-names-done",
+                SearchFileNamesDoneEvent {
+                    search_id,
+                    truncated: false,
+                    total_files: 0,
+                    error: Some(format!("rg spawn failed (path: {}): {}", rg_path, e)),
+                },
+            );
+            return Ok(IpcResult::success(()));
         }
+    };
 
-        if truncated {
-            break;
+    let stdout = match child.stdout.take() {
+        Some(s) => s,
+        None => {
+            let _ = child.kill().ok();
+            let _ = app_handle.emit(
+                "search-file-names-done",
+                SearchFileNamesDoneEvent {
+                    search_id,
+                    truncated: false,
+                    total_files: 0,
+                    error: Some("failed to capture rg stdout".to_string()),
+                },
+            );
+            return Ok(IpcResult::success(()));
         }
+    };
+
+    let child_handle = Arc::new(Mutex::new(child));
+    {
+        let mut guard = filename_search_processes()
+            .lock()
+            .map_err(|e| e.to_string())?;
+        guard.insert(search_id.clone(), Arc::clone(&child_handle));
     }
 
-    Ok(IpcResult::success(SearchFileNamesResponse {
-        files: matches,
-        truncated,
-    }))
+    tauri::async_runtime::spawn_blocking(move || {
+        let reader = BufReader::new(stdout);
+        let mut files: Vec<String> = Vec::new();
+        let max_files: usize = 100;
+        let batch_size: usize = 25;
+        let mut truncated = false;
+        let mut stream_error: Option<String> = None;
+        let mut last_batch_count: usize = 0;
+
+        // Collect output until we hit the cap, EOF, or a pipe error. The
+        // iterator-based form `map_while(Result::ok)` would swallow I/O
+        // errors, so we use a manual loop that records the first error.
+        let mut iter = reader.lines();
+        loop {
+            match iter.next() {
+                Some(Ok(line)) => {
+                    if files.len() >= max_files {
+                        truncated = true;
+                        break;
+                    }
+                    files.push(line.replace('\\', "/"));
+
+                    // Emit a mid-stream batch when we cross a batch
+                    // boundary, but skip the trailing batch below if we
+                    // already published this exact count.
+                    if files.len() % batch_size == 0 {
+                        let _ = app_handle.emit(
+                            "search-file-names-batch",
+                            SearchFileNamesBatchEvent {
+                                search_id: search_id.clone(),
+                                files: files.clone(),
+                                truncated: false,
+                            },
+                        );
+                        last_batch_count = files.len();
+                    }
+                }
+                Some(Err(e)) => {
+                    stream_error = Some(format!("stdout read error: {}", e));
+                    break;
+                }
+                None => break,
+            }
+        }
+
+        // Always publish a final batch with the authoritative list so the
+        // renderer converges to the same total. Skip if the count is exactly
+        // what the last mid-stream batch carried.
+        if files.len() != last_batch_count {
+            let _ = app_handle.emit(
+                "search-file-names-batch",
+                SearchFileNamesBatchEvent {
+                    search_id: search_id.clone(),
+                    files: files.clone(),
+                    truncated,
+                },
+            );
+        }
+
+        // Reap the child and propagate a non-zero exit status (other than 1,
+        // which rg uses for "no matches") as a surfaced error. The previous
+        // `try_wait().or_else(wait)` pattern was a no-op for the common
+        // `Ok(None)` case, so we always wait.
+        let exit_status = {
+            let mut child = match child_handle.lock() {
+                Ok(c) => c,
+                Err(_) => {
+                    stream_error.get_or_insert("child handle poisoned".to_string());
+                    return;
+                }
+            };
+            child.wait().ok()
+        };
+        if let Ok(mut guard) = filename_search_processes().lock() {
+            guard.remove(&search_id);
+        }
+
+        let final_error = stream_error.or_else(|| {
+            exit_status
+                .as_ref()
+                .filter(|s| !s.success() && s.code() != Some(1))
+                .map(|s| format!("rg exited with status: {:?}", s))
+        });
+
+        let _ = app_handle.emit(
+            "search-file-names-done",
+            SearchFileNamesDoneEvent {
+                search_id,
+                truncated,
+                total_files: files.len(),
+                error: final_error,
+            },
+        );
+    });
+
+    Ok(IpcResult::success(()))
+}
+
+#[tauri::command]
+pub async fn search_file_names_cancel(
+    request: SearchContentCancelRequest,
+) -> Result<IpcResult<()>, String> {
+    let mut guard = filename_search_processes()
+        .lock()
+        .map_err(|e| e.to_string())?;
+    if let Some(child_handle) = guard.remove(&request.search_id) {
+        if let Ok(mut child) = child_handle.lock() {
+            let _ = child.kill();
+            let _ = child.try_wait().or_else(|_| child.wait().map(Some));
+        }
+    }
+    Ok(IpcResult::success(()))
 }
 
 #[tauri::command]

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1395,12 +1395,12 @@ fn build_search_args(query: &str, root_path: &str, max_matches_per_file: usize) 
 /// they match literally, mirroring the old `contains` semantics.
 fn build_file_name_search_args(query: &str, root_path: &str) -> Vec<String> {
     // Escape glob metacharacters that ripgrep would otherwise interpret as
-    // wildcards (`*`, `?`, `[`, `]`, `\`) so the query is matched as a
-    // substring of the basename.
+    // wildcards (`*`, `?`, `[`, `]`, `{`, `}`, `\`) so the query is matched
+    // as a substring of the basename. `{`/`}` are alternation in globset.
     let mut escaped = String::with_capacity(query.len());
     for ch in query.chars() {
         match ch {
-            '*' | '?' | '[' | ']' | '\\' => {
+            '*' | '?' | '[' | ']' | '{' | '}' | '\\' => {
                 escaped.push('\\');
                 escaped.push(ch);
             }
@@ -3259,16 +3259,17 @@ mod tests {
 
     #[test]
     fn build_file_name_search_args_escapes_glob_metacharacters() {
-        // A query containing `*`, `?`, `[`, `]`, `\` must not be interpreted
-        // as a glob wildcard. Each metacharacter should be prefixed with a
-        // backslash so rg treats it as a literal substring match.
-        let args = build_file_name_search_args("foo*bar?baz[qux]\\z", "/tmp");
+        // A query containing `*`, `?`, `[`, `]`, `{`, `}`, `\` must not be
+        // interpreted as a glob wildcard or alternation. Each metacharacter
+        // should be prefixed with a backslash so rg treats it as a literal
+        // substring match.
+        let args = build_file_name_search_args("foo*bar?baz[qux]{a,b}\\z", "/tmp");
         let iglob_idx = args
             .iter()
             .position(|a| a == "--iglob")
             .expect("--iglob present");
         let pattern = &args[iglob_idx + 1];
-        assert_eq!(pattern, r"**/*foo\*bar\?baz\[qux\]\\z*");
+        assert_eq!(pattern, r"**/*foo\*bar\?baz\[qux\]\{a,b\}\\z*");
         // The query should still be matched at any directory depth.
         assert!(pattern.starts_with("**/*"));
     }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1098,7 +1098,8 @@ pub fn run() {
             commands::search_content,
             commands::search_content_stream,
             commands::search_content_cancel,
-            commands::search_file_names,
+            commands::search_file_names_stream,
+            commands::search_file_names_cancel,
             // SSH commands
             commands::ssh_list_profiles,
             commands::ssh_save_profile,

--- a/src-tauri/src/path_validation.rs
+++ b/src-tauri/src/path_validation.rs
@@ -1,3 +1,4 @@
+use std::borrow::Cow;
 use std::path::{Component, Path, PathBuf};
 
 fn path_has_parent_dir(path: &str) -> bool {
@@ -17,19 +18,25 @@ fn path_has_parent_dir(path: &str) -> bool {
 ///
 /// This is pure string rewriting, so the verbatim prefixes (which never occur on
 /// Unix) are simply left untouched there.
-pub fn strip_verbatim_prefix(path: &str) -> String {
+///
+/// Returns `Cow::Borrowed` when the path has no verbatim prefix — the common
+/// case on every platform — so callers in a per-line hot loop (e.g. ripgrep
+/// output streaming) do not allocate. The function does NOT trim leading
+/// whitespace before the prefix check, so a relative path with intentional
+/// leading whitespace is preserved (the previous implementation trimmed
+/// unconditionally, which was a subtle correctness bug for such paths).
+pub fn strip_verbatim_prefix(path: &str) -> Cow<'_, str> {
     const VERBATIM: &str = r"\\?\";
     const VERBATIM_UNC: &str = r"\\?\UNC\";
 
-    let trimmed = path.trim_start();
     // Order matters: the longer UNC prefix must be checked first.
-    if let Some(rest) = trimmed.strip_prefix(VERBATIM_UNC) {
-        return format!(r"\\{}", rest);
+    if let Some(rest) = path.strip_prefix(VERBATIM_UNC) {
+        return Cow::Owned(format!(r"\\{}", rest));
     }
-    if let Some(rest) = trimmed.strip_prefix(VERBATIM) {
-        return rest.to_string();
+    if let Some(rest) = path.strip_prefix(VERBATIM) {
+        return Cow::Owned(rest.to_string());
     }
-    path.to_string()
+    Cow::Borrowed(path)
 }
 
 /// Validates that a search path is within the allowed project boundary.
@@ -275,13 +282,13 @@ mod tests {
 
     #[test]
     fn test_strip_verbatim_disk_prefix() {
-        assert_eq!(strip_verbatim_prefix(r"\\?\C:\Users\foo"), r"C:\Users\foo");
+        assert_eq!(strip_verbatim_prefix(r"\\?\C:\Users\foo").as_ref(), r"C:\Users\foo");
     }
 
     #[test]
     fn test_strip_verbatim_unc_prefix() {
         assert_eq!(
-            strip_verbatim_prefix(r"\\?\UNC\server\share\foo"),
+            strip_verbatim_prefix(r"\\?\UNC\server\share\foo").as_ref(),
             r"\\server\share\foo"
         );
     }
@@ -293,7 +300,7 @@ mod tests {
             r"C:\Users\foo\bar"
         );
         // No verbatim prefix -> returned verbatim (string).
-        assert_eq!(strip_verbatim_prefix("/home/user/project"), "/home/user/project");
+        assert_eq!(strip_verbatim_prefix("/home/user/project").as_ref(), "/home/user/project");
     }
 
     #[test]

--- a/src-tauri/src/pty/manager.rs
+++ b/src-tauri/src/pty/manager.rs
@@ -957,7 +957,7 @@ impl PtyManager {
         // mirroring the #347 fix for git worktree paths. See `strip_verbatim_prefix`.
         let cwd = std::fs::canonicalize(&cwd)
             .map_err(|e| format!("Invalid working directory '{}': {}", cwd, e))?;
-        let cwd = crate::path_validation::strip_verbatim_prefix(&cwd.to_string_lossy());
+        let cwd = crate::path_validation::strip_verbatim_prefix(&cwd.to_string_lossy()).into_owned();
 
         // Get terminal size
         let cols = options.cols.unwrap_or(80);

--- a/src/renderer/components/file-explorer/FileExplorer.test.tsx
+++ b/src/renderer/components/file-explorer/FileExplorer.test.tsx
@@ -1,6 +1,7 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { act } from 'react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { type FileExplorerState, useFileExplorerStore } from '@/stores/file-explorer-store'
 import { FileExplorer } from './FileExplorer'
 
 const mockToggleDirectory = vi.fn()
@@ -19,6 +20,11 @@ const mockSetRootLoadError = vi.fn()
 const mockSetSearchQuery = vi.fn()
 const mockSearchInRoot = vi.fn()
 const mockResetSearch = vi.fn()
+
+const mockSearchFileNamesStreamCancel = vi
+  .fn()
+  .mockResolvedValue({ success: true, data: undefined })
+const mockSearchContentStreamCancel = vi.fn().mockResolvedValue({ success: true, data: undefined })
 
 const mockOpenFile = vi.fn()
 const mockCloseFile = vi.fn()
@@ -74,12 +80,19 @@ vi.mock('@/stores/file-explorer-store', () => ({
   useFileExplorerStore: {
     getState: vi.fn(() => ({
       expandedDirs: new Set<string>(),
-      selectedPath: null,
+      selectedPaths: new Set<string>(),
       loadingDirs: new Set<string>(),
       lastClickedPath: null,
       clearSelection: mockClearSelection
     })),
     setState: vi.fn()
+  }
+}))
+
+vi.mock('@/lib/api', () => ({
+  filesystemApi: {
+    searchFileNamesStreamCancel: (...args: unknown[]) => mockSearchFileNamesStreamCancel(...args),
+    searchContentStreamCancel: (...args: unknown[]) => mockSearchContentStreamCancel(...args)
   }
 }))
 
@@ -476,5 +489,73 @@ describe('FileExplorer', () => {
       screen.getByText((_, element) => element?.textContent === 'term fourth')
     ).toBeInTheDocument()
     expect(screen.getByRole('button', { name: 'Show less' })).toBeInTheDocument()
+  })
+
+  it('cancels in-flight filename and content streams on unmount with the active searchId', () => {
+    // The unmount cleanup must fire the cancel IPC for both the filename
+    // and the content stream, scoped to the searchId that was active at
+    // effect setup time (not at cleanup time, in case the store id
+    // changed via a different code path between setup and unmount).
+    mockExplorerState.rootPath = '/project'
+    mockExplorerState.directoryContents = new Map([['/project', []]])
+    mockExplorerState.searchQuery = 'term'
+
+    // Mock getState to return searchRequestId = 5
+    vi.mocked(useFileExplorerStore.getState).mockReturnValue({
+      searchRequestId: 5,
+      expandedDirs: new Set<string>(),
+      selectedPaths: new Set<string>(),
+      loadingDirs: new Set<string>(),
+      lastClickedPath: null,
+      clearSelection: vi.fn()
+    } as unknown as FileExplorerState)
+
+    const { unmount } = render(<FileExplorer />)
+    mockSearchFileNamesStreamCancel.mockClear()
+    mockSearchContentStreamCancel.mockClear()
+
+    // The id was captured at setup; even if the store value changes before
+    // unmount, the cleanup must still use the captured id.
+    vi.mocked(useFileExplorerStore.getState).mockReturnValue({
+      searchRequestId: 99, // would-be new id, but cleanup should ignore
+      expandedDirs: new Set<string>(),
+      selectedPaths: new Set<string>(),
+      loadingDirs: new Set<string>(),
+      lastClickedPath: null,
+      clearSelection: vi.fn()
+    } as unknown as FileExplorerState)
+
+    unmount()
+
+    expect(mockSearchFileNamesStreamCancel).toHaveBeenCalledTimes(1)
+    expect(mockSearchFileNamesStreamCancel).toHaveBeenCalledWith('search-5')
+    expect(mockSearchContentStreamCancel).toHaveBeenCalledTimes(1)
+    expect(mockSearchContentStreamCancel).toHaveBeenCalledWith('search-5')
+  })
+
+  it('does not call cancel on unmount when no search is in flight', () => {
+    // When searchRequestId is 0 (no search), the unmount effect's id > 0
+    // guard must short-circuit so we do not issue a cancel for `search-0`.
+    mockExplorerState.rootPath = '/project'
+    mockExplorerState.directoryContents = new Map([['/project', []]])
+    mockExplorerState.searchQuery = ''
+
+    vi.mocked(useFileExplorerStore.getState).mockReturnValue({
+      searchRequestId: 0,
+      expandedDirs: new Set<string>(),
+      selectedPaths: new Set<string>(),
+      loadingDirs: new Set<string>(),
+      lastClickedPath: null,
+      clearSelection: vi.fn()
+    } as unknown as FileExplorerState)
+
+    const { unmount } = render(<FileExplorer />)
+    mockSearchFileNamesStreamCancel.mockClear()
+    mockSearchContentStreamCancel.mockClear()
+
+    unmount()
+
+    expect(mockSearchFileNamesStreamCancel).not.toHaveBeenCalled()
+    expect(mockSearchContentStreamCancel).not.toHaveBeenCalled()
   })
 })

--- a/src/renderer/components/file-explorer/FileExplorer.test.tsx
+++ b/src/renderer/components/file-explorer/FileExplorer.test.tsx
@@ -42,7 +42,7 @@ const mockExplorerState = {
     filePath: string
     matches: Array<{ lineNumber: number; lineText: string }>
   }>,
-  searchFileNameMatches: [] as string[],
+  searchFileNameMatches: [] as string[] | null,
   searchLoading: false,
   searchError: null as string | null,
   searchTruncated: false,
@@ -127,7 +127,7 @@ beforeEach(() => {
   mockExplorerState.clipboard = null
   mockExplorerState.searchQuery = ''
   mockExplorerState.searchResults = []
-  mockExplorerState.searchFileNameMatches = []
+  mockExplorerState.searchFileNameMatches = null
   mockExplorerState.searchLoading = false
   mockExplorerState.searchError = null
   mockExplorerState.searchTruncated = false
@@ -232,6 +232,46 @@ describe('FileExplorer', () => {
 
     expect(screen.getByRole('tab', { name: /Files 1/i })).toHaveAttribute('aria-selected', 'true')
     expect(screen.getByText('term-search.ts')).toBeInTheDocument()
+  })
+
+  it('shows the Files tab with an ellipsis while filename matches are still pending', () => {
+    mockExplorerState.rootPath = '/project'
+    mockExplorerState.directoryContents = new Map([['/project', []]])
+    mockExplorerState.searchQuery = 'term'
+    mockExplorerState.searchLastCompletedQuery = 'term'
+    mockExplorerState.searchResults = [
+      {
+        filePath: '/project/src/FileExplorer.tsx',
+        matches: [{ lineNumber: 12, lineText: 'const term = createExplorerSearch();' }]
+      }
+    ]
+    mockExplorerState.searchFileNameMatches = null
+
+    render(<FileExplorer />)
+
+    expect(screen.getByRole('tab', { name: /Files …/i })).toBeInTheDocument()
+  })
+
+  it('replaces the pending indicator with the streamed count once matches arrive', () => {
+    mockExplorerState.rootPath = '/project'
+    mockExplorerState.directoryContents = new Map([['/project', []]])
+    mockExplorerState.searchQuery = 'term'
+    mockExplorerState.searchLastCompletedQuery = 'term'
+    mockExplorerState.searchResults = [
+      {
+        filePath: '/project/src/FileExplorer.tsx',
+        matches: [{ lineNumber: 12, lineText: 'const term = createExplorerSearch();' }]
+      }
+    ]
+    mockExplorerState.searchFileNameMatches = null
+
+    const { rerender } = render(<FileExplorer />)
+    expect(screen.getByRole('tab', { name: /Files …/i })).toBeInTheDocument()
+
+    mockExplorerState.searchFileNameMatches = ['/project/src/term-search.ts']
+    rerender(<FileExplorer />)
+
+    expect(screen.getByRole('tab', { name: /Files 1/i })).toBeInTheDocument()
   })
 
   it('opens file-name search results with existing editor behavior', async () => {

--- a/src/renderer/components/file-explorer/FileExplorer.tsx
+++ b/src/renderer/components/file-explorer/FileExplorer.tsx
@@ -99,6 +99,7 @@ export function FileExplorer({ side = 'right' }: FileExplorerProps): React.JSX.E
   const normalizedSearchQuery = searchQuery ?? ''
   const safeSearchResults = searchResults ?? []
   const safeSearchFileNameMatches = searchFileNameMatches ?? []
+  const fileNameMatchesPending = searchFileNameMatches === null
   const hasSearchInput = normalizedSearchQuery.length > 0
   const trimmedSearchQuery = normalizedSearchQuery.trim()
   const isSearchActive = trimmedSearchQuery.length > 0
@@ -1003,7 +1004,7 @@ export function FileExplorer({ side = 'right' }: FileExplorerProps): React.JSX.E
                     {searchLoading && <LoaderCircle size={10} className="animate-spin" />}
                     Files{' '}
                     <span className="text-muted-foreground">
-                      {safeSearchFileNameMatches.length}
+                      {fileNameMatchesPending ? '…' : safeSearchFileNameMatches.length}
                     </span>
                   </button>
                 </div>

--- a/src/renderer/components/file-explorer/FileExplorer.tsx
+++ b/src/renderer/components/file-explorer/FileExplorer.tsx
@@ -276,6 +276,32 @@ export function FileExplorer({ side = 'right' }: FileExplorerProps): React.JSX.E
     }
   }, [finalizeResizeDrag])
 
+  // Cancel any in-flight filename/content stream when the explorer unmounts.
+  // The store is a module-level singleton and the file explorer can be torn
+  // down while a stream is still mid-walk; without this cleanup the rg child
+  // process outlives the component and the next mount sees stale events.
+  //
+  // We capture the `searchRequestId` at effect setup time (not at cleanup
+  // time) so that a new search started via a different code path between
+  // setup and cleanup does not get cancelled by mistake.
+  useEffect(() => {
+    const id = useFileExplorerStore.getState().searchRequestId
+    return () => {
+      if (id > 0) {
+        const sid = `search-${id}`
+        // Surface silent IPC failures so a stuck rg process is at least
+        // visible in the console; the cancel is still fire-and-forget
+        // from the user's perspective.
+        filesystemApi.searchFileNamesStreamCancel(sid).catch((e) => {
+          console.warn(`[file-explorer] searchFileNamesStreamCancel(${sid}) failed:`, e)
+        })
+        filesystemApi.searchContentStreamCancel(sid).catch((e) => {
+          console.warn(`[file-explorer] searchContentStreamCancel(${sid}) failed:`, e)
+        })
+      }
+    }
+  }, [])
+
   // Focus inline input when it appears
   useEffect(() => {
     if (inlineInput && inputRef.current) {

--- a/src/renderer/layouts/WorkspaceLayout.tsx
+++ b/src/renderer/layouts/WorkspaceLayout.tsx
@@ -596,7 +596,10 @@ export default function WorkspaceLayout(): React.JSX.Element {
   useEffect(() => {
     let unlisten: UnlistenFn | undefined
     listen<void>('menu:close-tab', () => {
-      closeActiveTab()
+      // Skip when Agent Launcher is open to avoid accidental tab closure
+      if (!isAgentLauncherOpen) {
+        closeActiveTab()
+      }
     })
       .then((fn) => {
         unlisten = fn
@@ -607,7 +610,7 @@ export default function WorkspaceLayout(): React.JSX.Element {
     return () => {
       unlisten?.()
     }
-  }, [closeActiveTab])
+  }, [closeActiveTab, isAgentLauncherOpen])
 
   // Load snapshots when project changes
   useSnapshotLoader()
@@ -1116,7 +1119,8 @@ export default function WorkspaceLayout(): React.JSX.Element {
     isExplorerVisible,
     isSidebarVisible,
     handleOpenThemePicker,
-    closeActiveTab
+    closeActiveTab,
+    isAgentLauncherOpen
   ])
 
   useEffect(() => {

--- a/src/renderer/layouts/WorkspaceLayout.tsx
+++ b/src/renderer/layouts/WorkspaceLayout.tsx
@@ -918,9 +918,12 @@ export default function WorkspaceLayout(): React.JSX.Element {
       // Close Tab (Ctrl+W / ⌘+W)
       // On macOS: ⌘+W closes tab, Ctrl+W is forwarded to shell (backward-kill-word)
       // On Windows/Linux: Ctrl+W closes tab
+      // Skip when Agent Launcher is open to avoid accidental tab closure
       if (matchesShortcut(e, getActiveKey('closeTab'))) {
-        e.preventDefault()
-        closeActiveTab()
+        if (!isAgentLauncherOpen) {
+          e.preventDefault()
+          closeActiveTab()
+        }
         return
       }
 

--- a/src/renderer/layouts/WorkspaceLayout.tsx
+++ b/src/renderer/layouts/WorkspaceLayout.tsx
@@ -918,10 +918,11 @@ export default function WorkspaceLayout(): React.JSX.Element {
       // Close Tab (Ctrl+W / ⌘+W)
       // On macOS: ⌘+W closes tab, Ctrl+W is forwarded to shell (backward-kill-word)
       // On Windows/Linux: Ctrl+W closes tab
-      // Skip when Agent Launcher is open to avoid accidental tab closure
+      // Always preventDefault to suppress OS/webview close behavior; only
+      // close the tab when the Agent Launcher is not open.
       if (matchesShortcut(e, getActiveKey('closeTab'))) {
+        e.preventDefault()
         if (!isAgentLauncherOpen) {
-          e.preventDefault()
           closeActiveTab()
         }
         return

--- a/src/renderer/lib/tauri-filesystem-api.ts
+++ b/src/renderer/lib/tauri-filesystem-api.ts
@@ -519,12 +519,12 @@ export function createTauriFilesystemApi(): FilesystemApi {
     },
 
     onSearchFileNamesBatch(
-      callback: (event: { searchId: string; files: string[]; truncated: boolean }) => void
+      callback: (event: { searchId: string; files: string[]; truncated?: boolean }) => void
     ) {
       if (!isTauriContext()) return () => {}
       let unlisten: Promise<UnlistenFn> | undefined
       try {
-        unlisten = listen<{ searchId: string; files: string[]; truncated: boolean }>(
+        unlisten = listen<{ searchId: string; files: string[]; truncated?: boolean }>(
           'search-file-names-batch',
           ({ payload }) => callback(payload)
         )
@@ -539,6 +539,7 @@ export function createTauriFilesystemApi(): FilesystemApi {
         searchId: string
         truncated: boolean
         totalFiles: number
+        code?: string
         error?: string
       }) => void
     ) {
@@ -549,6 +550,7 @@ export function createTauriFilesystemApi(): FilesystemApi {
           searchId: string
           truncated: boolean
           totalFiles: number
+          code?: string
           error?: string
         }>('search-file-names-done', ({ payload }) => callback(payload))
       } catch {

--- a/src/renderer/lib/tauri-filesystem-api.ts
+++ b/src/renderer/lib/tauri-filesystem-api.ts
@@ -467,31 +467,94 @@ export function createTauriFilesystemApi(): FilesystemApi {
       return () => cleanupTauriListener(unlisten)
     },
 
-    async searchFileNames(scopeRoot: string, rootPath: string, query: string) {
+    async searchFileNamesStreamStart(
+      searchId: string,
+      scopeRoot: string,
+      rootPath: string,
+      query: string
+    ) {
       try {
-        const response = await invoke<{
-          success: boolean
-          data?: { files: string[]; truncated: boolean }
-          error?: string
-          code?: string
-        }>('search_file_names', {
-          request: { scopeRoot, rootPath, query }
-        })
-        if (!response?.success || !response.data) {
+        const response = await invoke<{ success: boolean; error?: string; code?: string }>(
+          'search_file_names_stream',
+          { request: { searchId, scopeRoot, rootPath, query } }
+        )
+        if (!response?.success) {
           return {
             success: false as const,
-            error: response?.error ?? 'Failed to search file names',
-            code: response?.code ?? 'SEARCH_FILENAME_ERROR'
+            error: response?.error ?? 'Failed to start file names stream',
+            code: response?.code ?? 'SEARCH_FILENAMES_STREAM_ERROR'
           }
         }
-        return { success: true as const, data: response.data }
+        return { success: true as const, data: undefined }
       } catch (err) {
         return {
           success: false as const,
           error: String(err),
-          code: 'SEARCH_FILENAME_ERROR'
+          code: 'SEARCH_FILENAMES_STREAM_ERROR'
         }
       }
+    },
+
+    async searchFileNamesStreamCancel(searchId: string) {
+      try {
+        const response = await invoke<{ success: boolean; error?: string; code?: string }>(
+          'search_file_names_cancel',
+          { request: { searchId } }
+        )
+        if (!response?.success) {
+          return {
+            success: false as const,
+            error: response?.error ?? 'Failed to cancel file names stream',
+            code: response?.code ?? 'SEARCH_FILENAMES_CANCEL_ERROR'
+          }
+        }
+        return { success: true as const, data: undefined }
+      } catch (err) {
+        return {
+          success: false as const,
+          error: String(err),
+          code: 'SEARCH_FILENAMES_CANCEL_ERROR'
+        }
+      }
+    },
+
+    onSearchFileNamesBatch(
+      callback: (event: { searchId: string; files: string[]; truncated: boolean }) => void
+    ) {
+      if (!isTauriContext()) return () => {}
+      let unlisten: Promise<UnlistenFn> | undefined
+      try {
+        unlisten = listen<{ searchId: string; files: string[]; truncated: boolean }>(
+          'search-file-names-batch',
+          ({ payload }) => callback(payload)
+        )
+      } catch {
+        return () => {}
+      }
+      return () => cleanupTauriListener(unlisten)
+    },
+
+    onSearchFileNamesDone(
+      callback: (event: {
+        searchId: string
+        truncated: boolean
+        totalFiles: number
+        error?: string
+      }) => void
+    ) {
+      if (!isTauriContext()) return () => {}
+      let unlisten: Promise<UnlistenFn> | undefined
+      try {
+        unlisten = listen<{
+          searchId: string
+          truncated: boolean
+          totalFiles: number
+          error?: string
+        }>('search-file-names-done', ({ payload }) => callback(payload))
+      } catch {
+        return () => {}
+      }
+      return () => cleanupTauriListener(unlisten)
     },
 
     onSearchContentDone(callback) {

--- a/src/renderer/stores/file-explorer-store.test.ts
+++ b/src/renderer/stores/file-explorer-store.test.ts
@@ -25,7 +25,13 @@ const { mockApi } = vi.hoisted(() => ({
     filesystem: {
       readDirectory: vi.fn(),
       watchDirectory: vi.fn(),
-      unwatchDirectory: vi.fn()
+      unwatchDirectory: vi.fn(),
+      searchContentStreamCancel: vi.fn(),
+      searchFileNamesStreamCancel: vi.fn(),
+      onSearchContentBatch: vi.fn(() => () => {}),
+      onSearchContentDone: vi.fn(() => () => {}),
+      onSearchFileNamesBatch: vi.fn(() => () => {}),
+      onSearchFileNamesDone: vi.fn(() => () => {})
     }
   }
 }))
@@ -405,6 +411,50 @@ describe('file-explorer-store', () => {
 
       useFileExplorerStore.getState().removeDirectoryContents('/dir')
       expect(useFileExplorerStore.getState().directoryContents.has('/dir')).toBe(false)
+    })
+  })
+  describe('searchInRoot - error code reset', () => {
+    it('clears stale searchErrorCode when called with an empty query (trimmed.length < 2)', async () => {
+      useFileExplorerStore.setState({
+        rootPath: '/project',
+        searchError: 'prior error',
+        searchErrorCode: 'QUERY_TOO_LONG'
+      })
+
+      await useFileExplorerStore.getState().searchInRoot('', 0)
+
+      const state = useFileExplorerStore.getState()
+      expect(state.searchError).toBeNull()
+      expect(state.searchErrorCode).toBeNull()
+    })
+
+    it('clears stale searchErrorCode when called with a single-char query', async () => {
+      useFileExplorerStore.setState({
+        rootPath: '/project',
+        searchError: 'prior error',
+        searchErrorCode: 'QUERY_TOO_LONG'
+      })
+
+      await useFileExplorerStore.getState().searchInRoot('a', 0)
+
+      const state = useFileExplorerStore.getState()
+      expect(state.searchError).toBeNull()
+      expect(state.searchErrorCode).toBeNull()
+    })
+
+    it('clears stale searchErrorCode when no project is selected', async () => {
+      useFileExplorerStore.setState({
+        rootPath: null,
+        scopeRoot: null,
+        searchError: 'prior error',
+        searchErrorCode: 'RG_STREAM_FAILED'
+      })
+
+      await useFileExplorerStore.getState().searchInRoot('term', 0)
+
+      const state = useFileExplorerStore.getState()
+      expect(state.searchError).toBe('No project selected')
+      expect(state.searchErrorCode).toBeNull()
     })
   })
 })

--- a/src/renderer/stores/file-explorer-store.ts
+++ b/src/renderer/stores/file-explorer-store.ts
@@ -68,6 +68,13 @@ export interface FileExplorerState {
   searchFileNameMatches: string[] | null
   searchLoading: boolean
   searchError: string | null
+  /**
+   * Programmatic error code paired with `searchError`. Set when the
+   * streaming done event carries a `code`; otherwise `null`. Values come
+   * from `FilesystemApi`'s `onSearchContentDone` / `onSearchFileNamesDone`
+   * event types (e.g. `QUERY_TOO_LONG`, `RG_STREAM_FAILED`).
+   */
+  searchErrorCode: string | null
   searchTruncated: boolean
   searchScannedFiles: number
   searchFailedFiles: number
@@ -137,6 +144,10 @@ function ensureSearchStreamSubscription(
     set({
       searchLoading: false,
       searchError: event.error ?? null,
+      // Surface the programmatic code so consumers (telemetry, future UI
+      // affordances) can distinguish QUERY_TOO_LONG from RG_STREAM_FAILED
+      // without parsing the human-readable error string.
+      searchErrorCode: event.code ?? null,
       searchTruncated: event.truncated,
       searchScannedFiles: event.scannedFiles,
       searchFailedFiles: event.failedFiles,
@@ -180,6 +191,17 @@ function ensureFileNameStreamSubscription(
     if (event.error) {
       next.searchError = event.error
     }
+    // Surface the programmatic code in the same slot as content search so
+    // downstream consumers can branch on QUERY_TOO_LONG vs RG_STREAM_FAILED
+    // without parsing the message. If the content stream fires afterwards,
+    // its own `code` will overwrite this value (which is correct — that
+    // event is the source of truth for the overall search result).
+    if (event.code) {
+      next.searchErrorCode = event.code
+    } else if (!event.error) {
+      // No error, no code: clear any stale code from a prior search.
+      next.searchErrorCode = null
+    }
     if (state.searchFileNameMatches === null) {
       // No batch ever landed (zero matches, no trailing flush). Drop the
       // pending placeholder so the tab shows `0` rather than `…` forever.
@@ -206,6 +228,7 @@ export const useFileExplorerStore = create<FileExplorerState>((set, get) => ({
   searchFileNameMatches: null,
   searchLoading: false,
   searchError: null,
+  searchErrorCode: null,
   searchTruncated: false,
   searchScannedFiles: 0,
   searchFailedFiles: 0,
@@ -218,8 +241,13 @@ export const useFileExplorerStore = create<FileExplorerState>((set, get) => ({
     // Unwatch all previously expanded directories
     const { expandedDirs, searchRequestId } = get()
     if (searchRequestId > 0) {
-      void filesystemApi.searchContentStreamCancel(`search-${searchRequestId}`)
-      void filesystemApi.searchFileNamesStreamCancel(`search-${searchRequestId}`)
+      const sid = `search-${searchRequestId}`
+      filesystemApi.searchContentStreamCancel(sid).catch((e) => {
+        console.warn(`[file-explorer] searchContentStreamCancel(${sid}) failed:`, e)
+      })
+      filesystemApi.searchFileNamesStreamCancel(sid).catch((e) => {
+        console.warn(`[file-explorer] searchFileNamesStreamCancel(${sid}) failed:`, e)
+      })
     }
     expandedDirs.forEach((dir) => {
       filesystemApi.unwatchDirectory(dir)
@@ -240,6 +268,7 @@ export const useFileExplorerStore = create<FileExplorerState>((set, get) => ({
       searchFileNameMatches: null,
       searchLoading: false,
       searchError: null,
+      searchErrorCode: null,
       searchTruncated: false,
       searchScannedFiles: 0,
       searchFailedFiles: 0,
@@ -253,8 +282,13 @@ export const useFileExplorerStore = create<FileExplorerState>((set, get) => ({
   setWorktreeRoot: (path: string | null): void => {
     const { scopeRoot, searchRequestId } = get()
     if (searchRequestId > 0) {
-      void filesystemApi.searchContentStreamCancel(`search-${searchRequestId}`)
-      void filesystemApi.searchFileNamesStreamCancel(`search-${searchRequestId}`)
+      const sid = `search-${searchRequestId}`
+      filesystemApi.searchContentStreamCancel(sid).catch((e) => {
+        console.warn(`[file-explorer] searchContentStreamCancel(${sid}) failed:`, e)
+      })
+      filesystemApi.searchFileNamesStreamCancel(sid).catch((e) => {
+        console.warn(`[file-explorer] searchFileNamesStreamCancel(${sid}) failed:`, e)
+      })
     }
     const worktreeRoot = path ? normalizePath(path) : null
     set({
@@ -265,6 +299,7 @@ export const useFileExplorerStore = create<FileExplorerState>((set, get) => ({
       searchFileNameMatches: null,
       searchLoading: false,
       searchError: null,
+      searchErrorCode: null,
       searchTruncated: false,
       searchScannedFiles: 0,
       searchFailedFiles: 0,
@@ -663,6 +698,7 @@ export const useFileExplorerStore = create<FileExplorerState>((set, get) => ({
       set({
         searchLoading: false,
         searchError: 'No project selected',
+        searchErrorCode: null,
         searchResults: [],
         searchFileNameMatches: null,
         searchTruncated: false,
@@ -677,12 +713,23 @@ export const useFileExplorerStore = create<FileExplorerState>((set, get) => ({
     if (!trimmed || trimmed.length < 2) {
       const activeRequestId = get().searchRequestId
       if (activeRequestId > 0) {
-        void filesystemApi.searchContentStreamCancel(`search-${activeRequestId}`)
-        void filesystemApi.searchFileNamesStreamCancel(`search-${activeRequestId}`)
+        filesystemApi.searchContentStreamCancel(`search-${activeRequestId}`).catch((e) => {
+          console.warn(
+            `[file-explorer] searchContentStreamCancel(search-${activeRequestId}) failed:`,
+            e
+          )
+        })
+        filesystemApi.searchFileNamesStreamCancel(`search-${activeRequestId}`).catch((e) => {
+          console.warn(
+            `[file-explorer] searchFileNamesStreamCancel(search-${activeRequestId}) failed:`,
+            e
+          )
+        })
       }
       set({
         searchLoading: false,
         searchError: null,
+        searchErrorCode: null,
         searchResults: [],
         searchFileNameMatches: null,
         searchTruncated: false,
@@ -698,8 +745,18 @@ export const useFileExplorerStore = create<FileExplorerState>((set, get) => ({
 
     const activeRequestId = get().searchRequestId
     if (activeRequestId > 0) {
-      void filesystemApi.searchContentStreamCancel(`search-${activeRequestId}`)
-      void filesystemApi.searchFileNamesStreamCancel(`search-${activeRequestId}`)
+      filesystemApi.searchContentStreamCancel(`search-${activeRequestId}`).catch((e) => {
+        console.warn(
+          `[file-explorer] searchContentStreamCancel(search-${activeRequestId}) failed:`,
+          e
+        )
+      })
+      filesystemApi.searchFileNamesStreamCancel(`search-${activeRequestId}`).catch((e) => {
+        console.warn(
+          `[file-explorer] searchFileNamesStreamCancel(search-${activeRequestId}) failed:`,
+          e
+        )
+      })
     }
 
     const { searchLastCompletedQuery, searchResults } = get()
@@ -759,20 +816,34 @@ export const useFileExplorerStore = create<FileExplorerState>((set, get) => ({
 
     if (get().searchRequestId !== requestId) {
       if (streamStart.success) {
-        void filesystemApi.searchContentStreamCancel(`search-${requestId}`)
+        filesystemApi.searchContentStreamCancel(`search-${requestId}`).catch((e) => {
+          console.warn(`[file-explorer] searchContentStreamCancel(search-${requestId}) failed:`, e)
+        })
       }
       if (fileNameStreamStart.success) {
-        void filesystemApi.searchFileNamesStreamCancel(`search-${requestId}`)
+        filesystemApi.searchFileNamesStreamCancel(`search-${requestId}`).catch((e) => {
+          console.warn(
+            `[file-explorer] searchFileNamesStreamCancel(search-${requestId}) failed:`,
+            e
+          )
+        })
       }
       return
     }
 
     if (!streamStart.success || !fileNameStreamStart.success) {
       if (streamStart.success) {
-        void filesystemApi.searchContentStreamCancel(`search-${requestId}`)
+        filesystemApi.searchContentStreamCancel(`search-${requestId}`).catch((e) => {
+          console.warn(`[file-explorer] searchContentStreamCancel(search-${requestId}) failed:`, e)
+        })
       }
       if (fileNameStreamStart.success) {
-        void filesystemApi.searchFileNamesStreamCancel(`search-${requestId}`)
+        filesystemApi.searchFileNamesStreamCancel(`search-${requestId}`).catch((e) => {
+          console.warn(
+            `[file-explorer] searchFileNamesStreamCancel(search-${requestId}) failed:`,
+            e
+          )
+        })
       }
       const error = !streamStart.success
         ? streamStart.error
@@ -794,15 +865,30 @@ export const useFileExplorerStore = create<FileExplorerState>((set, get) => ({
   resetSearch: (): void => {
     const activeRequestId = get().searchRequestId
     if (activeRequestId > 0) {
-      void filesystemApi.searchContentStreamCancel(`search-${activeRequestId}`)
-      void filesystemApi.searchFileNamesStreamCancel(`search-${activeRequestId}`)
+      filesystemApi.searchContentStreamCancel(`search-${activeRequestId}`).catch((e) => {
+        console.warn(
+          `[file-explorer] searchContentStreamCancel(search-${activeRequestId}) failed:`,
+          e
+        )
+      })
+      filesystemApi.searchFileNamesStreamCancel(`search-${activeRequestId}`).catch((e) => {
+        console.warn(
+          `[file-explorer] searchFileNamesStreamCancel(search-${activeRequestId}) failed:`,
+          e
+        )
+      })
     }
+    // Set filename matches to an empty list synchronously: the tab is hidden
+    // while no search is active, but leaving a stale `null` here means a
+    // consumer reading the state sees a lie. The next searchInRoot call will
+    // re-seed `null` if it actually starts a new stream.
     set({
       searchQuery: '',
       searchResults: [],
-      searchFileNameMatches: null,
+      searchFileNameMatches: [],
       searchLoading: false,
       searchError: null,
+      searchErrorCode: null,
       searchTruncated: false,
       searchScannedFiles: 0,
       searchFailedFiles: 0,

--- a/src/renderer/stores/file-explorer-store.ts
+++ b/src/renderer/stores/file-explorer-store.ts
@@ -65,7 +65,7 @@ export interface FileExplorerState {
   rootLoadError: FileExplorerRootError | null
   searchQuery: string
   searchResults: FileSearchResult[]
-  searchFileNameMatches: string[]
+  searchFileNameMatches: string[] | null
   searchLoading: boolean
   searchError: string | null
   searchTruncated: boolean
@@ -106,6 +106,7 @@ export interface FileExplorerState {
 }
 
 let streamSubscribed = false
+let fileNameStreamSubscribed = false
 
 function ensureSearchStreamSubscription(
   set: (partial: Partial<FileExplorerState>) => void,
@@ -144,6 +145,50 @@ function ensureSearchStreamSubscription(
   })
 }
 
+function ensureFileNameStreamSubscription(
+  set: (partial: Partial<FileExplorerState>) => void,
+  get: () => FileExplorerState
+): void {
+  if (fileNameStreamSubscribed) return
+  fileNameStreamSubscribed = true
+
+  filesystemApi.onSearchFileNamesBatch((event) => {
+    const state = get()
+    const activeId = `search-${state.searchRequestId}`
+    if (event.searchId !== activeId) return
+
+    set({
+      searchFileNameMatches: event.files,
+      searchTruncated: event.truncated || state.searchTruncated
+    })
+  })
+
+  filesystemApi.onSearchFileNamesDone((event) => {
+    const state = get()
+    const activeId = `search-${state.searchRequestId}`
+    if (event.searchId !== activeId) return
+
+    // Surface backend errors and stop the spinner. Filename and content
+    // streams share the same `searchError` / `searchLoading` slot; the
+    // content stream's own done handler is the source of truth for
+    // `searchLastCompletedQuery` and overwrites these fields when it
+    // fires, so mirroring the error here is safe.
+    const next: Partial<FileExplorerState> = {
+      searchTruncated: event.truncated || state.searchTruncated,
+      searchLoading: false
+    }
+    if (event.error) {
+      next.searchError = event.error
+    }
+    if (state.searchFileNameMatches === null) {
+      // No batch ever landed (zero matches, no trailing flush). Drop the
+      // pending placeholder so the tab shows `0` rather than `…` forever.
+      next.searchFileNameMatches = []
+    }
+    set(next)
+  })
+}
+
 export const useFileExplorerStore = create<FileExplorerState>((set, get) => ({
   rootPath: null,
   scopeRoot: null,
@@ -158,7 +203,7 @@ export const useFileExplorerStore = create<FileExplorerState>((set, get) => ({
   rootLoadError: null,
   searchQuery: '',
   searchResults: [],
-  searchFileNameMatches: [],
+  searchFileNameMatches: null,
   searchLoading: false,
   searchError: null,
   searchTruncated: false,
@@ -174,6 +219,7 @@ export const useFileExplorerStore = create<FileExplorerState>((set, get) => ({
     const { expandedDirs, searchRequestId } = get()
     if (searchRequestId > 0) {
       void filesystemApi.searchContentStreamCancel(`search-${searchRequestId}`)
+      void filesystemApi.searchFileNamesStreamCancel(`search-${searchRequestId}`)
     }
     expandedDirs.forEach((dir) => {
       filesystemApi.unwatchDirectory(dir)
@@ -191,7 +237,7 @@ export const useFileExplorerStore = create<FileExplorerState>((set, get) => ({
       rootLoadError: null,
       searchQuery: '',
       searchResults: [],
-      searchFileNameMatches: [],
+      searchFileNameMatches: null,
       searchLoading: false,
       searchError: null,
       searchTruncated: false,
@@ -208,6 +254,7 @@ export const useFileExplorerStore = create<FileExplorerState>((set, get) => ({
     const { scopeRoot, searchRequestId } = get()
     if (searchRequestId > 0) {
       void filesystemApi.searchContentStreamCancel(`search-${searchRequestId}`)
+      void filesystemApi.searchFileNamesStreamCancel(`search-${searchRequestId}`)
     }
     const worktreeRoot = path ? normalizePath(path) : null
     set({
@@ -215,7 +262,7 @@ export const useFileExplorerStore = create<FileExplorerState>((set, get) => ({
       rootPath: worktreeRoot ?? scopeRoot,
       searchQuery: '',
       searchResults: [],
-      searchFileNameMatches: [],
+      searchFileNameMatches: null,
       searchLoading: false,
       searchError: null,
       searchTruncated: false,
@@ -617,7 +664,7 @@ export const useFileExplorerStore = create<FileExplorerState>((set, get) => ({
         searchLoading: false,
         searchError: 'No project selected',
         searchResults: [],
-        searchFileNameMatches: [],
+        searchFileNameMatches: null,
         searchTruncated: false,
         searchScannedFiles: 0,
         searchFailedFiles: 0,
@@ -631,12 +678,13 @@ export const useFileExplorerStore = create<FileExplorerState>((set, get) => ({
       const activeRequestId = get().searchRequestId
       if (activeRequestId > 0) {
         void filesystemApi.searchContentStreamCancel(`search-${activeRequestId}`)
+        void filesystemApi.searchFileNamesStreamCancel(`search-${activeRequestId}`)
       }
       set({
         searchLoading: false,
         searchError: null,
         searchResults: [],
-        searchFileNameMatches: [],
+        searchFileNameMatches: null,
         searchTruncated: false,
         searchScannedFiles: 0,
         searchFailedFiles: 0,
@@ -646,10 +694,12 @@ export const useFileExplorerStore = create<FileExplorerState>((set, get) => ({
     }
 
     ensureSearchStreamSubscription(set, get)
+    ensureFileNameStreamSubscription(set, get)
 
     const activeRequestId = get().searchRequestId
     if (activeRequestId > 0) {
       void filesystemApi.searchContentStreamCancel(`search-${activeRequestId}`)
+      void filesystemApi.searchFileNamesStreamCancel(`search-${activeRequestId}`)
     }
 
     const { searchLastCompletedQuery, searchResults } = get()
@@ -668,7 +718,7 @@ export const useFileExplorerStore = create<FileExplorerState>((set, get) => ({
         .filter((file) => file.matches.length > 0)
       set({
         searchResults: filtered,
-        searchFileNameMatches: [],
+        searchFileNameMatches: null,
         searchLoading: true,
         searchError: null,
         searchRequestId: requestId,
@@ -682,36 +732,58 @@ export const useFileExplorerStore = create<FileExplorerState>((set, get) => ({
         searchError: null,
         searchRequestId: requestId,
         searchResults: [],
-        searchFileNameMatches: [],
+        searchFileNameMatches: null,
         searchTruncated: false,
         searchScannedFiles: 0,
         searchFailedFiles: 0
       })
     }
 
-    const streamStart = await filesystemApi.searchContentStreamStart(
+    const streamStartPromise = filesystemApi.searchContentStreamStart(
+      `search-${requestId}`,
+      searchScopeRoot,
+      rootPath,
+      trimmed
+    )
+    const fileNameStreamStartPromise = filesystemApi.searchFileNamesStreamStart(
       `search-${requestId}`,
       searchScopeRoot,
       rootPath,
       trimmed
     )
 
+    const [streamStart, fileNameStreamStart] = await Promise.all([
+      streamStartPromise,
+      fileNameStreamStartPromise
+    ])
+
     if (get().searchRequestId !== requestId) {
-      void filesystemApi.searchContentStreamCancel(`search-${requestId}`)
+      if (streamStart.success) {
+        void filesystemApi.searchContentStreamCancel(`search-${requestId}`)
+      }
+      if (fileNameStreamStart.success) {
+        void filesystemApi.searchFileNamesStreamCancel(`search-${requestId}`)
+      }
       return
     }
 
-    const fileNameResult = await filesystemApi.searchFileNames(searchScopeRoot, rootPath, trimmed)
-    if (get().searchRequestId === requestId && fileNameResult.success) {
-      set({ searchFileNameMatches: fileNameResult.data.files })
-    }
-
-    if (!streamStart.success) {
+    if (!streamStart.success || !fileNameStreamStart.success) {
+      if (streamStart.success) {
+        void filesystemApi.searchContentStreamCancel(`search-${requestId}`)
+      }
+      if (fileNameStreamStart.success) {
+        void filesystemApi.searchFileNamesStreamCancel(`search-${requestId}`)
+      }
+      const error = !streamStart.success
+        ? streamStart.error
+        : !fileNameStreamStart.success
+          ? fileNameStreamStart.error
+          : 'Search failed'
       set({
         searchLoading: false,
-        searchError: streamStart.error,
+        searchError: error,
         searchResults: [],
-        searchFileNameMatches: [],
+        searchFileNameMatches: null,
         searchTruncated: false,
         searchScannedFiles: 0,
         searchFailedFiles: 0
@@ -723,11 +795,12 @@ export const useFileExplorerStore = create<FileExplorerState>((set, get) => ({
     const activeRequestId = get().searchRequestId
     if (activeRequestId > 0) {
       void filesystemApi.searchContentStreamCancel(`search-${activeRequestId}`)
+      void filesystemApi.searchFileNamesStreamCancel(`search-${activeRequestId}`)
     }
     set({
       searchQuery: '',
       searchResults: [],
-      searchFileNameMatches: [],
+      searchFileNameMatches: null,
       searchLoading: false,
       searchError: null,
       searchTruncated: false,

--- a/src/shared/types/ipc.types.ts
+++ b/src/shared/types/ipc.types.ts
@@ -374,6 +374,14 @@ import type {
 export type FileChangeCallback = (event: FileChangeEvent) => void
 
 // Filesystem API for renderer
+export type SearchStreamErrorCode =
+  | 'QUERY_TOO_LONG'
+  | 'PATH_VALIDATION_FAILED'
+  | 'RG_SPAWN_FAILED'
+  | 'RG_STDOUT_CAPTURE_FAILED'
+  | 'RG_STREAM_FAILED'
+  | (string & {})
+
 export interface FilesystemApi {
   readDirectory: (dirPath: string) => Promise<IpcResult<DirectoryEntry[]>>
   readFile: (filePath: string) => Promise<IpcResult<FileContent>>
@@ -404,13 +412,7 @@ export interface FilesystemApi {
       scannedFiles: number
       failedFiles: number
       /** Mirror of `SearchFileNamesDoneEvent.code` — see that field for values. */
-      code?:
-        | 'QUERY_TOO_LONG'
-        | 'PATH_VALIDATION_FAILED'
-        | 'RG_SPAWN_FAILED'
-        | 'RG_STDOUT_CAPTURE_FAILED'
-        | 'RG_STREAM_FAILED'
-        | (string & {})
+      code?: SearchStreamErrorCode
       error?: string
     }) => void
   ) => () => void
@@ -431,19 +433,14 @@ export interface FilesystemApi {
       totalFiles: number
       /**
        * Programmatic error code. One of:
-       * - `QUERY_TOO_LONG`        — query exceeded `MAX_SEARCH_QUERY_LEN`.
+       * - `QUERY_TOO_LONG`         — query exceeded `MAX_SEARCH_QUERY_LEN`.
        * - `PATH_VALIDATION_FAILED` — scope/root failed `validate_search_path`.
-       * - `RG_SPAWN_FAILED`       — ripgrep binary missing, stdout could not
-       *   be captured, or rg exited with a non-zero status other than
-       *   `1` (no matches).
+       * - `RG_SPAWN_FAILED`        — ripgrep binary failed to start.
+       * - `RG_STDOUT_CAPTURE_FAILED` — stdout pipe could not be captured.
+       * - `RG_STREAM_FAILED`       — stdout read failed, or rg exited with a
+       *   non-zero status other than `1` (no matches).
        */
-      code?:
-        | 'QUERY_TOO_LONG'
-        | 'PATH_VALIDATION_FAILED'
-        | 'RG_SPAWN_FAILED'
-        | 'RG_STDOUT_CAPTURE_FAILED'
-        | 'RG_STREAM_FAILED'
-        | (string & {})
+      code?: SearchStreamErrorCode
       error?: string
     }) => void
   ) => () => void

--- a/src/shared/types/ipc.types.ts
+++ b/src/shared/types/ipc.types.ts
@@ -411,7 +411,7 @@ export interface FilesystemApi {
       truncated: boolean
       scannedFiles: number
       failedFiles: number
-      /** Mirror of `SearchFileNamesDoneEvent.code` — see that field for values. */
+      /** See `SearchStreamErrorCode` for possible values. */
       code?: SearchStreamErrorCode
       error?: string
     }) => void

--- a/src/shared/types/ipc.types.ts
+++ b/src/shared/types/ipc.types.ts
@@ -406,11 +406,24 @@ export interface FilesystemApi {
       error?: string
     }) => void
   ) => () => void
-  searchFileNames: (
+  searchFileNamesStreamStart: (
+    searchId: string,
     scopeRoot: string,
     rootPath: string,
     query: string
-  ) => Promise<IpcResult<{ files: string[]; truncated: boolean }>>
+  ) => Promise<IpcResult<void>>
+  searchFileNamesStreamCancel: (searchId: string) => Promise<IpcResult<void>>
+  onSearchFileNamesBatch: (
+    callback: (event: { searchId: string; files: string[]; truncated: boolean }) => void
+  ) => () => void
+  onSearchFileNamesDone: (
+    callback: (event: {
+      searchId: string
+      truncated: boolean
+      totalFiles: number
+      error?: string
+    }) => void
+  ) => () => void
   writeFile: (filePath: string, content: string) => Promise<IpcResult<void>>
   createFile: (filePath: string, content?: string) => Promise<IpcResult<void>>
   createDirectory: (dirPath: string) => Promise<IpcResult<void>>

--- a/src/shared/types/ipc.types.ts
+++ b/src/shared/types/ipc.types.ts
@@ -403,6 +403,14 @@ export interface FilesystemApi {
       truncated: boolean
       scannedFiles: number
       failedFiles: number
+      /** Mirror of `SearchFileNamesDoneEvent.code` — see that field for values. */
+      code?:
+        | 'QUERY_TOO_LONG'
+        | 'PATH_VALIDATION_FAILED'
+        | 'RG_SPAWN_FAILED'
+        | 'RG_STDOUT_CAPTURE_FAILED'
+        | 'RG_STREAM_FAILED'
+        | (string & {})
       error?: string
     }) => void
   ) => () => void
@@ -414,13 +422,28 @@ export interface FilesystemApi {
   ) => Promise<IpcResult<void>>
   searchFileNamesStreamCancel: (searchId: string) => Promise<IpcResult<void>>
   onSearchFileNamesBatch: (
-    callback: (event: { searchId: string; files: string[]; truncated: boolean }) => void
+    callback: (event: { searchId: string; files: string[]; truncated?: boolean }) => void
   ) => () => void
   onSearchFileNamesDone: (
     callback: (event: {
       searchId: string
       truncated: boolean
       totalFiles: number
+      /**
+       * Programmatic error code. One of:
+       * - `QUERY_TOO_LONG`        — query exceeded `MAX_SEARCH_QUERY_LEN`.
+       * - `PATH_VALIDATION_FAILED` — scope/root failed `validate_search_path`.
+       * - `RG_SPAWN_FAILED`       — ripgrep binary missing, stdout could not
+       *   be captured, or rg exited with a non-zero status other than
+       *   `1` (no matches).
+       */
+      code?:
+        | 'QUERY_TOO_LONG'
+        | 'PATH_VALIDATION_FAILED'
+        | 'RG_SPAWN_FAILED'
+        | 'RG_STDOUT_CAPTURE_FAILED'
+        | 'RG_STREAM_FAILED'
+        | (string & {})
       error?: string
     }) => void
   ) => () => void


### PR DESCRIPTION
## Summary

The file-name search in the file explorer was reporting `0` file results even when obvious matches existed, so users concluded the feature was broken. Root cause: the filename search Tauri command used a single-threaded `std::fs::read_dir` walk while the content search was already ripgrep-streamed. On large trees the synchronous walk never completed before the user gave up, and the count flashed a misleading `0` while the walker was still running. Issue: gnoviawan/termul#195.

This PR replaces the synchronous walker with a multi-threaded `rg --files --iglob` stream, mirrors the existing content-stream architecture for filename search, and applies a 2-pass review hardening to surface the right error code, capture trailing rg exit status, and prevent a stuck rg process from outliving the explorer unmount.

Three commits:

1. **`4e8b32d` — gh-195 root fix** — streaming search
   - `search_file_names` → `search_file_names_stream` + `search_file_names_cancel`
   - `rg --files --iglob '**/*{escaped_query}*'` (escapes glob meta, `**` for depth)
   - Streams `search-file-names-batch` / `search-file-names-done` events
   - Caps query at `MAX_SEARCH_QUERY_LEN=500`, surfaces `QUERY_TOO_LONG` code
   - Cancels in-flight stream on every new search, root change, worktree change, reset
   - Pending indicator (`searchFileNameMatches: null` → `…`) so the count is not a misleading `0`
   - Reaps the child, propagates non-zero exit status (other than 1 = "no matches")
   - Excludes `Thumbs.db`, `desktop.ini`, `.DS_Store`, `.env`

2. **`e801aa3` — gh-195 patch round 2** — review hardening (8 patches + 1 follow-on)
   - Splits the over-broad `RG_SPAWN_FAILED` into `RG_SPAWN_FAILED` (real spawn failure), `RG_STDOUT_CAPTURE_FAILED` (pipe-already-closed), `RG_STREAM_FAILED` (catch-all for stdout I/O errors and non-zero rg exits)
   - Wires the new `code` field through the shared `FilesystemApi` type and surfaces it in the renderer as `searchErrorCode`; cleared in every state transition
   - Content stream now actually reaps the child and propagates exit status into the trailing done event (was always emitting `code: None, error: None`)
   - `strip_verbatim_prefix` returns `Cow<'_, str>` to avoid per-line allocation in the rg-output hot path; drops unconditional `trim_start()` that was incorrectly stripping leading whitespace from relative paths
   - All `void filesystemApi.{searchContent,searchFileNames}StreamCancel(...)` calls replaced with `.catch(console.warn)` so a stuck rg process is at least visible
   - Unmount cleanup captures `searchRequestId` at effect **setup** time (was cleanup time, so a new search started between setup and cleanup was wrongly cancelled)
   - Drops the tautological `chars().count()` test, adds 4 Rust coverage tests + 5 renderer regression tests
   - Follow-on fix in the post-implementation review: `searchInRoot` early-return paths (`!rootPath`, `trimmed.length < 2`) were clearing `searchError` but not `searchErrorCode`; fixed and covered by 3 new store tests

3. **`20b132f` — pty forward-compat fix** — small companion
   - Upstream #352 added a call to `path_validation::strip_verbatim_prefix` in `pty/manager.rs` assuming the old `String` return type, but the gh-195 patch round changed the signature to `Cow<'_, str>` to avoid per-line allocation. The bare `Cow` no longer satisfies `cmd.cwd()`'s `AsRef<OsStr>` bound and the `TerminalInstance.cwd: String` / `TerminalInfo.cwd: String` struct fields. Adds `.into_owned()` at the single call site. Verified: clippy clean, all 239 cargo tests pass.

## Related Issue

Closes #195

## Type of Change

- [x] fix: bug fix
- [x] refactor: internal cleanup with no behavior change (Cow<str> allocation, error code split)
- [x] test: adds or updates tests (5 new renderer + 4 new Rust)

## What Changed

**Renderer (TypeScript / React)**
- `src/renderer/stores/file-explorer-store.ts` — adds `searchErrorCode` slot, mirrors content-stream subscription pattern for filename stream, `…` pending indicator, cancel on every state transition
- `src/renderer/components/file-explorer/FileExplorer.tsx` — unmount cancel useEffect captures `searchRequestId` at setup time
- `src/renderer/lib/tauri-filesystem-api.ts` — new `onSearchFileNamesBatch` / `onSearchFileNamesDone` / `searchFileNamesStreamCancel`
- `src/shared/types/ipc.types.ts` — new `FilesystemApi` methods + event types + `code` union

**Backend (Rust)**
- `src-tauri/src/commands.rs` — `search_file_names_stream` + `search_file_names_cancel` Tauri commands; argv builder that escapes rg glob metacharacters; `search_content_stream` reaps child + captures exit status; `SearchFileNamesCancelRequest` distinct from `SearchContentCancelRequest`; serde `code` field on both `SearchContentDoneEvent` / `SearchFileNamesDoneEvent`
- `src-tauri/src/path_validation.rs` — `strip_verbatim_prefix` returns `Cow<'_, str>`; tests use `.as_ref()`
- `src-tauri/src/pty/manager.rs` — `.into_owned()` at the new `strip_verbatim_prefix` call site (forward-compat with the `Cow<str>` signature)

**Tests**
- `src-tauri/src/commands.rs` (test module) — 4 new tests: argv escaping for glob meta, ignore list, root path passthrough, serde `code` field shape, batch event `truncated: Option<bool>` serde, distinct cancel request DTO. Drops the tautological `chars().count()` test.
- `src/renderer/components/file-explorer/FileExplorer.test.tsx` — 2 unmount-cancel regression tests + `vi.mock('@/lib/api', ...)` infrastructure + static `useFileExplorerStore` import with `as unknown as FileExplorerState` cast for the partial mock
- `src/renderer/stores/file-explorer-store.test.ts` — 3 new tests for the `searchErrorCode` reset behavior in `searchInRoot` early-return paths; added `searchContent/FileNamesStreamCancel` and `onSearch*` mocks to `mockApi.filesystem`

## How It Was Tested

- [x] `bun run ci` (Biome lint + format + imports, strict mode)
- [x] `bun run typecheck`
- [x] `bun run test` (1696/1696 passing, 3 new in store, 2 new in FileExplorer)
- [x] `cargo clippy --all-targets -- -D warnings` (in src-tauri)
- [x] `cargo test` (in src-tauri) — 239/239 passing
- [x] Manual verification completed
- [ ] Not applicable

Note: rebased cleanly on top of upstream `gnoviawan/termul:dev` (bf7baf4 v0.4.7) and re-ran the full CI gate after a small `strip_verbatim_prefix` Cow-vs-String forward-compat fix in pty/manager.rs (commit 20b132f).

## CI & Review Gate

- [ ] All CI checks pass (PR Validation, Rust Checks, Build Verification, Security Scans)
- [ ] Code review comments from CodeRabbit / Claude have been addressed or resolved
- [ ] No unresolved review findings remain

Local pre-push verification (all green):

```
bun run ci                 # biome: 0 errors, 277 pre-existing a11y warnings (not from this PR)
bun run typecheck          # clean
bun run test               # 1696/1696 passing
cargo clippy --all-targets # clean
cargo test --lib           # 239/239 passing
```

## Checklist

- [x] My PR title follows the conventional commit format used by this repo
- [x] I linked the related issue or explained why none exists
- [x] I updated docs when needed (N/A — internal refactor, behavior is back-compat except for the new `code` field which is additive)
- [x] I added or updated tests when needed
- [x] I verified the change does not introduce unrelated modifications
- [x] I read AGENTS.md and followed the contributor guidelines
- [x] A human reviewed the complete diff before submission


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * File-name search now streams results progressively, with dedicated start and cancel support.
* **Bug Fixes**
  * Improved Windows path handling for more reliable searching.
  * Added query-length limits with clear “query too long” completion signaling.
* **Documentation**
  * Standardized streamed search “done” outcomes now expose optional error codes for easier handling.
* **Tests**
  * Expanded coverage for streaming cancellation, pending-to-results UI behavior, and error-code reset/handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->