### PR TITLE
fix(acp): make chat-history continuation work after app restart

### DIFF
--- a/src-tauri/src/acp/manager.rs
+++ b/src-tauri/src/acp/manager.rs
@@ -100,6 +100,39 @@ fn session_reopen_timeout() -> Duration {
         .unwrap_or(SESSION_REOPEN_TIMEOUT)
 }
 
+/// Timed `session/load` / `session/resume`: map agent errors and timeouts to
+/// `Result<(), String>`, and record the session root on success.
+async fn run_session_reopen<Fut, T, E>(
+    op: &str,
+    session_id: &str,
+    cwd: &str,
+    req_state: &Mutex<DriverState>,
+    request: Fut,
+) -> Result<(), String>
+where
+    Fut: std::future::Future<Output = Result<T, E>>,
+    E: ToString,
+{
+    let timeout = session_reopen_timeout();
+    let outcome = tokio::time::timeout(timeout, request).await;
+    let result = match outcome {
+        Ok(result) => result.map(|_| ()).map_err(|e| e.to_string()),
+        Err(_) => {
+            log::warn!(
+                "[acp] session {session_id} {op} timed out after {timeout:?}; \
+                 check agent stderr in RUST_LOG=debug"
+            );
+            Err(format!("{op} timed out after {timeout:?}"))
+        }
+    };
+    if result.is_ok() {
+        req_state
+            .lock()
+            .set_session_root(session_id.to_string(), PathBuf::from(cwd));
+    }
+    result
+}
+
 /// Outcome of creating a new session, returned to the command caller.
 #[derive(Debug, Clone, serde::Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -1241,32 +1274,18 @@ async fn run_command_loop(
                 let req_cx = cx.clone();
                 let req_state = driver_state.clone();
                 spawn_request(&cx, slot, async move {
-                    let request = LoadSessionRequest::new(&session_id, cwd.clone());
                     // Bounded like session/new: a wedged agent must not park the
                     // renderer's reconnect forever (the reply sender would be
                     // held indefinitely).
-                    let timeout = session_reopen_timeout();
-                    let outcome = tokio::time::timeout(
-                        timeout,
+                    let request = LoadSessionRequest::new(&session_id, cwd.clone());
+                    let result = run_session_reopen(
+                        "session/load",
+                        &session_id.0,
+                        &cwd,
+                        &req_state,
                         req_cx.send_request(request).block_task(),
                     )
                     .await;
-                    let result = match outcome {
-                        Ok(result) => result.map(|_| ()).map_err(|e| e.to_string()),
-                        Err(_) => {
-                            log::warn!(
-                                "[acp] session {} session/load timed out after {timeout:?}; \
-                                 check agent stderr in RUST_LOG=debug",
-                                session_id.0
-                            );
-                            Err(format!("session/load timed out after {timeout:?}"))
-                        }
-                    };
-                    if result.is_ok() {
-                        req_state
-                            .lock()
-                            .set_session_root(session_id.0.clone(), PathBuf::from(&cwd));
-                    }
                     send_reply(&task_slot, result);
                 });
             }
@@ -1282,28 +1301,14 @@ async fn run_command_loop(
                 let req_state = driver_state.clone();
                 spawn_request(&cx, slot, async move {
                     let request = ResumeSessionRequest::new(&session_id, cwd.clone());
-                    let timeout = session_reopen_timeout();
-                    let outcome = tokio::time::timeout(
-                        timeout,
+                    let result = run_session_reopen(
+                        "session/resume",
+                        &session_id.0,
+                        &cwd,
+                        &req_state,
                         req_cx.send_request(request).block_task(),
                     )
                     .await;
-                    let result = match outcome {
-                        Ok(result) => result.map(|_| ()).map_err(|e| e.to_string()),
-                        Err(_) => {
-                            log::warn!(
-                                "[acp] session {} session/resume timed out after {timeout:?}; \
-                                 check agent stderr in RUST_LOG=debug",
-                                session_id.0
-                            );
-                            Err(format!("session/resume timed out after {timeout:?}"))
-                        }
-                    };
-                    if result.is_ok() {
-                        req_state
-                            .lock()
-                            .set_session_root(session_id.0.clone(), PathBuf::from(&cwd));
-                    }
                     send_reply(&task_slot, result);
                 });
             }

--- a/src-tauri/src/acp/manager.rs
+++ b/src-tauri/src/acp/manager.rs
@@ -60,6 +60,12 @@ const INIT_TIMEOUT: Duration = Duration::from_secs(30);
 /// former 30s budget on first launch). Overridable for diagnostics via
 /// [`session_new_timeout`].
 const SESSION_NEW_TIMEOUT: Duration = Duration::from_secs(60);
+/// How long to wait for `session/load` / `session/resume` before returning an
+/// error to the caller. Without a bound, a wedged agent parks the renderer's
+/// "reconnecting" state forever (the reopened chat can never recover). 60s
+/// matches the `session/new` budget: a load replays the full conversation and
+/// can legitimately take a while on large histories.
+const SESSION_REOPEN_TIMEOUT: Duration = Duration::from_secs(60);
 /// How long to wait, after `session/cancel`, for the agent to honor the cancel
 /// and reply to the in-flight prompt before we forcibly resolve the turn.
 const CANCEL_GRACE: Duration = Duration::from_secs(5);
@@ -79,6 +85,19 @@ fn session_new_timeout() -> Duration {
         .filter(|secs: &u64| *secs > 0)
         .map(Duration::from_secs)
         .unwrap_or(SESSION_NEW_TIMEOUT)
+}
+
+/// `session/load` / `session/resume` timeout, overridable via
+/// `TERMUL_ACP_SESSION_REOPEN_TIMEOUT_SECS` (seconds, must be > 0). Defaults
+/// to [`SESSION_REOPEN_TIMEOUT`]. A load replays the full conversation before
+/// responding, so very large histories may need a longer budget.
+fn session_reopen_timeout() -> Duration {
+    std::env::var("TERMUL_ACP_SESSION_REOPEN_TIMEOUT_SECS")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .filter(|secs: &u64| *secs > 0)
+        .map(Duration::from_secs)
+        .unwrap_or(SESSION_REOPEN_TIMEOUT)
 }
 
 /// Outcome of creating a new session, returned to the command caller.
@@ -1223,13 +1242,32 @@ async fn run_command_loop(
                 let req_state = driver_state.clone();
                 spawn_request(&cx, slot, async move {
                     let request = LoadSessionRequest::new(&session_id, cwd.clone());
-                    let result = req_cx.send_request(request).block_task().await;
+                    // Bounded like session/new: a wedged agent must not park the
+                    // renderer's reconnect forever (the reply sender would be
+                    // held indefinitely).
+                    let timeout = session_reopen_timeout();
+                    let outcome = tokio::time::timeout(
+                        timeout,
+                        req_cx.send_request(request).block_task(),
+                    )
+                    .await;
+                    let result = match outcome {
+                        Ok(result) => result.map(|_| ()).map_err(|e| e.to_string()),
+                        Err(_) => {
+                            log::warn!(
+                                "[acp] session {} session/load timed out after {timeout:?}; \
+                                 check agent stderr in RUST_LOG=debug",
+                                session_id.0
+                            );
+                            Err(format!("session/load timed out after {timeout:?}"))
+                        }
+                    };
                     if result.is_ok() {
                         req_state
                             .lock()
                             .set_session_root(session_id.0.clone(), PathBuf::from(&cwd));
                     }
-                    send_reply(&task_slot, result.map(|_| ()).map_err(|e| e.to_string()));
+                    send_reply(&task_slot, result);
                 });
             }
 
@@ -1244,13 +1282,29 @@ async fn run_command_loop(
                 let req_state = driver_state.clone();
                 spawn_request(&cx, slot, async move {
                     let request = ResumeSessionRequest::new(&session_id, cwd.clone());
-                    let result = req_cx.send_request(request).block_task().await;
+                    let timeout = session_reopen_timeout();
+                    let outcome = tokio::time::timeout(
+                        timeout,
+                        req_cx.send_request(request).block_task(),
+                    )
+                    .await;
+                    let result = match outcome {
+                        Ok(result) => result.map(|_| ()).map_err(|e| e.to_string()),
+                        Err(_) => {
+                            log::warn!(
+                                "[acp] session {} session/resume timed out after {timeout:?}; \
+                                 check agent stderr in RUST_LOG=debug",
+                                session_id.0
+                            );
+                            Err(format!("session/resume timed out after {timeout:?}"))
+                        }
+                    };
                     if result.is_ok() {
                         req_state
                             .lock()
                             .set_session_root(session_id.0.clone(), PathBuf::from(&cwd));
                     }
-                    send_reply(&task_slot, result.map(|_| ()).map_err(|e| e.to_string()));
+                    send_reply(&task_slot, result);
                 });
             }
 
@@ -1691,6 +1745,39 @@ mod tests {
             Ok(StopReason::Cancelled),
             "a stuck turn must be force-resolved as Cancelled after the grace window"
         );
+    }
+
+    /// Shape test (like `cancel_grace_forcibly_resolves_a_stuck_turn`): mirrors
+    /// the timeout-around-request pattern of the `LoadSession`/`ResumeSession`
+    /// arms against a never-resolving future, using a short local bound so the
+    /// test is fast. The arms themselves need a live connection + AppHandle and
+    /// are not driven here; this covers the match shape plus the production
+    /// timeout resolution below.
+    #[tokio::test]
+    async fn session_reopen_times_out_instead_of_hanging() {
+        const TEST_TIMEOUT: Duration = Duration::from_millis(50);
+        let request = std::future::pending::<Result<(), String>>();
+        let outcome = tokio::time::timeout(TEST_TIMEOUT, request).await;
+        let result: Result<(), String> = match outcome {
+            Ok(result) => result,
+            Err(_) => Err(format!("session/load timed out after {TEST_TIMEOUT:?}")),
+        };
+        assert!(
+            result.is_err_and(|e| e.contains("timed out")),
+            "a hung reopen must resolve to a timeout error"
+        );
+    }
+
+    /// The production reopen budget resolves to the 60s default and honors the
+    /// `TERMUL_ACP_SESSION_REOPEN_TIMEOUT_SECS` diagnostic override contract
+    /// (mirrors `session_new_timeout`). Only the default path is asserted —
+    /// mutating process env in a test would race other tests.
+    #[test]
+    fn session_reopen_timeout_defaults_to_constant() {
+        if std::env::var("TERMUL_ACP_SESSION_REOPEN_TIMEOUT_SECS").is_err() {
+            assert_eq!(session_reopen_timeout(), SESSION_REOPEN_TIMEOUT);
+        }
+        assert_eq!(SESSION_REOPEN_TIMEOUT, Duration::from_secs(60));
     }
 
     /// An empty prompt is rejected before any agent contact (EMPTY-CONTENT).

