### PR TITLE
feat(settings): add category sidebar with fuzzy search to settings pages

### DIFF
--- a/src/renderer/components/settings/AcpAgentsSettings.tsx
+++ b/src/renderer/components/settings/AcpAgentsSettings.tsx
@@ -216,7 +216,7 @@ export function AcpAgentsSettings(): React.JSX.Element {
         />
       </div>
 
-      <div className="space-y-2">
+      <div className="max-h-80 space-y-2 overflow-y-auto pr-1">
         {visible.length === 0 ? (
           <p className="py-4 text-center text-xs text-muted-foreground">No agents match.</p>
         ) : (

--- a/src/renderer/components/settings/SettingsLayout.test.tsx
+++ b/src/renderer/components/settings/SettingsLayout.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from '@testing-library/react'
+import { act, fireEvent, render, screen } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type { SettingsSearchEntry } from '@/lib/settings-search'
 import { type SettingsCategory, SettingsLayout, SettingsSection } from './SettingsLayout'
@@ -6,18 +6,43 @@ import { type SettingsCategory, SettingsLayout, SettingsSection } from './Settin
 // jsdom does not implement these; the layout uses them for navigation/scroll-spy.
 window.HTMLElement.prototype.scrollIntoView = vi.fn()
 
+// Capture the most recent observer so tests can drive intersection callbacks.
+let lastObserver: IntersectionObserverMock | null = null
+
 class IntersectionObserverMock {
-  observe = vi.fn()
+  callback: IntersectionObserverCallback
+  observed: Element[] = []
   unobserve = vi.fn()
   disconnect = vi.fn()
   takeRecords = vi.fn(() => [])
   root = null
   rootMargin = ''
   thresholds = []
-  constructor(_cb: IntersectionObserverCallback) {}
+  constructor(cb: IntersectionObserverCallback) {
+    this.callback = cb
+    lastObserver = this
+  }
+  observe = (el: Element): void => {
+    this.observed.push(el)
+  }
+  /** Test helper: fire the callback with the given section intersections. */
+  emit(items: Array<{ id: string; isIntersecting: boolean; top: number }>): void {
+    const entries = items.map((item) => {
+      const target = this.observed.find(
+        (el) => (el as HTMLElement).dataset.settingsSection === item.id
+      )
+      return {
+        target,
+        isIntersecting: item.isIntersecting,
+        boundingClientRect: { top: item.top } as DOMRectReadOnly
+      } as IntersectionObserverEntry
+    })
+    this.callback(entries, this as unknown as IntersectionObserver)
+  }
 }
 
 beforeEach(() => {
+  lastObserver = null
   vi.stubGlobal('IntersectionObserver', IntersectionObserverMock)
   ;(window.HTMLElement.prototype.scrollIntoView as ReturnType<typeof vi.fn>).mockClear()
 })
@@ -121,5 +146,24 @@ describe('SettingsLayout', () => {
     expect(search.value).toBe('')
     // Category buttons return after clearing.
     expect(screen.getByRole('button', { name: 'Updates' })).toBeInTheDocument()
+  })
+
+  it('activates the section nearest the viewport top via scroll-spy', () => {
+    renderLayout()
+    expect(lastObserver).not.toBeNull()
+
+    // "shell" is scrolled partway past the top (large negative top) while
+    // "updates" sits just below the viewport edge. The section closest to 0
+    // should win, not the one with the smallest raw top.
+    act(() => {
+      lastObserver?.emit([
+        { id: 'appearance', isIntersecting: false, top: -600 },
+        { id: 'shell', isIntersecting: true, top: -200 },
+        { id: 'updates', isIntersecting: true, top: 20 }
+      ])
+    })
+
+    expect(screen.getByRole('button', { name: 'Updates' })).toHaveAttribute('aria-current', 'true')
+    expect(screen.getByRole('button', { name: 'Shell' })).not.toHaveAttribute('aria-current')
   })
 })

--- a/src/renderer/components/settings/SettingsLayout.test.tsx
+++ b/src/renderer/components/settings/SettingsLayout.test.tsx
@@ -1,0 +1,125 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { SettingsSearchEntry } from '@/lib/settings-search'
+import { type SettingsCategory, SettingsLayout, SettingsSection } from './SettingsLayout'
+
+// jsdom does not implement these; the layout uses them for navigation/scroll-spy.
+window.HTMLElement.prototype.scrollIntoView = vi.fn()
+
+class IntersectionObserverMock {
+  observe = vi.fn()
+  unobserve = vi.fn()
+  disconnect = vi.fn()
+  takeRecords = vi.fn(() => [])
+  root = null
+  rootMargin = ''
+  thresholds = []
+  constructor(_cb: IntersectionObserverCallback) {}
+}
+
+beforeEach(() => {
+  vi.stubGlobal('IntersectionObserver', IntersectionObserverMock)
+  ;(window.HTMLElement.prototype.scrollIntoView as ReturnType<typeof vi.fn>).mockClear()
+})
+
+const categories: SettingsCategory[] = [
+  { id: 'appearance', label: 'Appearance' },
+  { id: 'shell', label: 'Shell' },
+  { id: 'updates', label: 'Updates' }
+]
+
+const searchIndex: SettingsSearchEntry[] = [
+  { categoryId: 'appearance', label: 'Font Family', description: 'monospace font' },
+  { categoryId: 'shell', label: 'Default Shell', keywords: ['bash'] },
+  { categoryId: 'updates', label: 'Auto-update', description: 'check for updates' }
+]
+
+function renderLayout() {
+  return render(
+    <SettingsLayout categories={categories} searchIndex={searchIndex}>
+      <SettingsSection id="appearance">
+        <h2>Appearance</h2>
+      </SettingsSection>
+      <SettingsSection id="shell">
+        <h2>Shell</h2>
+      </SettingsSection>
+      <SettingsSection id="updates">
+        <h2>Updates</h2>
+      </SettingsSection>
+    </SettingsLayout>
+  )
+}
+
+describe('SettingsLayout', () => {
+  it('renders all categories in the sidebar', () => {
+    renderLayout()
+    const nav = screen.getByRole('navigation', { name: /settings categories/i })
+    expect(nav).toBeInTheDocument()
+    for (const category of categories) {
+      expect(screen.getByRole('button', { name: category.label })).toBeInTheDocument()
+    }
+  })
+
+  it('marks the first category active by default', () => {
+    renderLayout()
+    expect(screen.getByRole('button', { name: 'Appearance' })).toHaveAttribute(
+      'aria-current',
+      'true'
+    )
+  })
+
+  it('scrolls to a section and activates it when a category is clicked', () => {
+    renderLayout()
+    const shellButton = screen.getByRole('button', { name: 'Shell' })
+    fireEvent.click(shellButton)
+    expect(window.HTMLElement.prototype.scrollIntoView).toHaveBeenCalled()
+    expect(shellButton).toHaveAttribute('aria-current', 'true')
+  })
+
+  it('renders the section content tagged with the category id', () => {
+    const { container } = renderLayout()
+    expect(container.querySelector('[data-settings-section="appearance"]')).toBeInTheDocument()
+    expect(container.querySelector('#settings-section-shell')).toBeInTheDocument()
+  })
+
+  it('filters to matching settings when searching', () => {
+    renderLayout()
+    const search = screen.getByLabelText('Search settings')
+    fireEvent.change(search, { target: { value: 'font' } })
+    expect(screen.getByText('Font Family')).toBeInTheDocument()
+    // Non-matching categories are not shown as plain category buttons while searching.
+    expect(screen.queryByRole('button', { name: 'Updates' })).not.toBeInTheDocument()
+  })
+
+  it('matches a setting via keywords', () => {
+    renderLayout()
+    const search = screen.getByLabelText('Search settings')
+    fireEvent.change(search, { target: { value: 'bash' } })
+    expect(screen.getByText('Default Shell')).toBeInTheDocument()
+  })
+
+  it('shows an empty state when no settings match', () => {
+    renderLayout()
+    const search = screen.getByLabelText('Search settings')
+    fireEvent.change(search, { target: { value: 'zzzzz' } })
+    expect(screen.getByText(/no settings match/i)).toBeInTheDocument()
+  })
+
+  it('selecting a search result scrolls to its section', () => {
+    renderLayout()
+    const search = screen.getByLabelText('Search settings')
+    fireEvent.change(search, { target: { value: 'font' } })
+    fireEvent.click(screen.getByText('Font Family'))
+    expect(window.HTMLElement.prototype.scrollIntoView).toHaveBeenCalled()
+  })
+
+  it('clears the search when the clear button is pressed', () => {
+    renderLayout()
+    const search = screen.getByLabelText('Search settings') as HTMLInputElement
+    fireEvent.change(search, { target: { value: 'font' } })
+    fireEvent.click(screen.getByLabelText('Clear search'))
+    expect(search.value).toBe('')
+    // Category buttons return after clearing.
+    expect(screen.getByRole('button', { name: 'Updates' })).toBeInTheDocument()
+  })
+})

--- a/src/renderer/components/settings/SettingsLayout.tsx
+++ b/src/renderer/components/settings/SettingsLayout.tsx
@@ -112,10 +112,14 @@ export function SettingsLayout({
     const recompute = (): void => {
       if (programmaticScrollRef.current) return
       let topId: string | undefined
-      let topValue = Number.POSITIVE_INFINITY
+      let bestDistance = Number.POSITIVE_INFINITY
+      // Pick the section whose top edge is closest to the viewport top (0),
+      // not the smallest raw value — sections scrolled past have large negative
+      // tops while still intersecting, and must not stay active.
       for (const [id, top] of visible) {
-        if (top < topValue) {
-          topValue = top
+        const distance = Math.abs(top)
+        if (distance < bestDistance) {
+          bestDistance = distance
           topId = id
         }
       }

--- a/src/renderer/components/settings/SettingsLayout.tsx
+++ b/src/renderer/components/settings/SettingsLayout.tsx
@@ -1,0 +1,263 @@
+import { Search, X } from 'lucide-react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { type SettingsSearchEntry, searchSettings } from '@/lib/settings-search'
+import { cn } from '@/lib/utils'
+
+/** A settings category shown in the left sidebar. */
+export interface SettingsCategory {
+  /** Stable id; also used as the scroll anchor target (`data-settings-section`). */
+  id: string
+  /** Sidebar label. */
+  label: string
+  /** Optional icon rendered before the label. */
+  icon?: React.ReactNode
+}
+
+interface SettingsLayoutProps {
+  /** Categories to render in the sidebar, in display order. */
+  categories: SettingsCategory[]
+  /** Flat search index across every category. */
+  searchIndex: readonly SettingsSearchEntry[]
+  /**
+   * Section content. Each section must be wrapped so its root carries
+   * `data-settings-section="<categoryId>"` — use {@link SettingsSection}.
+   */
+  children: React.ReactNode
+  /** Optional extra content rendered at the bottom of the sidebar. */
+  sidebarFooter?: React.ReactNode
+}
+
+/**
+ * Wrapper for a single settings section. Tags the section with its category id
+ * so {@link SettingsLayout} can scroll to it and track the active category via
+ * scroll-spy. The `id` doubles as a stable DOM id (`settings-section-<id>`) for
+ * anchor-based navigation.
+ */
+export function SettingsSection({
+  id,
+  children,
+  className
+}: {
+  id: string
+  children: React.ReactNode
+  className?: string
+}): React.JSX.Element {
+  return (
+    <section
+      id={`settings-section-${id}`}
+      data-settings-section={id}
+      className={cn('scroll-mt-4', className)}
+    >
+      {children}
+    </section>
+  )
+}
+
+/**
+ * Shared settings shell: a left sidebar listing categories with the active one
+ * highlighted, a fuzzy search box, and a scrollable content area. Clicking a
+ * category (or selecting a search result) scrolls the matching section into
+ * view; scroll-spy keeps the active category in sync while the user scrolls.
+ *
+ * The content remains a single scrollable column (scroll-spy navigation rather
+ * than show-one-at-a-time) so the existing save bar and unsaved-changes guard
+ * in ProjectSettings keep working unchanged.
+ */
+export function SettingsLayout({
+  categories,
+  searchIndex,
+  children,
+  sidebarFooter
+}: SettingsLayoutProps): React.JSX.Element {
+  const contentRef = useRef<HTMLDivElement | null>(null)
+  const [activeId, setActiveId] = useState<string | undefined>(categories[0]?.id)
+  const [query, setQuery] = useState('')
+  // While a programmatic scroll is in flight, suppress scroll-spy so the active
+  // highlight follows the click target rather than intermediate sections.
+  const programmaticScrollRef = useRef(false)
+  const programmaticTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  const results = useMemo(() => searchSettings(query, searchIndex), [query, searchIndex])
+  const isSearching = query.trim().length > 0
+
+  const scrollToSection = useCallback((id: string, anchorId?: string) => {
+    const root = contentRef.current
+    if (!root) return
+
+    const target =
+      (anchorId && root.querySelector<HTMLElement>(`#${CSS.escape(anchorId)}`)) ||
+      root.querySelector<HTMLElement>(`[data-settings-section="${CSS.escape(id)}"]`)
+    if (!target) return
+
+    programmaticScrollRef.current = true
+    if (programmaticTimerRef.current) clearTimeout(programmaticTimerRef.current)
+    programmaticTimerRef.current = setTimeout(() => {
+      programmaticScrollRef.current = false
+    }, 600)
+
+    setActiveId(id)
+    target.scrollIntoView({ behavior: 'smooth', block: 'start' })
+  }, [])
+
+  // Scroll-spy: highlight the section nearest the top of the viewport.
+  useEffect(() => {
+    const root = contentRef.current
+    if (!root || categories.length === 0) return
+
+    const sections = Array.from(root.querySelectorAll<HTMLElement>('[data-settings-section]'))
+    if (sections.length === 0) return
+
+    const visible = new Map<string, number>()
+
+    const recompute = (): void => {
+      if (programmaticScrollRef.current) return
+      let topId: string | undefined
+      let topValue = Number.POSITIVE_INFINITY
+      for (const [id, top] of visible) {
+        if (top < topValue) {
+          topValue = top
+          topId = id
+        }
+      }
+      if (topId) setActiveId(topId)
+    }
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        for (const entry of entries) {
+          const id = (entry.target as HTMLElement).dataset.settingsSection
+          if (!id) continue
+          if (entry.isIntersecting) {
+            visible.set(id, entry.boundingClientRect.top)
+          } else {
+            visible.delete(id)
+          }
+        }
+        recompute()
+      },
+      {
+        root,
+        threshold: [0, 0.1, 0.5],
+        rootMargin: '0px 0px -70% 0px'
+      }
+    )
+
+    for (const section of sections) observer.observe(section)
+
+    return () => {
+      observer.disconnect()
+      visible.clear()
+    }
+    // Re-run when the set of categories changes (sections added/removed).
+  }, [categories])
+
+  useEffect(() => {
+    return () => {
+      if (programmaticTimerRef.current) clearTimeout(programmaticTimerRef.current)
+    }
+  }, [])
+
+  const handleCategoryKeyDown = (
+    event: React.KeyboardEvent<HTMLButtonElement>,
+    index: number
+  ): void => {
+    if (event.key === 'ArrowDown' || event.key === 'ArrowUp') {
+      event.preventDefault()
+      const dir = event.key === 'ArrowDown' ? 1 : -1
+      const next = (index + dir + categories.length) % categories.length
+      const sidebar = event.currentTarget.parentElement
+      const buttons = sidebar?.querySelectorAll<HTMLButtonElement>('[data-category-button]')
+      buttons?.[next]?.focus()
+    }
+  }
+
+  return (
+    <div className="flex-1 flex min-h-0 overflow-hidden">
+      {/* Sidebar */}
+      <aside className="w-60 flex-shrink-0 border-r border-border bg-card/50 flex flex-col">
+        <div className="p-3 border-b border-border">
+          <div className="relative">
+            <Search
+              size={14}
+              className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground"
+            />
+            <input
+              type="text"
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              placeholder="Search settings..."
+              aria-label="Search settings"
+              className="w-full bg-secondary/50 border border-border rounded-md pl-8 pr-8 py-1.5 text-sm text-foreground focus:ring-2 focus:ring-primary focus:border-transparent outline-none transition-shadow"
+            />
+            {query && (
+              <button
+                type="button"
+                onClick={() => setQuery('')}
+                aria-label="Clear search"
+                className="absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground p-0.5 rounded"
+              >
+                <X size={14} />
+              </button>
+            )}
+          </div>
+        </div>
+
+        <nav aria-label="Settings categories" className="flex-1 overflow-y-auto p-2 space-y-0.5">
+          {isSearching ? (
+            results.length === 0 ? (
+              <p className="px-3 py-4 text-xs text-muted-foreground">
+                No settings match “{query.trim()}”.
+              </p>
+            ) : (
+              results.map((result) => (
+                <button
+                  key={`${result.categoryId}-${result.label}`}
+                  type="button"
+                  onClick={() => scrollToSection(result.categoryId, result.anchorId)}
+                  className="w-full flex flex-col items-start gap-0.5 text-left rounded-md px-3 py-2 text-sm text-foreground hover:bg-secondary focus:outline-none focus-visible:ring-2 focus-visible:ring-primary transition-colors"
+                >
+                  <span className="font-medium">{result.label}</span>
+                  <span className="text-[11px] text-muted-foreground">
+                    {categories.find((c) => c.id === result.categoryId)?.label}
+                  </span>
+                </button>
+              ))
+            )
+          ) : (
+            categories.map((category, index) => {
+              const isActive = category.id === activeId
+              return (
+                <button
+                  key={category.id}
+                  type="button"
+                  data-category-button
+                  aria-current={isActive ? 'true' : undefined}
+                  onClick={() => scrollToSection(category.id)}
+                  onKeyDown={(e) => handleCategoryKeyDown(e, index)}
+                  className={cn(
+                    'w-full flex items-center gap-2.5 rounded-md px-3 py-2 text-sm text-left transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-primary',
+                    isActive
+                      ? 'bg-primary/10 text-primary font-medium'
+                      : 'text-muted-foreground hover:bg-secondary hover:text-foreground'
+                  )}
+                >
+                  {category.icon && (
+                    <span className="flex-shrink-0 flex items-center">{category.icon}</span>
+                  )}
+                  <span className="truncate">{category.label}</span>
+                </button>
+              )
+            })
+          )}
+        </nav>
+
+        {sidebarFooter && <div className="p-2 border-t border-border">{sidebarFooter}</div>}
+      </aside>
+
+      {/* Content */}
+      <div ref={contentRef} className="flex-1 overflow-y-auto p-6 pb-32 min-w-0">
+        <div className="max-w-4xl mx-auto space-y-8">{children}</div>
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/lib/settings-search.test.ts
+++ b/src/renderer/lib/settings-search.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from 'vitest'
+import {
+  fuzzyScore,
+  type SettingsSearchEntry,
+  scoreEntry,
+  searchSettings
+} from '@/lib/settings-search'
+
+describe('fuzzyScore', () => {
+  it('returns 0 for an empty query', () => {
+    expect(fuzzyScore('', 'Font Family')).toBe(0)
+  })
+
+  it('matches a case-insensitive subsequence', () => {
+    expect(fuzzyScore('ff', 'Font Family')).not.toBeNull()
+    expect(fuzzyScore('FONT', 'font family')).not.toBeNull()
+  })
+
+  it('returns null when characters are not present in order', () => {
+    expect(fuzzyScore('zx', 'Font Family')).toBeNull()
+    expect(fuzzyScore('yltimaf', 'Font Family')).toBeNull()
+  })
+
+  it('returns null when the query is longer than the text', () => {
+    expect(fuzzyScore('abcdef', 'abc')).toBeNull()
+  })
+
+  it('scores consecutive matches higher than scattered ones', () => {
+    const consecutive = fuzzyScore('font', 'font family')
+    const scattered = fuzzyScore('fnt', 'font family')
+    expect(consecutive).not.toBeNull()
+    expect(scattered).not.toBeNull()
+    expect(consecutive as number).toBeGreaterThan(scattered as number)
+  })
+
+  it('rewards word-boundary matches', () => {
+    // Same query "fa": it starts a word (after the space) in "go fast" but is
+    // mid-word in "gofast". The boundary match should score higher.
+    const boundary = fuzzyScore('fa', 'go fast')
+    const midword = fuzzyScore('fa', 'gofast')
+    expect(boundary).not.toBeNull()
+    expect(midword).not.toBeNull()
+    expect(boundary as number).toBeGreaterThan(midword as number)
+  })
+})
+
+describe('scoreEntry', () => {
+  const entry: SettingsSearchEntry = {
+    categoryId: 'appearance',
+    label: 'Font Family',
+    description: 'Choose a monospace font for terminal text.',
+    keywords: ['typeface']
+  }
+
+  it('returns 0 for an empty query', () => {
+    expect(scoreEntry('', entry)).toBe(0)
+  })
+
+  it('weights a label match above a description-only match', () => {
+    // Same query in both fields: the label match should outrank a description match.
+    const labelEntry: SettingsSearchEntry = { categoryId: 'shell', label: 'Default Shell' }
+    const descEntry: SettingsSearchEntry = {
+      categoryId: 'updates',
+      label: 'Updates',
+      description: 'restart the shell after updating'
+    }
+    const labelMatch = scoreEntry('shell', labelEntry) as number
+    const descMatch = scoreEntry('shell', descEntry) as number
+    expect(labelMatch).not.toBeNull()
+    expect(descMatch).not.toBeNull()
+    expect(labelMatch).toBeGreaterThan(descMatch)
+  })
+
+  it('matches via keywords', () => {
+    expect(scoreEntry('typeface', entry)).not.toBeNull()
+  })
+
+  it('returns null when nothing matches', () => {
+    expect(scoreEntry('zzz', entry)).toBeNull()
+  })
+})
+
+describe('searchSettings', () => {
+  const index: SettingsSearchEntry[] = [
+    { categoryId: 'appearance', label: 'Font Family', description: 'monospace font' },
+    { categoryId: 'appearance', label: 'Font Size', description: 'adjust text size' },
+    { categoryId: 'updates', label: 'Auto-update', description: 'check for updates' },
+    { categoryId: 'shell', label: 'Default Shell', keywords: ['bash', 'zsh'] }
+  ]
+
+  it('returns an empty array for an empty or whitespace query', () => {
+    expect(searchSettings('', index)).toEqual([])
+    expect(searchSettings('   ', index)).toEqual([])
+  })
+
+  it('surfaces font settings for the query "font"', () => {
+    const results = searchSettings('font', index)
+    expect(results.length).toBeGreaterThanOrEqual(2)
+    expect(results.every((r) => r.label.startsWith('Font'))).toBe(true)
+  })
+
+  it('matches a setting through its keywords', () => {
+    const results = searchSettings('zsh', index)
+    expect(results[0]?.label).toBe('Default Shell')
+  })
+
+  it('sorts results by descending score', () => {
+    const results = searchSettings('update', index)
+    for (let i = 1; i < results.length; i++) {
+      expect(results[i - 1].score).toBeGreaterThanOrEqual(results[i].score)
+    }
+  })
+})

--- a/src/renderer/lib/settings-search.ts
+++ b/src/renderer/lib/settings-search.ts
@@ -1,0 +1,147 @@
+/**
+ * Lightweight fuzzy matching for the settings search box.
+ *
+ * Kept dependency-free and runtime-neutral so it can be unit tested under
+ * Vitest + jsdom without pulling in cmdk's React-bound command primitives.
+ * The settings UI only needs to match short labels/descriptions, so a
+ * subsequence matcher with simple proximity scoring is sufficient.
+ */
+
+/** A single searchable setting, flattened across all categories. */
+export interface SettingsSearchEntry {
+  /** Id of the category this setting belongs to. */
+  categoryId: string
+  /** Human-readable setting label (e.g. "Font Family"). */
+  label: string
+  /** Optional longer description used to broaden matches. */
+  description?: string
+  /** Extra search terms that should surface this setting. */
+  keywords?: string[]
+  /**
+   * Optional DOM id to scroll to when this result is selected. When omitted,
+   * selecting the result just switches to the owning category.
+   */
+  anchorId?: string
+}
+
+/** A scored search result. Higher score = better match. */
+export interface SettingsSearchResult extends SettingsSearchEntry {
+  score: number
+}
+
+/**
+ * Returns whether every character of `query` appears in `text` in order
+ * (case-insensitive subsequence match), plus a score. Returns `null` when
+ * there is no match.
+ *
+ * Scoring rewards: earlier first match, consecutive matches (no gaps), and
+ * matches at word boundaries — so "ff" ranks "Font Family" above an entry
+ * where the letters are scattered.
+ */
+export function fuzzyScore(query: string, text: string): number | null {
+  const q = query.toLowerCase()
+  const t = text.toLowerCase()
+
+  if (q.length === 0) return 0
+  if (q.length > t.length) return null
+
+  let score = 0
+  let textIndex = 0
+  let prevMatchIndex = -1
+
+  for (let i = 0; i < q.length; i++) {
+    const char = q[i]
+    const found = t.indexOf(char, textIndex)
+    if (found === -1) return null
+
+    // Reward consecutive matches (adjacent characters in the text).
+    if (prevMatchIndex !== -1 && found === prevMatchIndex + 1) {
+      score += 6
+    }
+
+    // Reward matches at the start of a word (start of string or after a
+    // separator), which strongly signals an intentional match.
+    const prevChar = found > 0 ? t[found - 1] : ' '
+    if (prevChar === ' ' || prevChar === '-' || prevChar === '_' || prevChar === '/') {
+      score += 4
+    }
+
+    // Penalize gaps between matched characters and a late first match.
+    if (prevMatchIndex !== -1) {
+      score -= Math.min(found - prevMatchIndex - 1, 4)
+    } else {
+      score -= Math.min(found, 4)
+    }
+
+    prevMatchIndex = found
+    textIndex = found + 1
+  }
+
+  return score
+}
+
+/**
+ * Scores a single entry against the query by matching the label, description,
+ * and keywords. Returns the best (highest) field score, with label matches
+ * weighted highest. Returns `null` when nothing matches.
+ */
+export function scoreEntry(query: string, entry: SettingsSearchEntry): number | null {
+  const q = query.trim()
+  if (q.length === 0) return 0
+
+  let best: number | null = null
+
+  const labelScore = fuzzyScore(q, entry.label)
+  if (labelScore !== null) {
+    // Strong bonus so label matches outrank description/keyword matches.
+    best = labelScore + 20
+  }
+
+  if (entry.description) {
+    const descScore = fuzzyScore(q, entry.description)
+    if (descScore !== null) {
+      const weighted = descScore + 5
+      best = best === null ? weighted : Math.max(best, weighted)
+    }
+  }
+
+  if (entry.keywords) {
+    for (const keyword of entry.keywords) {
+      const keywordScore = fuzzyScore(q, keyword)
+      if (keywordScore !== null) {
+        const weighted = keywordScore + 10
+        best = best === null ? weighted : Math.max(best, weighted)
+      }
+    }
+  }
+
+  return best
+}
+
+/**
+ * Searches the flat settings index for `query`, returning matching entries
+ * sorted by descending score. An empty/whitespace query returns `[]` so the
+ * caller can fall back to the full category list.
+ */
+export function searchSettings(
+  query: string,
+  index: readonly SettingsSearchEntry[]
+): SettingsSearchResult[] {
+  const q = query.trim()
+  if (q.length === 0) return []
+
+  const results: SettingsSearchResult[] = []
+  for (const entry of index) {
+    const score = scoreEntry(q, entry)
+    if (score !== null) {
+      results.push({ ...entry, score })
+    }
+  }
+
+  results.sort((a, b) => {
+    if (b.score !== a.score) return b.score - a.score
+    return a.label.localeCompare(b.label)
+  })
+
+  return results
+}

--- a/src/renderer/pages/AppPreferences.tsx
+++ b/src/renderer/pages/AppPreferences.tsx
@@ -9,7 +9,11 @@ import {
   FileText,
   FolderOpen,
   Keyboard,
+  Monitor,
+  Palette,
   RotateCcw,
+  Sliders,
+  Terminal,
   X
 } from 'lucide-react'
 import { useEffect, useState } from 'react'
@@ -17,6 +21,11 @@ import { useNavigate } from 'react-router-dom'
 import { ConfirmDialog } from '@/components/ConfirmDialog'
 import { ShortcutRecorder } from '@/components/ShortcutRecorder'
 import { AcpAgentsSettings } from '@/components/settings/AcpAgentsSettings'
+import {
+  type SettingsCategory,
+  SettingsLayout,
+  SettingsSection
+} from '@/components/settings/SettingsLayout'
 import { useResetAppSettings, useUpdateAppSetting } from '@/hooks/use-app-settings'
 import {
   useResetAllShortcuts,
@@ -25,6 +34,7 @@ import {
 } from '@/hooks/use-keyboard-shortcuts'
 import { logApi, shellApi, terminalApi } from '@/lib/api'
 import { availableColors, getColorClasses } from '@/lib/colors'
+import type { SettingsSearchEntry } from '@/lib/settings-search'
 import { isAurUpdateMode } from '@/lib/tauri-updater-api'
 import { cn } from '@/lib/utils'
 import {
@@ -52,6 +62,117 @@ import {
   TERMINAL_URL_OPEN_MODE_OPTIONS,
   type TerminalUrlOpenMode
 } from '@/types/settings'
+
+const APP_PREF_CATEGORIES: SettingsCategory[] = [
+  { id: 'appearance', label: 'Terminal Appearance', icon: <Palette size={16} /> },
+  { id: 'shell', label: 'Default Shell', icon: <Terminal size={16} /> },
+  { id: 'behavior', label: 'Terminal Behavior', icon: <Sliders size={16} /> },
+  { id: 'project-defaults', label: 'New Project Defaults', icon: <Monitor size={16} /> },
+  { id: 'ai-agents', label: 'AI Agents', icon: <Bot size={16} /> },
+  { id: 'shortcuts', label: 'Keyboard Shortcuts', icon: <Keyboard size={16} /> },
+  { id: 'updates', label: 'Updates', icon: <Download size={16} /> },
+  { id: 'diagnostics', label: 'Diagnostics & Logs', icon: <FileText size={16} /> },
+  { id: 'reset', label: 'Reset Settings', icon: <RotateCcw size={16} /> }
+]
+
+const APP_PREF_SEARCH_INDEX: SettingsSearchEntry[] = [
+  {
+    categoryId: 'appearance',
+    label: 'Font Family',
+    description: 'Choose a monospace font for terminal text.',
+    keywords: ['typeface', 'monospace']
+  },
+  {
+    categoryId: 'appearance',
+    label: 'Font Size',
+    description: 'Adjust terminal text size.',
+    keywords: ['text size', 'zoom']
+  },
+  {
+    categoryId: 'appearance',
+    label: 'Scrollback Buffer Size',
+    description: 'Number of lines to keep in terminal history.',
+    keywords: ['history', 'lines', 'memory']
+  },
+  {
+    categoryId: 'appearance',
+    label: 'Max Terminals Per Project',
+    description: 'Maximum number of terminal tabs allowed per project.',
+    keywords: ['tabs', 'limit']
+  },
+  {
+    categoryId: 'appearance',
+    label: 'Terminal Renderer',
+    description: 'GPU-accelerated rendering for terminal output.',
+    keywords: ['webgl', 'dom', 'gpu']
+  },
+  {
+    categoryId: 'shell',
+    label: 'Default Shell',
+    description: 'Set the default shell for new terminals.',
+    keywords: ['bash', 'zsh', 'powershell', 'fish']
+  },
+  {
+    categoryId: 'behavior',
+    label: 'Open Terminal Links In',
+    description: 'Choose how URLs from terminal output open.',
+    keywords: ['url', 'links', 'browser']
+  },
+  {
+    categoryId: 'behavior',
+    label: 'Orphan Detection',
+    description: 'Automatically clean up terminals that have been inactive.',
+    keywords: ['cleanup', 'inactive', 'timeout']
+  },
+  {
+    categoryId: 'behavior',
+    label: 'Timeout Before Cleanup',
+    description: 'Duration before inactive terminals are cleaned up.',
+    keywords: ['orphan', 'inactive']
+  },
+  {
+    categoryId: 'project-defaults',
+    label: 'Default Color',
+    description: 'New projects will use this color by default.',
+    keywords: ['theme', 'appearance']
+  },
+  {
+    categoryId: 'ai-agents',
+    label: 'AI Agents',
+    description: 'Enable ACP coding agents from the registry.',
+    keywords: ['acp', 'agent', 'coding assistant']
+  },
+  {
+    categoryId: 'shortcuts',
+    label: 'Keyboard Shortcuts',
+    description: 'Customize keyboard shortcuts to match your workflow.',
+    keywords: ['hotkeys', 'bindings', 'keybindings']
+  },
+  {
+    categoryId: 'updates',
+    label: 'Check for Updates',
+    description: 'Manage application updates and version information.',
+    keywords: ['version', 'upgrade']
+  },
+  {
+    categoryId: 'updates',
+    label: 'Auto-update',
+    description: 'Automatically check for updates.',
+    keywords: ['automatic', 'version']
+  },
+  {
+    categoryId: 'diagnostics',
+    label: 'Diagnostics & Logs',
+    description: 'Export or copy application logs to troubleshoot issues.',
+    keywords: ['logs', 'export', 'troubleshoot', 'debug']
+  },
+  {
+    categoryId: 'reset',
+    label: 'Reset Settings',
+    description: 'Restore all settings to their default values.',
+    keywords: ['restore', 'defaults', 'clear']
+  }
+]
 
 export default function AppPreferences(): React.JSX.Element {
   const navigate = useNavigate()
@@ -220,636 +341,631 @@ export default function AppPreferences(): React.JSX.Element {
         </div>
 
         {/* Content */}
-        <div className="flex-1 overflow-y-auto p-8 pb-32">
-          <div className="max-w-4xl mx-auto space-y-12">
-            {/* Terminal Appearance Section */}
-            <section>
-              <div className="flex items-start gap-6 border-b border-border pb-8">
-                <div className="w-1/3 pt-1">
-                  <h2 className="text-lg font-medium text-foreground">Terminal Appearance</h2>
-                  <p className="text-sm text-muted-foreground mt-1">
-                    Customize the look and feel of your terminal.
+        <SettingsLayout categories={APP_PREF_CATEGORIES} searchIndex={APP_PREF_SEARCH_INDEX}>
+          {/* Terminal Appearance Section */}
+          <SettingsSection id="appearance">
+            <div className="flex items-start gap-6 border-b border-border pb-6">
+              <div className="w-1/3 pt-1">
+                <h2 className="text-lg font-medium text-foreground">Terminal Appearance</h2>
+                <p className="text-sm text-muted-foreground mt-1">
+                  Customize the look and feel of your terminal.
+                </p>
+              </div>
+              <div className="w-2/3 space-y-4">
+                {/* Font Family */}
+                <div>
+                  <label className="block text-sm font-medium text-secondary-foreground mb-2">
+                    Font Family
+                  </label>
+                  <select
+                    value={fontFamily}
+                    onChange={(e) => handleFontFamilyChange(e.target.value)}
+                    className="w-full bg-secondary/50 border border-border rounded-lg px-3 py-2 text-sm text-foreground focus:ring-2 focus:ring-primary focus:border-transparent outline-none transition-shadow"
+                  >
+                    {FONT_FAMILY_OPTIONS.map((option) => (
+                      <option key={option.value} value={option.value}>
+                        {option.label}
+                      </option>
+                    ))}
+                  </select>
+                  <p className="text-xs text-muted-foreground mt-1">
+                    Choose a monospace font for terminal text.
                   </p>
                 </div>
-                <div className="w-2/3 space-y-6">
-                  {/* Font Family */}
-                  <div>
-                    <label className="block text-sm font-medium text-secondary-foreground mb-2">
-                      Font Family
-                    </label>
-                    <select
-                      value={fontFamily}
-                      onChange={(e) => handleFontFamilyChange(e.target.value)}
-                      className="w-full bg-secondary/50 border border-border rounded-lg px-3 py-2 text-sm text-foreground focus:ring-2 focus:ring-primary focus:border-transparent outline-none transition-shadow"
-                    >
-                      {FONT_FAMILY_OPTIONS.map((option) => (
-                        <option key={option.value} value={option.value}>
-                          {option.label}
-                        </option>
-                      ))}
-                    </select>
-                    <p className="text-xs text-muted-foreground mt-1">
-                      Choose a monospace font for terminal text.
-                    </p>
-                  </div>
 
-                  {/* Font Size */}
-                  <div>
-                    <label className="block text-sm font-medium text-secondary-foreground mb-2">
-                      Font Size: {fontSize}px
-                    </label>
-                    <div className="flex items-center gap-4">
-                      <input
-                        type="range"
-                        min={10}
-                        max={24}
-                        value={fontSize}
-                        onChange={(e) => handleFontSizeChange(parseInt(e.target.value, 10))}
-                        className="flex-1 h-2 bg-secondary rounded-lg appearance-none cursor-pointer accent-primary"
-                      />
-                      <span className="text-sm text-muted-foreground w-12 text-right">
-                        {fontSize}px
-                      </span>
+                {/* Font Size */}
+                <div>
+                  <label className="block text-sm font-medium text-secondary-foreground mb-2">
+                    Font Size: {fontSize}px
+                  </label>
+                  <div className="flex items-center gap-4">
+                    <input
+                      type="range"
+                      min={10}
+                      max={24}
+                      value={fontSize}
+                      onChange={(e) => handleFontSizeChange(parseInt(e.target.value, 10))}
+                      className="flex-1 h-2 bg-secondary rounded-lg appearance-none cursor-pointer accent-primary"
+                    />
+                    <span className="text-sm text-muted-foreground w-12 text-right">
+                      {fontSize}px
+                    </span>
+                  </div>
+                  <p className="text-xs text-muted-foreground mt-1">
+                    Adjust terminal text size (10-24px).
+                  </p>
+                </div>
+
+                {/* Buffer Size */}
+                <div>
+                  <label className="block text-sm font-medium text-secondary-foreground mb-2">
+                    Scrollback Buffer Size
+                  </label>
+                  <select
+                    value={bufferSize}
+                    onChange={(e) => handleBufferSizeChange(parseInt(e.target.value, 10))}
+                    className="w-full bg-secondary/50 border border-border rounded-lg px-3 py-2 text-sm text-foreground focus:ring-2 focus:ring-primary focus:border-transparent outline-none transition-shadow"
+                  >
+                    {BUFFER_SIZE_OPTIONS.map((option) => (
+                      <option key={option.value} value={option.value}>
+                        {option.label}
+                      </option>
+                    ))}
+                  </select>
+                  <p className="text-xs text-muted-foreground mt-1">
+                    Number of lines to keep in terminal history. Higher values use more memory.
+                    Changes apply to new terminals.
+                  </p>
+                </div>
+
+                {/* Max Terminals */}
+                <div>
+                  <label className="block text-sm font-medium text-secondary-foreground mb-2">
+                    Max Terminals Per Project
+                  </label>
+                  <select
+                    value={maxTerminals}
+                    onChange={(e) => handleMaxTerminalsChange(parseInt(e.target.value, 10))}
+                    className="w-full bg-secondary/50 border border-border rounded-lg px-3 py-2 text-sm text-foreground focus:ring-2 focus:ring-primary focus:border-transparent outline-none transition-shadow"
+                  >
+                    {MAX_TERMINALS_OPTIONS.map((option) => (
+                      <option key={option.value} value={option.value}>
+                        {option.label}
+                      </option>
+                    ))}
+                  </select>
+                  <p className="text-xs text-muted-foreground mt-1">
+                    Maximum number of terminal tabs allowed per project.
+                  </p>
+                </div>
+
+                {/* Terminal Renderer */}
+                <div>
+                  <label className="block text-sm font-medium text-secondary-foreground mb-2">
+                    Terminal Renderer
+                  </label>
+                  <select
+                    value={terminalRenderer}
+                    onChange={(e) => handleRendererChange(e.target.value)}
+                    className="w-full bg-secondary/50 border border-border rounded-lg px-3 py-2 text-sm text-foreground focus:ring-2 focus:ring-primary focus:border-transparent outline-none transition-shadow"
+                  >
+                    {TERMINAL_RENDERER_OPTIONS.map((option) => (
+                      <option key={option.value} value={option.value}>
+                        {option.label}
+                      </option>
+                    ))}
+                  </select>
+                  <p className="text-xs text-muted-foreground mt-1">
+                    GPU-accelerated rendering for terminal output. WebGL provides best performance.
+                    Changes apply to new terminals.
+                  </p>
+                </div>
+
+                {/* Preview */}
+                <div>
+                  <label className="block text-sm font-medium text-secondary-foreground mb-2">
+                    Preview
+                  </label>
+                  <div
+                    className="bg-terminal-bg border border-border rounded-md p-4 text-terminal-fg"
+                    style={{
+                      fontFamily: fontFamily,
+                      fontSize: `${fontSize}px`,
+                      lineHeight: 1.2
+                    }}
+                  >
+                    <div>$ echo "Hello, World!"</div>
+                    <div>Hello, World!</div>
+                    <div>$ ls -la</div>
+                    <div>drwxr-xr-x 5 user staff 160 Jan 11 10:00 .</div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </SettingsSection>
+
+          {/* Default Shell Section */}
+          <SettingsSection id="shell">
+            <div className="flex items-start gap-6 border-b border-border pb-6">
+              <div className="w-1/3 pt-1">
+                <h2 className="text-lg font-medium text-foreground">Default Shell</h2>
+                <p className="text-sm text-muted-foreground mt-1">
+                  Set the default shell for new terminals.
+                </p>
+              </div>
+              <div className="w-2/3 space-y-4">
+                <div>
+                  <label className="block text-sm font-medium text-secondary-foreground mb-2">
+                    Shell
+                  </label>
+                  <select
+                    value={(() => {
+                      // Normalize the stored defaultShell for display
+                      // If it's a path, use it directly; if it's a name, find matching shell's path
+                      if (!defaultShell) return ''
+                      if (defaultShell.includes('\\') || defaultShell.includes('/')) {
+                        return defaultShell
+                      }
+                      // Find shell by name or by basename of path
+                      const match = availableShells?.available.find((s) => {
+                        if (s.name === defaultShell) return true
+                        const pathBasename = s.path.split(/[\\/]/).pop()
+                        return pathBasename === defaultShell
+                      })
+                      return match?.path ?? defaultShell
+                    })()}
+                    onChange={(e) => handleDefaultShellChange(e.target.value)}
+                    className="w-full bg-secondary/50 border border-border rounded-lg px-3 py-2 text-sm text-foreground focus:ring-2 focus:ring-primary focus:border-transparent outline-none transition-shadow"
+                  >
+                    <option value="">System Default</option>
+                    {availableShells?.available?.map((shell) => (
+                      <option key={shell.path} value={shell.path}>
+                        {shell.displayName}
+                      </option>
+                    ))}
+                  </select>
+                  <p className="text-xs text-muted-foreground mt-1">
+                    This can be overridden per-project in project settings.
+                  </p>
+                </div>
+              </div>
+            </div>
+          </SettingsSection>
+
+          {/* Terminal Behavior Section */}
+          <SettingsSection id="behavior">
+            <div className="flex items-start gap-6 border-b border-border pb-6">
+              <div className="w-1/3 pt-1">
+                <h2 className="text-lg font-medium text-foreground">Terminal Behavior</h2>
+                <p className="text-sm text-muted-foreground mt-1">
+                  Configure how inactive terminals are managed.
+                </p>
+              </div>
+              <div className="w-2/3 space-y-4">
+                <div>
+                  <label className="block text-sm font-medium text-secondary-foreground mb-2">
+                    Open Terminal Links In
+                  </label>
+                  <select
+                    value={terminalUrlOpenMode}
+                    onChange={(e) => handleTerminalUrlOpenModeChange(e.target.value)}
+                    className="w-full bg-secondary/50 border border-border rounded-lg px-3 py-2 text-sm text-foreground focus:ring-2 focus:ring-primary focus:border-transparent outline-none transition-shadow"
+                  >
+                    {TERMINAL_URL_OPEN_MODE_OPTIONS.map((option) => (
+                      <option key={option.value} value={option.value}>
+                        {option.label}
+                      </option>
+                    ))}
+                  </select>
+                  <p className="text-xs text-muted-foreground mt-1">
+                    Choose whether Ctrl/Cmd+Click URLs from terminal output open in your system
+                    browser or a new Termul browser tab.
+                  </p>
+                </div>
+
+                {/* Orphan Detection Toggle */}
+                <div>
+                  <label className="block text-sm font-medium text-secondary-foreground mb-2">
+                    Orphan Detection
+                  </label>
+                  <div className="flex items-center justify-between bg-secondary/30 border border-border rounded-md px-4 py-3">
+                    <div className="flex-1">
+                      <div className="text-sm text-foreground">Enable orphan detection</div>
+                      <div className="text-xs text-muted-foreground mt-0.5">
+                        Automatically clean up terminals that have been inactive
+                      </div>
                     </div>
-                    <p className="text-xs text-muted-foreground mt-1">
-                      Adjust terminal text size (10-24px).
-                    </p>
-                  </div>
-
-                  {/* Buffer Size */}
-                  <div>
-                    <label className="block text-sm font-medium text-secondary-foreground mb-2">
-                      Scrollback Buffer Size
-                    </label>
-                    <select
-                      value={bufferSize}
-                      onChange={(e) => handleBufferSizeChange(parseInt(e.target.value, 10))}
-                      className="w-full bg-secondary/50 border border-border rounded-lg px-3 py-2 text-sm text-foreground focus:ring-2 focus:ring-primary focus:border-transparent outline-none transition-shadow"
+                    <button
+                      onClick={() => handleOrphanDetectionToggle(!orphanDetectionEnabled)}
+                      className={cn(
+                        'relative inline-flex h-6 w-11 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2',
+                        orphanDetectionEnabled ? 'bg-primary' : 'bg-input'
+                      )}
                     >
-                      {BUFFER_SIZE_OPTIONS.map((option) => (
-                        <option key={option.value} value={option.value}>
-                          {option.label}
-                        </option>
-                      ))}
-                    </select>
-                    <p className="text-xs text-muted-foreground mt-1">
-                      Number of lines to keep in terminal history. Higher values use more memory.
-                      Changes apply to new terminals.
-                    </p>
+                      <span
+                        className={cn(
+                          'inline-block h-4 w-4 transform rounded-full bg-white transition-transform',
+                          orphanDetectionEnabled ? 'translate-x-6' : 'translate-x-1'
+                        )}
+                      />
+                    </button>
                   </div>
+                </div>
 
-                  {/* Max Terminals */}
+                {/* Timeout Dropdown */}
+                <div>
+                  <label className="block text-sm font-medium text-secondary-foreground mb-2">
+                    Timeout Before Cleanup
+                  </label>
+                  <select
+                    value={orphanDetectionTimeout ?? 600000}
+                    onChange={(e) =>
+                      handleOrphanTimeoutChange(
+                        e.target.value ? parseInt(e.target.value, 10) : null
+                      )
+                    }
+                    disabled={!orphanDetectionEnabled}
+                    className="w-full bg-secondary/50 border border-border rounded-lg px-3 py-2 text-sm text-foreground focus:ring-2 focus:ring-primary focus:border-transparent outline-none transition-shadow disabled:opacity-50 disabled:cursor-not-allowed"
+                  >
+                    {ORPHAN_TIMEOUT_OPTIONS.map((option) => (
+                      <option key={option.value} value={option.value}>
+                        {option.label}
+                      </option>
+                    ))}
+                  </select>
+                  <p className="text-xs text-muted-foreground mt-1">
+                    Terminals inactive for this duration will be cleaned up (only if not displayed).
+                  </p>
+                </div>
+              </div>
+            </div>
+          </SettingsSection>
+
+          {/* New Project Defaults Section */}
+          <SettingsSection id="project-defaults">
+            <div className="flex items-start gap-6 border-b border-border pb-6">
+              <div className="w-1/3 pt-1">
+                <h2 className="text-lg font-medium text-foreground">New Project Defaults</h2>
+                <p className="text-sm text-muted-foreground mt-1">
+                  Set default options for new projects.
+                </p>
+              </div>
+              <div className="w-2/3 space-y-4">
+                <div>
+                  <label className="block text-sm font-medium text-secondary-foreground mb-2">
+                    Default Color
+                  </label>
+                  <div className="flex gap-2 flex-wrap">
+                    {availableColors.map((color) => {
+                      const colors = getColorClasses(color)
+                      return (
+                        <button
+                          key={color}
+                          onClick={() => handleDefaultProjectColorChange(color)}
+                          className={cn(
+                            'w-8 h-8 rounded-full transition-all',
+                            colors.bg,
+                            defaultProjectColor === color
+                              ? 'ring-2 ring-offset-2 ring-offset-background ring-current'
+                              : 'hover:opacity-80'
+                          )}
+                          title={color.charAt(0).toUpperCase() + color.slice(1)}
+                        />
+                      )
+                    })}
+                  </div>
+                  <p className="text-xs text-muted-foreground mt-2">
+                    New projects will use this color by default.
+                  </p>
+                </div>
+              </div>
+            </div>
+          </SettingsSection>
+
+          {/* AI Agents Section */}
+          <SettingsSection id="ai-agents">
+            <div className="flex items-start gap-6 border-b border-border pb-6">
+              <div className="w-1/3 pt-1">
+                <div className="flex items-center gap-2">
+                  <Bot size={18} className="text-primary" />
+                  <h2 className="text-lg font-medium text-foreground">AI Agents</h2>
+                </div>
+                <p className="text-sm text-muted-foreground mt-1">
+                  Enable ACP coding agents from the registry. Enabling one warms it in the
+                  background so chats start instantly.
+                </p>
+              </div>
+              <div className="w-2/3">
+                <AcpAgentsSettings />
+              </div>
+            </div>
+          </SettingsSection>
+
+          {/* Keyboard Shortcuts Section */}
+          <SettingsSection id="shortcuts">
+            <div className="flex items-start gap-6 border-b border-border pb-6">
+              <div className="w-1/3 pt-1">
+                <div className="flex items-center gap-2">
+                  <Keyboard size={18} className="text-primary" />
+                  <h2 className="text-lg font-medium text-foreground">Keyboard Shortcuts</h2>
+                </div>
+                <p className="text-sm text-muted-foreground mt-1">
+                  Customize keyboard shortcuts to match your workflow.
+                </p>
+                <button
+                  onClick={() => setIsResetShortcutsDialogOpen(true)}
+                  className="mt-4 flex items-center gap-2 text-xs text-muted-foreground hover:text-foreground transition-colors"
+                >
+                  <RotateCcw size={12} />
+                  Reset all shortcuts
+                </button>
+              </div>
+              <div className="w-2/3 space-y-4">
+                {Object.values(shortcuts).map((shortcut) => (
+                  <ShortcutRecorder
+                    key={shortcut.id}
+                    shortcut={shortcut}
+                    allShortcuts={shortcuts}
+                    onUpdate={updateShortcut}
+                    onReset={resetShortcut}
+                  />
+                ))}
+              </div>
+            </div>
+          </SettingsSection>
+
+          {/* Updates Section */}
+          <SettingsSection id="updates">
+            <div className="flex items-start gap-6 border-b border-border pb-6">
+              <div className="w-1/3 pt-1">
+                <div className="flex items-center gap-2">
+                  <Download size={18} className="text-primary" />
+                  <h2 className="text-lg font-medium text-foreground">Updates</h2>
+                </div>
+                <p className="text-sm text-muted-foreground mt-1">
+                  Manage application updates and version information.
+                </p>
+              </div>
+              <div className="w-2/3 space-y-4">
+                {/* Current Version */}
+                <div>
+                  <label className="block text-sm font-medium text-secondary-foreground mb-2">
+                    Current Version
+                  </label>
+                  <div className="bg-secondary/30 border border-border rounded-md px-4 py-3">
+                    <span className="text-sm font-mono text-foreground">
+                      v{import.meta.env.PACKAGE_VERSION || '0.1.0'}
+                    </span>
+                  </div>
+                </div>
+
+                {/* Update Status */}
+                {updateAvailable && version && (
                   <div>
                     <label className="block text-sm font-medium text-secondary-foreground mb-2">
-                      Max Terminals Per Project
-                    </label>
-                    <select
-                      value={maxTerminals}
-                      onChange={(e) => handleMaxTerminalsChange(parseInt(e.target.value, 10))}
-                      className="w-full bg-secondary/50 border border-border rounded-lg px-3 py-2 text-sm text-foreground focus:ring-2 focus:ring-primary focus:border-transparent outline-none transition-shadow"
-                    >
-                      {MAX_TERMINALS_OPTIONS.map((option) => (
-                        <option key={option.value} value={option.value}>
-                          {option.label}
-                        </option>
-                      ))}
-                    </select>
-                    <p className="text-xs text-muted-foreground mt-1">
-                      Maximum number of terminal tabs allowed per project.
-                    </p>
-                  </div>
-
-                  {/* Terminal Renderer */}
-                  <div>
-                    <label className="block text-sm font-medium text-secondary-foreground mb-2">
-                      Terminal Renderer
-                    </label>
-                    <select
-                      value={terminalRenderer}
-                      onChange={(e) => handleRendererChange(e.target.value)}
-                      className="w-full bg-secondary/50 border border-border rounded-lg px-3 py-2 text-sm text-foreground focus:ring-2 focus:ring-primary focus:border-transparent outline-none transition-shadow"
-                    >
-                      {TERMINAL_RENDERER_OPTIONS.map((option) => (
-                        <option key={option.value} value={option.value}>
-                          {option.label}
-                        </option>
-                      ))}
-                    </select>
-                    <p className="text-xs text-muted-foreground mt-1">
-                      GPU-accelerated rendering for terminal output. WebGL provides best
-                      performance. Changes apply to new terminals.
-                    </p>
-                  </div>
-
-                  {/* Preview */}
-                  <div>
-                    <label className="block text-sm font-medium text-secondary-foreground mb-2">
-                      Preview
+                      Update Available
                     </label>
                     <div
-                      className="bg-terminal-bg border border-border rounded-md p-4 text-terminal-fg"
-                      style={{
-                        fontFamily: fontFamily,
-                        fontSize: `${fontSize}px`,
-                        lineHeight: 1.2
-                      }}
-                    >
-                      <div>$ echo "Hello, World!"</div>
-                      <div>Hello, World!</div>
-                      <div>$ ls -la</div>
-                      <div>drwxr-xr-x 5 user staff 160 Jan 11 10:00 .</div>
-                    </div>
-                  </div>
-                </div>
-              </div>
-            </section>
-
-            {/* Default Shell Section */}
-            <section>
-              <div className="flex items-start gap-6 border-b border-border pb-8">
-                <div className="w-1/3 pt-1">
-                  <h2 className="text-lg font-medium text-foreground">Default Shell</h2>
-                  <p className="text-sm text-muted-foreground mt-1">
-                    Set the default shell for new terminals.
-                  </p>
-                </div>
-                <div className="w-2/3 space-y-6">
-                  <div>
-                    <label className="block text-sm font-medium text-secondary-foreground mb-2">
-                      Shell
-                    </label>
-                    <select
-                      value={(() => {
-                        // Normalize the stored defaultShell for display
-                        // If it's a path, use it directly; if it's a name, find matching shell's path
-                        if (!defaultShell) return ''
-                        if (defaultShell.includes('\\') || defaultShell.includes('/')) {
-                          return defaultShell
-                        }
-                        // Find shell by name or by basename of path
-                        const match = availableShells?.available.find((s) => {
-                          if (s.name === defaultShell) return true
-                          const pathBasename = s.path.split(/[\\/]/).pop()
-                          return pathBasename === defaultShell
-                        })
-                        return match?.path ?? defaultShell
-                      })()}
-                      onChange={(e) => handleDefaultShellChange(e.target.value)}
-                      className="w-full bg-secondary/50 border border-border rounded-lg px-3 py-2 text-sm text-foreground focus:ring-2 focus:ring-primary focus:border-transparent outline-none transition-shadow"
-                    >
-                      <option value="">System Default</option>
-                      {availableShells?.available?.map((shell) => (
-                        <option key={shell.path} value={shell.path}>
-                          {shell.displayName}
-                        </option>
-                      ))}
-                    </select>
-                    <p className="text-xs text-muted-foreground mt-1">
-                      This can be overridden per-project in project settings.
-                    </p>
-                  </div>
-                </div>
-              </div>
-            </section>
-
-            {/* Terminal Behavior Section */}
-            <section>
-              <div className="flex items-start gap-6 border-b border-border pb-8">
-                <div className="w-1/3 pt-1">
-                  <h2 className="text-lg font-medium text-foreground">Terminal Behavior</h2>
-                  <p className="text-sm text-muted-foreground mt-1">
-                    Configure how inactive terminals are managed.
-                  </p>
-                </div>
-                <div className="w-2/3 space-y-6">
-                  <div>
-                    <label className="block text-sm font-medium text-secondary-foreground mb-2">
-                      Open Terminal Links In
-                    </label>
-                    <select
-                      value={terminalUrlOpenMode}
-                      onChange={(e) => handleTerminalUrlOpenModeChange(e.target.value)}
-                      className="w-full bg-secondary/50 border border-border rounded-lg px-3 py-2 text-sm text-foreground focus:ring-2 focus:ring-primary focus:border-transparent outline-none transition-shadow"
-                    >
-                      {TERMINAL_URL_OPEN_MODE_OPTIONS.map((option) => (
-                        <option key={option.value} value={option.value}>
-                          {option.label}
-                        </option>
-                      ))}
-                    </select>
-                    <p className="text-xs text-muted-foreground mt-1">
-                      Choose whether Ctrl/Cmd+Click URLs from terminal output open in your system
-                      browser or a new Termul browser tab.
-                    </p>
-                  </div>
-
-                  {/* Orphan Detection Toggle */}
-                  <div>
-                    <label className="block text-sm font-medium text-secondary-foreground mb-2">
-                      Orphan Detection
-                    </label>
-                    <div className="flex items-center justify-between bg-secondary/30 border border-border rounded-md px-4 py-3">
-                      <div className="flex-1">
-                        <div className="text-sm text-foreground">Enable orphan detection</div>
-                        <div className="text-xs text-muted-foreground mt-0.5">
-                          Automatically clean up terminals that have been inactive
-                        </div>
-                      </div>
-                      <button
-                        onClick={() => handleOrphanDetectionToggle(!orphanDetectionEnabled)}
-                        className={cn(
-                          'relative inline-flex h-6 w-11 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2',
-                          orphanDetectionEnabled ? 'bg-primary' : 'bg-input'
-                        )}
-                      >
-                        <span
-                          className={cn(
-                            'inline-block h-4 w-4 transform rounded-full bg-white transition-transform',
-                            orphanDetectionEnabled ? 'translate-x-6' : 'translate-x-1'
-                          )}
-                        />
-                      </button>
-                    </div>
-                  </div>
-
-                  {/* Timeout Dropdown */}
-                  <div>
-                    <label className="block text-sm font-medium text-secondary-foreground mb-2">
-                      Timeout Before Cleanup
-                    </label>
-                    <select
-                      value={orphanDetectionTimeout ?? 600000}
-                      onChange={(e) =>
-                        handleOrphanTimeoutChange(
-                          e.target.value ? parseInt(e.target.value, 10) : null
-                        )
-                      }
-                      disabled={!orphanDetectionEnabled}
-                      className="w-full bg-secondary/50 border border-border rounded-lg px-3 py-2 text-sm text-foreground focus:ring-2 focus:ring-primary focus:border-transparent outline-none transition-shadow disabled:opacity-50 disabled:cursor-not-allowed"
-                    >
-                      {ORPHAN_TIMEOUT_OPTIONS.map((option) => (
-                        <option key={option.value} value={option.value}>
-                          {option.label}
-                        </option>
-                      ))}
-                    </select>
-                    <p className="text-xs text-muted-foreground mt-1">
-                      Terminals inactive for this duration will be cleaned up (only if not
-                      displayed).
-                    </p>
-                  </div>
-                </div>
-              </div>
-            </section>
-
-            {/* New Project Defaults Section */}
-            <section>
-              <div className="flex items-start gap-6 border-b border-border pb-8">
-                <div className="w-1/3 pt-1">
-                  <h2 className="text-lg font-medium text-foreground">New Project Defaults</h2>
-                  <p className="text-sm text-muted-foreground mt-1">
-                    Set default options for new projects.
-                  </p>
-                </div>
-                <div className="w-2/3 space-y-6">
-                  <div>
-                    <label className="block text-sm font-medium text-secondary-foreground mb-2">
-                      Default Color
-                    </label>
-                    <div className="flex gap-2 flex-wrap">
-                      {availableColors.map((color) => {
-                        const colors = getColorClasses(color)
-                        return (
-                          <button
-                            key={color}
-                            onClick={() => handleDefaultProjectColorChange(color)}
-                            className={cn(
-                              'w-8 h-8 rounded-full transition-all',
-                              colors.bg,
-                              defaultProjectColor === color
-                                ? 'ring-2 ring-offset-2 ring-offset-background ring-current'
-                                : 'hover:opacity-80'
-                            )}
-                            title={color.charAt(0).toUpperCase() + color.slice(1)}
-                          />
-                        )
-                      })}
-                    </div>
-                    <p className="text-xs text-muted-foreground mt-2">
-                      New projects will use this color by default.
-                    </p>
-                  </div>
-                </div>
-              </div>
-            </section>
-
-            {/* AI Agents Section */}
-            <section>
-              <div className="flex items-start gap-6 border-b border-border pb-8">
-                <div className="w-1/3 pt-1">
-                  <div className="flex items-center gap-2">
-                    <Bot size={18} className="text-primary" />
-                    <h2 className="text-lg font-medium text-foreground">AI Agents</h2>
-                  </div>
-                  <p className="text-sm text-muted-foreground mt-1">
-                    Enable ACP coding agents from the registry. Enabling one warms it in the
-                    background so chats start instantly.
-                  </p>
-                </div>
-                <div className="w-2/3">
-                  <AcpAgentsSettings />
-                </div>
-              </div>
-            </section>
-
-            {/* Keyboard Shortcuts Section */}
-            <section>
-              <div className="flex items-start gap-6 border-b border-border pb-8">
-                <div className="w-1/3 pt-1">
-                  <div className="flex items-center gap-2">
-                    <Keyboard size={18} className="text-primary" />
-                    <h2 className="text-lg font-medium text-foreground">Keyboard Shortcuts</h2>
-                  </div>
-                  <p className="text-sm text-muted-foreground mt-1">
-                    Customize keyboard shortcuts to match your workflow.
-                  </p>
-                  <button
-                    onClick={() => setIsResetShortcutsDialogOpen(true)}
-                    className="mt-4 flex items-center gap-2 text-xs text-muted-foreground hover:text-foreground transition-colors"
-                  >
-                    <RotateCcw size={12} />
-                    Reset all shortcuts
-                  </button>
-                </div>
-                <div className="w-2/3 space-y-4">
-                  {Object.values(shortcuts).map((shortcut) => (
-                    <ShortcutRecorder
-                      key={shortcut.id}
-                      shortcut={shortcut}
-                      allShortcuts={shortcuts}
-                      onUpdate={updateShortcut}
-                      onReset={resetShortcut}
-                    />
-                  ))}
-                </div>
-              </div>
-            </section>
-
-            {/* Updates Section */}
-            <section>
-              <div className="flex items-start gap-6 border-b border-border pb-8">
-                <div className="w-1/3 pt-1">
-                  <div className="flex items-center gap-2">
-                    <Download size={18} className="text-primary" />
-                    <h2 className="text-lg font-medium text-foreground">Updates</h2>
-                  </div>
-                  <p className="text-sm text-muted-foreground mt-1">
-                    Manage application updates and version information.
-                  </p>
-                </div>
-                <div className="w-2/3 space-y-6">
-                  {/* Current Version */}
-                  <div>
-                    <label className="block text-sm font-medium text-secondary-foreground mb-2">
-                      Current Version
-                    </label>
-                    <div className="bg-secondary/30 border border-border rounded-md px-4 py-3">
-                      <span className="text-sm font-mono text-foreground">
-                        v{import.meta.env.PACKAGE_VERSION || '0.1.0'}
-                      </span>
-                    </div>
-                  </div>
-
-                  {/* Update Status */}
-                  {updateAvailable && version && (
-                    <div>
-                      <label className="block text-sm font-medium text-secondary-foreground mb-2">
-                        Update Available
-                      </label>
-                      <div
-                        className={cn(
-                          'border rounded-md px-4 py-3 flex items-center gap-3',
-                          isManualUpdateMode
-                            ? 'bg-amber-500/10 border-amber-500/20'
-                            : 'bg-green-500/10 border-green-500/20'
-                        )}
-                      >
-                        <CheckCircle2
-                          size={18}
-                          className={cn(
-                            'flex-shrink-0',
-                            isManualUpdateMode ? 'text-amber-500' : 'text-green-500'
-                          )}
-                        />
-                        <div className="flex-1">
-                          <div className="text-sm font-medium text-foreground">
-                            Version {version} is available!
-                          </div>
-                          <div className="text-xs text-muted-foreground mt-0.5">
-                            {isAurUpdater
-                              ? 'Update through AUR with: yay -S termul-manager'
-                              : isManualUpdateMode
-                                ? 'Automatic update is unavailable. Please download and install the latest version manually.'
-                                : 'A new version is ready to download.'}
-                          </div>
-                        </div>
-                      </div>
-                    </div>
-                  )}
-
-                  {/* Update Error */}
-                  {updateError && (
-                    <div>
-                      <label className="block text-sm font-medium text-secondary-foreground mb-2">
-                        Update Error
-                      </label>
-                      <div className="bg-red-500/10 border border-red-500/20 rounded-md px-4 py-3 flex items-center gap-3">
-                        <AlertCircle size={18} className="text-red-500 flex-shrink-0" />
-                        <div className="flex-1">
-                          <div className="text-sm text-foreground">{updateError}</div>
-                        </div>
-                      </div>
-                    </div>
-                  )}
-
-                  {/* Check for Updates Button */}
-                  <div>
-                    <label className="block text-sm font-medium text-secondary-foreground mb-2">
-                      Check for Updates
-                    </label>
-                    <div className="flex items-center gap-2">
-                      <button
-                        onClick={checkForUpdates}
-                        disabled={isChecking}
-                        className="flex items-center gap-2 px-4 py-2 bg-primary hover:bg-primary/90 disabled:bg-primary/50 disabled:cursor-not-allowed border border-primary rounded-lg text-sm text-primary-foreground transition-colors"
-                      >
-                        <Download size={16} />
-                        {isChecking ? 'Checking for updates...' : 'Check for Updates'}
-                      </button>
-                      {updateAvailable && isManualUpdateMode && (
-                        <button
-                          onClick={installAndRestart}
-                          className="flex items-center gap-2 px-4 py-2 bg-amber-500 hover:bg-amber-500/90 border border-amber-500 rounded-lg text-sm text-white transition-colors"
-                        >
-                          <ExternalLink size={16} />
-                          Open Download Page
-                        </button>
+                      className={cn(
+                        'border rounded-md px-4 py-3 flex items-center gap-3',
+                        isManualUpdateMode
+                          ? 'bg-amber-500/10 border-amber-500/20'
+                          : 'bg-green-500/10 border-green-500/20'
                       )}
+                    >
+                      <CheckCircle2
+                        size={18}
+                        className={cn(
+                          'flex-shrink-0',
+                          isManualUpdateMode ? 'text-amber-500' : 'text-green-500'
+                        )}
+                      />
+                      <div className="flex-1">
+                        <div className="text-sm font-medium text-foreground">
+                          Version {version} is available!
+                        </div>
+                        <div className="text-xs text-muted-foreground mt-0.5">
+                          {isAurUpdater
+                            ? 'Update through AUR with: yay -S termul-manager'
+                            : isManualUpdateMode
+                              ? 'Automatic update is unavailable. Please download and install the latest version manually.'
+                              : 'A new version is ready to download.'}
+                        </div>
+                      </div>
                     </div>
-                    {lastChecked && (
-                      <p className="text-xs text-muted-foreground mt-1">
-                        Last checked: {formatLastChecked(lastChecked)}
-                      </p>
+                  </div>
+                )}
+
+                {/* Update Error */}
+                {updateError && (
+                  <div>
+                    <label className="block text-sm font-medium text-secondary-foreground mb-2">
+                      Update Error
+                    </label>
+                    <div className="bg-red-500/10 border border-red-500/20 rounded-md px-4 py-3 flex items-center gap-3">
+                      <AlertCircle size={18} className="text-red-500 flex-shrink-0" />
+                      <div className="flex-1">
+                        <div className="text-sm text-foreground">{updateError}</div>
+                      </div>
+                    </div>
+                  </div>
+                )}
+
+                {/* Check for Updates Button */}
+                <div>
+                  <label className="block text-sm font-medium text-secondary-foreground mb-2">
+                    Check for Updates
+                  </label>
+                  <div className="flex items-center gap-2">
+                    <button
+                      onClick={checkForUpdates}
+                      disabled={isChecking}
+                      className="flex items-center gap-2 px-4 py-2 bg-primary hover:bg-primary/90 disabled:bg-primary/50 disabled:cursor-not-allowed border border-primary rounded-lg text-sm text-primary-foreground transition-colors"
+                    >
+                      <Download size={16} />
+                      {isChecking ? 'Checking for updates...' : 'Check for Updates'}
+                    </button>
+                    {updateAvailable && isManualUpdateMode && (
+                      <button
+                        onClick={installAndRestart}
+                        className="flex items-center gap-2 px-4 py-2 bg-amber-500 hover:bg-amber-500/90 border border-amber-500 rounded-lg text-sm text-white transition-colors"
+                      >
+                        <ExternalLink size={16} />
+                        Open Download Page
+                      </button>
                     )}
                   </div>
-
-                  {/* Auto-update Toggle */}
-                  <div>
-                    <label className="block text-sm font-medium text-secondary-foreground mb-2">
-                      Auto-update
-                    </label>
-                    <div className="flex items-center justify-between bg-secondary/30 border border-border rounded-md px-4 py-3">
-                      <div className="flex-1">
-                        <div className="text-sm text-foreground">
-                          Automatically check for updates
-                        </div>
-                        <div className="text-xs text-muted-foreground mt-0.5">
-                          When enabled, the app will periodically check for new versions
-                        </div>
-                      </div>
-                      <button
-                        onClick={() => handleAutoUpdateToggle(!autoUpdateEnabled)}
-                        className={cn(
-                          'relative inline-flex h-6 w-11 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2',
-                          autoUpdateEnabled ? 'bg-primary' : 'bg-input'
-                        )}
-                      >
-                        <span
-                          className={cn(
-                            'inline-block h-4 w-4 transform rounded-full bg-white transition-transform',
-                            autoUpdateEnabled ? 'translate-x-6' : 'translate-x-1'
-                          )}
-                        />
-                      </button>
-                    </div>
-                  </div>
-
-                  {/* Skipped Version */}
-                  {skippedVersion && (
-                    <div>
-                      <label className="block text-sm font-medium text-secondary-foreground mb-2">
-                        Skipped Version
-                      </label>
-                      <div className="bg-secondary/30 border border-border rounded-md px-4 py-3">
-                        <div className="text-sm text-foreground">
-                          You are currently skipping version{' '}
-                          <span className="font-mono">{skippedVersion}</span>
-                        </div>
-                        <div className="text-xs text-muted-foreground mt-0.5">
-                          This version will not be offered again until a newer version is available.
-                        </div>
-                      </div>
-                    </div>
+                  {lastChecked && (
+                    <p className="text-xs text-muted-foreground mt-1">
+                      Last checked: {formatLastChecked(lastChecked)}
+                    </p>
                   )}
                 </div>
-              </div>
-            </section>
 
-            <section>
-              <div className="flex items-start gap-6 border-b border-border pb-8">
-                <div className="w-1/3 pt-1">
-                  <div className="flex items-center gap-2">
-                    <FileText size={18} className="text-primary" />
-                    <h2 className="text-lg font-medium text-foreground">Diagnostics & Logs</h2>
-                  </div>
-                  <p className="text-sm text-muted-foreground mt-1">
-                    Export or copy application logs to troubleshoot issues.
-                  </p>
-                </div>
-                <div className="w-2/3 space-y-4">
-                  <div className="grid grid-cols-2 gap-3">
-                    <button
-                      type="button"
-                      onClick={() => void logApi.revealLogDir()}
-                      className="flex items-center justify-start gap-2.5 px-4 py-3 bg-secondary/30 hover:bg-secondary/60 border border-border rounded-lg text-sm font-medium text-foreground transition-all hover:scale-[1.01] active:scale-[0.99] shadow-sm"
-                    >
-                      <FolderOpen size={16} className="text-muted-foreground" />
-                      <div className="text-left">
-                        <div>Reveal Log Folder</div>
-                        <div className="text-[10px] text-muted-foreground font-normal">
-                          Open in file explorer
-                        </div>
+                {/* Auto-update Toggle */}
+                <div>
+                  <label className="block text-sm font-medium text-secondary-foreground mb-2">
+                    Auto-update
+                  </label>
+                  <div className="flex items-center justify-between bg-secondary/30 border border-border rounded-md px-4 py-3">
+                    <div className="flex-1">
+                      <div className="text-sm text-foreground">Automatically check for updates</div>
+                      <div className="text-xs text-muted-foreground mt-0.5">
+                        When enabled, the app will periodically check for new versions
                       </div>
-                    </button>
-
+                    </div>
                     <button
-                      type="button"
-                      onClick={() => void logApi.exportLogFile()}
-                      className="flex items-center justify-start gap-2.5 px-4 py-3 bg-secondary/30 hover:bg-secondary/60 border border-border rounded-lg text-sm font-medium text-foreground transition-all hover:scale-[1.01] active:scale-[0.99] shadow-sm"
+                      onClick={() => handleAutoUpdateToggle(!autoUpdateEnabled)}
+                      className={cn(
+                        'relative inline-flex h-6 w-11 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2',
+                        autoUpdateEnabled ? 'bg-primary' : 'bg-input'
+                      )}
                     >
-                      <FileText size={16} className="text-muted-foreground" />
-                      <div className="text-left">
-                        <div>Export Log File...</div>
-                        <div className="text-[10px] text-muted-foreground font-normal">
-                          Save to a custom location
-                        </div>
-                      </div>
-                    </button>
-
-                    <button
-                      type="button"
-                      onClick={() => void logApi.copyLogContents()}
-                      className="flex items-center justify-start gap-2.5 px-4 py-3 bg-secondary/30 hover:bg-secondary/60 border border-border rounded-lg text-sm font-medium text-foreground transition-all hover:scale-[1.01] active:scale-[0.99] shadow-sm"
-                    >
-                      <Clipboard size={16} className="text-muted-foreground" />
-                      <div className="text-left">
-                        <div>Copy Log Contents</div>
-                        <div className="text-[10px] text-muted-foreground font-normal">
-                          Copy logs to clipboard
-                        </div>
-                      </div>
-                    </button>
-
-                    <button
-                      type="button"
-                      onClick={() => void logApi.exportLogToDefault()}
-                      className="flex items-center justify-start gap-2.5 px-4 py-3 bg-secondary/30 hover:bg-secondary/60 border border-border rounded-lg text-sm font-medium text-foreground transition-all hover:scale-[1.01] active:scale-[0.99] shadow-sm"
-                    >
-                      <Download size={16} className="text-muted-foreground" />
-                      <div className="text-left">
-                        <div>Export to Default Directory</div>
-                        <div className="text-[10px] text-muted-foreground font-normal">
-                          Save directly to Downloads
-                        </div>
-                      </div>
+                      <span
+                        className={cn(
+                          'inline-block h-4 w-4 transform rounded-full bg-white transition-transform',
+                          autoUpdateEnabled ? 'translate-x-6' : 'translate-x-1'
+                        )}
+                      />
                     </button>
                   </div>
                 </div>
-              </div>
-            </section>
 
-            {/* Reset Section */}
-            <section>
-              <div className="flex items-start gap-6 pb-8">
-                <div className="w-1/3 pt-1">
-                  <h2 className="text-lg font-medium text-foreground">Reset Settings</h2>
-                  <p className="text-sm text-muted-foreground mt-1">
-                    Restore all settings to their default values.
-                  </p>
+                {/* Skipped Version */}
+                {skippedVersion && (
+                  <div>
+                    <label className="block text-sm font-medium text-secondary-foreground mb-2">
+                      Skipped Version
+                    </label>
+                    <div className="bg-secondary/30 border border-border rounded-md px-4 py-3">
+                      <div className="text-sm text-foreground">
+                        You are currently skipping version{' '}
+                        <span className="font-mono">{skippedVersion}</span>
+                      </div>
+                      <div className="text-xs text-muted-foreground mt-0.5">
+                        This version will not be offered again until a newer version is available.
+                      </div>
+                    </div>
+                  </div>
+                )}
+              </div>
+            </div>
+          </SettingsSection>
+
+          <SettingsSection id="diagnostics">
+            <div className="flex items-start gap-6 border-b border-border pb-6">
+              <div className="w-1/3 pt-1">
+                <div className="flex items-center gap-2">
+                  <FileText size={18} className="text-primary" />
+                  <h2 className="text-lg font-medium text-foreground">Diagnostics & Logs</h2>
                 </div>
-                <div className="w-2/3">
+                <p className="text-sm text-muted-foreground mt-1">
+                  Export or copy application logs to troubleshoot issues.
+                </p>
+              </div>
+              <div className="w-2/3 space-y-4">
+                <div className="grid grid-cols-2 gap-3">
                   <button
-                    onClick={() => setIsResetDialogOpen(true)}
-                    className="flex items-center gap-2 px-4 py-2 bg-card hover:bg-secondary border border-border rounded-lg text-sm text-foreground transition-colors"
+                    type="button"
+                    onClick={() => void logApi.revealLogDir()}
+                    className="flex items-center justify-start gap-2.5 px-4 py-3 bg-secondary/30 hover:bg-secondary/60 border border-border rounded-lg text-sm font-medium text-foreground transition-all hover:scale-[1.01] active:scale-[0.99] shadow-sm"
                   >
-                    <RotateCcw size={16} />
-                    Reset to Defaults
+                    <FolderOpen size={16} className="text-muted-foreground" />
+                    <div className="text-left">
+                      <div>Reveal Log Folder</div>
+                      <div className="text-[10px] text-muted-foreground font-normal">
+                        Open in file explorer
+                      </div>
+                    </div>
+                  </button>
+
+                  <button
+                    type="button"
+                    onClick={() => void logApi.exportLogFile()}
+                    className="flex items-center justify-start gap-2.5 px-4 py-3 bg-secondary/30 hover:bg-secondary/60 border border-border rounded-lg text-sm font-medium text-foreground transition-all hover:scale-[1.01] active:scale-[0.99] shadow-sm"
+                  >
+                    <FileText size={16} className="text-muted-foreground" />
+                    <div className="text-left">
+                      <div>Export Log File...</div>
+                      <div className="text-[10px] text-muted-foreground font-normal">
+                        Save to a custom location
+                      </div>
+                    </div>
+                  </button>
+
+                  <button
+                    type="button"
+                    onClick={() => void logApi.copyLogContents()}
+                    className="flex items-center justify-start gap-2.5 px-4 py-3 bg-secondary/30 hover:bg-secondary/60 border border-border rounded-lg text-sm font-medium text-foreground transition-all hover:scale-[1.01] active:scale-[0.99] shadow-sm"
+                  >
+                    <Clipboard size={16} className="text-muted-foreground" />
+                    <div className="text-left">
+                      <div>Copy Log Contents</div>
+                      <div className="text-[10px] text-muted-foreground font-normal">
+                        Copy logs to clipboard
+                      </div>
+                    </div>
+                  </button>
+
+                  <button
+                    type="button"
+                    onClick={() => void logApi.exportLogToDefault()}
+                    className="flex items-center justify-start gap-2.5 px-4 py-3 bg-secondary/30 hover:bg-secondary/60 border border-border rounded-lg text-sm font-medium text-foreground transition-all hover:scale-[1.01] active:scale-[0.99] shadow-sm"
+                  >
+                    <Download size={16} className="text-muted-foreground" />
+                    <div className="text-left">
+                      <div>Export to Default Directory</div>
+                      <div className="text-[10px] text-muted-foreground font-normal">
+                        Save directly to Downloads
+                      </div>
+                    </div>
                   </button>
                 </div>
               </div>
-            </section>
-          </div>
-        </div>
+            </div>
+          </SettingsSection>
+
+          {/* Reset Section */}
+          <SettingsSection id="reset">
+            <div className="flex items-start gap-6 pb-6">
+              <div className="w-1/3 pt-1">
+                <h2 className="text-lg font-medium text-foreground">Reset Settings</h2>
+                <p className="text-sm text-muted-foreground mt-1">
+                  Restore all settings to their default values.
+                </p>
+              </div>
+              <div className="w-2/3">
+                <button
+                  onClick={() => setIsResetDialogOpen(true)}
+                  className="flex items-center gap-2 px-4 py-2 bg-card hover:bg-secondary border border-border rounded-lg text-sm text-foreground transition-colors"
+                >
+                  <RotateCcw size={16} />
+                  Reset to Defaults
+                </button>
+              </div>
+            </div>
+          </SettingsSection>
+        </SettingsLayout>
       </main>
 
       {/* Reset Confirmation Dialog */}

--- a/src/renderer/pages/ProjectSettings.tsx
+++ b/src/renderer/pages/ProjectSettings.tsx
@@ -1,7 +1,6 @@
 import type { DetectedShells } from '@shared/types/ipc.types'
 import {
   ChevronDown,
-  FolderCog,
   Info,
   KeySquare,
   Link2,
@@ -14,7 +13,7 @@ import {
   Upload,
   X
 } from 'lucide-react'
-import { useEffect, useRef, useState } from 'react'
+import { Fragment, useEffect, useRef, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { ConfirmDialog } from '@/components/ConfirmDialog'
 import { NewProjectModal } from '@/components/NewProjectModal'
@@ -523,8 +522,8 @@ export default function ProjectSettings() {
                     <div className="bg-secondary/80 w-10"></div>
 
                     {envVars.map((envVar, index) => (
-                      <>
-                        <div key={`key-${index}`} className="bg-card p-2">
+                      <Fragment key={index}>
+                        <div className="bg-card p-2">
                           <input
                             type="text"
                             value={envVar.key}
@@ -538,7 +537,7 @@ export default function ProjectSettings() {
                             className="w-full bg-transparent border-none text-sm font-mono text-primary focus:ring-0 px-2 py-1"
                           />
                         </div>
-                        <div key={`val-${index}`} className="bg-card p-2 relative group">
+                        <div className="bg-card p-2 relative group">
                           <input
                             type={envVar.isSecret ? 'password' : 'text'}
                             value={envVar.value}
@@ -555,10 +554,7 @@ export default function ProjectSettings() {
                             )}
                           />
                         </div>
-                        <div
-                          key={`action-${index}`}
-                          className="bg-card flex items-center justify-center"
-                        >
+                        <div className="bg-card flex items-center justify-center">
                           <button
                             onClick={() => removeEnvVar(index)}
                             className="text-muted-foreground hover:text-destructive p-1 rounded transition-colors"
@@ -566,7 +562,7 @@ export default function ProjectSettings() {
                             <X size={18} />
                           </button>
                         </div>
-                      </>
+                      </Fragment>
                     ))}
                   </div>
                 </div>
@@ -576,7 +572,7 @@ export default function ProjectSettings() {
 
           {/* Shell Settings Section */}
           <SettingsSection id="shell">
-            <div className="flex items-start gap-6">
+            <div className="flex items-start gap-6 border-b border-border pb-6">
               <div className="w-1/3 pt-1">
                 <h2 className="text-lg font-medium text-foreground">Shell Settings</h2>
                 <p className="text-sm text-muted-foreground mt-1">
@@ -641,7 +637,7 @@ export default function ProjectSettings() {
 
           {/* Worktree Symlink Directories Section */}
           <SettingsSection id="symlinks">
-            <div className="flex items-start gap-6">
+            <div className="flex items-start gap-6 border-b border-border pb-6">
               <div className="w-1/3 pt-1">
                 <h2 className="text-lg font-medium text-foreground">Worktree Symlinks</h2>
                 <p className="text-sm text-muted-foreground mt-1">

--- a/src/renderer/pages/ProjectSettings.tsx
+++ b/src/renderer/pages/ProjectSettings.tsx
@@ -115,7 +115,6 @@ export default function ProjectSettings() {
   const [rootPath, setRootPath] = useState(activeProject?.path || '')
   const [envVars, setEnvVars] = useState<EnvVariable[]>(activeProject?.envVars || [])
   const [shell, setShell] = useState(activeProject?.defaultShell || '')
-  const [startupCommand, setStartupCommand] = useState('')
   const [hasChanges, setHasChanges] = useState(false)
   const [symlinkDirs, setSymlinkDirs] = useState<string[]>(activeProject?.symlinkDirs ?? [])
   const [symlinkLoading, setSymlinkLoading] = useState(false)
@@ -612,25 +611,6 @@ export default function ProjectSettings() {
                     </div>
                   )}
                 </div>
-
-                <div>
-                  <label className="block text-sm font-medium text-secondary-foreground mb-2">
-                    Startup Command
-                  </label>
-                  <input
-                    type="text"
-                    value={startupCommand}
-                    onChange={(e) => {
-                      setStartupCommand(e.target.value)
-                      setHasChanges(true)
-                    }}
-                    placeholder="e.g. nvm use 16"
-                    className="w-full bg-secondary/50 border border-border rounded-md px-3 py-2 text-sm font-mono text-foreground focus:ring-2 focus:ring-primary focus:border-transparent outline-none shadow-sm"
-                  />
-                  <p className="text-xs text-muted-foreground mt-2">
-                    Command to execute immediately when a new terminal session starts.
-                  </p>
-                </div>
               </div>
             </div>
           </SettingsSection>
@@ -725,7 +705,6 @@ export default function ProjectSettings() {
                         checked={skipConfirmations}
                         onChange={(e) => {
                           setSkipConfirmations(e.target.checked)
-                          setHasChanges(true)
                         }}
                       />
                       <div className="w-9 h-5 bg-secondary rounded-full peer peer-checked:bg-primary after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-popover after:rounded-full after:h-4 after:w-4 after:transition-all peer-checked:after:translate-x-full"></div>
@@ -747,7 +726,6 @@ export default function ProjectSettings() {
                         checked={skipGitignoreSelection}
                         onChange={(e) => {
                           setSkipGitignoreSelection(e.target.checked)
-                          setHasChanges(true)
                         }}
                       />
                       <div className="w-9 h-5 bg-secondary rounded-full peer peer-checked:bg-primary after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-popover after:rounded-full after:h-4 after:w-4 after:transition-all peer-checked:after:translate-x-full"></div>
@@ -762,7 +740,6 @@ export default function ProjectSettings() {
                       value={defaultBranchPrefix}
                       onChange={(e) => {
                         setDefaultBranchPrefix(e.target.value)
-                        setHasChanges(true)
                       }}
                       placeholder="feature/"
                       className="w-full bg-secondary/50 border border-border rounded-md px-3 py-2 text-sm font-mono text-foreground focus:ring-2 focus:ring-primary focus:border-transparent outline-none"

--- a/src/renderer/pages/ProjectSettings.tsx
+++ b/src/renderer/pages/ProjectSettings.tsx
@@ -1,16 +1,107 @@
 import type { DetectedShells } from '@shared/types/ipc.types'
-import { ChevronDown, Info, Link2, Plus, RefreshCw, Save, Settings, Upload, X } from 'lucide-react'
+import {
+  ChevronDown,
+  FolderCog,
+  Info,
+  KeySquare,
+  Link2,
+  Plus,
+  RefreshCw,
+  Save,
+  Settings,
+  ShieldAlert,
+  TerminalSquare,
+  Upload,
+  X
+} from 'lucide-react'
 import { useEffect, useRef, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { ConfirmDialog } from '@/components/ConfirmDialog'
 import { NewProjectModal } from '@/components/NewProjectModal'
+import {
+  type SettingsCategory,
+  SettingsLayout,
+  SettingsSection
+} from '@/components/settings/SettingsLayout'
 import { Skeleton } from '@/components/ui/skeleton'
 import { dialogApi, filesystemApi, shellApi, worktreeApi } from '@/lib/api'
 import { availableColors, getColorClasses } from '@/lib/colors'
 import { mergeEnvVars, parseEnvFile } from '@/lib/env-parser'
+import type { SettingsSearchEntry } from '@/lib/settings-search'
 import { cn } from '@/lib/utils'
 import { useActiveProject, useActiveProjectId, useProjectActions } from '@/stores/project-store'
 import type { EnvVariable, ProjectColor } from '@/types/project'
+
+const PROJECT_SETTINGS_CATEGORIES: SettingsCategory[] = [
+  { id: 'general', label: 'General', icon: <Settings size={16} /> },
+  { id: 'env-vars', label: 'Environment Variables', icon: <KeySquare size={16} /> },
+  { id: 'shell', label: 'Shell Settings', icon: <TerminalSquare size={16} /> },
+  { id: 'symlinks', label: 'Worktree Symlinks', icon: <Link2 size={16} /> },
+  { id: 'emergency', label: 'Emergency Mode', icon: <ShieldAlert size={16} /> }
+]
+
+const PROJECT_SETTINGS_SEARCH_INDEX: SettingsSearchEntry[] = [
+  {
+    categoryId: 'general',
+    label: 'Project Name',
+    description: 'Basic project identification.',
+    keywords: ['rename', 'title']
+  },
+  {
+    categoryId: 'general',
+    label: 'Root Directory',
+    description: 'Project location on disk.',
+    keywords: ['path', 'folder', 'location']
+  },
+  {
+    categoryId: 'general',
+    label: 'Color & Appearance',
+    description: 'Project color and appearance.',
+    keywords: ['theme', 'color']
+  },
+  {
+    categoryId: 'env-vars',
+    label: 'Environment Variables',
+    description: 'Secrets and config injected into your shell session.',
+    keywords: ['env', 'secrets', 'config', 'dotenv']
+  },
+  {
+    categoryId: 'shell',
+    label: 'Default Shell',
+    description: 'Customize the terminal experience for this workspace.',
+    keywords: ['bash', 'zsh', 'powershell']
+  },
+  {
+    categoryId: 'shell',
+    label: 'Startup Command',
+    description: 'Command to execute when a new terminal session starts.',
+    keywords: ['init', 'startup', 'command']
+  },
+  {
+    categoryId: 'symlinks',
+    label: 'Worktree Symlinks',
+    description: 'Directories to symlink from the project root into worktrees.',
+    keywords: ['node_modules', 'gitignore', 'shared dependencies']
+  },
+  {
+    categoryId: 'emergency',
+    label: 'Skip Confirmation Dialogs',
+    description: 'Bypass non-essential prompts during worktree operations.',
+    keywords: ['emergency', 'confirm']
+  },
+  {
+    categoryId: 'emergency',
+    label: 'Skip .gitignore Selection',
+    description: 'Use default symlink settings when creating worktrees.',
+    keywords: ['emergency', 'gitignore']
+  },
+  {
+    categoryId: 'emergency',
+    label: 'Default Branch Prefix',
+    description: 'Prefix for new branch naming.',
+    keywords: ['branch', 'feature', 'hotfix']
+  }
+]
 
 export default function ProjectSettings() {
   const navigate = useNavigate()
@@ -301,394 +392,394 @@ export default function ProjectSettings() {
         </div>
 
         {/* Content */}
-        <div className="flex-1 overflow-y-auto p-8 pb-32">
-          <div className="max-w-4xl mx-auto space-y-12">
-            {/* General Section */}
-            <section>
-              <div className="flex items-start gap-6 border-b border-border pb-8">
-                <div className="w-1/3 pt-1">
-                  <h2 className="text-lg font-medium text-foreground">General</h2>
-                  <p className="text-sm text-muted-foreground mt-1">
-                    Basic project identification and location.
-                  </p>
+        <SettingsLayout
+          categories={PROJECT_SETTINGS_CATEGORIES}
+          searchIndex={PROJECT_SETTINGS_SEARCH_INDEX}
+        >
+          {/* General Section */}
+          <SettingsSection id="general">
+            <div className="flex items-start gap-6 border-b border-border pb-6">
+              <div className="w-1/3 pt-1">
+                <h2 className="text-lg font-medium text-foreground">General</h2>
+                <p className="text-sm text-muted-foreground mt-1">
+                  Basic project identification and location.
+                </p>
+              </div>
+              <div className="w-2/3 space-y-4">
+                <div>
+                  <label className="block text-sm font-medium text-secondary-foreground mb-2">
+                    Project Name
+                  </label>
+                  <input
+                    type="text"
+                    value={projectName}
+                    onChange={(e) => {
+                      setProjectName(e.target.value)
+                      setHasChanges(true)
+                    }}
+                    className="w-full bg-secondary/50 border border-border rounded-md px-3 py-2 text-sm text-foreground focus:ring-2 focus:ring-primary focus:border-transparent outline-none transition-shadow"
+                  />
                 </div>
-                <div className="w-2/3 space-y-6">
-                  <div>
-                    <label className="block text-sm font-medium text-secondary-foreground mb-2">
-                      Project Name
-                    </label>
+
+                <div>
+                  <label className="block text-sm font-medium text-secondary-foreground mb-2">
+                    Root Directory
+                  </label>
+                  <div className="flex gap-2">
                     <input
                       type="text"
-                      value={projectName}
+                      value={rootPath}
                       onChange={(e) => {
-                        setProjectName(e.target.value)
+                        setRootPath(e.target.value)
                         setHasChanges(true)
                       }}
-                      className="w-full bg-secondary/50 border border-border rounded-md px-3 py-2 text-sm text-foreground focus:ring-2 focus:ring-primary focus:border-transparent outline-none transition-shadow"
+                      className="flex-1 bg-secondary/50 border border-border rounded-md px-3 py-2 text-sm text-foreground font-mono focus:ring-2 focus:ring-primary outline-none"
                     />
-                  </div>
-
-                  <div>
-                    <label className="block text-sm font-medium text-secondary-foreground mb-2">
-                      Root Directory
-                    </label>
-                    <div className="flex gap-2">
-                      <input
-                        type="text"
-                        value={rootPath}
-                        onChange={(e) => {
-                          setRootPath(e.target.value)
+                    <button
+                      onClick={async () => {
+                        const result = await dialogApi.selectDirectory()
+                        if (result.success) {
+                          setRootPath(result.data)
                           setHasChanges(true)
-                        }}
-                        className="flex-1 bg-secondary/50 border border-border rounded-md px-3 py-2 text-sm text-foreground font-mono focus:ring-2 focus:ring-primary outline-none"
-                      />
-                      <button
-                        onClick={async () => {
-                          const result = await dialogApi.selectDirectory()
-                          if (result.success) {
-                            setRootPath(result.data)
-                            setHasChanges(true)
-                          }
-                        }}
-                        className="px-4 py-2 bg-card hover:bg-secondary border border-border rounded-md text-sm text-foreground transition-colors shadow-sm"
-                      >
-                        Browse
-                      </button>
-                    </div>
-                    <p className="text-xs text-muted-foreground mt-2">
-                      Changing the root directory only affects new terminals.
-                    </p>
+                        }
+                      }}
+                      className="px-4 py-2 bg-card hover:bg-secondary border border-border rounded-md text-sm text-foreground transition-colors shadow-sm"
+                    >
+                      Browse
+                    </button>
                   </div>
-
-                  <div>
-                    <label className="block text-sm font-medium text-secondary-foreground mb-3">
-                      Color & Appearance
-                    </label>
-                    <div className="flex gap-2 flex-wrap">
-                      {availableColors.map((color) => {
-                        const colors = getColorClasses(color)
-                        return (
-                          <button
-                            key={color}
-                            onClick={() => {
-                              setSelectedColor(color)
-                              setHasChanges(true)
-                            }}
-                            className={cn(
-                              'w-8 h-8 rounded-full transition-all',
-                              colors.bg,
-                              selectedColor === color
-                                ? 'ring-2 ring-offset-2 ring-offset-background ring-current shadow-sm'
-                                : 'border-2 border-transparent hover:opacity-80'
-                            )}
-                          />
-                        )
-                      })}
-                    </div>
-                  </div>
-                </div>
-              </div>
-            </section>
-
-            {/* Environment Variables Section */}
-            <section>
-              <div className="flex items-start gap-6 border-b border-border pb-8">
-                <div className="w-1/3 pt-1">
-                  <h2 className="text-lg font-medium text-foreground">Environment Variables</h2>
-                  <p className="text-sm text-muted-foreground mt-1">
-                    Secrets and config injected into your shell session. Secret values are cleared
-                    on app restart until secure storage is added.
-                  </p>
-                  <button
-                    onClick={addEnvVar}
-                    className="mt-4 text-xs flex items-center text-primary hover:text-primary/80 font-medium transition-colors"
-                  >
-                    <Plus size={14} className="mr-1" /> Add Variable
-                  </button>
-                  <button
-                    onClick={handleImportEnvFile}
-                    className="mt-2 text-xs flex items-center text-primary hover:text-primary/80 font-medium transition-colors"
-                  >
-                    <Upload size={14} className="mr-1" /> Import from .env
-                  </button>
-                  {importError && <p className="mt-2 text-xs text-destructive">{importError}</p>}
-                  {importWarnings && (
-                    <p className="mt-2 text-xs text-yellow-600 dark:text-yellow-400 whitespace-pre-line">
-                      {importWarnings}
-                    </p>
-                  )}
-                </div>
-                <div className="w-2/3">
-                  <div className="bg-secondary/30 rounded-lg border border-border overflow-hidden">
-                    <div className="grid grid-cols-[1fr_1.5fr_auto] gap-px bg-border">
-                      <div className="bg-secondary/80 px-4 py-2 text-xs font-semibold text-muted-foreground uppercase tracking-wider">
-                        Key
-                      </div>
-                      <div className="bg-secondary/80 px-4 py-2 text-xs font-semibold text-muted-foreground uppercase tracking-wider">
-                        Value
-                      </div>
-                      <div className="bg-secondary/80 w-10"></div>
-
-                      {envVars.map((envVar, index) => (
-                        <>
-                          <div key={`key-${index}`} className="bg-card p-2">
-                            <input
-                              type="text"
-                              value={envVar.key}
-                              onChange={(e) => {
-                                const newVars = [...envVars]
-                                newVars[index].key = e.target.value
-                                setEnvVars(newVars)
-                                setHasChanges(true)
-                              }}
-                              placeholder="KEY"
-                              className="w-full bg-transparent border-none text-sm font-mono text-primary focus:ring-0 px-2 py-1"
-                            />
-                          </div>
-                          <div key={`val-${index}`} className="bg-card p-2 relative group">
-                            <input
-                              type={envVar.isSecret ? 'password' : 'text'}
-                              value={envVar.value}
-                              onChange={(e) => {
-                                const newVars = [...envVars]
-                                newVars[index].value = e.target.value
-                                setEnvVars(newVars)
-                                setHasChanges(true)
-                              }}
-                              placeholder="Value"
-                              className={cn(
-                                'w-full bg-transparent border-none text-sm font-mono focus:ring-0 px-2 py-1',
-                                envVar.isSecret ? 'text-muted-foreground' : 'text-green-400'
-                              )}
-                            />
-                          </div>
-                          <div
-                            key={`action-${index}`}
-                            className="bg-card flex items-center justify-center"
-                          >
-                            <button
-                              onClick={() => removeEnvVar(index)}
-                              className="text-muted-foreground hover:text-destructive p-1 rounded transition-colors"
-                            >
-                              <X size={18} />
-                            </button>
-                          </div>
-                        </>
-                      ))}
-                    </div>
-                  </div>
-                </div>
-              </div>
-            </section>
-
-            {/* Shell Settings Section */}
-            <section>
-              <div className="flex items-start gap-6">
-                <div className="w-1/3 pt-1">
-                  <h2 className="text-lg font-medium text-foreground">Shell Settings</h2>
-                  <p className="text-sm text-muted-foreground mt-1">
-                    Customize the terminal experience for this workspace.
+                  <p className="text-xs text-muted-foreground mt-2">
+                    Changing the root directory only affects new terminals.
                   </p>
                 </div>
-                <div className="w-2/3 space-y-6">
-                  <div>
-                    <label className="block text-sm font-medium text-secondary-foreground mb-2">
-                      Default Shell
-                    </label>
-                    {shellsLoading ? (
-                      <Skeleton className="w-full h-10" />
-                    ) : (
-                      <div className="relative">
-                        <select
-                          value={shell}
-                          onChange={(e) => {
-                            setShell(e.target.value)
+
+                <div>
+                  <label className="block text-sm font-medium text-secondary-foreground mb-3">
+                    Color & Appearance
+                  </label>
+                  <div className="flex gap-2 flex-wrap">
+                    {availableColors.map((color) => {
+                      const colors = getColorClasses(color)
+                      return (
+                        <button
+                          key={color}
+                          onClick={() => {
+                            setSelectedColor(color)
                             setHasChanges(true)
                           }}
-                          className="w-full appearance-none bg-secondary/50 border border-border rounded-md pl-3 pr-10 py-2 text-sm text-foreground focus:ring-2 focus:ring-primary focus:border-transparent outline-none cursor-pointer shadow-sm"
-                        >
-                          {availableShells?.available && availableShells.available.length > 0 ? (
-                            availableShells.available.map((s) => (
-                              <option key={s.name} value={s.name}>
-                                {s.displayName}
-                              </option>
-                            ))
-                          ) : (
-                            <option value="">No shells detected</option>
+                          className={cn(
+                            'w-8 h-8 rounded-full transition-all',
+                            colors.bg,
+                            selectedColor === color
+                              ? 'ring-2 ring-offset-2 ring-offset-background ring-current shadow-sm'
+                              : 'border-2 border-transparent hover:opacity-80'
                           )}
-                        </select>
-                        <div className="pointer-events-none absolute inset-y-0 right-0 flex items-center px-3 text-muted-foreground">
-                          <ChevronDown size={14} />
-                        </div>
-                      </div>
-                    )}
-                  </div>
-
-                  <div>
-                    <label className="block text-sm font-medium text-secondary-foreground mb-2">
-                      Startup Command
-                    </label>
-                    <input
-                      type="text"
-                      value={startupCommand}
-                      onChange={(e) => {
-                        setStartupCommand(e.target.value)
-                        setHasChanges(true)
-                      }}
-                      placeholder="e.g. nvm use 16"
-                      className="w-full bg-secondary/50 border border-border rounded-md px-3 py-2 text-sm font-mono text-foreground focus:ring-2 focus:ring-primary focus:border-transparent outline-none shadow-sm"
-                    />
-                    <p className="text-xs text-muted-foreground mt-2">
-                      Command to execute immediately when a new terminal session starts.
-                    </p>
+                        />
+                      )
+                    })}
                   </div>
                 </div>
               </div>
-            </section>
+            </div>
+          </SettingsSection>
 
-            {/* Worktree Symlink Directories Section */}
-            <section>
-              <div className="flex items-start gap-6">
-                <div className="w-1/3 pt-1">
-                  <h2 className="text-lg font-medium text-foreground">Worktree Symlinks</h2>
-                  <p className="text-sm text-muted-foreground mt-1">
-                    Directories to symlink from the project root into worktrees. This allows shared
-                    dependencies (like{' '}
-                    <code className="text-xs bg-secondary/50 px-1 rounded">node_modules</code>)
-                    across worktrees without reinstalling.
+          {/* Environment Variables Section */}
+          <SettingsSection id="env-vars">
+            <div className="flex items-start gap-6 border-b border-border pb-6">
+              <div className="w-1/3 pt-1">
+                <h2 className="text-lg font-medium text-foreground">Environment Variables</h2>
+                <p className="text-sm text-muted-foreground mt-1">
+                  Secrets and config injected into your shell session. Secret values are cleared on
+                  app restart until secure storage is added.
+                </p>
+                <button
+                  onClick={addEnvVar}
+                  className="mt-4 text-xs flex items-center text-primary hover:text-primary/80 font-medium transition-colors"
+                >
+                  <Plus size={14} className="mr-1" /> Add Variable
+                </button>
+                <button
+                  onClick={handleImportEnvFile}
+                  className="mt-2 text-xs flex items-center text-primary hover:text-primary/80 font-medium transition-colors"
+                >
+                  <Upload size={14} className="mr-1" /> Import from .env
+                </button>
+                {importError && <p className="mt-2 text-xs text-destructive">{importError}</p>}
+                {importWarnings && (
+                  <p className="mt-2 text-xs text-yellow-600 dark:text-yellow-400 whitespace-pre-line">
+                    {importWarnings}
                   </p>
-                  <div className="mt-4 space-y-2">
-                    <button
-                      onClick={() => void syncFromGitignore()}
-                      disabled={symlinkLoading || !activeProject?.isGitRepo}
-                      className="text-xs flex items-center text-primary hover:text-primary/80 font-medium transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
-                    >
-                      <RefreshCw
-                        size={14}
-                        className={`mr-1 ${symlinkLoading ? 'animate-spin' : ''}`}
-                      />
-                      Sync from .gitignore
-                    </button>
-                    <button
-                      onClick={addSymlinkDir}
-                      className="text-xs flex items-center text-primary hover:text-primary/80 font-medium transition-colors"
-                    >
-                      <Plus size={14} className="mr-1" /> Add Directory
-                    </button>
-                  </div>
-                </div>
-                <div className="w-2/3">
-                  <div className="bg-secondary/30 rounded-lg border border-border p-3 space-y-2">
-                    {symlinkDirs.length === 0 ? (
-                      <p className="text-xs text-muted-foreground text-center py-4">
-                        No symlink directories configured. Click "Sync from .gitignore" to
-                        auto-detect.
-                      </p>
-                    ) : (
-                      symlinkDirs.map((dir, index) => (
-                        <div key={index} className="flex items-center gap-2">
-                          <Link2 size={12} className="text-muted-foreground flex-shrink-0" />
+                )}
+              </div>
+              <div className="w-2/3">
+                <div className="bg-secondary/30 rounded-lg border border-border overflow-hidden">
+                  <div className="grid grid-cols-[1fr_1.5fr_auto] gap-px bg-border">
+                    <div className="bg-secondary/80 px-4 py-2 text-xs font-semibold text-muted-foreground uppercase tracking-wider">
+                      Key
+                    </div>
+                    <div className="bg-secondary/80 px-4 py-2 text-xs font-semibold text-muted-foreground uppercase tracking-wider">
+                      Value
+                    </div>
+                    <div className="bg-secondary/80 w-10"></div>
+
+                    {envVars.map((envVar, index) => (
+                      <>
+                        <div key={`key-${index}`} className="bg-card p-2">
                           <input
                             type="text"
-                            value={dir}
-                            onChange={(e) => updateSymlinkDir(index, e.target.value)}
-                            placeholder="e.g. node_modules"
-                            className="flex-1 bg-secondary/50 border border-border rounded px-2 py-1 text-sm font-mono text-foreground focus:ring-1 focus:ring-primary outline-none placeholder-muted-foreground"
+                            value={envVar.key}
+                            onChange={(e) => {
+                              const newVars = [...envVars]
+                              newVars[index].key = e.target.value
+                              setEnvVars(newVars)
+                              setHasChanges(true)
+                            }}
+                            placeholder="KEY"
+                            className="w-full bg-transparent border-none text-sm font-mono text-primary focus:ring-0 px-2 py-1"
                           />
+                        </div>
+                        <div key={`val-${index}`} className="bg-card p-2 relative group">
+                          <input
+                            type={envVar.isSecret ? 'password' : 'text'}
+                            value={envVar.value}
+                            onChange={(e) => {
+                              const newVars = [...envVars]
+                              newVars[index].value = e.target.value
+                              setEnvVars(newVars)
+                              setHasChanges(true)
+                            }}
+                            placeholder="Value"
+                            className={cn(
+                              'w-full bg-transparent border-none text-sm font-mono focus:ring-0 px-2 py-1',
+                              envVar.isSecret ? 'text-muted-foreground' : 'text-green-400'
+                            )}
+                          />
+                        </div>
+                        <div
+                          key={`action-${index}`}
+                          className="bg-card flex items-center justify-center"
+                        >
                           <button
-                            onClick={() => removeSymlinkDir(index)}
+                            onClick={() => removeEnvVar(index)}
                             className="text-muted-foreground hover:text-destructive p-1 rounded transition-colors"
                           >
-                            <X size={14} />
+                            <X size={18} />
                           </button>
                         </div>
-                      ))
-                    )}
+                      </>
+                    ))}
                   </div>
                 </div>
               </div>
-            </section>
+            </div>
+          </SettingsSection>
 
-            {/* Emergency Mode & Expert Workflows Section */}
-            <section>
-              <div className="flex items-start gap-6">
-                <div className="w-1/3 pt-1">
-                  <h2 className="text-lg font-medium text-foreground">Emergency Mode</h2>
-                  <p className="text-sm text-muted-foreground mt-1">
-                    Power-user workflow settings for incident response and rapid worktree
-                    operations.
-                  </p>
-                </div>
-                <div className="w-2/3">
-                  <div className="bg-secondary/30 rounded-lg border border-border p-4 space-y-4">
-                    <div className="flex items-center justify-between">
-                      <div>
-                        <p className="text-sm font-medium text-foreground">
-                          Skip Confirmation Dialogs
-                        </p>
-                        <p className="text-xs text-muted-foreground">
-                          Bypass non-essential prompts during worktree operations.
-                        </p>
-                      </div>
-                      <label className="relative inline-flex items-center cursor-pointer">
-                        <input
-                          type="checkbox"
-                          className="sr-only peer"
-                          checked={skipConfirmations}
-                          onChange={(e) => {
-                            setSkipConfirmations(e.target.checked)
-                            setHasChanges(true)
-                          }}
-                        />
-                        <div className="w-9 h-5 bg-secondary rounded-full peer peer-checked:bg-primary after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-popover after:rounded-full after:h-4 after:w-4 after:transition-all peer-checked:after:translate-x-full"></div>
-                      </label>
-                    </div>
-                    <div className="flex items-center justify-between">
-                      <div>
-                        <p className="text-sm font-medium text-foreground">
-                          Skip .gitignore Selection
-                        </p>
-                        <p className="text-xs text-muted-foreground">
-                          Use default symlink settings when creating worktrees.
-                        </p>
-                      </div>
-                      <label className="relative inline-flex items-center cursor-pointer">
-                        <input
-                          type="checkbox"
-                          className="sr-only peer"
-                          checked={skipGitignoreSelection}
-                          onChange={(e) => {
-                            setSkipGitignoreSelection(e.target.checked)
-                            setHasChanges(true)
-                          }}
-                        />
-                        <div className="w-9 h-5 bg-secondary rounded-full peer peer-checked:bg-primary after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-popover after:rounded-full after:h-4 after:w-4 after:transition-all peer-checked:after:translate-x-full"></div>
-                      </label>
-                    </div>
-                    <div>
-                      <label className="block text-sm font-medium text-foreground mb-1">
-                        Default Branch Prefix
-                      </label>
-                      <input
-                        type="text"
-                        value={defaultBranchPrefix}
+          {/* Shell Settings Section */}
+          <SettingsSection id="shell">
+            <div className="flex items-start gap-6">
+              <div className="w-1/3 pt-1">
+                <h2 className="text-lg font-medium text-foreground">Shell Settings</h2>
+                <p className="text-sm text-muted-foreground mt-1">
+                  Customize the terminal experience for this workspace.
+                </p>
+              </div>
+              <div className="w-2/3 space-y-4">
+                <div>
+                  <label className="block text-sm font-medium text-secondary-foreground mb-2">
+                    Default Shell
+                  </label>
+                  {shellsLoading ? (
+                    <Skeleton className="w-full h-10" />
+                  ) : (
+                    <div className="relative">
+                      <select
+                        value={shell}
                         onChange={(e) => {
-                          setDefaultBranchPrefix(e.target.value)
+                          setShell(e.target.value)
                           setHasChanges(true)
                         }}
-                        placeholder="feature/"
-                        className="w-full bg-secondary/50 border border-border rounded-md px-3 py-2 text-sm font-mono text-foreground focus:ring-2 focus:ring-primary focus:border-transparent outline-none"
-                      />
-                      <p className="text-xs text-muted-foreground mt-1">
-                        Prefix for new branch naming (e.g. "feature/", "hotfix/").
+                        className="w-full appearance-none bg-secondary/50 border border-border rounded-md pl-3 pr-10 py-2 text-sm text-foreground focus:ring-2 focus:ring-primary focus:border-transparent outline-none cursor-pointer shadow-sm"
+                      >
+                        {availableShells?.available && availableShells.available.length > 0 ? (
+                          availableShells.available.map((s) => (
+                            <option key={s.name} value={s.name}>
+                              {s.displayName}
+                            </option>
+                          ))
+                        ) : (
+                          <option value="">No shells detected</option>
+                        )}
+                      </select>
+                      <div className="pointer-events-none absolute inset-y-0 right-0 flex items-center px-3 text-muted-foreground">
+                        <ChevronDown size={14} />
+                      </div>
+                    </div>
+                  )}
+                </div>
+
+                <div>
+                  <label className="block text-sm font-medium text-secondary-foreground mb-2">
+                    Startup Command
+                  </label>
+                  <input
+                    type="text"
+                    value={startupCommand}
+                    onChange={(e) => {
+                      setStartupCommand(e.target.value)
+                      setHasChanges(true)
+                    }}
+                    placeholder="e.g. nvm use 16"
+                    className="w-full bg-secondary/50 border border-border rounded-md px-3 py-2 text-sm font-mono text-foreground focus:ring-2 focus:ring-primary focus:border-transparent outline-none shadow-sm"
+                  />
+                  <p className="text-xs text-muted-foreground mt-2">
+                    Command to execute immediately when a new terminal session starts.
+                  </p>
+                </div>
+              </div>
+            </div>
+          </SettingsSection>
+
+          {/* Worktree Symlink Directories Section */}
+          <SettingsSection id="symlinks">
+            <div className="flex items-start gap-6">
+              <div className="w-1/3 pt-1">
+                <h2 className="text-lg font-medium text-foreground">Worktree Symlinks</h2>
+                <p className="text-sm text-muted-foreground mt-1">
+                  Directories to symlink from the project root into worktrees. This allows shared
+                  dependencies (like{' '}
+                  <code className="text-xs bg-secondary/50 px-1 rounded">node_modules</code>) across
+                  worktrees without reinstalling.
+                </p>
+                <div className="mt-4 space-y-2">
+                  <button
+                    onClick={() => void syncFromGitignore()}
+                    disabled={symlinkLoading || !activeProject?.isGitRepo}
+                    className="text-xs flex items-center text-primary hover:text-primary/80 font-medium transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                  >
+                    <RefreshCw
+                      size={14}
+                      className={`mr-1 ${symlinkLoading ? 'animate-spin' : ''}`}
+                    />
+                    Sync from .gitignore
+                  </button>
+                  <button
+                    onClick={addSymlinkDir}
+                    className="text-xs flex items-center text-primary hover:text-primary/80 font-medium transition-colors"
+                  >
+                    <Plus size={14} className="mr-1" /> Add Directory
+                  </button>
+                </div>
+              </div>
+              <div className="w-2/3">
+                <div className="bg-secondary/30 rounded-lg border border-border p-3 space-y-2">
+                  {symlinkDirs.length === 0 ? (
+                    <p className="text-xs text-muted-foreground text-center py-4">
+                      No symlink directories configured. Click "Sync from .gitignore" to
+                      auto-detect.
+                    </p>
+                  ) : (
+                    symlinkDirs.map((dir, index) => (
+                      <div key={index} className="flex items-center gap-2">
+                        <Link2 size={12} className="text-muted-foreground flex-shrink-0" />
+                        <input
+                          type="text"
+                          value={dir}
+                          onChange={(e) => updateSymlinkDir(index, e.target.value)}
+                          placeholder="e.g. node_modules"
+                          className="flex-1 bg-secondary/50 border border-border rounded px-2 py-1 text-sm font-mono text-foreground focus:ring-1 focus:ring-primary outline-none placeholder-muted-foreground"
+                        />
+                        <button
+                          onClick={() => removeSymlinkDir(index)}
+                          className="text-muted-foreground hover:text-destructive p-1 rounded transition-colors"
+                        >
+                          <X size={14} />
+                        </button>
+                      </div>
+                    ))
+                  )}
+                </div>
+              </div>
+            </div>
+          </SettingsSection>
+
+          {/* Emergency Mode & Expert Workflows Section */}
+          <SettingsSection id="emergency">
+            <div className="flex items-start gap-6">
+              <div className="w-1/3 pt-1">
+                <h2 className="text-lg font-medium text-foreground">Emergency Mode</h2>
+                <p className="text-sm text-muted-foreground mt-1">
+                  Power-user workflow settings for incident response and rapid worktree operations.
+                </p>
+              </div>
+              <div className="w-2/3">
+                <div className="bg-secondary/30 rounded-lg border border-border p-4 space-y-4">
+                  <div className="flex items-center justify-between">
+                    <div>
+                      <p className="text-sm font-medium text-foreground">
+                        Skip Confirmation Dialogs
+                      </p>
+                      <p className="text-xs text-muted-foreground">
+                        Bypass non-essential prompts during worktree operations.
                       </p>
                     </div>
+                    <label className="relative inline-flex items-center cursor-pointer">
+                      <input
+                        type="checkbox"
+                        className="sr-only peer"
+                        checked={skipConfirmations}
+                        onChange={(e) => {
+                          setSkipConfirmations(e.target.checked)
+                          setHasChanges(true)
+                        }}
+                      />
+                      <div className="w-9 h-5 bg-secondary rounded-full peer peer-checked:bg-primary after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-popover after:rounded-full after:h-4 after:w-4 after:transition-all peer-checked:after:translate-x-full"></div>
+                    </label>
+                  </div>
+                  <div className="flex items-center justify-between">
+                    <div>
+                      <p className="text-sm font-medium text-foreground">
+                        Skip .gitignore Selection
+                      </p>
+                      <p className="text-xs text-muted-foreground">
+                        Use default symlink settings when creating worktrees.
+                      </p>
+                    </div>
+                    <label className="relative inline-flex items-center cursor-pointer">
+                      <input
+                        type="checkbox"
+                        className="sr-only peer"
+                        checked={skipGitignoreSelection}
+                        onChange={(e) => {
+                          setSkipGitignoreSelection(e.target.checked)
+                          setHasChanges(true)
+                        }}
+                      />
+                      <div className="w-9 h-5 bg-secondary rounded-full peer peer-checked:bg-primary after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-popover after:rounded-full after:h-4 after:w-4 after:transition-all peer-checked:after:translate-x-full"></div>
+                    </label>
+                  </div>
+                  <div>
+                    <label className="block text-sm font-medium text-foreground mb-1">
+                      Default Branch Prefix
+                    </label>
+                    <input
+                      type="text"
+                      value={defaultBranchPrefix}
+                      onChange={(e) => {
+                        setDefaultBranchPrefix(e.target.value)
+                        setHasChanges(true)
+                      }}
+                      placeholder="feature/"
+                      className="w-full bg-secondary/50 border border-border rounded-md px-3 py-2 text-sm font-mono text-foreground focus:ring-2 focus:ring-primary focus:border-transparent outline-none"
+                    />
+                    <p className="text-xs text-muted-foreground mt-1">
+                      Prefix for new branch naming (e.g. "feature/", "hotfix/").
+                    </p>
                   </div>
                 </div>
               </div>
-            </section>
-          </div>
-        </div>
+            </div>
+          </SettingsSection>
+        </SettingsLayout>
 
         {/* Save Bar */}
         {hasChanges && (


### PR DESCRIPTION
## Summary

Both settings surfaces (`AppPreferences.tsx` and `ProjectSettings.tsx`) rendered as a single long, vertically-stacked column. With large `space-y-12` gaps and a two-column-per-section layout, the page grew very tall — the Keyboard Shortcuts section alone renders ~30 `ShortcutRecorder` rows, pushing everything below it far down. That meant heavy scrolling, high mouse travel to reach late sections (Updates/Reset), and no way to find a specific setting without visually scanning.

This PR redesigns both pages with a left sidebar of setting categories plus a fuzzy search box, extracted into a shared `SettingsLayout` so both pages stay consistent.

## Related Issue

Closes #249

<!-- Searched open and closed PRs for "settings", "sidebar", and #249 — no existing or prior PR addresses this issue. -->

## Type of Change

- [x] feat: new feature

## What Changed

- **New `SettingsLayout` + `SettingsSection`** (`src/renderer/components/settings/SettingsLayout.tsx`): left sidebar listing categories with the active one highlighted (`aria-current`), a fuzzy search input, and a scroll-spy content area. Clicking a category or a search result scrolls the matching section into view; an `IntersectionObserver` keeps the active category in sync while scrolling (programmatic scrolls briefly suppress it so the highlight follows the click target). Categories are keyboard-navigable (arrow keys + focus ring) and the search field is labeled.
- **New `settings-search` matcher** (`src/renderer/lib/settings-search.ts`): a dependency-free fuzzy subsequence matcher with proximity/word-boundary scoring. Kept runtime-neutral so it unit-tests cleanly under Vitest + jsdom rather than coupling to cmdk's React primitives. Powers a flat `{ categoryId, label, description, keywords }` index so a query like "font" surfaces Font Family/Font Size.
- **`AppPreferences.tsx`**: 9 categories + search index; each section wrapped in `SettingsSection`.
- **`ProjectSettings.tsx`**: 5 categories + search index; sections wrapped. The save bar and unsaved-changes guard stay outside the layout and are unchanged, so that behavior is preserved.
- **Compact layout + scrollable AI Agents**: tightened section spacing (`p-8`→`p-6`, `space-y-12`→`space-y-8`, `pb-8`→`pb-6`, `space-y-6`→`space-y-4`) and constrained the AI Agents list to a `max-h-80 overflow-y-auto` area so it scrolls internally instead of stretching the page.

Design note: content remains a single scrollable column with scroll-spy navigation (rather than show-one-at-a-time) specifically so ProjectSettings' save bar and unsaved-changes flow, which span all sections, keep working without rework.

## How It Was Tested

- [x] `bun run ci` (Biome lint + format + imports, strict mode)
- [x] `bun run typecheck`
- [x] `bun run test`
- [ ] `cargo clippy --all-targets -- -D warnings` (in src-tauri) — not applicable, renderer-only change
- [ ] `cargo test` (in src-tauri) — not applicable, renderer-only change
- [x] Manual verification completed

Added 23 unit tests: `settings-search.test.ts` (14) covers scoring, keyword matching, sorting, and empty queries; `SettingsLayout.test.tsx` (9) covers rendering, active state, click-to-scroll, search filtering/keywords, empty state, and clear. Full suite: 1719 passing. Production frontend build (`vite build --config vite.config.tauri.ts`) succeeds.

## Screenshots or Recordings

<img width="1590" height="937" alt="image" src="https://github.com/user-attachments/assets/b127d6d1-cb8a-4303-a852-4ea469c38ec4" />
<img width="1546" height="946" alt="image" src="https://github.com/user-attachments/assets/0bc3afe2-3cc6-4fd5-a649-1cc88446d4ec" />
<img width="1586" height="987" alt="image" src="https://github.com/user-attachments/assets/fcf44a45-8f81-41cc-a3fd-b4fe481288ea" />

## CI & Review Gate

- [x] All CI checks pass (PR Validation, Rust Checks, Build Verification, Security Scans)
- [ ] Code review comments from CodeRabbit / Claude have been addressed or resolved
- [ ] No unresolved review findings remain

## Checklist

- [x] My PR title follows the conventional commit format used by this repo
- [x] I linked the related issue or explained why none exists
- [ ] I updated docs when needed — no user-facing docs require changes for this UI refactor
- [x] I added or updated tests when needed
- [x] I verified the change does not introduce unrelated modifications
- [x] I read AGENTS.md and followed the contributor guidelines
- [x] A human reviewed the complete diff before submission


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added searchable settings for both preferences and project settings.
  * Organized settings into categorized sections with sidebar navigation.
  * Added keyboard navigation for switching categories (Arrow keys).

* **Improvements**
  * Enhanced fuzzy search quality using labels, descriptions, and keywords with ranked results.
  * Improved active-category tracking and smoother jump-to-section behavior.
  * Improved display of long agent lists with a constrained, scrollable layout.

* **Tests**
  * Added coverage for fuzzy scoring/search and settings layout + scrolling behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->