### PR TITLE
fix(acp): persist session index across app restarts (#403)

### DIFF
--- a/src/renderer/components/chat/ChatHistoryTab.tsx
+++ b/src/renderer/components/chat/ChatHistoryTab.tsx
@@ -24,10 +24,15 @@ export function ChatHistoryTab(): React.JSX.Element {
   }, [activeProject])
 
   // Hard isolation (ADR 0002): show only sessions whose `(projectId, cwd)`
-  // match the active project + its current worktree/root.
+  // match the active project + its current worktree/root. Fall back to
+  // projectId-only matching when the exact cwd filter yields nothing — the
+  // worktree/cwd may have changed since the chat was created (e.g. after
+  // restart or worktree pruning).
   const scopedIndex = useMemo(() => {
     if (!activeProjectId || !activeCwd) return []
-    return sessionIndex.filter((e) => e.projectId === activeProjectId && e.cwd === activeCwd)
+    const exact = sessionIndex.filter((e) => e.projectId === activeProjectId && e.cwd === activeCwd)
+    if (exact.length > 0) return exact
+    return sessionIndex.filter((e) => e.projectId === activeProjectId)
   }, [sessionIndex, activeProjectId, activeCwd])
 
   const [query, setQuery] = useState('')

--- a/src/renderer/components/chat/ChatHistoryTab.tsx
+++ b/src/renderer/components/chat/ChatHistoryTab.tsx
@@ -1,7 +1,7 @@
 import { MessageSquare, Search, Trash2 } from 'lucide-react'
 import { useCallback, useMemo, useState } from 'react'
 import { toast } from 'sonner'
-import { groupSessionsByRecency } from '@/lib/acp-history-persistence'
+import { groupSessionsByRecency, scopeSessionIndex } from '@/lib/acp-history-persistence'
 import { cn } from '@/lib/utils'
 import { useAcpStore } from '@/stores/acp-store'
 import { getActiveWorktreeFromStore, useActiveProject } from '@/stores/project-store'
@@ -23,17 +23,15 @@ export function ChatHistoryTab(): React.JSX.Element {
     return wt?.path ?? activeProject.path ?? ''
   }, [activeProject])
 
-  // Hard isolation (ADR 0002): show only sessions whose `(projectId, cwd)`
-  // match the active project + its current worktree/root. Fall back to
-  // projectId-only matching when the exact cwd filter yields nothing — the
-  // worktree/cwd may have changed since the chat was created (e.g. after
-  // restart or worktree pruning).
-  const scopedIndex = useMemo(() => {
-    if (!activeProjectId || !activeCwd) return []
-    const exact = sessionIndex.filter((e) => e.projectId === activeProjectId && e.cwd === activeCwd)
-    if (exact.length > 0) return exact
-    return sessionIndex.filter((e) => e.projectId === activeProjectId)
-  }, [sessionIndex, activeProjectId, activeCwd])
+  // ADR 0002 scoping: show only sessions whose `(projectId, cwd)` match the
+  // active project + worktree/root, falling back to projectId-only matching
+  // when the exact cwd yields nothing (a chat whose cwd drifted since it was
+  // created is still reachable instead of silently hidden). See
+  // `scopeSessionIndex` for the contract.
+  const scopedIndex = useMemo(
+    () => scopeSessionIndex(sessionIndex, activeProjectId, activeCwd),
+    [sessionIndex, activeProjectId, activeCwd]
+  )
 
   const [query, setQuery] = useState('')
 

