### PR TITLE
feat(ui): whole-UI zoom via Ctrl+=/-/0 (VS Code style)

### DIFF
--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -20,6 +20,7 @@
     "core:window:allow-set-position",
     "core:window:allow-set-size",
     "core:webview:default",
+    "core:webview:allow-set-webview-zoom",
     "store:default",
     "fs:allow-read-text-file",
     "fs:allow-write-text-file",

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -505,15 +505,9 @@ fn build_app_menu<R: tauri::Runtime>(
     let reload = MenuItemBuilder::with_id(MENU_ID_RELOAD, "Reload")
         .accelerator("CmdOrCtrl+R")
         .build(app)?;
-    let zoom_reset = MenuItemBuilder::with_id(MENU_ID_ZOOM_RESET, "Actual Size")
-        .accelerator("CmdOrCtrl+0")
-        .build(app)?;
-    let zoom_in = MenuItemBuilder::with_id(MENU_ID_ZOOM_IN, "Zoom In")
-        .accelerator("CmdOrCtrl+=")
-        .build(app)?;
-    let zoom_out = MenuItemBuilder::with_id(MENU_ID_ZOOM_OUT, "Zoom Out")
-        .accelerator("CmdOrCtrl+-")
-        .build(app)?;
+    let zoom_reset = MenuItemBuilder::with_id(MENU_ID_ZOOM_RESET, "Actual Size").build(app)?;
+    let zoom_in = MenuItemBuilder::with_id(MENU_ID_ZOOM_IN, "Zoom In").build(app)?;
+    let zoom_out = MenuItemBuilder::with_id(MENU_ID_ZOOM_OUT, "Zoom Out").build(app)?;
     let toggle_fullscreen =
         MenuItemBuilder::with_id(MENU_ID_TOGGLE_FULLSCREEN, "Toggle Full Screen").build(app)?;
 

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -38,6 +38,7 @@ import { useKeyboardShortcutsLoader } from './hooks/use-keyboard-shortcuts'
 import { useMenuUpdaterListener } from './hooks/use-menu-updater-listener'
 import { usePreventFileDropNavigation } from './hooks/use-prevent-file-drop-navigation'
 import { useProjectsAutoSave, useProjectsLoader } from './hooks/use-projects-persistence'
+import { useAppliedUiZoomSync } from './hooks/use-ui-zoom'
 import { useUpdateCheck } from './hooks/use-updater'
 import { useVisibilityState } from './hooks/use-visibility-state'
 
@@ -93,6 +94,7 @@ function AppEffects(): null {
   useContextBarSettings()
   useAppSettingsLoader()
   useAppliedColorThemeSync()
+  useAppliedUiZoomSync()
   useKeyboardShortcutsLoader()
   useProjectsLoader()
   useProjectsAutoSave()

--- a/src/renderer/TauriApp.tsx
+++ b/src/renderer/TauriApp.tsx
@@ -25,6 +25,7 @@ import { useRemoteProjects } from './hooks/use-remote-projects'
 import { useTerminalDetachedOutput } from './hooks/use-terminal-detached-output'
 import { useTerminalExitNotification } from './hooks/use-terminal-exit-notification'
 import { useTerminalRestore } from './hooks/use-terminal-restore'
+import { useAppliedUiZoomSync } from './hooks/use-ui-zoom'
 import { useUpdateCheck } from './hooks/use-updater'
 import { useVisibilityState } from './hooks/use-visibility-state'
 import { useTerminalAutoSave } from './hooks/useTerminalAutoSave'
@@ -51,6 +52,7 @@ function AppEffects(): null {
   useContextBarSettings()
   useAppSettingsLoader()
   useAppliedColorThemeSync()
+  useAppliedUiZoomSync()
   useKeyboardShortcutsLoader()
   useProjectsLoader()
   useProjectsAutoSave()

--- a/src/renderer/hooks/use-ui-zoom.test.ts
+++ b/src/renderer/hooks/use-ui-zoom.test.ts
@@ -1,0 +1,33 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { UI_ZOOM_MAX, UI_ZOOM_MIN } from '@/types/settings'
+import { applyUiZoom } from './use-ui-zoom'
+
+describe('applyUiZoom', () => {
+  beforeEach(() => {
+    document.documentElement.style.zoom = ''
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    document.documentElement.style.zoom = ''
+  })
+
+  it('clamps to the maximum zoom factor', () => {
+    // jsdom is not the Tauri webview, so the CSS-zoom fallback path runs.
+    const applied = applyUiZoom(99)
+    expect(applied).toBe(UI_ZOOM_MAX)
+    expect(document.documentElement.style.zoom).toBe(String(UI_ZOOM_MAX))
+  })
+
+  it('clamps to the minimum zoom factor', () => {
+    const applied = applyUiZoom(0)
+    expect(applied).toBe(UI_ZOOM_MIN)
+    expect(document.documentElement.style.zoom).toBe(String(UI_ZOOM_MIN))
+  })
+
+  it('applies an in-range factor unchanged', () => {
+    const applied = applyUiZoom(1.2)
+    expect(applied).toBe(1.2)
+    expect(document.documentElement.style.zoom).toBe('1.2')
+  })
+})

--- a/src/renderer/hooks/use-ui-zoom.test.ts
+++ b/src/renderer/hooks/use-ui-zoom.test.ts
@@ -1,6 +1,27 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { UI_ZOOM_MAX, UI_ZOOM_MIN } from '@/types/settings'
-import { applyUiZoom } from './use-ui-zoom'
+import { applyUiZoom, clampUiZoom } from './use-ui-zoom'
+
+// jsdom is not the Tauri webview, so applyUiZoom normally takes the CSS-`zoom`
+// fallback. We selectively force the Tauri path for the failure-propagation
+// test by mocking the webview module.
+vi.mock('@tauri-apps/api/webview', () => ({
+  getCurrentWebview: vi.fn()
+}))
+
+describe('clampUiZoom', () => {
+  it('clamps above the maximum', () => {
+    expect(clampUiZoom(99)).toBe(UI_ZOOM_MAX)
+  })
+
+  it('clamps below the minimum', () => {
+    expect(clampUiZoom(0)).toBe(UI_ZOOM_MIN)
+  })
+
+  it('passes an in-range value through unchanged', () => {
+    expect(clampUiZoom(1.2)).toBe(1.2)
+  })
+})
 
 describe('applyUiZoom', () => {
   beforeEach(() => {
@@ -8,26 +29,42 @@ describe('applyUiZoom', () => {
   })
 
   afterEach(() => {
-    vi.restoreAllMocks()
     document.documentElement.style.zoom = ''
+    vi.restoreAllMocks()
   })
 
-  it('clamps to the maximum zoom factor', () => {
-    // jsdom is not the Tauri webview, so the CSS-zoom fallback path runs.
-    const applied = applyUiZoom(99)
+  it('clamps to the maximum zoom factor', async () => {
+    const applied = await applyUiZoom(99)
     expect(applied).toBe(UI_ZOOM_MAX)
     expect(document.documentElement.style.zoom).toBe(String(UI_ZOOM_MAX))
   })
 
-  it('clamps to the minimum zoom factor', () => {
-    const applied = applyUiZoom(0)
+  it('clamps to the minimum zoom factor', async () => {
+    const applied = await applyUiZoom(0)
     expect(applied).toBe(UI_ZOOM_MIN)
     expect(document.documentElement.style.zoom).toBe(String(UI_ZOOM_MIN))
   })
 
-  it('applies an in-range factor unchanged', () => {
-    const applied = applyUiZoom(1.2)
+  it('applies an in-range factor unchanged', async () => {
+    const applied = await applyUiZoom(1.2)
     expect(applied).toBe(1.2)
     expect(document.documentElement.style.zoom).toBe('1.2')
+  })
+
+  it('propagates failures from the native zoom call', async () => {
+    const { getCurrentWebview } = await import('@tauri-apps/api/webview')
+    const setZoom = vi.fn().mockRejectedValue(new Error('boom'))
+    vi.mocked(getCurrentWebview).mockReturnValue({ setZoom } as unknown as never)
+    // Inject the Tauri internals marker so applyUiZoom takes the native path.
+    Object.defineProperty(window, '__TAURI_INTERNALS__', {
+      value: {},
+      configurable: true,
+      writable: true
+    })
+    try {
+      await expect(applyUiZoom(1)).rejects.toThrow('boom')
+    } finally {
+      delete (window as unknown as Record<string, unknown>).__TAURI_INTERNALS__
+    }
   })
 })

--- a/src/renderer/hooks/use-ui-zoom.ts
+++ b/src/renderer/hooks/use-ui-zoom.ts
@@ -1,0 +1,50 @@
+import { getCurrentWebview } from '@tauri-apps/api/webview'
+import { useEffect } from 'react'
+import { useAppSettingsLoaded, useUiZoomLevel } from '@/stores/app-settings-store'
+import { UI_ZOOM_MAX, UI_ZOOM_MIN } from '@/types/settings'
+
+/** True when running inside the Tauri desktop webview (vs. the plain web build). */
+function isTauri(): boolean {
+  return (
+    typeof window !== 'undefined' &&
+    typeof (window as unknown as Record<string, unknown>).__TAURI_INTERNALS__ !== 'undefined'
+  )
+}
+
+/**
+ * Apply a whole-UI zoom factor to the window.
+ *
+ * In Tauri this uses the native webview zoom (same mechanism as the View menu),
+ * which scales the entire UI — terminal canvas included — crisply, exactly like
+ * VS Code / Electron window zoom. In the plain web build it falls back to the
+ * CSS `zoom` property on the document root.
+ *
+ * Returns the clamped factor that was actually applied.
+ */
+export function applyUiZoom(level: number): number {
+  const clamped = Math.min(Math.max(level, UI_ZOOM_MIN), UI_ZOOM_MAX)
+  if (isTauri()) {
+    void getCurrentWebview()
+      .setZoom(clamped)
+      .catch((error) => {
+        console.error('Failed to apply webview zoom:', error)
+      })
+  } else if (typeof document !== 'undefined') {
+    document.documentElement.style.zoom = String(clamped)
+  }
+  return clamped
+}
+
+/**
+ * Keep the applied window zoom in sync with the persisted `uiZoomLevel` setting.
+ * Mount once at the app root (alongside `useAppliedColorThemeSync`).
+ */
+export function useAppliedUiZoomSync(): void {
+  const isLoaded = useAppSettingsLoaded()
+  const uiZoomLevel = useUiZoomLevel()
+
+  useEffect(() => {
+    if (!isLoaded) return
+    applyUiZoom(uiZoomLevel)
+  }, [isLoaded, uiZoomLevel])
+}

--- a/src/renderer/hooks/use-ui-zoom.ts
+++ b/src/renderer/hooks/use-ui-zoom.ts
@@ -3,6 +3,11 @@ import { useEffect } from 'react'
 import { useAppSettingsLoaded, useUiZoomLevel } from '@/stores/app-settings-store'
 import { UI_ZOOM_MAX, UI_ZOOM_MIN } from '@/types/settings'
 
+/** Clamp a zoom factor into the supported UI zoom bounds. */
+export function clampUiZoom(level: number): number {
+  return Math.min(Math.max(level, UI_ZOOM_MIN), UI_ZOOM_MAX)
+}
+
 /** True when running inside the Tauri desktop webview (vs. the plain web build). */
 function isTauri(): boolean {
   return (
@@ -12,23 +17,23 @@ function isTauri(): boolean {
 }
 
 /**
- * Apply a whole-UI zoom factor to the window.
+ * Apply a whole-UI zoom factor to the window and resolve to the clamped value.
  *
  * In Tauri this uses the native webview zoom (same mechanism as the View menu),
  * which scales the entire UI — terminal canvas included — crisply, exactly like
  * VS Code / Electron window zoom. In the plain web build it falls back to the
  * CSS `zoom` property on the document root.
  *
- * Returns the clamped factor that was actually applied.
+ * The call is async because the Tauri `setZoom` IPC is async: callers that care
+ * about whether the zoom actually took effect can `await` this and handle a
+ * rejection (the web build resolves synchronously). This keeps the persisted
+ * `uiZoomLevel` setting from silently desyncing with the real applied zoom when
+ * the native call fails.
  */
-export function applyUiZoom(level: number): number {
-  const clamped = Math.min(Math.max(level, UI_ZOOM_MIN), UI_ZOOM_MAX)
+export async function applyUiZoom(level: number): Promise<number> {
+  const clamped = clampUiZoom(level)
   if (isTauri()) {
-    void getCurrentWebview()
-      .setZoom(clamped)
-      .catch((error) => {
-        console.error('Failed to apply webview zoom:', error)
-      })
+    await getCurrentWebview().setZoom(clamped)
   } else if (typeof document !== 'undefined') {
     document.documentElement.style.zoom = String(clamped)
   }
@@ -37,7 +42,9 @@ export function applyUiZoom(level: number): number {
 
 /**
  * Keep the applied window zoom in sync with the persisted `uiZoomLevel` setting.
- * Mount once at the app root (alongside `useAppliedColorThemeSync`).
+ * Mount once at the app root (alongside `useAppliedColorThemeSync`). Failures to
+ * apply the native zoom are logged rather than thrown so a transient IPC error
+ * doesn't surface to the user as an unhandled rejection.
  */
 export function useAppliedUiZoomSync(): void {
   const isLoaded = useAppSettingsLoaded()
@@ -45,6 +52,8 @@ export function useAppliedUiZoomSync(): void {
 
   useEffect(() => {
     if (!isLoaded) return
-    applyUiZoom(uiZoomLevel)
+    applyUiZoom(uiZoomLevel).catch((error) => {
+      console.error('Failed to apply UI zoom:', error)
+    })
   }, [isLoaded, uiZoomLevel])
 }

--- a/src/renderer/layouts/WorkspaceLayout.close-persistence.test.tsx
+++ b/src/renderer/layouts/WorkspaceLayout.close-persistence.test.tsx
@@ -183,6 +183,7 @@ vi.mock('@/stores/keyboard-shortcuts-store', () => ({
 
 vi.mock('@/stores/app-settings-store', () => ({
   useTerminalFontSize: () => 14,
+  useUiZoomLevel: () => 1,
   useDefaultShell: () => 'bash',
   useMaxTerminalsPerProject: () => 10,
   useConfirmTerminalClose: () => true,

--- a/src/renderer/layouts/WorkspaceLayout.test.tsx
+++ b/src/renderer/layouts/WorkspaceLayout.test.tsx
@@ -110,6 +110,7 @@ vi.mock('@/stores/app-settings-store', () => ({
     }
   ),
   useTerminalFontSize: vi.fn(() => 14),
+  useUiZoomLevel: vi.fn(() => 1),
   useTerminalFontFamily: vi.fn(() => 'monospace'),
   useTerminalBufferSize: vi.fn(() => 10000),
   useDefaultShell: vi.fn(() => 'bash'),

--- a/src/renderer/layouts/WorkspaceLayout.tsx
+++ b/src/renderer/layouts/WorkspaceLayout.tsx
@@ -64,7 +64,7 @@ import {
   useConfirmTerminalClose,
   useDefaultShell,
   useMaxTerminalsPerProject,
-  useTerminalFontSize
+  useUiZoomLevel
 } from '@/stores/app-settings-store'
 import { useBrowserSessionStore } from '@/stores/browser-session-store'
 import { useCommandHistoryStore } from '@/stores/command-history-store'
@@ -105,7 +105,7 @@ import {
   usePaneRoot,
   useWorkspaceStore
 } from '@/stores/workspace-store'
-import { DEFAULT_APP_SETTINGS } from '@/types/settings'
+import { UI_ZOOM_DEFAULT, UI_ZOOM_MAX, UI_ZOOM_MIN, UI_ZOOM_STEP } from '@/types/settings'
 
 function getShortcutTargetContext(target: EventTarget | null): {
   isInEditor: boolean
@@ -707,7 +707,7 @@ export default function WorkspaceLayout(): React.JSX.Element {
     [shortcuts]
   )
 
-  const fontSize = useTerminalFontSize()
+  const uiZoomLevel = useUiZoomLevel()
   const colorTheme = useColorTheme()
   const appearanceMode = useAppearanceMode()
 
@@ -1051,26 +1051,26 @@ export default function WorkspaceLayout(): React.JSX.Element {
         return
       }
 
-      // Zoom in/out/reset
+      // Zoom in/out/reset — whole-UI zoom (VS Code style)
       if (matchesShortcut(e, getActiveKey('zoomIn'))) {
         e.preventDefault()
         e.stopPropagation()
-        const newSize = Math.min(fontSize + 1, 24)
-        if (newSize !== fontSize) updateAppSetting('terminalFontSize', newSize)
+        const next = Math.min(uiZoomLevel + UI_ZOOM_STEP, UI_ZOOM_MAX)
+        if (next !== uiZoomLevel) updateAppSetting('uiZoomLevel', next)
         return
       }
       if (matchesShortcut(e, getActiveKey('zoomOut'))) {
         e.preventDefault()
         e.stopPropagation()
-        const newSize = Math.max(fontSize - 1, 10)
-        if (newSize !== fontSize) updateAppSetting('terminalFontSize', newSize)
+        const next = Math.max(uiZoomLevel - UI_ZOOM_STEP, UI_ZOOM_MIN)
+        if (next !== uiZoomLevel) updateAppSetting('uiZoomLevel', next)
         return
       }
       if (matchesShortcut(e, getActiveKey('zoomReset'))) {
         e.preventDefault()
         e.stopPropagation()
-        if (fontSize !== DEFAULT_APP_SETTINGS.terminalFontSize) {
-          updateAppSetting('terminalFontSize', DEFAULT_APP_SETTINGS.terminalFontSize)
+        if (uiZoomLevel !== UI_ZOOM_DEFAULT) {
+          updateAppSetting('uiZoomLevel', UI_ZOOM_DEFAULT)
         }
         return
       }
@@ -1106,7 +1106,7 @@ export default function WorkspaceLayout(): React.JSX.Element {
     activeTerminalId,
     activeTerminal,
     getActiveKey,
-    fontSize,
+    uiZoomLevel,
     updateAppSetting,
     appDefaultShell,
     maxTerminals,
@@ -1154,22 +1154,22 @@ export default function WorkspaceLayout(): React.JSX.Element {
           cycleTab('prev')
           break
         case 'zoomIn': {
-          const newSize = Math.min(fontSize + 1, 24)
-          if (newSize !== fontSize) {
-            updateAppSetting('terminalFontSize', newSize)
+          const next = Math.min(uiZoomLevel + UI_ZOOM_STEP, UI_ZOOM_MAX)
+          if (next !== uiZoomLevel) {
+            updateAppSetting('uiZoomLevel', next)
           }
           break
         }
         case 'zoomOut': {
-          const newSize = Math.max(fontSize - 1, 10)
-          if (newSize !== fontSize) {
-            updateAppSetting('terminalFontSize', newSize)
+          const next = Math.max(uiZoomLevel - UI_ZOOM_STEP, UI_ZOOM_MIN)
+          if (next !== uiZoomLevel) {
+            updateAppSetting('uiZoomLevel', next)
           }
           break
         }
         case 'zoomReset':
-          if (fontSize !== DEFAULT_APP_SETTINGS.terminalFontSize) {
-            updateAppSetting('terminalFontSize', DEFAULT_APP_SETTINGS.terminalFontSize)
+          if (uiZoomLevel !== UI_ZOOM_DEFAULT) {
+            updateAppSetting('uiZoomLevel', UI_ZOOM_DEFAULT)
           }
           break
         case 'sidebarToggle':
@@ -1186,7 +1186,7 @@ export default function WorkspaceLayout(): React.JSX.Element {
     })
   }, [
     cycleTab,
-    fontSize,
+    uiZoomLevel,
     handleOpenThemePicker,
     updateAppSetting,
     updatePanelVisibility,

--- a/src/renderer/layouts/WorkspaceLayout.tsx
+++ b/src/renderer/layouts/WorkspaceLayout.tsx
@@ -758,6 +758,21 @@ export default function WorkspaceLayout(): React.JSX.Element {
     [shortcuts]
   )
 
+  // Shared whole-UI zoom action used by both the DOM keydown path and the
+  // keyboardApi.onShortcut callback so behavior stays identical.
+  const applyZoomAction = useCallback(
+    (action: 'zoomIn' | 'zoomOut' | 'zoomReset'): void => {
+      const next =
+        action === 'zoomIn'
+          ? Math.min(uiZoomLevel + UI_ZOOM_STEP, UI_ZOOM_MAX)
+          : action === 'zoomOut'
+            ? Math.max(uiZoomLevel - UI_ZOOM_STEP, UI_ZOOM_MIN)
+            : UI_ZOOM_DEFAULT
+      if (next !== uiZoomLevel) updateAppSetting('uiZoomLevel', next)
+    },
+    [uiZoomLevel, updateAppSetting]
+  )
+
   // Determine if we should show the terminal area (only on workspace dashboard)
   const isWorkspaceRoute = location.pathname === '/'
 
@@ -1055,23 +1070,19 @@ export default function WorkspaceLayout(): React.JSX.Element {
       if (matchesShortcut(e, getActiveKey('zoomIn'))) {
         e.preventDefault()
         e.stopPropagation()
-        const next = Math.min(uiZoomLevel + UI_ZOOM_STEP, UI_ZOOM_MAX)
-        if (next !== uiZoomLevel) updateAppSetting('uiZoomLevel', next)
+        applyZoomAction('zoomIn')
         return
       }
       if (matchesShortcut(e, getActiveKey('zoomOut'))) {
         e.preventDefault()
         e.stopPropagation()
-        const next = Math.max(uiZoomLevel - UI_ZOOM_STEP, UI_ZOOM_MIN)
-        if (next !== uiZoomLevel) updateAppSetting('uiZoomLevel', next)
+        applyZoomAction('zoomOut')
         return
       }
       if (matchesShortcut(e, getActiveKey('zoomReset'))) {
         e.preventDefault()
         e.stopPropagation()
-        if (uiZoomLevel !== UI_ZOOM_DEFAULT) {
-          updateAppSetting('uiZoomLevel', UI_ZOOM_DEFAULT)
-        }
+        applyZoomAction('zoomReset')
         return
       }
 
@@ -1106,8 +1117,7 @@ export default function WorkspaceLayout(): React.JSX.Element {
     activeTerminalId,
     activeTerminal,
     getActiveKey,
-    uiZoomLevel,
-    updateAppSetting,
+    applyZoomAction,
     appDefaultShell,
     maxTerminals,
     isWorkspaceRoute,
@@ -1153,24 +1163,14 @@ export default function WorkspaceLayout(): React.JSX.Element {
         case 'prevTerminal':
           cycleTab('prev')
           break
-        case 'zoomIn': {
-          const next = Math.min(uiZoomLevel + UI_ZOOM_STEP, UI_ZOOM_MAX)
-          if (next !== uiZoomLevel) {
-            updateAppSetting('uiZoomLevel', next)
-          }
+        case 'zoomIn':
+          applyZoomAction('zoomIn')
           break
-        }
-        case 'zoomOut': {
-          const next = Math.max(uiZoomLevel - UI_ZOOM_STEP, UI_ZOOM_MIN)
-          if (next !== uiZoomLevel) {
-            updateAppSetting('uiZoomLevel', next)
-          }
+        case 'zoomOut':
+          applyZoomAction('zoomOut')
           break
-        }
         case 'zoomReset':
-          if (uiZoomLevel !== UI_ZOOM_DEFAULT) {
-            updateAppSetting('uiZoomLevel', UI_ZOOM_DEFAULT)
-          }
+          applyZoomAction('zoomReset')
           break
         case 'sidebarToggle':
           void updatePanelVisibility('sidebarVisible', !isSidebarVisible).catch((error) => {
@@ -1184,14 +1184,7 @@ export default function WorkspaceLayout(): React.JSX.Element {
           break
       }
     })
-  }, [
-    cycleTab,
-    uiZoomLevel,
-    handleOpenThemePicker,
-    updateAppSetting,
-    updatePanelVisibility,
-    isSidebarVisible
-  ])
+  }, [cycleTab, applyZoomAction, handleOpenThemePicker, updatePanelVisibility, isSidebarVisible])
 
   const closeTerminalByRecordId = useCallback(
     async (terminalRecordId: string): Promise<boolean> => {

--- a/src/renderer/pages/AppPreferences.tsx
+++ b/src/renderer/pages/AppPreferences.tsx
@@ -95,6 +95,12 @@ const APP_PREF_SEARCH_INDEX: SettingsSearchEntry[] = [
   },
   {
     categoryId: 'appearance',
+    label: 'UI Zoom Level',
+    description: 'Zoom the entire interface (50–300%).',
+    keywords: ['ui zoom', 'zoom', 'interface scale', 'window zoom', 'magnify']
+  },
+  {
+    categoryId: 'appearance',
     label: 'Scrollback Buffer Size',
     description: 'Number of lines to keep in terminal history.',
     keywords: ['history', 'lines', 'memory']
@@ -396,8 +402,8 @@ export default function AppPreferences(): React.JSX.Element {
                     </span>
                   </div>
                   <p className="text-xs text-muted-foreground mt-1">
-                    Zoom the entire interface (50–300%). Also adjustable with Ctrl + / Ctrl - / Ctrl
-                    0.
+                    Zoom the entire interface (50–300%). Also adjustable with Ctrl+=, Ctrl+-,
+                    Ctrl+0.
                   </p>
                 </div>
 

--- a/src/renderer/pages/AppPreferences.tsx
+++ b/src/renderer/pages/AppPreferences.tsx
@@ -48,7 +48,8 @@ import {
   useTerminalFontFamily,
   useTerminalFontSize,
   useTerminalRenderer,
-  useTerminalUrlOpenMode
+  useTerminalUrlOpenMode,
+  useUiZoomLevel
 } from '@/stores/app-settings-store'
 import { useKeyboardShortcutsStore } from '@/stores/keyboard-shortcuts-store'
 import { useUpdaterActions, useUpdaterState } from '@/stores/updater-store'
@@ -60,7 +61,11 @@ import {
   ORPHAN_TIMEOUT_OPTIONS,
   TERMINAL_RENDERER_OPTIONS,
   TERMINAL_URL_OPEN_MODE_OPTIONS,
-  type TerminalUrlOpenMode
+  type TerminalUrlOpenMode,
+  UI_ZOOM_DEFAULT,
+  UI_ZOOM_MAX,
+  UI_ZOOM_MIN,
+  UI_ZOOM_STEP
 } from '@/types/settings'
 
 const APP_PREF_CATEGORIES: SettingsCategory[] = [
@@ -179,6 +184,7 @@ export default function AppPreferences(): React.JSX.Element {
   const isAurUpdater = isAurUpdateMode()
   const fontFamily = useTerminalFontFamily()
   const fontSize = useTerminalFontSize()
+  const uiZoomLevel = useUiZoomLevel()
   const bufferSize = useTerminalBufferSize()
   const terminalRenderer = useTerminalRenderer()
   const defaultShell = useDefaultShell()
@@ -235,6 +241,14 @@ export default function AppPreferences(): React.JSX.Element {
 
   const handleFontSizeChange = (value: number) => {
     updateSetting('terminalFontSize', value)
+  }
+
+  const handleUiZoomChange = (value: number) => {
+    updateSetting('uiZoomLevel', value)
+  }
+
+  const handleUiZoomReset = () => {
+    updateSetting('uiZoomLevel', UI_ZOOM_DEFAULT)
   }
 
   const handleBufferSizeChange = (value: number) => {
@@ -352,6 +366,41 @@ export default function AppPreferences(): React.JSX.Element {
                 </p>
               </div>
               <div className="w-2/3 space-y-4">
+                {/* UI Zoom Level (whole interface) */}
+                <div>
+                  <div className="flex items-center justify-between mb-2">
+                    <label className="block text-sm font-medium text-secondary-foreground">
+                      UI Zoom Level
+                    </label>
+                    <button
+                      type="button"
+                      onClick={handleUiZoomReset}
+                      className="text-xs text-primary hover:underline disabled:opacity-50"
+                      disabled={uiZoomLevel === UI_ZOOM_DEFAULT}
+                    >
+                      Reset to 100%
+                    </button>
+                  </div>
+                  <div className="flex items-center gap-4">
+                    <input
+                      type="range"
+                      min={UI_ZOOM_MIN}
+                      max={UI_ZOOM_MAX}
+                      step={UI_ZOOM_STEP}
+                      value={uiZoomLevel}
+                      onChange={(e) => handleUiZoomChange(parseFloat(e.target.value))}
+                      className="flex-1 h-2 bg-secondary rounded-lg appearance-none cursor-pointer accent-primary"
+                    />
+                    <span className="text-sm text-muted-foreground w-14 text-right">
+                      {Math.round(uiZoomLevel * 100)}%
+                    </span>
+                  </div>
+                  <p className="text-xs text-muted-foreground mt-1">
+                    Zoom the entire interface (50–300%). Also adjustable with Ctrl + / Ctrl - / Ctrl
+                    0.
+                  </p>
+                </div>
+
                 {/* Font Family */}
                 <div>
                   <label className="block text-sm font-medium text-secondary-foreground mb-2">

--- a/src/renderer/stores/app-settings-store.test.ts
+++ b/src/renderer/stores/app-settings-store.test.ts
@@ -134,7 +134,8 @@ describe('app-settings-store', () => {
         sshPanelVisible: true,
         remoteBindMode: 'localhost' as const,
         colorTheme: 'dracula',
-        appearanceMode: 'dark' as const
+        appearanceMode: 'dark' as const,
+        uiZoomLevel: 1
       }
 
       const { setSettings } = useAppSettingsStore.getState()
@@ -167,7 +168,8 @@ describe('app-settings-store', () => {
           sshPanelVisible: false,
           remoteBindMode: 'all' as const,
           colorTheme: 'nord',
-          appearanceMode: 'light' as const
+          appearanceMode: 'light' as const,
+          uiZoomLevel: 1.2
         },
         isLoaded: true
       })

--- a/src/renderer/stores/app-settings-store.ts
+++ b/src/renderer/stores/app-settings-store.ts
@@ -60,3 +60,4 @@ export const useFileExplorerVisibilitySetting = () =>
   useAppSettingsStore((state) => state.settings.fileExplorerVisible)
 export const useColorTheme = () => useAppSettingsStore((state) => state.settings.colorTheme)
 export const useAppearanceMode = () => useAppSettingsStore((state) => state.settings.appearanceMode)
+export const useUiZoomLevel = () => useAppSettingsStore((state) => state.settings.uiZoomLevel)

--- a/src/renderer/types/settings.ts
+++ b/src/renderer/types/settings.ts
@@ -62,7 +62,15 @@ export interface AppSettings {
   colorTheme: string
   /** Light, dark, or follow OS (maps to `{colorTheme}` / `{colorTheme}-light`). */
   appearanceMode: 'light' | 'dark'
+  /** Whole-UI zoom factor (1.0 = 100%). Scales the entire window like VS Code's window zoom. */
+  uiZoomLevel: number
 }
+
+/** Whole-UI zoom bounds — match the native View menu semantics (0.5x–3.0x, 10% steps). */
+export const UI_ZOOM_DEFAULT = 1.0
+export const UI_ZOOM_MIN = 0.5
+export const UI_ZOOM_MAX = 3.0
+export const UI_ZOOM_STEP = 0.1
 
 export type AppPanelVisibilitySettingKey =
   | 'sidebarVisible'
@@ -160,7 +168,8 @@ export const DEFAULT_APP_SETTINGS: AppSettings = {
   sshPanelVisible: true,
   remoteBindMode: 'localhost',
   colorTheme: 'termul',
-  appearanceMode: 'dark'
+  appearanceMode: 'dark',
+  uiZoomLevel: UI_ZOOM_DEFAULT
 }
 
 // Persistence key for app settings
@@ -237,19 +246,19 @@ export const DEFAULT_KEYBOARD_SHORTCUTS: KeyboardShortcutsConfig = {
   zoomIn: {
     id: 'zoomIn',
     label: 'Zoom In',
-    description: 'Increase terminal font size',
+    description: 'Zoom in the entire UI',
     defaultKey: 'ctrl+='
   },
   zoomOut: {
     id: 'zoomOut',
     label: 'Zoom Out',
-    description: 'Decrease terminal font size',
+    description: 'Zoom out the entire UI',
     defaultKey: 'ctrl+-'
   },
   zoomReset: {
     id: 'zoomReset',
     label: 'Reset Zoom',
-    description: 'Reset terminal font size to default',
+    description: 'Reset the whole-UI zoom to 100%',
     defaultKey: 'ctrl+0'
   },
   sidebarToggle: {


### PR DESCRIPTION
## Summary

Previously `Ctrl + +` / `Ctrl + -` / `Ctrl + 0` only changed the terminal font size, leaving the rest of the window untouched. This PR makes those shortcuts zoom the **entire interface** (terminal, sidebar, editors, browser — everything), matching the VS Code / Electron "window zoom" behaviour users expect. The zoom level persists across restarts and is also adjustable in Preferences. The terminal font size remains an independent preference.

## Related Issue

No related issue — this is a self-contained enhancement requested for VS Code-style whole-window zoom.

## Type of Change

- [x] feat: new feature
- [ ] fix: bug fix
- [ ] docs: documentation only
- [ ] style: formatting or non-functional styling changes
- [ ] refactor: internal cleanup with no behavior change
- [ ] perf: performance improvement
- [ ] test: adds or updates tests
- [ ] build: build or dependency changes
- [ ] ci: CI/CD workflow changes
- [ ] chore: maintenance or tooling
- [ ] revert: reverts a previous change

## What Changed

- Added a new `uiZoomLevel` setting to `AppSettings` (default `1.0`, range `0.5`–`3.0`, 10% steps) plus `UI_ZOOM_*` bounds/step constants in `types/settings.ts`.
- New hook `src/renderer/hooks/use-ui-zoom.ts`: `applyUiZoom()` uses the native Tauri `webview.setZoom` (crisp whole-window scaling, same as the existing View menu) with a CSS-`zoom` fallback for the plain web build; `useAppliedUiZoomSync()` keeps the window zoomed to the persisted setting on startup.
- Repurposed the `zoomIn` / `zoomOut` / `zoomReset` keyboard handlers in `WorkspaceLayout.tsx` to adjust `uiZoomLevel` (whole UI) instead of `terminalFontSize`. Updated both the window keydown handler and the backend shortcut-callback shim.
- Mounted the zoom-sync hook in both `TauriApp.tsx` and `App.tsx`, alongside the existing colour-theme sync.
- Added a **"UI Zoom Level"** slider (50–300%) with a Reset-to-100% button to the Terminal Appearance section in `AppPreferences.tsx`.
- Added the `core:webview:allow-set-webview-zoom` permission to `src-tauri/capabilities/default.json`.
- Removed the conflicting Rust View-menu **accelerators** for Actual Size / Zoom In / Zoom Out (`src-tauri/src/lib.rs`). The menu items remain clickable, but the keyboard shortcuts now have a single owner (the frontend) so there is no double-zoom jitter between the two systems.
- Updated the zoom shortcut descriptions in `DEFAULT_KEYBOARD_SHORTCUTS` to reflect whole-UI zoom.
- Tests: added `use-ui-zoom.test.ts` (clamping), updated the WorkspaceLayout mocks and `app-settings-store.test.ts` fixtures for the new `uiZoomLevel` field.

**Backward compatibility:** old persisted settings without `uiZoomLevel` are merged against defaults (`{ ...DEFAULT_APP_SETTINGS, ...data }`), so existing installs default to 100% zoom with no migration.

## How It Was Tested

- [x] `bun run ci` (Biome lint + format + imports, strict mode)
- [x] `bun run typecheck`
- [x] `bun run test`
- [ ] `cargo clippy --all-targets -- -D warnings` (in src-tauri)
- [ ] `cargo test` (in src-tauri)
- [ ] Manual verification completed
- [ ] Not applicable

Rust checks (`cargo check` / `clippy` / `test`) were not run locally; CI runs them on this PR. The Rust change is minimal (three menu-item accelerators removed; no signature/logic changes).

## Screenshots or Recordings

Not captured. The change is most visible by pressing `Ctrl + =` repeatedly in a running build and watching the whole window (sidebar, tabs, terminal) scale uniformly.

## Known limitation / follow-up

The native **View menu** "Actual Size / Zoom In / Zoom Out" items are still clickable but keep their own internal Rust-side `ViewMenuState`, so they can slightly desync from the keyboard/persisted level (e.g. clicking "Zoom In" after using `Ctrl+=`). The keyboard path — the primary request — is fully consistent and persisted. Unifying the menu onto the same persisted setting is a small follow-up if desired.

## CI & Review Gate

- [ ] All CI checks pass (PR Validation, Rust Checks, Build Verification, Security Scans)
- [ ] Code review comments from CodeRabbit / Claude have been addressed or resolved
- [ ] No unresolved review findings remain

## Checklist

- [x] My PR title follows the conventional commit format used by this repo
- [x] I linked the related issue or explained why none exists
- [x] I updated docs when needed
- [x] I added or updated tests when needed
- [x] I verified the change does not introduce unrelated modifications
- [x] I read AGENTS.md and followed the contributor guidelines
- [ ] A human reviewed the complete diff before submission
