### PR TITLE
fix(workspace): auto-dismiss agent launcher overlay when opening other panels

### DIFF
--- a/src/renderer/components/workspace/PaneContent.tsx
+++ b/src/renderer/components/workspace/PaneContent.tsx
@@ -1,4 +1,5 @@
 import type { ShellInfo } from '@shared/types/ipc.types'
+import { X } from 'lucide-react'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 // Import useShallow for selective re-rendering
 import { useShallow } from 'zustand/shallow'
@@ -422,6 +423,15 @@ export function PaneContent({
             if (e.key === 'Escape') useWorkspaceStore.getState().hideAgentLauncher()
           }}
         >
+          <button
+            type="button"
+            className="absolute right-3 top-3 z-10 flex h-8 w-8 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted/60 hover:text-foreground"
+            title="Close agent launcher (Esc)"
+            aria-label="Close agent launcher"
+            onClick={() => useWorkspaceStore.getState().hideAgentLauncher()}
+          >
+            <X className="h-4 w-4" />
+          </button>
           <AgentLauncher paneId={pane.id} />
         </div>
       ) : null}

--- a/src/renderer/stores/workspace-store.test.ts
+++ b/src/renderer/stores/workspace-store.test.ts
@@ -583,3 +583,67 @@ describe('workspace-store same-direction collapse (ADR-002.6)', () => {
     expect(Math.abs(sizeSum - 100)).toBeLessThan(1)
   })
 })
+
+describe('workspace-store agent launcher auto-dismiss', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+    useWorkspaceStore.setState(() => {
+      const root: LeafNode = { type: 'leaf', id: 'pane-root', tabs: [], activeTabId: null }
+      return {
+        root,
+        activePaneId: 'pane-root',
+        fullscreenPaneId: null,
+        agentLauncherPaneId: null
+      }
+    })
+  })
+
+  it('clears the launcher when a tab is added to the same pane', () => {
+    const store = useWorkspaceStore.getState()
+    store.showAgentLauncher('pane-root')
+    expect(useWorkspaceStore.getState().agentLauncherPaneId).toBe('pane-root')
+
+    store.addEditorTab('/a.ts', 'pane-root')
+
+    expect(useWorkspaceStore.getState().agentLauncherPaneId).toBeNull()
+  })
+
+  it('clears the launcher when activating a duplicate tab in the same pane', () => {
+    const store = useWorkspaceStore.getState()
+    store.addEditorTab('/a.ts', 'pane-root')
+    store.showAgentLauncher('pane-root')
+
+    // Re-adding the same file activates the existing tab and must still dismiss.
+    store.addEditorTab('/a.ts', 'pane-root')
+
+    expect(useWorkspaceStore.getState().agentLauncherPaneId).toBeNull()
+  })
+
+  it('clears the launcher when switching the active tab in the same pane', () => {
+    const store = useWorkspaceStore.getState()
+    store.addEditorTab('/a.ts', 'pane-root')
+    store.addEditorTab('/b.ts', 'pane-root')
+    store.showAgentLauncher('pane-root')
+
+    const leaf = useWorkspaceStore.getState().root as LeafNode
+    store.setActiveTab('pane-root', leaf.tabs[0].id)
+
+    expect(useWorkspaceStore.getState().agentLauncherPaneId).toBeNull()
+  })
+
+  it('leaves the launcher open when a tab is added to a different pane', () => {
+    const store = useWorkspaceStore.getState()
+    const tabA = createEditorTab('edit-/a.ts')
+    store.addTabToPane('pane-root', tabA)
+    store.splitPane('pane-root', 'horizontal', createEditorTab('edit-/b.ts'), 'right')
+
+    const split = useWorkspaceStore.getState().root as SplitNode
+    const leftPaneId = (split.children[0] as LeafNode).id
+    const rightPaneId = (split.children[1] as LeafNode).id
+
+    store.showAgentLauncher(leftPaneId)
+    store.addEditorTab('/c.ts', rightPaneId)
+
+    expect(useWorkspaceStore.getState().agentLauncherPaneId).toBe(leftPaneId)
+  })
+})

