### PR TITLE
fix(acp): wire mount-time prewarm into desktop + cache PATH probe

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -5950,9 +5950,12 @@ version = "0.4.8"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
+ "async-process",
  "axum",
  "chrono",
  "flate2",
+ "futures",
+ "futures-concurrency",
  "futures-util",
  "getrandom 0.2.17",
  "keyring",

--- a/src-tauri/src/pty/env_refresh.rs
+++ b/src-tauri/src/pty/env_refresh.rs
@@ -5,6 +5,12 @@
 
 use std::collections::HashMap;
 use std::path::Path;
+use std::sync::OnceLock;
+
+/// Process-lifetime cache for the OS-probed PATH, so `fresh_path()` does not
+/// spawn a login shell (Unix) or read the registry (Windows) on every agent
+/// launch. Matches the `RG_PATH_CACHE` pattern in `commands.rs`.
+static FRESH_PATH_CACHE: OnceLock<Option<String>> = OnceLock::new();
 
 #[cfg(target_os = "windows")]
 fn has_path_key(env: &HashMap<String, String>) -> bool {
@@ -123,16 +129,23 @@ pub fn path_for_resolution() -> std::ffi::OsString {
 }
 
 /// Returns the refreshed PATH string for the current platform, if obtainable.
+/// Cached for the process lifetime via `FRESH_PATH_CACHE` so the probe runs at
+/// most once; subsequent calls return the cached result without spawning a
+/// login shell or reading the registry.
 pub fn fresh_path() -> Option<String> {
-    #[cfg(target_os = "windows")]
-    {
-        read_windows_registry_path()
-    }
+    FRESH_PATH_CACHE
+        .get_or_init(|| {
+            #[cfg(target_os = "windows")]
+            {
+                read_windows_registry_path()
+            }
 
-    #[cfg(not(target_os = "windows"))]
-    {
-        probe_unix_login_path()
-    }
+            #[cfg(not(target_os = "windows"))]
+            {
+                probe_unix_login_path()
+            }
+        })
+        .clone()
 }
 
 #[cfg(not(target_os = "windows"))]

--- a/src/renderer/TauriApp.tsx
+++ b/src/renderer/TauriApp.tsx
@@ -9,7 +9,10 @@ import { TooltipProvider } from '@/components/ui/tooltip'
 import { useWindowState } from '@/hooks/use-window-state'
 import { useUpdateToast } from './components/UpdateAvailableToast'
 import { WhatsNewModal } from './components/WhatsNewModal'
+import { useAcpAgents } from './hooks/use-acp-agents'
+import { useAcpHistory } from './hooks/use-acp-history'
 import { useAcpListeners } from './hooks/use-acp-listeners'
+import { useAcpMcp } from './hooks/use-acp-mcp'
 import { useAppSettingsLoader } from './hooks/use-app-settings'
 import { useAppliedColorThemeSync } from './hooks/use-color-theme'
 import { useContextBarSettings } from './hooks/use-context-bar-settings'
@@ -65,6 +68,9 @@ function AppEffects(): null {
   useTerminalExitNotification()
   useRemoteProjects()
   useAcpListeners()
+  useAcpAgents()
+  useAcpHistory()
+  useAcpMcp()
   usePreventFileDropNavigation()
 
   // Initialize desktop notification permissions once at app startup

--- a/src/renderer/hooks/use-acp-agents.test.ts
+++ b/src/renderer/hooks/use-acp-agents.test.ts
@@ -140,4 +140,50 @@ describe('useAcpAgents', () => {
     await waitFor(() => expect(mockLoadAgentConfigs).toHaveBeenCalled())
     expect(mockPrewarmAgent).not.toHaveBeenCalled()
   })
+
+  it('re-warms when activeProjectId changes after mount', async () => {
+    projectRef.current.activeProjectId = 'proj-1'
+    mockLoadAgentConfigs.mockImplementation(async () => {
+      stateRef.current.agentConfigs = [config('acp-registry:claude-acp')]
+    })
+    mockPersistRead.mockResolvedValue({ success: true, data: undefined })
+
+    const { rerender } = renderHook(() => useAcpAgents())
+
+    await waitFor(() => {
+      expect(mockPrewarmAgent).toHaveBeenCalledWith(expect.any(String), '/work/proj-1')
+    })
+
+    const firstCallCount = mockPrewarmAgent.mock.calls.length
+
+    // Simulate project switch
+    projectRef.current.activeProjectId = 'proj-2'
+    rerender()
+
+    await waitFor(() => {
+      expect(mockPrewarmAgent).toHaveBeenCalledWith(expect.any(String), '/work/proj-2')
+    })
+    expect(mockPrewarmAgent.mock.calls.length).toBeGreaterThan(firstCallCount)
+  })
+
+  it('does not prewarm on mount when activeProjectId is empty, then prewarms after it resolves', async () => {
+    projectRef.current.activeProjectId = ''
+    mockLoadAgentConfigs.mockImplementation(async () => {
+      stateRef.current.agentConfigs = [config('acp-registry:claude-acp')]
+    })
+    mockPersistRead.mockResolvedValue({ success: true, data: undefined })
+
+    const { rerender } = renderHook(() => useAcpAgents())
+
+    await waitFor(() => expect(mockLoadAgentConfigs).toHaveBeenCalled())
+    expect(mockPrewarmAgent).not.toHaveBeenCalled()
+
+    // Project resolves after mount
+    projectRef.current.activeProjectId = 'proj-late'
+    rerender()
+
+    await waitFor(() => {
+      expect(mockPrewarmAgent).toHaveBeenCalledWith(expect.any(String), '/work/proj-late')
+    })
+  })
 })

