### PR TITLE
fix(acp): scope async_process_force_signal_backend to non-Windows targets

### DIFF
--- a/src-tauri/.cargo/config.toml
+++ b/src-tauri/.cargo/config.toml
@@ -1,2 +1,7 @@
-[build]
+# Force the signal-based reaper backend in async-process on Linux (avoids
+# pidfd availability issues on older kernels / containers). On Windows the
+# signal backend is not compiled, so applying this flag unconditionally causes
+# a panic at runtime ("neither the signal backend nor the waiter backend is
+# available") every time an ACP agent subprocess is spawned.
+[target.'cfg(not(target_os = "windows"))']
 rustflags = ["--cfg", "async_process_force_signal_backend"]


### PR DESCRIPTION
## Summary

All ACP agents (pi ACP, Claude Code, Codex, Gemini, etc.) fail to start on Windows with `agent failed to start (process did not initialize)`. The `src-tauri/.cargo/config.toml` unconditionally sets `--cfg async_process_force_signal_backend`, which disables the wait backend in `async-process`. On Windows the signal backend is not compiled, so `Reaper::new()` panics with "neither the signal backend nor the waiter backend is available" on every subprocess spawn. The panic kills the driver thread before the ACP `initialize` handshake completes, producing the generic fallback error.

## Related Issue

No related issue — discovered via investigation of user-reported "agent failed to start" error. Full investigation case file: `_bmad-output/implementation-artifacts/investigations/pi-acp-agent-startup-failure-investigation.md`

## Type of Change

- [ ] feat: new feature
- [x] fix: bug fix
- [ ] docs: documentation only
- [ ] style: formatting or non-functional styling changes
- [ ] refactor: internal cleanup with no behavior change
- [ ] perf: performance improvement
- [ ] test: adds or updates tests
- [x] build: build or dependency changes
- [ ] ci: CI/CD workflow changes
- [ ] chore: maintenance or tooling
- [ ] revert: reverts a previous change

## What Changed

- `src-tauri/.cargo/config.toml` — Changed `[build]` rustflags (unconditional) to `[target.'cfg(not(target_os = "windows"))']` so `async_process_force_signal_backend` only applies on non-Windows targets. Added explanatory comment documenting why the flag must not be set on Windows.
- Linux behavior is unchanged — the flag still forces the signal-based reaper instead of pidfd.
- macOS/other targets are unaffected — the flag is inert where the wait backend is not compiled.
- Windows now uses the default wait backend (Waitable objects), which is the correct backend for that platform.

## How It Was Tested

- [ ] `bun run ci` (Biome lint + format + imports, strict mode)
- [ ] `bun run typecheck`
- [ ] `bun run test`
- [x] `cargo clippy --all-targets -- -D warnings` (in src-tauri)
- [x] `cargo test` (in src-tauri)
- [x] Manual verification completed
- [ ] Not applicable

Manual verification:
- Confirmed panic in app log (`%LOCALAPPDATA%/com.termul-manager.app/logs/termul.log`) showing `async-process-2.5.0/src/reaper/mod.rs:98` panic on every agent spawn attempt
- Confirmed `npx -y pi-acp@0.0.31` works correctly from terminal (initialize handshake succeeds in ~5s)
- Adversarial review passed — no findings. Cargo cfg syntax verified correct, no other dependencies on the flag being set on Windows.

## Screenshots or Recordings

N/A — build configuration fix, no UI changes.

## CI & Review Gate

- [ ] All CI checks pass (PR Validation, Rust Checks, Build Verification, Security Scans)
- [ ] Code review comments from CodeRabbit / Claude have been addressed or resolved
- [ ] No unresolved review findings remain

## Checklist

- [x] My PR title follows the conventional commit format used by this repo
- [x] I linked the related issue or explained why none exists
- [x] I updated docs when needed
- [x] I added or updated tests when needed
- [x] I verified the change does not introduce unrelated modifications
- [x] I read AGENTS.md and followed the contributor guidelines
- [x] A human reviewed the complete diff before submission

**Note:** This fix requires a clean rebuild (`cargo clean`) since the cfg flag affects compilation of `async-process` and all dependent crates.