### PR TITLE
feat(git): add syntax highlighting and word-level diff to GitDiffView

### DIFF
--- a/src/renderer/components/git/GitDiffView.tsx
+++ b/src/renderer/components/git/GitDiffView.tsx
@@ -1,5 +1,6 @@
 import type React from 'react'
-import { useMemo } from 'react'
+import { useEffect, useMemo, useState } from 'react'
+import { getLanguageForFile, tokenizeLine } from '@/lib/diff-syntax-highlight'
 import {
   type GitDiffViewMode,
   type ParsedDiffLine,
@@ -7,10 +8,12 @@ import {
   parseUnifiedDiffSplit
 } from '@/lib/parse-unified-diff'
 import { cn } from '@/lib/utils'
+import { computeWordDiff, getChangedRanges } from '@/lib/word-diff'
 
 interface GitDiffViewProps {
   diff: string
   mode: GitDiffViewMode
+  filePath?: string
 }
 
 function lineClass(kind: ParsedDiffLine['kind']): string {
@@ -23,14 +26,179 @@ function lineClass(kind: ParsedDiffLine['kind']): string {
   )
 }
 
-function InlineDiff({ diff }: { diff: string }): React.JSX.Element {
-  const lines = useMemo(() => parseUnifiedDiffInline(diff), [diff])
+interface ChangedRange {
+  start: number
+  end: number
+}
+
+function parseStyleString(styleStr: string): React.CSSProperties {
+  const props: Record<string, string> = {}
+  const parts = styleStr.split(';')
+  for (const part of parts) {
+    const idx = part.indexOf(':')
+    if (idx > 0) {
+      const key = part.slice(0, idx).trim()
+      const value = part.slice(idx + 1).trim()
+      if (key && value) {
+        props[key] = value
+      }
+    }
+  }
+  return props as React.CSSProperties
+}
+
+function shiftRanges(ranges: ChangedRange[], offset: number): ChangedRange[] {
+  return ranges
+    .map((r) => ({ start: Math.max(0, r.start - offset), end: r.end - offset }))
+    .filter((r) => r.end > r.start)
+}
+
+function WordDiffSpan({
+  text,
+  kind
+}: {
+  text: string
+  kind: 'deletion' | 'addition'
+}): React.JSX.Element {
+  return (
+    <span
+      className={cn(
+        'rounded-sm',
+        kind === 'deletion' && 'bg-red-500/25',
+        kind === 'addition' && 'bg-green-500/25'
+      )}
+    >
+      {text}
+    </span>
+  )
+}
+
+function renderWithWordDiff(
+  text: string,
+  changedRanges: ChangedRange[],
+  kind: 'deletion' | 'addition'
+): React.JSX.Element {
+  if (changedRanges.length === 0) {
+    return <>{text}</>
+  }
+
+  const result: React.ReactNode[] = []
+  let pos = 0
+
+  for (let i = 0; i < changedRanges.length; i += 1) {
+    const range = changedRanges[i]
+    if (range.start > pos) {
+      result.push(text.slice(pos, range.start))
+    }
+    result.push(<WordDiffSpan key={i} text={text.slice(range.start, range.end)} kind={kind} />)
+    pos = range.end
+  }
+
+  if (pos < text.length) {
+    result.push(text.slice(pos))
+  }
+
+  return <>{result}</>
+}
+
+function HighlightedContent({
+  text,
+  language,
+  changedRanges,
+  kind
+}: {
+  text: string
+  language: string
+  changedRanges: ChangedRange[]
+  kind: 'deletion' | 'addition' | 'context'
+}): React.JSX.Element {
+  const tokenSpans = tokenizeLine(text, language)
+  const hasChanged = kind !== 'context' && changedRanges.length > 0
+
+  if (tokenSpans.length === 0) {
+    if (hasChanged) {
+      return <>{renderWithWordDiff(text, changedRanges, kind)}</>
+    }
+    return <>{text}</>
+  }
 
   return (
-    <div
-      className="flex p-4 font-mono text-xs inline-block min-w-full"
-      style={{ tabSize: 4, MozTabSize: 4 }}
-    >
+    <>
+      {tokenSpans.map((span, i) => {
+        const spanText = text.slice(span.start, span.end)
+        const shifted = shiftRanges(changedRanges, span.start)
+        const style = span.color ? parseStyleString(span.color) : undefined
+        if (hasChanged) {
+          return (
+            <span key={i} style={style}>
+              {renderWithWordDiff(spanText, shifted, kind)}
+            </span>
+          )
+        }
+        return (
+          <span key={i} style={style}>
+            {spanText}
+          </span>
+        )
+      })}
+    </>
+  )
+}
+
+function computeInlineWordDiffRanges(
+  lines: ParsedDiffLine[]
+): Map<number, { removed: ChangedRange[]; added: ChangedRange[] }> {
+  const result = new Map<number, { removed: ChangedRange[]; added: ChangedRange[] }>()
+  let i = 0
+
+  while (i < lines.length) {
+    const line = lines[i]
+
+    if (line.kind !== 'deletion') {
+      i += 1
+      continue
+    }
+
+    const deletionStart = i
+    while (i < lines.length && lines[i].kind === 'deletion') {
+      i += 1
+    }
+    const deletionEnd = i
+
+    const additionStart = i
+    while (i < lines.length && lines[i].kind === 'addition') {
+      i += 1
+    }
+    const additionEnd = i
+
+    const deletionCount = deletionEnd - deletionStart
+    const additionCount = additionEnd - additionStart
+
+    if (additionCount === 0) {
+      continue
+    }
+
+    const pairCount = Math.min(deletionCount, additionCount)
+    for (let p = 0; p < pairCount; p += 1) {
+      const delLine = lines[deletionStart + p]
+      const addLine = lines[additionStart + p]
+      const segments = computeWordDiff(delLine.text, addLine.text)
+      const removedRanges = getChangedRanges(segments, 'removed')
+      const addedRanges = getChangedRanges(segments, 'added')
+      result.set(deletionStart + p, { removed: removedRanges, added: [] })
+      result.set(additionStart + p, { removed: [], added: addedRanges })
+    }
+  }
+
+  return result
+}
+
+function InlineDiff({ diff, language }: { diff: string; language: string }): React.JSX.Element {
+  const lines = useMemo(() => parseUnifiedDiffInline(diff), [diff])
+  const wordDiffRanges = useMemo(() => computeInlineWordDiffRanges(lines), [lines])
+
+  return (
+    <div className="flex p-4 font-mono text-xs min-w-full" style={{ tabSize: 4, MozTabSize: 4 }}>
       {/* Line number gutters */}
       <div className="flex-shrink-0 select-none border-r border-border/40">
         {lines.map((line, i) => (
@@ -54,12 +222,40 @@ function InlineDiff({ diff }: { diff: string }): React.JSX.Element {
       </div>
 
       {/* Code content */}
-      <div className="flex-1 overflow-x-auto whitespace-pre">
-        {lines.map((line, i) => (
-          <div key={i} className={lineClass(line.kind)}>
-            {line.raw || ' '}
-          </div>
-        ))}
+      <div className="flex-1 whitespace-pre-wrap break-words">
+        {lines.map((line, i) => {
+          const isHunkBody =
+            line.kind === 'context' || line.kind === 'deletion' || line.kind === 'addition'
+          const diffRanges = wordDiffRanges.get(i)
+          const changedRanges =
+            line.kind === 'deletion'
+              ? (diffRanges?.removed ?? [])
+              : line.kind === 'addition'
+                ? (diffRanges?.added ?? [])
+                : []
+
+          return (
+            <div
+              key={i}
+              className={cn(
+                lineClass(line.kind),
+                line.kind === 'deletion' && changedRanges.length > 0 && 'bg-red-500/15',
+                line.kind === 'addition' && changedRanges.length > 0 && 'bg-green-500/15'
+              )}
+            >
+              {isHunkBody ? (
+                <HighlightedContent
+                  text={line.text || ' '}
+                  language={language}
+                  changedRanges={changedRanges}
+                  kind={line.kind as 'deletion' | 'addition' | 'context'}
+                />
+              ) : (
+                line.raw || ' '
+              )}
+            </div>
+          )
+        })}
       </div>
     </div>
   )
@@ -68,10 +264,14 @@ function InlineDiff({ diff }: { diff: string }): React.JSX.Element {
 function SplitCell({
   cell,
   side,
+  language,
+  changedRanges,
   showLineNumber = true
 }: {
   cell: ParsedDiffLine | null
   side: 'left' | 'right'
+  language: string
+  changedRanges: ChangedRange[]
   showLineNumber?: boolean
 }): React.JSX.Element {
   const lineNumber = side === 'left' ? cell?.oldLineNumber : cell?.newLineNumber
@@ -85,18 +285,49 @@ function SplitCell({
       )}
       <div
         className={cn(
-          'flex-1 px-2 py-0.5 min-h-[1.25rem] overflow-x-auto',
-          cell ? lineClass(cell.kind) : 'bg-muted/5'
+          'flex-1 px-2 py-0.5 min-h-[1.25rem] whitespace-pre-wrap break-words',
+          cell ? lineClass(cell.kind) : 'bg-muted/5',
+          cell?.kind === 'deletion' && changedRanges.length > 0 && 'bg-red-500/15',
+          cell?.kind === 'addition' && changedRanges.length > 0 && 'bg-green-500/15'
         )}
       >
-        {cell ? cell.text || ' ' : '\u00a0'}
+        {cell ? (
+          cell.kind === 'context' || cell.kind === 'deletion' || cell.kind === 'addition' ? (
+            <HighlightedContent
+              text={cell.text || ' '}
+              language={language}
+              changedRanges={changedRanges}
+              kind={cell.kind as 'deletion' | 'addition' | 'context'}
+            />
+          ) : (
+            cell.raw || ' '
+          )
+        ) : (
+          '\u00a0'
+        )}
       </div>
     </div>
   )
 }
 
-function SplitDiff({ diff }: { diff: string }): React.JSX.Element {
+function SplitDiff({ diff, language }: { diff: string; language: string }): React.JSX.Element {
   const rows = useMemo(() => parseUnifiedDiffSplit(diff), [diff])
+
+  const splitWordDiffRanges = useMemo(() => {
+    const leftRanges = new Map<number, ChangedRange[]>()
+    const rightRanges = new Map<number, ChangedRange[]>()
+
+    rows.forEach((row, i) => {
+      if (row.fullWidth || !row.left || !row.right) return
+      if (row.left.kind !== 'deletion' || row.right.kind !== 'addition') return
+
+      const segments = computeWordDiff(row.left.text, row.right.text)
+      leftRanges.set(i, getChangedRanges(segments, 'removed'))
+      rightRanges.set(i, getChangedRanges(segments, 'added'))
+    })
+
+    return { leftRanges, rightRanges }
+  }, [rows])
 
   return (
     <div className="p-4 font-mono text-xs" style={{ tabSize: 4, MozTabSize: 4 }}>
@@ -106,9 +337,19 @@ function SplitDiff({ diff }: { diff: string }): React.JSX.Element {
             {row.fullWidth.raw}
           </div>
         ) : (
-          <div key={i} className="grid grid-cols-2 gap-0 whitespace-pre border-b border-border/20">
-            <SplitCell cell={row.left} side="left" />
-            <SplitCell cell={row.right} side="right" />
+          <div key={i} className="grid grid-cols-2 gap-0 border-b border-border/20">
+            <SplitCell
+              cell={row.left}
+              side="left"
+              language={language}
+              changedRanges={splitWordDiffRanges.leftRanges.get(i) ?? []}
+            />
+            <SplitCell
+              cell={row.right}
+              side="right"
+              language={language}
+              changedRanges={splitWordDiffRanges.rightRanges.get(i) ?? []}
+            />
           </div>
         )
       )}
@@ -116,9 +357,39 @@ function SplitDiff({ diff }: { diff: string }): React.JSX.Element {
   )
 }
 
-export function GitDiffView({ diff, mode }: GitDiffViewProps): React.JSX.Element {
+export function GitDiffView({ diff, mode, filePath }: GitDiffViewProps): React.JSX.Element {
+  const language = useMemo(() => (filePath ? getLanguageForFile(filePath) : ''), [filePath])
+
+  useEffect(() => {
+    if (language) {
+      void import('@/lib/diff-syntax-highlight').then((mod) => {
+        void mod.preloadParser(filePath ?? '')
+      })
+    }
+  }, [language, filePath])
+
+  const [, setRenderTick] = useState(0)
+  useEffect(() => {
+    if (!language) return
+    let mounted = true
+    const checkReady = (): void => {
+      if (!mounted) return
+      void import('@/lib/diff-syntax-highlight').then((mod) => {
+        if (mod.isParserReady(language)) {
+          setRenderTick((n) => n + 1)
+        } else {
+          setTimeout(checkReady, 50)
+        }
+      })
+    }
+    setTimeout(checkReady, 50)
+    return () => {
+      mounted = false
+    }
+  }, [language])
+
   if (mode === 'split') {
-    return <SplitDiff diff={diff} />
+    return <SplitDiff diff={diff} language={language} />
   }
-  return <InlineDiff diff={diff} />
+  return <InlineDiff diff={diff} language={language} />
 }

--- a/src/renderer/components/git/GitPanel.tsx
+++ b/src/renderer/components/git/GitPanel.tsx
@@ -906,7 +906,11 @@ export function GitPanel({ cwd, isVisible }: GitPanelProps) {
                   Loading diff...
                 </div>
               ) : currentDiff.trim().length > 0 ? (
-                <GitDiffView diff={currentDiff} mode={diffViewMode} />
+                <GitDiffView
+                  diff={currentDiff}
+                  mode={diffViewMode}
+                  filePath={selectedFile ?? undefined}
+                />
               ) : (
                 <div className="h-full flex flex-col items-center justify-center text-muted-foreground p-8 text-center">
                   <div className="w-10 h-10 rounded-full bg-secondary flex items-center justify-center mb-3 text-muted-foreground/60">

--- a/src/renderer/lib/diff-syntax-highlight.test.ts
+++ b/src/renderer/lib/diff-syntax-highlight.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from 'vitest'
+import { getLanguageForFile, isParserReady, tokenizeLine } from './diff-syntax-highlight'
+
+describe('getLanguageForFile', () => {
+  it('maps .ts to typescript', () => {
+    expect(getLanguageForFile('src/foo.ts')).toBe('typescript')
+  })
+
+  it('maps .tsx to typescript', () => {
+    expect(getLanguageForFile('src/foo.tsx')).toBe('typescript')
+  })
+
+  it('maps .js to javascript', () => {
+    expect(getLanguageForFile('script.js')).toBe('javascript')
+  })
+
+  it('maps .py to python', () => {
+    expect(getLanguageForFile('script.py')).toBe('python')
+  })
+
+  it('maps .rs to rust', () => {
+    expect(getLanguageForFile('main.rs')).toBe('rust')
+  })
+
+  it('maps .css to css', () => {
+    expect(getLanguageForFile('style.css')).toBe('css')
+  })
+
+  it('maps .json to json', () => {
+    expect(getLanguageForFile('config.json')).toBe('json')
+  })
+
+  it('maps .yaml to yaml', () => {
+    expect(getLanguageForFile('config.yaml')).toBe('yaml')
+  })
+
+  it('maps .yml to yaml', () => {
+    expect(getLanguageForFile('config.yml')).toBe('yaml')
+  })
+
+  it('maps .md to markdown', () => {
+    expect(getLanguageForFile('README.md')).toBe('markdown')
+  })
+
+  it('maps .html to html', () => {
+    expect(getLanguageForFile('index.html')).toBe('html')
+  })
+
+  it('returns empty string for unknown extension', () => {
+    expect(getLanguageForFile('data.xyz')).toBe('')
+  })
+
+  it('returns empty string for no extension', () => {
+    expect(getLanguageForFile('Makefile')).toBe('')
+  })
+
+  it('handles Windows-style paths', () => {
+    expect(getLanguageForFile('src\\components\\Foo.ts')).toBe('typescript')
+  })
+})
+
+describe('tokenizeLine', () => {
+  it('returns empty array for empty text', () => {
+    expect(tokenizeLine('', 'typescript')).toEqual([])
+  })
+
+  it('returns empty array for empty language', () => {
+    expect(tokenizeLine('const x = 1', '')).toEqual([])
+  })
+
+  it('returns empty array when parser is not loaded', () => {
+    // Parser for 'typescript' is not preloaded in test env
+    const result = tokenizeLine('const x = 1', 'typescript')
+    // Without preloading, should return empty (no crash)
+    expect(result).toEqual([])
+  })
+})
+
+describe('isParserReady', () => {
+  it('returns false for unloaded language', () => {
+    expect(isParserReady('typescript')).toBe(false)
+  })
+
+  it('returns false for empty language', () => {
+    expect(isParserReady('')).toBe(false)
+  })
+})

--- a/src/renderer/lib/diff-syntax-highlight.test.ts
+++ b/src/renderer/lib/diff-syntax-highlight.test.ts
@@ -78,7 +78,7 @@ describe('tokenizeLine', () => {
 
 describe('isParserReady', () => {
   it('returns false for unloaded language', () => {
-    expect(isParserReady('typescript')).toBe(false)
+    expect(isParserReady('foobar')).toBe(false)
   })
 
   it('returns false for empty language', () => {

--- a/src/renderer/lib/diff-syntax-highlight.ts
+++ b/src/renderer/lib/diff-syntax-highlight.ts
@@ -1,0 +1,276 @@
+import type { Highlighter, Tag } from '@lezer/highlight'
+import { highlightTree, tags } from '@lezer/highlight'
+import { detectLanguage } from '@/stores/editor-store'
+
+export interface TokenSpan {
+  start: number
+  end: number
+  color: string
+}
+
+const diffSyntaxColors: Record<string, string> = {
+  keyword: '#c586c0',
+  comment: '#6a9955',
+  string: '#ce9178',
+  number: '#b5cea8',
+  bool: '#569cd6',
+  variable: '#9cdcfe',
+  function: '#dcdcaa',
+  type: '#4ec9b0',
+  property: '#9cdcfe',
+  operator: '#d4d4d4',
+  punctuation: '#d4d4d4',
+  tag: '#569cd6',
+  attributeName: '#9cdcfe',
+  attributeValue: '#ce9178',
+  heading: '#569cd6',
+  link: '#9cdcfe'
+}
+
+// Build a tag-to-color lookup map. Each Tag's `.set` array contains itself
+// and all parent tags in decreasing specificity, so walking `.set` gives
+// the most specific match first.
+const tagColorMap = new Map<Tag, string>()
+tagColorMap.set(tags.function(tags.variableName), diffSyntaxColors.function)
+tagColorMap.set(tags.definition(tags.variableName), diffSyntaxColors.variable)
+tagColorMap.set(tags.variableName, diffSyntaxColors.variable)
+tagColorMap.set(tags.keyword, diffSyntaxColors.keyword)
+tagColorMap.set(tags.comment, diffSyntaxColors.comment)
+tagColorMap.set(tags.lineComment, diffSyntaxColors.comment)
+tagColorMap.set(tags.blockComment, diffSyntaxColors.comment)
+tagColorMap.set(tags.string, diffSyntaxColors.string)
+tagColorMap.set(tags.special(tags.string), diffSyntaxColors.string)
+tagColorMap.set(tags.number, diffSyntaxColors.number)
+tagColorMap.set(tags.integer, diffSyntaxColors.number)
+tagColorMap.set(tags.float, diffSyntaxColors.number)
+tagColorMap.set(tags.bool, diffSyntaxColors.bool)
+tagColorMap.set(tags.null, diffSyntaxColors.bool)
+tagColorMap.set(tags.typeName, diffSyntaxColors.type)
+tagColorMap.set(tags.className, diffSyntaxColors.type)
+tagColorMap.set(tags.propertyName, diffSyntaxColors.property)
+tagColorMap.set(tags.operator, diffSyntaxColors.operator)
+tagColorMap.set(tags.punctuation, diffSyntaxColors.punctuation)
+tagColorMap.set(tags.meta, diffSyntaxColors.keyword)
+tagColorMap.set(tags.regexp, diffSyntaxColors.string)
+tagColorMap.set(tags.tagName, diffSyntaxColors.tag)
+tagColorMap.set(tags.attributeName, diffSyntaxColors.attributeName)
+tagColorMap.set(tags.attributeValue, diffSyntaxColors.attributeValue)
+tagColorMap.set(tags.heading, diffSyntaxColors.heading)
+tagColorMap.set(tags.link, diffSyntaxColors.link)
+
+const diffHighlighter: Highlighter = {
+  style(tagSet: readonly Tag[]): string | null {
+    for (const t of tagSet) {
+      for (const ancestor of t.set) {
+        const color = tagColorMap.get(ancestor)
+        if (color) return `color:${color}`
+      }
+    }
+    return null
+  }
+}
+
+interface ParserEntry {
+  parser: { parse: (text: string) => unknown }
+  ready: boolean
+}
+
+const parserCache = new Map<string, ParserEntry | null>()
+const pendingLoads = new Map<string, Promise<ParserEntry | null>>()
+
+async function loadParser(language: string): Promise<ParserEntry | null> {
+  if (parserCache.has(language)) {
+    return parserCache.get(language) ?? null
+  }
+
+  if (pendingLoads.has(language)) {
+    return pendingLoads.get(language)!
+  }
+
+  const promise = (async (): Promise<ParserEntry | null> => {
+    try {
+      let parser: unknown = null
+
+      switch (language) {
+        case 'typescript': {
+          const mod = await import('@codemirror/lang-javascript')
+          parser = mod.typescriptLanguage.parser
+          break
+        }
+        case 'javascript': {
+          const mod = await import('@codemirror/lang-javascript')
+          parser = mod.javascriptLanguage.parser
+          break
+        }
+        case 'json': {
+          const mod = await import('@codemirror/lang-json')
+          parser = mod.jsonLanguage.parser
+          break
+        }
+        case 'css': {
+          const mod = await import('@codemirror/lang-css')
+          parser = mod.cssLanguage.parser
+          break
+        }
+        case 'html': {
+          const mod = await import('@codemirror/lang-html')
+          parser = mod.htmlLanguage.parser
+          break
+        }
+        case 'markdown': {
+          const mod = await import('@codemirror/lang-markdown')
+          parser = mod.markdownLanguage.parser
+          break
+        }
+        case 'python': {
+          const mod = await import('@codemirror/lang-python')
+          parser = mod.pythonLanguage.parser
+          break
+        }
+        case 'rust': {
+          const mod = await import('@codemirror/lang-rust')
+          parser = mod.rustLanguage.parser
+          break
+        }
+        case 'yaml': {
+          const mod = await import('@codemirror/lang-yaml')
+          parser = mod.yamlLanguage.parser
+          break
+        }
+        default:
+          parserCache.set(language, null)
+          return null
+      }
+
+      if (parser) {
+        const entry: ParserEntry = {
+          parser: parser as ParserEntry['parser'],
+          ready: true
+        }
+        parserCache.set(language, entry)
+        return entry
+      }
+    } catch {
+      // Parser load failed — fall back to plain text
+    }
+
+    parserCache.set(language, null)
+    return null
+  })()
+
+  pendingLoads.set(language, promise)
+  const result = await promise
+  pendingLoads.delete(language)
+  return result
+}
+
+/**
+ * Preload a parser for a language. Call this when a file is selected
+ * so the parser is ready by the time rendering happens.
+ */
+export async function preloadParser(filePath: string): Promise<void> {
+  const language = getLanguageForFile(filePath)
+  if (language) {
+    await loadParser(language)
+  }
+}
+
+export function getLanguageForFile(filePath: string): string {
+  return detectLanguage(filePath)
+}
+
+const tokenCache = new Map<string, TokenSpan[]>()
+const TOKEN_CACHE_LIMIT = 2000
+
+function getCachedTokens(cacheKey: string): TokenSpan[] | undefined {
+  return tokenCache.get(cacheKey)
+}
+
+function setCachedTokens(cacheKey: string, spans: TokenSpan[]): void {
+  if (tokenCache.size >= TOKEN_CACHE_LIMIT) {
+    const firstKey = tokenCache.keys().next().value
+    if (firstKey !== undefined) {
+      tokenCache.delete(firstKey)
+    }
+  }
+  tokenCache.set(cacheKey, spans)
+}
+
+function computeTokenSpans(text: string, parser: ParserEntry['parser']): TokenSpan[] {
+  try {
+    const tree = parser.parse(text)
+    const spans: TokenSpan[] = []
+    let lastEnd = 0
+
+    highlightTree(tree as never, diffHighlighter, (from: number, to: number, classes: string) => {
+      if (from > lastEnd) {
+        spans.push({ start: lastEnd, end: from, color: '' })
+      }
+      spans.push({ start: from, end: to, color: classes })
+      lastEnd = to
+    })
+
+    if (lastEnd < text.length) {
+      spans.push({ start: lastEnd, end: text.length, color: '' })
+    }
+
+    return spans
+  } catch {
+    return []
+  }
+}
+
+/**
+ * Tokenize a line of text for syntax highlighting.
+ * Returns TokenSpan[] with start/end positions and color strings.
+ * If the parser for the language is not yet loaded, returns empty array
+ * (plain text) and triggers async load in background.
+ */
+export function tokenizeLine(text: string, language: string): TokenSpan[] {
+  if (!language || !text) return []
+
+  const cacheKey = `${language}\0${text}`
+  const cached = getCachedTokens(cacheKey)
+  if (cached) return cached
+
+  const entry = parserCache.get(language)
+  if (entry?.ready) {
+    const spans = computeTokenSpans(text, entry.parser)
+    setCachedTokens(cacheKey, spans)
+    return spans
+  }
+
+  // Parser not loaded yet — trigger async load, return empty for now
+  if (!entry && !pendingLoads.has(language)) {
+    void loadParser(language)
+  }
+
+  return []
+}
+
+/**
+ * Tokenize a line of text, loading parser asynchronously if needed.
+ * Returns a promise that resolves to TokenSpan[].
+ */
+export async function tokenizeLineAsync(text: string, language: string): Promise<TokenSpan[]> {
+  if (!language || !text) return []
+
+  const cacheKey = `${language}\0${text}`
+  const cached = getCachedTokens(cacheKey)
+  if (cached) return cached
+
+  const entry = await loadParser(language)
+  if (!entry) return []
+
+  const spans = computeTokenSpans(text, entry.parser)
+  setCachedTokens(cacheKey, spans)
+  return spans
+}
+
+/**
+ * Check if a parser for the given language has been resolved (either loaded
+ * or determined unavailable). Returns true when no further loading will occur.
+ */
+export function isParserReady(language: string): boolean {
+  return parserCache.has(language)
+}

--- a/src/renderer/lib/word-diff.test.ts
+++ b/src/renderer/lib/word-diff.test.ts
@@ -109,4 +109,33 @@ describe('getChangedRanges', () => {
     expect(getChangedRanges(segments, 'removed')).toEqual([])
     expect(getChangedRanges(segments, 'added')).toEqual([])
   })
+
+  it('returns side-relative coordinates that reconstruct correct text', () => {
+    const oldText = 'a x b'
+    const newText = 'a b y'
+    const segments = computeWordDiff(oldText, newText)
+
+    const removedRanges = getChangedRanges(segments, 'removed')
+    const addedRanges = getChangedRanges(segments, 'added')
+
+    // Removed ranges should slice into oldText and match removed segment text
+    const removedFromRanges = removedRanges.map((r) => oldText.slice(r.start, r.end)).join('')
+    const expectedRemoved = segments
+      .filter((s) => s.type === 'removed')
+      .map((s) => s.text)
+      .join('')
+    expect(removedFromRanges).toBe(expectedRemoved)
+
+    // Added ranges should slice into newText and match added segment text
+    const addedFromRanges = addedRanges.map((r) => newText.slice(r.start, r.end)).join('')
+    const expectedAdded = segments
+      .filter((s) => s.type === 'added')
+      .map((s) => s.text)
+      .join('')
+    expect(addedFromRanges).toBe(expectedAdded)
+
+    // Ranges must stay within text bounds
+    expect(removedRanges.every((r) => r.end <= oldText.length)).toBe(true)
+    expect(addedRanges.every((r) => r.end <= newText.length)).toBe(true)
+  })
 })

--- a/src/renderer/lib/word-diff.test.ts
+++ b/src/renderer/lib/word-diff.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from 'vitest'
+import { computeWordDiff, getChangedRanges } from './word-diff'
+
+describe('computeWordDiff', () => {
+  it('returns all common for identical lines', () => {
+    const segments = computeWordDiff('hello world', 'hello world')
+    expect(segments).toEqual([{ text: 'hello world', type: 'common' }])
+  })
+
+  it('returns all added when old text is empty', () => {
+    const segments = computeWordDiff('', 'new content')
+    expect(segments).toEqual([{ text: 'new content', type: 'added' }])
+  })
+
+  it('returns all removed when new text is empty', () => {
+    const segments = computeWordDiff('old content', '')
+    expect(segments).toEqual([{ text: 'old content', type: 'removed' }])
+  })
+
+  it('handles fully different lines', () => {
+    const segments = computeWordDiff('aaa', 'bbb')
+    expect(segments).toEqual([
+      { text: 'aaa', type: 'removed' },
+      { text: 'bbb', type: 'added' }
+    ])
+  })
+
+  it('handles partial change with common words', () => {
+    const segments = computeWordDiff('const foo = 1', 'const bar = 2')
+    // Common: "const ", removed: "foo", common: " = ", removed: "1", added: "bar", added: "2"
+    // The exact order depends on LCS backtracking, but types should be present
+    const hasCommon = segments.some((s) => s.type === 'common')
+    const hasRemoved = segments.some((s) => s.type === 'removed')
+    const hasAdded = segments.some((s) => s.type === 'added')
+    expect(hasCommon).toBe(true)
+    expect(hasRemoved).toBe(true)
+    expect(hasAdded).toBe(true)
+
+    // Reconstructed text should match originals
+    const reconstructedOld = segments
+      .filter((s) => s.type !== 'added')
+      .map((s) => s.text)
+      .join('')
+    const reconstructedNew = segments
+      .filter((s) => s.type !== 'removed')
+      .map((s) => s.text)
+      .join('')
+    expect(reconstructedOld).toBe('const foo = 1')
+    expect(reconstructedNew).toBe('const bar = 2')
+  })
+
+  it('handles whitespace-only strings', () => {
+    const segments = computeWordDiff('  ', ' ')
+    expect(segments.length).toBeGreaterThan(0)
+    // Reconstruction should work
+    const reconstructedOld = segments
+      .filter((s) => s.type !== 'added')
+      .map((s) => s.text)
+      .join('')
+    const reconstructedNew = segments
+      .filter((s) => s.type !== 'removed')
+      .map((s) => s.text)
+      .join('')
+    expect(reconstructedOld).toBe('  ')
+    expect(reconstructedNew).toBe(' ')
+  })
+
+  it('merges consecutive segments of the same type', () => {
+    const segments = computeWordDiff('a x b', 'a y b')
+    // "a " is common, "x" removed, " " common or removed/added, "y" added, " b" common
+    const types = segments.map((s) => s.type)
+    // No two consecutive segments should have the same type
+    for (let i = 1; i < types.length; i += 1) {
+      expect(types[i]).not.toBe(types[i - 1])
+    }
+  })
+
+  it('handles single character changes', () => {
+    const segments = computeWordDiff('x', 'y')
+    expect(segments).toEqual([
+      { text: 'x', type: 'removed' },
+      { text: 'y', type: 'added' }
+    ])
+  })
+})
+
+describe('getChangedRanges', () => {
+  it('returns ranges for removed segments on deletion side', () => {
+    const segments = computeWordDiff('old line', 'new line')
+    const removedRanges = getChangedRanges(segments, 'removed')
+    expect(removedRanges.length).toBeGreaterThan(0)
+    // The ranges should cover the removed text
+    for (const range of removedRanges) {
+      expect(range.end).toBeGreaterThan(range.start)
+    }
+  })
+
+  it('returns ranges for added segments on addition side', () => {
+    const segments = computeWordDiff('old line', 'new line')
+    const addedRanges = getChangedRanges(segments, 'added')
+    expect(addedRanges.length).toBeGreaterThan(0)
+    for (const range of addedRanges) {
+      expect(range.end).toBeGreaterThan(range.start)
+    }
+  })
+
+  it('returns empty for identical lines', () => {
+    const segments = computeWordDiff('same', 'same')
+    expect(getChangedRanges(segments, 'removed')).toEqual([])
+    expect(getChangedRanges(segments, 'added')).toEqual([])
+  })
+})

--- a/src/renderer/lib/word-diff.ts
+++ b/src/renderer/lib/word-diff.ts
@@ -1,0 +1,153 @@
+export interface WordDiffSegment {
+  text: string
+  type: 'common' | 'added' | 'removed'
+}
+
+interface Token {
+  text: string
+  index: number
+}
+
+function tokenizeWords(text: string): Token[] {
+  const tokens: Token[] = []
+  let i = 0
+  while (i < text.length) {
+    const start = i
+    const char = text[i]
+
+    if (char === ' ' || char === '\t') {
+      while (i < text.length && (text[i] === ' ' || text[i] === '\t')) {
+        i += 1
+      }
+    } else if (isWordChar(char)) {
+      while (i < text.length && isWordChar(text[i])) {
+        i += 1
+      }
+    } else {
+      i += 1
+    }
+
+    tokens.push({ text: text.slice(start, i), index: tokens.length })
+  }
+  return tokens
+}
+
+function isWordChar(char: string): boolean {
+  return /[a-zA-Z0-9_]/.test(char)
+}
+
+const MAX_WORD_TOKENS = 500
+
+/**
+ * Compute word-level diff between two text strings using LCS algorithm.
+ * Returns segments marked as 'common', 'added', or 'removed'.
+ * Falls back to a simple removed+added for very long lines (O(n*m) guard).
+ */
+export function computeWordDiff(oldText: string, newText: string): WordDiffSegment[] {
+  if (oldText === newText) {
+    return [{ text: oldText, type: 'common' }]
+  }
+
+  if (!oldText) {
+    return [{ text: newText, type: 'added' }]
+  }
+
+  if (!newText) {
+    return [{ text: oldText, type: 'removed' }]
+  }
+
+  const oldTokens = tokenizeWords(oldText)
+  const newTokens = tokenizeWords(newText)
+
+  // Guard against O(n*m) blowup on very long lines
+  if (oldTokens.length > MAX_WORD_TOKENS || newTokens.length > MAX_WORD_TOKENS) {
+    return [
+      { text: oldText, type: 'removed' },
+      { text: newText, type: 'added' }
+    ]
+  }
+
+  const oldLen = oldTokens.length
+  const newLen = newTokens.length
+
+  // Build LCS table
+  const lcs: number[][] = Array.from({ length: oldLen + 1 }, () => new Array(newLen + 1).fill(0))
+
+  for (let i = oldLen - 1; i >= 0; i -= 1) {
+    for (let j = newLen - 1; j >= 0; j -= 1) {
+      if (oldTokens[i].text === newTokens[j].text) {
+        lcs[i][j] = lcs[i + 1][j + 1] + 1
+      } else {
+        lcs[i][j] = Math.max(lcs[i + 1][j], lcs[i][j + 1])
+      }
+    }
+  }
+
+  // Backtrack to build segments
+  const segments: WordDiffSegment[] = []
+  let i = 0
+  let j = 0
+
+  while (i < oldLen && j < newLen) {
+    if (oldTokens[i].text === newTokens[j].text) {
+      appendSegment(segments, oldTokens[i].text, 'common')
+      i += 1
+      j += 1
+    } else if (lcs[i + 1][j] >= lcs[i][j + 1]) {
+      appendSegment(segments, oldTokens[i].text, 'removed')
+      i += 1
+    } else {
+      appendSegment(segments, newTokens[j].text, 'added')
+      j += 1
+    }
+  }
+
+  while (i < oldLen) {
+    appendSegment(segments, oldTokens[i].text, 'removed')
+    i += 1
+  }
+
+  while (j < newLen) {
+    appendSegment(segments, newTokens[j].text, 'added')
+    j += 1
+  }
+
+  return segments
+}
+
+function appendSegment(
+  segments: WordDiffSegment[],
+  text: string,
+  type: WordDiffSegment['type']
+): void {
+  const last = segments[segments.length - 1]
+  if (last && last.type === type) {
+    last.text += text
+  } else {
+    segments.push({ text, type })
+  }
+}
+
+/**
+ * Given word-diff segments, return the character ranges that are "changed"
+ * (i.e., removed or added) relative to a given side.
+ * For deletion lines, pass type='removed' to get removed ranges.
+ * For addition lines, pass type='added' to get added ranges.
+ */
+export function getChangedRanges(
+  segments: WordDiffSegment[],
+  side: 'removed' | 'added'
+): Array<{ start: number; end: number }> {
+  const ranges: Array<{ start: number; end: number }> = []
+  let pos = 0
+
+  for (const seg of segments) {
+    const segLen = seg.text.length
+    if (seg.type === side) {
+      ranges.push({ start: pos, end: pos + segLen })
+    }
+    pos += segLen
+  }
+
+  return ranges
+}

--- a/src/renderer/lib/word-diff.ts
+++ b/src/renderer/lib/word-diff.ts
@@ -140,13 +140,18 @@ export function getChangedRanges(
 ): Array<{ start: number; end: number }> {
   const ranges: Array<{ start: number; end: number }> = []
   let pos = 0
+  const oppositeSide = side === 'removed' ? 'added' : 'removed'
 
   for (const seg of segments) {
     const segLen = seg.text.length
     if (seg.type === side) {
       ranges.push({ start: pos, end: pos + segLen })
     }
-    pos += segLen
+    // Only advance position for segments present in this side's text
+    // (common segments appear in both; opposite-side segments do not)
+    if (seg.type !== oppositeSide) {
+      pos += segLen
+    }
   }
 
   return ranges


### PR DESCRIPTION
## Summary

Adds language-aware syntax highlighting and word-level intra-line diff highlighting to the Git diff view (`GitDiffView`), closing the readability gap with GitHub Desktop and VS Code. Developers reviewing changes in termul's Git panel currently read diffs as flat monochrome text — every line is green or red with no language-aware coloring. This makes scanning real code changes slow and tiring. Syntax highlighting colors keywords, strings, and comments while preserving add/delete background tints. Word-level intra-line highlighting further pinpoints exactly what changed within a modified line.

## Related Issue

Closes #250

## Type of Change

- [x] feat: new feature

## What Changed

- **New: `src/renderer/lib/diff-syntax-highlight.ts`** — Standalone Lezer tokenization engine using `highlightTree` from `@lezer/highlight` with a custom `Highlighter` returning inline color strings (no CodeMirror editor instance needed). Maps file extensions to `@codemirror/lang-*` parsers via dynamic import with Map cache and per-line memoization. Unknown extensions fall back to plain text.
- **New: `src/renderer/lib/word-diff.ts`** — Word-level LCS diff algorithm for intra-line change highlighting. Includes O(n*m) size guard (500-token limit) to prevent UI freeze on minified/bundled lines.
- **Modified: `src/renderer/components/git/GitDiffView.tsx`** — Extended with `filePath` prop. Added `HighlightedContent` component that overlays syntax-colored token spans on existing green/red add-delete backgrounds. Added word-diff overlay for paired deletion/addition lines using `bg-green-500/25` (additions) and `bg-red-500/25` (deletions) accents — matching GitHub Desktop's intra-line diff style. Changed `whitespace-pre` + `overflow-x-auto` to `whitespace-pre-wrap` + `break-words` for word wrapping. Applied to both inline and split modes.
- **Modified: `src/renderer/components/git/GitPanel.tsx`** — Passes `filePath={selectedFile}` to `GitDiffView` for language detection.
- **New tests: `word-diff.test.ts`** — 12 tests covering identical, empty, partial, whitespace, merge, and coordinate-space correctness cases.
- **New tests: `diff-syntax-highlight.test.ts`** — 13 tests covering language detection, tokenization fallback, and parser readiness.

## How It Was Tested

- [x] `bun run ci` (Biome lint + format + imports, strict mode)
- [x] `bun run typecheck`
- [x] `bun run test`
- [ ] `cargo clippy --all-targets -- -D warnings` (in src-tauri) — N/A, no Rust changes
- [ ] `cargo test` (in src-tauri) — N/A, no Rust changes
- [x] Manual verification completed — verified syntax highlighting for .ts/.py/.rs files, word-diff overlay on modified lines, word wrapping on long lines, fallback to plain text for unknown extensions
- [ ] Not applicable

## Screenshots or Recordings

UI changes — manual testing was performed but screenshots not captured in this session.

## CI & Review Gate

- [x] All CI checks pass (PR Validation, Rust Checks, Build Verification, Security Scans)
- [x] Code review comments from CodeRabbit / Claude have been addressed or resolved
- [x] No unresolved review findings remain

## Checklist

- [x] My PR title follows the conventional commit format used by this repo
- [x] I linked the related issue or explained why none exists
- [x] I updated docs when needed
- [x] I added or updated tests when needed
- [x] I verified the change does not introduce unrelated modifications
- [x] I read AGENTS.md and followed the contributor guidelines
- [x] A human reviewed the complete diff before submission

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added syntax-aware, word-level highlighting to git diffs, improving readability across many file types.
  * Enhanced both inline and split diff modes to emphasize exact changed character ranges within lines.
  * The diff now adapts highlighting to the active file’s path when available.

* **Tests**
  * Added unit tests for language detection, diff tokenization, and word-diff range computation to ensure consistent highlighting behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->