--- a/src/renderer/components/chat/AgentChatPanel.test.tsx
+++ b/src/renderer/components/chat/AgentChatPanel.test.tsx
@@ -1,0 +1,138 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { AcpSession } from '@/stores/acp-store'
+
+const { mockOpen, sessionRef, indexRef, openingRef } = vi.hoisted(() => ({
+  mockOpen: vi.fn(),
+  // AcpSession shape; typed loosely here because vi.hoisted runs before the
+  // type-only import below is usable at runtime. `seedLiveSession` constructs
+  // the value with a `satisfies AcpSession` check.
+  sessionRef: { current: null as object | null },
+  indexRef: { current: [] as Array<{ id: string }> },
+  openingRef: { current: {} as Record<string, true> }
+}))
+
+vi.mock('@/stores/acp-store', () => {
+  const state = () => ({
+    agents: {},
+    commands: {},
+    toolCalls: {},
+    plans: {},
+    pendingPermissions: {},
+    sessionIndex: indexRef.current,
+    openingHistoryIds: openingRef.current,
+    openHistorySession: mockOpen,
+    sendPrompt: vi.fn(),
+    sendPromptBlocks: vi.fn(),
+    cancelPrompt: vi.fn(),
+    setConfigOption: vi.fn(),
+    setMode: vi.fn(),
+    setModel: vi.fn()
+  })
+  return {
+    useAcpStore: (sel: (s: unknown) => unknown) => sel(state()),
+    useAcpSession: () => sessionRef.current,
+    useAcpMessages: () => []
+  }
+})
+
+// Child components pull in heavy chat rendering; the states under test render
+// before any of them mount.
+vi.mock('./ChatErrorNotice', () => ({ ChatErrorNotice: () => null }))
+vi.mock('./ChatInputBar', () => ({ ChatInputBar: () => null }))
+vi.mock('./ChatMessageList', () => ({ ChatMessageList: () => null }))
+vi.mock('./PermissionDialog', () => ({ PermissionDialog: () => null }))
+vi.mock('./PlanPanel', () => ({ PlanPanel: () => null }))
+vi.mock('./chat-timeline', () => ({
+  buildTimeline: () => [],
+  consolidateThoughtGroups: (items: unknown[]) => items
+}))
+
+import { AgentChatPanel } from './AgentChatPanel'
+
+function seedLiveSession(id: string): void {
+  sessionRef.current = {
+    id,
+    agentId: 'agent-1',
+    cwd: '/w',
+    projectId: 'p1',
+    status: 'closed',
+    title: null,
+    activeTurn: false,
+    openTurnId: null,
+    modes: null,
+    models: null,
+    configOptions: [],
+    lastError: null,
+    createdAt: 1
+  } satisfies AcpSession
+}
+
+describe('AgentChatPanel restored-tab rehydration', () => {
+  beforeEach(() => {
+    mockOpen.mockReset().mockResolvedValue(undefined)
+    sessionRef.current = null
+    indexRef.current = []
+    openingRef.current = {}
+  })
+
+  it('rehydrates a visible restored tab from persisted history', () => {
+    indexRef.current = [{ id: 's1' }]
+    render(<AgentChatPanel sessionId="s1" isVisible />)
+    expect(screen.getByText(/Restoring chat/)).toBeInTheDocument()
+    expect(mockOpen).toHaveBeenCalledTimes(1)
+    expect(mockOpen).toHaveBeenCalledWith('s1')
+  })
+
+  it('does not rehydrate a hidden tab (no background cold spawns)', () => {
+    indexRef.current = [{ id: 's1' }]
+    render(<AgentChatPanel sessionId="s1" isVisible={false} />)
+    expect(mockOpen).not.toHaveBeenCalled()
+  })
+
+  it('rehydrates when a hidden tab becomes the active tab', () => {
+    indexRef.current = [{ id: 's1' }]
+    const { rerender } = render(<AgentChatPanel sessionId="s1" isVisible={false} />)
+    expect(mockOpen).not.toHaveBeenCalled()
+    rerender(<AgentChatPanel sessionId="s1" isVisible />)
+    expect(mockOpen).toHaveBeenCalledTimes(1)
+    expect(mockOpen).toHaveBeenCalledWith('s1')
+  })
+
+  it('keeps the placeholder when no history exists for the tab', () => {
+    render(<AgentChatPanel sessionId="s-gone" isVisible />)
+    expect(screen.getByText(/No active chat for this pane/)).toBeInTheDocument()
+    expect(mockOpen).not.toHaveBeenCalled()
+  })
+
+  it('surfaces a rehydrate failure with a retry affordance', async () => {
+    indexRef.current = [{ id: 's1' }]
+    mockOpen.mockRejectedValueOnce(new Error('spawn boom'))
+    render(<AgentChatPanel sessionId="s1" isVisible />)
+    await waitFor(() => {
+      expect(screen.getByText(/Failed to restore chat/)).toBeInTheDocument()
+    })
+    // Retry clears the error and re-attempts the open.
+    fireEvent.click(screen.getByRole('button', { name: 'Retry' }))
+    await waitFor(() => {
+      expect(mockOpen).toHaveBeenCalledTimes(2)
+    })
+  })
+
+  it('shows a reconnecting banner while a closed session is being reopened', () => {
+    seedLiveSession('s1')
+    openingRef.current = { s1: true }
+    render(<AgentChatPanel sessionId="s1" isVisible />)
+    expect(screen.getByText(/Reconnecting to agent/)).toBeInTheDocument()
+  })
+
+  it('offers a Reconnect action for a closed session with history (no dead end)', () => {
+    // A failed background reconnect leaves the session registered but closed;
+    // the pane must offer a working way to re-attempt the reopen.
+    seedLiveSession('s1')
+    indexRef.current = [{ id: 's1' }]
+    render(<AgentChatPanel sessionId="s1" isVisible />)
+    fireEvent.click(screen.getByRole('button', { name: 'Reconnect' }))
+    expect(mockOpen).toHaveBeenCalledWith('s1')
+  })
+})

--- a/src/renderer/components/chat/AgentChatPanel.tsx
+++ b/src/renderer/components/chat/AgentChatPanel.tsx
@@ -1,6 +1,8 @@
-import { useCallback, useMemo, useState } from 'react'
+import { Loader2 } from 'lucide-react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
 import { toast } from 'sonner'
 import { useShallow } from 'zustand/shallow'
+import { Button } from '@/components/ui/button'
 import type { AvailableCommand, ContentBlock, PlanEntry, SessionId, ToolCall } from '@/lib/acp-api'
 import { useAcpMessages, useAcpSession, useAcpStore } from '@/stores/acp-store'
 import { ChatErrorNotice } from './ChatErrorNotice'
@@ -24,13 +26,22 @@ const EMPTY_PLAN: PlanEntry[] = []
 
 interface AgentChatPanelProps {
   sessionId: SessionId
+  /**
+   * Whether this panel's tab is the pane's active tab. Gates the restored-tab
+   * rehydrate so only visible chats trigger `openHistorySession` (a hidden
+   * restored tab must not cold-spawn an agent in the background).
+   */
+  isVisible?: boolean
 }
 
 /**
  * Top-level agent-chat pane body. Renders the header, message thread, and input
  * for a single session. Mounted by PaneContent for `agent-chat` tabs.
  */
