### PR TITLE
feat(acp): discover agent-native sessions via session/list with per-CLI icons (#407)

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -5950,9 +5950,12 @@ version = "0.4.8"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
+ "async-process",
  "axum",
  "chrono",
  "flate2",
+ "futures",
+ "futures-concurrency",
  "futures-util",
  "getrandom 0.2.17",
  "keyring",

--- a/src-tauri/src/acp/commands.rs
+++ b/src-tauri/src/acp/commands.rs
@@ -84,13 +84,16 @@ pub async fn acp_close_session(
     manager.close_session(&agent_id, session_id).await
 }
 
-/// List sessions on an agent.
+/// List sessions on an agent (requires `sessionCapabilities.list`).
+/// Pass `cwd` to filter by working directory; `cursor` for pagination.
 #[tauri::command]
 pub async fn acp_list_sessions(
     manager: State<'_, Arc<AcpManager>>,
     agent_id: AgentId,
+    cwd: Option<String>,
+    cursor: Option<String>,
 ) -> Result<ListSessionsResponse, String> {
-    manager.list_sessions(&agent_id).await
+    manager.list_sessions(&agent_id, cwd, cursor).await
 }
 
 /// Send a prompt turn. Accepts either structured ACP content blocks or, for

--- a/src-tauri/src/acp/manager.rs
+++ b/src-tauri/src/acp/manager.rs
@@ -120,6 +120,8 @@ enum AcpCommand {
         reply: oneshot::Sender<Result<(), String>>,
     },
     ListSessions {
+        cwd: Option<String>,
+        cursor: Option<String>,
         reply: oneshot::Sender<Result<ListSessionsResponse, String>>,
     },
     SendPrompt {
@@ -386,13 +388,24 @@ impl AcpManager {
         send_command(&tx, |reply| AcpCommand::CloseSession { session_id, reply }).await
     }
 
-    /// List sessions on the given agent.
+    /// List sessions on the given agent. Gated on the agent's
+    /// `sessionCapabilities.list`. Pass `cwd` to filter by working directory;
+    /// pass `cursor` for pagination (opaque token from a prior response).
     pub async fn list_sessions(
         &self,
         agent_id: &AgentId,
+        cwd: Option<String>,
+        cursor: Option<String>,
     ) -> Result<ListSessionsResponse, String> {
+        let caps = self.capabilities(agent_id)?;
+        gate_list_sessions(&caps)?;
         let tx = self.command_tx(agent_id)?;
-        send_command(&tx, |reply| AcpCommand::ListSessions { reply }).await
+        send_command(&tx, |reply| AcpCommand::ListSessions {
+            cwd,
+            cursor,
+            reply,
+        })
+        .await
     }
 
     /// Send a prompt and await the turn's stop reason. Streaming updates arrive
@@ -595,6 +608,17 @@ fn gate_close_session(caps: &AgentCapabilities) -> Result<(), String> {
         Ok(())
     } else {
         Err("agent does not support session/close".to_string())
+    }
+}
+
+/// Capability gate for `session/list`: requires `sessionCapabilities.list`.
+/// Per the ACP spec: "If `sessionCapabilities.list` is not present … Clients
+/// MUST NOT attempt to call `session/list`."
+fn gate_list_sessions(caps: &AgentCapabilities) -> Result<(), String> {
+    if caps.session_capabilities.list.is_some() {
+        Ok(())
+    } else {
+        Err("agent does not support session/list (sessionCapabilities.list)".to_string())
     }
 }
 
@@ -1253,12 +1277,22 @@ async fn run_command_loop(
                 });
             }
 