--- a/src/renderer/stores/workspace-store.ts
+++ b/src/renderer/stores/workspace-store.ts
@@ -370,13 +370,21 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => {
     },
 
     addTabToPane: (paneId: string, tab: WorkspaceTab): void => {
-      const { root } = get()
+      const { root, agentLauncherPaneId } = get()
       const pane = findPaneById(root, paneId)
       if (pane?.type !== 'leaf') return
 
+      // Opening or activating any tab means the user has moved on from the
+      // agent launcher overlay; auto-dismiss it so it never blocks the panel
+      // the user just opened (e.g. an editor, git, or browser tab).
+      const nextLauncherPaneId = agentLauncherPaneId === paneId ? null : agentLauncherPaneId
+
       // Prevent duplicate in same pane
       if (pane.tabs.some((t) => t.id === tab.id)) {
-        set({ root: updateLeaf(root, paneId, (l) => ({ ...l, activeTabId: tab.id })) })
+        set({
+          root: updateLeaf(root, paneId, (l) => ({ ...l, activeTabId: tab.id })),
+          agentLauncherPaneId: nextLauncherPaneId
+        })
         return
       }
 
@@ -387,7 +395,8 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => {
       }))
       set((state) => ({
         root: newRoot,
-        activePaneId: resolveActivePaneId(state.fullscreenPaneId, paneId)
+        activePaneId: resolveActivePaneId(state.fullscreenPaneId, paneId),
+        agentLauncherPaneId: nextLauncherPaneId
       }))
     },
 
@@ -597,14 +606,16 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => {
     },
 
     setActiveTab: (paneId: string, tabId: string): void => {
-      const { root, fullscreenPaneId } = get()
+      const { root, fullscreenPaneId, agentLauncherPaneId } = get()
       const newRoot = updateLeaf(root, paneId, (leaf) => ({
         ...leaf,
         activeTabId: tabId
       }))
       set({
         root: newRoot,
-        activePaneId: resolveActivePaneId(fullscreenPaneId, paneId)
+        activePaneId: resolveActivePaneId(fullscreenPaneId, paneId),
+        // Switching to an existing tab dismisses the launcher overlay for that pane.
+        agentLauncherPaneId: agentLauncherPaneId === paneId ? null : agentLauncherPaneId
       })
     },
 
