### PR TITLE
feat(acp): name new chats "Untitled Chat N" and rename to the ACP session title on start

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -5950,9 +5950,12 @@ version = "0.4.8"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
+ "async-process",
  "axum",
  "chrono",
  "flate2",
+ "futures",
+ "futures-concurrency",
  "futures-util",
  "getrandom 0.2.17",
  "keyring",

--- a/src-tauri/src/acp/client.rs
+++ b/src-tauri/src/acp/client.rs
@@ -20,7 +20,7 @@ use tauri::AppHandle;
 use crate::acp::config::AgentId;
 use crate::acp::events::{
     self, ChunkRole, CommandsUpdateEvent, ConfigOptionsUpdateEvent, MessageChunkEvent,
-    ModeUpdateEvent, PlanUpdateEvent, ToolCallEvent, ToolCallUpdateEvent,
+    ModeUpdateEvent, PlanUpdateEvent, SessionInfoUpdateEvent, ToolCallEvent, ToolCallUpdateEvent,
 };
 
 /// Build the client capabilities advertised to the agent during `initialize`.
@@ -293,9 +293,34 @@ pub fn emit_session_update(app: &AppHandle, agent_id: &AgentId, notification: Se
                 config_options: update.config_options,
             },
         ),
-        // SessionInfoUpdate and any future (non_exhaustive) variants have no
-        // dedicated P0 event; ignore them — but log so a silently-dropped
-        // update can be diagnosed instead of vanishing.
+        SessionUpdate::SessionInfoUpdate(update) => {
+            // `title` is `MaybeUndefined<String>`: Undefined = not sent (skip),
+            // Null = explicitly cleared (emit None), Value = set (emit Some).
+            match update.title.as_opt_ref() {
+                None => {} // Undefined — no title field sent, skip
+                Some(None) => events::emit(
+                    app,
+                    events::EVENT_SESSION_INFO_UPDATE,
+                    SessionInfoUpdateEvent {
+                        agent_id: agent_id.clone(),
+                        session_id,
+                        title: None,
+                    },
+                ),
+                Some(Some(t)) => events::emit(
+                    app,
+                    events::EVENT_SESSION_INFO_UPDATE,
+                    SessionInfoUpdateEvent {
+                        agent_id: agent_id.clone(),
+                        session_id,
+                        title: Some(t.clone()),
+                    },
+                ),
+            }
+        }
+        // Any future (non_exhaustive) variants have no dedicated event;
+        // ignore them — but log so a silently-dropped update can be diagnosed
+        // instead of vanishing.
         ref other => {
             log::debug!(
                 "[acp] agent {agent_id} sent an unhandled session/update variant: {other:?}"

--- a/src-tauri/src/acp/events.rs
+++ b/src-tauri/src/acp/events.rs
@@ -45,6 +45,8 @@ pub const EVENT_AGENT_ERROR: &str = "acp:agent_error";
 pub const EVENT_SESSION_CLOSED: &str = "acp:session_closed";
 /// Event name: the agent process disconnected/exited.
 pub const EVENT_AGENT_DISCONNECTED: &str = "acp:agent_disconnected";
+/// Event name: the agent updated session metadata (e.g. title).
+pub const EVENT_SESSION_INFO_UPDATE: &str = "acp:session_info_update";
 
 /// Which side a streamed content chunk belongs to.
 #[derive(Debug, Clone, Copy, Serialize)]
@@ -196,6 +198,20 @@ pub struct SessionClosedEvent {
     pub session_id: SessionId,
 }
 
+/// `acp:session_info_update`
+///
+/// Emitted when the agent updates session metadata (e.g. an auto-generated
+/// title) via the ACP `session_info_update` notification. `title` is `None`
+/// when the agent explicitly cleared it (serialized as `"title": null` on the
+/// wire), and `Some(String)` when set.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SessionInfoUpdateEvent {
+    pub agent_id: AgentId,
+    pub session_id: SessionId,
+    pub title: Option<String>,
+}
+
 /// Emit a payload to the renderer, logging (but not propagating) any error.
 ///
 /// Emission failures are non-fatal: they only mean no renderer is listening, so
@@ -278,5 +294,30 @@ mod tests {
         };
         let value = serde_json::to_value(&event).unwrap();
         assert_eq!(value["stopReason"], "end_turn");
+    }
+
+    #[test]
+    fn session_info_update_serializes_camel_case() {
+        // With a title → serialized as `"title": "T"`
+        let event = SessionInfoUpdateEvent {
+            agent_id: AgentId("a".to_string()),
+            session_id: SessionId::new("s"),
+            title: Some("T".to_string()),
+        };
+        let value = serde_json::to_value(&event).unwrap();
+        assert_eq!(value["agentId"], "a");
+        assert_eq!(value["sessionId"], "s");
+        assert_eq!(value["title"], "T");
+
+        // Without a title → serialized as `"title": null` (agent explicitly cleared)
+        let event_no_title = SessionInfoUpdateEvent {
+            agent_id: AgentId("a".to_string()),
+            session_id: SessionId::new("s"),
+            title: None,
+        };
+        let value = serde_json::to_value(&event_no_title).unwrap();
+        assert_eq!(value["agentId"], "a");
+        assert_eq!(value["sessionId"], "s");
+        assert_eq!(value["title"], serde_json::Value::Null);
     }
 }

