### PR TITLE
feat(updater): show What's New release-notes popup after update

### DIFF
--- a/src/renderer/TauriApp.tsx
+++ b/src/renderer/TauriApp.tsx
@@ -8,6 +8,7 @@ import { Toaster } from '@/components/ui/toaster'
 import { TooltipProvider } from '@/components/ui/tooltip'
 import { useWindowState } from '@/hooks/use-window-state'
 import { useUpdateToast } from './components/UpdateAvailableToast'
+import { WhatsNewModal } from './components/WhatsNewModal'
 import { useAcpListeners } from './hooks/use-acp-listeners'
 import { useAppSettingsLoader } from './hooks/use-app-settings'
 import { useAppliedColorThemeSync } from './hooks/use-color-theme'
@@ -28,6 +29,7 @@ import { useTerminalRestore } from './hooks/use-terminal-restore'
 import { useAppliedUiZoomSync } from './hooks/use-ui-zoom'
 import { useUpdateCheck } from './hooks/use-updater'
 import { useVisibilityState } from './hooks/use-visibility-state'
+import { useWhatsNew } from './hooks/use-whats-new'
 import { useTerminalAutoSave } from './hooks/useTerminalAutoSave'
 import WorkspaceLayout from './layouts/WorkspaceLayout'
 import { initNotificationPermissions } from './lib/tauri-notification-api'