--- a/src/renderer/hooks/use-acp-agents.test.ts
+++ b/src/renderer/hooks/use-acp-agents.test.ts
@@ -186,4 +186,40 @@ describe('useAcpAgents', () => {
       expect(mockPrewarmAgent).toHaveBeenCalledWith(expect.any(String), '/work/proj-late')
     })
   })
+
+  it('cancels the stale prewarm run when the active project switches mid-flight', async () => {
+    projectRef.current.activeProjectId = 'proj-1'
+    mockLoadAgentConfigs.mockImplementation(async () => {
+      stateRef.current.agentConfigs = [config('acp-registry:claude-acp')]
+    })
+    // Block each in-flight run at persistenceApi.read (which runs AFTER the cwd
+    // snapshot) so a project switch can happen while run #1 is still in flight.
+    const persistResolvers: Array<() => void> = []
+    mockPersistRead.mockImplementation(
+      () =>
+        new Promise<{ success: boolean; data: unknown }>((resolve) => {
+          persistResolvers.push(() => resolve({ success: true, data: undefined }))
+        })
+    )
+
+    const { rerender } = renderHook(() => useAcpAgents())
+
+    // Run #1 (proj-1) is in flight, blocked on persistRead; cwd = '/work/proj-1'.
+    await waitFor(() => expect(persistResolvers).toHaveLength(1))
+
+    // Switch project + re-render: cleanup cancels run #1; run #2 (proj-2) starts.
+    projectRef.current.activeProjectId = 'proj-2'
+    rerender()
+    await waitFor(() => expect(persistResolvers).toHaveLength(2))
+
+    // Resume run #1 (cancelled) — it must NOT prewarm the stale proj-1 cwd.
+    persistResolvers[0]()
+    // Resume run #2 (the latest) — it prewarms the proj-2 cwd.
+    persistResolvers[1]()
+
+    await waitFor(() => {
+      expect(mockPrewarmAgent).toHaveBeenCalledWith(expect.any(String), '/work/proj-2')
+    })
+    expect(mockPrewarmAgent).not.toHaveBeenCalledWith(expect.any(String), '/work/proj-1')
+  })
 })

--- a/src/renderer/hooks/use-acp-agents.test.ts
+++ b/src/renderer/hooks/use-acp-agents.test.ts
@@ -222,4 +222,33 @@ describe('useAcpAgents', () => {
     })
     expect(mockPrewarmAgent).not.toHaveBeenCalledWith(expect.any(String), '/work/proj-1')
   })