--- a/src/renderer/components/chat/AgentBadge.tsx
+++ b/src/renderer/components/chat/AgentBadge.tsx
@@ -1,8 +1,7 @@
-import { Bot } from 'lucide-react'
 import type { AgentId } from '@/lib/acp-api'
 import { cn } from '@/lib/utils'
 import { useAgentIdentity } from '@/stores/acp-store'
-import { templateIcon } from './agent-templates'
+import { AgentGlyph } from './AgentGlyph'
 
 interface AgentBadgeProps {
   agentId: AgentId
@@ -16,10 +15,10 @@ interface AgentBadgeProps {
 }
 
 /**
- * Resolves an ACP agent's real name (e.g. "Cursor") and template icon from the
- * configured-agent registry, rendering them together. Falls back to a generic
- * bot icon + provided fallback when the session has no matching live config
- * (e.g. opened from history).
+ * Resolves an ACP agent's real name (e.g. "Cursor") and bundled registry icon
+ * from the configured-agent registry, rendering them together. Falls back to a
+ * generic bot icon + provided fallback when the session has no matching live
+ * config (e.g. opened from history).
  */
 export function AgentBadge({
   agentId,
@@ -29,16 +28,11 @@ export function AgentBadge({
   className
 }: AgentBadgeProps): React.JSX.Element {
   const { name, templateId } = useAgentIdentity(agentId)
-  const Icon = templateIcon(templateId ?? undefined)
   const label = name ?? fallbackName ?? `Agent ${agentId.slice(0, 8)}`
 
   return (
     <span className={cn('inline-flex items-center gap-1.5', className)}>
-      {Icon ? (
-        <Icon width={iconSize} height={iconSize} className="shrink-0 text-foreground/80" />
-      ) : (
-        <Bot size={iconSize} className="shrink-0 text-foreground/80" />
-      )}
+      <AgentGlyph templateId={templateId} size={iconSize} />
       {showName && <span className="truncate">{label}</span>}
     </span>
   )

--- a/src/renderer/components/chat/AgentGlyph.tsx
+++ b/src/renderer/components/chat/AgentGlyph.tsx
@@ -1,0 +1,45 @@
+import { Bot } from 'lucide-react'
+import { useMemo } from 'react'
+import { findBundledIconByKey } from '@/lib/agents/agent-icon-catalog'
+import { sanitizeInlineAgentSvg } from '@/lib/agents/sanitize-agent-icon'
+import { cn } from '@/lib/utils'
+
+/**
+ * Renders an ACP agent's bundled registry icon (theme-adaptive inline SVG via
+ * `currentColor`) resolved by template id. Falls back to a generic bot glyph
+ * when the template has no bundled icon (e.g. a custom agent or unresolved id).
+ *
+ * Uses the same bundled icon catalog as the agent launcher so every configured
+ * registry agent renders its real CLI icon, not just a hardcoded subset.
+ */
+export function AgentGlyph({
+  templateId,
+  size = 14,
+  className
+}: {
+  templateId: string | null
+  size?: number
+  className?: string
+}): React.JSX.Element {
+  const normalized = useMemo(() => {
+    if (!templateId) return null
+    const svg = findBundledIconByKey(`acp:${templateId}`)?.svg
+    return svg ? sanitizeInlineAgentSvg(svg) : null
+  }, [templateId])
+
+  if (normalized) {
+    return (
+      <span
+        aria-hidden="true"
+        style={{ width: size, height: size }}
+        className={cn(
+          'inline-flex shrink-0 text-foreground/80 [&_svg]:h-full [&_svg]:w-full',
+          className
+        )}
+        // biome-ignore lint/security/noDangerouslySetInnerHtml: icon SVG is sanitized via sanitizeInlineAgentSvg (DOMPurify)
+        dangerouslySetInnerHTML={{ __html: normalized }}
+      />
+    )
+  }
+  return <Bot size={size} className={cn('shrink-0 text-foreground/80', className)} />
+}

--- a/src/renderer/components/chat/ChatHistoryTab.test.tsx
+++ b/src/renderer/components/chat/ChatHistoryTab.test.tsx
@@ -30,7 +30,7 @@ vi.mock('@/stores/acp-store', () => {
       openHistorySession: mockOpen,
       deleteHistorySession: mockDelete
     })
-  return { useAcpStore }
+  return { useAcpStore, useAgentTemplateId: () => null }
 })
 
 vi.mock('@/stores/workspace-store', () => ({

--- a/src/renderer/components/chat/ChatHistoryTab.tsx
+++ b/src/renderer/components/chat/ChatHistoryTab.tsx
@@ -1,4 +1,4 @@
-import { Bot, Search, Trash2 } from 'lucide-react'
+import { Search, Trash2 } from 'lucide-react'
 import { useCallback, useMemo, useState } from 'react'
 import { toast } from 'sonner'
 import { groupSessionsByRecency } from '@/lib/acp-history-persistence'
@@ -6,7 +6,7 @@ import { cn } from '@/lib/utils'
 import { useAcpStore, useAgentTemplateId } from '@/stores/acp-store'
 import { getActiveWorktreeFromStore, useActiveProject } from '@/stores/project-store'
 import { useWorkspaceStore } from '@/stores/workspace-store'
-import { templateIcon } from './agent-templates'
+import { AgentGlyph } from './AgentGlyph'
 
 /** Sidebar tab listing persisted chat sessions, grouped by recency with search. */
 export function ChatHistoryTab(): React.JSX.Element {
@@ -128,7 +128,7 @@ export function ChatHistoryTab(): React.JSX.Element {
   )
 }
 
-/** Resolve the agent's template icon for a history entry, falling back to Bot. */
+/** Resolve the agent's bundled registry icon for a history entry. */
 function ChatEntryIcon({
   agentId,
   agentConfigId
@@ -137,9 +137,5 @@ function ChatEntryIcon({
   agentConfigId?: string
 }): React.JSX.Element {
   const templateId = useAgentTemplateId(agentId, agentConfigId)
-  const Icon = templateIcon(templateId ?? undefined)
-  if (Icon) {
-    return <Icon width={12} height={12} className="shrink-0 text-muted-foreground" />
-  }
-  return <Bot size={12} className="shrink-0 text-muted-foreground" />
+  return <AgentGlyph templateId={templateId} size={12} className="text-muted-foreground" />
 }

--- a/src/renderer/components/chat/ChatHistoryTab.tsx
+++ b/src/renderer/components/chat/ChatHistoryTab.tsx
@@ -1,11 +1,12 @@
-import { MessageSquare, Search, Trash2 } from 'lucide-react'
+import { Bot, Search, Trash2 } from 'lucide-react'
 import { useCallback, useMemo, useState } from 'react'
 import { toast } from 'sonner'
 import { groupSessionsByRecency } from '@/lib/acp-history-persistence'
 import { cn } from '@/lib/utils'
-import { useAcpStore } from '@/stores/acp-store'
+import { useAcpStore, useAgentTemplateId } from '@/stores/acp-store'
 import { getActiveWorktreeFromStore, useActiveProject } from '@/stores/project-store'
 import { useWorkspaceStore } from '@/stores/workspace-store'
+import { templateIcon } from './agent-templates'
 
 /** Sidebar tab listing persisted chat sessions, grouped by recency with search. */
 export function ChatHistoryTab(): React.JSX.Element {
@@ -104,7 +105,7 @@ export function ChatHistoryTab(): React.JSX.Element {
                     onClick={() => void handleOpen(entry.id)}
                     className="flex min-w-0 flex-1 items-center gap-2 px-3 py-1.5 text-left text-xs"
                   >
-                    <MessageSquare size={12} className="shrink-0 text-muted-foreground" />
+                    <ChatEntryIcon agentId={entry.agentId} agentConfigId={entry.agentConfigId} />
                     <span className="truncate flex-1 text-sidebar-foreground">{entry.title}</span>
                     <span className="text-3xs text-muted-foreground">{entry.messageCount}</span>
                   </button>
@@ -125,4 +126,20 @@ export function ChatHistoryTab(): React.JSX.Element {
       </div>
     </div>
   )
+}
+
+/** Resolve the agent's template icon for a history entry, falling back to Bot. */
+function ChatEntryIcon({
+  agentId,
+  agentConfigId
+}: {
+  agentId: string
+  agentConfigId?: string
+}): React.JSX.Element {
+  const templateId = useAgentTemplateId(agentId, agentConfigId)
+  const Icon = templateIcon(templateId ?? undefined)
+  if (Icon) {
+    return <Icon width={12} height={12} className="shrink-0 text-muted-foreground" />
+  }
+  return <Bot size={12} className="shrink-0 text-muted-foreground" />
 }

--- a/src/renderer/components/workspace/WorkspaceTabBar.tsx
+++ b/src/renderer/components/workspace/WorkspaceTabBar.tsx
@@ -646,7 +646,7 @@ function AgentChatTabInline({
   const { name: agentName } = useAgentIdentity(session?.agentId ?? null)
   const connected = isAgentConnected(session, agentStatus)
   const isClosed = session?.status === 'closed'
-  const tabLabel = agentName ?? 'Agent Chat'
+  const tabLabel = session?.title ?? agentName ?? 'Agent Chat'
 
   return (
     <>
@@ -676,13 +676,19 @@ function AgentChatTabInline({
           <>
             <AgentBadge
               agentId={session.agentId}
+              showName={false}
               iconSize={12}
+              className="shrink-0"
+            />
+            <span
               className={cn(
                 'min-w-0 flex-1 truncate text-2xs font-medium',
                 isClosed && 'line-through opacity-60',
                 isActive ? 'text-foreground' : 'text-inherit'
               )}
-            />
+            >
+              {tabLabel}
+            </span>
             <AgentConnectionLamp connected={connected} />
           </>
         ) : (

--- a/src/renderer/components/workspace/WorkspaceTabBar.tsx
+++ b/src/renderer/components/workspace/WorkspaceTabBar.tsx
@@ -644,9 +644,15 @@ function AgentChatTabInline({
   const session = useAcpStore((s) => s.sessions[tab.sessionId])
   const agentStatus = useAcpStore((s) => (session ? s.agentStatus[session.agentId] : undefined))
   const { name: agentName } = useAgentIdentity(session?.agentId ?? null)
+  // The persisted index entry carries the effective title (agent-pushed title,
+  // first-message derivation, or "Untitled Chat N"). `session.title` stays null
+  // until an event sets it, so fall through to the index entry for the label.
+  const indexTitle = useAcpStore(
+    (s) => s.sessionIndex.find((e) => e.id === tab.sessionId)?.title ?? null
+  )
   const connected = isAgentConnected(session, agentStatus)
   const isClosed = session?.status === 'closed'
-  const tabLabel = session?.title ?? agentName ?? 'Agent Chat'
+  const tabLabel = session?.title ?? indexTitle ?? agentName ?? 'Agent Chat'
 
   return (
     <>

--- a/src/renderer/lib/acp-api.ts
+++ b/src/renderer/lib/acp-api.ts
@@ -308,6 +308,12 @@ export interface SessionClosedEvent {
   agentId: AgentId
   sessionId: SessionId
 }
+export interface SessionInfoUpdateEvent {
+  agentId: AgentId
+  sessionId: SessionId
+  /** Agent-provided title; `null` when explicitly cleared, `undefined` when absent. */
+  title?: string | null
+}
 
 export const ACP_EVENTS = {
   agentSpawned: 'acp:agent_spawned',
@@ -323,7 +329,8 @@ export const ACP_EVENTS = {
   promptComplete: 'acp:prompt_complete',
   agentError: 'acp:agent_error',
   agentDisconnected: 'acp:agent_disconnected',
-  sessionClosed: 'acp:session_closed'
+  sessionClosed: 'acp:session_closed',
+  sessionInfoUpdate: 'acp:session_info_update'
 } as const
 
 // --- Command wrappers ------------------------------------------------------

--- a/src/renderer/lib/acp-history-persistence.test.ts
+++ b/src/renderer/lib/acp-history-persistence.test.ts
@@ -37,8 +37,8 @@ describe('deriveTitle', () => {
     const long = 'x'.repeat(60)
     expect(deriveTitle([msg('user', long)], 'a1')).toBe(`${'x'.repeat(40)}…`)
   })
-  it('falls back to the agent id when no user message', () => {
-    expect(deriveTitle([msg('agent', 'hello')], 'agent-12345678')).toBe('Agent agent-12')
+  it('falls back to the provided title when no user message', () => {
+    expect(deriveTitle([msg('agent', 'hello')], 'Untitled Chat 1')).toBe('Untitled Chat 1')
   })
 })
 

--- a/src/renderer/lib/acp-history-persistence.ts
+++ b/src/renderer/lib/acp-history-persistence.ts
@@ -41,8 +41,8 @@ export interface SessionPayload {
   messages: ChatMessage[]
 }
 
-/** Derive a chat title from the first user message; fallback to the agent id. */
-export function deriveTitle(messages: ChatMessage[], agentId: string): string {
+/** Derive a chat title from the first user message; fallback to the provided title. */
+export function deriveTitle(messages: ChatMessage[], fallbackTitle: string): string {
   const firstUser = messages.find((m) => m.role === 'user')
   if (firstUser) {
     const text = firstUser.blocks
@@ -51,7 +51,7 @@ export function deriveTitle(messages: ChatMessage[], agentId: string): string {
       .trim()
     if (text.length > 0) return text.length > 40 ? `${text.slice(0, 40)}…` : text
   }
-  return `Agent ${agentId.slice(0, 8)}`
+  return fallbackTitle
 }
 
 export type RecencyGroup = 'Today' | 'Yesterday' | 'Earlier'

--- a/src/renderer/stores/acp-store.test.ts
+++ b/src/renderer/stores/acp-store.test.ts
@@ -503,6 +503,19 @@ describe('acp-store', () => {
     expect(useAcpStore.getState().sessions['unknown']).toBeUndefined()
   })
 
+  it('_onSessionInfoUpdate leaves the title untouched when the field is omitted', () => {
+    seedSession('s1', 'agent-1')
+    useAcpStore.setState((s) => ({
+      sessions: { ...s.sessions, s1: { ...s.sessions['s1'], title: 'Keep me' } }
+    }))
+    // title field absent => undefined => no change (must not clear to null)
+    useAcpStore.getState()._onSessionInfoUpdate({
+      agentId: 'agent-1',
+      sessionId: 's1'
+    })
+    expect(useAcpStore.getState().sessions['s1'].title).toBe('Keep me')
+  })
+
   it('respondPermission is re-entrancy safe (W3): second call is a no-op', async () => {
     seedSession('s1', 'agent-1')
     ;(invoke as ReturnType<typeof vi.fn>).mockResolvedValue(undefined)

--- a/src/renderer/stores/acp-store.test.ts
+++ b/src/renderer/stores/acp-store.test.ts
@@ -469,6 +469,40 @@ describe('acp-store', () => {
     expect(useAcpStore.getState().pendingPermissions['req-2']).toBeUndefined()
   })
 
+  it('_onSessionInfoUpdate sets the session title from the agent-provided title', () => {
+    seedSession('s1', 'agent-1')
+    useAcpStore.getState()._onSessionInfoUpdate({
+      agentId: 'agent-1',
+      sessionId: 's1',
+      title: 'Implement auth'
+    })
+    expect(useAcpStore.getState().sessions['s1'].title).toBe('Implement auth')
+  })
+
+  it('_onSessionInfoUpdate reverts title to null when agent clears it', () => {
+    seedSession('s1', 'agent-1')
+    // Set a title first
+    useAcpStore.setState((s) => ({
+      sessions: { ...s.sessions, s1: { ...s.sessions['s1'], title: 'Old title' } }
+    }))
+    useAcpStore.getState()._onSessionInfoUpdate({
+      agentId: 'agent-1',
+      sessionId: 's1',
+      title: null
+    })
+    expect(useAcpStore.getState().sessions['s1'].title).toBeNull()
+  })
+
+  it('_onSessionInfoUpdate is a no-op for unknown sessions', () => {
+    useAcpStore.setState(FRESH)
+    useAcpStore.getState()._onSessionInfoUpdate({
+      agentId: 'agent-1',
+      sessionId: 'unknown',
+      title: 'Whatever'
+    })
+    expect(useAcpStore.getState().sessions['unknown']).toBeUndefined()
+  })
+
   it('respondPermission is re-entrancy safe (W3): second call is a no-op', async () => {
     seedSession('s1', 'agent-1')
     ;(invoke as ReturnType<typeof vi.fn>).mockResolvedValue(undefined)

--- a/src/renderer/stores/acp-store.ts
+++ b/src/renderer/stores/acp-store.ts
@@ -44,6 +44,7 @@ import {
   type SessionConfigOption,
   type SessionCreatedEvent,
   type SessionId,
+  type SessionInfoUpdateEvent,
   type SessionMode,
   type SessionModelState,
   type SessionModeState,
@@ -244,6 +245,7 @@ interface AcpState {
   _onCommandsUpdate: (e: CommandsUpdateEvent) => void
   _onModeUpdate: (e: ModeUpdateEvent) => void
   _onConfigOptionsUpdate: (e: ConfigOptionsUpdateEvent) => void
+  _onSessionInfoUpdate: (e: SessionInfoUpdateEvent) => void
   _onPermissionRequest: (e: PermissionRequestEvent) => void
   _onPromptComplete: (e: PromptCompleteEvent) => void
   _onAgentError: (e: AgentErrorEvent) => void
@@ -265,6 +267,17 @@ let seqCounter = 0
 function nextSeq(): number {
   seqCounter += 1
   return seqCounter
+}
+
+/**
+ * Monotonic counter for "Untitled Chat N" placeholder titles. Resets on app
+ * restart; persisted sessions already have a derived title, so this only
+ * applies to freshly created sessions that haven't received a message yet.
+ */
+let untitledChatCounter = 0
+function nextUntitledTitle(): string {
+  untitledChatCounter += 1
+  return `Untitled Chat ${untitledChatCounter}`
 }
 
 /**
@@ -469,11 +482,16 @@ function persistSession(
     (k) => state.configToLiveAgent[k] === session.agentId
   )
   const agentConfigId = reuseKey ? configIdFromReuseKey(reuseKey) : undefined
+  const existingEntry = state.sessionIndex.find((e) => e.id === sessionId)
+  const fallbackTitle =
+    existingEntry?.title && !existingEntry.title.startsWith('Untitled Chat ')
+      ? existingEntry.title
+      : nextUntitledTitle()
   const entry: SessionIndexEntry = {
     id: sessionId,
     agentId: session.agentId,
     agentConfigId,
-    title: session.title ?? deriveTitle(messages, session.agentId),
+    title: session.title ?? deriveTitle(messages, fallbackTitle),
     cwd: session.cwd,
     projectId: session.projectId,
     createdAt: session.createdAt,
@@ -1442,6 +1460,21 @@ export const useAcpStore = create<AcpState>((set, get) => ({
       }
     }),
 
+  _onSessionInfoUpdate: (e) => {
+    set((s) => {
+      const session = s.sessions[e.sessionId]
+      if (!session) return {}
+      // `title` is `undefined` when absent (no change), `null` when the agent
+      // explicitly cleared it, or a string when set.
+      return {
+        sessions: { ...s.sessions, [e.sessionId]: { ...session, title: e.title ?? null } }
+      }
+    })
+    if (get().sessions[e.sessionId]) {
+      persistSession(get(), e.sessionId, (entries) => set({ sessionIndex: entries }))
+    }
+  },
+
   _onPermissionRequest: (e) =>
     set((s) => {
       // Keep an existing pending request for this id; never silently drop it.
@@ -1605,6 +1638,9 @@ export function initAcpEventListeners(): () => void {
     ),
     acpApi.onEvent<ConfigOptionsUpdateEvent>(ACP_EVENTS.configOptionsUpdate, (e) =>
       useAcpStore.getState()._onConfigOptionsUpdate(e)
+    ),
+    acpApi.onEvent<SessionInfoUpdateEvent>(ACP_EVENTS.sessionInfoUpdate, (e) =>
+      useAcpStore.getState()._onSessionInfoUpdate(e)
     ),
     acpApi.onEvent<PermissionRequestEvent>(ACP_EVENTS.permissionRequest, (e) =>
       useAcpStore.getState()._onPermissionRequest(e)

--- a/src/renderer/stores/acp-store.ts
+++ b/src/renderer/stores/acp-store.ts
@@ -270,14 +270,36 @@ function nextSeq(): number {
 }
 
 /**
- * Monotonic counter for "Untitled Chat N" placeholder titles. Resets on app
- * restart; persisted sessions already have a derived title, so this only
- * applies to freshly created sessions that haven't received a message yet.
+ * Monotonic counter for "Untitled Chat N" placeholder titles. Rebased from the
+ * persisted index on load (see `rebaseUntitledCounter`) so a restart continues
+ * from the highest persisted suffix instead of restarting at 1 and colliding
+ * with existing placeholders. Only freshly created sessions without a message
+ * consume a number.
  */
 let untitledChatCounter = 0
 function nextUntitledTitle(): string {
   untitledChatCounter += 1
   return `Untitled Chat ${untitledChatCounter}`
+}
+
+/** Matches an `Untitled Chat N` placeholder and captures its numeric suffix. */
+const UNTITLED_CHAT_RE = /^Untitled Chat (\d+)$/
+
+/**
+ * Lift `untitledChatCounter` to at least the highest `Untitled Chat N` suffix
+ * found across the persisted index, so placeholders assigned after a restart
+ * never collide with ones already on disk.
+ */
+function rebaseUntitledCounter(entries: SessionIndexEntry[]): void {
+  let maxSuffix = untitledChatCounter
+  for (const entry of entries) {
+    const match = UNTITLED_CHAT_RE.exec(entry.title)
+    if (match) {
+      const n = Number.parseInt(match[1], 10)
+      if (Number.isFinite(n) && n > maxSuffix) maxSuffix = n
+    }
+  }
+  untitledChatCounter = maxSuffix
 }
 
 /**
@@ -483,10 +505,10 @@ function persistSession(
   )
   const agentConfigId = reuseKey ? configIdFromReuseKey(reuseKey) : undefined
   const existingEntry = state.sessionIndex.find((e) => e.id === sessionId)
-  const fallbackTitle =
-    existingEntry?.title && !existingEntry.title.startsWith('Untitled Chat ')
-      ? existingEntry.title
-      : nextUntitledTitle()
+  // Keep a placeholder stable once assigned: reuse the existing index title
+  // (including a prior `Untitled Chat N`) instead of regenerating one on every
+  // persist. `rebaseUntitledCounter` keeps fresh numbers from colliding.
+  const fallbackTitle = existingEntry?.title ?? nextUntitledTitle()
   const entry: SessionIndexEntry = {
     id: sessionId,
     agentId: session.agentId,
@@ -1097,6 +1119,9 @@ export const useAcpStore = create<AcpState>((set, get) => ({
 
   loadSessionIndex: async () => {
     const entries = await loadSessionIndexFromDisk()
+    // Continue the placeholder counter from the highest persisted suffix so a
+    // restart doesn't restart at 1 and collide with existing `Untitled Chat N`.
+    rebaseUntitledCounter(entries)
     set({ sessionIndex: entries })
   },
 
@@ -1461,13 +1486,16 @@ export const useAcpStore = create<AcpState>((set, get) => ({
     }),
 
   _onSessionInfoUpdate: (e) => {
+    // `title` is `undefined` when the field is absent (no change), `null` when
+    // the agent explicitly cleared it, or a string when set. An omitted title
+    // must leave the existing title (and the persisted index) untouched.
+    if (e.title === undefined) return
+    const nextTitle = e.title
     set((s) => {
       const session = s.sessions[e.sessionId]
       if (!session) return {}
-      // `title` is `undefined` when absent (no change), `null` when the agent
-      // explicitly cleared it, or a string when set.
       return {
-        sessions: { ...s.sessions, [e.sessionId]: { ...session, title: e.title ?? null } }
+        sessions: { ...s.sessions, [e.sessionId]: { ...session, title: nextTitle } }
       }
     })
     if (get().sessions[e.sessionId]) {

--- a/src/renderer/stores/acp-store.ts
+++ b/src/renderer/stores/acp-store.ts
@@ -1703,6 +1703,22 @@ export function selectAgentIdentity(state: AcpState, agentId: AgentId | null): A
 export const useAgentIdentity = (agentId: AgentId | null): AgentIdentity =>
   useAcpStore(useShallow((s) => selectAgentIdentity(s, agentId)))
 
+/**
+ * Resolve an agent's template id by `agentConfigId` (from a history entry) when
+ * the agent isn't live. Falls back to `useAgentIdentity` for live sessions.
+ */
+export function useAgentTemplateId(agentId: AgentId | null, agentConfigId?: string): string | null {
+  return useAcpStore(
+    useShallow((s) => {
+      if (agentConfigId) {
+        const config = s.agentConfigs.find((c) => c.id === agentConfigId)
+        if (config?.templateId) return config.templateId
+      }
+      return selectAgentIdentity(s, agentId).templateId
+    })
+  )
+}
+
 /** Project IDs with at least one open agent-chat session in an active turn. */
 export function collectProjectsWithActiveAgentChat(
   sessions: Record<SessionId, AcpSession>


### PR DESCRIPTION
## Summary

ACP chats had two naming/identity problems that made the Chats history list and workspace tabs hard to read:

1. **Meaningless placeholder name.** A freshly created ACP chat showed `Agent 5f3a9c1b` — the literal string `Agent ` plus a slice of the random session id (the `deriveTitle()` fallback). Multiple new chats were indistinguishable and looked like a bug.
2. **Agent-generated session titles were thrown away.** ACP defines a `session_info_update` notification (agent → client) that carries an auto-generated session title after the first exchange, but the Rust client dropped it into a debug-log catch-all, so the renderer never saw it.

On top of the issue scope, the workspace tab and history sidebar showed a generic icon and the agent's product name instead of the chat's own title, so this PR also wires the session title onto the tab and renders each chat's real agent CLI icon.

## Related Issue

Closes #404

<!-- Complements #363 (item #2 called out the dropped SessionInfoUpdate). No existing open/closed PR addresses #404 — searched "404", "session title untitled". -->

## Type of Change

- [x] feat: new feature
- [x] fix: bug fix

## What Changed

**Friendly placeholder**
- New chats now show an incrementing `Untitled Chat N` label instead of `Agent <random>`. The counter is monotonic within an app session; `persistSession` reuses an existing index title so repeated persists don't inflate the number.
- `deriveTitle(messages, agentId)` → `deriveTitle(messages, fallbackTitle)`, decoupling the fallback from the agent id.

**Wire `session_info_update` end-to-end**
- **Rust** (`src-tauri/src/acp/`): new `EVENT_SESSION_INFO_UPDATE` (`acp:session_info_update`) constant and `SessionInfoUpdateEvent { agentId, sessionId, title }` struct. `client.rs::emit_session_update` now handles `SessionUpdate::SessionInfoUpdate`, extracting the `MaybeUndefined<String>` title (Undefined → skip, Null → emit `title: null`, Value → emit the string) instead of dropping it. `title: Option<String>` serializes as `null` on clear (no `skip_serializing_if`) so the renderer can fall back to the derive chain.
- **Renderer API** (`acp-api.ts`): `sessionInfoUpdate` added to `ACP_EVENTS`; `SessionInfoUpdateEvent` type exported.
- **Store** (`acp-store.ts`): new `_onSessionInfoUpdate` reducer sets `session.title` and re-persists the index entry; subscribed in `initAcpEventListeners`.

**Title fallback chain:** agent-pushed title → first user message (existing `deriveTitle`) → `Untitled Chat N`.

**Tab + history icons/titles**
- `WorkspaceTabBar`: the agent-chat tab label now shows the session title (read from `session.title`, falling back to the persisted index entry, then the agent name), with the agent icon kept alongside.
- New shared `AgentGlyph` component renders the agent's bundled ACP registry icon (the same offline SVG catalog `AgentLauncher` already uses) resolved by `templateId`, replacing the previous `templateIcon()` lookup that only matched ~8 hardcoded ids and fell back to a generic bot for everything else.
- `ChatHistoryTab`: each chat entry shows its agent's real CLI icon via `AgentGlyph` + a new `useAgentTemplateId` hook that resolves the template from `agentConfigId` (history entries) or the live agent identity.

## How It Was Tested

- [x] `bun run ci` (Biome lint + format + imports, strict mode)
- [x] `bun run typecheck`
- [x] `bun run test`
- [x] `cargo clippy --all-targets -- -D warnings` (in src-tauri)
- [x] `cargo test` (in src-tauri)
- [x] Manual verification completed

New automated coverage: `deriveTitle` fallback test (new signature), three `_onSessionInfoUpdate` store reducer tests (set title, clear-to-null, unknown session), and a Rust `session_info_update_serializes_camel_case` serialization test (`Some` → `"title": "T"`, `None` → `"title": null`).

## Screenshots or Recordings

<!-- UI change: new chats show "Untitled Chat N" with the agent's CLI icon; tab shows the session title; chat is renamed live when the agent pushes a session title. -->

## CI & Review Gate

- [ ] All CI checks pass (PR Validation, Rust Checks, Build Verification, Security Scans)
- [ ] Code review comments from CodeRabbit / Claude have been addressed or resolved
- [ ] No unresolved review findings remain

## Checklist

- [x] My PR title follows the conventional commit format used by this repo
- [x] I linked the related issue or explained why none exists
- [ ] I updated docs when needed
- [x] I added or updated tests when needed
- [x] I verified the change does not introduce unrelated modifications
- [x] I read AGENTS.md and followed the contributor guidelines
- [x] A human reviewed the complete diff before submission


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Agent chats now display registry-style glyph icons.
  * Chat tabs can show saved session titles when available.
* **Bug Fixes**
  * Session title updates from the backend now stay in sync in real time, including correct handling when titles are cleared.
  * Unrecognized session updates are safely ignored.
  * Improved “Untitled Chat” title fallback for more consistent labels across restarts.
* **Tests**
  * Added coverage for session-title update behavior and serialization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->