-            AcpCommand::ListSessions { reply } => {
+            AcpCommand::ListSessions {
+                cwd,
+                cursor,
+                reply,
+            } => {
                 let slot = reply_slot(reply);
                 let task_slot = slot.clone();
                 let req_cx = cx.clone();
                 spawn_request(&cx, slot, async move {
-                    let request = agent_client_protocol::schema::ListSessionsRequest::new();
+                    let mut request = agent_client_protocol::schema::ListSessionsRequest::new();
+                    if let Some(cwd) = cwd {
+                        request = request.cwd(std::path::PathBuf::from(cwd));
+                    }
+                    if let Some(cursor) = cursor {
+                        request = request.cursor(cursor);
+                    }
                     let result = req_cx.send_request(request).block_task().await;
                     send_reply(&task_slot, result.map_err(|e| e.to_string()));
                 });
@@ -1554,6 +1588,10 @@ mod tests {
         assert!(
             gate_resume_session(&caps).is_err(),
             "default agent must not advertise resume"
+        );
+        assert!(
+            gate_list_sessions(&caps).is_err(),
+            "default agent must not advertise session/list"
         );
     }
 

--- a/src-tauri/src/acp/manager.rs
+++ b/src-tauri/src/acp/manager.rs
@@ -1103,11 +1103,16 @@ async fn run_command_loop(
         Ok(Ok(response)) => {
             let auth_method_ids: Vec<String> =
                 response.auth_methods.iter().map(|m| m.id().to_string()).collect();
+            let session_caps = &response.agent_capabilities.session_capabilities;
             log::info!(
-                "[acp] agent {agent_id} initialized: protocol={:?} auth_methods={:?} loadSession={}",
+                "[acp] agent {agent_id} initialized: protocol={:?} auth_methods={:?} \
+                 loadSession={} sessionCapabilities.list={} resume={} close={}",
                 response.protocol_version,
                 auth_method_ids,
                 response.agent_capabilities.load_session,
+                session_caps.list.is_some(),
+                session_caps.resume.is_some(),
+                session_caps.close.is_some(),
             );
 
             spawned.store(true, Ordering::Release);

--- a/src/renderer/components/chat/ChatHistoryTab.test.tsx
+++ b/src/renderer/components/chat/ChatHistoryTab.test.tsx
@@ -2,10 +2,20 @@ import { fireEvent, render, screen } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type { SessionIndexEntry } from '@/lib/acp-history-persistence'
 
-const { mockOpen, mockDelete, mockAddTab, sessionIndexRef, projectRef } = vi.hoisted(() => ({
+const {
+  mockOpen,
+  mockDelete,
+  mockAddTab,
+  mockDiscover,
+  mockOpenDiscovered,
+  sessionIndexRef,
+  projectRef
+} = vi.hoisted(() => ({
   mockOpen: vi.fn(),
   mockDelete: vi.fn(),
   mockAddTab: vi.fn(),
+  mockDiscover: vi.fn().mockResolvedValue(undefined),
+  mockOpenDiscovered: vi.fn().mockResolvedValue(undefined),
   sessionIndexRef: { current: [] as SessionIndexEntry[] },
   projectRef: {
     current: null as {
@@ -28,13 +38,26 @@ vi.mock('@/stores/acp-store', () => {
     sel({
       sessionIndex: sessionIndexRef.current,
       openHistorySession: mockOpen,
-      deleteHistorySession: mockDelete
+      deleteHistorySession: mockDelete,
+      discoveredSessions: {},
+      agents: {},
+      agentConfigs: [],
+      configToLiveAgent: {},
+      discoverSessions: mockDiscover,
+      openDiscoveredSession: mockOpenDiscovered
     })
-  return { useAcpStore }
+  // selectAgentIdentity stub: returns nulls (no live agent config in tests).
+  const selectAgentIdentity = () => ({ name: null, templateId: null })
+  const configIdFromReuseKey = () => ''
+  return { useAcpStore, selectAgentIdentity, configIdFromReuseKey }
 })
 
 vi.mock('@/stores/workspace-store', () => ({
   useWorkspaceStore: () => mockAddTab
+}))
+
+vi.mock('./agent-templates', () => ({
+  templateIcon: () => undefined
 }))
 
 vi.mock('@/stores/project-store', () => ({
@@ -70,6 +93,8 @@ describe('ChatHistoryTab scoping', () => {
     mockOpen.mockReset()
     mockDelete.mockReset()
     mockAddTab.mockReset()
+    mockDiscover.mockReset().mockResolvedValue(undefined)
+    mockOpenDiscovered.mockReset().mockResolvedValue(undefined)
     sessionIndexRef.current = []
     projectRef.current = {
       id: 'p1',

--- a/src/renderer/components/chat/ChatHistoryTab.test.tsx
+++ b/src/renderer/components/chat/ChatHistoryTab.test.tsx
@@ -156,4 +156,45 @@ describe('ChatHistoryTab scoping', () => {
     fireEvent.click(screen.getByText('s1'))
     expect(mockOpen).toHaveBeenCalledWith('s1')
   })
+
+  it('caps the rendered rows and lazily loads more', () => {
+    // 60 sessions; page size is 50, so the first render shows 50 + a Load more.
+    sessionIndexRef.current = Array.from({ length: 60 }, (_, i) =>
+      entry(`s${i}`, {
+        projectId: 'p1',
+        cwd: '/work',
+        title: `chat-${i}`,
+        // Descending recency so newest (chat-0) sorts first and is visible.
+        lastActivityAt: 60 - i
+      })
+    )
+    render(<ChatHistoryTab />)
+    // First page is visible.
+    expect(screen.getByText('chat-0')).toBeInTheDocument()
+    expect(screen.getByText('chat-49')).toBeInTheDocument()
+    // Beyond the cap is not yet rendered.
+    expect(screen.queryByText('chat-50')).not.toBeInTheDocument()
+    // Load-more reveals the rest.
+    fireEvent.click(screen.getByText(/Load more/))
+    expect(screen.getByText('chat-50')).toBeInTheDocument()
+    expect(screen.getByText('chat-59')).toBeInTheDocument()
+  })
+
+  it('search reaches sessions beyond the rendered window', () => {
+    sessionIndexRef.current = Array.from({ length: 60 }, (_, i) =>
+      entry(`s${i}`, {
+        projectId: 'p1',
+        cwd: '/work',
+        title: `chat-${i}`,
+        lastActivityAt: 60 - i
+      })
+    )
+    render(<ChatHistoryTab />)
+    // chat-55 is past the initial cap; searching for it still finds it.
+    expect(screen.queryByText('chat-55')).not.toBeInTheDocument()
+    fireEvent.change(screen.getByPlaceholderText('Search chats…'), {
+      target: { value: 'chat-55' }
+    })
+    expect(screen.getByText('chat-55')).toBeInTheDocument()
+  })
 })

--- a/src/renderer/components/chat/ChatHistoryTab.test.tsx
+++ b/src/renderer/components/chat/ChatHistoryTab.test.tsx
@@ -41,6 +41,7 @@ vi.mock('@/stores/acp-store', () => {
       deleteHistorySession: mockDelete,
       discoveredSessions: {},
       agents: {},
+      agentStatus: {},
       agentConfigs: [],
       configToLiveAgent: {},
       discoverSessions: mockDiscover,

--- a/src/renderer/components/chat/ChatHistoryTab.tsx
+++ b/src/renderer/components/chat/ChatHistoryTab.tsx
@@ -1,16 +1,44 @@
-import { MessageSquare, Search, Trash2 } from 'lucide-react'
-import { useCallback, useMemo, useState } from 'react'
+import { Bot, Search, Trash2 } from 'lucide-react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
 import { toast } from 'sonner'
 import { groupSessionsByRecency } from '@/lib/acp-history-persistence'
 import { cn } from '@/lib/utils'
-import { useAcpStore } from '@/stores/acp-store'
+import { configIdFromReuseKey, useAcpStore } from '@/stores/acp-store'
 import { getActiveWorktreeFromStore, useActiveProject } from '@/stores/project-store'
 import { useWorkspaceStore } from '@/stores/workspace-store'
+import { templateIcon } from './agent-templates'
 
-/** Sidebar tab listing persisted chat sessions, grouped by recency with search. */
+/** A unified sidebar entry: either from the local mirror or discovered via session/list. */
+interface SidebarEntry {
+  /** Session id (same as sessionId for discovered entries). */
+  id: string
+  title: string
+  messageCount: number
+  status: string
+  /** Template icon component for this entry's agent, if resolvable. */
+  icon?: ReturnType<typeof templateIcon>
+  /** True when this entry comes from agent discovery (not the local mirror). */
+  discovered: boolean
+  /** Agent id for discovered entries (used to open via load/resume). */
+  agentId?: string
+  /** Cwd for discovered entries (used to open via load/resume). */
+  cwd?: string
+  /** Last activity timestamp (for grouping). */
+  lastActivityAt: number
+  /** Whether this entry can be opened (agent has load or resume capability). */
+  canOpen: boolean
+}
+
+/** Sidebar tab listing persisted + discovered chat sessions, grouped by recency with search. */
 export function ChatHistoryTab(): React.JSX.Element {
   const sessionIndex = useAcpStore((s) => s.sessionIndex)
+  const discoveredSessions = useAcpStore((s) => s.discoveredSessions)
+  const agents = useAcpStore((s) => s.agents)
+  const agentConfigs = useAcpStore((s) => s.agentConfigs)
+  const configToLiveAgent = useAcpStore((s) => s.configToLiveAgent)
   const openHistorySession = useAcpStore((s) => s.openHistorySession)
+  const openDiscoveredSession = useAcpStore((s) => s.openDiscoveredSession)
+  const discoverSessions = useAcpStore((s) => s.discoverSessions)
   const deleteHistorySession = useAcpStore((s) => s.deleteHistorySession)
   const addAgentChatTab = useWorkspaceStore((s) => s.addAgentChatTab)
   // Subscribe to the full active-project record so the sidebar re-scopes when
@@ -23,6 +51,30 @@ export function ChatHistoryTab(): React.JSX.Element {
     return wt?.path ?? activeProject.path ?? ''
   }, [activeProject])
 
+  // Helper: resolve templateId for an agentId via the configToLiveAgent + agentConfigs.
+  const resolveTemplateId = useCallback(
+    (agentId: string): string | null => {
+      const reuseKey = Object.keys(configToLiveAgent).find((k) => configToLiveAgent[k] === agentId)
+      const configId = reuseKey ? configIdFromReuseKey(reuseKey) : undefined
+      const config = configId ? agentConfigs.find((c) => c.id === configId) : undefined
+      return config?.templateId ?? null
+    },
+    [configToLiveAgent, agentConfigs]
+  )
+
+  // Trigger discovery for all connected agents with `list` capability when
+  // the active cwd changes or agents come online.
+  const agentIds = useMemo(() => Object.keys(agents), [agents])
+  useEffect(() => {
+    if (!activeCwd) return
+    for (const agentId of agentIds) {
+      const caps = agents[agentId]?.capabilities
+      if (caps?.sessionCapabilities?.list) {
+        void discoverSessions(agentId, activeCwd)
+      }
+    }
+  }, [activeCwd, agentIds, agents, discoverSessions])
+
   // Hard isolation (ADR 0002): show only sessions whose `(projectId, cwd)`
   // match the active project + its current worktree/root.
   const scopedIndex = useMemo(() => {
@@ -30,28 +82,79 @@ export function ChatHistoryTab(): React.JSX.Element {
     return sessionIndex.filter((e) => e.projectId === activeProjectId && e.cwd === activeCwd)
   }, [sessionIndex, activeProjectId, activeCwd])
 
+  // Build a unified sidebar list: local mirror + discovered sessions (deduped).
+  const mergedEntries = useMemo(() => {
+    const mirrorIds = new Set(scopedIndex.map((e) => e.id))
+    const entries: SidebarEntry[] = scopedIndex.map((e) => {
+      const templateId = resolveTemplateId(e.agentId)
+      const icon = templateIcon(templateId ?? undefined)
+      return {
+        id: e.id,
+        title: e.title,
+        messageCount: e.messageCount,
+        status: e.status,
+        icon,
+        discovered: false,
+        lastActivityAt: e.lastActivityAt,
+        canOpen: true
+      }
+    })
+
+    // Add discovered sessions not already in the local mirror.
+    for (const [agentId, sessions] of Object.entries(discoveredSessions)) {
+      const caps = agents[agentId]?.capabilities
+      const canOpen = caps?.loadSession === true || caps?.sessionCapabilities?.resume != null
+      const templateId = resolveTemplateId(agentId)
+      const icon = templateIcon(templateId ?? undefined)
+
+      for (const info of sessions) {
+        // Dedupe: skip if already in the local mirror.
+        if (mirrorIds.has(info.sessionId)) continue
+        // Filter by active cwd.
+        if (activeCwd && info.cwd && info.cwd !== activeCwd) continue
+
+        entries.push({
+          id: info.sessionId,
+          title: info.title || `Session ${info.sessionId.slice(0, 8)}`,
+          messageCount: 0,
+          status: 'active',
+          icon,
+          discovered: true,
+          agentId,
+          cwd: info.cwd || activeCwd,
+          lastActivityAt: info.updatedAt ? Date.parse(info.updatedAt) || Date.now() : Date.now(),
+          canOpen
+        })
+      }
+    }
+
+    return entries
+  }, [scopedIndex, discoveredSessions, agents, activeCwd, resolveTemplateId])
+
   const [query, setQuery] = useState('')
 
   const groups = useMemo(() => {
     const filtered =
       query.trim().length === 0
-        ? scopedIndex
-        : scopedIndex.filter((e) => e.title.toLowerCase().includes(query.trim().toLowerCase()))
+        ? mergedEntries
+        : mergedEntries.filter((e) => e.title.toLowerCase().includes(query.trim().toLowerCase()))
     return groupSessionsByRecency(filtered, Date.now())
-  }, [scopedIndex, query])
+  }, [mergedEntries, query])
 
   const handleOpen = useCallback(
-    async (id: string) => {
-      // Open the session first; only add the tab if it succeeds, so a failed
-      // load doesn't leave a dead tab behind.
+    async (entry: SidebarEntry) => {
       try {
-        await openHistorySession(id)
-        addAgentChatTab(id)
+        if (entry.discovered && entry.agentId && entry.cwd) {
+          await openDiscoveredSession(entry.agentId, entry.id, entry.cwd, activeProjectId)
+        } else {
+          await openHistorySession(entry.id)
+        }
+        addAgentChatTab(entry.id)
       } catch (err) {
         toast.error(`Failed to open chat: ${String(err)}`)
       }
     },
-    [addAgentChatTab, openHistorySession]
+    [addAgentChatTab, openHistorySession, openDiscoveredSession, activeProjectId]
   )
 
   const handleDelete = useCallback(
@@ -81,7 +184,7 @@ export function ChatHistoryTab(): React.JSX.Element {
       </div>
 
       <div className="flex-1 overflow-y-auto py-1">
-        {scopedIndex.length === 0 ? (
+        {mergedEntries.length === 0 ? (
           <div className="flex flex-col items-center justify-center p-6 text-center text-xs text-muted-foreground opacity-70">
             No chats yet. Start one with the New Chat button.
           </div>
@@ -96,27 +199,46 @@ export function ChatHistoryTab(): React.JSX.Element {
                   key={entry.id}
                   className={cn(
                     'group flex w-full items-center gap-2 pr-2 hover:bg-sidebar-accent',
-                    entry.status === 'closed' && 'opacity-70'
+                    entry.status === 'closed' && 'opacity-70',
+                    entry.discovered && !entry.canOpen && 'opacity-50'
                   )}
                 >
                   <button
                     type="button"
-                    onClick={() => void handleOpen(entry.id)}
-                    className="flex min-w-0 flex-1 items-center gap-2 px-3 py-1.5 text-left text-xs"
+                    disabled={entry.discovered && !entry.canOpen}
+                    onClick={() => void handleOpen(entry)}
+                    title={
+                      entry.discovered && !entry.canOpen
+                        ? 'Agent does not support loading or resuming sessions'
+                        : undefined
+                    }
+                    className="flex min-w-0 flex-1 items-center gap-2 px-3 py-1.5 text-left text-xs disabled:cursor-not-allowed"
                   >
-                    <MessageSquare size={12} className="shrink-0 text-muted-foreground" />
+                    {entry.icon ? (
+                      <entry.icon
+                        width={12}
+                        height={12}
+                        className="shrink-0 text-muted-foreground"
+                      />
+                    ) : (
+                      <Bot size={12} className="shrink-0 text-muted-foreground" />
+                    )}
                     <span className="truncate flex-1 text-sidebar-foreground">{entry.title}</span>
-                    <span className="text-3xs text-muted-foreground">{entry.messageCount}</span>
+                    {!entry.discovered && (
+                      <span className="text-3xs text-muted-foreground">{entry.messageCount}</span>
+                    )}
                   </button>
-                  <button
-                    type="button"
-                    aria-label="Delete chat"
-                    title="Delete chat"
-                    onClick={() => handleDelete(entry.id)}
-                    className="opacity-0 group-hover:opacity-100 p-0.5 rounded-md hover:bg-background/50"
-                  >
-                    <Trash2 size={11} />
-                  </button>
+                  {!entry.discovered && (
+                    <button
+                      type="button"
+                      aria-label="Delete chat"
+                      title="Delete chat"
+                      onClick={() => handleDelete(entry.id)}
+                      className="opacity-0 group-hover:opacity-100 p-0.5 rounded-md hover:bg-background/50"
+                    >
+                      <Trash2 size={11} />
+                    </button>
+                  )}
                 </div>
               ))}
             </div>

--- a/src/renderer/components/chat/ChatHistoryTab.tsx
+++ b/src/renderer/components/chat/ChatHistoryTab.tsx
@@ -1,5 +1,5 @@
 import { Bot, Search, Trash2 } from 'lucide-react'
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { toast } from 'sonner'
 import { groupSessionsByRecency } from '@/lib/acp-history-persistence'
 import { cn } from '@/lib/utils'
@@ -7,6 +7,9 @@ import { configIdFromReuseKey, discoveryKey, useAcpStore } from '@/stores/acp-st
 import { getActiveWorktreeFromStore, useActiveProject } from '@/stores/project-store'
 import { useWorkspaceStore } from '@/stores/workspace-store'
 import { templateIcon } from './agent-templates'
+
+/** How many sidebar rows to render per lazy-load page. */
+const SIDEBAR_PAGE_SIZE = 50
 
 /** A unified sidebar entry: either from the local mirror or discovered via session/list. */
 interface SidebarEntry {
@@ -143,14 +146,55 @@ export function ChatHistoryTab(): React.JSX.Element {
   }, [scopedIndex, discoveredSessions, agents, agentStatus, activeCwd, resolveAgentIdentity])
 
   const [query, setQuery] = useState('')
+  // Lazy rendering: keep all results in memory but only render a growing window
+  // (discovery can return hundreds of sessions; rendering all rows is the cost).
+  const [visibleCount, setVisibleCount] = useState(SIDEBAR_PAGE_SIZE)
+  const scrollRef = useRef<HTMLDivElement>(null)
+  const sentinelRef = useRef<HTMLDivElement>(null)
 
-  const groups = useMemo(() => {
-    const filtered =
-      query.trim().length === 0
+  // Filter the FULL set by query first (so search reaches every session, not
+  // just the rendered window), then sort newest-first so the visible cap keeps
+  // the most recent sessions.
+  const filtered = useMemo(() => {
+    const q = query.trim().toLowerCase()
+    const base =
+      q.length === 0
         ? mergedEntries
-        : mergedEntries.filter((e) => e.title.toLowerCase().includes(query.trim().toLowerCase()))
-    return groupSessionsByRecency(filtered, Date.now())
+        : mergedEntries.filter((e) => e.title.toLowerCase().includes(q))
+    return base.slice().sort((a, b) => b.lastActivityAt - a.lastActivityAt)
   }, [mergedEntries, query])
+
+  // Reset the window when the query or active scope changes.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: reset on scope/query change
+  useEffect(() => {
+    setVisibleCount(SIDEBAR_PAGE_SIZE)
+  }, [query, activeProjectId, activeCwd])
+
+  const visible = useMemo(() => filtered.slice(0, visibleCount), [filtered, visibleCount])
+  const hasMore = filtered.length > visible.length
+
+  const groups = useMemo(() => groupSessionsByRecency(visible, Date.now()), [visible])
+
+  // Grow the window when the bottom sentinel scrolls into view (lazy load).
+  // `visibleCount` is intentionally in the deps so the observer re-arms after
+  // each growth: IntersectionObserver only fires on intersection transitions, so
+  // a sentinel already in view after a grow needs a fresh observe() to re-check.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: visibleCount re-arms the observer
+  useEffect(() => {
+    if (!hasMore) return
+    const sentinel = sentinelRef.current
+    if (!sentinel) return
+    const observer = new IntersectionObserver(
+      (obsEntries) => {
+        if (obsEntries.some((e) => e.isIntersecting)) {
+          setVisibleCount((c) => c + SIDEBAR_PAGE_SIZE)
+        }
+      },
+      { root: scrollRef.current, rootMargin: '200px' }
+    )
+    observer.observe(sentinel)
+    return () => observer.disconnect()
+  }, [hasMore, visibleCount])
 
   const handleOpen = useCallback(
     async (entry: SidebarEntry) => {
@@ -194,12 +238,12 @@ export function ChatHistoryTab(): React.JSX.Element {
         </div>
       </div>
 
-      <div className="flex-1 overflow-y-auto py-1">
+      <div ref={scrollRef} className="flex-1 overflow-y-auto py-1">
         {mergedEntries.length === 0 ? (
           <div className="flex flex-col items-center justify-center p-6 text-center text-xs text-muted-foreground opacity-70">
             No chats yet. Start one with the New Chat button.
           </div>
-        ) : groups.length === 0 ? (
+        ) : filtered.length === 0 ? (
           <div className="px-3 py-4 text-center text-xs text-muted-foreground">No matches.</div>
         ) : (
           groups.map(({ group, entries }) => (
@@ -262,6 +306,17 @@ export function ChatHistoryTab(): React.JSX.Element {
               ))}
             </div>
           ))
+        )}
+        {hasMore && (
+          <div ref={sentinelRef} className="px-3 py-2">
+            <button
+              type="button"
+              onClick={() => setVisibleCount((c) => c + SIDEBAR_PAGE_SIZE)}
+              className="w-full rounded-md py-1 text-3xs text-muted-foreground hover:bg-sidebar-accent"
+            >
+              Load more ({filtered.length - visible.length} more)
+            </button>
+          </div>
         )}
       </div>
     </div>

--- a/src/renderer/components/chat/ChatHistoryTab.tsx
+++ b/src/renderer/components/chat/ChatHistoryTab.tsx
@@ -21,6 +21,8 @@ interface SidebarEntry {
   discovered: boolean
   /** Agent id for discovered entries (used to open via load/resume). */
   agentId?: string
+  /** Owning agent display name (e.g. "Codex CLI"), for discovered entries. */
+  agentName?: string | null
   /** Cwd for discovered entries (used to open via load/resume). */
   cwd?: string
   /** Last activity timestamp (for grouping). */
@@ -48,6 +50,7 @@ export function ChatHistoryTab(): React.JSX.Element {
   const sessionIndex = useAcpStore((s) => s.sessionIndex)
   const discoveredSessions = useAcpStore((s) => s.discoveredSessions)
   const agents = useAcpStore((s) => s.agents)
+  const agentStatus = useAcpStore((s) => s.agentStatus)
   const agentConfigs = useAcpStore((s) => s.agentConfigs)
   const configToLiveAgent = useAcpStore((s) => s.configToLiveAgent)
   const openHistorySession = useAcpStore((s) => s.openHistorySession)
@@ -65,13 +68,14 @@ export function ChatHistoryTab(): React.JSX.Element {
     return wt?.path ?? activeProject.path ?? ''
   }, [activeProject])
 
-  // Helper: resolve templateId for an agentId via the configToLiveAgent + agentConfigs.
-  const resolveTemplateId = useCallback(
-    (agentId: string): string | null => {
+  // Helper: resolve display name + templateId for an agentId via the
+  // configToLiveAgent + agentConfigs mapping (same path as useAgentIdentity).
+  const resolveAgentIdentity = useCallback(
+    (agentId: string): { name: string | null; templateId: string | null } => {
       const reuseKey = Object.keys(configToLiveAgent).find((k) => configToLiveAgent[k] === agentId)
       const configId = reuseKey ? configIdFromReuseKey(reuseKey) : undefined
       const config = configId ? agentConfigs.find((c) => c.id === configId) : undefined
-      return config?.templateId ?? null
+      return { name: config?.name ?? null, templateId: config?.templateId ?? null }
     },
     [configToLiveAgent, agentConfigs]
   )
@@ -100,7 +104,7 @@ export function ChatHistoryTab(): React.JSX.Element {
   const mergedEntries = useMemo(() => {
     const mirrorIds = new Set(scopedIndex.map((e) => e.id))
     const entries: SidebarEntry[] = scopedIndex.map((e) => {
-      const templateId = resolveTemplateId(e.agentId)
+      const { templateId } = resolveAgentIdentity(e.agentId)
       const icon = templateIcon(templateId ?? undefined)
       return {
         id: e.id,
@@ -116,9 +120,13 @@ export function ChatHistoryTab(): React.JSX.Element {
 
     // Add discovered sessions not already in the local mirror.
     for (const [agentId, sessions] of Object.entries(discoveredSessions)) {
+      // Only surface discovered sessions for an agent that is still connected.
+      // A disconnected agent can't service session/load|resume, so its entries
+      // would render as un-clickable; drop them instead of showing dead rows.
+      if (agentStatus[agentId] !== 'connected') continue
       const caps = agents[agentId]?.capabilities
       const canOpen = caps?.loadSession === true || caps?.sessionCapabilities?.resume != null
-      const templateId = resolveTemplateId(agentId)
+      const { name: agentName, templateId } = resolveAgentIdentity(agentId)
       const icon = templateIcon(templateId ?? undefined)
 
       for (const info of sessions) {
@@ -138,6 +146,7 @@ export function ChatHistoryTab(): React.JSX.Element {
           icon,
           discovered: true,
           agentId,
+          agentName,
           cwd: info.cwd || activeCwd,
           lastActivityAt: info.updatedAt ? Date.parse(info.updatedAt) || Date.now() : Date.now(),
           canOpen
@@ -146,7 +155,7 @@ export function ChatHistoryTab(): React.JSX.Element {
     }
 
     return entries
-  }, [scopedIndex, discoveredSessions, agents, activeCwd, resolveTemplateId])
+  }, [scopedIndex, discoveredSessions, agents, agentStatus, activeCwd, resolveAgentIdentity])
 
   const [query, setQuery] = useState('')
 
@@ -227,7 +236,9 @@ export function ChatHistoryTab(): React.JSX.Element {
                     title={
                       entry.discovered && !entry.canOpen
                         ? 'Agent does not support loading or resuming sessions'
-                        : undefined
+                        : entry.discovered && entry.agentName
+                          ? `${entry.title} — ${entry.agentName} (resume from CLI history)`
+                          : entry.title
                     }
                     className="flex min-w-0 flex-1 items-center gap-2 px-3 py-1.5 text-left text-xs disabled:cursor-not-allowed"
                   >
@@ -241,7 +252,13 @@ export function ChatHistoryTab(): React.JSX.Element {
                       <Bot size={12} className="shrink-0 text-muted-foreground" />
                     )}
                     <span className="truncate flex-1 text-sidebar-foreground">{entry.title}</span>
-                    {!entry.discovered && (
+                    {entry.discovered ? (
+                      entry.agentName ? (
+                        <span className="text-3xs text-muted-foreground/70 shrink-0">
+                          {entry.agentName}
+                        </span>
+                      ) : null
+                    ) : (
                       <span className="text-3xs text-muted-foreground">{entry.messageCount}</span>
                     )}
                   </button>

--- a/src/renderer/components/chat/ChatHistoryTab.tsx
+++ b/src/renderer/components/chat/ChatHistoryTab.tsx
@@ -29,6 +29,20 @@ interface SidebarEntry {
   canOpen: boolean
 }
 
+/**
+ * Normalize a filesystem path for comparison: forward slashes, no trailing
+ * slash, lowercased (Windows paths are case-insensitive; on POSIX this is a
+ * harmless over-match for the rare mixed-case duplicate).
+ */
+function normalizeCwd(p: string): string {
+  return p.replace(/\\/g, '/').replace(/\/+$/, '').toLowerCase()
+}
+
+/** True when two cwd strings refer to the same directory after normalization. */
+function cwdMatches(a: string, b: string): boolean {
+  return normalizeCwd(a) === normalizeCwd(b)
+}
+
 /** Sidebar tab listing persisted + discovered chat sessions, grouped by recency with search. */
 export function ChatHistoryTab(): React.JSX.Element {
   const sessionIndex = useAcpStore((s) => s.sessionIndex)
@@ -110,8 +124,11 @@ export function ChatHistoryTab(): React.JSX.Element {
       for (const info of sessions) {
         // Dedupe: skip if already in the local mirror.
         if (mirrorIds.has(info.sessionId)) continue
-        // Filter by active cwd.
-        if (activeCwd && info.cwd && info.cwd !== activeCwd) continue
+        // Filter by active cwd. The backend already passes cwd to session/list,
+        // so this is a defensive secondary filter for agents that ignore it.
+        // Compare normalized (separators + case + trailing slash) so a Windows
+        // path mismatch (E:\foo vs E:/foo/) can't wrongly hide a session.
+        if (activeCwd && info.cwd && !cwdMatches(info.cwd, activeCwd)) continue
 
         entries.push({
           id: info.sessionId,

--- a/src/renderer/components/chat/ChatHistoryTab.tsx
+++ b/src/renderer/components/chat/ChatHistoryTab.tsx
@@ -3,7 +3,7 @@ import { useCallback, useEffect, useMemo, useState } from 'react'
 import { toast } from 'sonner'
 import { groupSessionsByRecency } from '@/lib/acp-history-persistence'
 import { cn } from '@/lib/utils'
-import { configIdFromReuseKey, useAcpStore } from '@/stores/acp-store'
+import { configIdFromReuseKey, discoveryKey, useAcpStore } from '@/stores/acp-store'
 import { getActiveWorktreeFromStore, useActiveProject } from '@/stores/project-store'
 import { useWorkspaceStore } from '@/stores/workspace-store'
 import { templateIcon } from './agent-templates'
@@ -29,20 +29,6 @@ interface SidebarEntry {
   lastActivityAt: number
   /** Whether this entry can be opened (agent has load or resume capability). */
   canOpen: boolean
-}
-
-/**
- * Normalize a filesystem path for comparison: forward slashes, no trailing
- * slash, lowercased (Windows paths are case-insensitive; on POSIX this is a
- * harmless over-match for the rare mixed-case duplicate).
- */
-function normalizeCwd(p: string): string {
-  return p.replace(/\\/g, '/').replace(/\/+$/, '').toLowerCase()
-}
-
-/** True when two cwd strings refer to the same directory after normalization. */
-function cwdMatches(a: string, b: string): boolean {
-  return normalizeCwd(a) === normalizeCwd(b)
 }
 
 /** Sidebar tab listing persisted + discovered chat sessions, grouped by recency with search. */
@@ -118,12 +104,16 @@ export function ChatHistoryTab(): React.JSX.Element {
       }
     })
 
-    // Add discovered sessions not already in the local mirror.
-    for (const [agentId, sessions] of Object.entries(discoveredSessions)) {
+    // Add discovered sessions not already in the local mirror. Results are keyed
+    // per (agent, cwd), so look up the active cwd's slot for each connected agent.
+    for (const agentId of Object.keys(agents)) {
       // Only surface discovered sessions for an agent that is still connected.
       // A disconnected agent can't service session/load|resume, so its entries
       // would render as un-clickable; drop them instead of showing dead rows.
       if (agentStatus[agentId] !== 'connected') continue
+      if (!activeCwd) continue
+      const sessions = discoveredSessions[discoveryKey(agentId, activeCwd)]
+      if (!sessions || sessions.length === 0) continue
       const caps = agents[agentId]?.capabilities
       const canOpen = caps?.loadSession === true || caps?.sessionCapabilities?.resume != null
       const { name: agentName, templateId } = resolveAgentIdentity(agentId)
@@ -132,11 +122,6 @@ export function ChatHistoryTab(): React.JSX.Element {
       for (const info of sessions) {
         // Dedupe: skip if already in the local mirror.
         if (mirrorIds.has(info.sessionId)) continue
-        // Filter by active cwd. The backend already passes cwd to session/list,
-        // so this is a defensive secondary filter for agents that ignore it.
-        // Compare normalized (separators + case + trailing slash) so a Windows
-        // path mismatch (E:\foo vs E:/foo/) can't wrongly hide a session.
-        if (activeCwd && info.cwd && !cwdMatches(info.cwd, activeCwd)) continue
 
         entries.push({
           id: info.sessionId,

--- a/src/renderer/lib/acp-api.ts
+++ b/src/renderer/lib/acp-api.ts
@@ -83,7 +83,7 @@ export interface SessionConfigOption {
 
 export interface AgentCapabilities {
   loadSession?: boolean
-  sessionCapabilities?: { resume?: unknown; close?: unknown } | null
+  sessionCapabilities?: { resume?: unknown; close?: unknown; list?: unknown } | null
   mcpCapabilities?: { http?: boolean; sse?: boolean } | null
   promptCapabilities?: { image?: boolean; audio?: boolean; embeddedContext?: boolean } | null
   [k: string]: unknown
@@ -228,7 +228,18 @@ export interface NewSessionOutcome {
   configOptions?: SessionConfigOption[] | null
 }
 
+/** A session discovered via `session/list` (agent-native session). */
+export interface SessionInfo {
+  sessionId: SessionId
+  cwd: string
+  title?: string | null
+  updatedAt?: string | null
+  [k: string]: unknown
+}
+
 export interface ListSessionsResponse {
+  sessions: SessionInfo[]
+  nextCursor?: string | null
   [k: string]: unknown
 }
 
@@ -406,8 +417,12 @@ export async function acpCloseSession(agentId: AgentId, sessionId: SessionId): P
   await invoke('acp_close_session', { agentId, sessionId })
 }
 
-export async function acpListSessions(agentId: AgentId): Promise<ListSessionsResponse> {
-  return invoke<ListSessionsResponse>('acp_list_sessions', { agentId })
+export async function acpListSessions(
+  agentId: AgentId,
+  cwd?: string,
+  cursor?: string
+): Promise<ListSessionsResponse> {
+  return invoke<ListSessionsResponse>('acp_list_sessions', { agentId, cwd, cursor })
 }
 
 export async function acpSendPrompt(

--- a/src/renderer/lib/acp-history-persistence.ts
+++ b/src/renderer/lib/acp-history-persistence.ts
@@ -57,16 +57,16 @@ export function deriveTitle(messages: ChatMessage[], agentId: string): string {
 export type RecencyGroup = 'Today' | 'Yesterday' | 'Earlier'
 
 /** Bucket sessions by lastActivityAt relative to `now`. Sorted newest-first within groups. */
-export function groupSessionsByRecency(
-  entries: SessionIndexEntry[],
+export function groupSessionsByRecency<T extends { lastActivityAt: number }>(
+  entries: T[],
   now: number
-): { group: RecencyGroup; entries: SessionIndexEntry[] }[] {
+): { group: RecencyGroup; entries: T[] }[] {
   const startOfToday = new Date(now)
   startOfToday.setHours(0, 0, 0, 0)
   const todayMs = startOfToday.getTime()
   const yesterdayMs = todayMs - 24 * 60 * 60 * 1000
 
-  const buckets: Record<RecencyGroup, SessionIndexEntry[]> = {
+  const buckets: Record<RecencyGroup, T[]> = {
     Today: [],
     Yesterday: [],
     Earlier: []

--- a/src/renderer/stores/acp-store.test.ts
+++ b/src/renderer/stores/acp-store.test.ts
@@ -55,6 +55,8 @@ const FRESH = {
   preparingChatKeys: {},
   prepareChatErrors: {},
   sessionIndex: [],
+  discoveredSessions: {},
+  discoveringAgents: {},
   mcpServers: [],
   sessions: {},
   activeSessionId: null,
@@ -1543,5 +1545,140 @@ describe('acp-store multi-project isolation', () => {
       connected: false,
       warming: false
     })
+  })
+})
+
+describe('session discovery (gh-407)', () => {
+  beforeEach(() => {
+    vi.mocked(invoke).mockReset()
+    useAcpStore.setState({
+      ...FRESH,
+      agents: {},
+      agentStatus: {},
+      discoveredSessions: {},
+      discoveringAgents: {}
+    })
+  })
+
+  it('discoverSessions skips agents without sessionCapabilities.list', async () => {
+    useAcpStore.setState({
+      agents: {
+        'agent-1': { id: 'agent-1', capabilities: { loadSession: false } }
+      },
+      agentStatus: { 'agent-1': 'connected' }
+    })
+    await useAcpStore.getState().discoverSessions('agent-1', '/work')
+    // invoke should not have been called for acp_list_sessions
+    const listCalls = vi.mocked(invoke).mock.calls.filter(([cmd]) => cmd === 'acp_list_sessions')
+    expect(listCalls).toHaveLength(0)
+    // No discovered sessions stored.
+    expect(useAcpStore.getState().discoveredSessions['agent-1']).toBeUndefined()
+  })
+
+  it('discoverSessions calls acp_list_sessions when list capability is advertised', async () => {
+    useAcpStore.setState({
+      agents: {
+        'agent-1': {
+          id: 'agent-1',
+          capabilities: { loadSession: false, sessionCapabilities: { list: {} } }
+        }
+      },
+      agentStatus: { 'agent-1': 'connected' }
+    })
+    vi.mocked(invoke).mockResolvedValue({
+      sessions: [{ sessionId: 'sess-1', cwd: '/work', title: 'Test Session' }],
+      nextCursor: null
+    })
+    await useAcpStore.getState().discoverSessions('agent-1', '/work')
+    const listCalls = vi.mocked(invoke).mock.calls.filter(([cmd]) => cmd === 'acp_list_sessions')
+    expect(listCalls).toHaveLength(1)
+    expect(listCalls[0]![1]).toMatchObject({ agentId: 'agent-1', cwd: '/work' })
+    const discovered = useAcpStore.getState().discoveredSessions['agent-1']
+    expect(discovered).toHaveLength(1)
+    expect(discovered![0]!.sessionId).toBe('sess-1')
+  })
+
+  it('discoverSessions paginates until nextCursor is absent', async () => {
+    useAcpStore.setState({
+      agents: {
+        'agent-1': {
+          id: 'agent-1',
+          capabilities: { loadSession: false, sessionCapabilities: { list: {} } }
+        }
+      },
+      agentStatus: { 'agent-1': 'connected' }
+    })
+    let callCount = 0
+    vi.mocked(invoke).mockImplementation(async () => {
+      callCount++
+      if (callCount === 1) {
+        return {
+          sessions: [{ sessionId: 'sess-1', cwd: '/work' }],
+          nextCursor: 'cursor-1'
+        }
+      }
+      return {
+        sessions: [{ sessionId: 'sess-2', cwd: '/work' }],
+        nextCursor: null
+      }
+    })
+    await useAcpStore.getState().discoverSessions('agent-1', '/work')
+    const discovered = useAcpStore.getState().discoveredSessions['agent-1']
+    expect(discovered).toHaveLength(2)
+    expect(discovered![0]!.sessionId).toBe('sess-1')
+    expect(discovered![1]!.sessionId).toBe('sess-2')
+  })
+
+  it('discoverSessions clears discovered entries on failure', async () => {
+    useAcpStore.setState({
+      agents: {
+        'agent-1': {
+          id: 'agent-1',
+          capabilities: { loadSession: false, sessionCapabilities: { list: {} } }
+        }
+      },
+      agentStatus: { 'agent-1': 'connected' },
+      discoveredSessions: { 'agent-1': [{ sessionId: 'old', cwd: '/work' }] }
+    })
+    vi.mocked(invoke).mockRejectedValue(new Error('agent error'))
+    await useAcpStore.getState().discoverSessions('agent-1', '/work')
+    expect(useAcpStore.getState().discoveredSessions['agent-1']).toBeUndefined()
+  })
+
+  it('_onAgentDisconnected clears discovered sessions for that agent', () => {
+    useAcpStore.setState({
+      discoveredSessions: {
+        'agent-1': [{ sessionId: 'sess-1', cwd: '/work' }],
+        'agent-2': [{ sessionId: 'sess-2', cwd: '/work' }]
+      }
+    })
+    useAcpStore.getState()._onAgentDisconnected({ agentId: 'agent-1' })
+    expect(useAcpStore.getState().discoveredSessions['agent-1']).toBeUndefined()
+    expect(useAcpStore.getState().discoveredSessions['agent-2']).toBeDefined()
+  })
+
+  it('openDiscoveredSession throws when agent has neither load nor resume', async () => {
+    useAcpStore.setState({
+      agents: {
+        'agent-1': { id: 'agent-1', capabilities: { loadSession: false } }
+      },
+      agentStatus: { 'agent-1': 'connected' }
+    })
+    await expect(
+      useAcpStore.getState().openDiscoveredSession('agent-1', 'sess-1', '/work', 'p1')
+    ).rejects.toThrow(/does not support loading or resuming/)
+  })
+
+  it('openDiscoveredSession calls acp_load_session when loadSession is advertised', async () => {
+    useAcpStore.setState({
+      agents: {
+        'agent-1': { id: 'agent-1', capabilities: { loadSession: true } }
+      },
+      agentStatus: { 'agent-1': 'connected' }
+    })
+    vi.mocked(invoke).mockResolvedValue(undefined)
+    await useAcpStore.getState().openDiscoveredSession('agent-1', 'sess-1', '/work', 'p1')
+    const loadCalls = vi.mocked(invoke).mock.calls.filter(([cmd]) => cmd === 'acp_load_session')
+    expect(loadCalls).toHaveLength(1)
   })
 })

--- a/src/renderer/stores/acp-store.test.ts
+++ b/src/renderer/stores/acp-store.test.ts
@@ -39,6 +39,7 @@ import {
   agentReuseKey,
   collectProjectsWithActiveAgentChat,
   configIdFromReuseKey,
+  discoveryKey,
   prepareChatKey,
   selectAgentIdentity,
   selectConfigWarmState,
@@ -56,7 +57,7 @@ const FRESH = {
   prepareChatErrors: {},
   sessionIndex: [],
   discoveredSessions: {},
-  discoveringAgents: {},
+  discoveringKeys: {},
   mcpServers: [],
   sessions: {},
   activeSessionId: null,
@@ -1556,7 +1557,7 @@ describe('session discovery (gh-407)', () => {
       agents: {},
       agentStatus: {},
       discoveredSessions: {},
-      discoveringAgents: {}
+      discoveringKeys: {}
     })
   })
 
@@ -1572,7 +1573,9 @@ describe('session discovery (gh-407)', () => {
     const listCalls = vi.mocked(invoke).mock.calls.filter(([cmd]) => cmd === 'acp_list_sessions')
     expect(listCalls).toHaveLength(0)
     // No discovered sessions stored.
-    expect(useAcpStore.getState().discoveredSessions['agent-1']).toBeUndefined()
+    expect(
+      useAcpStore.getState().discoveredSessions[discoveryKey('agent-1', '/work')]
+    ).toBeUndefined()
   })
 
   it('discoverSessions calls acp_list_sessions when list capability is advertised', async () => {
@@ -1593,7 +1596,7 @@ describe('session discovery (gh-407)', () => {
     const listCalls = vi.mocked(invoke).mock.calls.filter(([cmd]) => cmd === 'acp_list_sessions')
     expect(listCalls).toHaveLength(1)
     expect(listCalls[0]![1]).toMatchObject({ agentId: 'agent-1', cwd: '/work' })
-    const discovered = useAcpStore.getState().discoveredSessions['agent-1']
+    const discovered = useAcpStore.getState().discoveredSessions[discoveryKey('agent-1', '/work')]
     expect(discovered).toHaveLength(1)
     expect(discovered![0]!.sessionId).toBe('sess-1')
   })
@@ -1623,7 +1626,7 @@ describe('session discovery (gh-407)', () => {
       }
     })
     await useAcpStore.getState().discoverSessions('agent-1', '/work')
-    const discovered = useAcpStore.getState().discoveredSessions['agent-1']
+    const discovered = useAcpStore.getState().discoveredSessions[discoveryKey('agent-1', '/work')]
     expect(discovered).toHaveLength(2)
     expect(discovered![0]!.sessionId).toBe('sess-1')
     expect(discovered![1]!.sessionId).toBe('sess-2')
@@ -1638,23 +1641,31 @@ describe('session discovery (gh-407)', () => {
         }
       },
       agentStatus: { 'agent-1': 'connected' },
-      discoveredSessions: { 'agent-1': [{ sessionId: 'old', cwd: '/work' }] }
+      discoveredSessions: {
+        [discoveryKey('agent-1', '/work')]: [{ sessionId: 'old', cwd: '/work' }]
+      }
     })
     vi.mocked(invoke).mockRejectedValue(new Error('agent error'))
     await useAcpStore.getState().discoverSessions('agent-1', '/work')
-    expect(useAcpStore.getState().discoveredSessions['agent-1']).toBeUndefined()
+    expect(
+      useAcpStore.getState().discoveredSessions[discoveryKey('agent-1', '/work')]
+    ).toBeUndefined()
   })
 
   it('_onAgentDisconnected clears discovered sessions for that agent', () => {
     useAcpStore.setState({
       discoveredSessions: {
-        'agent-1': [{ sessionId: 'sess-1', cwd: '/work' }],
-        'agent-2': [{ sessionId: 'sess-2', cwd: '/work' }]
+        [discoveryKey('agent-1', '/work')]: [{ sessionId: 'sess-1', cwd: '/work' }],
+        [discoveryKey('agent-2', '/work')]: [{ sessionId: 'sess-2', cwd: '/work' }]
       }
     })
     useAcpStore.getState()._onAgentDisconnected({ agentId: 'agent-1' })
-    expect(useAcpStore.getState().discoveredSessions['agent-1']).toBeUndefined()
-    expect(useAcpStore.getState().discoveredSessions['agent-2']).toBeDefined()
+    expect(
+      useAcpStore.getState().discoveredSessions[discoveryKey('agent-1', '/work')]
+    ).toBeUndefined()
+    expect(
+      useAcpStore.getState().discoveredSessions[discoveryKey('agent-2', '/work')]
+    ).toBeDefined()
   })
 
   it('openDiscoveredSession throws when agent has neither load nor resume', async () => {

--- a/src/renderer/stores/acp-store.test.ts
+++ b/src/renderer/stores/acp-store.test.ts
@@ -1625,6 +1625,52 @@ describe('session discovery (gh-407)', () => {
     ).toBeUndefined()
   })
 
+  it('discoverSessions skips agents that are not connected (stale after disconnect)', async () => {
+    useAcpStore.setState({
+      agents: {
+        'agent-1': {
+          id: 'agent-1',
+          capabilities: { loadSession: false, sessionCapabilities: { list: {} } }
+        }
+      },
+      // _onAgentDisconnected leaves the agent present but flips status to 'error'.
+      agentStatus: { 'agent-1': 'error' }
+    })
+    await useAcpStore.getState().discoverSessions('agent-1', '/work')
+    const listCalls = vi.mocked(invoke).mock.calls.filter(([cmd]) => cmd === 'acp_list_sessions')
+    expect(listCalls).toHaveLength(0)
+    expect(
+      useAcpStore.getState().discoveredSessions[discoveryKey('agent-1', '/work')]
+    ).toBeUndefined()
+  })
+
+  it('discoverSessions treats an empty-string cursor as a valid page token', async () => {
+    useAcpStore.setState({
+      agents: {
+        'agent-1': {
+          id: 'agent-1',
+          capabilities: { loadSession: false, sessionCapabilities: { list: {} } }
+        }
+      },
+      agentStatus: { 'agent-1': 'connected' }
+    })
+    let callCount = 0
+    vi.mocked(invoke).mockImplementation(async () => {
+      callCount++
+      if (callCount === 1) {
+        // Opaque empty-string cursor must NOT end pagination.
+        return { sessions: [{ sessionId: 'sess-1', cwd: '/work' }], nextCursor: '' }
+      }
+      return { sessions: [{ sessionId: 'sess-2', cwd: '/work' }], nextCursor: null }
+    })
+    await useAcpStore.getState().discoverSessions('agent-1', '/work')
+    const listCalls = vi.mocked(invoke).mock.calls.filter(([cmd]) => cmd === 'acp_list_sessions')
+    expect(listCalls).toHaveLength(2)
+    expect(listCalls[1]![1]).toMatchObject({ cursor: '' })
+    const discovered = useAcpStore.getState().discoveredSessions[discoveryKey('agent-1', '/work')]
+    expect(discovered).toHaveLength(2)
+  })
+
   it('discoverSessions calls acp_list_sessions when list capability is advertised', async () => {
     useAcpStore.setState({
       agents: {

--- a/src/renderer/stores/acp-store.ts
+++ b/src/renderer/stores/acp-store.ts
@@ -596,8 +596,14 @@ export function configIdFromReuseKey(key: string): string {
  */
 export function normalizeCwd(cwd: string): string {
   const trimmed = cwd.trim()
+  if (trimmed === '') return ''
   const isWindowsPath = /^[a-zA-Z]:/.test(trimmed) || trimmed.includes('\\')
-  const slashed = trimmed.replace(/\\/g, '/').replace(/\/+$/, '')
+  let slashed = trimmed.replace(/\\/g, '/').replace(/\/+$/, '')
+  // Preserve roots: stripping trailing slashes must not collapse a root like
+  // "/" (POSIX) or "C:/" (Windows drive) into "" / "C:", which would alias the
+  // no-cwd key or lose the drive root.
+  if (slashed === '') slashed = '/'
+  else if (/^[a-zA-Z]:$/.test(slashed)) slashed = `${slashed}/`
   return isWindowsPath ? slashed.toLowerCase() : slashed
 }
 
@@ -1288,6 +1294,10 @@ export const useAcpStore = create<AcpState>((set, get) => ({
 
     // Prevent duplicate concurrent discovery for the same (agent, cwd).
     if (get().discoveringKeys[key]) return
+    // Gate on a LIVE connection, not just capability presence: _onAgentDisconnected
+    // leaves the agent in `agents` (status 'error') but it can no longer service
+    // session/list. Skip stale agents up front.
+    if (get().agentStatus[agentId] !== 'connected') return
     set((s) => ({ discoveringKeys: { ...s.discoveringKeys, [key]: true } }))
 
     try {
@@ -1306,9 +1316,14 @@ export const useAcpStore = create<AcpState>((set, get) => ({
             all.push(info)
           }
         }
-        if (!res.nextCursor) break
+        // Treat the cursor as opaque: only stop when it is absent (nullish).
+        // An empty-string cursor is a valid token and must NOT end pagination.
+        if (res.nextCursor == null) break
         cursor = res.nextCursor
       }
+      // Drop the result if the agent disconnected while the request was in
+      // flight, so a slow response can't repopulate state after teardown.
+      if (get().agentStatus[agentId] !== 'connected') return
       // Log only counts + context — never session metadata (titles/ids/cwd can
       // be sensitive). Detailed payloads stay out of the console.
       console.info(`[acp] discoverSessions: agent ${agentId} returned ${all.length} session(s)`)

--- a/src/renderer/stores/acp-store.ts
+++ b/src/renderer/stores/acp-store.ts
@@ -153,10 +153,12 @@ interface AcpState {
   sessionIndex: SessionIndexEntry[]
 
   // Discovered (agent-native) sessions via `session/list` — ephemeral, not persisted.
-  // Keyed by agentId; each entry is the agent's SessionInfo[] for the active cwd.
-  discoveredSessions: Record<AgentId, SessionInfo[]>
-  /** Agents whose discovery is currently in flight (prevents duplicate requests). */
-  discoveringAgents: Record<AgentId, true>
+  // Keyed by `discoveryKey(agentId, cwd)` so each (agent, cwd) pair owns its own
+  // result slot; switching cwd never clobbers another cwd's results, and a slow
+  // in-flight discovery for one cwd can't overwrite a newer cwd's results.
+  discoveredSessions: Record<string, SessionInfo[]>
+  /** discoveryKeys whose discovery is currently in flight (prevents duplicate requests). */
+  discoveringKeys: Record<string, true>
 
   // Global MCP server registry (persisted)
   mcpServers: StoredMcpServer[]
@@ -546,6 +548,24 @@ export function configIdFromReuseKey(key: string): string {
   return nul === -1 ? key : key.slice(0, nul)
 }
 
+/**
+ * Normalize a filesystem path for keying/comparison: forward slashes, no
+ * trailing slash, lowercased. Windows paths are case-insensitive and may mix
+ * separators; on POSIX this is a harmless over-match for rare mixed-case dirs.
+ */
+export function normalizeCwd(cwd: string): string {
+  return cwd.trim().replace(/\\/g, '/').replace(/\/+$/, '').toLowerCase()
+}
+
+/**
+ * Stable key for a discovery result/in-flight slot, scoped per (agent, cwd) so
+ * switching cwd never clobbers another cwd's results and a slow in-flight
+ * discovery can't overwrite a newer cwd's results. cwd is normalized.
+ */
+export function discoveryKey(agentId: AgentId, cwd: string): string {
+  return `${agentId}\0${normalizeCwd(cwd)}`
+}
+
 /** Stable key for prepare/start dedupe (MCP list order-independent). */
 export function prepareChatKey(
   configId: string,
@@ -736,7 +756,7 @@ export const useAcpStore = create<AcpState>((set, get) => ({
   prepareChatErrors: {},
   sessionIndex: [],
   discoveredSessions: {},
-  discoveringAgents: {},
+  discoveringKeys: {},
   mcpServers: [],
   sessions: {},
   activeSessionId: null,
@@ -1214,9 +1234,14 @@ export const useAcpStore = create<AcpState>((set, get) => ({
       return
     }
 
-    // Prevent duplicate concurrent discovery for the same agent.
-    if (get().discoveringAgents[agentId]) return
-    set((s) => ({ discoveringAgents: { ...s.discoveringAgents, [agentId]: true } }))
+    // Scope the result + in-flight slot per (agent, cwd) so switching cwd never
+    // clobbers another cwd's results, and a slow in-flight discovery for one cwd
+    // can't overwrite a newer cwd's results.
+    const key = discoveryKey(agentId, cwd)
+
+    // Prevent duplicate concurrent discovery for the same (agent, cwd).
+    if (get().discoveringKeys[key]) return
+    set((s) => ({ discoveringKeys: { ...s.discoveringKeys, [key]: true } }))
 
     try {
       const all: SessionInfo[] = []
@@ -1234,21 +1259,21 @@ export const useAcpStore = create<AcpState>((set, get) => ({
         `[acp] discoverSessions: agent ${agentId} returned ${all.length} session(s) for cwd ${cwd}`,
         all.map((s) => ({ sessionId: s.sessionId, cwd: s.cwd, title: s.title }))
       )
-      set((s) => ({ discoveredSessions: { ...s.discoveredSessions, [agentId]: all } }))
+      set((s) => ({ discoveredSessions: { ...s.discoveredSessions, [key]: all } }))
     } catch (e) {
       // Best-effort: log warning, don't toast (discovery is opportunistic).
       console.warn('[acp] session/list failed for agent', agentId, e)
-      // Clear any stale discovered entries for this agent.
+      // Clear any stale discovered entries for this (agent, cwd).
       set((s) => {
         const next = { ...s.discoveredSessions }
-        delete next[agentId]
+        delete next[key]
         return { discoveredSessions: next }
       })
     } finally {
       set((s) => {
-        const next = { ...s.discoveringAgents }
-        delete next[agentId]
-        return { discoveringAgents: next }
+        const next = { ...s.discoveringKeys }
+        delete next[key]
+        return { discoveringKeys: next }
       })
     }
   },
@@ -1660,7 +1685,11 @@ export const useAcpStore = create<AcpState>((set, get) => ({
         }
       }
       const discoveredSessions = { ...s.discoveredSessions }
-      delete discoveredSessions[e.agentId]
+      // Keys are `discoveryKey(agentId, cwd)`; drop every cwd slot for this agent.
+      const prefix = `${e.agentId}\0`
+      for (const k of Object.keys(discoveredSessions)) {
+        if (k.startsWith(prefix)) delete discoveredSessions[k]
+      }
       return {
         agentStatus,
         sessions,

--- a/src/renderer/stores/acp-store.ts
+++ b/src/renderer/stores/acp-store.ts
@@ -44,6 +44,7 @@ import {
   type SessionConfigOption,
   type SessionCreatedEvent,
   type SessionId,
+  type SessionInfo,
   type SessionMode,
   type SessionModelState,
   type SessionModeState,
@@ -151,6 +152,12 @@ interface AcpState {
   // Persisted chat-history index (loaded on mount; payloads load lazily)
   sessionIndex: SessionIndexEntry[]
 
+  // Discovered (agent-native) sessions via `session/list` — ephemeral, not persisted.
+  // Keyed by agentId; each entry is the agent's SessionInfo[] for the active cwd.
+  discoveredSessions: Record<AgentId, SessionInfo[]>
+  /** Agents whose discovery is currently in flight (prevents duplicate requests). */
+  discoveringAgents: Record<AgentId, true>
+
   // Global MCP server registry (persisted)
   mcpServers: StoredMcpServer[]
 
@@ -214,6 +221,17 @@ interface AcpState {
   loadSessionIndex: () => Promise<void>
   openHistorySession: (id: string) => Promise<void>
   deleteHistorySession: (id: string) => Promise<void>
+
+  // Actions — session discovery (gh-407)
+  /** Discover agent-native sessions via `session/list` for the given cwd. Best-effort, silent on failure. */
+  discoverSessions: (agentId: AgentId, cwd: string) => Promise<void>
+  /** Continue a discovered (non-mirror) session via load/resume, following the decideResume policy. */
+  openDiscoveredSession: (
+    agentId: AgentId,
+    sessionId: SessionId,
+    cwd: string,
+    projectId: string
+  ) => Promise<void>
 
   // Actions — MCP server registry (P6)
   loadMcpServers: () => Promise<void>
@@ -717,6 +735,8 @@ export const useAcpStore = create<AcpState>((set, get) => ({
   preparingChatKeys: {},
   prepareChatErrors: {},
   sessionIndex: [],
+  discoveredSessions: {},
+  discoveringAgents: {},
   mcpServers: [],
   sessions: {},
   activeSessionId: null,
@@ -1176,6 +1196,105 @@ export const useAcpStore = create<AcpState>((set, get) => ({
     }
   },
 
+  // --- Session discovery (gh-407) -------------------------------------------
+
+  discoverSessions: async (agentId, cwd) => {
+    // Gate on sessionCapabilities.list — never call session/list without it.
+    const agent = get().agents[agentId]
+    if (!agent?.capabilities) return
+    if (!agent.capabilities.sessionCapabilities?.list) return
+
+    // Prevent duplicate concurrent discovery for the same agent.
+    if (get().discoveringAgents[agentId]) return
+    set((s) => ({ discoveringAgents: { ...s.discoveringAgents, [agentId]: true } }))
+
+    try {
+      const all: SessionInfo[] = []
+      let cursor: string | undefined
+      // Safety cap: 10 pages max.
+      for (let i = 0; i < 10; i++) {
+        const res = await acpApi.listSessions(agentId, cwd || undefined, cursor)
+        if (Array.isArray(res.sessions)) {
+          all.push(...res.sessions)
+        }
+        if (!res.nextCursor) break
+        cursor = res.nextCursor
+      }
+      set((s) => ({ discoveredSessions: { ...s.discoveredSessions, [agentId]: all } }))
+    } catch (e) {
+      // Best-effort: log warning, don't toast (discovery is opportunistic).
+      console.warn('[acp] session/list failed for agent', agentId, e)
+      // Clear any stale discovered entries for this agent.
+      set((s) => {
+        const next = { ...s.discoveredSessions }
+        delete next[agentId]
+        return { discoveredSessions: next }
+      })
+    } finally {
+      set((s) => {
+        const next = { ...s.discoveringAgents }
+        delete next[agentId]
+        return { discoveringAgents: next }
+      })
+    }
+  },
+
+  openDiscoveredSession: async (agentId, sessionId, cwd, projectId) => {
+    const connected = get().agentStatus[agentId] === 'connected'
+    const capabilities = get().agents[agentId]?.capabilities ?? null
+    const strategy = decideResume({ connected, capabilities })
+
+    if (strategy === 'local') {
+      throw new Error(
+        'agent does not support loading or resuming sessions (no loadSession or sessionCapabilities.resume)'
+      )
+    }
+
+    // Create a minimal session record so streaming events (session/update)
+    // during replay have a session to attach to, mirroring openHistorySession.
+    set((s) => ({
+      sessions: {
+        ...s.sessions,
+        [sessionId]: {
+          id: sessionId,
+          agentId,
+          cwd,
+          projectId,
+          status: 'closed',
+          title: null,
+          activeTurn: false,
+          openTurnId: null,
+          modes: null,
+          models: null,
+          configOptions: [],
+          lastError: null,
+          createdAt: Date.now()
+        }
+      },
+      messages: { ...s.messages, [sessionId]: [] }
+    }))
+
+    if (strategy === 'load') {
+      // Agent replays history via session/update; clear local copy to avoid dupes.
+      try {
+        await acpApi.loadSession(agentId, sessionId, cwd)
+        set((s) => ({ sessions: withSessionActive(s.sessions, sessionId) }))
+      } catch (err) {
+        // Restore empty messages so the pane doesn't show stale content.
+        set((s) => ({ sessions: withSessionResumeError(s.sessions, sessionId, err) }))
+        throw err
+      }
+    } else if (strategy === 'resume') {
+      try {
+        await acpApi.resumeSession(agentId, sessionId, cwd)
+        set((s) => ({ sessions: withSessionActive(s.sessions, sessionId) }))
+      } catch (err) {
+        set((s) => ({ sessions: withSessionResumeError(s.sessions, sessionId, err) }))
+        throw err
+      }
+    }
+  },
+
   loadMcpServers: async () => {
     const list = await loadMcpServersFromDisk()
     set({ mcpServers: list })
@@ -1526,10 +1645,13 @@ export const useAcpStore = create<AcpState>((set, get) => ({
           affected.push(id)
         }
       }
+      const discoveredSessions = { ...s.discoveredSessions }
+      delete discoveredSessions[e.agentId]
       return {
         agentStatus,
         sessions,
-        pendingPermissions: dropPermissionsForAgent(s.pendingPermissions, e.agentId)
+        pendingPermissions: dropPermissionsForAgent(s.pendingPermissions, e.agentId),
+        discoveredSessions
       }
     })
     // Persist the closed status for each session the disconnect affected, so the

--- a/src/renderer/stores/acp-store.ts
+++ b/src/renderer/stores/acp-store.ts
@@ -1201,8 +1201,18 @@ export const useAcpStore = create<AcpState>((set, get) => ({
   discoverSessions: async (agentId, cwd) => {
     // Gate on sessionCapabilities.list — never call session/list without it.
     const agent = get().agents[agentId]
-    if (!agent?.capabilities) return
-    if (!agent.capabilities.sessionCapabilities?.list) return
+    if (!agent?.capabilities) {
+      console.info('[acp] discoverSessions: no capabilities for agent', agentId)
+      return
+    }
+    if (!agent.capabilities.sessionCapabilities?.list) {
+      console.info(
+        '[acp] discoverSessions: agent does not advertise sessionCapabilities.list, skipping',
+        agentId,
+        agent.capabilities.sessionCapabilities
+      )
+      return
+    }
 
     // Prevent duplicate concurrent discovery for the same agent.
     if (get().discoveringAgents[agentId]) return
@@ -1220,6 +1230,10 @@ export const useAcpStore = create<AcpState>((set, get) => ({
         if (!res.nextCursor) break
         cursor = res.nextCursor
       }
+      console.info(
+        `[acp] discoverSessions: agent ${agentId} returned ${all.length} session(s) for cwd ${cwd}`,
+        all.map((s) => ({ sessionId: s.sessionId, cwd: s.cwd, title: s.title }))
+      )
       set((s) => ({ discoveredSessions: { ...s.discoveredSessions, [agentId]: all } }))
     } catch (e) {
       // Best-effort: log warning, don't toast (discovery is opportunistic).

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -24,6 +24,17 @@ class ResizeObserverMock {
 
 window.ResizeObserver = ResizeObserverMock
 
+class IntersectionObserverMock {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+  takeRecords() {
+    return []
+  }
+}
+
+window.IntersectionObserver = IntersectionObserverMock as unknown as typeof IntersectionObserver
+
 vi.mock('@tauri-apps/api/core', () => ({
   invoke: vi.fn()
 }))


### PR DESCRIPTION
## Summary

Termul's Chats sidebar only showed sessions that Termul itself created and mirrored locally. It never surfaced an agent/CLI's own native session history — the conversations you can already resume from the terminal (`pi resume`, `claude --resume`, Codex/Gemini history). This PR makes the sidebar a union of Termul's local mirror **and** the agent's native sessions discovered via the ACP `session/list` method, each rendered with its own CLI icon, and clicking a discovered session continues it via the existing `session/load` / `session/resume` path.

The backend plumbing already existed (`acp_list_sessions`) but was ungated and had no UI caller. This wires it end-to-end with proper capability gating, typing, per-CLI icons, cwd-scoped discovery, and lazy rendering for large result sets.

## Related Issue

Closes #407

## Type of Change

- [x] feat: new feature
- [x] fix: bug fix
- [x] perf: performance improvement

## What Changed

**Discovery (core feature)**
- Backend: added `gate_list_sessions` mirroring the existing `gate_load_session`/`resume`/`close` pattern; gated `list_sessions` on `sessionCapabilities.list`; threaded `cwd` + `cursor` through `AcpCommand::ListSessions` and the `acp_list_sessions` command into `ListSessionsRequest`.
- Renderer: replaced the untyped `ListSessionsResponse` with typed `SessionInfo[]` + `nextCursor`; added `list` to `AgentCapabilities.sessionCapabilities`; added `cwd`/`cursor` params to `acpListSessions`.
- Store: new `discoverSessions` action (capability-gated, paginated) and `openDiscoveredSession` (creates a session record before load/resume so replayed history attaches); clears discovered sessions on agent disconnect.
- Sidebar: merges local mirror + discovered sessions deduped by `sessionId`, renders per-CLI icons via `templateIcon`, labels the owning agent, and disables un-openable entries (no `loadSession`/`resume`).

**Fixes from live `tauri dev` testing**
- Only render discovered sessions for **currently-connected** agents — a disconnected/reaped agent has no capabilities, so its rows rendered disabled (not-allowed cursor).
- Scope discovery results + the in-flight guard per `(agent, cwd)` via `discoveryKey` — switching worktree/project mid-discovery (e.g. fetching hundreds of sessions) previously dropped the new cwd's fetch or let a slow stale fetch overwrite newer results, leaving the sidebar empty after a switch.

**Performance**
- Lazy-render the sidebar with a hard cap (50/page) that grows on scroll via `IntersectionObserver` (with a "Load more" button fallback). Discovery can return hundreds of sessions; search filters the full set before capping so older sessions stay findable.

**Scope note:** Live title updates via `session_info_update` were intentionally deferred to #404 to keep this PR focused.

## How It Was Tested

- [x] `bun run ci` (Biome lint + format + imports, strict mode)
- [x] `bun run typecheck`
- [x] `bun run test` (2032 passed, 42 skipped)
- [ ] `cargo clippy --all-targets -- -D warnings` (in src-tauri)
- [x] `cargo test` (in src-tauri — 36 acp tests pass, incl. new `gate_list_sessions`)
- [x] Manual verification completed

Manual verification in `tauri dev` on Windows: connected pi + codex agents (both advertise `sessionCapabilities.list=true`, `loadSession=true`); discovery returned 500 pi sessions for the active project, rendered with per-CLI icons and lazy paging; switching project/worktree re-scopes correctly.

## Screenshots or Recordings

<!-- UI change — sidebar now shows discovered sessions with per-CLI icons. -->

## CI & Review Gate

- [ ] All CI checks pass (PR Validation, Rust Checks, Build Verification, Security Scans)
- [ ] Code review comments from CodeRabbit / Claude have been addressed or resolved
- [ ] No unresolved review findings remain

## Checklist

- [x] My PR title follows the conventional commit format used by this repo
- [x] I linked the related issue or explained why none exists
- [ ] I updated docs when needed
- [x] I added or updated tests when needed
- [x] I verified the change does not introduce unrelated modifications
- [x] I read AGENTS.md and followed the contributor guidelines
- [ ] A human reviewed the complete diff before submission


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added agent-native session discovery that lists sessions using working-directory filtering and cursor-based pagination, surfaced in chat history with “Load more”.
  * Updated the chat history sidebar to merge local and discovered sessions, with search/sorting across the combined list and lazy rendering.
* **Bug Fixes**
  * Correctly clears discovered sessions when an agent disconnects.
  * Refines discovered-session opening (capability-aware) and distinguishes “No chats yet” vs “No matches”.
* **Tests**
  * Expanded coverage for discovery gating, pagination (including cursor chaining), de-duplication, capped/lazy rendering, and search across hidden rows.
  * Added an IntersectionObserver mock for stable UI tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->