+
+  it('cancels the in-flight prewarm when the component unmounts before persistRead resolves', async () => {
+    projectRef.current.activeProjectId = 'proj-1'
+    mockLoadAgentConfigs.mockImplementation(async () => {
+      stateRef.current.agentConfigs = [config('acp-registry:claude-acp')]
+    })
+    // Block the run at persistenceApi.read (which runs AFTER the cwd snapshot)
+    // so unmount can happen while the prewarm sequence is still in flight.
+    let resolvePersistRead!: () => void
+    mockPersistRead.mockImplementation(
+      () =>
+        new Promise<{ success: boolean; data: unknown }>((resolve) => {
+          resolvePersistRead = () => resolve({ success: true, data: undefined })
+        })
+    )
+
+    const { unmount } = renderHook(() => useAcpAgents())
+
+    // The run is in flight, blocked on persistRead; cwd = '/work/proj-1'.
+    await waitFor(() => expect(mockPersistRead).toHaveBeenCalledTimes(1))
+
+    // Unmount fires the effect cleanup -> cancelled = true.
+    unmount()
+
+    // Resume the in-flight continuation; it must no-op and never prewarm.
+    resolvePersistRead()
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    expect(mockPrewarmAgent).not.toHaveBeenCalled()
+  })
 })

--- a/src/renderer/hooks/use-acp-agents.ts
+++ b/src/renderer/hooks/use-acp-agents.ts
@@ -24,9 +24,12 @@ export function useAcpAgents(): void {
   const saveAgentConfig = useAcpStore((s) => s.saveAgentConfig)
   const activeProjectId = useProjectStore((s) => s.activeProjectId)
   useEffect(() => {
+    let cancelled = false
     void (async () => {
       await loadAgentConfigs()
+      if (cancelled) return
       const runtime = await acpApi.probeRuntime()
+      if (cancelled) return
       const { agentConfigs, prewarmAgent } = useAcpStore.getState()
       const cwd = activeProjectId ? getDefaultCwdForProject(activeProjectId) : ''
       if (cwd.trim().length === 0) return
@@ -37,6 +40,7 @@ export function useAcpAgents(): void {
         runtime
       )
       const persisted = await persistenceApi.read<unknown>(PersistenceKeys.lastSelectedAgent)
+      if (cancelled) return
       const saved = persisted.success ? (persisted.data as Partial<LastSelectedAgent> | null) : null
       const selected =
         saved?.mode === 'acp' && typeof saved.agentId === 'string'
@@ -48,8 +52,16 @@ export function useAcpAgents(): void {
       if (!entry?.config) return
       if (!agentConfigs.some((config) => config.id === entry.config?.id)) {
         await saveAgentConfig(entry.config)
+        if (cancelled) return
       }
+      // `activeProjectId` is a dep, so a project switch re-runs this effect
+      // and flips `cancelled` on the previous (in-flight) run via its cleanup.
+      // Guard every await boundary so only the latest run reaches prewarmAgent.
+      if (cancelled) return
       void prewarmAgent(entry.config.id, cwd)
     })()
+    return () => {
+      cancelled = true
+    }
   }, [loadAgentConfigs, saveAgentConfig, activeProjectId])
 }

--- a/src/renderer/hooks/use-acp-agents.ts
+++ b/src/renderer/hooks/use-acp-agents.ts
@@ -22,12 +22,12 @@ import { useProjectStore } from '@/stores/project-store'
 export function useAcpAgents(): void {
   const loadAgentConfigs = useAcpStore((s) => s.loadAgentConfigs)
   const saveAgentConfig = useAcpStore((s) => s.saveAgentConfig)
+  const activeProjectId = useProjectStore((s) => s.activeProjectId)
   useEffect(() => {
     void (async () => {
       await loadAgentConfigs()
       const runtime = await acpApi.probeRuntime()
       const { agentConfigs, prewarmAgent } = useAcpStore.getState()
-      const activeProjectId = useProjectStore.getState().activeProjectId
       const cwd = activeProjectId ? getDefaultCwdForProject(activeProjectId) : ''
       if (cwd.trim().length === 0) return
       const supportedAgents = buildSupportedAcpAgents(
@@ -51,5 +51,5 @@ export function useAcpAgents(): void {
       }
       void prewarmAgent(entry.config.id, cwd)
     })()
-  }, [loadAgentConfigs, saveAgentConfig])
+  }, [loadAgentConfigs, saveAgentConfig, activeProjectId])
 }