-export function AgentChatPanel({ sessionId }: AgentChatPanelProps): React.JSX.Element {
+export function AgentChatPanel({
+  sessionId,
+  isVisible = true
+}: AgentChatPanelProps): React.JSX.Element {
   const session = useAcpSession(sessionId)
   const messages = useAcpMessages(sessionId)
   const imageCapable = useAcpStore((s) =>
@@ -56,6 +67,25 @@ export function AgentChatPanel({ sessionId }: AgentChatPanelProps): React.JSX.El
   const setConfigOption = useAcpStore((s) => s.setConfigOption)
   const setMode = useAcpStore((s) => s.setMode)
   const setModel = useAcpStore((s) => s.setModel)
+
+  // Restored-tab rehydration: a persisted `agent-chat` tab can outlive its
+  // in-memory session (app restart). When this panel is visible, its session
+  // record is missing, and history exists for the id, reopen it from history
+  // (deduped store-side against a concurrent sidebar open).
+  const openHistorySession = useAcpStore((s) => s.openHistorySession)
+  const hasHistoryEntry = useAcpStore((s) => s.sessionIndex.some((e) => e.id === sessionId))
+  const isOpeningHistory = useAcpStore((s) => Boolean(s.openingHistoryIds[sessionId]))
+  const [rehydrateError, setRehydrateError] = useState<string | null>(null)
+  useEffect(() => {
+    if (!isVisible || session || !hasHistoryEntry || rehydrateError) return
+    let cancelled = false
+    void openHistorySession(sessionId).catch((err) => {
+      if (!cancelled) setRehydrateError(String(err))
+    })
+    return () => {
+      cancelled = true
+    }
+  }, [isVisible, session, hasHistoryEntry, rehydrateError, openHistorySession, sessionId])
 
   // Composer seed (edit a message / pick a starter prompt) + dismissed-error tracking.
   const [seed, setSeed] = useState<{ text: string; nonce: number } | null>(null)
@@ -158,6 +188,24 @@ export function AgentChatPanel({ sessionId }: AgentChatPanelProps): React.JSX.El
   const showTyping = Boolean(session?.activeTurn) && !hasTurnOutput
 
   if (!session) {
+    if (rehydrateError) {
+      return (
+        <div className="flex h-full flex-col items-center justify-center gap-3 text-sm text-muted-foreground">
+          <div className="max-w-md px-6 text-center">Failed to restore chat: {rehydrateError}</div>
+          <Button type="button" variant="outline" size="sm" onClick={() => setRehydrateError(null)}>
+            Retry
+          </Button>
+        </div>
+      )
+    }
+    if (isOpeningHistory || hasHistoryEntry) {
+      return (
+        <div className="flex h-full items-center justify-center gap-2 text-sm text-muted-foreground">
+          <Loader2 size={14} className="animate-spin" />
+          Restoring chat…
+        </div>
+      )
+    }
     return (
       <div className="flex h-full items-center justify-center text-sm text-muted-foreground">
         No active chat for this pane.
@@ -171,6 +219,28 @@ export function AgentChatPanel({ sessionId }: AgentChatPanelProps): React.JSX.El
 
   return (
     <div className="flex h-full flex-col bg-background">
+      {isClosed && isOpeningHistory && (
+        <div className="flex items-center gap-2 border-b border-border/60 bg-muted/30 px-3 py-1.5 text-xs text-muted-foreground">
+          <Loader2 size={12} className="animate-spin" />
+          Reconnecting to agent…
+        </div>
+      )}
+      {isClosed && !isOpeningHistory && hasHistoryEntry && (
+        <div className="flex items-center justify-between gap-2 border-b border-border/60 bg-muted/30 px-3 py-1.5 text-xs text-muted-foreground">
+          <span>Chat disconnected.</span>
+          <button
+            type="button"
+            onClick={() => {
+              void openHistorySession(sessionId).catch((err) => {
+                toast.error(`Failed to reconnect chat: ${String(err)}`)
+              })
+            }}
+            className="rounded-md border border-border/60 px-2 py-0.5 text-xs hover:bg-background/60"
+          >
+            Reconnect
+          </button>
+        </div>
+      )}
       <ChatErrorNotice
         message={activeError}
         onRetry={canRetryLastUserTurn && !session.activeTurn ? handleRetry : undefined}

--- a/src/renderer/components/chat/ChatHistoryTab.test.tsx
+++ b/src/renderer/components/chat/ChatHistoryTab.test.tsx
@@ -158,6 +158,25 @@ describe('ChatHistoryTab scoping', () => {
     expect(mockOpen).toHaveBeenCalledWith('s1')
   })
 
+  it('opens the tab immediately without waiting for the history reconnect', () => {
+    // A cold agent spawn can take ~30s+; the click must not block on it. The
+    // tab is added synchronously and openHistorySession runs in the background.
+    sessionIndexRef.current = [entry('s1', { projectId: 'p1', cwd: '/work' })]
+    let resolveOpen: (() => void) | undefined
+    mockOpen.mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveOpen = resolve
+        })
+    )
+    render(<ChatHistoryTab />)
+    fireEvent.click(screen.getByText('s1'))
+    // Tab added while the open is still pending.
+    expect(mockAddTab).toHaveBeenCalledWith('s1')
+    expect(mockOpen).toHaveBeenCalledWith('s1')
+    resolveOpen?.()
+  })
+
   it('caps the rendered rows and lazily loads more', () => {
     // 60 sessions; page size is 50, so the first render shows 50 + a Load more.
     sessionIndexRef.current = Array.from({ length: 60 }, (_, i) =>

--- a/src/renderer/components/chat/ChatHistoryTab.tsx
+++ b/src/renderer/components/chat/ChatHistoryTab.tsx
@@ -203,11 +203,19 @@ export function ChatHistoryTab(): React.JSX.Element {
     async (entry: SidebarEntry) => {
       try {
         if (entry.discovered && entry.agentId && entry.cwd) {
+          // Discovered entries have no local transcript to show, so the pane
+          // only becomes useful once load/resume succeeds — keep awaiting.
           await openDiscoveredSession(entry.agentId, entry.id, entry.cwd, activeProjectId)
+          addAgentChatTab(entry.id)
         } else {
-          await openHistorySession(entry.id)
+          // Mirror entries: open the tab immediately (the pane shows a
+          // restoring state, then the local transcript) and reconnect in the
+          // background — a cold agent spawn must not block the click.
+          addAgentChatTab(entry.id)
+          void openHistorySession(entry.id).catch((err) => {
+            toast.error(`Failed to reconnect chat: ${String(err)}`)
+          })
         }
-        addAgentChatTab(entry.id)
       } catch (err) {
         toast.error(`Failed to open chat: ${String(err)}`)
       }

--- a/src/renderer/components/workspace/PaneContent.tsx
+++ b/src/renderer/components/workspace/PaneContent.tsx
@@ -395,7 +395,7 @@ export function PaneContent({
                     key={tab.id}
                     className={isVisible ? 'w-full h-full' : INACTIVE_TAB_PANE_CLASS}
                   >
-                    <AgentChatPanel sessionId={tab.sessionId} />
+                    <AgentChatPanel sessionId={tab.sessionId} isVisible={isVisible} />
                   </div>
                 )
               })}

--- a/src/renderer/stores/acp-store.test.ts
+++ b/src/renderer/stores/acp-store.test.ts
@@ -36,6 +36,7 @@ vi.mock('@/lib/acp-mcp-persistence', async (orig) => {
 
 import { invoke } from '@tauri-apps/api/core'
 import {
+  _resetInFlightHistoryOpensForTesting,
   agentReuseKey,
   collectProjectsWithActiveAgentChat,
   configIdFromReuseKey,
@@ -56,6 +57,7 @@ const FRESH = {
   preparingChatKeys: {},
   prepareChatErrors: {},
   sessionIndex: [],
+  openingHistoryIds: {},
   discoveredSessions: {},
   discoveringKeys: {},
   mcpServers: [],
@@ -168,6 +170,7 @@ describe('collectProjectsWithActiveAgentChat', () => {
 describe('acp-store', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    _resetInFlightHistoryOpensForTesting()
     useAcpStore.setState(FRESH)
   })
 
@@ -360,6 +363,64 @@ describe('acp-store', () => {
       stopReason: 'refusal'
     })
     expect(useAcpStore.getState().sessions['s1'].lastError).toMatch(/refused/i)
+  })
+
+  it('prompt_complete mirrors the transcript to disk so agent replies survive a restart', async () => {
+    // Only user sends used to persist; a reply followed by an app quit was lost.
+    seedSession('s1', 'agent-1')
+    useAcpStore.setState({
+      sessionIndex: [
+        {
+          id: 's1',
+          agentId: 'agent-1',
+          title: 'T',
+          cwd: '/work',
+          projectId: 'p1',
+          createdAt: 0,
+          lastActivityAt: 0,
+          messageCount: 1,
+          status: 'active'
+        }
+      ]
+    })
+    useAcpStore.getState()._onMessageChunk({
+      agentId: 'agent-1',
+      sessionId: 's1',
+      role: 'agent',
+      content: { type: 'text', text: 'the answer' }
+    })
+    const { saveSessionPayload } = await import('@/lib/acp-history-persistence')
+    ;(saveSessionPayload as ReturnType<typeof vi.fn>).mockClear()
+    useAcpStore.getState()._onPromptComplete({
+      agentId: 'agent-1',
+      sessionId: 's1',
+      stopReason: 'end_turn'
+    })
+    await flushTurnEnd()
+    expect(saveSessionPayload).toHaveBeenCalledWith(
+      's1',
+      expect.objectContaining({
+        messages: [expect.objectContaining({ role: 'agent', streaming: false })]
+      })
+    )
+  })
+
+  it('prompt_complete does not resurrect a chat deleted while the turn was in flight', async () => {
+    // deleteHistorySession removed the index entry mid-turn; the turn-end
+    // persist must not write it back.
+    seedSession('s1', 'agent-1')
+    // No sessionIndex entry for s1 (deleted).
+    const { saveSessionPayload, saveSessionIndex } = await import('@/lib/acp-history-persistence')
+    ;(saveSessionPayload as ReturnType<typeof vi.fn>).mockClear()
+    ;(saveSessionIndex as ReturnType<typeof vi.fn>).mockClear()
+    useAcpStore.getState()._onPromptComplete({
+      agentId: 'agent-1',
+      sessionId: 's1',
+      stopReason: 'end_turn'
+    })
+    await flushTurnEnd()
+    expect(saveSessionPayload).not.toHaveBeenCalled()
+    expect(useAcpStore.getState().sessionIndex).toEqual([])
   })
 
   it('agent_disconnected marks the agent error and closes its sessions', () => {
@@ -1233,8 +1294,11 @@ describe('acp-store', () => {
       sessionId: 's-closed',
       cwd: '/w'
     })
-    // load strategy clears then agent replays; with no replay, messages stay empty
-    expect(useAcpStore.getState().messages['s-closed']).toEqual([])
+    // The local transcript stays visible while (and after) the load: an agent
+    // that replays nothing must not blank the chat. A real replay replaces it
+    // (covered by the replay tests below).
+    expect(useAcpStore.getState().messages['s-closed']).toHaveLength(1)
+    expect(useAcpStore.getState().messages['s-closed'][0].id).toBe('m1')
     expect(useAcpStore.getState().sessions['s-closed'].status).toBe('active')
   })
 
@@ -1330,12 +1394,30 @@ describe('acp-store', () => {
         }
       ]
     })
-    // acp_load_session rejects
-    ;(invoke as ReturnType<typeof vi.fn>).mockRejectedValueOnce('load boom')
+    // The agent streams a PARTIAL replay (replacing the mirror), then the load
+    // rejects — the restore path must bring the full local transcript back.
+    vi.mocked(invoke).mockImplementation(async (cmd: string) => {
+      if (cmd !== 'acp_load_session') {
+        throw new Error(`unexpected invoke command in load-failure test: ${cmd}`)
+      }
+      useAcpStore.getState()._onMessageChunk({
+        agentId: 'agent-1',
+        sessionId: 's-load',
+        role: 'user',
+        content: { type: 'text', text: 'partial replay' }
+      })
+      throw new Error('load boom')
+    })
     await expect(useAcpStore.getState().openHistorySession('s-load')).rejects.toBeDefined()
-    // transcript was restored (not left empty) and the error surfaced
-    expect(useAcpStore.getState().messages['s-load']).toHaveLength(1)
-    expect(useAcpStore.getState().sessions['s-load'].lastError).toMatch(/Resume failed/)
+    // transcript was restored (not the partial replay) and the error surfaced
+    const messages = useAcpStore.getState().messages['s-load']
+    expect(messages).toHaveLength(1)
+    expect(messages[0].id).toBe('m1')
+    const session = useAcpStore.getState().sessions['s-load']
+    expect(session.lastError).toMatch(/Resume failed/)
+    expect(session.status).toBe('closed')
+    expect(session.replaying).toBeNull()
+    vi.mocked(invoke).mockReset()
   })
 
   it('openHistorySession reuses the current live agent when the persisted agentId is stale after restart', async () => {
@@ -1487,6 +1569,351 @@ describe('acp-store', () => {
     expect(invoke).not.toHaveBeenCalled()
     expect(useAcpStore.getState().messages['s-legacy']).toHaveLength(1)
     expect(useAcpStore.getState().sessions['s-legacy'].status).toBe('closed')
+  })
+
+  it('openHistorySession renders replayed session/load history instead of dropping it', async () => {
+    // The core "empty reopened chat" bug: replayed session/update chunks arrive
+    // while the load IPC is in flight (session still 'closed'). They must be
+    // accepted, and the FIRST replayed chunk replaces the local mirror so the
+    // conversation is not duplicated.
+    useAcpStore.setState((s) => ({
+      agents: { ...s.agents, 'agent-1': { id: 'agent-1', capabilities: { loadSession: true } } },
+      agentStatus: { ...s.agentStatus, 'agent-1': 'connected' }
+    }))
+    const { loadSessionPayload } = await import('@/lib/acp-history-persistence')
+    ;(loadSessionPayload as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      metadata: {
+        id: 's-replay',
+        agentId: 'agent-1',
+        title: 'Replayed',
+        cwd: '/w',
+        projectId: 'p1',
+        createdAt: 1,
+        lastActivityAt: 2,
+        messageCount: 1,
+        status: 'closed'
+      },
+      messages: [
+        {
+          id: 'mirror-1',
+          role: 'user',
+          blocks: [{ type: 'text', text: 'stale local copy' }],
+          streaming: false,
+          timestamp: 0
+        }
+      ]
+    })
+    // The agent streams the replay BEFORE responding to session/load.
+    vi.mocked(invoke).mockImplementation(async (cmd: string) => {
+      if (cmd !== 'acp_load_session') {
+        throw new Error(`unexpected invoke command in replay test: ${cmd}`)
+      }
+      useAcpStore.getState()._onMessageChunk({
+        agentId: 'agent-1',
+        sessionId: 's-replay',
+        role: 'user',
+        content: { type: 'text', text: 'replayed question' }
+      })
+      useAcpStore.getState()._onMessageChunk({
+        agentId: 'agent-1',
+        sessionId: 's-replay',
+        role: 'agent',
+        content: { type: 'text', text: 'replayed answer' }
+      })
+      return undefined
+    })
+    await useAcpStore.getState().openHistorySession('s-replay')
+    const messages = useAcpStore.getState().messages['s-replay']
+    expect(messages).toHaveLength(2)
+    expect(messages[0].blocks).toEqual([{ type: 'text', text: 'replayed question' }])
+    expect(messages[1].blocks).toEqual([{ type: 'text', text: 'replayed answer' }])
+    expect(useAcpStore.getState().sessions['s-replay'].status).toBe('active')
+    // The replay window closes on a deferred macrotask (straggler tolerance).
+    expect(useAcpStore.getState().sessions['s-replay'].replaying).toBe('streaming')
+    await flushTurnEnd()
+    expect(useAcpStore.getState().sessions['s-replay'].replaying).toBeNull()
+    vi.mocked(invoke).mockReset()
+  })
+
+  it('openHistorySession accepts straggler chunks of an in-progress replay after load resolves', async () => {
+    useAcpStore.setState((s) => ({
+      agents: { ...s.agents, 'agent-1': { id: 'agent-1', capabilities: { loadSession: true } } },
+      agentStatus: { ...s.agentStatus, 'agent-1': 'connected' }
+    }))
+    const { loadSessionPayload } = await import('@/lib/acp-history-persistence')
+    ;(loadSessionPayload as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      metadata: {
+        id: 's-straggle',
+        agentId: 'agent-1',
+        title: 'Straggler',
+        cwd: '/w',
+        projectId: 'p1',
+        createdAt: 1,
+        lastActivityAt: 2,
+        messageCount: 0,
+        status: 'closed'
+      },
+      messages: []
+    })
+    // The replay STARTS while the load is in flight (streaming), so its window
+    // stays open one macrotask past the response for chunks that lose the IPC
+    // race.
+    vi.mocked(invoke).mockImplementation(async (cmd: string) => {
+      if (cmd !== 'acp_load_session') {
+        throw new Error(`unexpected invoke command in straggler test: ${cmd}`)
+      }
+      useAcpStore.getState()._onMessageChunk({
+        agentId: 'agent-1',
+        sessionId: 's-straggle',
+        role: 'user',
+        content: { type: 'text', text: 'replayed question' }
+      })
+      return undefined
+    })
+    await useAcpStore.getState().openHistorySession('s-straggle')
+    useAcpStore.getState()._onMessageChunk({
+      agentId: 'agent-1',
+      sessionId: 's-straggle',
+      role: 'agent',
+      content: { type: 'text', text: 'late replay tail' }
+    })
+    expect(useAcpStore.getState().messages['s-straggle']).toHaveLength(2)
+    await flushTurnEnd()
+    expect(useAcpStore.getState().sessions['s-straggle'].replaying).toBeNull()
+    vi.mocked(invoke).mockReset()
+  })
+
+  it('openHistorySession keeps the local transcript when the agent replays nothing', async () => {
+    // 'pending' must close as soon as the load response arrives with no replay:
+    // a live chunk landing afterwards (e.g. an agent-initiated status message)
+    // must APPEND-or-drop, never replace the restored conversation.
+    useAcpStore.setState((s) => ({
+      agents: { ...s.agents, 'agent-1': { id: 'agent-1', capabilities: { loadSession: true } } },
+      agentStatus: { ...s.agentStatus, 'agent-1': 'connected' }
+    }))
+    const { loadSessionPayload } = await import('@/lib/acp-history-persistence')
+    ;(loadSessionPayload as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      metadata: {
+        id: 's-noreplay',
+        agentId: 'agent-1',
+        title: 'No replay',
+        cwd: '/w',
+        projectId: 'p1',
+        createdAt: 1,
+        lastActivityAt: 2,
+        messageCount: 2,
+        status: 'closed'
+      },
+      messages: [
+        {
+          id: 'm1',
+          role: 'user',
+          blocks: [{ type: 'text', text: 'question' }],
+          streaming: false,
+          timestamp: 0
+        },
+        {
+          id: 'm2',
+          role: 'agent',
+          blocks: [{ type: 'text', text: 'answer' }],
+          streaming: false,
+          timestamp: 1
+        }
+      ]
+    })
+    ;(invoke as ReturnType<typeof vi.fn>).mockResolvedValueOnce(undefined)
+    await useAcpStore.getState().openHistorySession('s-noreplay')
+    expect(useAcpStore.getState().sessions['s-noreplay'].replaying).toBeNull()
+    // A live chunk after the empty replay must not wipe the mirror.
+    useAcpStore.getState()._onMessageChunk({
+      agentId: 'agent-1',
+      sessionId: 's-noreplay',
+      role: 'agent',
+      content: { type: 'text', text: 'greeting' }
+    })
+    const messages = useAcpStore.getState().messages['s-noreplay']
+    expect(messages.length).toBeGreaterThanOrEqual(2)
+    expect(messages[0].id).toBe('m1')
+    expect(messages[1].id).toBe('m2')
+  })
+
+  it('openHistorySession replay drops stale tool calls from a previous live period', async () => {
+    useAcpStore.setState((s) => ({
+      agents: { ...s.agents, 'agent-1': { id: 'agent-1', capabilities: { loadSession: true } } },
+      agentStatus: { ...s.agentStatus, 'agent-1': 'connected' },
+      toolCalls: { 's-tools': [{ toolCallId: 'stale-1', seq: 1 }] }
+    }))
+    const { loadSessionPayload } = await import('@/lib/acp-history-persistence')
+    ;(loadSessionPayload as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      metadata: {
+        id: 's-tools',
+        agentId: 'agent-1',
+        title: 'Tools',
+        cwd: '/w',
+        projectId: 'p1',
+        createdAt: 1,
+        lastActivityAt: 2,
+        messageCount: 0,
+        status: 'closed'
+      },
+      messages: []
+    })
+    vi.mocked(invoke).mockImplementation(async (cmd: string) => {
+      if (cmd !== 'acp_load_session') {
+        throw new Error(`unexpected invoke command in tool-replay test: ${cmd}`)
+      }
+      useAcpStore.getState()._onMessageChunk({
+        agentId: 'agent-1',
+        sessionId: 's-tools',
+        role: 'user',
+        content: { type: 'text', text: 'replayed' }
+      })
+      return undefined
+    })
+    await useAcpStore.getState().openHistorySession('s-tools')
+    // The replay replaced the transcript; the stale tool calls went with it.
+    expect(useAcpStore.getState().toolCalls['s-tools']).toEqual([])
+    vi.mocked(invoke).mockReset()
+  })
+
+  it('a follow-up prompt can be sent after a replayed reopen (AC1)', async () => {
+    useAcpStore.setState((s) => ({
+      agents: { ...s.agents, 'agent-1': { id: 'agent-1', capabilities: { loadSession: true } } },
+      agentStatus: { ...s.agentStatus, 'agent-1': 'connected' }
+    }))
+    const { loadSessionPayload } = await import('@/lib/acp-history-persistence')
+    ;(loadSessionPayload as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      metadata: {
+        id: 's-followup',
+        agentId: 'agent-1',
+        title: 'Follow up',
+        cwd: '/w',
+        projectId: 'p1',
+        createdAt: 1,
+        lastActivityAt: 2,
+        messageCount: 0,
+        status: 'closed'
+      },
+      messages: []
+    })
+    vi.mocked(invoke).mockImplementation(async (cmd: string) => {
+      if (cmd === 'acp_load_session') {
+        useAcpStore.getState()._onMessageChunk({
+          agentId: 'agent-1',
+          sessionId: 's-followup',
+          role: 'agent',
+          content: { type: 'text', text: 'replayed answer' }
+        })
+        return undefined
+      }
+      if (cmd === 'acp_send_prompt') return 'end_turn'
+      throw new Error(`unexpected invoke command in follow-up test: ${cmd}`)
+    })
+    await useAcpStore.getState().openHistorySession('s-followup')
+    await flushTurnEnd()
+    await useAcpStore.getState().sendPrompt('s-followup', 'continue please')
+    await flushTurnEnd()
+    expect(invoke).toHaveBeenCalledWith('acp_send_prompt', {
+      agentId: 'agent-1',
+      sessionId: 's-followup',
+      text: 'continue please'
+    })
+    const messages = useAcpStore.getState().messages['s-followup']
+    expect(messages.some((m) => m.role === 'user')).toBe(true)
+    vi.mocked(invoke).mockReset()
+  })
+
+  it('a title update streamed mid-replay does not persist the partial transcript', async () => {
+    // _onSessionInfoUpdate persists — but a mid-replay persist would truncate
+    // the on-disk history to whatever has replayed so far.
+    useAcpStore.setState((s) => ({
+      agents: { ...s.agents, 'agent-1': { id: 'agent-1', capabilities: { loadSession: true } } },
+      agentStatus: { ...s.agentStatus, 'agent-1': 'connected' },
+      sessionIndex: [
+        {
+          id: 's-midpersist',
+          agentId: 'agent-1',
+          title: 'Old',
+          cwd: '/w',
+          projectId: 'p1',
+          createdAt: 1,
+          lastActivityAt: 2,
+          messageCount: 5,
+          status: 'closed'
+        }
+      ]
+    }))
+    const { loadSessionPayload, saveSessionPayload } = await import('@/lib/acp-history-persistence')
+    ;(loadSessionPayload as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      metadata: {
+        id: 's-midpersist',
+        agentId: 'agent-1',
+        title: 'Old',
+        cwd: '/w',
+        projectId: 'p1',
+        createdAt: 1,
+        lastActivityAt: 2,
+        messageCount: 5,
+        status: 'closed'
+      },
+      messages: []
+    })
+    ;(saveSessionPayload as ReturnType<typeof vi.fn>).mockClear()
+    vi.mocked(invoke).mockImplementation(async (cmd: string) => {
+      if (cmd !== 'acp_load_session') {
+        throw new Error(`unexpected invoke command in mid-persist test: ${cmd}`)
+      }
+      // Replay starts, then the agent streams a title update mid-replay.
+      useAcpStore.getState()._onMessageChunk({
+        agentId: 'agent-1',
+        sessionId: 's-midpersist',
+        role: 'user',
+        content: { type: 'text', text: 'partial replay' }
+      })
+      useAcpStore.getState()._onSessionInfoUpdate({
+        agentId: 'agent-1',
+        sessionId: 's-midpersist',
+        title: 'New title'
+      })
+      return undefined
+    })
+    await useAcpStore.getState().openHistorySession('s-midpersist')
+    expect(saveSessionPayload).not.toHaveBeenCalled()
+    vi.mocked(invoke).mockReset()
+  })
+
+  it('openHistorySession coalesces concurrent opens for the same chat', async () => {
+    useAcpStore.setState((s) => ({
+      agents: { ...s.agents, 'agent-1': { id: 'agent-1', capabilities: { loadSession: true } } },
+      agentStatus: { ...s.agentStatus, 'agent-1': 'connected' }
+    }))
+    const { loadSessionPayload } = await import('@/lib/acp-history-persistence')
+    // Only ONE disk read is budgeted: if dedupe fails, the second call falls
+    // through to the default (null payload) and rejects the test loudly.
+    ;(loadSessionPayload as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      metadata: {
+        id: 's-race',
+        agentId: 'agent-1',
+        title: 'Race',
+        cwd: '/w',
+        projectId: 'p1',
+        createdAt: 1,
+        lastActivityAt: 2,
+        messageCount: 0,
+        status: 'closed'
+      },
+      messages: []
+    })
+    ;(invoke as ReturnType<typeof vi.fn>).mockResolvedValueOnce(undefined)
+    // Sidebar click + restored-tab rehydrate race at startup.
+    await Promise.all([
+      useAcpStore.getState().openHistorySession('s-race'),
+      useAcpStore.getState().openHistorySession('s-race')
+    ])
+    const loadCalls = vi.mocked(invoke).mock.calls.filter(([cmd]) => cmd === 'acp_load_session')
+    expect(loadCalls).toHaveLength(1)
+    expect(loadSessionPayload).toHaveBeenCalledTimes(1)
+    expect(useAcpStore.getState().openingHistoryIds['s-race']).toBeUndefined()
   })
 
   it('deleteHistorySession removes the index entry (P5)', async () => {

--- a/src/renderer/stores/acp-store.test.ts
+++ b/src/renderer/stores/acp-store.test.ts
@@ -1420,6 +1420,126 @@ describe('acp-store', () => {
     vi.mocked(invoke).mockReset()
   })
 
+  it('openHistorySession does not activate a chat deleted during load', async () => {
+    useAcpStore.setState((s) => ({
+      agents: { ...s.agents, 'agent-1': { id: 'agent-1', capabilities: { loadSession: true } } },
+      agentStatus: { ...s.agentStatus, 'agent-1': 'connected' },
+      sessionIndex: [
+        {
+          id: 's-del-ok',
+          agentId: 'agent-1',
+          title: 'Doomed',
+          cwd: '/w',
+          createdAt: 1,
+          lastActivityAt: 2,
+          messageCount: 1,
+          status: 'closed'
+        }
+      ]
+    }))
+    const { loadSessionPayload } = await import('@/lib/acp-history-persistence')
+    ;(loadSessionPayload as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      metadata: {
+        id: 's-del-ok',
+        agentId: 'agent-1',
+        title: 'Doomed',
+        cwd: '/w',
+        createdAt: 1,
+        lastActivityAt: 2,
+        messageCount: 1,
+        status: 'closed'
+      },
+      messages: [
+        {
+          id: 'm1',
+          role: 'user',
+          blocks: [{ type: 'text', text: 'prior' }],
+          streaming: false,
+          timestamp: 0
+        }
+      ]
+    })
+    vi.mocked(invoke).mockImplementation(async (cmd: string) => {
+      if (cmd !== 'acp_load_session') {
+        throw new Error(`unexpected invoke command: ${cmd}`)
+      }
+      await useAcpStore.getState().deleteHistorySession('s-del-ok')
+    })
+    await useAcpStore.getState().openHistorySession('s-del-ok')
+    const session = useAcpStore.getState().sessions['s-del-ok']
+    expect(session.status).toBe('closed')
+    expect(session.replaying).toBeNull()
+    expect(session.lastError).toBeNull()
+    expect(useAcpStore.getState().sessionIndex.some((e) => e.id === 's-del-ok')).toBe(false)
+    vi.mocked(invoke).mockReset()
+  })
+
+  it('openHistorySession does not restore or error a chat deleted during a failed load', async () => {
+    useAcpStore.setState((s) => ({
+      agents: { ...s.agents, 'agent-1': { id: 'agent-1', capabilities: { loadSession: true } } },
+      agentStatus: { ...s.agentStatus, 'agent-1': 'connected' },
+      sessionIndex: [
+        {
+          id: 's-del-fail',
+          agentId: 'agent-1',
+          title: 'Doomed',
+          cwd: '/w',
+          createdAt: 1,
+          lastActivityAt: 2,
+          messageCount: 1,
+          status: 'closed'
+        }
+      ]
+    }))
+    const { loadSessionPayload } = await import('@/lib/acp-history-persistence')
+    ;(loadSessionPayload as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      metadata: {
+        id: 's-del-fail',
+        agentId: 'agent-1',
+        title: 'Doomed',
+        cwd: '/w',
+        createdAt: 1,
+        lastActivityAt: 2,
+        messageCount: 1,
+        status: 'closed'
+      },
+      messages: [
+        {
+          id: 'm1',
+          role: 'user',
+          blocks: [{ type: 'text', text: 'prior' }],
+          streaming: false,
+          timestamp: 0
+        }
+      ]
+    })
+    vi.mocked(invoke).mockImplementation(async (cmd: string) => {
+      if (cmd !== 'acp_load_session') {
+        throw new Error(`unexpected invoke command: ${cmd}`)
+      }
+      useAcpStore.getState()._onMessageChunk({
+        agentId: 'agent-1',
+        sessionId: 's-del-fail',
+        role: 'user',
+        content: { type: 'text', text: 'partial replay' }
+      })
+      await useAcpStore.getState().deleteHistorySession('s-del-fail')
+      throw new Error('load boom')
+    })
+    // Must resolve (not reject) so callers do not toast after an intentional delete.
+    await expect(useAcpStore.getState().openHistorySession('s-del-fail')).resolves.toBeUndefined()
+    const session = useAcpStore.getState().sessions['s-del-fail']
+    expect(session.status).toBe('closed')
+    expect(session.lastError).toBeNull()
+    expect(session.replaying).toBeNull()
+    // Partial replay must not be overwritten by the failure restore path.
+    const messages = useAcpStore.getState().messages['s-del-fail']
+    expect(
+      messages.some((m) => m.blocks.some((b) => b.type === 'text' && b.text === 'partial replay'))
+    ).toBe(true)
+    vi.mocked(invoke).mockReset()
+  })
+
   it('openHistorySession reuses the current live agent when the persisted agentId is stale after restart', async () => {
     // After an app restart the persisted `agentId` is a dead per-process UUID,
     // but `agentConfigId`+cwd maps to a freshly spawned (prewarmed) live agent.

--- a/src/renderer/stores/acp-store.ts
+++ b/src/renderer/stores/acp-store.ts
@@ -835,6 +835,18 @@ async function openHistorySessionInner(
   set: TurnEndSetter,
   id: string
 ): Promise<void> {
+  // Snapshot before any await so a delete during cold-spawn / capability wait
+  // is still detected as a mid-open transition (not "never indexed").
+  const wasIndexed = get().sessionIndex.some((e) => e.id === id)
+  const deletedMidOpen = (): boolean => wasIndexed && !get().sessionIndex.some((e) => e.id === id)
+  const clearReplayIfPresent = (): void => {
+    set((s) => {
+      const session = s.sessions[id]
+      if (!session?.replaying) return {}
+      return { sessions: { ...s.sessions, [id]: { ...session, replaying: null } } }
+    })
+  }
+
   const payload = await loadSessionPayload(id)
   if (!payload) throw new Error(`no persisted history for ${id}`)
   const meta = payload.metadata
@@ -910,6 +922,9 @@ async function openHistorySessionInner(
     })
   }
 
+  // Deleted during spawn/capability wait — leave the closed record alone.
+  if (deletedMidOpen()) return
+
   const connected = get().agentStatus[liveAgentId] === 'connected'
   const capabilities = get().agents[liveAgentId]?.capabilities ?? null
   const strategy = decideResume({ connected, capabilities })
@@ -933,22 +948,11 @@ async function openHistorySessionInner(
     }
   })
 
