### PR TITLE
fix(acp): resolve high CPU usage and thread spin loops on Linux

### DIFF
--- a/src-tauri/.cargo/config.toml
+++ b/src-tauri/.cargo/config.toml
@@ -1,0 +1,2 @@
+[build]
+rustflags = ["--cfg", "async_process_force_signal_backend"]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -46,6 +46,9 @@ portable-pty = "0.9"
 anyhow = "1"
 tokio = { version = "1", features = ["full"] }
 parking_lot = "0.12"
+futures = "0.3"
+futures-concurrency = "7"
+async-process = "2"
 
 # ACP (Agent Client Protocol) — ADR-003 P0
 # NOTE: agent-client-protocol 0.12 ships its own `AcpAgent`/`Stdio` transport
@@ -109,6 +112,7 @@ keyring = { version = "3.6", features = ["apple-native"] }
 [target.'cfg(target_os = "linux")'.dependencies]
 keyring = { version = "3.6", features = ["sync-secret-service", "crypto-rust"] }
 
+
 [target.'cfg(windows)'.dependencies]
 winreg = "0.55"
 windows-sys = { version = "0.59", features = ["Win32_UI_WindowsAndMessaging", "Win32_Foundation"] }
@@ -134,3 +138,8 @@ winapi = { version = "0.3", features = [
 # Keep the `= "0.12"` requirement above; this only redirects where it resolves.
 [patch.crates-io]
 agent-client-protocol = { path = "vendor/agent-client-protocol" }
+
+
+
+
+

--- a/src-tauri/vendor/agent-client-protocol/src/acp_agent.rs
+++ b/src-tauri/vendor/agent-client-protocol/src/acp_agent.rs
@@ -279,14 +279,19 @@ impl<Counterpart: AcpAgentCounterpartRole> crate::ConnectTo<Counterpart> for Acp
             let mut stderr_lines = stderr_reader.lines();
             let mut collected = String::new();
             while let Some(line_result) = stderr_lines.next().await {
-                if let Ok(line) = line_result {
-                    if let Some(ref callback) = debug_callback {
-                        callback(&line, LineDirection::Stderr);
+                match line_result {
+                    Ok(line) => {
+                        if let Some(ref callback) = debug_callback {
+                            callback(&line, LineDirection::Stderr);
+                        }
+                        if !collected.is_empty() {
+                            collected.push('\n');
+                        }
+                        collected.push_str(&line);
                     }
-                    if !collected.is_empty() {
-                        collected.push('\n');
+                    Err(_) => {
+                        break;
                     }
-                    collected.push_str(&line);
                 }
             }
             drop(stderr_tx.send(collected));


### PR DESCRIPTION
Forces async-process to use the stable signal reaper backend on Linux avoiding the level-triggered epoll infinite loop in the pidfd wait backend, and adds a break inside acp_agent stderr loop on stream error states to prevent spin loops.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability for async process handling, reducing issues when connecting to background services.
  * Connection diagnostics now stop cleanly if error output can’t be read, helping avoid hangs or noisy failures.

* **Chores**
  * Updated build and dependency settings to support the new async process behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->