### PR TITLE
ci: enforce PR template by validating description on pull_request

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -71,7 +71,9 @@ jobs:
         run: bun run scripts/validate-pr-body.ts
 
       - name: Post or update failure comment
-        if: failure() && steps.validate.outcome == 'failure'
+        # Skip on forked PRs: GITHUB_TOKEN is read-only there, so the comment
+        # API calls would 403. Validation itself still gates forked PRs.
+        if: failure() && steps.validate.outcome == 'failure' && github.event.pull_request.head.repo.full_name == github.repository
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
@@ -95,7 +97,9 @@ jobs:
             }
 
       - name: Resolve failure comment on success
-        if: success()
+        # Skip on forked PRs (read-only GITHUB_TOKEN) to avoid a 403 turning a
+        # passing validation into a failed job.
+        if: success() && github.event.pull_request.head.repo.full_name == github.repository
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -47,6 +47,9 @@ jobs:
     name: Validate PR Description
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -59,11 +62,52 @@ jobs:
           bun-version: 1.3.x
 
       - name: Validate PR description against template
+        id: validate
         env:
           # Pass the body via env, never interpolated into the shell, to avoid
           # command injection from attacker-controlled PR descriptions.
           PR_BODY: ${{ github.event.pull_request.body }}
+          PR_BODY_COMMENT_FILE: ${{ runner.temp }}/pr-body-comment.md
         run: bun run scripts/validate-pr-body.ts
+
+      - name: Post or update failure comment
+        if: failure() && steps.validate.outcome == 'failure'
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+        with:
+          script: |
+            const fs = require('node:fs');
+            const marker = '<!-- pr-body-validation -->';
+            const path = `${process.env.RUNNER_TEMP}/pr-body-comment.md`;
+            let body;
+            try {
+              body = fs.readFileSync(path, 'utf8');
+            } catch {
+              body = `${marker}\n## ❌ PR description does not satisfy the template\n\nPlease fill in every required section of the PR template.`;
+            }
+            const { owner, repo } = context.repo;
+            const issue_number = context.issue.number;
+            const { data: comments } = await github.rest.issues.listComments({ owner, repo, issue_number, per_page: 100 });
+            const existing = comments.find((c) => c.body && c.body.includes(marker));
+            if (existing) {
+              await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body });
+            } else {
+              await github.rest.issues.createComment({ owner, repo, issue_number, body });
+            }
+
+      - name: Resolve failure comment on success
+        if: success()
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+        with:
+          script: |
+            const marker = '<!-- pr-body-validation -->';
+            const { owner, repo } = context.repo;
+            const issue_number = context.issue.number;
+            const { data: comments } = await github.rest.issues.listComments({ owner, repo, issue_number, per_page: 100 });
+            const existing = comments.find((c) => c.body && c.body.includes(marker));
+            if (existing) {
+              const body = `${marker}\n## ✅ PR description satisfies the template\n\nThanks for filling it in.`;
+              await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body });
+            }
 
   validate:
     name: Lint, Typecheck & Test

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -2,6 +2,7 @@ name: PR Validation
 
 on:
   pull_request:
+    types: [opened, edited, synchronize, reopened]
     branches: [main, develop, dev]
 
 permissions:
@@ -42,8 +43,32 @@ jobs:
             The subject "{subject}" must not start with an uppercase letter.
             Use lowercase like: "feat: add new feature"
 
+  pr-body-check:
+    name: Validate PR Description
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        with:
+          bun-version: 1.3.x
+
+      - name: Validate PR description against template
+        env:
+          # Pass the body via env, never interpolated into the shell, to avoid
+          # command injection from attacker-controlled PR descriptions.
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: bun run scripts/validate-pr-body.ts
+
   validate:
     name: Lint, Typecheck & Test
+    # Code jobs don't need to re-run when only the PR description is edited.
+    if: github.event.action != 'edited'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -71,6 +96,7 @@ jobs:
 
   rust-checks:
     name: Rust Checks
+    if: github.event.action != 'edited'
     runs-on: ubuntu-22.04
     timeout-minutes: 20
     steps:
@@ -114,6 +140,7 @@ jobs:
 
   rust-windows-check:
     name: Rust Windows Smoke Check
+    if: github.event.action != 'edited'
     runs-on: windows-latest
     timeout-minutes: 15
     steps:
@@ -139,6 +166,7 @@ jobs:
 
   build-check:
     name: Verify Tauri Frontend Build
+    if: github.event.action != 'edited'
     needs: [validate, rust-checks, rust-windows-check]
     runs-on: ubuntu-latest
     timeout-minutes: 15