-  // A chat deleted while the reconnect was in flight must stay deleted: skip
-  // activation (the record was already marked closed by the delete). Detected
-  // as a transition — indexed when the open started, gone afterwards — so a
-  // session that was never indexed is not mistaken for a deleted one.
-  const wasIndexed = get().sessionIndex.some((e) => e.id === id)
-  const deletedMidOpen = (): boolean => wasIndexed && !get().sessionIndex.some((e) => e.id === id)
-
   if (strategy === 'load') {
     try {
       await acpApi.loadSession(liveAgentId, id, meta.cwd)
       if (deletedMidOpen()) {
-        set((s) => {
-          const session = s.sessions[id]
-          if (!session) return {}
-          return { sessions: { ...s.sessions, [id]: { ...session, replaying: null } } }
-        })
+        clearReplayIfPresent()
         return
       }
       set((s) => {
@@ -971,6 +975,12 @@ async function openHistorySessionInner(
       })
       scheduleReplayEnd(set, id)
     } catch (err) {
+      // Deleted mid-load: do not restore transcript or surface a resume error
+      // (delete already closed the session; a toast would be misleading).
+      if (deletedMidOpen()) {
+        clearReplayIfPresent()
+        return
+      }
       // Load failed — restore the local transcript so the user still sees
       // history (a partial replay may have replaced it).
       set((s) => ({
@@ -985,6 +995,7 @@ async function openHistorySessionInner(
       if (deletedMidOpen()) return
       set((s) => ({ sessions: withSessionActive(s.sessions, id) }))
     } catch (err) {
+      if (deletedMidOpen()) return
       set((s) => ({ sessions: withSessionResumeError(s.sessions, id, err) }))
       throw err
     }

--- a/src/renderer/stores/acp-store.ts
+++ b/src/renderer/stores/acp-store.ts
@@ -119,6 +119,17 @@ export interface AcpSession {
   configOptions: SessionConfigOption[]
   lastError: string | null
   createdAt: number
+  /**
+   * Set while a `session/load` replay may still deliver history chunks.
+   * 'pending' → load sent, no replayed chunk yet (the locally persisted
+   * transcript stays visible); 'streaming' → the first replayed chunk replaced
+   * the local transcript and later chunks append. Chunks for a session in
+   * either state are accepted even while `status` is still 'closed' (the load
+   * IPC is in flight). Cleared on a deferred macrotask after the load resolves
+   * (see `scheduleReplayEnd`) so stragglers that lose the IPC race still land.
+   * Absent/null means no replay is in flight.
+   */
+  replaying?: 'pending' | 'streaming' | null
 }
 
 export interface PendingPermission {
@@ -154,6 +165,9 @@ interface AcpState {
 
   // Persisted chat-history index (loaded on mount; payloads load lazily)
   sessionIndex: SessionIndexEntry[]
+
+  /** Session ids whose `openHistorySession` is in flight (drives UI loading states). */
+  openingHistoryIds: Record<string, true>
 
   // Discovered (agent-native) sessions via `session/list` — ephemeral, not persisted.
   // Keyed by `discoveryKey(agentId, cwd)` so each (agent, cwd) pair owns its own
@@ -375,6 +389,10 @@ function mayStartChunkMessage(
   role: MessageRole
 ): boolean {
   if (session.openTurnId) return true
+  // A session/load replay re-streams the whole conversation (user and agent
+  // turns alike) outside any prompt turn; every replayed chunk may open a
+  // bubble.
+  if (session.replaying) return true
   const last = messages[messages.length - 1]
   if ((role === 'agent' || role === 'thought') && last?.role === 'user') return true
   return false
@@ -445,7 +463,28 @@ function withSessionResumeError(
 ): Record<SessionId, AcpSession> {
   const session = sessions[sessionId]
   if (!session) return sessions
-  return { ...sessions, [sessionId]: { ...session, lastError: `Resume failed: ${String(err)}` } }
+  return {
+    ...sessions,
+    [sessionId]: { ...session, replaying: null, lastError: `Resume failed: ${String(err)}` }
+  }
+}
+
+/**
+ * End a session/load replay after the macrotask queue drains, so replayed
+ * chunks that lose the IPC race against the `acp_load_session` response are
+ * still accepted (mirrors `scheduleTurnEnd`). Idempotent when already cleared.
+ */
+function scheduleReplayEnd(set: TurnEndSetter, sessionId: SessionId): void {
+  setTimeout(() => {
+    set((s) => {
+      const current = s.sessions[sessionId]
+      if (!current?.replaying) return {}
+      return {
+        messages: finalizeStreaming(s.messages, sessionId),
+        sessions: { ...s.sessions, [sessionId]: { ...current, replaying: null } }
+      }
+    })
+  }, 0)
 }
 
 /** Remove all pending permissions belonging to a session. */
@@ -484,9 +523,11 @@ type TurnEndSetter = (
  */
 function scheduleTurnEnd(set: TurnEndSetter, sessionId: SessionId, stopReason?: StopReason): void {
   setTimeout(() => {
+    let closedTurn = false
     set((s) => {
       const current = s.sessions[sessionId]
       if (!current?.openTurnId) return {}
+      closedTurn = true
       const note = stopReason !== undefined ? noteForStopReason(stopReason) : null
       return {
         messages: finalizeStreaming(s.messages, sessionId),
@@ -501,6 +542,16 @@ function scheduleTurnEnd(set: TurnEndSetter, sessionId: SessionId, stopReason?: 
         }
       }
     })
+    // Re-mirror after the turn actually closed: chunks that lost the IPC race
+    // and landed inside this deferred window are in memory but were missed by
+    // the persist in `_onPromptComplete`. Guarded against deleted sessions so
+    // the write can't resurrect a removed index entry.
+    if (closedTurn) {
+      const state = useAcpStore.getState()
+      if (state.sessions[sessionId] && state.sessionIndex.some((e) => e.id === sessionId)) {
+        persistSession(state, sessionId, (entries) => set({ sessionIndex: entries }))
+      }
+    }
   }, 0)
 }
 
@@ -521,7 +572,16 @@ function persistSession(
 ): void {
   const session = state.sessions[sessionId]
   if (!session) return
-  const messages = state.messages[sessionId] ?? []
+  // Never mirror a mid-replay transcript: while `session/load` is replaying,
+  // `messages` holds a partial reconstruction, and persisting it (e.g. via a
+  // title update streamed as part of the replay) would truncate the on-disk
+  // history if the app quits before the next full persist.
+  if (session.replaying) return
+  // `streaming` is transient UI state; persisting it would restore a message
+  // stuck in its shimmer state after a restart.
+  const messages = (state.messages[sessionId] ?? []).map((m) =>
+    m.streaming ? { ...m, streaming: false } : m
+  )
   const reuseKey = Object.keys(state.configToLiveAgent).find(
     (k) => state.configToLiveAgent[k] === session.agentId
   )
@@ -640,6 +700,20 @@ export function prepareChatKey(
 /** In-flight `session/new` for a prepare key. */
 const inFlightPrepared = new Map<string, Promise<SessionId | null>>()
 
+/**
+ * In-flight `openHistorySession` calls keyed by session id, so the sidebar
+ * click and the restored-tab rehydrate (which can race at startup) coalesce
+ * into one open instead of double-loading/spawning. Held outside reactive
+ * state (promises don't belong in the store); the reactive
+ * `openingHistoryIds` map mirrors membership for UI loading states.
+ */
+const inFlightHistoryOpens = new Map<string, Promise<void>>()
+
+/** Test-only: clear the module-level open dedupe map between tests. */
+export function _resetInFlightHistoryOpensForTesting(): void {
+  inFlightHistoryOpens.clear()
+}
+
 type EnsureLiveAgentOptions = {
   /** Mirror membership in `warmingConfigs` for the prewarm UI. */
   registerWarmUi?: boolean
@@ -743,6 +817,182 @@ function cancelPreparedChatEntry(
 }
 
 /**
+ * Body of `openHistorySession` (deduped by the store action via
+ * `inFlightHistoryOpens`): load the persisted payload, remap to the current
+ * live agent for the chat's config+cwd, decide the reopen strategy, register
+ * the session with its local transcript, and run load/resume when the
+ * capability allows.
+ *
+ * 'load' semantics: the locally persisted transcript stays visible while
+ * `session/load` is in flight; the session is marked `replaying: 'pending'`
+ * so `_onMessageChunk` accepts the agent's replayed history (the session is
+ * still 'closed' until load resolves). The FIRST replayed chunk replaces the
+ * local transcript (avoids duplication); an agent that replays nothing leaves
+ * the local transcript in place.
+ */
+async function openHistorySessionInner(
+  get: () => AcpState,
+  set: TurnEndSetter,
+  id: string
+): Promise<void> {
+  const payload = await loadSessionPayload(id)
+  if (!payload) throw new Error(`no persisted history for ${id}`)
+  const meta = payload.metadata
+
+  // Rebase the process-wide seq counter so live events appended after the
+  // restored transcript sort after it (nextSeq() returns > max restored seq).
+  let maxRestoredSeq = 0
+  for (const m of payload.messages) {
+    if (typeof m.seq === 'number' && m.seq > maxRestoredSeq) maxRestoredSeq = m.seq
+  }
+  rebaseSeqCounter(maxRestoredSeq)
+
+  // Register the session record + local transcript BEFORE any agent work, so
+  // the pane shows the conversation instantly; the (possibly ~30s cold-spawn)
+  // reconnect below then only upgrades the session in place. The persisted
+  // `meta.agentId` may be a stale per-process UUID — remapped after spawn.
+  set((s) => ({
+    sessions: {
+      ...s.sessions,
+      [id]: {
+        id,
+        agentId: meta.agentId,
+        cwd: meta.cwd,
+        projectId: meta.projectId,
+        status: 'closed',
+        title: meta.title,
+        activeTurn: false,
+        openTurnId: null,
+        modes: null,
+        models: null,
+        configOptions: [],
+        lastError: null,
+        createdAt: meta.createdAt,
+        replaying: null
+      }
+    },
+    messages: { ...s.messages, [id]: payload.messages }
+  }))
+
+  // Resolve the CURRENT live agent for this chat's config+cwd. Without this
+  // remap the `agentStatus`/`agents` lookups miss (stale UUID after restart)
+  // and `decideResume` falls to 'local', leaving `sendPrompt` rejected.
+  let liveAgentId: AgentId = meta.agentId
+  // Guard both fields: `ensureLiveAgent` trims `cwd` (throws on undefined),
+  // and a missing/empty cwd can't map to a live agent anyway — fall through
+  // to read-only 'local' instead of throwing (spec: do not throw).
+  if (meta.agentConfigId && meta.cwd) {
+    const ensured = await ensureLiveAgent(get, set, meta.agentConfigId, meta.cwd, {
+      silentSpawnFailure: true
+    })
+    if (ensured) liveAgentId = ensured
+  }
+  // Capabilities arrive asynchronously via `acp:agent_spawned` for a freshly
+  // spawned agent. Wait briefly so `decideResume` sees them instead of racing
+  // to 'local'. A prewarmed agent already has them by this point.
+  if (get().agentStatus[liveAgentId] === 'connected' && !get().agents[liveAgentId]?.capabilities) {
+    await new Promise<void>((resolve) => {
+      if (get().agents[liveAgentId]?.capabilities) {
+        resolve()
+        return
+      }
+      const timeout = setTimeout(() => {
+        unsubscribe()
+        resolve()
+      }, 3000)
+      const unsubscribe = useAcpStore.subscribe((state) => {
+        if (state.agents[liveAgentId]?.capabilities) {
+          clearTimeout(timeout)
+          unsubscribe()
+          resolve()
+        }
+      })
+    })
+  }
+
+  const connected = get().agentStatus[liveAgentId] === 'connected'
+  const capabilities = get().agents[liveAgentId]?.capabilities ?? null
+  const strategy = decideResume({ connected, capabilities })
+
+  // Point the record at the resolved live agent so streaming events from
+  // `session/load` route to this session, and (for 'load') open the replay
+  // window BEFORE the IPC is sent — replayed chunks stream in while the load
+  // request is still in flight and must be accepted, not dropped.
+  set((s) => {
+    const session = s.sessions[id]
+    if (!session) return {}
+    return {
+      sessions: {
+        ...s.sessions,
+        [id]: {
+          ...session,
+          agentId: liveAgentId,
+          replaying: strategy === 'load' ? ('pending' as const) : null
+        }
+      }
+    }
+  })
+
+  // A chat deleted while the reconnect was in flight must stay deleted: skip
+  // activation (the record was already marked closed by the delete). Detected
+  // as a transition — indexed when the open started, gone afterwards — so a
+  // session that was never indexed is not mistaken for a deleted one.
+  const wasIndexed = get().sessionIndex.some((e) => e.id === id)
+  const deletedMidOpen = (): boolean => wasIndexed && !get().sessionIndex.some((e) => e.id === id)
+
+  if (strategy === 'load') {
+    try {
+      await acpApi.loadSession(liveAgentId, id, meta.cwd)
+      if (deletedMidOpen()) {
+        set((s) => {
+          const session = s.sessions[id]
+          if (!session) return {}
+          return { sessions: { ...s.sessions, [id]: { ...session, replaying: null } } }
+        })
+        return
+      }
+      set((s) => {
+        const session = s.sessions[id]
+        if (!session) return { sessions: s.sessions }
+        // 'pending' after the response means the agent replayed nothing while
+        // the request was in flight: close the window immediately so a later
+        // live chunk can't replace the local transcript. An in-progress
+        // ('streaming') replay keeps its window one macrotask longer for
+        // chunks that lose the IPC race against the response.
+        return {
+          sessions: withSessionActive(
+            {
+              ...s.sessions,
+              [id]: session.replaying === 'pending' ? { ...session, replaying: null } : session
+            },
+            id
+          )
+        }
+      })
+      scheduleReplayEnd(set, id)
+    } catch (err) {
+      // Load failed — restore the local transcript so the user still sees
+      // history (a partial replay may have replaced it).
+      set((s) => ({
+        messages: { ...s.messages, [id]: payload.messages },
+        sessions: withSessionResumeError(s.sessions, id, err)
+      }))
+      throw err
+    }
+  } else if (strategy === 'resume') {
+    try {
+      await acpApi.resumeSession(liveAgentId, id, meta.cwd)
+      if (deletedMidOpen()) return
+      set((s) => ({ sessions: withSessionActive(s.sessions, id) }))
+    } catch (err) {
+      set((s) => ({ sessions: withSessionResumeError(s.sessions, id, err) }))
+      throw err
+    }
+  }
+  // 'local' → nothing more; the transcript is already shown.
+}
+
+/**
  * Shared orchestration for a user-initiated prompt turn: stage the optimistic
  * user message, mark the turn active, persist, then dispatch to the agent and
  * schedule turn-end. On failure, finalize any streaming markers and record the
@@ -813,6 +1063,7 @@ export const useAcpStore = create<AcpState>((set, get) => ({
   preparingChatKeys: {},
   prepareChatErrors: {},
   sessionIndex: [],
+  openingHistoryIds: {},
   discoveredSessions: {},
   discoveringKeys: {},
   mcpServers: [],
@@ -864,7 +1115,13 @@ export const useAcpStore = create<AcpState>((set, get) => ({
       const sessions = { ...s.sessions }
       for (const id of Object.keys(sessions)) {
         if (sessions[id].agentId === agentId) {
-          sessions[id] = { ...sessions[id], status: 'closed', activeTurn: false, openTurnId: null }
+          sessions[id] = {
+            ...sessions[id],
+            status: 'closed',
+            activeTurn: false,
+            openTurnId: null,
+            replaying: null
+          }
         }
       }
       return {
@@ -900,7 +1157,8 @@ export const useAcpStore = create<AcpState>((set, get) => ({
             models: outcome.models ?? existing?.models ?? null,
             configOptions: outcome.configOptions ?? existing?.configOptions ?? [],
             lastError: existing?.lastError ?? null,
-            createdAt: existing?.createdAt ?? Date.now()
+            createdAt: existing?.createdAt ?? Date.now(),
+            replaying: null
           }
         },
         messages: { ...s.messages, [sessionId]: s.messages[sessionId] ?? [] },
@@ -932,7 +1190,8 @@ export const useAcpStore = create<AcpState>((set, get) => ({
           ...sessions[sessionId],
           status: 'closed',
           activeTurn: false,
-          openTurnId: null
+          openTurnId: null,
+          replaying: null
         }
       }
       return {
@@ -1190,112 +1449,26 @@ export const useAcpStore = create<AcpState>((set, get) => ({
     // from persisted history via load/resume/local below.
     if (cached && cached.status !== 'closed') return
 
-    const payload = await loadSessionPayload(id)
-    if (!payload) throw new Error(`no persisted history for ${id}`)
-    const meta = payload.metadata
+    // Coalesce concurrent opens for the same chat (sidebar click + restored-tab
+    // rehydrate race at startup) into a single load/spawn.
+    const inFlight = inFlightHistoryOpens.get(id)
+    if (inFlight) return inFlight
 
-    // Resolve the CURRENT live agent for this chat's config+cwd. The persisted
-    // `meta.agentId` is a per-process UUID that is stale after an app restart
-    // (the new agent process has a different id); without this remap the
-    // `agentStatus`/`agents` lookups miss and `decideResume` falls to 'local',
-    // leaving the session closed and `sendPrompt` rejected.
-    let liveAgentId: AgentId = meta.agentId
-    // Guard both fields: `ensureLiveAgent` trims `cwd` (throws on undefined),
-    // and a missing/empty cwd can't map to a live agent anyway — fall through
-    // to read-only 'local' instead of throwing (spec: do not throw).
-    if (meta.agentConfigId && meta.cwd) {
-      const ensured = await ensureLiveAgent(get, set, meta.agentConfigId, meta.cwd, {
-        silentSpawnFailure: true
-      })
-      if (ensured) liveAgentId = ensured
-    }
-    // Capabilities arrive asynchronously via `acp:agent_spawned` for a freshly
-    // spawned agent. Wait briefly so `decideResume` sees them instead of racing
-    // to 'local'. A prewarmed agent already has them by this point.
-    if (
-      get().agentStatus[liveAgentId] === 'connected' &&
-      !get().agents[liveAgentId]?.capabilities
-    ) {
-      await new Promise<void>((resolve) => {
-        if (get().agents[liveAgentId]?.capabilities) {
-          resolve()
-          return
-        }
-        const timeout = setTimeout(() => {
-          unsubscribe()
-          resolve()
-        }, 3000)
-        const unsubscribe = useAcpStore.subscribe((state) => {
-          if (state.agents[liveAgentId]?.capabilities) {
-            clearTimeout(timeout)
-            unsubscribe()
-            resolve()
-          }
+    const task = (async () => {
+      try {
+        await openHistorySessionInner(get, set, id)
+      } finally {
+        inFlightHistoryOpens.delete(id)
+        set((s) => {
+          const openingHistoryIds = { ...s.openingHistoryIds }
+          delete openingHistoryIds[id]
+          return { openingHistoryIds }
         })
-      })
-    }
-
-    const connected = get().agentStatus[liveAgentId] === 'connected'
-    const capabilities = get().agents[liveAgentId]?.capabilities ?? null
-    const strategy = decideResume({ connected, capabilities })
-
-    // Rebase the process-wide seq counter so live events appended after the
-    // restored transcript sort after it (nextSeq() returns > max restored seq).
-    let maxRestoredSeq = 0
-    for (const m of payload.messages) {
-      if (typeof m.seq === 'number' && m.seq > maxRestoredSeq) maxRestoredSeq = m.seq
-    }
-    rebaseSeqCounter(maxRestoredSeq)
-
-    // Show the persisted transcript locally and register the session record so the
-    // pane has content regardless of strategy. Use the resolved live agent id so
-    // streaming events from `session/load` route to this session.
-    set((s) => ({
-      sessions: {
-        ...s.sessions,
-        [id]: {
-          id,
-          agentId: liveAgentId,
-          cwd: meta.cwd,
-          projectId: meta.projectId,
-          status: 'closed',
-          title: meta.title,
-          activeTurn: false,
-          openTurnId: null,
-          modes: null,
-          models: null,
-          configOptions: [],
-          lastError: null,
-          createdAt: meta.createdAt
-        }
-      },
-      messages: { ...s.messages, [id]: payload.messages }
-    }))
-
-    if (strategy === 'load') {
-      // Agent replays history via session/update; clear local copy to avoid dupes.
-      set((s) => ({ messages: { ...s.messages, [id]: [] } }))
-      try {
-        await acpApi.loadSession(liveAgentId, id, meta.cwd)
-        set((s) => ({ sessions: withSessionActive(s.sessions, id) }))
-      } catch (err) {
-        // Load failed — restore the local transcript so the user still sees history.
-        set((s) => ({
-          messages: { ...s.messages, [id]: payload.messages },
-          sessions: withSessionResumeError(s.sessions, id, err)
-        }))
-        throw err
       }
-    } else if (strategy === 'resume') {
-      try {
-        await acpApi.resumeSession(liveAgentId, id, meta.cwd)
-        set((s) => ({ sessions: withSessionActive(s.sessions, id) }))
-      } catch (err) {
-        set((s) => ({ sessions: withSessionResumeError(s.sessions, id, err) }))
-        throw err
-      }
-    }
-    // 'local' → nothing more; the transcript is already shown.
+    })()
+    inFlightHistoryOpens.set(id, task)
+    set((s) => ({ openingHistoryIds: { ...s.openingHistoryIds, [id]: true } }))
+    return task
   },
 
   deleteHistorySession: async (id) => {
@@ -1305,7 +1478,13 @@ export const useAcpStore = create<AcpState>((set, get) => ({
       // reflects the deletion instead of showing stale content.
       const sessions = { ...s.sessions }
       if (sessions[id]) {
-        sessions[id] = { ...sessions[id], status: 'closed', activeTurn: false, openTurnId: null }
+        sessions[id] = {
+          ...sessions[id],
+          status: 'closed',
+          activeTurn: false,
+          openTurnId: null,
+          replaying: null
+        }
       }
       return { sessionIndex: next, sessions }
     })
@@ -1413,6 +1592,8 @@ export const useAcpStore = create<AcpState>((set, get) => ({
 
     // Create a minimal session record so streaming events (session/update)
     // during replay have a session to attach to, mirroring openHistorySession.
+    // For the 'load' strategy the session is marked replaying so replayed
+    // chunks are accepted while the session is still 'closed' (load in flight).
     set((s) => ({
       sessions: {
         ...s.sessions,
@@ -1429,20 +1610,44 @@ export const useAcpStore = create<AcpState>((set, get) => ({
           models: null,
           configOptions: [],
           lastError: null,
-          createdAt: Date.now()
+          createdAt: Date.now(),
+          replaying: strategy === 'load' ? 'pending' : null
         }
       },
       messages: { ...s.messages, [sessionId]: [] }
     }))
 
     if (strategy === 'load') {
-      // Agent replays history via session/update; clear local copy to avoid dupes.
+      // Agent replays history via session/update into the empty transcript.
       try {
         await acpApi.loadSession(agentId, sessionId, cwd)
-        set((s) => ({ sessions: withSessionActive(s.sessions, sessionId) }))
+        set((s) => {
+          const session = s.sessions[sessionId]
+          if (!session) return { sessions: s.sessions }
+          // 'pending' after the response = no replay arrived; close the window
+          // now so a later live chunk can't replace the transcript. See
+          // openHistorySessionInner for the same rule.
+          return {
+            sessions: withSessionActive(
+              {
+                ...s.sessions,
+                [sessionId]:
+                  session.replaying === 'pending' ? { ...session, replaying: null } : session
+              },
+              sessionId
+            )
+          }
+        })
+        // Deferred so replayed chunks that lose the IPC race still land.
+        scheduleReplayEnd(set, sessionId)
       } catch (err) {
-        // Restore empty messages so the pane doesn't show stale content.
-        set((s) => ({ sessions: withSessionResumeError(s.sessions, sessionId, err) }))
+        // Drop any partially replayed content so the pane doesn't show a
+        // half-loaded transcript under the error (there is no local mirror to
+        // restore for a discovered session).
+        set((s) => ({
+          messages: { ...s.messages, [sessionId]: [] },
+          sessions: withSessionResumeError(s.sessions, sessionId, err)
+        }))
         throw err
       }
     } else if (strategy === 'resume') {
@@ -1612,7 +1817,8 @@ export const useAcpStore = create<AcpState>((set, get) => ({
             models: e.models ?? null,
             configOptions: e.configOptions ?? [],
             lastError: null,
-            createdAt: Date.now()
+            createdAt: Date.now(),
+            replaying: null
           }
         },
         messages: { ...s.messages, [e.sessionId]: s.messages[e.sessionId] ?? [] }
@@ -1622,11 +1828,40 @@ export const useAcpStore = create<AcpState>((set, get) => ({
   _onMessageChunk: (e) =>
     set((s) => {
       const session = s.sessions[e.sessionId]
-      // Drop chunks for unknown or already-closed sessions (no orphan state).
-      if (!session || session.status === 'closed') return {}
+      // Drop chunks for unknown or already-closed sessions (no orphan state) —
+      // unless a session/load replay is in flight: the session stays 'closed'
+      // until the load IPC resolves, but its replayed chunks must land.
+      if (!session || (session.status === 'closed' && !session.replaying)) return {}
+      const role = e.role as MessageRole
+      // First replayed chunk: the agent is re-streaming the full conversation,
+      // which supersedes the locally persisted mirror. Replace the transcript
+      // (avoids duplicating history) and let later chunks append after it.
+      // Stale tool calls from a previous live period are dropped too — the
+      // replay re-delivers the conversation's tool calls, and keeping the old
+      // list would render each of them twice.
+      if (session.replaying === 'pending') {
+        // A whitespace-only first chunk must not count as "real replay
+        // content" — replacing the mirror with it would blank the chat.
+        if (e.content.type === 'text' && !(e.content.text ?? '').trim().length) return {}
+        const message: ChatMessage = {
+          id: newId('msg'),
+          role,
+          blocks: [e.content],
+          streaming: true,
+          timestamp: Date.now(),
+          seq: nextSeq()
+        }
+        return {
+          messages: { ...s.messages, [e.sessionId]: [message] },
+          toolCalls: { ...s.toolCalls, [e.sessionId]: [] },
+          sessions: {
+            ...s.sessions,
+            [e.sessionId]: { ...session, replaying: 'streaming' }
+          }
+        }
+      }
       const list = s.messages[e.sessionId] ?? []
       const last = list[list.length - 1]
-      const role = e.role as MessageRole
       // Attach to the trailing assistant/user message for this turn (including
       // chunks that arrive after streaming was finalized but IPC lagged) —
       // UNLESS a tool call landed after that message. Coalescing across a tool
@@ -1779,15 +2014,28 @@ export const useAcpStore = create<AcpState>((set, get) => ({
         }
       }
     })
+    // Mirror the finished turn (including the agent's reply) to disk. Without
+    // this, only user sends persist and a restart loses the last reply. Skip
+    // sessions no longer in the index — persisting would resurrect a chat the
+    // user deleted while the turn was in flight.
+    if (
+      get().sessions[e.sessionId] &&
+      get().sessionIndex.some((entry) => entry.id === e.sessionId)
+    ) {
+      persistSession(get(), e.sessionId, (entries) => set({ sessionIndex: entries }))
+    }
     scheduleTurnEnd(set, e.sessionId, e.stopReason)
   },
 
-  _onAgentError: (e) =>
+  _onAgentError: (e) => {
     set((s) => {
       const agentStatus = { ...s.agentStatus, [e.agentId]: 'error' as AgentStatus }
       if (e.sessionId && s.sessions[e.sessionId]) {
         return {
           agentStatus,
+          // Finalize streaming markers: the turn is over (errored), and the
+          // persist below must not capture a message mid-shimmer.
+          messages: finalizeStreaming(s.messages, e.sessionId),
           sessions: {
             ...s.sessions,
             [e.sessionId]: {
@@ -1811,7 +2059,18 @@ export const useAcpStore = create<AcpState>((set, get) => ({
         }
       }
       return { agentStatus, sessions }
-    }),
+    })
+    // A turn that errored still produced transcript content (partial reply);
+    // mirror it to disk so a restart doesn't lose it. Skip sessions that are
+    // no longer in the index — persisting would resurrect a deleted chat.
+    if (
+      e.sessionId &&
+      get().sessions[e.sessionId] &&
+      get().sessionIndex.some((entry) => entry.id === e.sessionId)
+    ) {
+      persistSession(get(), e.sessionId, (entries) => set({ sessionIndex: entries }))
+    }
+  },
 
   _onAgentDisconnected: (e) => {
     const affected: SessionId[] = []
@@ -1820,7 +2079,13 @@ export const useAcpStore = create<AcpState>((set, get) => ({
       const sessions = { ...s.sessions }
       for (const id of Object.keys(sessions)) {
         if (sessions[id].agentId === e.agentId && sessions[id].status !== 'closed') {
-          sessions[id] = { ...sessions[id], status: 'closed', activeTurn: false, openTurnId: null }
+          sessions[id] = {
+            ...sessions[id],
+            status: 'closed',
+            activeTurn: false,
+            openTurnId: null,
+            replaying: null
+          }
           affected.push(id)
         }
       }
@@ -1856,7 +2121,13 @@ export const useAcpStore = create<AcpState>((set, get) => ({
         pendingPermissions,
         sessions: {
           ...s.sessions,
-          [e.sessionId]: { ...session, status: 'closed', activeTurn: false, openTurnId: null }
+          [e.sessionId]: {
+            ...session,
+            status: 'closed',
+            activeTurn: false,
+            openTurnId: null,
+            replaying: null
+          }
         }
       }
     })


### PR DESCRIPTION
## Summary

After app restart, ACP chats could not be continued: `session/load` replay chunks were dropped while the session stayed `closed`, restored `agent-chat` tabs never rehydrated, sidebar open blocked on cold agent spawn, and agent replies were not persisted (only user sends). This PR fixes continuation end-to-end so reopened chats show history and accept follow-ups.

## Related Issue

No related issue — reproduced locally after restart when reopening ACP chat history (empty replay, dead restored tabs, long sidebar wait, missing agent replies on disk).

Prior related work (not duplicates — this is a follow-on for remaining continuation gaps):
- #416 — live agent remap on reopen after restart
- #413 — session index persistence across restarts
- #293 — don't wipe live transcript when reopening from history
- #315 — reactivate history sessions / slash menu

Searched open + closed PRs for "acp chat history" / continuation; no open PR covers replay acceptance + tab rehydrate + turn-end persist + load/resume timeout together.

## Type of Change

- [ ] feat: new feature
- [x] fix: bug fix
- [ ] docs: documentation only
- [ ] style: formatting or non-functional styling changes
- [ ] refactor: internal cleanup with no behavior change
- [ ] perf: performance improvement
- [x] test: adds or updates tests
- [ ] build: build or dependency changes
- [ ] ci: CI/CD workflow changes
- [ ] chore: maintenance or tooling
- [ ] revert: reverts a previous change

Primary: fix. Tests added/updated in the same change.

## What Changed

- **Replay window:** `AcpSession.replaying` lets `_onMessageChunk` accept `session/load` chunks while status is still `closed`; first chunk replaces the local mirror; empty/failed load keeps local transcript.
- **Deduped reopen:** concurrent `openHistorySession(id)` coalesces via an in-flight map; UI can show opening state.
- **Restored tabs:** visible `agent-chat` tabs rehydrate from `sessionIndex` via `AgentChatPanel` (loading / error+retry); `PaneContent` passes `isVisible`.
- **Sidebar:** mirror history entries open the tab immediately with local transcript; reconnect runs in the background.
- **Persistence:** persist transcript on prompt complete / agent error (and straggler path) so agent replies survive restart.
- **Rust timeout:** 60s `SESSION_REOPEN_TIMEOUT` on `session/load` and `session/resume` (override via `TERMUL_ACP_SESSION_REOPEN_TIMEOUT_SECS`).
- **Delete-during-open:** snapshot index membership before async reopen work; skip activation and failed-load restore when the chat is deleted mid-open.

Out of scope (deferred): new-chat latency / broader prewarm / streaming virtualization.

## How It Was Tested

- [x] `bun run ci` (Biome lint + format + imports, strict mode)
- [x] `bun run typecheck`
- [x] `bun run test`
- [ ] `cargo clippy --all-targets -- -D warnings` (in src-tauri)
- [ ] `cargo test` (in src-tauri)
- [ ] Manual verification completed
- [ ] Not applicable

Notes: Rust toolchain not available on this machine — `cargo clippy` / `cargo test` must be covered by CI (PR Validation / Rust Checks). Renderer coverage includes `acp-store.test.ts`, new `AgentChatPanel.test.tsx`, and updated `ChatHistoryTab.test.tsx`.

## Screenshots or Recordings

N/A for this PR — behavior is continuation/persistence/timeouts; no intentional visual redesign. Restored-tab loading / reconnect banner are existing patterns with small UX wiring.

## CI & Review Gate

- [ ] All CI checks pass (PR Validation, Rust Checks, Build Verification, Security Scans)
- [ ] Code review comments from CodeRabbit / Claude have been addressed or resolved
- [ ] No unresolved review findings remain

Will wait for green CI and CodeRabbit before considering merge-ready.

## Checklist

- [x] My PR title follows the conventional commit format used by this repo
- [x] I linked the related issue or explained why none exists
- [x] I updated docs when needed
- [x] I added or updated tests when needed
- [x] I verified the change does not introduce unrelated modifications
- [x] I read AGENTS.md and followed the contributor guidelines
- [x] A human reviewed the complete diff before submission

Docs: no public docs change required; implementation notes live under local `_bmad-output` (gitignored).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Restored chat tabs now reconnect automatically when they become visible.
  - Added loading, disconnected, error, and retry states for chat restoration.
  - Chat tabs open immediately while background reconnection continues.
  - Replayed chat history now preserves messages and supports follow-up prompts.

- **Bug Fixes**
  - Prevented stalled reconnections from blocking the interface indefinitely.
  - Improved transcript persistence across restarts and recovery from failed loads.
  - Prevented duplicate or missing messages during chat restoration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->