### PR TITLE
fix(ui): consistent typography scale and left-panel density

### DIFF
--- a/src/renderer/components/AiPromptDialog.tsx
+++ b/src/renderer/components/AiPromptDialog.tsx
@@ -104,9 +104,7 @@ export function AiPromptDialog({ isOpen, onClose, context }: AiPromptDialogProps
 
         {/* Template selector */}
         <div className="px-4 py-2 border-b border-border">
-          <label className="text-[10px] font-medium text-muted-foreground uppercase tracking-wider">
-            Tool
-          </label>
+          <label className="label-group text-muted-foreground">Tool</label>
           <div className="flex gap-2 mt-1">
             {BUILT_IN_TEMPLATES.map((tpl) => {
               const TplIcon = TOOL_ICONS[tpl.toolName] ?? MessageSquare
@@ -133,7 +131,7 @@ export function AiPromptDialog({ isOpen, onClose, context }: AiPromptDialogProps
         {/* Prompt preview */}
         <div className="flex-1 overflow-auto px-4 py-3">
           <div className="flex items-center justify-between mb-2">
-            <span className="text-[10px] font-medium text-muted-foreground uppercase tracking-wider">
+            <span className="label-group text-muted-foreground">
               {selectedTemplate.name} — Paste this into {selectedTemplate.toolName}
             </span>
           </div>

--- a/src/renderer/components/AiPromptDialog.tsx
+++ b/src/renderer/components/AiPromptDialog.tsx
@@ -142,7 +142,7 @@ export function AiPromptDialog({ isOpen, onClose, context }: AiPromptDialogProps
 
         {/* Footer */}
         <div className="flex items-center justify-between px-4 py-3 border-t border-border">
-          <span className="text-[10px] text-muted-foreground">
+          <span className="text-3xs text-muted-foreground">
             Variables: {selectedTemplate.variables.join(', ')}
           </span>
           <button

--- a/src/renderer/components/CommandHistoryModal.tsx
+++ b/src/renderer/components/CommandHistoryModal.tsx
@@ -228,7 +228,7 @@ export function CommandHistoryModal({
             )}
 
             {/* Footer */}
-            <div className="bg-background px-4 py-2 border-t border-border flex items-center justify-between text-[10px] text-muted-foreground font-medium uppercase tracking-wider">
+            <div className="label-group bg-background px-4 py-2 border-t border-border flex items-center justify-between text-muted-foreground">
               <div className="flex items-center space-x-4">
                 <span className="flex items-center">
                   <kbd className="bg-secondary text-foreground px-1 rounded mr-1">↑↓</kbd> to

--- a/src/renderer/components/CommandPalette.tsx
+++ b/src/renderer/components/CommandPalette.tsx
@@ -499,7 +499,7 @@ export function CommandPalette({
                 ))}
               </CommandList>
 
-              <div className="flex items-center justify-end gap-3 border-t border-border bg-background px-3 py-2 text-[10px] font-medium uppercase tracking-wider text-muted-foreground">
+              <div className="label-group flex items-center justify-end gap-3 border-t border-border bg-background px-3 py-2 text-muted-foreground">
                 <span className="flex items-center gap-3">
                   <span className="flex items-center">
                     <kbd className="mr-1 rounded bg-secondary px-1 text-foreground">↑↓</kbd>

--- a/src/renderer/components/CommandPalette.tsx
+++ b/src/renderer/components/CommandPalette.tsx
@@ -416,7 +416,7 @@ export function CommandPalette({
         </div>
         <div className="flex shrink-0 items-center gap-1.5">
           {cmd.shortcut && (
-            <CommandShortcut className="rounded border border-border bg-secondary/70 px-1.5 py-0.5 font-mono text-[10px] tracking-normal text-muted-foreground">
+            <CommandShortcut className="rounded border border-border bg-secondary/70 px-1.5 py-0.5 font-mono text-3xs tracking-normal text-muted-foreground">
               {cmd.shortcut}
             </CommandShortcut>
           )}
@@ -467,7 +467,7 @@ export function CommandPalette({
             onClick={(e) => e.stopPropagation()}
           >
             <Command
-              className="[&_[cmdk-group-heading]]:px-2.5 [&_[cmdk-group-heading]]:py-1 [&_[cmdk-group-heading]]:text-[10px] [&_[cmdk-group-heading]]:font-semibold [&_[cmdk-group-heading]]:uppercase [&_[cmdk-group-heading]]:tracking-wider [&_[cmdk-group-heading]]:text-muted-foreground"
+              className="[&_[cmdk-group-heading]]:px-2.5 [&_[cmdk-group-heading]]:py-1 [&_[cmdk-group-heading]]:text-3xs [&_[cmdk-group-heading]]:font-semibold [&_[cmdk-group-heading]]:uppercase [&_[cmdk-group-heading]]:tracking-wider [&_[cmdk-group-heading]]:text-muted-foreground"
               shouldFilter={true}
             >
               <CommandInput

--- a/src/renderer/components/ConflictResolutionPanel.tsx
+++ b/src/renderer/components/ConflictResolutionPanel.tsx
@@ -115,7 +115,7 @@ export function ConflictResolutionPanel({
                   <>
                     <button
                       onClick={() => handleFileStatusChange(file.filePath, 'resolved')}
-                      className="px-1.5 py-0.5 rounded text-[9px] font-medium bg-green-500/10 text-green-500 hover:bg-green-500/20 transition-colors"
+                      className="px-1.5 py-0.5 rounded text-4xs font-medium bg-green-500/10 text-green-500 hover:bg-green-500/20 transition-colors"
                       title="Mark as resolved"
                     >
                       ✓
@@ -123,7 +123,7 @@ export function ConflictResolutionPanel({
                     {file.status !== 'resolving' && (
                       <button
                         onClick={() => handleFileStatusChange(file.filePath, 'resolving')}
-                        className="px-1.5 py-0.5 rounded text-[9px] font-medium bg-blue-500/10 text-blue-500 hover:bg-blue-500/20 transition-colors"
+                        className="px-1.5 py-0.5 rounded text-4xs font-medium bg-blue-500/10 text-blue-500 hover:bg-blue-500/20 transition-colors"
                         title="Mark as resolving"
                       >
                         ↻
@@ -142,7 +142,7 @@ export function ConflictResolutionPanel({
         <div className="text-center py-4">
           <CheckCircle2 size={24} className="mx-auto mb-2 text-green-500" />
           <p className="text-xs font-medium text-foreground">All conflicts resolved!</p>
-          <p className="text-[10px] text-muted-foreground mt-0.5">Ready to complete the merge.</p>
+          <p className="text-3xs text-muted-foreground mt-0.5">Ready to complete the merge.</p>
         </div>
       )}
     </div>

--- a/src/renderer/components/MergePreviewDialog.tsx
+++ b/src/renderer/components/MergePreviewDialog.tsx
@@ -97,7 +97,7 @@ export function MergePreviewDialog({
                 </div>
                 <span
                   className={cn(
-                    'text-[10px] px-1.5 py-0.5 rounded font-medium',
+                    'text-3xs px-1.5 py-0.5 rounded font-medium',
                     preview.detectionMode === 'accurate'
                       ? 'bg-green-500/10 text-green-500'
                       : 'bg-yellow-500/10 text-yellow-500'
@@ -139,7 +139,7 @@ export function MergePreviewDialog({
                       <span className="flex-1 truncate text-foreground">{file.path}</span>
                       <span
                         className={cn(
-                          'text-[9px] px-1 rounded font-medium',
+                          'text-4xs px-1 rounded font-medium',
                           file.severity === 'high'
                             ? 'bg-destructive/10 text-destructive'
                             : file.severity === 'medium'

--- a/src/renderer/components/MergePreviewDialog.tsx
+++ b/src/renderer/components/MergePreviewDialog.tsx
@@ -129,9 +129,7 @@ export function MergePreviewDialog({
               {/* Conflict files list */}
               {preview.conflictFiles.length > 0 && (
                 <div className="space-y-1 max-h-[180px] overflow-auto">
-                  <p className="text-[10px] font-medium text-muted-foreground uppercase tracking-wider">
-                    Conflicted Files
-                  </p>
+                  <p className="label-group text-muted-foreground">Conflicted Files</p>
                   {preview.conflictFiles.map((file) => (
                     <div
                       key={file.path}
@@ -159,9 +157,7 @@ export function MergePreviewDialog({
               {/* Changed files list (no conflict) */}
               {preview.changedFiles.length > 0 && (
                 <div className="space-y-1 max-h-[100px] overflow-auto">
-                  <p className="text-[10px] font-medium text-muted-foreground uppercase tracking-wider">
-                    Files that will change
-                  </p>
+                  <p className="label-group text-muted-foreground">Files that will change</p>
                   {preview.changedFiles.map((file) => (
                     <div
                       key={file}

--- a/src/renderer/components/NewProjectModal.tsx
+++ b/src/renderer/components/NewProjectModal.tsx
@@ -278,21 +278,21 @@ export function NewProjectModal({ isOpen, onClose, onCreateProject }: NewProject
                     <ChevronDown size={14} />
                   </div>
                 </div>
-                <p className="text-[10px] text-muted-foreground mt-1 leading-snug">
+                <p className="text-3xs text-muted-foreground mt-1 leading-snug">
                   {selectedTemplate.description}
                 </p>
               </div>
 
               {selectedTemplate.envVars && selectedTemplate.envVars.length > 0 && (
                 <div className="bg-secondary/40 border border-border/60 rounded p-2.5 mt-2">
-                  <span className="text-[10px] font-semibold text-muted-foreground block mb-1.5">
+                  <span className="text-3xs font-semibold text-muted-foreground block mb-1.5">
                     Included Environment Variables:
                   </span>
                   <div className="flex flex-wrap gap-1.5">
                     {selectedTemplate.envVars.map((ev) => (
                       <span
                         key={ev.key}
-                        className="text-[10px] font-mono bg-background border border-border/80 px-2 py-0.5 rounded text-secondary-foreground"
+                        className="text-3xs font-mono bg-background border border-border/80 px-2 py-0.5 rounded text-secondary-foreground"
                       >
                         {ev.key}={ev.value}
                       </span>

--- a/src/renderer/components/NewWorktreeModal.tsx
+++ b/src/renderer/components/NewWorktreeModal.tsx
@@ -405,7 +405,7 @@ export function NewWorktreeModal({ isOpen, onClose, projectId }: NewWorktreeModa
                   placeholder="e.g. try-new-hero"
                   className="w-full bg-secondary border border-border rounded px-3 py-1.5 text-sm text-foreground focus:ring-1 focus:ring-primary outline-none placeholder-muted-foreground"
                 />
-                <p className="text-[10px] text-muted-foreground mt-0.5">
+                <p className="text-3xs text-muted-foreground mt-0.5">
                   A separate place to work. Your main project stays untouched.
                 </p>
               </div>
@@ -419,7 +419,7 @@ export function NewWorktreeModal({ isOpen, onClose, projectId }: NewWorktreeModa
               >
                 <GitBranch size={12} aria-hidden="true" />
                 <span>Advanced (branch options)</span>
-                <span className="text-[10px]" aria-hidden="true">
+                <span className="text-3xs" aria-hidden="true">
                   {showAdvanced ? '▼' : '▶'}
                 </span>
               </button>
@@ -515,10 +515,10 @@ export function NewWorktreeModal({ isOpen, onClose, projectId }: NewWorktreeModa
                                   <GitBranch size={10} className="mr-1.5 flex-shrink-0" />
                                   <span className="truncate flex-1">{branch.name}</span>
                                   {branch.isCurrent && (
-                                    <span className="text-[10px] text-primary ml-1">current</span>
+                                    <span className="text-3xs text-primary ml-1">current</span>
                                   )}
                                   {branch.isRemote && (
-                                    <span className="text-[10px] text-muted-foreground ml-1">
+                                    <span className="text-3xs text-muted-foreground ml-1">
                                       remote
                                     </span>
                                   )}
@@ -547,7 +547,7 @@ export function NewWorktreeModal({ isOpen, onClose, projectId }: NewWorktreeModa
                           }
                           className="w-full bg-secondary border border-border rounded px-3 py-1.5 text-sm text-foreground focus:ring-1 focus:ring-primary outline-none placeholder-muted-foreground"
                         />
-                        <p className="text-[10px] text-muted-foreground mt-0.5">
+                        <p className="text-3xs text-muted-foreground mt-0.5">
                           {newBranchName && sanitizeBranchName(newBranchName) !== newBranchName
                             ? `Will be sanitized to: ${sanitizeBranchName(newBranchName)}`
                             : 'Defaults to the name above.'}
@@ -565,7 +565,7 @@ export function NewWorktreeModal({ isOpen, onClose, projectId }: NewWorktreeModa
                           placeholder="HEAD, main, or a commit hash"
                           className="w-full bg-secondary border border-border rounded px-3 py-1.5 text-sm text-foreground focus:ring-1 focus:ring-primary outline-none placeholder-muted-foreground"
                         />
-                        <p className="text-[10px] text-muted-foreground mt-0.5">
+                        <p className="text-3xs text-muted-foreground mt-0.5">
                           Defaults to HEAD if not specified
                         </p>
                       </div>
@@ -579,7 +579,7 @@ export function NewWorktreeModal({ isOpen, onClose, projectId }: NewWorktreeModa
                 <label className="block text-xs font-medium text-muted-foreground mb-1">
                   Path Preview
                 </label>
-                <code className="block text-[10px] text-muted-foreground bg-secondary/50 border border-border rounded px-3 py-1.5 overflow-x-auto whitespace-nowrap">
+                <code className="block text-3xs text-muted-foreground bg-secondary/50 border border-border rounded px-3 py-1.5 overflow-x-auto whitespace-nowrap">
                   {pathPreview}
                 </code>
               </div>
@@ -593,7 +593,7 @@ export function NewWorktreeModal({ isOpen, onClose, projectId }: NewWorktreeModa
                   >
                     <Link2 size={12} />
                     <span>Symlink Directories ({project.symlinkDirs.length})</span>
-                    <span className="text-[10px]">{showSymlinkSection ? '▼' : '▶'}</span>
+                    <span className="text-3xs">{showSymlinkSection ? '▼' : '▶'}</span>
                   </button>
                   {showSymlinkSection && (
                     <div className="mt-1.5 border border-border rounded bg-secondary/30 p-2 space-y-1">
@@ -619,7 +619,7 @@ export function NewWorktreeModal({ isOpen, onClose, projectId }: NewWorktreeModa
                           <span>{dir}</span>
                         </label>
                       ))}
-                      <p className="text-[10px] text-muted-foreground mt-1">
+                      <p className="text-3xs text-muted-foreground mt-1">
                         Checked directories will be symlinked from the project root into the
                         worktree.
                       </p>

--- a/src/renderer/components/ProjectSidebar.tsx
+++ b/src/renderer/components/ProjectSidebar.tsx
@@ -1064,7 +1064,7 @@ export function ProjectSidebar({
     <aside className="w-64 bg-sidebar flex flex-col flex-shrink-0 rounded-xl h-full">
       {/* Header with inline + button */}
       <div className="h-9 flex items-center justify-between px-3 border-b border-sidebar-border rounded-t-xl">
-        <span className="text-xs tracking-wider text-sidebar-foreground uppercase">Projects</span>
+        <span className="label-section text-sidebar-foreground">Projects</span>
         <div className="flex items-center gap-1">
           <button
             onClick={handleCreateGroup}
@@ -1489,7 +1489,7 @@ export function ProjectSidebar({
                 <button
                   onClick={() => setShowArchived(!showArchived)}
                   disabled={isSearching}
-                  className="w-full flex items-center px-3 py-1.5 text-xs tracking-wider text-sidebar-foreground uppercase hover:bg-sidebar-accent/50 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-primary disabled:cursor-default disabled:hover:bg-transparent"
+                  className="label-section w-full flex items-center px-3 py-1.5 text-sidebar-foreground hover:bg-sidebar-accent/50 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-primary disabled:cursor-default disabled:hover:bg-transparent"
                   aria-expanded={showArchived || isSearching}
                   aria-label={`Archived projects (${filteredArchivedProjects.length})`}
                 >
@@ -2046,7 +2046,7 @@ const ProjectItem = memo(function ProjectItem({
                         return next
                       })
                     }}
-                    className="flex items-center w-full px-2 py-0.5 text-[10px] font-semibold text-muted-foreground/60 uppercase tracking-wider hover:text-muted-foreground/80 transition-colors"
+                    className="label-group flex items-center w-full px-2 py-0.5 text-muted-foreground/60 hover:text-muted-foreground/80 transition-colors"
                   >
                     <span>{isCollapsed ? '▶' : '▼'}</span>
                     <span className="ml-1">{group.name}</span>

--- a/src/renderer/components/ProjectSidebar.tsx
+++ b/src/renderer/components/ProjectSidebar.tsx
@@ -1245,7 +1245,7 @@ export function ProjectSidebar({
                               {group.name}
                             </span>
                           )}
-                          <span className="text-[10px] text-muted-foreground/40 px-2 font-normal">
+                          <span className="text-3xs text-muted-foreground/40 px-2 font-normal">
                             {gpProjects.length}
                           </span>
                         </div>
@@ -2050,7 +2050,7 @@ const ProjectItem = memo(function ProjectItem({
                   >
                     <span>{isCollapsed ? '▶' : '▼'}</span>
                     <span className="ml-1">{group.name}</span>
-                    <span className="ml-auto text-[9px] font-normal text-muted-foreground/40">
+                    <span className="ml-auto text-4xs font-normal text-muted-foreground/40">
                       {group.items.length}
                     </span>
                   </button>
@@ -2186,7 +2186,7 @@ const WorktreeItem = memo(function WorktreeItem({
       {!isRoot && <HealthBadge status={healthStatus} />}
       {!isRoot && isTermulManaged === false && (
         <span
-          className="text-[10px] text-amber-500/70 ml-1"
+          className="text-3xs text-amber-500/70 ml-1"
           title="External worktree (not created by Termul)"
         >
           ext

--- a/src/renderer/components/ProjectSidebar.tsx
+++ b/src/renderer/components/ProjectSidebar.tsx
@@ -1195,7 +1195,7 @@ export function ProjectSidebar({
                             }
                           }}
                           className={cn(
-                            'w-full flex items-center px-1.5 py-1 hover:bg-sidebar-accent/50 rounded transition-colors text-left cursor-pointer select-none',
+                            'w-full flex items-center h-7 px-1.5 hover:bg-sidebar-accent/50 rounded transition-colors text-left cursor-pointer select-none',
                             activeDragOverGroupId === group.id &&
                               'bg-primary/20 border border-primary/50'
                           )}
@@ -1237,15 +1237,15 @@ export function ProjectSidebar({
                                 }
                                 setEditingGroupId(null)
                               }}
-                              className="flex-1 min-w-0 bg-sidebar-accent border border-border rounded px-1 py-0.5 text-xs text-foreground outline-none focus:ring-1 focus:ring-primary mr-2"
+                              className="flex-1 min-w-0 bg-sidebar-accent border border-border rounded px-1 py-0.5 text-sm text-foreground outline-none focus:ring-1 focus:ring-primary mr-2"
                               onClick={(e) => e.stopPropagation()}
                             />
                           ) : (
-                            <span className="text-xs font-semibold text-muted-foreground truncate flex-1">
+                            <span className="text-sm font-medium text-sidebar-foreground truncate flex-1">
                               {group.name}
                             </span>
                           )}
-                          <span className="text-3xs text-muted-foreground/40 px-2 font-normal">
+                          <span className="text-xs text-muted-foreground/60 px-2 font-normal">
                             {gpProjects.length}
                           </span>
                         </div>

--- a/src/renderer/components/RemoteAccessPopover.tsx
+++ b/src/renderer/components/RemoteAccessPopover.tsx
@@ -150,7 +150,7 @@ export function RemoteAccessPopover(): React.JSX.Element {
                     <>
                       The server listens on <strong>localhost only</strong>. To reach it from
                       another device, use a tunnel (e.g.{' '}
-                      <code className="text-[11px]">cloudflared</code>) or switch to &quot;All
+                      <code className="text-2xs">cloudflared</code>) or switch to &quot;All
                       interfaces&quot; and restart.
                     </>
                   )}

--- a/src/renderer/components/ShortcutRecorder.tsx
+++ b/src/renderer/components/ShortcutRecorder.tsx
@@ -128,7 +128,7 @@ export function ShortcutRecorder({
             <div className="truncate text-xs font-medium text-secondary-foreground">
               {shortcut.label}
             </div>
-            <div className="truncate text-[11px] text-muted-foreground">{shortcut.description}</div>
+            <div className="truncate text-2xs text-muted-foreground">{shortcut.description}</div>
           </div>
 
           {isCustomized && (
@@ -153,7 +153,7 @@ export function ShortcutRecorder({
             onBlur={handleBlur}
             onKeyDown={handleKeyboardActivate}
             className={`
-              min-w-[88px] shrink-0 rounded-md border px-2 py-1 text-center font-mono text-[11px] transition-all cursor-pointer
+              min-w-[88px] shrink-0 rounded-md border px-2 py-1 text-center font-mono text-2xs transition-all cursor-pointer
               ${
                 isRecording
                   ? 'border-primary bg-primary/10 ring-2 ring-primary/30'
@@ -172,7 +172,7 @@ export function ShortcutRecorder({
         </div>
 
         {conflict && (
-          <div className="mt-1 text-[11px] text-red-500">
+          <div className="mt-1 text-2xs text-red-500">
             Conflicts with "{conflict.label}".{' '}
             <button
               type="button"

--- a/src/renderer/components/SidebarTabs.tsx
+++ b/src/renderer/components/SidebarTabs.tsx
@@ -42,9 +42,7 @@ export function SidebarTabs(props: SidebarTabsProps): React.JSX.Element {
         ) : (
           <aside className="w-full bg-sidebar flex flex-col flex-shrink-0 rounded-xl h-full overflow-hidden">
             <div className="h-9 flex items-center px-3 border-b border-sidebar-border rounded-t-xl">
-              <span className="text-xs tracking-wider text-sidebar-foreground uppercase">
-                Chats
-              </span>
+              <span className="label-section text-sidebar-foreground">Chats</span>
             </div>
             <div className="flex-1 min-h-0">
               <ChatHistoryTab />

--- a/src/renderer/components/SidebarTabs.tsx
+++ b/src/renderer/components/SidebarTabs.tsx
@@ -70,7 +70,7 @@ function TabButton({
       type="button"
       onClick={onClick}
       className={cn(
-        'flex-1 flex items-center justify-center gap-1.5 rounded-md py-1 text-[11px] font-medium transition-colors',
+        'flex-1 flex items-center justify-center gap-1.5 rounded-md py-1 text-2xs font-medium transition-colors',
         active ? 'bg-sidebar-accent text-foreground' : 'text-muted-foreground hover:text-foreground'
       )}
     >

--- a/src/renderer/components/TauriTitleBar.tsx
+++ b/src/renderer/components/TauriTitleBar.tsx
@@ -44,10 +44,7 @@ export function TauriTitleBar(): React.JSX.Element {
       className="h-8 flex items-center justify-between bg-card border-b border-border select-none shrink-0"
       data-tauri-drag-region
     >
-      <span
-        className="text-xs font-semibold text-muted-foreground tracking-wider uppercase px-3"
-        data-tauri-drag-region
-      >
+      <span className="label-section text-muted-foreground px-3" data-tauri-drag-region>
         termul
       </span>
 

--- a/src/renderer/components/TerminalTabBar.tsx
+++ b/src/renderer/components/TerminalTabBar.tsx
@@ -348,21 +348,21 @@ function TerminalTab({ terminal, isActive, onSelect, onClose, onRename }: Termin
             onKeyDown={handleKeyDown}
             onBlur={handleBlur}
             onClick={(e) => e.stopPropagation()}
-            className="text-[11px] font-medium bg-transparent border-b border-primary outline-none w-full"
+            className="text-2xs font-medium bg-transparent border-b border-primary outline-none w-full"
           />
         ) : (
           <>
             <span
               onDoubleClick={handleDoubleClick}
               className={cn(
-                'text-[11px] font-medium truncate max-w-[80px]',
+                'text-2xs font-medium truncate max-w-[80px]',
                 isActive && 'text-foreground'
               )}
             >
               {terminal.name}
             </span>
             {terminalWorktree && (
-              <span className="ml-1.5 inline-flex items-center gap-0.5 rounded-sm bg-accent/10 px-1 py-0.5 text-[9px] font-medium text-accent-foreground/80 leading-none">
+              <span className="ml-1.5 inline-flex items-center gap-0.5 rounded-sm bg-accent/10 px-1 py-0.5 text-4xs font-medium text-accent-foreground/80 leading-none">
                 <GitBranch size={8} />
                 <span className="max-w-[50px] truncate">{terminalWorktree.name}</span>
               </span>

--- a/src/renderer/components/TerminalView.tsx
+++ b/src/renderer/components/TerminalView.tsx
@@ -69,9 +69,7 @@ export function EmptyTerminalPane({ onCreateTerminal }: { onCreateTerminal: () =
       <div className="flex-1 flex flex-col items-center justify-center text-center">
         <h3 className="text-muted-foreground font-medium mb-4">Create New Terminal</h3>
         <div className="flex items-center gap-2 mb-4">
-          <label className="text-xs text-muted-foreground uppercase font-semibold tracking-wide">
-            Shell:
-          </label>
+          <label className="label-section text-muted-foreground">Shell:</label>
           <select className="bg-secondary text-foreground text-sm border-none rounded px-2 py-1 focus:ring-1 focus:ring-primary cursor-pointer">
             <option>PowerShell</option>
             <option>Command Prompt</option>

--- a/src/renderer/components/ThemePicker.tsx
+++ b/src/renderer/components/ThemePicker.tsx
@@ -209,7 +209,7 @@ export function ThemePicker(): React.JSX.Element | null {
           <Palette size={16} className="text-primary shrink-0" aria-hidden="true" />
           <div className="min-w-0 flex-1">
             <h2 className="text-sm font-medium text-foreground leading-none">Color Themes</h2>
-            <p className="text-[11px] text-muted-foreground mt-0.5">
+            <p className="text-2xs text-muted-foreground mt-0.5">
               Hover to preview · Enter to apply
             </p>
           </div>
@@ -311,7 +311,7 @@ export function ThemePicker(): React.JSX.Element | null {
           )}
         </div>
 
-        <footer className="border-t border-border px-3 py-2 text-[11px] text-muted-foreground">
+        <footer className="border-t border-border px-3 py-2 text-2xs text-muted-foreground">
           Esc cancel · Enter apply
         </footer>
       </section>

--- a/src/renderer/components/ThemePicker.tsx
+++ b/src/renderer/components/ThemePicker.tsx
@@ -258,9 +258,7 @@ export function ThemePicker(): React.JSX.Element | null {
               const rows = filteredRows.filter((row) => row.familyId === family.familyId)
               return (
                 <div key={family.familyId} className="mb-3 last:mb-0">
-                  <p className="px-2 pb-1 text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">
-                    {family.name}
-                  </p>
+                  <p className="label-group px-2 pb-1 text-muted-foreground">{family.name}</p>
                   {rows.map((row) => {
                     const index = rowCounter
                     rowCounter += 1

--- a/src/renderer/components/agents/AgentIcon.tsx
+++ b/src/renderer/components/agents/AgentIcon.tsx
@@ -61,7 +61,7 @@ export const AgentIcon = memo(function AgentIcon({
   return (
     <span
       aria-hidden="true"
-      className={`flex shrink-0 items-center justify-center rounded-sm bg-foreground/10 text-[8px] font-semibold uppercase ${className}`}
+      className={`flex shrink-0 items-center justify-center rounded-sm bg-foreground/10 text-4xs font-semibold uppercase ${className}`}
     >
       {resolved.displayName?.charAt(0) ?? '?'}
     </span>

--- a/src/renderer/components/agents/AgentLauncher.tsx
+++ b/src/renderer/components/agents/AgentLauncher.tsx
@@ -514,7 +514,7 @@ export function AgentLauncher({
                       type="button"
                       onClick={() => handleModeChange(mode)}
                       className={cn(
-                        'rounded px-1.5 py-0.5 text-[10px] font-medium uppercase transition-colors',
+                        'rounded px-1.5 py-0.5 text-3xs font-medium uppercase transition-colors',
                         effectiveMode === mode
                           ? 'bg-background text-foreground shadow-sm'
                           : 'text-muted-foreground hover:text-foreground'
@@ -528,7 +528,7 @@ export function AgentLauncher({
                 </div>
               ) : (
                 <span
-                  className="rounded bg-muted/40 px-1.5 py-0.5 text-[10px] font-medium uppercase text-muted-foreground"
+                  className="rounded bg-muted/40 px-1.5 py-0.5 text-3xs font-medium uppercase text-muted-foreground"
                   title={`This agent runs as ${effectiveMode.toUpperCase()}`}
                 >
                   {effectiveMode}
@@ -586,14 +586,14 @@ export function AgentLauncher({
         </div>
 
         {/* Hint */}
-        <span className="text-center text-[11px] text-muted-foreground/50">
+        <span className="text-center text-2xs text-muted-foreground/50">
           Tab to complete · Enter to launch · Shift+Enter for newline · Esc to dismiss
         </span>
 
         {/* Plain terminal */}
         <div className="flex items-center gap-3 pt-1">
           <div className="h-px flex-1 bg-border/50" aria-hidden />
-          <span className="shrink-0 text-[11px] text-muted-foreground/50">or run terminal</span>
+          <span className="shrink-0 text-2xs text-muted-foreground/50">or run terminal</span>
           <div className="h-px flex-1 bg-border/50" aria-hidden />
         </div>
 
@@ -606,7 +606,7 @@ export function AgentLauncher({
                 variant="outline"
                 size="sm"
                 disabled={isSpawningTerminal}
-                className="h-8 gap-2 text-[11px]"
+                className="h-8 gap-2 text-2xs"
                 onClick={() => void spawnShellTerminal(shell)}
               >
                 <TerminalIcon size={12} className="opacity-70" />
@@ -619,7 +619,7 @@ export function AgentLauncher({
               variant="outline"
               size="sm"
               disabled={isSpawningTerminal}
-              className="h-8 gap-2 text-[11px]"
+              className="h-8 gap-2 text-2xs"
               onClick={() => void spawnShellTerminal()}
             >
               <TerminalIcon size={12} className="opacity-70" />
@@ -648,7 +648,7 @@ function EntryRow({ entry }: { entry: UnifiedAgentEntry }): React.JSX.Element {
         {entry.modes.map((mode) => (
           <span
             key={mode}
-            className="rounded bg-foreground/10 px-1 text-[9px] font-semibold uppercase text-muted-foreground"
+            className="rounded bg-foreground/10 px-1 text-4xs font-semibold uppercase text-muted-foreground"
           >
             {mode}
           </span>
@@ -681,7 +681,7 @@ const EntryGlyph = memo(function EntryGlyph({
   return (
     <span
       aria-hidden="true"
-      className="flex h-4 w-4 items-center justify-center rounded-sm bg-foreground/10 text-[9px] font-semibold uppercase"
+      className="flex h-4 w-4 items-center justify-center rounded-sm bg-foreground/10 text-4xs font-semibold uppercase"
     >
       {entry?.name.charAt(0) ?? 'A'}
     </span>

--- a/src/renderer/components/browser/AnnotationPanel.tsx
+++ b/src/renderer/components/browser/AnnotationPanel.tsx
@@ -66,11 +66,11 @@ function AnnotationElementDetails({ geometry }: { geometry: ElementGeometry }): 
   return (
     <div className="space-y-2">
       <div className="flex flex-wrap items-center gap-2">
-        <Badge variant="outline" className="font-mono text-[10px] px-1.5 py-0">
+        <Badge variant="outline" className="font-mono text-3xs px-1.5 py-0">
           {`<${geometry.tagName}>`}
         </Badge>
         <Badge
-          className={cn('text-[10px] border', selectorConfidenceClass[geometry.selectorConfidence])}
+          className={cn('text-3xs border', selectorConfidenceClass[geometry.selectorConfidence])}
         >
           {geometry.selectorConfidence}
         </Badge>
@@ -78,7 +78,7 @@ function AnnotationElementDetails({ geometry }: { geometry: ElementGeometry }): 
 
       <Tooltip>
         <TooltipTrigger asChild>
-          <div className="text-[11px] text-muted-foreground font-mono break-all cursor-default">
+          <div className="text-2xs text-muted-foreground font-mono break-all cursor-default">
             {selectorPreview}
           </div>
         </TooltipTrigger>
@@ -89,7 +89,7 @@ function AnnotationElementDetails({ geometry }: { geometry: ElementGeometry }): 
 
       <Tooltip>
         <TooltipTrigger asChild>
-          <div className="text-[11px] text-muted-foreground cursor-default whitespace-pre-wrap break-words">
+          <div className="text-2xs text-muted-foreground cursor-default whitespace-pre-wrap break-words">
             {textPreview}
           </div>
         </TooltipTrigger>
@@ -146,7 +146,7 @@ function AnnotationItem({
       <div className="flex items-center gap-2">
         <span
           className={cn(
-            'inline-flex items-center rounded-full border px-2 py-0.5 text-[10px] font-semibold',
+            'inline-flex items-center rounded-full border px-2 py-0.5 text-3xs font-semibold',
             intentBadgeClass[annotation.intent]
           )}
         >
@@ -156,7 +156,7 @@ function AnnotationItem({
           className={cn('h-2 w-2 rounded-full', severityColorClass[annotation.severity])}
           title={annotation.severity}
         />
-        <span className="text-[10px] text-muted-foreground capitalize">{annotation.severity}</span>
+        <span className="text-3xs text-muted-foreground capitalize">{annotation.severity}</span>
         <div className="flex-1" />
         <button
           onClick={(e) => {
@@ -171,7 +171,7 @@ function AnnotationItem({
       </div>
 
       {annotation.type === 'region' && annotation.geometry.type === 'rect' && (
-        <div className="text-[11px] text-muted-foreground font-mono">
+        <div className="text-2xs text-muted-foreground font-mono">
           rect(
           {Math.round(annotation.geometry.x)}, {Math.round(annotation.geometry.y)},{' '}
           {Math.round(annotation.geometry.width)}, {Math.round(annotation.geometry.height)})
@@ -415,7 +415,7 @@ export function AnnotationPanel({
           </Tooltip>
         </div>
 
-        <p className="text-[10px] text-muted-foreground">
+        <p className="text-3xs text-muted-foreground">
           Session-scoped: annotations last until app close
         </p>
       </div>

--- a/src/renderer/components/chat/AgentChatPanel.tsx
+++ b/src/renderer/components/chat/AgentChatPanel.tsx
@@ -96,12 +96,12 @@ export function AgentChatPanel({ sessionId }: AgentChatPanelProps): React.JSX.El
     <div className="flex h-full flex-col bg-background">
       <AgentHeader session={session} agentStatus={agentStatus} />
       {session.lastError && (
-        <div className="border-b border-red-500/30 bg-red-500/10 px-3 py-1 text-[11px] text-red-400">
+        <div className="border-b border-red-500/30 bg-red-500/10 px-3 py-1 text-2xs text-red-400">
           {session.lastError}
         </div>
       )}
       {pendingAuth && pendingAuth.methods.length > 0 && (
-        <div className="flex flex-wrap items-center gap-2 border-b border-amber-500/30 bg-amber-500/10 px-3 py-1.5 text-[11px] text-amber-400">
+        <div className="flex flex-wrap items-center gap-2 border-b border-amber-500/30 bg-amber-500/10 px-3 py-1.5 text-2xs text-amber-400">
           <span>{pendingAuth.message ?? 'This agent requires authentication.'}</span>
           {pendingAuth.methods.map((m) => (
             <button

--- a/src/renderer/components/chat/AgentHeader.tsx
+++ b/src/renderer/components/chat/AgentHeader.tsx
@@ -165,7 +165,7 @@ export function AgentHeader({ session, agentStatus }: AgentHeaderProps): React.J
           STATUS_COLOR[effectiveStatus ?? 'idle'] ?? 'text-muted-foreground'
         )}
       />
-      <span className="text-[11px] text-muted-foreground">{statusLabel}</span>
+      <span className="text-2xs text-muted-foreground">{statusLabel}</span>
     </div>
   )
 }

--- a/src/renderer/components/chat/AgentHeader.tsx
+++ b/src/renderer/components/chat/AgentHeader.tsx
@@ -62,7 +62,7 @@ export function ConfigChip({
         </button>
       </PopoverTrigger>
       <PopoverContent align="start" side="top" className="w-56 p-1">
-        <div className="px-2 py-1 text-[10px] font-semibold uppercase tracking-wide text-muted-foreground/70">
+        <div className="label-group px-2 py-1 text-muted-foreground/70">
           {promoted ? fallbackLabel : option.name}
         </div>
         {option.options.map((v) => (
@@ -112,9 +112,7 @@ export function ModeChip({
         </button>
       </PopoverTrigger>
       <PopoverContent align="start" side="top" className="w-56 p-1">
-        <div className="px-2 py-1 text-[10px] font-semibold uppercase tracking-wide text-muted-foreground/70">
-          Mode
-        </div>
+        <div className="label-group px-2 py-1 text-muted-foreground/70">Mode</div>
         {modes.availableModes.map((m) => (
           <button
             key={m.id}

--- a/src/renderer/components/chat/ChatHistoryTab.tsx
+++ b/src/renderer/components/chat/ChatHistoryTab.tsx
@@ -73,9 +73,7 @@ export function ChatHistoryTab(): React.JSX.Element {
         ) : (
           groups.map(({ group, entries }) => (
             <div key={group}>
-              <div className="px-3 py-1 text-[10px] font-semibold uppercase tracking-wide text-muted-foreground/70">
-                {group}
-              </div>
+              <div className="label-group px-3 py-1 text-muted-foreground/70">{group}</div>
               {entries.map((entry) => (
                 <div
                   key={entry.id}

--- a/src/renderer/components/chat/ChatHistoryTab.tsx
+++ b/src/renderer/components/chat/ChatHistoryTab.tsx
@@ -89,7 +89,7 @@ export function ChatHistoryTab(): React.JSX.Element {
                   >
                     <MessageSquare size={12} className="shrink-0 text-muted-foreground" />
                     <span className="truncate flex-1 text-sidebar-foreground">{entry.title}</span>
-                    <span className="text-[10px] text-muted-foreground">{entry.messageCount}</span>
+                    <span className="text-3xs text-muted-foreground">{entry.messageCount}</span>
                   </button>
                   <button
                     type="button"

--- a/src/renderer/components/chat/ChatMessage.tsx
+++ b/src/renderer/components/chat/ChatMessage.tsx
@@ -37,7 +37,7 @@ function ChatMessageComponent({ message, agentId }: ChatMessageProps): React.JSX
     const lines = text.split('\n').filter((l) => l.trim().length > 0).length
     return (
       <details className="mx-4 my-1 border-l-2 border-border/70 pl-3">
-        <summary className="cursor-pointer list-none text-[11px] italic text-muted-foreground marker:hidden">
+        <summary className="cursor-pointer list-none text-2xs italic text-muted-foreground marker:hidden">
           Thinking{lines > 0 ? ` · ${lines} line${lines === 1 ? '' : 's'}` : ''}
           {message.streaming && '…'}
         </summary>
@@ -52,7 +52,7 @@ function ChatMessageComponent({ message, agentId }: ChatMessageProps): React.JSX
 
   return (
     <div className="px-4 py-3">
-      <div className="mb-2 flex items-center gap-1.5 text-[11px] font-medium text-muted-foreground">
+      <div className="mb-2 flex items-center gap-1.5 text-2xs font-medium text-muted-foreground">
         {isUser ? (
           <>
             <User size={12} />

--- a/src/renderer/components/chat/ChatMessageList.tsx
+++ b/src/renderer/components/chat/ChatMessageList.tsx
@@ -68,7 +68,7 @@ export function ChatMessageList({
 function TypingIndicator({ agentId }: { agentId: AgentId }): React.JSX.Element {
   return (
     <div className="px-4 py-3">
-      <div className="mb-2 flex items-center gap-1.5 text-[11px] font-medium text-muted-foreground">
+      <div className="mb-2 flex items-center gap-1.5 text-2xs font-medium text-muted-foreground">
         <AgentBadge agentId={agentId} iconSize={12} />
       </div>
       <output className="flex items-center gap-1" aria-label="Agent is typing">

--- a/src/renderer/components/chat/DiffPreview.tsx
+++ b/src/renderer/components/chat/DiffPreview.tsx
@@ -20,16 +20,16 @@ export function DiffPreview({ diff }: DiffPreviewProps): React.JSX.Element {
     <div className="rounded border border-border/50 bg-background/50 text-xs">
       <div className="flex items-center gap-2 border-b border-border/40 px-2 py-1">
         <FileDiff size={12} className="text-muted-foreground" />
-        <span className="truncate font-mono text-[11px]">{diff.path}</span>
+        <span className="truncate font-mono text-2xs">{diff.path}</span>
         {isNewFile && (
-          <span className="rounded bg-green-400/10 px-1 text-[10px] text-green-400">new</span>
+          <span className="rounded bg-green-400/10 px-1 text-3xs text-green-400">new</span>
         )}
-        <span className="ml-auto font-mono text-[10px] text-muted-foreground">
+        <span className="ml-auto font-mono text-3xs text-muted-foreground">
           <span className="text-green-400">+{added}</span>{' '}
           <span className="text-red-400">−{removed}</span>
         </span>
       </div>
-      <div className="max-h-48 overflow-auto p-2 font-mono text-[11px] leading-snug">
+      <div className="max-h-48 overflow-auto p-2 font-mono text-2xs leading-snug">
         {lines.map((line, i) => (
           <div
             key={i}

--- a/src/renderer/components/chat/PermissionDialog.tsx
+++ b/src/renderer/components/chat/PermissionDialog.tsx
@@ -93,7 +93,7 @@ export function PermissionDialog({ permission }: PermissionDialogProps): React.J
           )}
         </div>
         <DialogFooter className="sm:justify-start">
-          <span className="text-[11px] text-muted-foreground">
+          <span className="text-2xs text-muted-foreground">
             Closing this dialog declines the request.
           </span>
         </DialogFooter>

--- a/src/renderer/components/chat/PlanPanel.tsx
+++ b/src/renderer/components/chat/PlanPanel.tsx
@@ -24,7 +24,7 @@ export function PlanPanel({ entries }: PlanPanelProps): React.JSX.Element | null
   if (entries.length === 0) return null
   return (
     <div className="mx-4 my-2 rounded-md border border-border/50 bg-card/30">
-      <div className="flex items-center gap-1.5 border-b border-border/40 px-3 py-1.5 text-[11px] font-semibold text-muted-foreground">
+      <div className="flex items-center gap-1.5 border-b border-border/40 px-3 py-1.5 text-2xs font-semibold text-muted-foreground">
         <ListChecks size={12} />
         Plan
       </div>

--- a/src/renderer/components/chat/SlashCommandMenu.tsx
+++ b/src/renderer/components/chat/SlashCommandMenu.tsx
@@ -90,9 +90,7 @@ export const SlashCommandMenu = forwardRef<SlashMenuHandle, SlashCommandMenuProp
       >
         {sections.map((section) => (
           <div key={section.id}>
-            <div className="px-3 py-1 text-[10px] font-semibold uppercase tracking-wide text-muted-foreground/70">
-              {section.heading}
-            </div>
+            <div className="label-group px-3 py-1 text-muted-foreground/70">{section.heading}</div>
             {section.items.map((item) => {
               flatIndex += 1
               const isHighlighted = flatIndex === highlight

--- a/src/renderer/components/chat/ToolCallCard.tsx
+++ b/src/renderer/components/chat/ToolCallCard.tsx
@@ -105,7 +105,7 @@ function ToolCallCardComponent({ toolCall }: ToolCallCardProps): React.JSX.Eleme
         </span>
         <span
           className={cn(
-            'ml-auto flex items-center gap-1 rounded px-1.5 py-0.5 text-[10px] font-medium',
+            'ml-auto flex items-center gap-1 rounded px-1.5 py-0.5 text-3xs font-medium',
             status.className
           )}
         >

--- a/src/renderer/components/file-explorer/FileExplorer.tsx
+++ b/src/renderer/components/file-explorer/FileExplorer.tsx
@@ -856,7 +856,7 @@ export function FileExplorer({ side = 'right' }: FileExplorerProps): React.JSX.E
       style={{ width: explorerWidth }}
     >
       {/* Header */}
-      <div className="flex items-center justify-between px-3 h-10 border-b border-border flex-shrink-0 rounded-t-xl">
+      <div className="flex items-center justify-between px-3 h-9 border-b border-border flex-shrink-0 rounded-t-xl">
         <span className="label-section text-sidebar-foreground">Explorer</span>
         <button
           onClick={collapseAll}

--- a/src/renderer/components/file-explorer/FileExplorer.tsx
+++ b/src/renderer/components/file-explorer/FileExplorer.tsx
@@ -942,8 +942,8 @@ export function FileExplorer({ side = 'right' }: FileExplorerProps): React.JSX.E
               isSearchTooShort ||
               showSearchEmptyState ||
               !resultsAreCurrent) && (
-              <div className="rounded-md border border-border/70 bg-background/60 px-2 py-1.5 text-[10px] leading-relaxed text-muted-foreground">
-                <p className="text-[10px] font-medium text-foreground">
+              <div className="rounded-md border border-border/70 bg-background/60 px-2 py-1.5 text-3xs leading-relaxed text-muted-foreground">
+                <p className="text-3xs font-medium text-foreground">
                   {searchLoading
                     ? `Searching for “${trimmedSearchQuery}”…`
                     : hasPartialSearchError
@@ -971,7 +971,7 @@ export function FileExplorer({ side = 'right' }: FileExplorerProps): React.JSX.E
             )}
 
             {(searchTruncated || searchFailedFiles > 0) && (
-              <div className="rounded-md border border-border/70 bg-background/60 px-2 py-1.5 text-[10px] leading-relaxed text-muted-foreground">
+              <div className="rounded-md border border-border/70 bg-background/60 px-2 py-1.5 text-3xs leading-relaxed text-muted-foreground">
                 {searchTruncated
                   ? 'Results were truncated for performance.'
                   : 'Some files could not be fully searched.'}
@@ -997,7 +997,7 @@ export function FileExplorer({ side = 'right' }: FileExplorerProps): React.JSX.E
                       setSearchResultTab('content')
                     }}
                     className={cn(
-                      'flex items-center justify-center gap-1 rounded-md px-2 py-1 text-[10px] font-medium transition-colors',
+                      'flex items-center justify-center gap-1 rounded-md px-2 py-1 text-3xs font-medium transition-colors',
                       searchResultTab === 'content'
                         ? 'bg-secondary text-foreground shadow-sm'
                         : 'text-muted-foreground hover:bg-background/70 hover:text-foreground'
@@ -1016,7 +1016,7 @@ export function FileExplorer({ side = 'right' }: FileExplorerProps): React.JSX.E
                       setSearchResultTab('files')
                     }}
                     className={cn(
-                      'flex items-center justify-center gap-1 rounded-md px-2 py-1 text-[10px] font-medium transition-colors',
+                      'flex items-center justify-center gap-1 rounded-md px-2 py-1 text-3xs font-medium transition-colors',
                       searchResultTab === 'files'
                         ? 'bg-secondary text-foreground shadow-sm'
                         : 'text-muted-foreground hover:bg-background/70 hover:text-foreground'
@@ -1048,10 +1048,10 @@ export function FileExplorer({ side = 'right' }: FileExplorerProps): React.JSX.E
                     >
                       <div className="flex min-w-0 items-center justify-between gap-2">
                         <div className="min-w-0 flex-1">
-                          <span className="truncate text-[11px] font-medium text-foreground">
+                          <span className="truncate text-2xs font-medium text-foreground">
                             {fileName}
                           </span>
-                          <span className="ml-1.5 truncate text-[10px] text-muted-foreground">
+                          <span className="ml-1.5 truncate text-3xs text-muted-foreground">
                             {relativePath}
                           </span>
                         </div>
@@ -1085,14 +1085,14 @@ export function FileExplorer({ side = 'right' }: FileExplorerProps): React.JSX.E
                       >
                         <div className="flex min-w-0 items-center justify-between gap-2">
                           <div className="min-w-0 flex-1">
-                            <span className="truncate text-[11px] font-medium text-foreground">
+                            <span className="truncate text-2xs font-medium text-foreground">
                               {fileName}
                             </span>
-                            <span className="ml-1.5 truncate text-[10px] text-muted-foreground">
+                            <span className="ml-1.5 truncate text-3xs text-muted-foreground">
                               {relativePath}
                             </span>
                           </div>
-                          <span className="shrink-0 text-[9px] text-muted-foreground">
+                          <span className="shrink-0 text-4xs text-muted-foreground">
                             {fileResult.matches.length} hit
                             {fileResult.matches.length === 1 ? '' : 's'}
                           </span>
@@ -1105,9 +1105,9 @@ export function FileExplorer({ side = 'right' }: FileExplorerProps): React.JSX.E
                             onClick={() =>
                               void handleSearchMatchClick(fileResult.filePath, match.lineNumber)
                             }
-                            className="group flex w-full items-center gap-2 overflow-hidden px-2 py-0.5 text-left text-[10px] text-foreground transition-colors hover:bg-secondary/50 focus:outline-none focus-visible:ring-1 focus-visible:ring-primary"
+                            className="group flex w-full items-center gap-2 overflow-hidden px-2 py-0.5 text-left text-3xs text-foreground transition-colors hover:bg-secondary/50 focus:outline-none focus-visible:ring-1 focus-visible:ring-primary"
                           >
-                            <span className="shrink-0 min-w-[22px] text-right text-[9px] text-muted-foreground">
+                            <span className="shrink-0 min-w-[22px] text-right text-4xs text-muted-foreground">
                               {match.lineNumber}
                             </span>
                             <span className="block min-w-0 flex-1 truncate text-foreground/90">
@@ -1119,7 +1119,7 @@ export function FileExplorer({ side = 'right' }: FileExplorerProps): React.JSX.E
                           <button
                             type="button"
                             onClick={() => toggleExpandedSearchResult(fileResult.filePath)}
-                            className="px-2 py-0.5 text-[10px] text-muted-foreground transition-colors hover:text-foreground focus:outline-none"
+                            className="px-2 py-0.5 text-3xs text-muted-foreground transition-colors hover:text-foreground focus:outline-none"
                           >
                             Show {hiddenCount} more
                           </button>
@@ -1128,7 +1128,7 @@ export function FileExplorer({ side = 'right' }: FileExplorerProps): React.JSX.E
                           <button
                             type="button"
                             onClick={() => toggleExpandedSearchResult(fileResult.filePath)}
-                            className="px-2 py-0.5 text-[10px] text-muted-foreground transition-colors hover:text-foreground focus:outline-none"
+                            className="px-2 py-0.5 text-3xs text-muted-foreground transition-colors hover:text-foreground focus:outline-none"
                           >
                             Show less
                           </button>

--- a/src/renderer/components/file-explorer/FileExplorer.tsx
+++ b/src/renderer/components/file-explorer/FileExplorer.tsx
@@ -857,7 +857,7 @@ export function FileExplorer({ side = 'right' }: FileExplorerProps): React.JSX.E
     >
       {/* Header */}
       <div className="flex items-center justify-between px-3 h-10 border-b border-border flex-shrink-0 rounded-t-xl">
-        <span className="text-xs tracking-wider text-sidebar-foreground uppercase">Explorer</span>
+        <span className="label-section text-sidebar-foreground">Explorer</span>
         <button
           onClick={collapseAll}
           className="text-muted-foreground hover:text-foreground transition-colors p-0.5"

--- a/src/renderer/components/git/GitHistoryPanel.tsx
+++ b/src/renderer/components/git/GitHistoryPanel.tsx
@@ -222,13 +222,13 @@ function CommitRow({ commit }: { commit: GitCommit }): React.JSX.Element {
         ))}
       </div>
       <span className="text-xs text-foreground truncate flex-1 min-w-0">{commit.subject}</span>
-      <span className="text-[10px] text-muted-foreground truncate max-w-[120px] shrink-0">
+      <span className="text-3xs text-muted-foreground truncate max-w-[120px] shrink-0">
         {commit.author}
       </span>
-      <span className="text-[10px] text-muted-foreground/70 shrink-0 w-10 text-right">
+      <span className="text-3xs text-muted-foreground/70 shrink-0 w-10 text-right">
         {formatRelativeTime(commit.date)}
       </span>
-      <span className="font-mono text-[10px] text-muted-foreground/60 shrink-0 w-14">
+      <span className="font-mono text-3xs text-muted-foreground/60 shrink-0 w-14">
         {commit.shortHash}
       </span>
     </div>
@@ -240,7 +240,7 @@ function RefChip({ raw }: { raw: string }): React.JSX.Element {
   return (
     <span
       className={cn(
-        'inline-flex items-center gap-1 px-1.5 h-4 rounded text-[9px] font-medium leading-none',
+        'inline-flex items-center gap-1 px-1.5 h-4 rounded text-4xs font-medium leading-none',
         kind === 'head' && 'bg-primary/15 text-primary',
         kind === 'tag' && 'bg-amber-500/15 text-amber-500',
         kind === 'remote' && 'bg-muted-foreground/15 text-muted-foreground',

--- a/src/renderer/components/git/GitPanel.tsx
+++ b/src/renderer/components/git/GitPanel.tsx
@@ -720,9 +720,9 @@ export function GitPanel({ cwd, isVisible }: GitPanelProps) {
                       className="group flex w-full min-w-0 items-center justify-between px-2 py-1.5 rounded hover:bg-secondary/40 text-xs text-foreground cursor-default transition-all"
                     >
                       <div className="flex flex-col min-w-0 flex-1 pr-1.5">
-                        <span className="font-semibold text-muted-foreground text-[10px]">{`stash@{${s.index}}`}</span>
+                        <span className="font-semibold text-muted-foreground text-3xs">{`stash@{${s.index}}`}</span>
                         <span
-                          className="truncate text-muted-foreground text-[11px] leading-tight"
+                          className="truncate text-muted-foreground text-2xs leading-tight"
                           title={s.message}
                         >
                           {s.message || 'No message'}
@@ -784,7 +784,7 @@ export function GitPanel({ cwd, isVisible }: GitPanelProps) {
           />
           <label
             className={cn(
-              'flex items-center gap-2 text-[11px] select-none',
+              'flex items-center gap-2 text-2xs select-none',
               commitContext?.hasHead
                 ? 'text-muted-foreground cursor-pointer'
                 : 'text-muted-foreground/40 cursor-not-allowed'
@@ -845,7 +845,7 @@ export function GitPanel({ cwd, isVisible }: GitPanelProps) {
           >
             <ArrowUp size={14} className={cn(isPushing && 'animate-pulse')} />
             {isPushing ? 'Pushing...' : pushLabel}
-            {behind > 0 && <span className="text-[10px] text-amber-500">↓{behind}</span>}
+            {behind > 0 && <span className="text-3xs text-amber-500">↓{behind}</span>}
           </Button>
         </div>
       </div>
@@ -1016,7 +1016,7 @@ export function GitPanel({ cwd, isVisible }: GitPanelProps) {
                 onChange={(e) => setStashMessage(e.target.value)}
               />
             </div>
-            <label className="flex items-center gap-2 cursor-pointer select-none text-[11px]">
+            <label className="flex items-center gap-2 cursor-pointer select-none text-2xs">
               <input
                 type="checkbox"
                 className="h-3.5 w-3.5 accent-primary"
@@ -1272,8 +1272,8 @@ function FileItem({
     >
       <GitStatusBadge status={file.status} />
       <div className="flex-1 min-w-0 flex flex-col overflow-hidden">
-        <span className="text-[11px] font-medium truncate leading-tight">{fileName}</span>
-        {dirName && <span className="text-[9px] truncate opacity-50 leading-tight">{dirName}</span>}
+        <span className="text-2xs font-medium truncate leading-tight">{fileName}</span>
+        {dirName && <span className="text-4xs truncate opacity-50 leading-tight">{dirName}</span>}
       </div>
       <div
         className={cn(

--- a/src/renderer/components/git/GitPanel.tsx
+++ b/src/renderer/components/git/GitPanel.tsx
@@ -894,7 +894,7 @@ export function GitPanel({ cwd, isVisible }: GitPanelProps) {
                     <Columns2 size={14} />
                   </Button>
                 </div>
-                <span className="text-[10px] uppercase tracking-wider text-muted-foreground">
+                <span className="label-group text-muted-foreground">
                   {selectedStaged ? 'Staged' : 'Working tree'}
                 </span>
               </div>
@@ -1098,7 +1098,7 @@ function SectionHeader({
 }) {
   return (
     <div className="group/section flex items-center justify-between px-2 py-1">
-      <div className="text-[10px] font-bold text-muted-foreground uppercase tracking-wider flex items-center gap-2">
+      <div className="label-group text-muted-foreground flex items-center gap-2">
         <ChevronDown size={12} />
         {label} ({count})
         {selectionCount > 1 && (

--- a/src/renderer/components/settings/AcpAgentsSettings.tsx
+++ b/src/renderer/components/settings/AcpAgentsSettings.tsx
@@ -136,7 +136,7 @@ function AgentRow({ agent, platformArch }: AgentRowProps): React.JSX.Element {
         <div className="flex items-center gap-2">
           <span className="truncate text-sm font-medium text-foreground">{agent.name}</span>
           {agent.version && (
-            <span className="shrink-0 font-mono text-[10px] text-muted-foreground">
+            <span className="shrink-0 font-mono text-3xs text-muted-foreground">
               v{agent.version}
             </span>
           )}
@@ -144,7 +144,7 @@ function AgentRow({ agent, platformArch }: AgentRowProps): React.JSX.Element {
             <Badge
               variant="secondary"
               className={cn(
-                'h-4 px-1.5 text-[10px]',
+                'h-4 px-1.5 text-3xs',
                 warmBadge.tone === 'ready' && 'text-green-500',
                 warmBadge.tone === 'auth' && 'text-amber-500'
               )}
@@ -157,7 +157,7 @@ function AgentRow({ agent, platformArch }: AgentRowProps): React.JSX.Element {
           <p className="mt-0.5 line-clamp-2 text-xs text-muted-foreground">{agent.description}</p>
         )}
         {!runnable && (
-          <p className="mt-1 text-[11px] text-amber-500">
+          <p className="mt-1 text-2xs text-amber-500">
             {derived.kind === 'needs-install'
               ? derived.archiveUrl
                 ? installing

--- a/src/renderer/components/settings/SettingsLayout.tsx
+++ b/src/renderer/components/settings/SettingsLayout.tsx
@@ -221,7 +221,7 @@ export function SettingsLayout({
                   className="w-full flex flex-col items-start gap-0.5 text-left rounded-md px-3 py-2 text-sm text-foreground hover:bg-secondary focus:outline-none focus-visible:ring-2 focus-visible:ring-primary transition-colors"
                 >
                   <span className="font-medium">{result.label}</span>
-                  <span className="text-[11px] text-muted-foreground">
+                  <span className="text-2xs text-muted-foreground">
                     {categories.find((c) => c.id === result.categoryId)?.label}
                   </span>
                 </button>

--- a/src/renderer/components/ssh/PortForwardPanel.tsx
+++ b/src/renderer/components/ssh/PortForwardPanel.tsx
@@ -104,7 +104,7 @@ export function PortForwardPanel({ connection }: PortForwardPanelProps): React.J
           ))}
         </div>
       ) : (
-        <p className="text-[10px] text-muted-foreground">No active port forwards</p>
+        <p className="text-3xs text-muted-foreground">No active port forwards</p>
       )}
 
       {/* Add form */}
@@ -142,13 +142,13 @@ export function PortForwardPanel({ connection }: PortForwardPanelProps): React.J
           <div className="flex justify-end gap-1">
             <button
               onClick={() => setShowAdd(false)}
-              className="px-2 py-0.5 text-[10px] rounded border border-border hover:bg-accent"
+              className="px-2 py-0.5 text-3xs rounded border border-border hover:bg-accent"
             >
               Cancel
             </button>
             <button
               onClick={handleAdd}
-              className="px-2 py-0.5 text-[10px] rounded bg-primary text-primary-foreground hover:bg-primary/90"
+              className="px-2 py-0.5 text-3xs rounded bg-primary text-primary-foreground hover:bg-primary/90"
             >
               Start
             </button>

--- a/src/renderer/components/ssh/RemoteFileExplorer.tsx
+++ b/src/renderer/components/ssh/RemoteFileExplorer.tsx
@@ -204,7 +204,7 @@ export function RemoteFileExplorer({
 
           {/* Size */}
           {!isDir && (
-            <span className="text-[10px] text-muted-foreground">{formatSize(entry.size)}</span>
+            <span className="text-3xs text-muted-foreground">{formatSize(entry.size)}</span>
           )}
 
           {/* Actions */}

--- a/src/renderer/components/ssh/SSHFileEditor.tsx
+++ b/src/renderer/components/ssh/SSHFileEditor.tsx
@@ -55,7 +55,7 @@ export function SSHFileEditor({ connectionId }: SSHFileEditorProps): React.JSX.E
         <div className="h-8 flex items-center justify-between px-3 border-b border-border bg-muted/30">
           <div className="flex items-center gap-2">
             <FileEdit className="h-3 w-3 text-muted-foreground" />
-            <span className="text-[11px] font-mono text-muted-foreground">{editingFile.name}</span>
+            <span className="text-2xs font-mono text-muted-foreground">{editingFile.name}</span>
           </div>
           <div className="flex items-center gap-1">
             <button

--- a/src/renderer/components/ssh/SSHFileExplorer.tsx
+++ b/src/renderer/components/ssh/SSHFileExplorer.tsx
@@ -144,7 +144,7 @@ export function SSHFileExplorer({
           />
           <span className="flex-1 truncate">{entry.name}</span>
           {!isDir && (
-            <span className="text-[10px] text-muted-foreground hidden group-hover:inline">
+            <span className="text-3xs text-muted-foreground hidden group-hover:inline">
               {formatSize(entry.size)}
             </span>
           )}
@@ -234,7 +234,7 @@ export function SSHFileExplorer({
 
       {isConnected && (
         <div className="px-3 py-1 border-b border-border">
-          <span className="text-[10px] text-muted-foreground font-mono truncate block">
+          <span className="text-3xs text-muted-foreground font-mono truncate block">
             {currentPath}
           </span>
         </div>

--- a/src/renderer/components/ssh/SSHPanel.tsx
+++ b/src/renderer/components/ssh/SSHPanel.tsx
@@ -158,7 +158,7 @@ export function SSHPanel({
                   <div className="flex-1 min-w-0">
                     <div className="text-xs font-medium truncate">{profile.name}</div>
                     {showCredentials && (
-                      <div className="text-[10px] text-muted-foreground truncate">
+                      <div className="text-3xs text-muted-foreground truncate">
                         {profile.username}@{profile.host}:{profile.port}
                       </div>
                     )}

--- a/src/renderer/components/ssh/SSHPanel.tsx
+++ b/src/renderer/components/ssh/SSHPanel.tsx
@@ -66,7 +66,7 @@ export function SSHPanel({
       {/* Header */}
       <div className="h-9 flex items-center justify-between px-3">
         <div className="flex items-center gap-1.5">
-          <span className="text-xs tracking-wider text-sidebar-foreground uppercase">SSH</span>
+          <span className="label-section text-sidebar-foreground">SSH</span>
           <button
             onClick={() => setShowCredentials(!showCredentials)}
             className="group h-5 w-5 inline-flex items-center justify-center rounded hover:bg-sidebar-accent transition-colors"

--- a/src/renderer/components/ssh/SSHProfileForm.tsx
+++ b/src/renderer/components/ssh/SSHProfileForm.tsx
@@ -207,7 +207,7 @@ export function SSHProfileForm({
                 className="mt-1 w-full px-3 py-1.5 text-sm bg-muted border border-border rounded focus:outline-none focus:ring-1 focus:ring-ring"
               />
               {profile?.hasStoredPassphrase && (
-                <p className="mt-1 text-[10px] text-muted-foreground">
+                <p className="mt-1 text-3xs text-muted-foreground">
                   🔒 Passphrase stored securely in OS keychain. Leave blank to keep existing.
                 </p>
               )}
@@ -225,7 +225,7 @@ export function SSHProfileForm({
                 placeholder={profile?.hasStoredPassword ? '••••••••' : 'Enter password'}
                 className="mt-1 w-full px-3 py-1.5 text-sm bg-muted border border-border rounded focus:outline-none focus:ring-1 focus:ring-ring"
               />
-              <p className="mt-1 text-[10px] text-muted-foreground">
+              <p className="mt-1 text-3xs text-muted-foreground">
                 {profile?.hasStoredPassword
                   ? '🔒 Password stored securely in OS keychain. Leave blank to keep existing.'
                   : '🔒 Password will be stored in your OS keychain (Windows Credential Manager / macOS Keychain)'}

--- a/src/renderer/components/ssh/SSHStatusBadge.tsx
+++ b/src/renderer/components/ssh/SSHStatusBadge.tsx
@@ -20,7 +20,7 @@ export function SSHStatusBadge({ status, className }: SSHStatusBadgeProps): Reac
   return (
     <span
       className={cn(
-        'inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-medium',
+        'inline-flex items-center px-1.5 py-0.5 rounded text-3xs font-medium',
         config.color,
         className
       )}

--- a/src/renderer/components/ssh/SSHWorkspace.tsx
+++ b/src/renderer/components/ssh/SSHWorkspace.tsx
@@ -23,17 +23,17 @@ export function SSHWorkspace({ profile, conn }: SSHWorkspaceProps): React.JSX.El
             <Terminal className="h-3.5 w-3.5 text-muted-foreground" />
             <span className="text-xs font-medium">SSH: {profile.name}</span>
             {conn.isConnected ? (
-              <span className="flex items-center gap-1 text-[10px] text-green-500">
+              <span className="flex items-center gap-1 text-3xs text-green-500">
                 <span className="h-1.5 w-1.5 rounded-full bg-green-500" />
                 Connected
               </span>
             ) : conn.isConnectingStatus || conn.isConnecting ? (
-              <span className="flex items-center gap-1 text-[10px] text-yellow-500">
+              <span className="flex items-center gap-1 text-3xs text-yellow-500">
                 <span className="h-1.5 w-1.5 rounded-full bg-yellow-500 animate-pulse" />
                 Connecting
               </span>
             ) : (
-              <span className="flex items-center gap-1 text-[10px] text-muted-foreground">
+              <span className="flex items-center gap-1 text-3xs text-muted-foreground">
                 <span className="h-1.5 w-1.5 rounded-full bg-muted-foreground/40" />
                 Disconnected
               </span>
@@ -43,7 +43,7 @@ export function SSHWorkspace({ profile, conn }: SSHWorkspaceProps): React.JSX.El
             {conn.isConnected || conn.localTerminalPtyId ? (
               <button
                 onClick={conn.handleDisconnect}
-                className="px-2 py-0.5 text-[10px] rounded border border-border hover:bg-destructive/10 hover:text-destructive flex items-center gap-1"
+                className="px-2 py-0.5 text-3xs rounded border border-border hover:bg-destructive/10 hover:text-destructive flex items-center gap-1"
               >
                 <WifiOff className="h-3 w-3" />
                 Disconnect
@@ -52,7 +52,7 @@ export function SSHWorkspace({ profile, conn }: SSHWorkspaceProps): React.JSX.El
               <button
                 onClick={conn.handleConnect}
                 disabled={conn.isConnecting}
-                className="px-2 py-0.5 text-[10px] rounded bg-primary text-primary-foreground hover:bg-primary/90 flex items-center gap-1 disabled:opacity-50"
+                className="px-2 py-0.5 text-3xs rounded bg-primary text-primary-foreground hover:bg-primary/90 flex items-center gap-1 disabled:opacity-50"
               >
                 <Terminal className="h-3 w-3" />
                 {conn.isConnecting ? 'Connecting...' : 'Connect'}

--- a/src/renderer/components/terminal/ConnectedTerminal.tsx
+++ b/src/renderer/components/terminal/ConnectedTerminal.tsx
@@ -1731,7 +1731,7 @@ function ConnectedTerminalComponent({
                   <div className="w-20 h-20 rounded-2xl bg-destructive/10 flex items-center justify-center mb-3 shadow-inner group-hover:scale-110 transition-transform duration-500">
                     <AlertTriangle className="text-destructive" size={40} />
                   </div>
-                  <span className="text-[10px] uppercase tracking-[0.2em] font-black text-destructive/80 text-center">
+                  <span className="text-3xs uppercase tracking-[0.2em] font-black text-destructive/80 text-center">
                     CRITICAL ERROR
                   </span>
                 </div>
@@ -1757,7 +1757,7 @@ function ConnectedTerminalComponent({
                       <RefreshCcw size={20} /> Reconnect Session
                     </button>
                     <div className="hidden sm:block h-8 w-px bg-border/50 mx-2" />
-                    <div className="text-[10px] text-muted-foreground/60 font-mono">
+                    <div className="text-3xs text-muted-foreground/60 font-mono">
                       REF::{targetId?.slice(0, 8)}
                     </div>
                   </div>

--- a/src/renderer/components/workspace/EditorTab.tsx
+++ b/src/renderer/components/workspace/EditorTab.tsx
@@ -100,7 +100,7 @@ export function EditorTab({
           size={12}
           className="mr-2"
         />
-        <span className={cn('text-[11px] font-medium truncate', isActive && 'text-foreground')}>
+        <span className={cn('text-2xs font-medium truncate', isActive && 'text-foreground')}>
           {fileName}
         </span>
         <button

--- a/src/renderer/components/workspace/WorkspaceTabBar.tsx
+++ b/src/renderer/components/workspace/WorkspaceTabBar.tsx
@@ -171,12 +171,12 @@ function TerminalTabInline({
             }}
             onBlur={handleSave}
             onClick={(e) => e.stopPropagation()}
-            className="text-[11px] font-medium bg-transparent border-b border-primary outline-none w-full"
+            className="text-2xs font-medium bg-transparent border-b border-primary outline-none w-full"
           />
         ) : (
           <span
             onDoubleClick={handleDoubleClick}
-            className={cn('text-[11px] font-medium', isActive && 'text-foreground')}
+            className={cn('text-2xs font-medium', isActive && 'text-foreground')}
           >
             {terminal.name}
           </span>
@@ -394,7 +394,7 @@ function BrowserTabInline({
         )}
 
         <Globe size={12} className={cn('mr-2', isActive ? 'text-primary' : '')} />
-        <span className={cn('text-[11px] font-medium truncate', isActive && 'text-foreground')}>
+        <span className={cn('text-2xs font-medium truncate', isActive && 'text-foreground')}>
           {label}
         </span>
         <button
@@ -484,11 +484,11 @@ function GitTabInline({
         )}
       >
         <GitBranch size={12} className={isActive ? 'text-primary' : ''} />
-        <span className="truncate text-[11px] font-medium flex-1">Git Changes</span>
+        <span className="truncate text-2xs font-medium flex-1">Git Changes</span>
         {totalChanges > 0 && (
           <span
             className={cn(
-              'px-1 min-w-[14px] h-3.5 flex items-center justify-center rounded-full text-[9px] font-bold',
+              'px-1 min-w-[14px] h-3.5 flex items-center justify-center rounded-full text-4xs font-bold',
               isActive
                 ? 'bg-primary text-primary-foreground'
                 : 'bg-muted-foreground/20 text-muted-foreground'
@@ -580,7 +580,7 @@ function GitHistoryTabInline({
         )}
       >
         <History size={12} className={isActive ? 'text-primary' : ''} />
-        <span className="truncate text-[11px] font-medium flex-1">Git History</span>
+        <span className="truncate text-2xs font-medium flex-1">Git History</span>
         <button
           onClick={(e) => {
             e.stopPropagation()
@@ -670,7 +670,7 @@ function AgentChatTabInline({
         <Bot size={12} className={isActive ? 'text-primary' : ''} />
         <span
           className={cn(
-            'truncate text-[11px] font-medium flex-1',
+            'truncate text-2xs font-medium flex-1',
             isClosed && 'line-through opacity-60'
           )}
         >
@@ -1157,7 +1157,7 @@ export function WorkspaceTabBar({
 
             {isTerminalMenuOpen && (
               <div className="absolute top-full right-0 mt-1 w-44 bg-popover border border-border rounded-md shadow-lg z-50 overflow-hidden">
-                <div className="px-2.5 py-1 text-[11px] font-medium text-muted-foreground bg-secondary/30">
+                <div className="px-2.5 py-1 text-2xs font-medium text-muted-foreground bg-secondary/30">
                   Terminal
                 </div>
                 {loading ? (
@@ -1172,22 +1172,20 @@ export function WorkspaceTabBar({
                         key={shell.name}
                         onClick={() => handleSelectShell(shell)}
                         className={cn(
-                          'w-full px-2.5 py-1.5 text-left text-[11px] hover:bg-secondary flex items-center gap-2 leading-none',
+                          'w-full px-2.5 py-1.5 text-left text-2xs hover:bg-secondary flex items-center gap-2 leading-none',
                           shell.name === defaultShell && 'text-primary'
                         )}
                       >
                         <TerminalIcon size={11} />
                         <span className="truncate">{shell.displayName}</span>
                         {shell.name === defaultShell && (
-                          <span className="ml-auto text-[10px] text-muted-foreground">
-                            (default)
-                          </span>
+                          <span className="ml-auto text-3xs text-muted-foreground">(default)</span>
                         )}
                       </button>
                     ))}
                   </div>
                 ) : (
-                  <div className="px-2.5 py-1.5 text-[11px] text-muted-foreground">
+                  <div className="px-2.5 py-1.5 text-2xs text-muted-foreground">
                     No shells detected
                   </div>
                 )}

--- a/src/renderer/index.css
+++ b/src/renderer/index.css
@@ -395,7 +395,7 @@
     line-height: 1.4;
   }
   .label-group {
-    @apply text-[10px] font-semibold uppercase tracking-wider;
+    @apply text-3xs font-semibold uppercase tracking-wider;
     line-height: 1.4;
   }
 }

--- a/src/renderer/index.css
+++ b/src/renderer/index.css
@@ -366,6 +366,40 @@
   }
 }
 
+/* ------------------------------------------------------------
+ * Uppercase label scale.
+ *
+ * Two canonical typography-only roles for the uppercase tracked
+ * label element that previously drifted across ~25 call sites
+ * (sizes 10/12px, weights normal/medium/semibold/bold, tracking
+ * wide/wider). The two classes intentionally NORMALIZE weight and
+ * tracking to a single value per role — this is a deliberate
+ * unification, so some migrated labels render slightly lighter or
+ * heavier than before by design.
+ *
+ *   .label-section -> 12px panel / section headers
+ *                     (Projects, Explorer, SSH, Terminal, settings)
+ *   .label-group   -> 10px menu / group / field micro-labels
+ *                     (command palette groups, dialog field labels)
+ *
+ * These set size / weight / tracking / transform / line-height
+ * ONLY. Color and opacity stay at the call site because sidebar
+ * chrome (text-sidebar-foreground) and content surfaces
+ * (text-muted-foreground) legitimately differ. Behavioral classes
+ * (padding, hover, focus, truncate, cmdk selectors) also stay at
+ * the call site.
+ * ------------------------------------------------------------ */
+@layer components {
+  .label-section {
+    @apply text-xs font-normal uppercase tracking-wider;
+    line-height: 1.4;
+  }
+  .label-group {
+    @apply text-[10px] font-semibold uppercase tracking-wider;
+    line-height: 1.4;
+  }
+}
+
 /* Agent chat markdown prose (ref: key-agent-chat-pane mockup) */
 @layer components {
   .chat-prose {

--- a/src/renderer/pages/AppPreferences.tsx
+++ b/src/renderer/pages/AppPreferences.tsx
@@ -893,7 +893,7 @@ export default function AppPreferences(): React.JSX.Element {
                     <FolderOpen size={16} className="text-muted-foreground" />
                     <div className="text-left">
                       <div>Reveal Log Folder</div>
-                      <div className="text-[10px] text-muted-foreground font-normal">
+                      <div className="text-3xs text-muted-foreground font-normal">
                         Open in file explorer
                       </div>
                     </div>
@@ -907,7 +907,7 @@ export default function AppPreferences(): React.JSX.Element {
                     <FileText size={16} className="text-muted-foreground" />
                     <div className="text-left">
                       <div>Export Log File...</div>
-                      <div className="text-[10px] text-muted-foreground font-normal">
+                      <div className="text-3xs text-muted-foreground font-normal">
                         Save to a custom location
                       </div>
                     </div>
@@ -921,7 +921,7 @@ export default function AppPreferences(): React.JSX.Element {
                     <Clipboard size={16} className="text-muted-foreground" />
                     <div className="text-left">
                       <div>Copy Log Contents</div>
-                      <div className="text-[10px] text-muted-foreground font-normal">
+                      <div className="text-3xs text-muted-foreground font-normal">
                         Copy logs to clipboard
                       </div>
                     </div>
@@ -935,7 +935,7 @@ export default function AppPreferences(): React.JSX.Element {
                     <Download size={16} className="text-muted-foreground" />
                     <div className="text-left">
                       <div>Export to Default Directory</div>
-                      <div className="text-[10px] text-muted-foreground font-normal">
+                      <div className="text-3xs text-muted-foreground font-normal">
                         Save directly to Downloads
                       </div>
                     </div>

--- a/src/renderer/pages/ProjectSettings.tsx
+++ b/src/renderer/pages/ProjectSettings.tsx
@@ -512,10 +512,10 @@ export default function ProjectSettings() {
               <div className="w-2/3">
                 <div className="bg-secondary/30 rounded-lg border border-border overflow-hidden">
                   <div className="grid grid-cols-[1fr_1.5fr_auto] gap-px bg-border">
-                    <div className="bg-secondary/80 px-4 py-2 text-xs font-semibold text-muted-foreground uppercase tracking-wider">
+                    <div className="label-section bg-secondary/80 px-4 py-2 text-muted-foreground">
                       Key
                     </div>
-                    <div className="bg-secondary/80 px-4 py-2 text-xs font-semibold text-muted-foreground uppercase tracking-wider">
+                    <div className="label-section bg-secondary/80 px-4 py-2 text-muted-foreground">
                       Value
                     </div>
                     <div className="bg-secondary/80 w-10"></div>

--- a/src/renderer/pages/WorkspaceSnapshots.tsx
+++ b/src/renderer/pages/WorkspaceSnapshots.tsx
@@ -251,7 +251,7 @@ function SnapshotCard({
             {snapshot.tag && (
               <span
                 className={cn(
-                  'px-2 py-0.5 rounded text-[10px] uppercase font-bold tracking-wider border',
+                  'px-2 py-0.5 rounded text-3xs uppercase font-bold tracking-wider border',
                   snapshot.tag === 'stable'
                     ? 'bg-green-900/30 text-green-400 border-green-800/50'
                     : 'bg-primary/10 text-primary border-primary/30'

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -80,6 +80,16 @@ export default {
           orange: 'hsl(var(--project-orange) / <alpha-value>)'
         }
       },
+      fontSize: {
+        // Sub-xs scale. Tailwind's default fontSize stops at `xs` (12px),
+        // which forced ad-hoc `text-[Npx]` values for captions / badges /
+        // micro-labels across the renderer. These three size-only tokens
+        // fill that gap. Size-only (no [size, lineHeight] tuple) on purpose
+        // so existing `leading-*` and inherited line-heights are preserved.
+        '2xs': '0.6875rem', // 11px
+        '3xs': '0.625rem', // 10px
+        '4xs': '0.5625rem' // 9px
+      },
       fontFamily: {
         // Variable Inter (bundled). Fall through to native UI fonts so we still
         // look right if the bundled font fails to load. Ubuntu/Cantarell are


### PR DESCRIPTION
## Summary

The renderer's typography and left-column panels had accumulated inconsistencies that made the UI feel unpolished:

- The uppercase "label" element (panel headers, group headings, field labels) was hand-rolled at ~25 call sites with ~15 different combinations of size, weight, tracking, and color — so the same conceptual element rendered differently across the app.
- Tailwind's default `fontSize` scale stops at `xs` (12px) and the project defined no custom `fontSize`, forcing 127 ad-hoc `text-[Npx]` values (8/9/10/11px) for captions, badges, and micro-labels — four undocumented sizes with no scale.
- The File Explorer panel header was `h-10` while every other panel header is `h-9`, so its bottom border sat 4px below its neighbors in the same row.
- The Projects sidebar had an inverted hierarchy: group names rendered smaller and dimmer than the project items nested inside them, and the group count badge was nearly invisible (10px at 40% opacity).

This PR makes typography and left-column density consistent and readable across the app.

## Related Issue

No related issue — these inconsistencies were found by a direct UI audit of the typography and left-column panels, not filed as a ticket.

Context: this is related to #334 (Explorer vs Projects header consistency), which was already resolved by #372. This PR does **not** re-fix #334 — it generalizes the underlying label pattern into shared utilities and addresses the broader font-scale, header-height, and sidebar-density inconsistencies surfaced while reviewing that area.

## Type of Change

- [ ] feat: new feature
- [x] fix: bug fix
- [ ] docs: documentation only
- [ ] style: formatting or non-functional styling changes
- [x] refactor: internal cleanup with no behavior change
- [ ] perf: performance improvement
- [ ] test: adds or updates tests
- [ ] build: build or dependency changes
- [ ] ci: CI/CD workflow changes
- [ ] chore: maintenance or tooling
- [ ] revert: reverts a previous change

## What Changed

Four cohesive commits, all scoped to the renderer + `tailwind.config.ts`:

1. **`.label-section` / `.label-group` utilities** (`index.css`) — two typography-only classes; migrated ~25 hand-rolled uppercase label sites to them. Color/opacity stays at each call site.
2. **Sub-xs font-size scale** (`tailwind.config.ts`) — added size-only tokens `2xs` (11px), `3xs` (10px), `4xs` (9px); migrated all 127 arbitrary `text-[Npx]` sizes 1:1. The lone `text-[8px]` rounds up to 9px for legibility. Tokens carry no baked line-height, so existing `leading-*` is preserved exactly.
3. **Explorer header height** — `h-10` → `h-9` so its baseline aligns with the SidebarTabs/Projects column it sits beside.
4. **Projects sidebar density/hierarchy** — group names now match Explorer's flat density (`text-sm`, readable `text-sidebar-foreground`, `h-7` rows), distinguished by folder icon + chevron rather than smaller/dimmer text; count badge raised to a legible `text-xs`/60%.

Out of scope (intentionally untouched): badge/pill elements with backgrounds, the cmdk-rendered group heading, the numeric Tailwind scale, and font families.

## How It Was Tested

- [x] `bun run ci` (Biome lint + format + imports, strict mode)
- [x] `bun run typecheck`
- [x] `bun run test` (1740 passed, 42 skipped)
- [ ] `cargo clippy --all-targets -- -D warnings` (in src-tauri)
- [ ] `cargo test` (in src-tauri)
- [x] Manual verification completed

No Rust was touched, so cargo checks are not applicable. Each change also went through an adversarial review pass (blind/edge-case/acceptance reviewers) during development; two over-eager migrations (an avatar monogram and a crash-overlay sub-label) were reverted as a result.

## Screenshots or Recordings

<!-- Will add before/after of the Projects sidebar + Explorer header alignment. -->

## CI & Review Gate

- [ ] All CI checks pass (PR Validation, Rust Checks, Build Verification, Security Scans)
- [ ] Code review comments from CodeRabbit / Claude have been addressed or resolved
- [ ] No unresolved review findings remain

## Checklist

- [x] My PR title follows the conventional commit format used by this repo
- [x] I linked the related issue or explained why none exists
- [ ] I updated docs when needed
- [x] I added or updated tests when needed
- [x] I verified the change does not introduce unrelated modifications
- [x] I read AGENTS.md and followed the contributor guidelines
- [x] A human reviewed the complete diff before submission


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved visual consistency across dialogs, panels, tabs, and lists by standardizing label and helper text sizing with new refined typography tokens.
  * Updated numerous small UI text elements (headers, badges, captions, tooltips, empty states, and key hints) to use the same consistent scale and muted label styling.
* **Chores**
  * Added shared typography utility classes and Tailwind font-size tokens to support the updated design system.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->