--- a/scripts/validate-pr-body.test.ts
+++ b/scripts/validate-pr-body.test.ts
@@ -66,6 +66,18 @@ describe('validatePrBody', () => {
     expect(result.errors.some((e) => /Summary/i.test(e))).toBe(true)
   })
 
+  it('strips multiple comments and is idempotent (repeated sanitization)', () => {
+    // A comment-only section with several comments must read as empty, and
+    // re-running the strip must not change a comment-free result.
+    const body = validBody.replace(
+      '## Summary\n\nThis fixes a crash when opening the settings page with no saved layout.',
+      '## Summary\n\n<!-- a --><!-- b --><!-- c -->'
+    )
+    const result = validatePrBody(body)
+    expect(result.ok).toBe(false)
+    expect(result.errors.some((e) => /Summary.*empty/i.test(e))).toBe(true)
+  })
+
   it('requires a linked issue or an explicit no-issue note', () => {
     const body = validBody.replace('Closes #123', 'Closes #')
     const result = validatePrBody(body)

--- a/scripts/validate-pr-body.test.ts
+++ b/scripts/validate-pr-body.test.ts
@@ -1,0 +1,158 @@
+import { describe, expect, it } from 'vitest'
+import { validatePrBody } from './validate-pr-body'
+
+// A fully, correctly filled template.
+const validBody = `## Summary
+
+This fixes a crash when opening the settings page with no saved layout.
+
+## Related Issue
+
+Closes #123
+
+## Type of Change
+
+- [x] fix: bug fix
+
+## What Changed
+
+- Guard against undefined layout in SettingsLayout
+- Add fallback default config
+
+## How It Was Tested
+
+- [x] \`bun run test\`
+- [x] Manual verification completed
+
+## Checklist
+
+- [x] My PR title follows the conventional commit format used by this repo
+`
+
+describe('validatePrBody', () => {
+  it('passes a fully filled template', () => {
+    const result = validatePrBody(validBody)
+    expect(result.errors).toEqual([])
+    expect(result.ok).toBe(true)
+  })
+
+  it('rejects an empty body', () => {
+    const result = validatePrBody('')
+    expect(result.ok).toBe(false)
+    expect(result.errors[0]).toMatch(/empty/i)
+  })
+
+  it('rejects undefined body', () => {
+    expect(validatePrBody(undefined).ok).toBe(false)
+  })
+
+  it('flags an empty Summary with only a bare bullet', () => {
+    const body = validBody.replace(
+      'This fixes a crash when opening the settings page with no saved layout.',
+      '-'
+    )
+    const result = validatePrBody(body)
+    expect(result.ok).toBe(false)
+    expect(result.errors.some((e) => /Summary.*empty/i.test(e))).toBe(true)
+  })
+
+  it('treats HTML-comment-only sections as empty', () => {
+    const body = validBody.replace(
+      '## Summary\n\nThis fixes a crash when opening the settings page with no saved layout.',
+      '## Summary\n\n<!-- describe here -->'
+    )
+    const result = validatePrBody(body)
+    expect(result.ok).toBe(false)
+    expect(result.errors.some((e) => /Summary/i.test(e))).toBe(true)
+  })
+
+  it('requires a linked issue or an explicit no-issue note', () => {
+    const body = validBody.replace('Closes #123', 'Closes #')
+    const result = validatePrBody(body)
+    expect(result.ok).toBe(false)
+    expect(result.errors.some((e) => /Related Issue/i.test(e))).toBe(true)
+  })
+
+  it('accepts an explicit "no related issue" explanation', () => {
+    const body = validBody.replace('Closes #123', 'No related issue — internal tooling tweak.')
+    const result = validatePrBody(body)
+    expect(result.errors.some((e) => /Related Issue/i.test(e))).toBe(false)
+  })
+
+  it('accepts Fixes/Resolves keywords', () => {
+    expect(
+      validatePrBody(validBody.replace('Closes #123', 'Fixes #99')).errors.some((e) =>
+        /Related Issue/i.test(e)
+      )
+    ).toBe(false)
+    expect(
+      validatePrBody(validBody.replace('Closes #123', 'Resolves #99')).errors.some((e) =>
+        /Related Issue/i.test(e)
+      )
+    ).toBe(false)
+  })
+
+  it('requires at least one Type of Change box checked', () => {
+    const body = validBody.replace('- [x] fix: bug fix', '- [ ] fix: bug fix')
+    const result = validatePrBody(body)
+    expect(result.ok).toBe(false)
+    expect(result.errors.some((e) => /Type of Change/i.test(e))).toBe(true)
+  })
+
+  it('requires non-empty What Changed', () => {
+    const body = validBody.replace(
+      '- Guard against undefined layout in SettingsLayout\n- Add fallback default config',
+      '-'
+    )
+    const result = validatePrBody(body)
+    expect(result.ok).toBe(false)
+    expect(result.errors.some((e) => /What Changed/i.test(e))).toBe(true)
+  })
+
+  it('requires at least one How It Was Tested box checked', () => {
+    const body = validBody
+      .replace('- [x] `bun run test`', '- [ ] `bun run test`')
+      .replace('- [x] Manual verification completed', '- [ ] Manual verification completed')
+    const result = validatePrBody(body)
+    expect(result.ok).toBe(false)
+    expect(result.errors.some((e) => /How It Was Tested/i.test(e))).toBe(true)
+  })
+
+  it('reports missing sections when the template is gutted', () => {
+    const result = validatePrBody('Just some random text with no headings.')
+    expect(result.ok).toBe(false)
+    expect(result.errors.length).toBeGreaterThanOrEqual(5)
+  })
+
+  it('handles CRLF line endings', () => {
+    const result = validatePrBody(validBody.replace(/\n/g, '\r\n'))
+    expect(result.ok).toBe(true)
+  })
+
+  it('validates a required section even when it is the last one in the body', () => {
+    // Body where "How It Was Tested" is the final section (no trailing heading).
+    const body = `## Summary
+
+Real summary text.
+
+## Related Issue
+
+Closes #1
+
+## Type of Change
+
+- [x] fix: bug fix
+
+## What Changed
+
+- did a thing
+
+## How It Was Tested
+
+- [ ] \`bun run test\`
+`
+    const result = validatePrBody(body)
+    expect(result.ok).toBe(false)
+    expect(result.errors.some((e) => /How It Was Tested/i.test(e))).toBe(true)
+  })
+})

--- a/scripts/validate-pr-body.ts
+++ b/scripts/validate-pr-body.ts
@@ -17,8 +17,19 @@ export interface ValidationResult {
 
 // HTML comments in the template are guidance, not content. Strip them so an
 // untouched template's placeholder text doesn't read as "filled in".
+//
+// Strip repeatedly until the string stops changing: a single pass over
+// `<!--[\s\S]*?-->` can leave a fresh `<!--` behind on crafted/overlapping
+// input (e.g. `<!--<!---->-->`), which is the incomplete-sanitization class
+// CodeQL flags (js/incomplete-multi-character-sanitization).
 function stripComments(body: string): string {
-  return body.replace(/<!--[\s\S]*?-->/g, '')
+  let previous: string
+  let current = body
+  do {
+    previous = current
+    current = current.replace(/<!--[\s\S]*?-->/g, '')
+  } while (current !== previous)
+  return current
 }
 
 function sectionBody(body: string, heading: string): string | null {
@@ -116,9 +127,35 @@ export function validatePrBody(rawBody: string | undefined | null): ValidationRe
   return { ok: errors.length === 0, errors }
 }
 
+// Build the markdown comment body posted on the PR when validation fails.
+export function buildFailureComment(errors: string[]): string {
+  const items = errors.map((e) => `- ${e}`).join('\n')
+  return [
+    '<!-- pr-body-validation -->',
+    '## ❌ PR description does not satisfy the template',
+    '',
+    'This PR is missing required information from the PR template. Please edit the',
+    'PR **description** (not a comment) and fill in every required section:',
+    '',
+    items,
+    '',
+    'Template: [`.github/PULL_REQUEST_TEMPLATE.md`](../blob/HEAD/.github/PULL_REQUEST_TEMPLATE.md)',
+    '',
+    'This check re-runs automatically when you edit the description.'
+  ].join('\n')
+}
+
 // CLI entry — only runs when invoked directly, not when imported by tests.
 if (import.meta.main) {
   const result = validatePrBody(process.env.PR_BODY)
+
+  // Emit a markdown comment body for the workflow to post on failure.
+  const commentPath = process.env.PR_BODY_COMMENT_FILE
+  if (commentPath && !result.ok) {
+    const { writeFileSync } = await import('node:fs')
+    writeFileSync(commentPath, buildFailureComment(result.errors), 'utf8')
+  }
+
   if (result.ok) {
     console.log('✅ PR description satisfies the template.')
     process.exit(0)

--- a/scripts/validate-pr-body.ts
+++ b/scripts/validate-pr-body.ts
@@ -1,0 +1,135 @@
+/**
+ * Validates a pull request description against the repo PR template.
+ *
+ * A git pre-commit/pre-push hook cannot see the PR body — that text only
+ * exists on GitHub. This runs as a required CI check on `pull_request`
+ * events so untemplated PRs (from humans OR CLI agents) are blocked at the
+ * merge gate, not merely discouraged in CLAUDE.md / AGENTS.md.
+ *
+ * Usage (CI):
+ *   PR_BODY="$PR_BODY" PR_TITLE="$PR_TITLE" bun run scripts/validate-pr-body.ts
+ */
+
+export interface ValidationResult {
+  ok: boolean
+  errors: string[]
+}
+
+// HTML comments in the template are guidance, not content. Strip them so an
+// untouched template's placeholder text doesn't read as "filled in".
+function stripComments(body: string): string {
+  return body.replace(/<!--[\s\S]*?-->/g, '')
+}
+
+function sectionBody(body: string, heading: string): string | null {
+  // Find "## <heading>" and return everything up to the next "## " heading
+  // (any level-2 heading) or the end of the body. Index-based to avoid the
+  // \Z end-of-string anchor, which JavaScript regex does not support.
+  const escaped = heading.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+  const headingRe = new RegExp(`^##\\s+${escaped}\\s*$`, 'm')
+  const headingMatch = body.match(headingRe)
+  if (headingMatch?.index === undefined) {
+    return null
+  }
+
+  const start = headingMatch.index + headingMatch[0].length
+  const rest = body.slice(start)
+  const nextHeading = rest.match(/^##\s/m)
+  const end = nextHeading?.index === undefined ? rest.length : nextHeading.index
+  return rest.slice(0, end)
+}
+
+// A section is "empty" when, after removing comments, list bullets with no
+// text (`-`), and whitespace, nothing meaningful remains.
+function isSectionEmpty(content: string): boolean {
+  const cleaned = stripComments(content)
+    .split('\n')
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0)
+    // Drop bare bullets / empty list items left from the template.
+    .filter((line) => line !== '-' && line !== '*' && line !== '- ' && line !== '*')
+  return cleaned.length === 0
+}
+
+export function validatePrBody(rawBody: string | undefined | null): ValidationResult {
+  const errors: string[] = []
+  const body = (rawBody ?? '').replace(/\r\n/g, '\n')
+
+  if (body.trim().length === 0) {
+    return {
+      ok: false,
+      errors: [
+        'PR description is empty. Fill in the PR template at .github/PULL_REQUEST_TEMPLATE.md.'
+      ]
+    }
+  }
+
+  // 1. Summary must explain what + why.
+  const summary = sectionBody(body, 'Summary')
+  if (summary === null) {
+    errors.push('Missing "## Summary" section — restore it from the PR template.')
+  } else if (isSectionEmpty(summary)) {
+    errors.push('"## Summary" is empty. Describe what this PR does and WHY.')
+  }
+
+  // 2. Related Issue: require a real "Closes #<n>" or an explicit "no issue" note.
+  const related = sectionBody(body, 'Related Issue')
+  if (related === null) {
+    errors.push('Missing "## Related Issue" section — restore it from the PR template.')
+  } else {
+    const cleaned = stripComments(related)
+    const linksIssue = /(?:closes|fixes|resolves|refs?)\s+#\d+/i.test(cleaned)
+    const explainsNoIssue = /no\s+(?:related\s+)?issue/i.test(cleaned)
+    if (!linksIssue && !explainsNoIssue) {
+      errors.push(
+        '"## Related Issue" has no linked issue. Use "Closes #<number>" or explain why no issue exists.'
+      )
+    }
+  }
+
+  // 3. Type of Change: at least one checkbox ticked.
+  const type = sectionBody(body, 'Type of Change')
+  if (type === null) {
+    errors.push('Missing "## Type of Change" section — restore it from the PR template.')
+  } else if (!/- \[x\]/i.test(stripComments(type))) {
+    errors.push('"## Type of Change" has no box checked. Mark the change type with [x].')
+  }
+
+  // 4. What Changed must list real content.
+  const whatChanged = sectionBody(body, 'What Changed')
+  if (whatChanged === null) {
+    errors.push('Missing "## What Changed" section — restore it from the PR template.')
+  } else if (isSectionEmpty(whatChanged)) {
+    errors.push('"## What Changed" is empty. List the concrete changes.')
+  }
+
+  // 5. How It Was Tested: at least one box ticked (incl. "Not applicable").
+  const tested = sectionBody(body, 'How It Was Tested')
+  if (tested === null) {
+    errors.push('Missing "## How It Was Tested" section — restore it from the PR template.')
+  } else if (!/- \[x\]/i.test(stripComments(tested))) {
+    errors.push(
+      '"## How It Was Tested" has no box checked. Mark how you verified the change (or "Not applicable").'
+    )
+  }
+
+  return { ok: errors.length === 0, errors }
+}
+
+// CLI entry — only runs when invoked directly, not when imported by tests.
+if (import.meta.main) {
+  const result = validatePrBody(process.env.PR_BODY)
+  if (result.ok) {
+    console.log('✅ PR description satisfies the template.')
+    process.exit(0)
+  }
+  console.error('❌ PR description does not satisfy the template:\n')
+  for (const err of result.errors) {
+    console.error(`  • ${err}`)
+  }
+  console.error(
+    '\nEdit the PR description and fill in every required section.' +
+      '\nTemplate: .github/PULL_REQUEST_TEMPLATE.md'
+  )
+  process.exit(1)
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -10,7 +10,7 @@ export default defineConfig({
     globals: true,
     environment: 'jsdom',
     setupFiles: ['./vitest.setup.ts'],
-    include: ['src/**/*.test.{ts,tsx}'],
+    include: ['src/**/*.test.{ts,tsx}', 'scripts/**/*.test.ts'],
     typecheck: {
       tsconfig: 'tsconfig.web.json'
     }


### PR DESCRIPTION
## Summary

Our PR template (`.github/PULL_REQUEST_TEMPLATE.md`) and contributor guidance in `CLAUDE.md`/`AGENTS.md` are advisory only. A git pre-commit or pre-push hook cannot see the PR description — that text lives on GitHub and only exists when someone runs `gh pr create` or fills the web form. As a result, contributors (and CLI agents) keep opening PRs with empty or untouched templates and nothing blocks them. This adds a server-side check that runs on `pull_request` events and fails when the required template sections are missing or empty, so the template is finally enforced at the merge gate rather than merely requested.

## Related Issue

No related issue — follow-up to repeated untemplated PRs raised during maintenance. Closes nothing; opens the enforcement mechanism referenced in `CLAUDE.md`.

## Type of Change

- [x] ci: CI/CD workflow changes

## What Changed

- Added `scripts/validate-pr-body.ts`: a pure, testable validator plus CLI entry that checks Summary, Related Issue (`Closes #N` or an explicit no-issue note), at least one Type-of-Change box, What Changed, and at least one How-It-Was-Tested box. Strips HTML comments so an untouched template reads as empty, and handles CRLF line endings.
- Added `scripts/validate-pr-body.test.ts`: 14 vitest cases covering empty/undefined body, comment-only sections, missing issue links, unchecked boxes, gutted templates, and last-section matching.
- Updated `.github/workflows/pr-validation.yml`: new `pr-body-check` job; added `edited` to the `pull_request` trigger so the check re-runs when a contributor fills in the body; guarded the heavy code jobs (`validate`, `rust-checks`, `rust-windows-check`, `build-check`) with `if: github.event.action != 'edited'` so description-only edits don't burn CI minutes. PR body is passed via the `PR_BODY` env var, never shell-interpolated, to avoid command injection from attacker-controlled descriptions.
- Updated `vitest.config.ts`: test glob now includes `scripts/**/*.test.ts`.

## How It Was Tested

- [x] `bun run test`
- [x] `bun run typecheck`
- [x] Manual verification completed

Local verification in the worktree: `vitest` 14/14 pass, `bun run typecheck` clean, `biome check` clean, workflow YAML parses, and the CLI exits 1 on an empty/untemplated body and 0 on a complete one.

## Screenshots or Recordings

Not applicable — CI-only change, no UI.

## CI & Review Gate

- [ ] All CI checks pass (PR Validation, Rust Checks, Build Verification, Security Scans)
- [ ] Code review comments from CodeRabbit / Claude have been addressed or resolved
- [ ] No unresolved review findings remain

## Checklist

- [x] My PR title follows the conventional commit format used by this repo
- [x] I linked the related issue or explained why none exists
- [x] I updated docs when needed
- [x] I added or updated tests when needed
- [x] I verified the change does not introduce unrelated modifications
- [x] I read AGENTS.md and followed the contributor guidelines
- [ ] A human reviewed the complete diff before submission

> Note: one item above is intentionally left unchecked — a human has not yet reviewed the complete diff. Please review before merge.

## Activation note

This check only blocks merges once `Validate PR Description` is added as a required status check in branch protection for `dev`. Until then it runs and reports but does not gate.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Implemented automated PR description validation against a template, checking for required sections and content completeness.
  * Added validation feedback via GitHub comments when PR descriptions don't meet requirements.
  * Optimized CI to skip heavy validation jobs when only the PR description is edited, reducing unnecessary build time.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->