### PR TITLE
fix(terminal): wire pasteText to send bracketed paste markers directly to PTY

### DIFF
--- a/src/renderer/components/terminal/ConnectedTerminal.test.tsx
+++ b/src/renderer/components/terminal/ConnectedTerminal.test.tsx
@@ -1144,6 +1144,37 @@ describe('ConnectedTerminal', () => {
       })
     })
 
+    it('should write bracket-wrapped paste data to PTY via terminalApi.write', async () => {
+      const clipboardText = 'Line 1\nLine 2\nLine 3'
+      vi.mocked(clipboardApi).readText.mockResolvedValue({ success: true, data: clipboardText })
+
+      render(<ConnectedTerminal />)
+
+      await vi.waitFor(() => {
+        expect(mockTerminalInstance.attachCustomKeyEventHandler).toHaveBeenCalled()
+      })
+
+      const handler = mockTerminalInstance.attachCustomKeyEventHandler.mock.calls[0][0]
+
+      const event = new KeyboardEvent('keydown', {
+        key: 'v',
+        ctrlKey: true,
+        bubbles: true
+      })
+
+      handler(event)
+
+      await vi.waitFor(() => {
+        expect(vi.mocked(terminalApi).write).toHaveBeenCalledWith(
+          'terminal-123',
+          '\x1b[200~Line 1\rLine 2\rLine 3\x1b[201~'
+        )
+      })
+
+      // terminal.paste should NOT be called when pasteText is wired
+      expect(mockTerminalInstance.paste).not.toHaveBeenCalled()
+    })
+
     it('should select all on Ctrl+A', async () => {
       render(<ConnectedTerminal />)
 

--- a/src/renderer/components/terminal/ConnectedTerminal.tsx
+++ b/src/renderer/components/terminal/ConnectedTerminal.tsx
@@ -339,6 +339,11 @@ function ConnectedTerminalComponent({
 
   const { copySelection, pasteFromClipboard, hasSelection } = useTerminalClipboard({
     terminal: terminalInstance,
+    pasteText: async (text: string) => {
+      const ptyId = ptyIdRef.current
+      if (!ptyId) return
+      await terminalApi.write(ptyId, text)
+    },
     onImagePaste: async () => {
       const ptyId = ptyIdRef.current
       if (!ptyId) return

--- a/src/renderer/components/terminal/ConnectedTerminal.tsx
+++ b/src/renderer/components/terminal/ConnectedTerminal.tsx
@@ -342,7 +342,16 @@ function ConnectedTerminalComponent({
     pasteText: async (text: string) => {
       const ptyId = ptyIdRef.current
       if (!ptyId) return
-      await terminalApi.write(ptyId, text)
+      try {
+        const result = await terminalApi.write(ptyId, text)
+        if (!result.success && onErrorRef.current) {
+          onErrorRef.current(result.error)
+        }
+      } catch (err) {
+        if (onErrorRef.current) {
+          onErrorRef.current(err instanceof Error ? err.message : 'Paste write failed')
+        }
+      }
     },
     onImagePaste: async () => {
       const ptyId = ptyIdRef.current

--- a/src/renderer/hooks/use-terminal-clipboard.test.ts
+++ b/src/renderer/hooks/use-terminal-clipboard.test.ts
@@ -397,6 +397,93 @@ Line 3`
     })
   })
 
+  describe('pasteFromClipboard with pasteText callback', () => {
+    it('should call pasteText with bracket-wrapped text and not call terminal.paste', async () => {
+      const clipboardText = 'Hello World'
+      const mockTerminal = createMockTerminal(false, '')
+      const mockPasteText = vi.fn()
+      mockClipboardApi.readText.mockResolvedValue({ success: true, data: clipboardText })
+
+      const { result } = renderHook(() =>
+        useTerminalClipboard({
+          terminal: mockTerminal as unknown as Terminal,
+          pasteText: mockPasteText
+        })
+      )
+
+      await act(async () => {
+        await result.current.pasteFromClipboard()
+      })
+
+      expect(mockPasteText).toHaveBeenCalledWith('\x1b[200~Hello World\x1b[201~')
+      expect(mockTerminal.paste).not.toHaveBeenCalled()
+    })
+
+    it('should sanitize ESC characters before wrapping in brackets', async () => {
+      const clipboardText = '\x1b[?2004hmalicious\x1b[?2004l'
+      const mockTerminal = createMockTerminal(false, '')
+      const mockPasteText = vi.fn()
+      mockClipboardApi.readText.mockResolvedValue({ success: true, data: clipboardText })
+
+      const { result } = renderHook(() =>
+        useTerminalClipboard({
+          terminal: mockTerminal as unknown as Terminal,
+          pasteText: mockPasteText
+        })
+      )
+
+      await act(async () => {
+        await result.current.pasteFromClipboard()
+      })
+
+      expect(mockPasteText).toHaveBeenCalledWith(
+        '\x1b[200~\u241b[?2004hmalicious\u241b[?2004l\x1b[201~'
+      )
+    })
+
+    it('should normalize multiline text and wrap in brackets via pasteText', async () => {
+      const clipboardText = `Line 1
+Line 2
+Line 3`
+      const mockTerminal = createMockTerminal(false, '')
+      const mockPasteText = vi.fn()
+      mockClipboardApi.readText.mockResolvedValue({ success: true, data: clipboardText })
+
+      const { result } = renderHook(() =>
+        useTerminalClipboard({
+          terminal: mockTerminal as unknown as Terminal,
+          pasteText: mockPasteText
+        })
+      )
+
+      await act(async () => {
+        await result.current.pasteFromClipboard()
+      })
+
+      expect(mockPasteText).toHaveBeenCalledWith('\x1b[200~Line 1\rLine 2\rLine 3\x1b[201~')
+      expect(mockTerminal.paste).not.toHaveBeenCalled()
+    })
+
+    it('should handle pasteText when clipboard is empty', async () => {
+      const mockTerminal = createMockTerminal(false, '')
+      const mockPasteText = vi.fn()
+      mockClipboardApi.readText.mockResolvedValue({ success: true, data: '' })
+
+      const { result } = renderHook(() =>
+        useTerminalClipboard({
+          terminal: mockTerminal as unknown as Terminal,
+          pasteText: mockPasteText
+        })
+      )
+
+      await act(async () => {
+        await result.current.pasteFromClipboard()
+      })
+
+      expect(mockPasteText).not.toHaveBeenCalled()
+    })
+  })
+
   describe('terminal reference stability', () => {
     it('should maintain stable callback references', async () => {
       const mockTerminal = createMockTerminal(true, 'text')

--- a/src/renderer/hooks/use-terminal-clipboard.ts
+++ b/src/renderer/hooks/use-terminal-clipboard.ts
@@ -23,6 +23,13 @@ function normalizePasteText(text: string): string {
   return text.replace(/\r?\n/g, '\r')
 }
 
+// Sanitize ESC characters to prevent injected escape sequences from exiting
+// the bracketed paste region. Matches xterm.js's bracketTextForPaste() behavior
+// (replaces \x1b with its visible representation U+241B = ␛).
+function sanitizeEscapeSequences(text: string): string {
+  return text.split(String.fromCharCode(0x1b)).join('\u241b')
+}
+
 export function useTerminalClipboard(
   options: UseTerminalClipboardOptions
 ): UseTerminalClipboardReturn {
@@ -113,7 +120,8 @@ export function useTerminalClipboard(
         }
         const normalizedText = normalizePasteText(result.data)
         if (pasteText) {
-          await pasteText(`${BRACKETED_PASTE_START}${normalizedText}${BRACKETED_PASTE_END}`)
+          const sanitizedText = sanitizeEscapeSequences(normalizedText)
+          await pasteText(`${BRACKETED_PASTE_START}${sanitizedText}${BRACKETED_PASTE_END}`)
         } else {
           currentTerminal.paste(normalizedText)
         }


### PR DESCRIPTION
## Summary

Pasting multi-line text into termul's built-in terminal sends each line as a separate input/command instead of as a single paste block. This happens because `terminal.paste()` only wraps content in bracketed-paste markers when the shell has explicitly enabled the mode (`\x1b[?2004h`), and many shells (cmd.exe, older bash, `/bin/sh`) never do. The `useTerminalClipboard` hook already had a `pasteText` code path that manually adds bracket markers, but `ConnectedTerminal` never passed it — making it dead code.

## Related Issue

No related issue exists in the tracker. This bug was discovered and root-caused through a forensic investigation of multi-line paste behavior in termul's terminal. See the investigation case file linked at the bottom.

## Type of Change

- [x] fix: bug fix

## What Changed

**Core fix — wire the dead-code `pasteText` path:**

- `src/renderer/components/terminal/ConnectedTerminal.tsx`: Added `pasteText` callback to `useTerminalClipboard` call that writes bracket-wrapped text directly to the PTY via `terminalApi.write(ptyId, text)`. This bypasses `terminal.paste()` which only adds bracket markers when the shell has enabled the mode.

**Security — ESC sanitization:**

- `src/renderer/hooks/use-terminal-clipboard.ts`: Added `sanitizeEscapeSequences()` function that replaces ESC (`\x1b`) with U+241B (␛) before wrapping in bracket markers. Matches xterm.js's `bracketTextForPaste()` security behavior — prevents injected escape sequences from prematurely closing the bracketed paste region.

**Tests:**

- `src/renderer/hooks/use-terminal-clipboard.test.ts`: 4 new tests — bracket wrapping via pasteText, ESC sanitization, multiline normalization + brackets, empty clipboard guard.
- `src/renderer/components/terminal/ConnectedTerminal.test.tsx`: Integration test verifying `terminalApi.write` receives bracket-wrapped data and `terminal.paste` is NOT called.

## How It Was Tested

- [x] `bun run ci` (Biome lint + format + imports, strict mode)
- [x] `bun run typecheck`
- [x] `bun run test`
- [ ] `cargo clippy --all-targets -- -D warnings` (in src-tauri) — not applicable (no Rust changes)
- [ ] `cargo test` (in src-tauri) — not applicable (no Rust changes)
- [x] Manual verification completed
- [ ] Not applicable

**Test results:**
- 33/33 hook tests pass (including 4 new pasteText path tests)
- 81/81 ConnectedTerminal integration tests pass (20 pre-existing skips)
- 3 adversarial reviews completed (Blind Hunter, Edge Case Hunter, Acceptance Auditor) — no critical or worth-fixing findings

## Screenshots or Recordings

Not applicable — no UI visual changes (terminal paste behavior change only).

## CI & Review Gate

- [ ] All CI checks pass (PR Validation, Rust Checks, Build Verification, Security Scans)
- [ ] Code review comments from CodeRabbit / Claude have been addressed or resolved
- [ ] No unresolved review findings remain

_Waiting for CI and CodeRabbit to complete._

## Checklist

- [x] My PR title follows the conventional commit format used by this repo
- [x] I linked the related issue or explained why none exists
- [x] I updated docs when needed — no docs changes needed (internal behavior fix)
- [x] I added or updated tests when needed — 5 new tests added
- [x] I verified the change does not introduce unrelated modifications
- [x] I read AGENTS.md and followed the contributor guidelines
- [x] A human reviewed the complete diff before submission

## Investigation

Root cause analysis: [`_bmad-output/implementation-artifacts/investigations/tui-paste-multiline-investigation.md`](https://github.com/gnoviawan/termul/blob/dev/_bmad-output/implementation-artifacts/investigations/tui-paste-multiline-investigation.md)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved clipboard paste handling with enhanced character processing to prevent special characters from disrupting paste operations.

* **Bug Fixes**
  * Fixed issue where certain control characters could interfere with clipboard paste functionality.

* **Tests**
  * Added comprehensive test coverage for clipboard paste behavior and character sanitization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->