### PR TITLE
fix(acp): resolve live agent by config+cwd when reopening history after restart

### DIFF
--- a/src/renderer/stores/acp-store.test.ts
+++ b/src/renderer/stores/acp-store.test.ts
@@ -1403,9 +1403,13 @@ describe('acp-store', () => {
         ...s.agentConfigs
       ]
     }))
-    ;(invoke as ReturnType<typeof vi.fn>)
-      .mockResolvedValueOnce('spawned-1') // acp_spawn_agent -> new live agent id
-      .mockResolvedValueOnce(undefined) // acp_load_session
+    // Route by command name (not call order) so any unexpected invoke call fails
+    // loudly instead of silently consuming a queued result.
+    vi.mocked(invoke).mockImplementation(async (cmd: string) => {
+      if (cmd === 'acp_spawn_agent') return 'spawned-1'
+      if (cmd === 'acp_load_session') return undefined
+      throw new Error(`unexpected invoke command in spawn-wait test: ${cmd}`)
+    })
     const { loadSessionPayload } = await import('@/lib/acp-history-persistence')
     ;(loadSessionPayload as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
       metadata: {
@@ -1449,6 +1453,7 @@ describe('acp-store', () => {
     })
     expect(useAcpStore.getState().sessions['s-spawn'].agentId).toBe('spawned-1')
     expect(useAcpStore.getState().sessions['s-spawn'].status).toBe('active')
+    vi.mocked(invoke).mockReset()
   })
 
   it('openHistorySession opens read-only when agentConfigId is missing', async () => {

--- a/src/renderer/stores/acp-store.test.ts
+++ b/src/renderer/stores/acp-store.test.ts
@@ -1393,6 +1393,64 @@ describe('acp-store', () => {
     expect(useAcpStore.getState().sessions['s-reopen'].status).toBe('active')
   })
 
+  it('openHistorySession waits for spawned-agent capabilities before resuming', async () => {
+    // No prewarmed agent for cfg-spawn+/w -> ensureLiveAgent spawns one. Its
+    // capabilities arrive asynchronously via _onAgentSpawned; the session must
+    // resume on the spawned agent only after the wait/subscribe path resolves.
+    useAcpStore.setState((s) => ({
+      agentConfigs: [
+        { id: 'cfg-spawn', name: 'Spawn', command: 'spawn', args: [], env: {} },
+        ...s.agentConfigs
+      ]
+    }))
+    ;(invoke as ReturnType<typeof vi.fn>)
+      .mockResolvedValueOnce('spawned-1') // acp_spawn_agent -> new live agent id
+      .mockResolvedValueOnce(undefined) // acp_load_session
+    const { loadSessionPayload } = await import('@/lib/acp-history-persistence')
+    ;(loadSessionPayload as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      metadata: {
+        id: 's-spawn',
+        agentId: 'stale-spawn-uuid',
+        agentConfigId: 'cfg-spawn',
+        title: 'Spawn',
+        cwd: '/w',
+        projectId: 'p1',
+        createdAt: 1,
+        lastActivityAt: 2,
+        messageCount: 1,
+        status: 'closed'
+      },
+      messages: [
+        {
+          id: 'm1',
+          role: 'user',
+          blocks: [{ type: 'text', text: 'prior' }],
+          streaming: false,
+          timestamp: 0
+        }
+      ]
+    })
+    const p = useAcpStore.getState().openHistorySession('s-spawn')
+    await flushTurnEnd()
+    // Spawn completed: the new agent is connected but capabilities are still
+    // null, so openHistorySession is parked in the capability wait (no load yet).
+    expect(useAcpStore.getState().agentStatus['spawned-1']).toBe('connected')
+    expect(useAcpStore.getState().agents['spawned-1']?.capabilities).toBeNull()
+    expect(invoke).not.toHaveBeenCalledWith('acp_load_session', expect.anything())
+    // Capabilities arrive async -> subscribe resolves the wait -> session resumes.
+    useAcpStore
+      .getState()
+      ._onAgentSpawned({ agentId: 'spawned-1', capabilities: { loadSession: true } })
+    await p
+    expect(invoke).toHaveBeenCalledWith('acp_load_session', {
+      agentId: 'spawned-1',
+      sessionId: 's-spawn',
+      cwd: '/w'
+    })
+    expect(useAcpStore.getState().sessions['s-spawn'].agentId).toBe('spawned-1')
+    expect(useAcpStore.getState().sessions['s-spawn'].status).toBe('active')
+  })
+
   it('openHistorySession opens read-only when agentConfigId is missing', async () => {
     // Legacy persisted entries lack `agentConfigId`; we can't remap to a live
     // agent, so the chat opens read-only (current behavior) instead of throwing.

--- a/src/renderer/stores/acp-store.test.ts
+++ b/src/renderer/stores/acp-store.test.ts
@@ -1338,6 +1338,94 @@ describe('acp-store', () => {
     expect(useAcpStore.getState().sessions['s-load'].lastError).toMatch(/Resume failed/)
   })
 
+  it('openHistorySession reuses the current live agent when the persisted agentId is stale after restart', async () => {
+    // After an app restart the persisted `agentId` is a dead per-process UUID,
+    // but `agentConfigId`+cwd maps to a freshly spawned (prewarmed) live agent.
+    useAcpStore.setState((s) => ({
+      agentConfigs: [
+        { id: 'cfg-1', name: 'Agent1', command: 'agent', args: [], env: {} },
+        ...s.agentConfigs
+      ],
+      configToLiveAgent: {
+        ...s.configToLiveAgent,
+        [agentReuseKey('cfg-1', '/w')]: 'fresh-agent'
+      },
+      agents: {
+        ...s.agents,
+        'fresh-agent': { id: 'fresh-agent', capabilities: { loadSession: true } }
+      },
+      agentStatus: { ...s.agentStatus, 'fresh-agent': 'connected' }
+    }))
+    const { loadSessionPayload } = await import('@/lib/acp-history-persistence')
+    ;(loadSessionPayload as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      metadata: {
+        id: 's-reopen',
+        agentId: 'stale-dead-uuid',
+        agentConfigId: 'cfg-1',
+        title: 'Reopen me',
+        cwd: '/w',
+        projectId: 'p1',
+        createdAt: 1,
+        lastActivityAt: 2,
+        messageCount: 1,
+        status: 'closed'
+      },
+      messages: [
+        {
+          id: 'm1',
+          role: 'user',
+          blocks: [{ type: 'text', text: 'prior' }],
+          streaming: false,
+          timestamp: 0
+        }
+      ]
+    })
+    ;(invoke as ReturnType<typeof vi.fn>).mockResolvedValueOnce(undefined)
+    await useAcpStore.getState().openHistorySession('s-reopen')
+    // load targets the FRESH live agent (not the stale persisted UUID) and the
+    // session becomes active so the user can continue the conversation.
+    expect(invoke).toHaveBeenCalledWith('acp_load_session', {
+      agentId: 'fresh-agent',
+      sessionId: 's-reopen',
+      cwd: '/w'
+    })
+    expect(useAcpStore.getState().sessions['s-reopen'].agentId).toBe('fresh-agent')
+    expect(useAcpStore.getState().sessions['s-reopen'].status).toBe('active')
+  })
+
+  it('openHistorySession opens read-only when agentConfigId is missing', async () => {
+    // Legacy persisted entries lack `agentConfigId`; we can't remap to a live
+    // agent, so the chat opens read-only (current behavior) instead of throwing.
+    const { loadSessionPayload } = await import('@/lib/acp-history-persistence')
+    ;(loadSessionPayload as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      metadata: {
+        id: 's-legacy',
+        agentId: 'old-uuid',
+        title: 'Legacy',
+        cwd: '/w',
+        projectId: 'p1',
+        createdAt: 1,
+        lastActivityAt: 2,
+        messageCount: 1,
+        status: 'closed'
+      },
+      messages: [
+        {
+          id: 'm1',
+          role: 'user',
+          blocks: [{ type: 'text', text: 'old' }],
+          streaming: false,
+          timestamp: 0
+        }
+      ]
+    })
+    await useAcpStore.getState().openHistorySession('s-legacy')
+    // No live agent resolvable -> 'local' strategy: transcript shown, no IPC.
+    expect(invoke).not.toHaveBeenCalled()
+    expect(useAcpStore.getState().messages['s-legacy']).toHaveLength(1)
+    expect(useAcpStore.getState().sessions['s-legacy'].status).toBe('closed')
+  })
+
   it('deleteHistorySession removes the index entry (P5)', async () => {
     useAcpStore.setState({
       sessionIndex: [

--- a/src/renderer/stores/acp-store.ts
+++ b/src/renderer/stores/acp-store.ts
@@ -1194,8 +1194,49 @@ export const useAcpStore = create<AcpState>((set, get) => ({
     if (!payload) throw new Error(`no persisted history for ${id}`)
     const meta = payload.metadata
 
-    const connected = get().agentStatus[meta.agentId] === 'connected'
-    const capabilities = get().agents[meta.agentId]?.capabilities ?? null
+    // Resolve the CURRENT live agent for this chat's config+cwd. The persisted
+    // `meta.agentId` is a per-process UUID that is stale after an app restart
+    // (the new agent process has a different id); without this remap the
+    // `agentStatus`/`agents` lookups miss and `decideResume` falls to 'local',
+    // leaving the session closed and `sendPrompt` rejected.
+    let liveAgentId: AgentId = meta.agentId
+    // Guard both fields: `ensureLiveAgent` trims `cwd` (throws on undefined),
+    // and a missing/empty cwd can't map to a live agent anyway — fall through
+    // to read-only 'local' instead of throwing (spec: do not throw).
+    if (meta.agentConfigId && meta.cwd) {
+      const ensured = await ensureLiveAgent(get, set, meta.agentConfigId, meta.cwd, {
+        silentSpawnFailure: true
+      })
+      if (ensured) liveAgentId = ensured
+    }
+    // Capabilities arrive asynchronously via `acp:agent_spawned` for a freshly
+    // spawned agent. Wait briefly so `decideResume` sees them instead of racing
+    // to 'local'. A prewarmed agent already has them by this point.
+    if (
+      get().agentStatus[liveAgentId] === 'connected' &&
+      !get().agents[liveAgentId]?.capabilities
+    ) {
+      await new Promise<void>((resolve) => {
+        if (get().agents[liveAgentId]?.capabilities) {
+          resolve()
+          return
+        }
+        const timeout = setTimeout(() => {
+          unsubscribe()
+          resolve()
+        }, 3000)
+        const unsubscribe = useAcpStore.subscribe((state) => {
+          if (state.agents[liveAgentId]?.capabilities) {
+            clearTimeout(timeout)
+            unsubscribe()
+            resolve()
+          }
+        })
+      })
+    }
+
+    const connected = get().agentStatus[liveAgentId] === 'connected'
+    const capabilities = get().agents[liveAgentId]?.capabilities ?? null
     const strategy = decideResume({ connected, capabilities })
 
     // Rebase the process-wide seq counter so live events appended after the
@@ -1207,13 +1248,14 @@ export const useAcpStore = create<AcpState>((set, get) => ({
     rebaseSeqCounter(maxRestoredSeq)
 
     // Show the persisted transcript locally and register the session record so the
-    // pane has content regardless of strategy.
+    // pane has content regardless of strategy. Use the resolved live agent id so
+    // streaming events from `session/load` route to this session.
     set((s) => ({
       sessions: {
         ...s.sessions,
         [id]: {
           id,
-          agentId: meta.agentId,
+          agentId: liveAgentId,
           cwd: meta.cwd,
           projectId: meta.projectId,
           status: 'closed',
@@ -1234,7 +1276,7 @@ export const useAcpStore = create<AcpState>((set, get) => ({
       // Agent replays history via session/update; clear local copy to avoid dupes.
       set((s) => ({ messages: { ...s.messages, [id]: [] } }))
       try {
-        await acpApi.loadSession(meta.agentId, id, meta.cwd)
+        await acpApi.loadSession(liveAgentId, id, meta.cwd)
         set((s) => ({ sessions: withSessionActive(s.sessions, id) }))
       } catch (err) {
         // Load failed — restore the local transcript so the user still sees history.
@@ -1246,7 +1288,7 @@ export const useAcpStore = create<AcpState>((set, get) => ({
       }
     } else if (strategy === 'resume') {
       try {
-        await acpApi.resumeSession(meta.agentId, id, meta.cwd)
+        await acpApi.resumeSession(liveAgentId, id, meta.cwd)
         set((s) => ({ sessions: withSessionActive(s.sessions, id) }))
       } catch (err) {
         set((s) => ({ sessions: withSessionResumeError(s.sessions, id, err) }))


### PR DESCRIPTION
## Summary

After restarting termul, reopening a persisted chat showed the agent as "closed" and `sendPrompt` rejected with `"session is closed"`, so the conversation could not continue. `openHistorySession` resolved the agent by the persisted **live agent UUID** (`meta.agentId`), which is stale after an app restart — the new agent process has a different id — so `decideResume` always returned `'local'` and the session stayed `status:'closed'` even though a fresh agent for the same config was connected and advertised `loadSession=true`.

This PR resolves the **current live agent** for the chat's `agentConfigId`+`cwd` (reuse a connected one, else spawn via `ensureLiveAgent`), waits briefly for `acp:agent_spawned` capabilities on a fresh spawn, and targets the resolved live id (instead of the stale `meta.agentId`) for the `agentStatus`/`agents` lookups, the session record `agentId`, and the `acpApi.loadSession`/`resumeSession` IPC calls. Legacy entries without `agentConfigId` still open read-only (no throw) — behavior preserved.

## Related Issue

No related issue tracked — reported directly by the maintainer (real, experienced problem). Searched open AND closed PRs/issues — no duplicates. Related prior work that surrounds this area: #403 (persist session index across restarts — which surfaces this latent bug), #412 (mount-time prewarm), #293 (don't wipe live transcript when reopening from history), #315 (reactivate history sessions).

## Type of Change

- [x] fix: bug fix

## What Changed

- `src/renderer/stores/acp-store.ts` — `openHistorySession`:
  - Resolve the live agent via `ensureLiveAgent(get, set, meta.agentConfigId, meta.cwd, { silentSpawnFailure: true })` when **both** fields are present (the `&& meta.cwd` guard avoids a `cwd.trim()` throw on corrupted entries → stays spec-compliant "do not throw").
  - Wait briefly (3s, subscribe + timeout) for `acp:agent_spawned` capabilities so a freshly-spawned agent isn't misread as `'local'`. A prewarmed agent already has capabilities, so the wait is skipped.
  - Use the resolved `liveAgentId` (falling back to `meta.agentId` only when unresolved) for: `agentStatus`/`agents` lookups, the session record `agentId` (so `session/update` replay events route correctly), and `acpApi.loadSession`/`resumeSession`.
- `src/renderer/stores/acp-store.test.ts` — two regression tests:
  1. Stale persisted `agentId` + `agentConfigId`→fresh connected agent (capabilities `loadSession:true`) ⇒ `acp_load_session` invoked with the **live** agent id and session becomes `active`.
  2. Missing `agentConfigId` ⇒ transcript shown read-only, `status:'closed'`, no IPC, no throw.

No changes to `decideResume`/`acp-resume-policy.ts`, the persisted `SessionIndexEntry` schema, `persistSession`, `openDiscoveredSession`, `withSessionResumeError`, or any Rust code.

## How It Was Tested

- [x] `bun run ci` (Biome lint + format + imports, strict mode) — full repo, 606 files, exit 0
- [x] `bun run typecheck` — node + web + test configs clean
- [x] `bun run test` — full suite, 2056 passed / 42 skipped
- [ ] `cargo clippy --all-targets -D warnings` — N/A (no Rust changes)
- [ ] `cargo test` — N/A (no Rust changes)
- [ ] Manual verification completed — not yet (automated tests only; recommend a Tauri rebuild smoke test of reopen-after-restart before merge)
- [ ] Not applicable

## Screenshots or Recordings

N/A — behavior fix only, no UI/layout change.

## CI & Review Gate

- [ ] All CI checks pass (PR Validation, Rust Checks, Build Verification, Security Scans) — pending; will monitor
- [ ] Code review comments from CodeRabbit addressed/resolved — pending
- [ ] No unresolved review findings remain — local adversarial review run (see Notes)

## Checklist

- [x] PR title follows the conventional commit format used by this repo (`fix(acp): ...`)
- [x] Linked the related issue or explained why none exists — no GH issue; maintainer-reported; related prior PRs listed above
- [x] Updated docs when needed — no user-facing doc change (internal store behavior)
- [x] Added or updated tests — two regression tests added
- [x] Verified the change does not introduce unrelated modifications — 2 files, single concern
- [x] Read AGENTS.md and followed the contributor guidelines
- [ ] A human reviewed the complete diff before submission — awaiting maintainer review on GitHub

## Notes

- A local three-reviewer adversarial pass was run before pushing: blind hunter, edge-case hunter, acceptance auditor. The acceptance auditor found **no spec/AC violations**. One real defect was found and patched (a missing `cwd` guard that could throw on a corrupted persisted entry). Remaining reviewer findings were false-premise (refuted by the code) or spec-compliant. The `withSessionResumeError` load-failure UX (a failed reload presents as generic "closed") was intentionally scoped out of this PR per its spec and logged for a future focused PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Reopening past sessions now reconnects to the correct currently connected live agent after restart by remapping stale saved agent details to the right active process.
  - Session resume is more reliable: the app waits for agent readiness/capabilities before deciding how to reopen, preventing incorrect resume behavior.
  - Legacy or incomplete saved session metadata no longer triggers live-state resume attempts; such sessions open read-only with the saved transcript.
- **Tests**
  - Added/expanded coverage for reopened-session behavior across persisted remapping and newly spawned agents.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
