### PR TITLE
fix(acp): surface agent error messages when session_id is None

### DIFF
--- a/src/renderer/components/chat/AgentHeader.tsx
+++ b/src/renderer/components/chat/AgentHeader.tsx
@@ -145,6 +145,13 @@ export function AgentHeader({ session, agentStatus }: AgentHeaderProps): React.J
   const isClosed = session.status === 'closed'
   const effectiveStatus: AgentStatus | undefined = isClosed ? 'error' : agentStatus
 
+  let statusLabel: string
+  if (isClosed) {
+    statusLabel = session.lastError ?? 'closed'
+  } else {
+    statusLabel = effectiveStatus ?? 'idle'
+  }
+
   return (
     <div className="flex items-center gap-2 bg-transparent px-3 py-1.5">
       <AgentBadge
@@ -160,9 +167,7 @@ export function AgentHeader({ session, agentStatus }: AgentHeaderProps): React.J
           STATUS_COLOR[effectiveStatus ?? 'idle'] ?? 'text-muted-foreground'
         )}
       />
-      <span className="text-[11px] text-muted-foreground">
-        {isClosed ? 'closed' : (effectiveStatus ?? 'idle')}
-      </span>
+      <span className="text-[11px] text-muted-foreground">{statusLabel}</span>
     </div>
   )
 }

--- a/src/renderer/stores/acp-store.test.ts
+++ b/src/renderer/stores/acp-store.test.ts
@@ -1215,6 +1215,99 @@ describe('acp-store multi-project isolation', () => {
     expect(identity).toEqual({ name: 'Claude', templateId: 'claude-acp' })
   })
 
