### PR TITLE
fix(linux): correct browser webview boundaries and positioning using GTK overlays

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -146,6 +146,7 @@ ssh2 = "0.9"
 # don't require a system OpenSSL/Perl build toolchain.
 [target.'cfg(target_os = "linux")'.dependencies]
 keyring = { version = "3.6", features = ["sync-secret-service", "crypto-rust"] }
+gtk = "0.18"
 
 [target.'cfg(windows)'.dependencies]
 winreg = "0.55"

--- a/src-tauri/src/browser_tab_manager.rs
+++ b/src-tauri/src/browser_tab_manager.rs
@@ -538,11 +538,13 @@ impl BrowserTabManager {
 
         #[cfg(target_os = "linux")]
         {
-            let _ = webview.with_webview(move |child_platform| {
-                use gtk::prelude::*;
-                let child_widget = child_platform.inner();
-                child_widget.show();
-            });
+            webview
+                .with_webview(move |child_platform| {
+                    use gtk::prelude::*;
+                    let child_widget = child_platform.inner();
+                    child_widget.show();
+                })
+                .map_err(|e| format!("Show dispatch failed: {e}"))?;
         }
 
         webview
@@ -556,11 +558,13 @@ impl BrowserTabManager {
 
         #[cfg(target_os = "linux")]
         {
-            let _ = webview.with_webview(move |child_platform| {
-                use gtk::prelude::*;
-                let child_widget = child_platform.inner();
-                child_widget.hide();
-            });
+            webview
+                .with_webview(move |child_platform| {
+                    use gtk::prelude::*;
+                    let child_widget = child_platform.inner();
+                    child_widget.hide();
+                })
+                .map_err(|e| format!("Hide dispatch failed: {e}"))?;
         }
 
         webview

--- a/src-tauri/src/browser_tab_manager.rs
+++ b/src-tauri/src/browser_tab_manager.rs
@@ -2,17 +2,6 @@ use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 use tauri::{AppHandle, Manager};
 
-struct SendWrapper<T>(pub T);
-unsafe impl<T> Send for SendWrapper<T> {}
-unsafe impl<T> Sync for SendWrapper<T> {}
-
-impl<T> SendWrapper<T> {
-    pub fn take(self) -> T {
-        self.0
-    }
-}
-
-
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct BrowserTabInfo {
@@ -184,7 +173,7 @@ impl BrowserTabManager {
         });
     }
 
-    pub fn create(
+    pub async fn create(
         &self,
         tab_id: String,
         url: String,
@@ -200,104 +189,103 @@ impl BrowserTabManager {
             tauri::WebviewUrl::External(parsed_url),
         );
 
-        let scale_factor = window.scale_factor().unwrap_or(1.0);
-        log::info!("[BrowserTab] create original bounds: x={}, y={}, w={}, h={}, scale_factor={}", bounds.x, bounds.y, bounds.width, bounds.height, scale_factor);
-
-        #[cfg(target_os = "linux")]
-        let (x, y, w, h) = (
-            bounds.x / scale_factor,
-            bounds.y / scale_factor,
-            bounds.width / scale_factor,
-            bounds.height / scale_factor,
-        );
-
-        #[cfg(not(target_os = "linux"))]
-        let (x, y, w, h) = (bounds.x, bounds.y, bounds.width, bounds.height);
-
-        log::info!("[BrowserTab] create scaled bounds: x={}, y={}, w={}, h={}", x, y, w, h);
-
         let _webview = window
             .add_child(
                 builder,
-                tauri::LogicalPosition::new(x, y),
-                tauri::LogicalSize::new(w, h),
+                tauri::LogicalPosition::new(bounds.x, bounds.y),
+                tauri::LogicalSize::new(bounds.width, bounds.height),
             )
             .map_err(|e| format!("Failed to create webview: {}", e))?;
 
         #[cfg(target_os = "linux")]
         {
-            let child_webview = _webview.clone();
-            if let Ok(main_webview) = window.get_webview("main").ok_or_else(|| "Main webview not found".to_string()) {
-                let bounds_clone = bounds.clone();
-                let _ = main_webview.with_webview(move |main_platform| {
-                    let main_widget = main_platform.inner().clone();
-                    let main_widget_wrapped = SendWrapper(main_widget);
-                    let _ = child_webview.with_webview(move |child_platform| {
-                        let child_widget = child_platform.inner().clone();
-                        let main_widget = main_widget_wrapped.take();
-                        let handle_reparent = || -> Result<(), String> {
-                            use gtk::prelude::*;
+            // Confirm the main webview still exists before changing the GTK hierarchy.
+            if window.get_webview("main").is_none() {
+                let _ = _webview.close();
+                return Err("Main webview not found".to_string());
+            }
 
-                            let parent = main_widget.parent()
-                                .ok_or_else(|| "Main webview has no parent".to_string())?;
+            let (reparent_tx, reparent_rx) = tokio::sync::oneshot::channel();
+            let reparent_bounds = bounds.clone();
+            let dispatch_result = _webview.with_webview(move |child_platform| {
+                let result = (|| -> Result<(), String> {
+                    use gtk::prelude::*;
 
-                            let overlay = if parent.type_().name() == "GtkOverlay" {
-                                parent.dynamic_cast::<gtk::Overlay>()
-                                    .map_err(|_| "Parent is not GtkOverlay".to_string())?
-                            } else {
-                                let vbox = parent.dynamic_cast::<gtk::Box>()
-                                    .map_err(|_| "Main webview parent is not GtkBox".to_string())?;
+                    let child_widget = child_platform.inner();
+                    let parent = child_widget
+                        .parent()
+                        .ok_or_else(|| "Child webview has no parent".to_string())?;
+                    let vbox = parent
+                        .dynamic_cast::<gtk::Box>()
+                        .map_err(|_| "Child webview parent is not GtkBox".to_string())?;
 
-                                let new_overlay = gtk::Overlay::new();
-                                new_overlay.set_hexpand(true);
-                                new_overlay.set_vexpand(true);
+                    // On first creation the main and child webviews are siblings in the
+                    // window's default GtkBox. Later tabs reuse the overlay already placed
+                    // beside the newly-created child, so no GTK handle crosses callbacks.
+                    vbox.remove(&child_widget);
+                    let overlay = if let Some(existing) = vbox
+                        .children()
+                        .into_iter()
+                        .find_map(|widget| widget.dynamic_cast::<gtk::Overlay>().ok())
+                    {
+                        existing
+                    } else {
+                        let main_widget = vbox
+                            .children()
+                            .into_iter()
+                            .find(|widget| widget.type_().name() == "WebKitWebView")
+                            .ok_or_else(|| "Main GTK webview widget not found".to_string())?;
+                        let overlay = gtk::Overlay::new();
+                        overlay.set_hexpand(true);
+                        overlay.set_vexpand(true);
+                        main_widget.set_hexpand(true);
+                        main_widget.set_vexpand(true);
+                        vbox.remove(&main_widget);
+                        vbox.pack_start(&overlay, true, true, 0);
+                        overlay.add(&main_widget);
+                        main_widget.show();
+                        overlay.show();
+                        overlay
+                    };
 
-                                main_widget.set_hexpand(true);
-                                main_widget.set_vexpand(true);
+                    child_widget.set_halign(gtk::Align::Start);
+                    child_widget.set_valign(gtk::Align::Start);
+                    child_widget.set_margin_start(reparent_bounds.x.round() as i32);
+                    child_widget.set_margin_top(reparent_bounds.y.round() as i32);
+                    child_widget.set_size_request(
+                        reparent_bounds.width.round() as i32,
+                        reparent_bounds.height.round() as i32,
+                    );
+                    overlay.add_overlay(&child_widget);
+                    child_widget.show();
+                    overlay.show();
+                    Ok(())
+                })();
 
-                                vbox.remove(&main_widget);
-                                vbox.pack_start(&new_overlay, true, true, 0);
-                                new_overlay.add(&main_widget);
-                                new_overlay.show();
-                                new_overlay
-                            };
+                let _ = reparent_tx.send(result);
+            });
 
-                            if let Some(child_parent) = child_widget.parent() {
-                                if let Ok(vbox) = child_parent.dynamic_cast::<gtk::Box>() {
-                                    vbox.remove(&child_widget);
-                                }
-                            }
+            if let Err(error) = dispatch_result {
+                let _ = _webview.close();
+                return Err(format!("Failed to dispatch Linux GTK reparent: {error}"));
+            }
 
-                            let width = (bounds_clone.width / scale_factor) as i32;
-                            let height = (bounds_clone.height / scale_factor) as i32;
-                            let x_pos = (bounds_clone.x / scale_factor) as i32;
-                            let y_pos = (bounds_clone.y / scale_factor) as i32;
-
-                            child_widget.set_halign(gtk::Align::Start);
-                            child_widget.set_valign(gtk::Align::Start);
-                            child_widget.set_margin_start(x_pos);
-                            child_widget.set_margin_top(y_pos);
-                            child_widget.set_size_request(width, height);
-                            child_widget.show();
-
-                            overlay.add_overlay(&child_widget);
-                            overlay.show_all();
-                            Ok(())
-                        };
-
-                        if let Err(e) = handle_reparent() {
-                            log::error!("[BrowserTab] Linux GTK reparent failed: {}", e);
-                        } else {
-                            log::info!("[BrowserTab] Linux GTK reparent succeeded");
-                        }
-                    });
-                });
-            } else {
-                log::error!("[BrowserTab] Linux GTK reparent failed: Main webview not found");
+            match reparent_rx.await {
+                Ok(Ok(())) => {
+                    log::info!("[BrowserTab] Linux GTK reparent succeeded");
+                }
+                Ok(Err(error)) => {
+                    let _ = _webview.close();
+                    return Err(format!("Linux GTK reparent failed: {error}"));
+                }
+                Err(error) => {
+                    let _ = _webview.close();
+                    return Err(format!("Linux GTK reparent callback canceled: {error}"));
+                }
             }
         }
 
-        // Start background poller to sync URL and loading state from webview
+        // Start background poller only after native placement succeeds.
         self.start_url_poller(tab_id.clone());
 
         let info = BrowserTabInfo {
@@ -517,23 +505,19 @@ impl BrowserTabManager {
 
         #[cfg(target_os = "linux")]
         {
-            let window = self.get_window()?;
-            let scale_factor = window.scale_factor().unwrap_or(1.0);
-            let w = bounds.width / scale_factor;
-            let h = bounds.height / scale_factor;
-            let x = bounds.x / scale_factor;
-            let y = bounds.y / scale_factor;
-
-            log::info!("[BrowserTab] resize: scaled target bounds x={}, y={}, w={}, h={}, scale={}", x, y, w, h, scale_factor);
-
-            let _ = webview.with_webview(move |child_platform| {
-                use gtk::prelude::*;
-                let child_widget = child_platform.inner();
-                child_widget.set_margin_start(x as i32);
-                child_widget.set_margin_top(y as i32);
-                child_widget.set_size_request(w as i32, h as i32);
-                child_widget.queue_resize();
-            });
+            webview
+                .with_webview(move |child_platform| {
+                    use gtk::prelude::*;
+                    let child_widget = child_platform.inner();
+                    child_widget.set_margin_start(bounds.x.round() as i32);
+                    child_widget.set_margin_top(bounds.y.round() as i32);
+                    child_widget.set_size_request(
+                        bounds.width.round() as i32,
+                        bounds.height.round() as i32,
+                    );
+                    child_widget.queue_resize();
+                })
+                .map_err(|e| format!("Resize dispatch failed: {e}"))?;
             Ok(())
         }
 

--- a/src-tauri/src/browser_tab_manager.rs
+++ b/src-tauri/src/browser_tab_manager.rs
@@ -2,6 +2,17 @@ use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 use tauri::{AppHandle, Manager};
 
+struct SendWrapper<T>(pub T);
+unsafe impl<T> Send for SendWrapper<T> {}
+unsafe impl<T> Sync for SendWrapper<T> {}
+
+impl<T> SendWrapper<T> {
+    pub fn take(self) -> T {
+        self.0
+    }
+}
+
+
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct BrowserTabInfo {
@@ -189,13 +200,102 @@ impl BrowserTabManager {
             tauri::WebviewUrl::External(parsed_url),
         );
 
+        let scale_factor = window.scale_factor().unwrap_or(1.0);
+        log::info!("[BrowserTab] create original bounds: x={}, y={}, w={}, h={}, scale_factor={}", bounds.x, bounds.y, bounds.width, bounds.height, scale_factor);
+
+        #[cfg(target_os = "linux")]
+        let (x, y, w, h) = (
+            bounds.x / scale_factor,
+            bounds.y / scale_factor,
+            bounds.width / scale_factor,
+            bounds.height / scale_factor,
+        );
+
+        #[cfg(not(target_os = "linux"))]
+        let (x, y, w, h) = (bounds.x, bounds.y, bounds.width, bounds.height);
+
+        log::info!("[BrowserTab] create scaled bounds: x={}, y={}, w={}, h={}", x, y, w, h);
+
         let _webview = window
             .add_child(
                 builder,
-                tauri::LogicalPosition::new(bounds.x, bounds.y),
-                tauri::LogicalSize::new(bounds.width, bounds.height),
+                tauri::LogicalPosition::new(x, y),
+                tauri::LogicalSize::new(w, h),
             )
             .map_err(|e| format!("Failed to create webview: {}", e))?;
+
+        #[cfg(target_os = "linux")]
+        {
+            let child_webview = _webview.clone();
+            if let Ok(main_webview) = window.get_webview("main").ok_or_else(|| "Main webview not found".to_string()) {
+                let bounds_clone = bounds.clone();
+                let _ = main_webview.with_webview(move |main_platform| {
+                    let main_widget = main_platform.inner().clone();
+                    let main_widget_wrapped = SendWrapper(main_widget);
+                    let _ = child_webview.with_webview(move |child_platform| {
+                        let child_widget = child_platform.inner().clone();
+                        let main_widget = main_widget_wrapped.take();
+                        let handle_reparent = || -> Result<(), String> {
+                            use gtk::prelude::*;
+
+                            let parent = main_widget.parent()
+                                .ok_or_else(|| "Main webview has no parent".to_string())?;
+
+                            let overlay = if parent.type_().name() == "GtkOverlay" {
+                                parent.dynamic_cast::<gtk::Overlay>()
+                                    .map_err(|_| "Parent is not GtkOverlay".to_string())?
+                            } else {
+                                let vbox = parent.dynamic_cast::<gtk::Box>()
+                                    .map_err(|_| "Main webview parent is not GtkBox".to_string())?;
+
+                                let new_overlay = gtk::Overlay::new();
+                                new_overlay.set_hexpand(true);
+                                new_overlay.set_vexpand(true);
+
+                                main_widget.set_hexpand(true);
+                                main_widget.set_vexpand(true);
+
+                                vbox.remove(&main_widget);
+                                vbox.pack_start(&new_overlay, true, true, 0);
+                                new_overlay.add(&main_widget);
+                                new_overlay.show();
+                                new_overlay
+                            };
+
+                            if let Some(child_parent) = child_widget.parent() {
+                                if let Ok(vbox) = child_parent.dynamic_cast::<gtk::Box>() {
+                                    vbox.remove(&child_widget);
+                                }
+                            }
+
+                            let width = (bounds_clone.width / scale_factor) as i32;
+                            let height = (bounds_clone.height / scale_factor) as i32;
+                            let x_pos = (bounds_clone.x / scale_factor) as i32;
+                            let y_pos = (bounds_clone.y / scale_factor) as i32;
+
+                            child_widget.set_halign(gtk::Align::Start);
+                            child_widget.set_valign(gtk::Align::Start);
+                            child_widget.set_margin_start(x_pos);
+                            child_widget.set_margin_top(y_pos);
+                            child_widget.set_size_request(width, height);
+                            child_widget.show();
+
+                            overlay.add_overlay(&child_widget);
+                            overlay.show_all();
+                            Ok(())
+                        };
+
+                        if let Err(e) = handle_reparent() {
+                            log::error!("[BrowserTab] Linux GTK reparent failed: {}", e);
+                        } else {
+                            log::info!("[BrowserTab] Linux GTK reparent succeeded");
+                        }
+                    });
+                });
+            } else {
+                log::error!("[BrowserTab] Linux GTK reparent failed: Main webview not found");
+            }
+        }
 
         // Start background poller to sync URL and loading state from webview
         self.start_url_poller(tab_id.clone());
@@ -414,17 +514,53 @@ impl BrowserTabManager {
 
     pub fn resize(&self, tab_id: &str, bounds: BrowserBounds) -> Result<(), String> {
         let webview = self.get_webview(tab_id)?;
-        webview
-            .set_bounds(tauri::Rect {
-                position: tauri::LogicalPosition::new(bounds.x, bounds.y).into(),
-                size: tauri::LogicalSize::new(bounds.width, bounds.height).into(),
-            })
-            .map_err(|e| format!("Resize failed: {}", e))?;
-        Ok(())
+
+        #[cfg(target_os = "linux")]
+        {
+            let window = self.get_window()?;
+            let scale_factor = window.scale_factor().unwrap_or(1.0);
+            let w = bounds.width / scale_factor;
+            let h = bounds.height / scale_factor;
+            let x = bounds.x / scale_factor;
+            let y = bounds.y / scale_factor;
+
+            log::info!("[BrowserTab] resize: scaled target bounds x={}, y={}, w={}, h={}, scale={}", x, y, w, h, scale_factor);
+
+            let _ = webview.with_webview(move |child_platform| {
+                use gtk::prelude::*;
+                let child_widget = child_platform.inner();
+                child_widget.set_margin_start(x as i32);
+                child_widget.set_margin_top(y as i32);
+                child_widget.set_size_request(w as i32, h as i32);
+                child_widget.queue_resize();
+            });
+            Ok(())
+        }
+
+        #[cfg(not(target_os = "linux"))]
+        {
+            webview
+                .set_bounds(tauri::Rect {
+                    position: tauri::LogicalPosition::new(bounds.x, bounds.y).into(),
+                    size: tauri::LogicalSize::new(bounds.width, bounds.height).into(),
+                })
+                .map_err(|e| format!("Resize failed: {}", e))?;
+            Ok(())
+        }
     }
 
     pub fn show(&self, tab_id: &str) -> Result<(), String> {
         let webview = self.get_webview(tab_id)?;
+
+        #[cfg(target_os = "linux")]
+        {
+            let _ = webview.with_webview(move |child_platform| {
+                use gtk::prelude::*;
+                let child_widget = child_platform.inner();
+                child_widget.show();
+            });
+        }
+
         webview
             .show()
             .map_err(|e| format!("Show failed: {}", e))?;
@@ -433,6 +569,16 @@ impl BrowserTabManager {
 
     pub fn hide(&self, tab_id: &str) -> Result<(), String> {
         let webview = self.get_webview(tab_id)?;
+
+        #[cfg(target_os = "linux")]
+        {
+            let _ = webview.with_webview(move |child_platform| {
+                use gtk::prelude::*;
+                let child_widget = child_platform.inner();
+                child_widget.hide();
+            });
+        }
+
         webview
             .hide()
             .map_err(|e| format!("Hide failed: {}", e))?;
@@ -445,6 +591,21 @@ impl BrowserTabManager {
     }
 
     pub fn destroy(&self, tab_id: &str) -> Result<(), String> {
+        #[cfg(target_os = "linux")]
+        {
+            if let Ok(webview) = self.get_webview(tab_id) {
+                let _ = webview.with_webview(move |child_platform| {
+                    use gtk::prelude::*;
+                    let child_widget = child_platform.inner();
+                    if let Some(parent) = child_widget.parent() {
+                        if let Ok(overlay) = parent.dynamic_cast::<gtk::Overlay>() {
+                            overlay.remove(&child_widget);
+                        }
+                    }
+                });
+            }
+        }
+
         if let Ok(webview) = self.get_webview(tab_id) {
             let _ = webview.close();
         }
@@ -493,6 +654,24 @@ impl BrowserTabManager {
     pub fn destroy_all(&self) {
         let mut tabs = self.tabs.lock().unwrap_or_else(|e| e.into_inner());
         let ids: Vec<String> = tabs.keys().cloned().collect();
+
+        #[cfg(target_os = "linux")]
+        {
+            for id in &ids {
+                if let Ok(webview) = self.get_webview(id) {
+                    let _ = webview.with_webview(move |child_platform| {
+                        use gtk::prelude::*;
+                        let child_widget = child_platform.inner();
+                        if let Some(parent) = child_widget.parent() {
+                            if let Ok(overlay) = parent.dynamic_cast::<gtk::Overlay>() {
+                                overlay.remove(&child_widget);
+                            }
+                        }
+                    });
+                }
+            }
+        }
+
         for id in ids {
             if let Ok(webview) = self.get_webview(&id) {
                 let _ = webview.close();

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -788,7 +788,7 @@ pub async fn browser_tab_create(
     bounds: BrowserBounds,
     browser_manager: State<'_, Arc<BrowserTabManager>>,
 ) -> Result<IpcResult<BrowserTabInfo>, String> {
-    match browser_manager.create(tab_id, url, bounds) {
+    match browser_manager.create(tab_id, url, bounds).await {
         Ok(info) => Ok(IpcResult::success(info)),
         Err(e) => Ok(IpcResult::error(e, "BROWSER_TAB_CREATE_FAILED")),
     }

--- a/src/renderer/hooks/use-browser-webview.test.tsx
+++ b/src/renderer/hooks/use-browser-webview.test.tsx
@@ -1,0 +1,102 @@
+import { act, render, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  browserTabCreate,
+  browserTabDestroy,
+  browserTabHide,
+  browserTabResize,
+  browserTabShow
+} from '@/lib/browser-api'
+import { useBrowserSessionStore } from '@/stores/browser-session-store'
+import { useBrowserWebview } from './use-browser-webview'
+
+vi.mock('@/lib/browser-api', () => ({
+  browserTabCreate: vi.fn(),
+  browserTabDestroy: vi.fn(),
+  browserTabHide: vi.fn(),
+  browserTabNavigate: vi.fn(),
+  browserTabResize: vi.fn(),
+  browserTabShow: vi.fn(),
+  onBrowserTabLoaded: vi.fn(() => ({ unlisten: vi.fn() })),
+  onBrowserTabNavigated: vi.fn(() => ({ unlisten: vi.fn() }))
+}))
+
+let resizeCallback: ResizeObserverCallback | null = null
+
+class ResizeObserverMock {
+  constructor(callback: ResizeObserverCallback) {
+    resizeCallback = callback
+  }
+
+  observe(): void {}
+  disconnect(): void {}
+  unobserve(): void {}
+}
+
+function BrowserWebviewHarness(): JSX.Element {
+  const { containerRef } = useBrowserWebview('browser-1', true, 'https://example.com')
+  return <div ref={containerRef} />
+}
+
+describe('useBrowserWebview bounds updates', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    resizeCallback = null
+    vi.stubGlobal('ResizeObserver', ResizeObserverMock)
+    vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockReturnValue({
+      x: 120.5,
+      y: 48.25,
+      width: 640.75,
+      height: 360.5,
+      top: 48.25,
+      right: 761.25,
+      bottom: 408.75,
+      left: 120.5,
+      toJSON: () => ({})
+    })
+    vi.mocked(browserTabCreate).mockResolvedValue({
+      success: true,
+      data: { id: 'browser-1', url: 'https://example.com', title: '' }
+    })
+    vi.mocked(browserTabDestroy).mockResolvedValue({ success: true, data: undefined })
+    vi.mocked(browserTabResize).mockResolvedValue({ success: true, data: undefined })
+    vi.mocked(browserTabShow).mockResolvedValue({ success: true, data: undefined })
+    vi.mocked(browserTabHide).mockResolvedValue({ success: true, data: undefined })
+    useBrowserSessionStore.getState().createTab('browser-1', 'https://example.com')
+  })
+
+  afterEach(() => {
+    useBrowserSessionStore.getState().removeTab('browser-1')
+    vi.restoreAllMocks()
+    vi.unstubAllGlobals()
+  })
+
+  it('keeps DOM bounds in logical pixels without resize diagnostic logging', async () => {
+    const consoleLog = vi.spyOn(console, 'log').mockImplementation(() => {})
+    const view = render(<BrowserWebviewHarness />)
+
+    await waitFor(() => expect(browserTabCreate).toHaveBeenCalledTimes(1))
+    expect(browserTabCreate).toHaveBeenCalledWith('browser-1', 'https://example.com', {
+      x: 120.5,
+      y: 48.25,
+      width: 640.75,
+      height: 360.5
+    })
+
+    await act(async () => {
+      resizeCallback?.([], {} as ResizeObserver)
+      resizeCallback?.([], {} as ResizeObserver)
+    })
+
+    await waitFor(() => expect(browserTabResize).toHaveBeenCalledTimes(2))
+    expect(browserTabResize).toHaveBeenLastCalledWith('browser-1', {
+      x: 120.5,
+      y: 48.25,
+      width: 640.75,
+      height: 360.5
+    })
+    expect(consoleLog).not.toHaveBeenCalled()
+
+    view.unmount()
+  })
+})

--- a/src/renderer/hooks/use-browser-webview.ts
+++ b/src/renderer/hooks/use-browser-webview.ts
@@ -1,3 +1,4 @@
+import { invoke } from '@tauri-apps/api/core'
 import { useCallback, useEffect, useRef } from 'react'
 import {
   browserTabCreate,
@@ -54,7 +55,29 @@ export function useBrowserWebview(browserTabId: string, isVisible: boolean, url:
 
   const updateBounds = useCallback(() => {
     const el = containerRef.current
-    if (!el || !createdRef.current) return
+    if (!el) return
+
+    const ancestors = []
+    let current: HTMLElement | null = el
+    for (let i = 0; i < 9; i++) {
+      if (!current) break
+      ancestors.push({
+        level: i,
+        tagName: current.tagName,
+        className: current.className,
+        clientHeight: current.clientHeight,
+        rectHeight: current.getBoundingClientRect().height
+      })
+      current = current.parentElement
+    }
+
+    console.log('[BrowserWebview] DOM heights debug:', ancestors)
+    invoke('log_frontend_error', {
+      level: 'warn',
+      message: `[BrowserWebview] DOM heights debug: ${JSON.stringify(ancestors)}`
+    }).catch(console.error)
+
+    if (!createdRef.current) return
     const bounds = getElementBounds(el)
     browserTabResize(browserTabId, bounds)
       .then((result) => {

--- a/src/renderer/hooks/use-browser-webview.ts
+++ b/src/renderer/hooks/use-browser-webview.ts
@@ -1,4 +1,3 @@
-import { invoke } from '@tauri-apps/api/core'
 import { useCallback, useEffect, useRef } from 'react'
 import {
   browserTabCreate,
@@ -55,29 +54,7 @@ export function useBrowserWebview(browserTabId: string, isVisible: boolean, url:
 
   const updateBounds = useCallback(() => {
     const el = containerRef.current
-    if (!el) return
-
-    const ancestors = []
-    let current: HTMLElement | null = el
-    for (let i = 0; i < 9; i++) {
-      if (!current) break
-      ancestors.push({
-        level: i,
-        tagName: current.tagName,
-        className: current.className,
-        clientHeight: current.clientHeight,
-        rectHeight: current.getBoundingClientRect().height
-      })
-      current = current.parentElement
-    }
-
-    console.log('[BrowserWebview] DOM heights debug:', ancestors)
-    invoke('log_frontend_error', {
-      level: 'warn',
-      message: `[BrowserWebview] DOM heights debug: ${JSON.stringify(ancestors)}`
-    }).catch(console.error)
-
-    if (!createdRef.current) return
+    if (!el || !createdRef.current) return
     const bounds = getElementBounds(el)
     browserTabResize(browserTabId, bounds)
       .then((result) => {

--- a/src/renderer/layouts/WorkspaceLayout.test.tsx
+++ b/src/renderer/layouts/WorkspaceLayout.test.tsx
@@ -11,10 +11,10 @@ const { platformState } = vi.hoisted(() => ({
   platformState: { isMac: false }
 }))
 
-vi.mock('@/lib/tauri-runtime', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('@/lib/tauri-runtime')>()
-  return { ...actual, isTauriContext: () => true }
-})
+vi.mock('@/lib/tauri-runtime', () => ({
+  isTauriContext: () => true,
+  cleanupTauriListener: (unlisten: (() => void) | null | undefined) => unlisten?.()
+}))
 
 vi.mock('@/lib/platform', async () => {
   const actual = await vi.importActual<typeof import('@/lib/platform')>('@/lib/platform')


### PR DESCRIPTION
## Summary

- Fixes browser child webviews appearing below the browser tab on Linux by reparenting them into the main GTK overlay.
- Keeps renderer-provided bounds in CSS/logical pixels so HiDPI Linux layouts are not double-scaled.
- Removes the blanket unsafe `Send`/`Sync` wrapper around GTK handles.
- Waits for GTK placement to complete before registering the tab or starting its URL poller, and closes the child webview if placement fails.
- Removes repeated DOM-height diagnostics from resize handling.

## Related Issue

Closes #387

No duplicate pull request addressing this Linux GTK placement bug was found during the original contribution flow.

## Type of Change

- [ ] feat: new feature
- [x] fix: bug fix
- [ ] docs: documentation only
- [ ] style: formatting or non-functional styling changes
- [ ] refactor: internal cleanup with no behavior change
- [ ] perf: performance improvement
- [x] test: adds or updates tests
- [x] build: build or dependency changes
- [ ] ci: CI/CD workflow changes
- [ ] chore: maintenance or tooling
- [ ] revert: reverts a previous change

## What Changed

- Added Linux GTK overlay placement using only UI-thread widget access.
- Made `BrowserTabManager::create` asynchronous so GTK callback errors are returned through the existing `IpcResult` contract.
- Added cleanup for missing-main-webview, callback dispatch, callback cancellation, and GTK hierarchy failures.
- Removed Linux scale-factor division from browser creation and resize paths.
- Propagated Linux resize, show, and hide dispatch failures.
- Removed repeated renderer console/backend diagnostics and added regression coverage for logical bounds.
- Added the Linux-only GTK dependency required by the native placement implementation.

## How It Was Tested

- [x] `bun run ci` (Biome lint + format + imports, strict mode)
- [x] `bun run typecheck` (GitHub PR Validation: Lint, Typecheck & Test)
- [x] `bun run test` (GitHub PR Validation: Lint, Typecheck & Test)
- [x] `cargo clippy --all-targets -- -D warnings` (GitHub PR Validation: Rust Checks)
- [x] `cargo test` (GitHub PR Validation: Rust Checks)
- [ ] Manual verification completed
- [ ] Not applicable

Focused local validation completed:

- `npx vitest run src/renderer/hooks/use-browser-webview.test.tsx`
- `npx biome check src/renderer/hooks/use-browser-webview.ts src/renderer/hooks/use-browser-webview.test.tsx`
- `cargo check --manifest-path src-tauri/Cargo.toml --all-targets`

GitHub validation also passed the Windows Rust smoke check, standalone server build, web/Tauri frontend builds, CodeQL, dependency review, and secret scan.

## Screenshots or Recordings

Existing reproduction screenshots are available in #387. The automated Linux Rust/build gates pass; no Linux desktop runtime was available for a new recording.

## CI & Review Gate

- [x] All CI checks pass (PR Validation, Rust Checks, Build Verification, Security Scans)
- [x] Code review comments from CodeRabbit / Claude have been addressed in the pushed code
- [x] No unresolved review findings remain

## Checklist

- [x] My PR title follows the conventional commit format used by this repo
- [x] I linked the related issue or explained why none exists
- [x] I updated docs when needed (no user-facing documentation change required)
- [x] I added or updated tests when needed
- [x] I verified the change does not introduce unrelated modifications
- [x] I read AGENTS.md and followed the contributor guidelines
- [x] A human reviewed the complete diff before submission