### PR DESCRIPTION
## Summary

On the desktop (Tauri) build, the first Ctrl+T → Agent Launcher after a cold app start takes ~1 minute to populate models/modes/commands. The ACP background-prewarm hooks (`useAcpAgents`, `useAcpHistory`, `useAcpMcp`) were mounted only in the web fallback (`App.tsx`) and never added to the canonical Tauri entry (`TauriApp.tsx`). Additionally, the per-spawn PATH probe (`env_refresh::fresh_path`) was uncached, adding a login-shell spawn (Unix) or registry read (Windows) to every cold agent launch.

This PR wires the three missing hooks into `TauriApp.tsx`, adds a reactive `activeProjectId` dependency so prewarm re-runs when the active project resolves or changes, and memoizes `fresh_path()` behind a process-lifetime `OnceLock` to eliminate the per-spawn PATH probe.

## Related Issue

Closes #405

## Type of Change

- [x] fix: bug fix
- [x] perf: performance improvement

## What Changed

- **`src/renderer/TauriApp.tsx`** — Mounted `useAcpAgents()`, `useAcpHistory()`, `useAcpMcp()` in `AppEffects` alongside the existing `useAcpListeners()`, matching the web fallback (`App.tsx`). This moves spawn + `initialize` off the Ctrl+T critical path so the agent is already `connected` before the user opens the launcher.

- **`src/renderer/hooks/use-acp-agents.ts`** — Changed `activeProjectId` from an imperative `useProjectStore.getState()` snapshot to a reactive `useProjectStore((s) => s.activeProjectId)` subscription, and added it to the effect dependency array. Prewarm now re-runs when the active project resolves (late load) or changes (project switch). The existing `inFlightWarms` dedupe and `agentReuseKey` per-project isolation are untouched — no double-spawn risk.

- **`src-tauri/src/pty/env_refresh.rs`** — Memoized `fresh_path()` behind a process-lifetime `static FRESH_PATH_CACHE: OnceLock<Option<String>>`, matching the existing `RG_PATH_CACHE` pattern in `commands.rs`. The probe (login shell on Unix, registry read on Windows) now runs at most once per process lifetime instead of on every agent spawn.

- **`src/renderer/hooks/use-acp-agents.test.ts`** — Added two tests: re-warm on project change, and no-prewarm-then-prewarm when `activeProjectId` resolves after mount.

## How It Was Tested

- [ ] `bun run ci` (Biome lint + format + imports, strict mode)
- [x] `bun run typecheck`
- [x] `bun run test`
- [x] `cargo test` (in src-tauri)
- [ ] `cargo clippy --all-targets -- -D warnings` (in src-tauri)
- [ ] Manual verification completed

**Test results:** 2025 passed, 42 skipped, 0 failed. Rust `env_refresh` tests: 5 passed, 0 failed.

## Screenshots or Recordings

N/A — performance fix, no UI changes.

## CI & Review Gate

- [ ] All CI checks pass (PR Validation, Rust Checks, Build Verification, Security Scans)
- [ ] Code review comments from CodeRabbit / Claude have been addressed or resolved
- [ ] No unresolved review findings remain

## Checklist

- [x] My PR title follows the conventional commit format used by this repo
- [x] I linked the related issue or explained why none exists
- [ ] I updated docs when needed
- [x] I added or updated tests when needed
- [x] I verified the change does not introduce unrelated modifications
- [x] I read AGENTS.md and followed the contributor guidelines
- [ ] A human reviewed the complete diff before submission

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * ACP functionality is now fully wired into app startup for agents, history, and MCP.
* **Bug Fixes**
  * Agent prewarming now correctly tracks active project changes, including late project availability and preventing stale in-flight prewarm runs.
  * PATH refresh is now cached per process to avoid repeated OS probing and improve responsiveness.
* **Tests**
  * Expanded hook coverage for project switching, late project resolution, and cancellation/concurrency behavior during prewarm.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->