+  it('agent_error with session_id sets lastError on that session', () => {
+    seedSession('s1', 'agent-1')
+    useAcpStore.getState()._onAgentError({
+      agentId: 'agent-1',
+      sessionId: 's1',
+      message: 'credit limit exceeded'
+    })
+    expect(useAcpStore.getState().agentStatus['agent-1']).toBe('error')
+    expect(useAcpStore.getState().sessions['s1'].lastError).toBe('credit limit exceeded')
+    expect(useAcpStore.getState().sessions['s1'].activeTurn).toBe(false)
+  })
+
+  it('agent_error with session_id None sets lastError on all sessions for that agent', () => {
+    seedSession('s1', 'agent-1')
+    seedSession('s2', 'agent-1')
+    // seedSession overwrites; re-seed both
+    useAcpStore.setState({
+      sessions: {
+        s1: {
+          id: 's1',
+          agentId: 'agent-1',
+          cwd: '/work',
+          status: 'active',
+          title: null,
+          activeTurn: false,
+          openTurnId: null,
+          modes: null,
+          configOptions: [],
+          lastError: null,
+          createdAt: 0
+        },
+        s2: {
+          id: 's2',
+          agentId: 'agent-1',
+          cwd: '/work',
+          status: 'active',
+          title: null,
+          activeTurn: false,
+          openTurnId: null,
+          modes: null,
+          configOptions: [],
+          lastError: null,
+          createdAt: 0
+        }
+      }
+    })
+    useAcpStore.getState()._onAgentError({
+      agentId: 'agent-1',
+      message: 'insufficient credit'
+    })
+    expect(useAcpStore.getState().agentStatus['agent-1']).toBe('error')
+    expect(useAcpStore.getState().sessions['s1'].lastError).toBe('insufficient credit')
+    expect(useAcpStore.getState().sessions['s2'].lastError).toBe('insufficient credit')
+  })
+
+  it('agent_error followed by agent_disconnected preserves lastError on closed sessions', () => {
+    seedSession('s1', 'agent-1')
+    useAcpStore.getState()._onAgentError({
+      agentId: 'agent-1',
+      message: 'fatal: api key revoked'
+    })
+    useAcpStore.getState()._onAgentDisconnected({ agentId: 'agent-1' })
+    expect(useAcpStore.getState().sessions['s1'].status).toBe('closed')
+    expect(useAcpStore.getState().sessions['s1'].lastError).toBe('fatal: api key revoked')
+  })
+
+  it('stop reasons end_turn and cancelled produce no error note', () => {
+    seedSession('s1', 'agent-1')
+    useAcpStore.getState()._onPromptComplete({
+      agentId: 'agent-1',
+      sessionId: 's1',
+      stopReason: 'end_turn'
+    })
+    expect(useAcpStore.getState().sessions['s1'].lastError).toBeNull()
+    seedSession('s2', 'agent-1')
+    useAcpStore.getState()._onPromptComplete({
+      agentId: 'agent-1',
+      sessionId: 's2',
+      stopReason: 'cancelled'
+    })
+    expect(useAcpStore.getState().sessions['s2'].lastError).toBeNull()
+  })
+
+  it('unknown stop reasons surface a descriptive note instead of being silently dropped', () => {
+    seedSession('s1', 'agent-1')
+    useAcpStore.getState()._onPromptComplete({
+      agentId: 'agent-1',
+      sessionId: 's1',
+      stopReason: 'insufficient_credit'
+    })
+    expect(useAcpStore.getState().sessions['s1'].lastError).toMatch(/insufficient_credit/i)
+  })
+
   it('selectConfigWarmState rolls up status across all per-cwd processes', () => {
     useAcpStore.setState((s) => ({
       agentStatus: { ...s.agentStatus, 'agent-a': 'needs-auth', 'agent-b': 'connected' },

--- a/src/renderer/stores/acp-store.ts
+++ b/src/renderer/stores/acp-store.ts
@@ -282,9 +282,11 @@ function noteForStopReason(reason: StopReason): string | null {
       return 'Response stopped: token limit reached.'
     case 'max_turn_requests':
       return 'Response stopped: too many tool-call rounds.'
-    default:
-      // 'end_turn' and 'cancelled' are expected completions — no error note.
+    case 'end_turn':
+    case 'cancelled':
       return null
+    default:
+      return `Response stopped: ${reason}`
   }
 }
 
@@ -1383,7 +1385,18 @@ export const useAcpStore = create<AcpState>((set, get) => ({
           }
         }
       }
-      return { agentStatus }
+      const sessions = { ...s.sessions }
+      for (const id of Object.keys(sessions)) {
+        if (sessions[id].agentId === e.agentId && sessions[id].status !== 'closed') {
+          sessions[id] = {
+            ...sessions[id],
+            lastError: e.message,
+            activeTurn: false,
+            openTurnId: null
+          }
+        }
+      }
+      return { agentStatus, sessions }
     }),
 
   _onAuthRequired: (e) =>


### PR DESCRIPTION
## Problem

When using opencode ACP and selecting an AI model with an account that has insufficient credit, the chat UI showed only "closed" / red dot without surfacing the actual error message.

**Root cause:** Two gaps in the error propagation chain:

1. **`_onAgentError` dropped error when `session_id` is `None`** — connection-level agent errors (crash, insufficient credit, API key revoked) emit `acp:agent_error` with `session_id: None`, but the frontend reducer only stored the message when `session_id` was non-null. The error was silently discarded.

2. **`noteForStopReason` returned `null` for unknown stop reasons** — if the agent completed a turn with a non-standard stop reason, it fell through to `default: null`, silently swallowing the reason.

## Changes

| File | Change |
|------|--------|
| `src/renderer/stores/acp-store.ts` | `_onAgentError`: when `session_id` is `None`, propagate the error to all active sessions for that agent |
| `src/renderer/stores/acp-store.ts` | `noteForStopReason`: return descriptive note for unknown stop reasons instead of silently returning `null` |
| `src/renderer/components/chat/AgentHeader.tsx` | Show `session.lastError` as the status label when session is closed |
| `src/renderer/stores/acp-store.test.ts` | 5 new tests covering each scenario |

## Verification

- TypeScript typecheck: ✅
- Biome lint/format: ✅
- All 1694 tests passing: ✅
- New tests verify:
  - Error with session_id → sets lastError on that session
  - Error without session_id → sets lastError on all agent sessions
  - Error followed by disconnect → preserves lastError
  - Unknown stop reasons → descriptive note displayed
  - end_turn/cancelled → still produce no error note

Closes #370

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved agent status display to correctly show error messages and connection states
  * Enhanced error handling to properly propagate agent errors across affected sessions
  * Refined handling of agent completion states and stop reasons

* **Tests**
  * Added comprehensive test coverage for agent error handling and session state management

<!-- end of auto-generated comment: release notes by coderabbit.ai -->