@@ -97,6 +99,7 @@ const router = createHashRouter(
 
 export default function TauriApp(): React.JSX.Element {
   const isWindowStateReady = useWindowState()
+  const whatsNew = useWhatsNew()
 
   useEffect(() => {
     if (!isWindowStateReady) return
@@ -123,6 +126,13 @@ export default function TauriApp(): React.JSX.Element {
           <Toaster />
           <Sonner />
           <RouterProvider router={router} future={{ v7_startTransition: true }} />
+          <WhatsNewModal
+            isOpen={whatsNew.isOpen}
+            version={whatsNew.version}
+            notes={whatsNew.notes}
+            htmlUrl={whatsNew.htmlUrl}
+            onClose={whatsNew.close}
+          />
         </ErrorBoundary>
       </TooltipProvider>
     </QueryClientProvider>

--- a/src/renderer/components/WhatsNewModal.tsx
+++ b/src/renderer/components/WhatsNewModal.tsx
@@ -1,0 +1,157 @@
+import { AnimatePresence, motion } from 'framer-motion'
+import { ExternalLink, Sparkles, X } from 'lucide-react'
+import { type KeyboardEvent, useCallback, useEffect, useMemo } from 'react'
+import { renderChatMarkdown } from '@/lib/chat-markdown'
+import { openerApi } from '@/lib/tauri-opener-api'
+
+interface WhatsNewModalProps {
+  isOpen: boolean
+  version: string
+  notes?: string | null
+  htmlUrl?: string | null
+  onClose: () => void
+}
+
+export function WhatsNewModal({
+  isOpen,
+  version,
+  notes,
+  htmlUrl,
+  onClose
+}: WhatsNewModalProps): React.JSX.Element {
+  useEffect(() => {
+    if (!isOpen) return
+
+    const handleEscape = (e: globalThis.KeyboardEvent): void => {
+      if (e.key === 'Escape') {
+        e.preventDefault()
+        onClose()
+      }
+    }
+
+    window.addEventListener('keydown', handleEscape)
+    return () => window.removeEventListener('keydown', handleEscape)
+  }, [isOpen, onClose])
+
+  const handleKeyDown = useCallback(
+    (e: KeyboardEvent<HTMLDivElement>) => {
+      if (e.key === 'Escape') {
+        e.preventDefault()
+        onClose()
+      }
+    },
+    [onClose]
+  )
+
+  const handleViewOnGitHub = useCallback(() => {
+    // Only hand http(s) URLs to the system opener; htmlUrl originates from a
+    // network response, so guard against unexpected schemes.
+    if (htmlUrl && /^https?:\/\//i.test(htmlUrl)) {
+      void openerApi.openUrlWithSystemBrowser(htmlUrl)
+    }
+  }, [htmlUrl])
+
+  // Release notes are GitHub-flavored markdown; render to sanitized HTML
+  // (DOMPurify via the shared chat-markdown renderer) so headings, lists, and
+  // links display properly instead of as raw markup.
+  const notesHtml = useMemo(() => (notes ? renderChatMarkdown(notes) : null), [notes])
+
+  return (
+    <AnimatePresence>
+      {isOpen && (
+        <motion.div
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          exit={{ opacity: 0 }}
+          className="fixed inset-0 bg-black/60 backdrop-blur-sm z-50 flex items-center justify-center"
+          onClick={onClose}
+        >
+          <motion.div
+            initial={{ opacity: 0, scale: 0.95, y: 10 }}
+            animate={{ opacity: 1, scale: 1, y: 0 }}
+            exit={{ opacity: 0, scale: 0.95, y: 10 }}
+            transition={{ duration: 0.15 }}
+            className="bg-card rounded-lg shadow-2xl w-[500px] border border-border overflow-hidden"
+            onClick={(e) => e.stopPropagation()}
+            onKeyDown={handleKeyDown}
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="whats-new-title"
+            tabIndex={-1}
+          >
+            {/* Header */}
+            <div className="px-4 py-3 border-b border-border flex justify-between items-center bg-secondary/50">
+              <div className="flex items-center gap-2">
+                <div className="w-5 h-5 rounded bg-primary/10 flex items-center justify-center">
+                  <Sparkles className="w-3 h-3 text-primary" />
+                </div>
+                <h3 id="whats-new-title" className="text-sm font-semibold text-foreground">
+                  What's New
+                </h3>
+              </div>
+              <button
+                type="button"
+                onClick={onClose}
+                className="text-muted-foreground hover:text-foreground transition-colors"
+              >
+                <X size={14} />
+              </button>
+            </div>
+
+            {/* Content */}
+            <div className="p-4 space-y-4">
+              {/* Version Info */}
+              <div className="flex items-baseline gap-2">
+                <span className="text-xs font-medium text-muted-foreground">
+                  Updated to version
+                </span>
+                <span className="text-sm font-semibold text-foreground">{version}</span>
+              </div>
+
+              {/* Release Notes */}
+              <div>
+                <span className="block text-xs font-medium text-muted-foreground mb-1.5">
+                  Release Notes
+                </span>
+                <div className="max-h-[320px] overflow-y-auto pr-1">
+                  {notesHtml ? (
+                    <div
+                      className="chat-prose text-xs leading-relaxed text-foreground"
+                      // biome-ignore lint/security/noDangerouslySetInnerHtml: HTML is sanitized via renderChatMarkdown (DOMPurify)
+                      dangerouslySetInnerHTML={{ __html: notesHtml }}
+                    />
+                  ) : (
+                    <p className="text-xs text-muted-foreground leading-relaxed">
+                      Release notes aren't available for this version.
+                    </p>
+                  )}
+                </div>
+              </div>
+            </div>
+
+            {/* Footer */}
+            <div className="px-4 py-3 bg-secondary/50 flex justify-end gap-2 border-t border-border flex-wrap">
+              {htmlUrl && (
+                <button
+                  type="button"
+                  onClick={handleViewOnGitHub}
+                  className="px-3 py-1.5 text-xs font-medium text-muted-foreground hover:text-foreground transition-colors flex items-center gap-1.5"
+                >
+                  <ExternalLink size={13} />
+                  <span>View on GitHub</span>
+                </button>
+              )}
+              <button
+                type="button"
+                onClick={onClose}
+                className="px-3 py-1.5 text-xs font-medium rounded bg-primary text-primary-foreground hover:bg-primary/90 shadow-md shadow-primary/20 transition-all"
+              >
+                Got it
+              </button>
+            </div>
+          </motion.div>
+        </motion.div>
+      )}
+    </AnimatePresence>
+  )
+}

--- a/src/renderer/hooks/use-whats-new.test.ts
+++ b/src/renderer/hooks/use-whats-new.test.ts
@@ -1,0 +1,136 @@
+import { renderHook, waitFor } from '@testing-library/react'
+import { act } from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('@/lib/tauri-release-notes', () => ({
+  compareVersions: vi.fn(),
+  fetchReleaseNotes: vi.fn(),
+  getCurrentAppVersion: vi.fn(),
+  getLastSeenVersion: vi.fn(),
+  setLastSeenVersion: vi.fn()
+}))
+
+import {
+  compareVersions,
+  fetchReleaseNotes,
+  getCurrentAppVersion,
+  getLastSeenVersion,
+  setLastSeenVersion
+} from '@/lib/tauri-release-notes'
+import { useWhatsNew } from './use-whats-new'
+
+const mockedCompare = vi.mocked(compareVersions)
+const mockedFetch = vi.mocked(fetchReleaseNotes)
+const mockedGetCurrent = vi.mocked(getCurrentAppVersion)
+const mockedGetLastSeen = vi.mocked(getLastSeenVersion)
+const mockedSetLastSeen = vi.mocked(setLastSeenVersion)
+
+describe('useWhatsNew', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockedSetLastSeen.mockResolvedValue(undefined)
+    // Default numeric comparison so tests that don't override behave sensibly.
+    mockedCompare.mockImplementation((a, b) => (a === b ? 0 : a > b ? 1 : -1))
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('records current version and shows nothing on fresh install', async () => {
+    mockedGetCurrent.mockResolvedValue('0.4.7')
+    mockedGetLastSeen.mockResolvedValue(null)
+
+    const { result } = renderHook(() => useWhatsNew())
+
+    await waitFor(() => {
+      expect(mockedSetLastSeen).toHaveBeenCalledWith('0.4.7')
+    })
+    expect(result.current.isOpen).toBe(false)
+    expect(mockedFetch).not.toHaveBeenCalled()
+  })
+
+  it('shows the popup with notes after an update', async () => {
+    mockedGetCurrent.mockResolvedValue('0.4.7')
+    mockedGetLastSeen.mockResolvedValue('0.4.6')
+    mockedCompare.mockReturnValue(1)
+    mockedFetch.mockResolvedValue({
+      version: '0.4.7',
+      notes: '- New stuff',
+      htmlUrl: 'https://example.com'
+    })
+
+    const { result } = renderHook(() => useWhatsNew())
+
+    await waitFor(() => {
+      expect(result.current.isOpen).toBe(true)
+    })
+    expect(result.current.version).toBe('0.4.7')
+    expect(result.current.notes).toBe('- New stuff')
+    expect(result.current.htmlUrl).toBe('https://example.com')
+    expect(mockedSetLastSeen).toHaveBeenCalledWith('0.4.7')
+  })
+
+  it('does not show the popup when the version is unchanged', async () => {
+    mockedGetCurrent.mockResolvedValue('0.4.7')
+    mockedGetLastSeen.mockResolvedValue('0.4.7')
+    mockedCompare.mockReturnValue(0)
+
+    const { result } = renderHook(() => useWhatsNew())
+
+    await waitFor(() => {
+      expect(mockedGetLastSeen).toHaveBeenCalled()
+    })
+    expect(result.current.isOpen).toBe(false)
+    expect(mockedFetch).not.toHaveBeenCalled()
+    expect(mockedSetLastSeen).not.toHaveBeenCalled()
+  })
+
+  it('does not show the popup on a downgrade', async () => {
+    mockedGetCurrent.mockResolvedValue('0.4.6')
+    mockedGetLastSeen.mockResolvedValue('0.4.7')
+    mockedCompare.mockReturnValue(-1)
+
+    const { result } = renderHook(() => useWhatsNew())
+
+    await waitFor(() => {
+      expect(mockedGetLastSeen).toHaveBeenCalled()
+    })
+    expect(result.current.isOpen).toBe(false)
+    expect(mockedFetch).not.toHaveBeenCalled()
+    expect(mockedSetLastSeen).not.toHaveBeenCalled()
+  })
+
+  it('marks the version seen even when the fetch fails, without opening', async () => {
+    mockedGetCurrent.mockResolvedValue('0.4.7')
+    mockedGetLastSeen.mockResolvedValue('0.4.6')
+    mockedCompare.mockReturnValue(1)
+    mockedFetch.mockResolvedValue(null)
+
+    const { result } = renderHook(() => useWhatsNew())
+
+    await waitFor(() => {
+      expect(mockedSetLastSeen).toHaveBeenCalledWith('0.4.7')
+    })
+    expect(result.current.isOpen).toBe(false)
+  })
+
+  it('closes when close() is called', async () => {
+    mockedGetCurrent.mockResolvedValue('0.4.7')
+    mockedGetLastSeen.mockResolvedValue('0.4.6')
+    mockedCompare.mockReturnValue(1)
+    mockedFetch.mockResolvedValue({ version: '0.4.7', notes: '- New', htmlUrl: null })
+
+    const { result } = renderHook(() => useWhatsNew())
+
+    await waitFor(() => {
+      expect(result.current.isOpen).toBe(true)
+    })
+
+    act(() => {
+      result.current.close()
+    })
+
+    expect(result.current.isOpen).toBe(false)
+  })
+})

--- a/src/renderer/hooks/use-whats-new.ts
+++ b/src/renderer/hooks/use-whats-new.ts
@@ -1,0 +1,103 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import {
+  compareVersions,
+  fetchReleaseNotes,
+  getCurrentAppVersion,
+  getLastSeenVersion,
+  setLastSeenVersion
+} from '@/lib/tauri-release-notes'
+
+interface WhatsNewState {
+  isOpen: boolean
+  version: string
+  notes: string | null
+  htmlUrl: string | null
+}
+
+const CLOSED_STATE: WhatsNewState = {
+  isOpen: false,
+  version: '',
+  notes: null,
+  htmlUrl: null
+}
+
+export interface UseWhatsNewResult {
+  isOpen: boolean
+  version: string
+  notes: string | null
+  htmlUrl: string | null
+  close: () => void
+}
+
+/**
+ * useWhatsNew Hook
+ *
+ * On mount, compares the running app version against the persisted last-seen
+ * version. When the app was just updated to a newer version, it fetches that
+ * version's GitHub release notes and opens a one-time "What's New" popup,
+ * recording the version so it never re-shows.
+ *
+ * Behavior:
+ * - Fresh install (no last-seen version): records current version, no popup.
+ * - Same version or downgrade: no popup.
+ * - Updated version: fetch notes, persist current version regardless of fetch
+ *   outcome, and open the popup when a release record was resolved.
+ */
+export function useWhatsNew(): UseWhatsNewResult {
+  const [state, setState] = useState<WhatsNewState>(CLOSED_STATE)
+  const hasRunRef = useRef(false)
+
+  useEffect(() => {
+    if (hasRunRef.current) return
+    hasRunRef.current = true
+
+    const run = async (): Promise<void> => {
+      try {
+        const current = await getCurrentAppVersion()
+        const lastSeen = await getLastSeenVersion()
+
+        // Fresh install: record silently, never show on first launch.
+        if (!lastSeen) {
+          await setLastSeenVersion(current)
+          return
+        }
+
+        // Same version or downgrade (e.g. dev builds): nothing to show.
+        if (compareVersions(current, lastSeen) <= 0) {
+          return
+        }
+
+        const release = await fetchReleaseNotes(current)
+
+        // Mark seen regardless of fetch outcome so a flaky GitHub request does
+        // not pin a stale popup on every launch.
+        await setLastSeenVersion(current)
+
+        if (release) {
+          setState({
+            isOpen: true,
+            version: release.version,
+            notes: release.notes,
+            htmlUrl: release.htmlUrl
+          })
+        }
+      } catch {
+        // Never block startup or surface errors for this best-effort popup.
+      }
+    }
+
+    void run()
+  }, [])
+
+  const close = useCallback(() => {
+    setState(CLOSED_STATE)
+  }, [])
+
+  return {
+    isOpen: state.isOpen,
+    version: state.version,
+    notes: state.notes,
+    htmlUrl: state.htmlUrl,
+    close
+  }
+}

--- a/src/renderer/lib/__tests__/tauri-release-notes.test.ts
+++ b/src/renderer/lib/__tests__/tauri-release-notes.test.ts
@@ -1,0 +1,158 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('@tauri-apps/api/app', () => ({
+  getVersion: vi.fn()
+}))
+
+vi.mock('@tauri-apps/plugin-store', () => ({
+  Store: {
+    load: vi.fn()
+  }
+}))
+
+import { getVersion } from '@tauri-apps/api/app'
+import { Store } from '@tauri-apps/plugin-store'
+import {
+  _resetReleaseNotesStoreForTesting,
+  compareVersions,
+  fetchReleaseNotes,
+  getCurrentAppVersion,
+  getLastSeenVersion,
+  normalizeVersion,
+  setLastSeenVersion
+} from '../tauri-release-notes'
+
+const mockStore = {
+  get: vi.fn(),
+  set: vi.fn(),
+  delete: vi.fn(),
+  save: vi.fn()
+}
+
+const originalFetch = globalThis.fetch
+
+function mockFetchResponse(body: unknown, ok = true, status = 200): void {
+  globalThis.fetch = vi.fn().mockResolvedValue({
+    ok,
+    status,
+    json: vi.fn().mockResolvedValue(body)
+  }) as never
+}
+
+describe('tauri-release-notes', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    _resetReleaseNotesStoreForTesting()
+
+    vi.mocked(Store.load).mockResolvedValue(mockStore as never)
+    mockStore.get.mockResolvedValue(null)
+    mockStore.set.mockResolvedValue(undefined)
+    mockStore.delete.mockResolvedValue(undefined)
+    mockStore.save.mockResolvedValue(undefined)
+  })
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch
+  })
+
+  describe('normalizeVersion', () => {
+    it('strips leading v and build/prerelease metadata', () => {
+      expect(normalizeVersion('v0.4.7')).toBe('0.4.7')
+      expect(normalizeVersion('0.4.7-beta.1')).toBe('0.4.7')
+      expect(normalizeVersion('0.4.7+build.5')).toBe('0.4.7')
+    })
+  })
+
+  describe('compareVersions', () => {
+    it('returns positive when a is newer', () => {
+      expect(compareVersions('0.4.7', '0.4.6')).toBeGreaterThan(0)
+    })
+
+    it('returns negative when a is older', () => {
+      expect(compareVersions('0.4.6', '0.4.7')).toBeLessThan(0)
+    })
+
+    it('returns zero when equal', () => {
+      expect(compareVersions('0.4.7', 'v0.4.7')).toBe(0)
+    })
+  })
+
+  describe('getCurrentAppVersion', () => {
+    it('returns the Tauri app version', async () => {
+      vi.mocked(getVersion).mockResolvedValue('0.4.7')
+      await expect(getCurrentAppVersion()).resolves.toBe('0.4.7')
+    })
+  })
+
+  describe('last-seen version store', () => {
+    it('getLastSeenVersion returns null when nothing stored', async () => {
+      const result = await getLastSeenVersion()
+      expect(result).toBeNull()
+      expect(mockStore.get).toHaveBeenCalledWith('whatsNew.lastSeenVersion')
+    })
+
+    it('getLastSeenVersion returns the stored value', async () => {
+      mockStore.get.mockResolvedValue('0.4.6')
+      await expect(getLastSeenVersion()).resolves.toBe('0.4.6')
+    })
+
+    it('setLastSeenVersion stores and saves', async () => {
+      await setLastSeenVersion('0.4.7')
+      expect(mockStore.set).toHaveBeenCalledWith('whatsNew.lastSeenVersion', '0.4.7')
+      expect(mockStore.save).toHaveBeenCalledTimes(1)
+    })
+
+    it('reuses the loaded store instance between calls', async () => {
+      await getLastSeenVersion()
+      await getLastSeenVersion()
+      expect(Store.load).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('fetchReleaseNotes', () => {
+    it('maps a successful response with notes', async () => {
+      mockFetchResponse({
+        tag_name: 'v0.4.7',
+        body: '### Features\n- Something new',
+        html_url: 'https://github.com/gnoviawan/termul/releases/tag/v0.4.7'
+      })
+
+      const result = await fetchReleaseNotes('0.4.7')
+
+      expect(globalThis.fetch).toHaveBeenCalledWith(
+        'https://api.github.com/repos/gnoviawan/termul/releases/tags/v0.4.7',
+        expect.objectContaining({
+          headers: { Accept: 'application/vnd.github+json' }
+        })
+      )
+      expect(result).toEqual({
+        version: '0.4.7',
+        notes: '### Features\n- Something new',
+        htmlUrl: 'https://github.com/gnoviawan/termul/releases/tag/v0.4.7'
+      })
+    })
+
+    it('returns null notes when the release body is empty', async () => {
+      mockFetchResponse({ tag_name: 'v0.4.7', body: '   ', html_url: 'https://example.com' })
+      const result = await fetchReleaseNotes('0.4.7')
+      expect(result).toEqual({ version: '0.4.7', notes: null, htmlUrl: 'https://example.com' })
+    })
+
+    it('returns null when the release tag is not found (404)', async () => {
+      mockFetchResponse({}, false, 404)
+      await expect(fetchReleaseNotes('0.4.7')).resolves.toBeNull()
+    })
+
+    it('returns null when the request throws (network error / timeout)', async () => {
+      globalThis.fetch = vi.fn().mockRejectedValue(new Error('aborted')) as never
+      await expect(fetchReleaseNotes('0.4.7')).resolves.toBeNull()
+    })
+
+    it('returns null for an empty version', async () => {
+      const fetchSpy = vi.fn()
+      globalThis.fetch = fetchSpy as never
+      await expect(fetchReleaseNotes('')).resolves.toBeNull()
+      expect(fetchSpy).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/src/renderer/lib/tauri-release-notes.ts
+++ b/src/renderer/lib/tauri-release-notes.ts
@@ -1,0 +1,141 @@
+import { getVersion } from '@tauri-apps/api/app'
+import { Store } from '@tauri-apps/plugin-store'
+
+const STORE_FILE = 'whats-new.json'
+const LAST_SEEN_VERSION_KEY = 'whatsNew.lastSeenVersion'
+
+const GITHUB_RELEASE_BY_TAG_URL = 'https://api.github.com/repos/gnoviawan/termul/releases/tags'
+const RELEASE_FETCH_TIMEOUT_MS = 8000
+
+let storeInstance: Store | null = null
+
+async function getStore(): Promise<Store> {
+  if (storeInstance) return storeInstance
+
+  storeInstance = await Store.load(STORE_FILE, {
+    autoSave: false,
+    defaults: {}
+  })
+
+  return storeInstance
+}
+
+/**
+ * Release notes resolved for a specific version.
+ */
+export interface ReleaseNotes {
+  version: string
+  notes: string | null
+  htmlUrl: string | null
+}
+
+interface GitHubRelease {
+  tag_name?: string
+  name?: string
+  body?: string
+  html_url?: string
+  published_at?: string
+}
+
+/**
+ * Strip a leading `v` and any build/prerelease metadata so versions compare on
+ * their numeric release components only.
+ */
+export function normalizeVersion(version: string): string {
+  return version.trim().replace(/^v/i, '').split(/[+-]/)[0] ?? version
+}
+
+/**
+ * Compare two semver-like versions. Returns >0 when `a` is newer than `b`,
+ * <0 when older, and 0 when equal on their numeric components.
+ */
+export function compareVersions(a: string, b: string): number {
+  const partsA = normalizeVersion(a)
+    .split('.')
+    .map((part) => Number.parseInt(part, 10) || 0)
+  const partsB = normalizeVersion(b)
+    .split('.')
+    .map((part) => Number.parseInt(part, 10) || 0)
+  const length = Math.max(partsA.length, partsB.length, 3)
+
+  for (let index = 0; index < length; index += 1) {
+    const diff = (partsA[index] ?? 0) - (partsB[index] ?? 0)
+    if (diff !== 0) return diff
+  }
+
+  return 0
+}
+
+/**
+ * Get the running application version.
+ */
+export async function getCurrentAppVersion(): Promise<string> {
+  return getVersion()
+}
+
+/**
+ * Read the last version for which the What's New popup was shown.
+ * Returns null when nothing has been recorded yet (e.g. fresh install).
+ */
+export async function getLastSeenVersion(): Promise<string | null> {
+  const store = await getStore()
+  const value = await store.get<string>(LAST_SEEN_VERSION_KEY)
+  return value ?? null
+}
+
+/**
+ * Persist the version for which the What's New popup has been shown so it is
+ * not shown again for the same version.
+ */
+export async function setLastSeenVersion(version: string): Promise<void> {
+  const store = await getStore()
+  await store.set(LAST_SEEN_VERSION_KEY, version)
+  await store.save()
+}
+
+/**
+ * Fetch GitHub release notes for a specific version tag (`v{version}`).
+ * Returns null when the release is missing, has no notes, or the request fails.
+ */
+export async function fetchReleaseNotes(version: string): Promise<ReleaseNotes | null> {
+  const normalized = normalizeVersion(version)
+  if (!normalized) return null
+
+  const controller = new AbortController()
+  const timeoutId = window.setTimeout(() => {
+    controller.abort()
+  }, RELEASE_FETCH_TIMEOUT_MS)
+
+  try {
+    const response = await fetch(`${GITHUB_RELEASE_BY_TAG_URL}/v${normalized}`, {
+      headers: {
+        Accept: 'application/vnd.github+json'
+      },
+      signal: controller.signal
+    })
+
+    if (!response.ok) {
+      return null
+    }
+
+    const release = (await response.json()) as GitHubRelease
+    const body = release.body?.trim()
+
+    return {
+      version: normalized,
+      notes: body && body.length > 0 ? body : null,
+      htmlUrl: release.html_url ?? null
+    }
+  } catch {
+    // Network errors, aborts, and malformed responses degrade silently — the
+    // caller still records the version as seen so a transient failure does not
+    // pin a stale popup.
+    return null
+  } finally {
+    window.clearTimeout(timeoutId)
+  }
+}
+
+export function _resetReleaseNotesStoreForTesting(): void {
+  storeInstance = null
+}


### PR DESCRIPTION
## Summary

Termul had no in-app surface telling users what changed after they updated and relaunched. The existing updater toasts/modal fire *before* install; nothing greeted the user *after* restarting into a newer build. This adds a one-time "What's New" popup that fetches the new version's GitHub release notes and shows them on first launch after an update.

## Related Issue

No related issue — this change came from a direct user/maintainer request rather than a tracked bug. Searched open and closed PRs for "release notes popup" / "what's new"; no duplicate exists.

## Type of Change

- [x] feat: new feature

## What Changed

- `src/renderer/lib/tauri-release-notes.ts` — new facade: persisted last-seen version via `@tauri-apps/plugin-store` (`whats-new.json`), current-version lookup, and GitHub release-by-tag fetch (`/releases/tags/v{version}`) with an 8s AbortController timeout. Behind a mockable facade per the project's Tauri-first architecture.
- `src/renderer/hooks/use-whats-new.ts` — startup decision logic: fresh install records silently (no popup), same-version/downgrade does nothing, and the version is marked seen even if the fetch fails so a flaky GitHub call can't pin a stale popup.
- `src/renderer/components/WhatsNewModal.tsx` — the popup. Renders release notes as sanitized markdown (reuses the existing `marked` + DOMPurify `renderChatMarkdown` helper — no new dependency), scrollable, with `role="dialog"`/`aria-modal` semantics and the GitHub link routed through the `tauri-opener-api` facade with an `https` scheme guard.
- `src/renderer/TauriApp.tsx` — mounts the hook and renders the modal at the app root.
- Tests: `tauri-release-notes.test.ts` and `use-whats-new.test.ts` cover every I/O-matrix branch (fresh install, update, same version, downgrade, fetch failure still persists, 404/empty notes).

## How It Was Tested

- [x] `bun run ci` (Biome lint + format + imports, strict mode)
- [x] `bun run typecheck`
- [x] `bun run test` (1813 passed, 42 skipped — includes 20 new tests)
- [ ] `cargo clippy --all-targets -- -D warnings` (in src-tauri)
- [ ] `cargo test` (in src-tauri)
- [x] Manual verification completed

Rust checks marked N/A — this change is renderer-only and touches no Rust code. Manually verified in `tauri dev` by seeding an older last-seen version: the popup appears once with the formatted, scrollable `v0.4.7` notes, and does not reappear on the next launch.

## Screenshots or Recordings

_Manually verified locally; release notes render as formatted markdown in a scrollable area. Happy to attach a recording if useful._

## CI & Review Gate

- [ ] All CI checks pass (PR Validation, Rust Checks, Build Verification, Security Scans)
- [ ] Code review comments from CodeRabbit / Claude have been addressed or resolved
- [ ] No unresolved review findings remain

## Checklist

- [x] My PR title follows the conventional commit format used by this repo
- [x] I linked the related issue or explained why none exists
- [ ] I updated docs when needed (no user-facing docs affected; behavior is self-evident)
- [x] I added or updated tests when needed
- [x] I verified the change does not introduce unrelated modifications
- [x] I read AGENTS.md and followed the contributor guidelines
- [x] A human reviewed the complete diff before submission


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a "What's New" modal that displays release notes when the app updates to a new version. The modal can be dismissed via a close button, backdrop click, or keyboard shortcut, and includes a link to view the full release on GitHub when available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