@@ -712,7 +723,7 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => {
 
     addTerminalTab: (terminalId: string, targetPaneId?: string): void => {
       const id = terminalTabId(terminalId)
-      const { root, activePaneId } = get()
+      const { root, activePaneId, agentLauncherPaneId } = get()
       const paneId = targetPaneId ?? activePaneId
 
       // Check if already exists in any pane
@@ -722,7 +733,8 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => {
         const { fullscreenPaneId } = get()
         set({
           root: updateLeaf(root, existing.id, (l) => ({ ...l, activeTabId: id })),
-          activePaneId: resolveActivePaneId(fullscreenPaneId, existing.id)
+          activePaneId: resolveActivePaneId(fullscreenPaneId, existing.id),
+          agentLauncherPaneId: agentLauncherPaneId === existing.id ? null : agentLauncherPaneId
         })
         return
       }
@@ -765,7 +777,7 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => {
 
     addEditorTab: (filePath: string, targetPaneId?: string): void => {
       const id = editorTabId(filePath)
-      const { root, activePaneId } = get()
+      const { root, activePaneId, agentLauncherPaneId } = get()
       const paneId = targetPaneId ?? activePaneId
 
       // Check if already exists in target pane — activate it
@@ -774,7 +786,8 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => {
         const { fullscreenPaneId } = get()
         set({
           root: updateLeaf(root, paneId, (l) => ({ ...l, activeTabId: id })),
-          activePaneId: resolveActivePaneId(fullscreenPaneId, paneId)
+          activePaneId: resolveActivePaneId(fullscreenPaneId, paneId),
+          agentLauncherPaneId: agentLauncherPaneId === paneId ? null : agentLauncherPaneId
         })
         return
       }
@@ -785,7 +798,7 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => {
 
     addBrowserTab: (browserTabId: string, targetPaneId?: string): void => {
       const id = makeBrowserTabId(browserTabId)
-      const { root, activePaneId } = get()
+      const { root, activePaneId, agentLauncherPaneId } = get()
       const paneId = targetPaneId ?? activePaneId
 
       // Check if already exists in any pane — activate it
@@ -794,7 +807,8 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => {
         const { fullscreenPaneId } = get()
         set({
           root: updateLeaf(root, existing.id, (l) => ({ ...l, activeTabId: id })),
-          activePaneId: resolveActivePaneId(fullscreenPaneId, existing.id)
+          activePaneId: resolveActivePaneId(fullscreenPaneId, existing.id),
+          agentLauncherPaneId: agentLauncherPaneId === existing.id ? null : agentLauncherPaneId
         })
         return
       }
@@ -805,7 +819,7 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => {
 
     addAgentChatTab: (sessionId: string, targetPaneId?: string): void => {
       const id = agentChatTabId(sessionId)
-      const { root, activePaneId } = get()
+      const { root, activePaneId, agentLauncherPaneId } = get()
       const paneId = targetPaneId ?? activePaneId
 
       // Check if already exists in any pane — activate it
@@ -814,7 +828,8 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => {
         const { fullscreenPaneId } = get()
         set({
           root: updateLeaf(root, existing.id, (l) => ({ ...l, activeTabId: id })),
-          activePaneId: resolveActivePaneId(fullscreenPaneId, existing.id)
+          activePaneId: resolveActivePaneId(fullscreenPaneId, existing.id),
+          agentLauncherPaneId: agentLauncherPaneId === existing.id ? null : agentLauncherPaneId
         })
         return
       }


### PR DESCRIPTION
## Summary

The **New agent chat** launcher renders as a full-pane modal overlay (`absolute inset-0 z-30`, `aria-modal`) in `PaneContent`. `agentLauncherPaneId` was only cleared by `hideAgentLauncher()` (triggered by `Esc` or a successful launch). When a user clicked **New agent chat** and then opened a file via File Explorer, Git Changes, Git History, or a browser tab, the new tab activated underneath but the launcher overlay stayed painted on top — blocking the panel the user just opened, with no discoverable way to dismiss it.

This makes the launcher feel like it "traps" the pane: users can't reach other panels and don't know `Esc` closes it.

## Related Issue

Closes #388

No existing open/closed PR covers this. PR #368 / issue #365 were about `Ctrl+W` while the launcher is open — a different problem.

## Type of Change

- [x] fix: bug fix

## What Changed

- `src/renderer/stores/workspace-store.ts`: clear `agentLauncherPaneId` whenever the user moves on within that pane — in `addTabToPane`, `setActiveTab`, and the activation early-returns of `addEditorTab`, `addTerminalTab`, `addBrowserTab`, and `addAgentChatTab`. Adding/activating a tab in a **different** pane leaves the launcher open.
- `src/renderer/components/workspace/PaneContent.tsx`: add a visible close (X) button to the launcher overlay for discoverability (in addition to the existing `Esc` handler).
- `src/renderer/stores/workspace-store.test.ts`: add tests covering add-tab dismiss, duplicate-activation dismiss, active-tab-switch dismiss, and the "different pane keeps it open" case.

Re-opening still works: clicking **New agent chat** calls `showAgentLauncher` again.

## How It Was Tested

- [x] `bun run ci` (Biome lint + format + imports, strict mode)
- [x] `bun run typecheck`
- [x] `bun run test` (1838 passed, 42 skipped; new workspace-store tests pass)
- [ ] `cargo clippy --all-targets -- -D warnings` (in src-tauri)
- [ ] `cargo test` (in src-tauri)
- [x] Manual verification completed

Rust checks are **Not applicable** — this is a renderer-only change with no Rust modifications.

## Screenshots or Recordings


https://github.com/user-attachments/assets/11e38768-24f0-4485-bea3-a42358eafc50



## CI & Review Gate

- [ ] All CI checks pass (PR Validation, Rust Checks, Build Verification, Security Scans)
- [ ] Code review comments from CodeRabbit / Claude have been addressed or resolved
- [ ] No unresolved review findings remain

## Checklist

- [x] My PR title follows the conventional commit format used by this repo
- [x] I linked the related issue or explained why none exists
- [x] I updated docs when needed (no docs impacted)
- [x] I added or updated tests when needed
- [x] I verified the change does not introduce unrelated modifications
- [x] I read AGENTS.md and followed the contributor guidelines
- [x] A human reviewed the complete diff before submission


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Added an explicit close button to the Agent Launcher overlay, positioned in the top-right corner for convenient access

## Improvements
* Agent Launcher now automatically dismisses when you add tabs or switch tabs within a pane
* Escape-key shortcut to close the launcher remains available

<!-- end of auto-generated comment: release notes by coderabbit.ai -->