### PR TITLE
fix(git): include remote branches in status-bar branch picker search

### DIFF
--- a/src/renderer/components/GitBranchPicker.test.tsx
+++ b/src/renderer/components/GitBranchPicker.test.tsx
@@ -100,7 +100,7 @@ describe('GitBranchPicker', () => {
     expect(screen.queryByText('No branches yet.')).toBeNull()
   })
 
-  it('shows empty state when the repo has no local branches', async () => {
+  it('lists remote branches when the repo has no local branches', async () => {
     mockBranches.mockResolvedValue({
       success: true,
       data: [{ name: 'origin/main', isRemote: true, isCurrent: false, hasOtherWorktree: false }]
@@ -109,8 +109,9 @@ describe('GitBranchPicker', () => {
     render(<GitBranchPicker {...defaultProps} />)
     await openPicker()
 
-    expect(screen.getByText('No branches yet.')).toBeDefined()
-    expect(screen.queryByText('This folder is not a git repository.')).toBeNull()
+    expect(screen.getByText('origin/main')).toBeDefined()
+    expect(screen.getByText('remote')).toBeDefined()
+    expect(screen.queryByText('No branches yet.')).toBeNull()
   })
 
   it('shows search empty state when branches exist but none match', async () => {
@@ -131,6 +132,61 @@ describe('GitBranchPicker', () => {
 
     expect(screen.getByText('No branches match your search.')).toBeDefined()
     expect(screen.queryByText('No branches yet.')).toBeNull()
+  })
+
+  it('lists remote-only branches with a remote tag', async () => {
+    mockBranches.mockResolvedValue({
+      success: true,
+      data: [
+        { name: 'dev', isRemote: false, isCurrent: true, hasOtherWorktree: false },
+        {
+          name: 'origin/feat/git-history-graph',
+          isRemote: true,
+          isCurrent: false,
+          hasOtherWorktree: false
+        }
+      ]
+    })
+
+    render(<GitBranchPicker {...defaultProps} />)
+    await openPicker()
+
+    // Remote-only branch should appear in the list alongside local branches
+    await waitFor(() => {
+      expect(screen.getByText('origin/feat/git-history-graph')).toBeDefined()
+    })
+    expect(screen.getByText('remote')).toBeDefined()
+    expect(screen.queryByText('No branches yet.')).toBeNull()
+  })
+
+  it('checks out a remote branch with isRemote=true and strips prefix in toast', async () => {
+    mockBranches.mockResolvedValue({
+      success: true,
+      data: [
+        { name: 'dev', isRemote: false, isCurrent: true, hasOtherWorktree: false },
+        {
+          name: 'origin/feature',
+          isRemote: true,
+          isCurrent: false,
+          hasOtherWorktree: false
+        }
+      ]
+    })
+
+    mockCheckout.mockResolvedValue(undefined)
+
+    render(<GitBranchPicker {...defaultProps} />)
+    await openPicker()
+
+    await waitFor(() => {
+      expect(screen.getByText('origin/feature')).toBeDefined()
+    })
+
+    fireEvent.click(screen.getByText('origin/feature'))
+
+    await waitFor(() => {
+      expect(mockCheckout).toHaveBeenCalledWith('/repo', 'origin/feature', true)
+    })
   })
 
   it('ignores stale branch loads from a previous repo path', async () => {

--- a/src/renderer/components/GitBranchPicker.tsx
+++ b/src/renderer/components/GitBranchPicker.tsx
@@ -117,25 +117,40 @@ export function GitBranchPicker({
     }
   }, [open, loadBranches])
 
-  const localBranches = useMemo(() => branches.filter((branch) => !branch.isRemote), [branches])
+  // Local branch short names — used to suppress remote duplicates
+  const localBranchNames = useMemo(
+    () =>
+      new Set(branches.filter((b) => !b.isRemote).map((b) => b.name)),
+    [branches]
+  )
 
   const filteredBranches = useMemo(() => {
     const query = branchSearch.trim().toLowerCase()
-    return localBranches
-      .filter((branch) => !query || branch.name.toLowerCase().includes(query))
+    return branches
+      .filter((branch) => {
+        // Skip symbolic refs like origin/HEAD
+        if (branch.isRemote && branch.name.endsWith('/HEAD')) return false
+        // Skip remote branches that already have a local counterpart
+        if (branch.isRemote) {
+          const slash = branch.name.indexOf('/')
+          const shortName = slash >= 0 ? branch.name.slice(slash + 1) : branch.name
+          if (localBranchNames.has(shortName)) return false
+        }
+        return !query || branch.name.toLowerCase().includes(query)
+      })
       .sort((a, b) => {
         if (a.isCurrent) return -1
         if (b.isCurrent) return 1
         return a.name.localeCompare(b.name)
       })
-  }, [localBranches, branchSearch])
+  }, [branches, branchSearch, localBranchNames])
 
   const emptyListMessage = useMemo((): string | null => {
     if (loadError || branchesLoading) return null
-    if (localBranches.length === 0) return 'No branches yet.'
+    if (branches.length === 0) return 'No branches yet.'
     if (branchSearch.trim()) return 'No branches match your search.'
     return null
-  }, [branchSearch, branchesLoading, loadError, localBranches.length])
+  }, [branchSearch, branchesLoading, loadError, branches.length])
 
   const canCreateBranch = !branchesLoading && !loadError
 
@@ -287,6 +302,9 @@ export function GitBranchPicker({
                 <span className="truncate flex-1">{branch.name}</span>
                 {branch.isCurrent && (
                   <span className="text-[10px] text-muted-foreground">current</span>
+                )}
+                {branch.isRemote && (
+                  <span className="text-[10px] text-muted-foreground">remote</span>
                 )}
                 {branch.hasOtherWorktree && (
                   <span className="text-[10px] text-muted-foreground">worktree</span>

--- a/src/renderer/components/GitBranchPicker.tsx
+++ b/src/renderer/components/GitBranchPicker.tsx
@@ -117,17 +117,16 @@ export function GitBranchPicker({
     }
   }, [open, loadBranches])
 
-  // Local branch short names — used to suppress remote duplicates
+  // Local branch short names - used to suppress remote duplicates
   const localBranchNames = useMemo(
-    () =>
-      new Set(branches.filter((b) => !b.isRemote).map((b) => b.name)),
+    () => new Set(branches.filter((b) => !b.isRemote).map((b) => b.name)),
     [branches]
   )
 
-  const filteredBranches = useMemo(() => {
-    const query = branchSearch.trim().toLowerCase()
-    return branches
-      .filter((branch) => {
+  // Branches after structural filtering (symref removal, local-duplicate suppression)
+  const visibleBranches = useMemo(
+    () =>
+      branches.filter((branch) => {
         // Skip symbolic refs like origin/HEAD
         if (branch.isRemote && branch.name.endsWith('/HEAD')) return false
         // Skip remote branches that already have a local counterpart
@@ -136,21 +135,29 @@ export function GitBranchPicker({
           const shortName = slash >= 0 ? branch.name.slice(slash + 1) : branch.name
           if (localBranchNames.has(shortName)) return false
         }
-        return !query || branch.name.toLowerCase().includes(query)
-      })
+        return true
+      }),
+    [branches, localBranchNames]
+  )
+
+  const filteredBranches = useMemo(() => {
+    const query = branchSearch.trim().toLowerCase()
+    return visibleBranches
+      .filter((branch) => !query || branch.name.toLowerCase().includes(query))
       .sort((a, b) => {
         if (a.isCurrent) return -1
         if (b.isCurrent) return 1
         return a.name.localeCompare(b.name)
       })
-  }, [branches, branchSearch, localBranchNames])
+  }, [visibleBranches, branchSearch])
 
   const emptyListMessage = useMemo((): string | null => {
     if (loadError || branchesLoading) return null
-    if (branches.length === 0) return 'No branches yet.'
-    if (branchSearch.trim()) return 'No branches match your search.'
+    if (visibleBranches.length === 0) return 'No branches yet.'
+    if (branchSearch.trim() && filteredBranches.length === 0)
+      return 'No branches match your search.'
     return null
-  }, [branchSearch, branchesLoading, loadError, branches.length])
+  }, [branchSearch, branchesLoading, loadError, visibleBranches.length, filteredBranches.length])
 
   const canCreateBranch = !branchesLoading && !loadError
 


### PR DESCRIPTION
## Summary

The status-bar git branch picker filtered out all remote branches before searching and displaying, making any branch that exists only on the remote invisible and unsearchable. This fixes the reported bug where searching for a known branch yields no match even though the branch exists in the repo.

## Related Issue

No related issue — reported directly by the user during investigation. Case file: `_bmad-output/implementation-artifacts/investigations/branch-picker-search-investigation.md`

## Type of Change

- [ ] feat: new feature
- [x] fix: bug fix
- [ ] docs: documentation only
- [ ] style: formatting or non-functional styling changes
- [ ] refactor: internal cleanup with no behavior change
- [ ] perf: performance improvement
- [ ] test: adds or updates tests
- [ ] build: build or dependency changes
- [ ] ci: CI/CD workflow changes
- [ ] chore: maintenance or tooling
- [ ] revert: reverts a previous change

## What Changed

- **Removed the local-only filter** — search and display now operate on all branches instead of `localBranches = branches.filter(!isRemote)`
- **Added `origin/HEAD` symref filtering** — symbolic refs are excluded from the list
- **Added local-duplicate suppression** — remote branches that already have a local counterpart (e.g. `origin/main` when local `main` exists) are hidden to avoid checkout conflicts
- **Added "remote" tag** to remote branch entries, mirroring the existing "current"/"worktree" tags
- **Split `filteredBranches` into `visibleBranches` (structural filter) + `filteredBranches` (search filter)** — `emptyListMessage` now keys off `visibleBranches.length` so it shows "No branches yet." when all entries are structurally filtered out
- **Updated tests**: rewrote the test that locked in the old bug, added tests for remote branch visibility and remote checkout behavior

## How It Was Tested

- [ ] `bun run ci` (Biome lint + format + imports, strict mode)
- [x] `bun run typecheck`
- [x] `bun run test`
- [ ] `cargo clippy --all-targets -- -D warnings` (in src-tauri)
- [ ] `cargo test` (in src-tauri)
- [x] Manual verification completed
- [ ] Not applicable

## Screenshots or Recordings

N/A — no visual layout change, only list contents change.

## CI & Review Gate

- [ ] All CI checks pass (PR Validation, Rust Checks, Build Verification, Security Scans)
- [ ] Code review comments from CodeRabbit / Claude have been addressed or resolved
- [ ] No unresolved review findings remain

## Checklist

- [x] My PR title follows the conventional commit format used by this repo
- [x] I linked the related issue or explained why none exists
- [x] I updated docs when needed
- [x] I added or updated tests when needed
- [x] I verified the change does not introduce unrelated modifications
- [x] I read AGENTS.md and followed the contributor guidelines
- [x] A human reviewed the complete diff before submission

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Branch picker now clearly labels remote branches with a **remote** badge.
  * Current branches remain prioritized at the top of the list, with results sorted for easier scanning.

* **Bug Fixes**
  * Remote-only branches now appear in the branch picker instead of showing an empty state.
  * Duplicate remote entries and placeholder `/HEAD` refs are hidden for a cleaner branch list.
  * Empty-state messaging is now more accurate for both “no branches yet” and search results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->