--- a/src/renderer/layouts/WorkspaceLayout.close-persistence.test.tsx
+++ b/src/renderer/layouts/WorkspaceLayout.close-persistence.test.tsx
@@ -20,6 +20,7 @@ const {
   mockKeyboardOnShortcut,
   mockUpdatePanelVisibility,
   mockWaitForPendingAppSettingsPersistence,
+  mockWaitForPendingSessionIndexWrite,
   mockToastError
 } = vi.hoisted(() => ({
   activeProject: {
@@ -81,6 +82,7 @@ const {
   mockKeyboardOnShortcut: vi.fn(() => vi.fn()),
   mockUpdatePanelVisibility: vi.fn(async () => undefined),
   mockWaitForPendingAppSettingsPersistence: vi.fn(async () => undefined),
+  mockWaitForPendingSessionIndexWrite: vi.fn(async () => undefined),
   mockToastError: vi.fn()
 }))
 
@@ -216,6 +218,10 @@ vi.mock('@/hooks/use-app-settings', () => ({
   useUpdateAppSettings: () => vi.fn(),
   useUpdatePanelVisibility: () => mockUpdatePanelVisibility,
   waitForPendingAppSettingsPersistence: mockWaitForPendingAppSettingsPersistence
+}))
+
+vi.mock('@/lib/acp-history-persistence', () => ({
+  waitForPendingSessionIndexWrite: mockWaitForPendingSessionIndexWrite
 }))
 
 vi.mock('@/hooks/use-file-watcher', () => ({
@@ -362,6 +368,7 @@ describe('WorkspaceLayout close persistence', () => {
     mockFlushPendingWrites.mockResolvedValue({ success: true, data: undefined })
     mockUpdatePanelVisibility.mockResolvedValue(undefined)
     mockWaitForPendingAppSettingsPersistence.mockResolvedValue(undefined)
+    mockWaitForPendingSessionIndexWrite.mockResolvedValue(undefined)
     mockCloseRequested.mockImplementation(() => vi.fn())
   })
 
@@ -376,6 +383,21 @@ describe('WorkspaceLayout close persistence', () => {
 
     await waitFor(() => {
       expect(mockFlushPendingWrites).toHaveBeenCalledTimes(1)
+      expect(mockRespondToClose).toHaveBeenCalledWith('close')
+    })
+  })
+
+  it('awaits pending session index write before closing', async () => {
+    renderLayout()
+
+    const closeHandler = (mockCloseRequested.mock.calls as unknown as Array<[() => void]>)[0]?.[0]
+
+    await act(async () => {
+      closeHandler?.()
+    })
+
+    await waitFor(() => {
+      expect(mockWaitForPendingSessionIndexWrite).toHaveBeenCalledTimes(1)
       expect(mockRespondToClose).toHaveBeenCalledWith('close')
     })
   })

--- a/src/renderer/layouts/WorkspaceLayout.tsx
+++ b/src/renderer/layouts/WorkspaceLayout.tsx
@@ -572,8 +572,8 @@ export default function WorkspaceLayout(): React.JSX.Element {
       }
 
       // Note: waitForPendingSessionIndexWrite swallows rejections internally
-      // (trackPendingIndexWrite wraps with .catch(() => undefined)), so this
-      // branch is effectively dead code — kept as a defensive guard in case the
+      // (trackPendingIndexWrite catches and logs them), so this branch is
+      // effectively dead code — kept as a defensive guard in case the
       // swallowing behavior changes.
       if (pendingSessionIndexResult.status === 'rejected') {
         console.error(

--- a/src/renderer/layouts/WorkspaceLayout.tsx
+++ b/src/renderer/layouts/WorkspaceLayout.tsx
@@ -40,6 +40,7 @@ import { useCreateSnapshot, useSnapshotLoader } from '@/hooks/use-snapshots'
 import { useSSHConnection } from '@/hooks/use-ssh-connection'
 import { useWorktreeShortcuts } from '@/hooks/use-worktree-shortcuts'
 import { saveTerminalLayout } from '@/hooks/useTerminalAutoSave'
+import { waitForPendingSessionIndexWrite } from '@/lib/acp-history-persistence'
 import { launchAgentInPane } from '@/lib/agent-launch'
 import { BUILT_IN_AGENTS } from '@/lib/agents/agent-registry'
 import { loadCustomAgents } from '@/lib/agents/custom-agents'
@@ -556,15 +557,28 @@ export default function WorkspaceLayout(): React.JSX.Element {
 
   const closeAppWithPersistenceFlush = useCallback(async () => {
     try {
-      const [pendingAppSettingsResult, pendingPersistenceResult] = await Promise.allSettled([
-        waitForPendingAppSettingsPersistence(),
-        persistenceApi.flushPendingWrites()
-      ])
+      const [pendingAppSettingsResult, pendingPersistenceResult, pendingSessionIndexResult] =
+        await Promise.allSettled([
+          waitForPendingAppSettingsPersistence(),
+          persistenceApi.flushPendingWrites(),
+          waitForPendingSessionIndexWrite()
+        ])
 
       if (pendingAppSettingsResult.status === 'rejected') {
         console.error(
           'Failed to wait for app settings persistence before close:',
           pendingAppSettingsResult.reason
+        )
+      }
+
+      // Note: waitForPendingSessionIndexWrite swallows rejections internally
+      // (trackPendingIndexWrite wraps with .catch(() => undefined)), so this
+      // branch is effectively dead code — kept as a defensive guard in case the
+      // swallowing behavior changes.
+      if (pendingSessionIndexResult.status === 'rejected') {
+        console.error(
+          'Failed to wait for session index persistence before close:',
+          pendingSessionIndexResult.reason
         )
       }
 

--- a/src/renderer/lib/acp-history-persistence.test.ts
+++ b/src/renderer/lib/acp-history-persistence.test.ts
@@ -12,6 +12,7 @@ vi.mock('@/lib/api', () => ({
 import { persistenceApi } from '@/lib/api'
 import type { ChatMessage } from '@/stores/acp-store'
 import {
+  _resetPendingIndexWriteTrackerForTesting,
   deriveTitle,
   groupSessionsByRecency,
   loadSessionIndex,
@@ -20,7 +21,9 @@ import {
   type SessionIndexEntry,
   saveSessionPayload,
   sessionPayloadKey,
-  WIPE_MIGRATION_KEY
+  trackPendingIndexWrite,
+  WIPE_MIGRATION_KEY,
+  waitForPendingSessionIndexWrite
 } from './acp-history-persistence'
 
 function msg(role: ChatMessage['role'], text: string): ChatMessage {
@@ -218,5 +221,45 @@ describe('runHistoryWipeMigration', () => {
     await expect(runHistoryWipeMigration()).rejects.toThrow('storage unavailable')
     expect(persistenceApi.delete).not.toHaveBeenCalled()
     expect(persistenceApi.write).not.toHaveBeenCalledWith(WIPE_MIGRATION_KEY, true)
+  })
+})
+
+describe('waitForPendingSessionIndexWrite', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    _resetPendingIndexWriteTrackerForTesting()
+  })
+
+  it('resolves immediately when no pending write has been tracked', async () => {
+    await expect(waitForPendingSessionIndexWrite()).resolves.toBeUndefined()
+  })
+
+  it('waits for an in-flight write to complete', async () => {
+    let resolveWrite: () => void
+    const pending = new Promise<void>((resolve) => {
+      resolveWrite = resolve
+    })
+    trackPendingIndexWrite(pending)
+
+    let waitDone = false
+    void waitForPendingSessionIndexWrite().then(() => {
+      waitDone = true
+    })
+
+    // Give microtasks a chance to flush
+    await Promise.resolve()
+    expect(waitDone).toBe(false)
+
+    resolveWrite!()
+    await waitForPendingSessionIndexWrite()
+    expect(waitDone).toBe(true)
+  })
+
+  it('handles write rejection without throwing', async () => {
+    const rejected = Promise.reject(new Error('write failed'))
+    trackPendingIndexWrite(rejected)
+
+    // The wait function should not throw — errors are swallowed by trackPendingIndexWrite
+    await expect(waitForPendingSessionIndexWrite()).resolves.toBeUndefined()
   })
 })

--- a/src/renderer/lib/acp-history-persistence.test.ts
+++ b/src/renderer/lib/acp-history-persistence.test.ts
@@ -20,6 +20,7 @@ import {
   SESSION_INDEX_KEY,
   type SessionIndexEntry,
   saveSessionPayload,
+  scopeSessionIndex,
   sessionPayloadKey,
   trackPendingIndexWrite,
   WIPE_MIGRATION_KEY,
@@ -224,11 +225,15 @@ describe('runHistoryWipeMigration', () => {
   })
 })
 
-describe('waitForPendingSessionIndexWrite', () => {
+describe('trackPendingIndexWrite / waitForPendingSessionIndexWrite', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     _resetPendingIndexWriteTrackerForTesting()
   })
+
+  // Drain the microtask queue (via one macrotask) so promise chains settle
+  // without relying on a fixed number of `await Promise.resolve()` ticks.
+  const flush = (): Promise<void> => new Promise((resolve) => setTimeout(resolve, 0))
 
   it('resolves immediately when no pending write has been tracked', async () => {
     await expect(waitForPendingSessionIndexWrite()).resolves.toBeUndefined()
@@ -239,15 +244,14 @@ describe('waitForPendingSessionIndexWrite', () => {
     const pending = new Promise<void>((resolve) => {
       resolveWrite = resolve
     })
-    trackPendingIndexWrite(pending)
+    void trackPendingIndexWrite(() => pending)
 
     let waitDone = false
     void waitForPendingSessionIndexWrite().then(() => {
       waitDone = true
     })
 
-    // Give microtasks a chance to flush
-    await Promise.resolve()
+    await flush()
     expect(waitDone).toBe(false)
 
     resolveWrite!()
@@ -255,11 +259,147 @@ describe('waitForPendingSessionIndexWrite', () => {
     expect(waitDone).toBe(true)
   })
 
-  it('handles write rejection without throwing', async () => {
-    const rejected = Promise.reject(new Error('write failed'))
-    trackPendingIndexWrite(rejected)
+  it('handles write rejection without throwing and logs the error', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+    void trackPendingIndexWrite(() => Promise.reject(new Error('write failed')))
 
-    // The wait function should not throw — errors are swallowed by trackPendingIndexWrite
+    // The wait function should not throw — errors are logged and swallowed by
+    // trackPendingIndexWrite so the chain never breaks.
     await expect(waitForPendingSessionIndexWrite()).resolves.toBeUndefined()
+    expect(consoleError).toHaveBeenCalledWith(
+      '[acp] failed to persist session index',
+      expect.any(Error)
+    )
+    consoleError.mockRestore()
+  })
+
+  it('serializes concurrent writes so a stale write cannot land last', async () => {
+    // Regression for the persist/delete race: the second factory must not be
+    // called until the first write finishes, so writes never overlap on the
+    // same Tauri Store key.
+    const order: string[] = []
+    let resolveFirst: () => void
+    const first = new Promise<void>((resolve) => {
+      resolveFirst = resolve
+    })
+    const firstWrite = vi.fn(() => {
+      order.push('first-start')
+      return first.then(() => {
+        order.push('first-end')
+      })
+    })
+    const secondWrite = vi.fn(() => {
+      order.push('second-start')
+      return Promise.resolve().then(() => {
+        order.push('second-end')
+      })
+    })
+
+    void trackPendingIndexWrite(firstWrite)
+    void trackPendingIndexWrite(secondWrite)
+
+    await flush()
+    expect(firstWrite).toHaveBeenCalledTimes(1)
+    expect(secondWrite).not.toHaveBeenCalled()
+    expect(order).toEqual(['first-start'])
+
+    resolveFirst!()
+    await waitForPendingSessionIndexWrite()
+
+    expect(secondWrite).toHaveBeenCalledTimes(1)
+    // First fully finished before second started → no overlap.
+    expect(order).toEqual(['first-start', 'first-end', 'second-start', 'second-end'])
+  })
+
+  it('awaits a write queued while the close path is draining', async () => {
+    // Regression for the shutdown race: a trackPendingIndexWrite() scheduled
+    // after waitForPendingSessionIndexWrite() started must still be awaited
+    // before the wait resolves — otherwise window.destroy() loses the last
+    // history update.
+    let resolveFirst: () => void
+    const first = new Promise<void>((resolve) => {
+      resolveFirst = resolve
+    })
+    let resolveSecond: () => void
+    const second = new Promise<void>((resolve) => {
+      resolveSecond = resolve
+    })
+
+    void trackPendingIndexWrite(() => first)
+
+    let waitDone = false
+    void waitForPendingSessionIndexWrite().then(() => {
+      waitDone = true
+    })
+    await flush()
+    expect(waitDone).toBe(false)
+
+    // While the first write is still in flight, queue a second write (a final
+    // persistSession firing during shutdown).
+    void trackPendingIndexWrite(() => second)
+
+    // Finishing the first write must NOT release the close wait — the queued
+    // second write is still pending.
+    resolveFirst!()
+    await flush()
+    expect(waitDone).toBe(false)
+
+    resolveSecond!()
+    await waitForPendingSessionIndexWrite()
+    expect(waitDone).toBe(true)
+  })
+})
+
+describe('scopeSessionIndex', () => {
+  function entry(id: string, projectId: string, cwd: string): SessionIndexEntry {
+    return {
+      id,
+      agentId: 'a',
+      title: id,
+      cwd,
+      projectId,
+      createdAt: 0,
+      lastActivityAt: 0,
+      messageCount: 0,
+      status: 'active'
+    }
+  }
+
+  it('returns [] when projectId or cwd is empty', () => {
+    const entries = [entry('s1', 'p1', '/a')]
+    expect(scopeSessionIndex(entries, '', '/a')).toEqual([])
+    expect(scopeSessionIndex(entries, 'p1', '')).toEqual([])
+    expect(scopeSessionIndex(entries, '', '')).toEqual([])
+  })
+
+  it('returns exact (projectId, cwd) matches', () => {
+    const entries = [entry('s1', 'p1', '/a'), entry('s2', 'p1', '/b'), entry('s3', 'p2', '/a')]
+    expect(scopeSessionIndex(entries, 'p1', '/a').map((e) => e.id)).toEqual(['s1'])
+  })
+
+  it('falls back to projectId-only matching when no exact cwd match exists', () => {
+    // Regression: a chat whose worktree/cwd drifted since it was created must
+    // still be reachable instead of silently hidden.
+    const entries = [
+      entry('s1', 'p1', '/old-cwd'),
+      entry('s2', 'p1', '/also-old'),
+      entry('s3', 'p2', '/a')
+    ]
+    expect(
+      scopeSessionIndex(entries, 'p1', '/a')
+        .map((e) => e.id)
+        .sort()
+    ).toEqual(['s1', 's2'])
+  })
+
+  it('does not fall back when exact matches exist', () => {
+    const entries = [entry('s1', 'p1', '/a'), entry('s2', 'p1', '/other')]
+    // Exact match present → only the exact entry is returned (no fallback).
+    expect(scopeSessionIndex(entries, 'p1', '/a').map((e) => e.id)).toEqual(['s1'])
+  })
+
+  it('returns [] when no entry matches projectId at all', () => {
+    const entries = [entry('s1', 'p2', '/a')]
+    expect(scopeSessionIndex(entries, 'p1', '/a')).toEqual([])
   })
 })

--- a/src/renderer/lib/acp-history-persistence.ts
+++ b/src/renderer/lib/acp-history-persistence.ts
@@ -25,9 +25,10 @@ export interface SessionIndexEntry {
   title: string
   cwd: string
   /**
-   * Owning `Project.id`. History is hard-isolated per project + worktree
-   * (`(projectId, cwd)`); sessions with any other value are invisible.
-   * See ADR 0002.
+   * Owning `Project.id`. The Chats sidebar scopes the index per project +
+   * worktree (`(projectId, cwd)`) and falls back to projectId-only matching
+   * when the exact cwd yields nothing, so a chat whose cwd drifted since it
+   * was created is still shown (see `scopeSessionIndex`). See ADR 0002.
    */
   projectId: string
   createdAt: number
@@ -85,6 +86,25 @@ export function groupSessionsByRecency(
     .filter((g) => g.entries.length > 0)
 }
 
+/**
+ * Scope the session index for the Chats sidebar (ADR 0002). Returns entries
+ * whose `(projectId, cwd)` match the active project + worktree/root. When the
+ * exact cwd filter yields nothing, falls back to projectId-only matching so a
+ * chat whose worktree/cwd drifted since it was created (e.g. after restart or
+ * worktree pruning) is still reachable instead of silently hidden. Returns `[]`
+ * when `projectId` or `cwd` is empty.
+ */
+export function scopeSessionIndex(
+  entries: SessionIndexEntry[],
+  projectId: string,
+  cwd: string
+): SessionIndexEntry[] {
+  if (!projectId || !cwd) return []
+  const exact = entries.filter((e) => e.projectId === projectId && e.cwd === cwd)
+  if (exact.length > 0) return exact
+  return entries.filter((e) => e.projectId === projectId)
+}
+
 export async function loadSessionIndex(): Promise<SessionIndexEntry[]> {
   const res = await persistenceApi.read<SessionIndexEntry[]>(SESSION_INDEX_KEY)
   if (res.success && Array.isArray(res.data)) return res.data
@@ -92,29 +112,71 @@ export async function loadSessionIndex(): Promise<SessionIndexEntry[]> {
 }
 
 /**
- * Track the latest session-index write so the close path can await it before
- * `window.destroy()`. Mirrors the `waitForPendingAppSettingsPersistence` pattern.
- * Errors are swallowed here because they are already logged at the call site
- * (`persistSession` in `acp-store.ts`).
+ * Track a session-index write so the close path can await it before
+ * `window.destroy()`. Mirrors the `waitForPendingAppSettingsPersistence`
+ * count/waiter pattern.
  *
- * Writes are **chained** rather than replaced: if `persistSession` is called
- * twice in rapid succession, the second write awaits the first before firing.
- * This prevents concurrent writes to the same Tauri Store key from racing and
- * potentially corrupting the session index file on disk.
+ * Takes a **factory** (not a pre-started promise): the write does not begin
+ * until prior tracked writes finish. This serializes concurrent persist/delete
+ * writes to the same Tauri Store key, so a stale write (e.g. a persist issued
+ * just before a delete) cannot land last and win the race.
+ *
+ * A write queued while the close path is draining is still awaited:
+ * `waitForPendingSessionIndexWrite` first awaits the chain, then — if the
+ * in-flight count is non-zero — waits on a waiter that resolves only when the
+ * count reaches zero, so the last history update is not lost to
+ * `window.destroy()`.
+ *
+ * Errors are logged and swallowed here so the chain never breaks and callers
+ * do not need their own `.catch`.
  */
 let pendingIndexWrite: Promise<void> = Promise.resolve()
+let pendingIndexWriteCount = 0
+let pendingIndexWriteWaiters: Array<() => void> = []
 
-export function trackPendingIndexWrite(promise: Promise<void>): void {
-  pendingIndexWrite = pendingIndexWrite.then(() => promise.catch(() => undefined))
+function notifyIndexWriteSettled(): void {
+  if (pendingIndexWriteCount === 0 && pendingIndexWriteWaiters.length > 0) {
+    const waiters = pendingIndexWriteWaiters
+    pendingIndexWriteWaiters = []
+    for (const resolve of waiters) resolve()
+  }
+}
+
+/**
+ * Serialize and track a session-index write. Returns a promise that resolves
+ * once this write (and all writes tracked before it) settle — callers that
+ * need to sequence a follow-up (e.g. deleting the payload after the index
+ * write) can `await` it.
+ */
+export function trackPendingIndexWrite(write: () => Promise<void>): Promise<void> {
+  pendingIndexWriteCount += 1
+  const chained = pendingIndexWrite.then(async () => {
+    try {
+      await write()
+    } catch (e) {
+      console.error('[acp] failed to persist session index', e)
+    } finally {
+      pendingIndexWriteCount = Math.max(0, pendingIndexWriteCount - 1)
+      notifyIndexWriteSettled()
+    }
+  })
+  pendingIndexWrite = chained
+  return chained
 }
 
 export async function waitForPendingSessionIndexWrite(): Promise<void> {
   await pendingIndexWrite
+  if (pendingIndexWriteCount === 0) return
+  await new Promise<void>((resolve) => {
+    pendingIndexWriteWaiters.push(resolve)
+  })
 }
 
 /** Test-only: reset the tracker between tests to avoid cross-test leakage. */
 export function _resetPendingIndexWriteTrackerForTesting(): void {
   pendingIndexWrite = Promise.resolve()
+  pendingIndexWriteCount = 0
+  pendingIndexWriteWaiters = []
 }
 
 export async function saveSessionIndex(entries: SessionIndexEntry[]): Promise<void> {

--- a/src/renderer/lib/acp-history-persistence.ts
+++ b/src/renderer/lib/acp-history-persistence.ts
@@ -91,6 +91,32 @@ export async function loadSessionIndex(): Promise<SessionIndexEntry[]> {
   return []
 }
 
+/**
+ * Track the latest session-index write so the close path can await it before
+ * `window.destroy()`. Mirrors the `waitForPendingAppSettingsPersistence` pattern.
+ * Errors are swallowed here because they are already logged at the call site
+ * (`persistSession` in `acp-store.ts`).
+ *
+ * Writes are **chained** rather than replaced: if `persistSession` is called
+ * twice in rapid succession, the second write awaits the first before firing.
+ * This prevents concurrent writes to the same Tauri Store key from racing and
+ * potentially corrupting the session index file on disk.
+ */
+let pendingIndexWrite: Promise<void> = Promise.resolve()
+
+export function trackPendingIndexWrite(promise: Promise<void>): void {
+  pendingIndexWrite = pendingIndexWrite.then(() => promise.catch(() => undefined))
+}
+
+export async function waitForPendingSessionIndexWrite(): Promise<void> {
+  await pendingIndexWrite
+}
+
+/** Test-only: reset the tracker between tests to avoid cross-test leakage. */
+export function _resetPendingIndexWriteTrackerForTesting(): void {
+  pendingIndexWrite = Promise.resolve()
+}
+
 export async function saveSessionIndex(entries: SessionIndexEntry[]): Promise<void> {
   const res = await persistenceApi.write(SESSION_INDEX_KEY, entries)
   if (!res.success) {

--- a/src/renderer/stores/acp-store.ts
+++ b/src/renderer/stores/acp-store.ts
@@ -97,7 +97,8 @@ export interface AcpSession {
   cwd: string
   /**
    * Owning `Project.id`. Persisted onto every history entry so the index can
-   * be filtered per-project + per-worktree (`(projectId, cwd)`). See ADR 0002.
+   * be scoped per-project + per-worktree (`(projectId, cwd)`, with a
+   * projectId-only fallback when the exact cwd yields nothing). See ADR 0002.
    */
   projectId: string
   status: SessionStatus
@@ -485,13 +486,15 @@ function persistSession(
   const nextIndex = [entry, ...state.sessionIndex.filter((e) => e.id !== sessionId)]
   setIndex(nextIndex)
   const payload: SessionPayload = { metadata: entry, messages }
-  const indexWrite = saveSessionIndexToDisk(nextIndex)
   // Track the index write so the close path (closeAppWithPersistenceFlush)
-  // can await it before window.destroy(). The payload write below uses
-  // writeDebounced() and is covered by flushPendingWrites() — the index write
-  // uses write() (non-debounced) and is NOT covered, hence the explicit tracking.
-  trackPendingIndexWrite(indexWrite)
-  void indexWrite.catch((e) => console.error('[acp] failed to persist session index', e))
+  // can await it before window.destroy(). trackPendingIndexWrite takes a
+  // factory so the write does not start until prior tracked writes finish —
+  // this serializes overlapping persist/delete writes to the same Tauri Store
+  // key and prevents a stale write from landing last. Errors are logged inside
+  // the tracker. The payload write below uses writeDebounced() and is covered
+  // by flushPendingWrites(); the index write uses write() (non-debounced) and
+  // is NOT covered, hence the explicit tracking.
+  void trackPendingIndexWrite(() => saveSessionIndexToDisk(nextIndex))
   void saveSessionPayload(sessionId, payload).catch((e) =>
     console.error('[acp] failed to persist session payload', e)
   )
@@ -1174,9 +1177,11 @@ export const useAcpStore = create<AcpState>((set, get) => ({
     // Reclaim any app-owned temp files staged for this session.
     void deleteSessionTempFiles(id)
     try {
-      const indexWrite = saveSessionIndexToDisk(next)
-      trackPendingIndexWrite(indexWrite)
-      await indexWrite
+      // Await the tracked index write (serialized with other index writes) so
+      // the index reflects the deletion before the payload is removed. The
+      // tracker swallows/logs index-write errors, so this await resolves even
+      // on failure; deleteSessionPayload failures are caught below.
+      await trackPendingIndexWrite(() => saveSessionIndexToDisk(next))
       await deleteSessionPayload(id)
     } catch (e) {
       console.error('[acp] failed to delete session history', e)

--- a/src/renderer/stores/acp-store.ts
+++ b/src/renderer/stores/acp-store.ts
@@ -60,7 +60,8 @@ import {
   type SessionIndexEntry,
   type SessionPayload,
   saveSessionIndex as saveSessionIndexToDisk,
-  saveSessionPayload
+  saveSessionPayload,
+  trackPendingIndexWrite
 } from '@/lib/acp-history-persistence'
 import {
   loadMcpServers as loadMcpServersFromDisk,
@@ -484,9 +485,13 @@ function persistSession(
   const nextIndex = [entry, ...state.sessionIndex.filter((e) => e.id !== sessionId)]
   setIndex(nextIndex)
   const payload: SessionPayload = { metadata: entry, messages }
-  void saveSessionIndexToDisk(nextIndex).catch((e) =>
-    console.error('[acp] failed to persist session index', e)
-  )
+  const indexWrite = saveSessionIndexToDisk(nextIndex)
+  // Track the index write so the close path (closeAppWithPersistenceFlush)
+  // can await it before window.destroy(). The payload write below uses
+  // writeDebounced() and is covered by flushPendingWrites() — the index write
+  // uses write() (non-debounced) and is NOT covered, hence the explicit tracking.
+  trackPendingIndexWrite(indexWrite)
+  void indexWrite.catch((e) => console.error('[acp] failed to persist session index', e))
   void saveSessionPayload(sessionId, payload).catch((e) =>
     console.error('[acp] failed to persist session payload', e)
   )
@@ -1169,7 +1174,9 @@ export const useAcpStore = create<AcpState>((set, get) => ({
     // Reclaim any app-owned temp files staged for this session.
     void deleteSessionTempFiles(id)
     try {
-      await saveSessionIndexToDisk(next)
+      const indexWrite = saveSessionIndexToDisk(next)
+      trackPendingIndexWrite(indexWrite)
+      await indexWrite
       await deleteSessionPayload(id)
     } catch (e) {
       console.error('[acp] failed to delete session history', e)


### PR DESCRIPTION
## Summary

ACP chat history was lost after app restart because the session index was written fire-and-forget (`void saveSessionIndexToDisk()`) and was not awaited by the close-path flush. If the app closed before `store.save()` completed, the index never reached disk. The Chats sidebar also hard-filtered by `(projectId, cwd)`, so if the active worktree/cwd changed on restart, sessions were silently hidden even when the data was on disk.

## Related Issue

Closes #403

## Type of Change

- [x] fix: bug fix

## What Changed

**Persistence tracking (`acp-history-persistence.ts`)**
- Added `trackPendingIndexWrite(write)` taking a **factory** so the write does not start until prior tracked writes finish — this serializes concurrent persist/delete writes to the same Tauri Store key and prevents a stale write from landing last.
- Added `waitForPendingSessionIndexWrite()` using a **count/waiter** pattern (mirrors `waitForPendingAppSettingsPersistence`): it awaits the chain, then waits on a waiter if any write is still in-flight, so a write queued during the close-path drain is not lost to `window.destroy()`.
- Added `scopeSessionIndex(entries, projectId, cwd)` with the projectId-only fallback, and `_resetPendingIndexWriteTrackerForTesting()` for test isolation.

**Store integration (`acp-store.ts`)**
- `persistSession()` tracks its index write via `trackPendingIndexWrite(() => saveSessionIndexToDisk(nextIndex))`.
- `deleteHistorySession()` awaits the tracked write before deleting the payload.

**Close path (`WorkspaceLayout.tsx`)**
- `closeAppWithPersistenceFlush()` now awaits `waitForPendingSessionIndexWrite()` alongside `flushPendingWrites()` and `waitForPendingAppSettingsPersistence()` in `Promise.allSettled`.

**Chat history scoping (`ChatHistoryTab.tsx`)**
- `scopedIndex` now uses `scopeSessionIndex`, falling back to projectId-only matching when no exact `(projectId, cwd)` match exists, so a chat whose worktree/cwd drifted since it was created is still reachable.

**Tests (`acp-history-persistence.test.ts`)**
- Regression tests for: write serialization (no stale-write race), a write queued during the close-path drain, rejection handling, and the projectId-only `scopeSessionIndex` fallback path. Plus a close-path integration test verifying `waitForPendingSessionIndexWrite` is awaited before close.

## How It Was Tested

- [x] `bun run ci` (Biome lint + format + imports, strict mode)
- [x] `bun run typecheck`
- [x] `bun run test`
- [ ] `cargo clippy --all-targets -- -D warnings` (in src-tauri)
- [ ] `cargo test` (in src-tauri)
- [x] Manual verification completed
- [ ] Not applicable

## Root Cause

Investigation case file: `_bmad-output/implementation-artifacts/investigations/403-acp-history-not-persisted-investigation.md`

**Primary cause (Hypothesis 3 — Confirmed):** `persistSession()` fired `void saveSessionIndexToDisk(nextIndex)` fire-and-forget. The close path only called `flushPendingWrites()`, which flushes debounced writes (session payloads via `writeDebounced()`), NOT the non-debounced index write (via `write()`). If the app closed before the index write's `store.save()` completed, the index was lost.

**Secondary cause (Hypothesis 1 — Confirmed mechanism):** `ChatHistoryTab.tsx` filtered by `(projectId, cwd)`. If the worktree/cwd context changed on restart (e.g., worktree pruned by reconciliation), sessions were hidden.

**Refuted:** Wipe migration recurrence (Hypothesis 2) — the migration is correctly gated with fail-closed logic.

## Review

Reviewed by 3 adversarial reviewers (Blind Hunter, Edge Case Hunter, Acceptance Auditor). Review findings addressed: the write tracker now uses a factory + count/waiter pattern (serialization + drain-safe close), and the scoped-filter fallback is extracted into a tested `scopeSessionIndex` helper with accurate comments. Merged `dev` to resolve conflicts with #414 (untitled chat) and #407/#415 (session discovery).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved chat history scoping by prioritizing exact `(project, folder)` matches, then falling back to `(project)` when no exact folder matches exist.
  * Made app close more reliable by waiting for pending session-history index persistence as part of the shutdown flow.
  * Improved consistency of session-history index updates during save and delete operations by coordinating overlapping writes.
* **Tests**
  * Expanded coverage for pending session-index write tracking and close-time persistence behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
