### PR TITLE
chore: release v0.4.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "termul-manager",
   "productName": "Termul Manager",
-  "version": "0.4.7",
+  "version": "0.4.8",
   "description": "Project-aware terminal that treats workspaces as first-class citizens",
   "author": "gnoviawan",
   "contributors": [

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -5946,7 +5946,7 @@ dependencies = [
 
 [[package]]
 name = "termul-manager"
-version = "0.4.7"
+version = "0.4.8"
 dependencies = [
  "agent-client-protocol",
  "anyhow",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "termul-manager"
-version = "0.4.7"
+version = "0.4.8"
 description = "Project-aware terminal that treats workspaces as first-class citizens"
 authors = ["gnoviawan", "mannnrachman (Tauri port)"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "https://schema.tauri.app/config/2",
 	"productName": "Termul Manager",
-	"version": "0.4.7",
+	"version": "0.4.8",
 	"identifier": "com.termul-manager.app",
 	"build": {
 		"beforeDevCommand": "npx vite --config vite.config.tauri.ts",

--- a/src/renderer/components/ProjectSidebar.tsx
+++ b/src/renderer/components/ProjectSidebar.tsx
@@ -1533,7 +1533,7 @@ export function ProjectSidebar({
       {/* Version - pinned bottom */}
       <div className="p-2 rounded-b-xl">
         <div className="w-full h-6 inline-flex items-center justify-center">
-          <span className="text-xs text-muted-foreground">Termul v0.4.7</span>
+          <span className="text-xs text-muted-foreground">Termul v0.4.8</span>
         </div>
       </div>
 


### PR DESCRIPTION
## Summary

Automated version bump to v0.4.8. This is a maintenance release that updates the version string across all tracked locations to prepare for tagging and the release build.

## Related Issue

No related issue — this is a routine version bump for the v0.4.8 release.

## Type of Change

- [ ] feat: new feature
- [ ] fix: bug fix
- [ ] docs: documentation only
- [ ] style: formatting or non-functional styling changes
- [ ] refactor: internal cleanup with no behavior change
- [ ] perf: performance improvement
- [ ] test: adds or updates tests
- [ ] build: build or dependency changes
- [ ] ci: CI/CD workflow changes
- [x] chore: maintenance or tooling
- [ ] revert: reverts a previous change

## What Changed

- `package.json` — version bumped from 0.4.7 to 0.4.8
- `src-tauri/Cargo.toml` — package version bumped to 0.4.8
- `src-tauri/Cargo.lock` — `termul-manager` entry updated to 0.4.8
- `src-tauri/tauri.conf.json` — version bumped to 0.4.8
- `src/renderer/components/ProjectSidebar.tsx` — sidebar label updated to `Termul v0.4.8`

## How It Was Tested

- [ ] `bun run ci` (Biome lint + format + imports, strict mode)
- [x] `bun run typecheck`
- [x] `bun run test`
- [ ] `cargo clippy --all-targets -- -D warnings` (in src-tauri)
- [ ] `cargo test` (in src-tauri)
- [ ] Manual verification completed
- [ ] Not applicable

## Screenshots or Recordings

Not applicable — no UI or behavior changes, only version string updates.

## CI & Review Gate

- [ ] All CI checks pass (PR Validation, Rust Checks, Build Verification, Security Scans)
- [ ] Code review comments from CodeRabbit / Claude have been addressed or resolved
- [ ] No unresolved review findings remain

## Checklist

- [x] My PR title follows the conventional commit format used by this repo
- [x] I linked the related issue or explained why none exists
- [x] I updated docs when needed
- [x] I added or updated tests when needed
- [x] I verified the change does not introduce unrelated modifications
- [x] I read AGENTS.md and followed the contributor guidelines
- [x] A human reviewed the complete diff before submission