### PR TITLE
fix: unblock shortcut recording (native menu accelerators + multi-modifier combos)

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -175,6 +175,36 @@ fn get_home_directory() -> Result<String, String> {
     }
 }
 
+/// Temporarily remove the native application menu so its keyboard accelerators
+/// (e.g. `Cmd+W`, `Cmd+R`, `Cmd+C`) stop intercepting key events before they
+/// reach the webview. The renderer's shortcut recorder calls this while it is
+/// capturing a keybinding so the user can record any combination, including
+/// ones that collide with a menu accelerator. No-op on Linux (no app menu).
+#[tauri::command]
+fn suspend_app_menu(app: tauri::AppHandle) -> Result<(), String> {
+    #[cfg(not(target_os = "linux"))]
+    {
+        app.remove_menu().map_err(|e| e.to_string())?;
+    }
+    #[cfg(target_os = "linux")]
+    let _ = &app;
+    Ok(())
+}
+
+/// Restore the native application menu removed by `suspend_app_menu`. Rebuilds
+/// the menu from scratch so accelerators resume working once recording ends.
+#[tauri::command]
+fn restore_app_menu(app: tauri::AppHandle) -> Result<(), String> {
+    #[cfg(not(target_os = "linux"))]
+    {
+        let menu = build_app_menu(&app).map_err(|e| e.to_string())?;
+        app.set_menu(menu).map_err(|e| e.to_string())?;
+    }
+    #[cfg(target_os = "linux")]
+    let _ = &app;
+    Ok(())
+}
+
 #[tauri::command]
 fn reveal_log_dir_command(app: tauri::AppHandle) -> Result<(), String> {
     reveal_log_dir(&app)
@@ -1031,6 +1061,8 @@ pub fn run() {
             detect_shells,
             get_default_shell,
             get_home_directory,
+            suspend_app_menu,
+            restore_app_menu,
             reveal_log_dir_command,
             export_log_file_command,
             copy_log_contents_command,

--- a/src/renderer/components/ShortcutRecorder.tsx
+++ b/src/renderer/components/ShortcutRecorder.tsx
@@ -1,5 +1,6 @@
 import { RotateCcw } from 'lucide-react'
 import { useCallback, useEffect, useRef, useState } from 'react'
+import { beginShortcutCapture, endShortcutCapture } from '@/lib/shortcut-capture'
 import {
   findConflictingShortcut,
   formatKeyForDisplay,
@@ -111,7 +112,20 @@ export function ShortcutRecorder({
     [handleClick, isRecording]
   )
 
-  // Attach keydown listener when recording
+  // Suspend the native app menu while recording so its accelerators (e.g. ⌘W,
+  // ⌘R, ⌘C) stop intercepting keys before they reach the webview, letting the
+  // user record any combination. Keyed only on `isRecording` so a change in
+  // `handleKeyDown`'s identity does not churn the menu mid-recording.
+  useEffect(() => {
+    if (!isRecording) return
+    void beginShortcutCapture()
+    return () => {
+      void endShortcutCapture()
+    }
+  }, [isRecording])
+
+  // Attach the capture-phase keydown listener while recording. Re-binds when
+  // `handleKeyDown` changes identity (e.g. after the shortcut map updates).
   useEffect(() => {
     if (isRecording && inputRef.current) {
       inputRef.current.focus()

--- a/src/renderer/lib/shortcut-capture.ts
+++ b/src/renderer/lib/shortcut-capture.ts
@@ -1,0 +1,47 @@
+import { invoke } from '@tauri-apps/api/core'
+import { isTauri } from './api-bridge'
+
+/**
+ * Native menu accelerators (e.g. ⌘W, ⌘R, ⌘C on macOS, Ctrl+W on Windows) are
+ * handled by the OS menu before the key event reaches the webview, so the
+ * shortcut recorder never sees them. While recording a keybinding we ask the
+ * Rust side to remove the app menu, then restore it when recording ends.
+ *
+ * A refcount guards against overlapping recorders (e.g. clicking a second
+ * recorder before the first blurs): the menu stays suspended until the last
+ * active capture releases it.
+ */
+let activeCaptures = 0
+
+// Serialize the suspend/restore IPC so the two commands can never land out of
+// order. Without this, a fast blur-then-click between recorders (refcount
+// 1 -> 0 -> 1) issues `restore` then `suspend` as independent IPC calls; if
+// `suspend` (cheap) overtakes `restore` (rebuilds the menu) the menu would be
+// left in place while the next recorder is still capturing.
+let ipcQueue: Promise<void> = Promise.resolve()
+
+function enqueueMenuIpc(command: 'suspend_app_menu' | 'restore_app_menu'): Promise<void> {
+  const run = async (): Promise<void> => {
+    try {
+      await invoke(command)
+    } catch {
+      // Non-fatal: the recorder still works for combos the menu does not own,
+      // and the menu is rebuilt on the next app launch regardless.
+    }
+  }
+  ipcQueue = ipcQueue.then(run, run)
+  return ipcQueue
+}
+
+export async function beginShortcutCapture(): Promise<void> {
+  activeCaptures += 1
+  if (activeCaptures > 1 || !isTauri()) return
+  await enqueueMenuIpc('suspend_app_menu')
+}
+
+export async function endShortcutCapture(): Promise<void> {
+  if (activeCaptures === 0) return
+  activeCaptures -= 1
+  if (activeCaptures > 0 || !isTauri()) return
+  await enqueueMenuIpc('restore_app_menu')
+}

--- a/src/renderer/stores/keyboard-shortcuts-store.test.ts
+++ b/src/renderer/stores/keyboard-shortcuts-store.test.ts
@@ -247,6 +247,31 @@ describe('normalizeKeyEvent', () => {
     })
     expect(normalizeKeyEvent(event)).toBe('ctrl+shift+alt+n')
   })
+
+  it('should emit both cmd and ctrl for a ⌘⌃ combo on macOS', async () => {
+    const { isMac: currentIsMac } = await import('@/lib/platform')
+    const event = new KeyboardEvent('keydown', { key: 't', ctrlKey: true, metaKey: true })
+    if (currentIsMac) {
+      // macOS: both modifiers emitted in canonical order (ctrl before cmd).
+      expect(normalizeKeyEvent(event)).toBe('ctrl+cmd+t')
+    } else {
+      // Non-macOS: ctrl takes precedence, cmd is dropped.
+      expect(normalizeKeyEvent(event)).toBe('ctrl+t')
+    }
+  })
+
+  it('should emit a full four-modifier combo on macOS', async () => {
+    const { isMac: currentIsMac } = await import('@/lib/platform')
+    if (!currentIsMac) return
+    const event = new KeyboardEvent('keydown', {
+      key: 't',
+      ctrlKey: true,
+      metaKey: true,
+      shiftKey: true,
+      altKey: true
+    })
+    expect(normalizeKeyEvent(event)).toBe('ctrl+cmd+shift+alt+t')
+  })
 })
 
 describe('formatKeyForDisplay', () => {
@@ -342,5 +367,17 @@ describe('matchesShortcut', () => {
     if (currentIsMac) return // tested in shell passthrough guard test
     const event = new KeyboardEvent('keydown', { key: 'k', ctrlKey: true })
     expect(matchesShortcut(event, 'ctrl+k')).toBe(true)
+  })
+
+  it('should match a ⌘⌃ combo exactly without aliasing on macOS', async () => {
+    const { isMac: currentIsMac } = await import('@/lib/platform')
+    if (!currentIsMac) return
+    const event = new KeyboardEvent('keydown', { key: 't', ctrlKey: true, metaKey: true })
+    // Exact multi-modifier match succeeds.
+    expect(matchesShortcut(event, 'ctrl+cmd+t')).toBe(true)
+    // The cross-modifier alias must NOT fire for multi-modifier combos,
+    // so it never collapses into a single-modifier binding.
+    expect(matchesShortcut(event, 'cmd+t')).toBe(false)
+    expect(matchesShortcut(event, 'ctrl+t')).toBe(false)
   })
 })

--- a/src/renderer/stores/keyboard-shortcuts-store.test.ts
+++ b/src/renderer/stores/keyboard-shortcuts-store.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it } from 'vitest'
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 import { DEFAULT_KEYBOARD_SHORTCUTS } from '@/types/settings'
 import {
   findConflictingShortcut,
@@ -377,6 +377,54 @@ describe('matchesShortcut', () => {
     expect(matchesShortcut(event, 'ctrl+cmd+t')).toBe(true)
     // The cross-modifier alias must NOT fire for multi-modifier combos,
     // so it never collapses into a single-modifier binding.
+    expect(matchesShortcut(event, 'cmd+t')).toBe(false)
+    expect(matchesShortcut(event, 'ctrl+t')).toBe(false)
+  })
+})
+
+// The macOS branches above are guarded by the runtime `isMac` value, so they
+// no-op on non-macOS CI. This block mocks `@/lib/platform` to force macOS and
+// re-imports the store, exercising the regression deterministically everywhere.
+describe('macOS multi-modifier normalization (platform mocked)', () => {
+  let normalizeKeyEvent: typeof import('./keyboard-shortcuts-store').normalizeKeyEvent
+  let matchesShortcut: typeof import('./keyboard-shortcuts-store').matchesShortcut
+
+  beforeAll(async () => {
+    vi.resetModules()
+    vi.doMock('@/lib/platform', async () => {
+      const actual = await vi.importActual<typeof import('@/lib/platform')>('@/lib/platform')
+      return { ...actual, isMac: true }
+    })
+    const mod = await import('./keyboard-shortcuts-store')
+    normalizeKeyEvent = mod.normalizeKeyEvent
+    matchesShortcut = mod.matchesShortcut
+  })
+
+  afterAll(() => {
+    vi.doUnmock('@/lib/platform')
+    vi.resetModules()
+  })
+
+  it('emits both cmd and ctrl for a ⌘⌃ combo', () => {
+    const event = new KeyboardEvent('keydown', { key: 't', ctrlKey: true, metaKey: true })
+    expect(normalizeKeyEvent(event)).toBe('ctrl+cmd+t')
+  })
+
+  it('emits a full four-modifier combo', () => {
+    const event = new KeyboardEvent('keydown', {
+      key: 't',
+      ctrlKey: true,
+      metaKey: true,
+      shiftKey: true,
+      altKey: true
+    })
+    expect(normalizeKeyEvent(event)).toBe('ctrl+cmd+shift+alt+t')
+  })
+
+  it('matches a ⌘⌃ combo exactly without aliasing', () => {
+    const event = new KeyboardEvent('keydown', { key: 't', ctrlKey: true, metaKey: true })
+    expect(matchesShortcut(event, 'ctrl+cmd+t')).toBe(true)
+    // The cross-modifier alias must not fire for multi-modifier combos.
     expect(matchesShortcut(event, 'cmd+t')).toBe(false)
     expect(matchesShortcut(event, 'ctrl+t')).toBe(false)
   })

--- a/src/renderer/stores/keyboard-shortcuts-store.ts
+++ b/src/renderer/stores/keyboard-shortcuts-store.ts
@@ -100,18 +100,19 @@ function shortcutsEqual(left: string, right: string): boolean {
 //   ctrl → Ctrl key on Windows/Linux, or Ctrl key on macOS
 //   cmd  → Meta/⌘ key on macOS (only emitted on macOS)
 //
-// On macOS both modifiers can technically be held simultaneously, but in
-// practice users only use one at a time for app shortcuts, so we emit the
-// first that matches the platform convention.
+// On macOS both modifiers can be held simultaneously (e.g. ⌘⌃T); each is
+// emitted as its own token so multi-modifier combos record correctly.
 export function normalizeKeyEvent(e: KeyboardEvent): string {
   const parts: string[] = []
 
   // Add modifiers in canonical order matching persisted defaults.
   if (isMac) {
-    // macOS: prefer cmd (metaKey) but also track ctrl if only ctrl is held.
-    // This lets us distinguish ⌘+K from Ctrl+K on macOS.
+    // macOS: emit ctrl and cmd independently so multi-modifier combos like
+    // ⌘⌃T (cmd+ctrl held together) can be recorded. A single modifier still
+    // emits just that token, preserving the ⌘+K vs Ctrl+K distinction.
+    // Canonical order is ctrl before cmd (see MODIFIER_ORDER).
+    if (e.ctrlKey) parts.push('ctrl')
     if (e.metaKey) parts.push('cmd')
-    else if (e.ctrlKey) parts.push('ctrl')
   } else {
     if (e.ctrlKey) parts.push('ctrl')
     else if (e.metaKey) parts.push('cmd')
@@ -190,13 +191,19 @@ export function matchesShortcut(e: KeyboardEvent, shortcutKey: string): boolean 
 
   // macOS cross-modifier alias: 'cmd+x' matches 'ctrl+x' config and vice-versa.
   // This lets the same 'ctrl+k' default work with both ⌘+K and Ctrl+K on Mac.
+  // Only single-modifier combos are aliased — when both ⌘ and ⌃ are held
+  // (e.g. ⌘⌃T) the combo is matched exactly, never swapped, otherwise the
+  // alias would corrupt it into 'cmd+cmd+t'.
   if (isMac) {
-    const aliased = normalized.startsWith('cmd+')
-      ? `ctrl+${normalized.slice(4)}`
-      : normalized.startsWith('ctrl+')
-        ? `cmd+${normalized.slice(5)}`
-        : normalized
-    return shortcutsEqual(aliased, shortcutKey)
+    const parts = normalized.split('+')
+    const hasCmd = parts.includes('cmd')
+    const hasCtrl = parts.includes('ctrl')
+    if (hasCmd !== hasCtrl) {
+      const aliased = parts
+        .map((part) => (part === 'cmd' ? 'ctrl' : part === 'ctrl' ? 'cmd' : part))
+        .join('+')
+      return shortcutsEqual(aliased, shortcutKey)
+    }
   }
 
   return false


### PR DESCRIPTION
## Summary

Two related defects prevented the keyboard-mapping recorder from capturing valid shortcuts:

1. **Native menu accelerators** — on macOS the native app menu registers key equivalents (Cmd+W, Cmd+R, Cmd+C, etc.) and `performKeyEquivalent` consumes those combos before the webview ever sees a `keydown`. Remapping "Close Tab" from Ctrl+W to Cmd+W silently failed because Cmd+W was swallowed by the menu.
2. **Multi-modifier combos** — `normalizeKeyEvent` emitted only one of cmd/ctrl (an `else if`), so combos holding both (e.g. `Cmd+Ctrl+T`) lost the ctrl token and could not be recorded at all.

This PR suspends the native app menu for the duration of a recording session, and emits both cmd and ctrl when held together so multi-modifier combos record correctly.

## Related Issue

No related issue exists for this bug. No existing open/closed PR addresses the shortcut *recorder* capture failure (searched "shortcut native menu" / "multi modifier"). #303 is unrelated — it fixes Cmd+W runtime behavior, not the recorder.

## Type of Change

- [x] fix: bug fix

## What Changed

- `src-tauri/src/lib.rs`: add `suspend_app_menu` / `restore_app_menu` IPC commands (`remove_menu` / rebuild via `build_app_menu` + `set_menu`), registered in the invoke handler. No-op on Linux (no app menu).
- `src/renderer/lib/shortcut-capture.ts`: new helper with refcount + serialized IPC queue so concurrent recorders never leave the menu suspended and suspend/restore can't land out of order.
- `src/renderer/components/ShortcutRecorder.tsx`: suspend the menu while recording (effect keyed on `isRecording`) and attach the capture-phase keydown listener (effect keyed on `handleKeyDown`).
- `src/renderer/stores/keyboard-shortcuts-store.ts`: `normalizeKeyEvent` now emits both cmd and ctrl in canonical order; the macOS cmd↔ctrl alias in `matchesShortcut` is restricted to single-modifier combos so `Cmd+Ctrl+T` matches exactly instead of collapsing into `cmd+cmd+t`.
- Tests: cover multi-modifier capture and exact (non-aliased) matching.

## How It Was Tested

- [x] `bun run typecheck`
- [x] `bun run test` (keyboard-shortcuts-store: 40 passed)
- [x] `cargo clippy --all-targets -- -D warnings` (in src-tauri)
- [x] `cargo test` (in src-tauri)
- [x] Manual verification completed

## Screenshots or Recordings

N/A — no visual change.

## CI & Review Gate

- [ ] All CI checks pass (PR Validation, Rust Checks, Build Verification, Security Scans)
- [ ] Code review comments from CodeRabbit / Claude have been addressed or resolved
- [ ] No unresolved review findings remain

## Checklist

- [x] My PR title follows the conventional commit format used by this repo
- [x] I linked the related issue or explained why none exists
- [ ] I updated docs when needed
- [x] I added or updated tests when needed
- [x] I verified the change does not introduce unrelated modifications
- [x] I read AGENTS.md and followed the contributor guidelines
- [x] A human reviewed the complete diff before submission


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved keyboard shortcut recording by temporarily suspending and restoring the native application menu during capture, including more reliable handling for rapid start/stop and overlapping sessions to reduce native accelerator conflicts.
  * Refined macOS keyboard shortcut normalization and matching so multi-modifier combinations (e.g., `⌘⌃` and `ctrl+cmd+shift+alt`) match exactly and avoid incorrect aliasing.
* **Tests**
  * Expanded macOS-specific test coverage to verify the updated normalization and matching behavior, including “no aliasing” regression cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
