### PR TITLE
fix(terminal): send newline (LF) on Shift+Enter instead of CR

### DIFF
--- a/src/renderer/components/terminal/ConnectedTerminal.test.tsx
+++ b/src/renderer/components/terminal/ConnectedTerminal.test.tsx
@@ -1197,6 +1197,60 @@ describe('ConnectedTerminal', () => {
       expect(mockTerminalInstance.selectAll).toHaveBeenCalled()
     })
 
+    it('should send a newline (LF) on Shift+Enter instead of CR', async () => {
+      render(<ConnectedTerminal />)
+
+      await vi.waitFor(() => {
+        expect(mockTerminalInstance.attachCustomKeyEventHandler).toHaveBeenCalled()
+      })
+      // Wait for spawn so the PTY id is bound before the key is dispatched.
+      await vi.waitFor(() => {
+        expect(vi.mocked(terminalApi).spawn).toHaveBeenCalled()
+      })
+
+      const handler = mockTerminalInstance.attachCustomKeyEventHandler.mock.calls[0][0]
+
+      const event = new KeyboardEvent('keydown', {
+        key: 'Enter',
+        shiftKey: true,
+        bubbles: true,
+        cancelable: true
+      })
+
+      const result = handler(event)
+
+      // Must prevent xterm's default (\r) so the app receives a newline.
+      expect(result).toBe(false)
+      expect(event.defaultPrevented).toBe(true)
+
+      // The same byte Ctrl+J produces (LF) is written to the PTY.
+      await vi.waitFor(() => {
+        expect(vi.mocked(terminalApi).write).toHaveBeenCalledWith('terminal-123', '\n')
+      })
+    })
+
+    it('should not remap Shift+Enter when another modifier is held', async () => {
+      render(<ConnectedTerminal />)
+
+      await vi.waitFor(() => {
+        expect(mockTerminalInstance.attachCustomKeyEventHandler).toHaveBeenCalled()
+      })
+
+      const handler = mockTerminalInstance.attachCustomKeyEventHandler.mock.calls[0][0]
+
+      // Ctrl+Shift+Enter must NOT be swallowed — it may be an app shortcut.
+      const event = new KeyboardEvent('keydown', {
+        key: 'Enter',
+        shiftKey: true,
+        ctrlKey: true,
+        bubbles: true
+      })
+
+      const result = handler(event)
+
+      expect(result).toBe(true)
+    })
+
     it('should handle Cmd key on macOS for copy/paste', async () => {
       // On non-macOS test environments (jsdom has empty platform),
       // isPlatformModifier checks ctrlKey, not metaKey.

--- a/src/renderer/components/terminal/ConnectedTerminal.tsx
+++ b/src/renderer/components/terminal/ConnectedTerminal.tsx
@@ -663,6 +663,26 @@ function ConnectedTerminalComponent({
         return true
       }
 
+      // Shift+Enter → newline (LF). xterm.js sends \r for Enter regardless of
+      // Shift, so multiline TUI apps (Claude Code, Ink, etc.) can't tell it
+      // apart from a plain Enter and treat it as "submit". Send \n (LF) — the
+      // same byte Ctrl+J produces — so Shift+Enter inserts a newline instead.
+      // Pure Shift+Enter only: ignore it when other modifiers are held (so
+      // Cmd/Ctrl+Shift+Enter app shortcuts are unaffected) and during IME
+      // composition.
+      if (
+        event.key === 'Enter' &&
+        event.shiftKey &&
+        !event.ctrlKey &&
+        !event.metaKey &&
+        !event.altKey &&
+        !event.isComposing
+      ) {
+        event.preventDefault()
+        handleTerminalData('\n')
+        return false
+      }
+
       return true
     })
 


### PR DESCRIPTION
## Summary

xterm.js sends `\r` (CR) for the **Enter** key regardless of whether **Shift** is held. Multiline TUI applications (Claude Code, Ink-based REPLs, etc.) therefore cannot distinguish **Shift+Enter** from a plain **Enter** and treat it as "submit" — so Shift+Enter fails to insert a newline. Users had to fall back to **Ctrl+J** (which sends `\n` / LF) just to get a newline, making the typing experience unpleasant.

This intercepts a **pure Shift+Enter** in the terminal's custom key handler and writes `\n` (LF) to the PTY — the same byte Ctrl+J produces — so Shift+Enter inserts a newline while plain Enter still submits. Other modifier combos (Ctrl/Cmd+Shift+Enter) and IME composition are left untouched.

## Related Issue

No related issue — reported directly as a daily UX pain (Shift+Enter failing to insert a newline in multiline TUI apps; users fell back to Ctrl+J). Searched open + closed PRs/issues for "shift enter", "newline", "ctrl+j" — no existing or duplicate work found.

## Type of Change

- [x] fix: bug fix

## What Changed

**`src/renderer/components/terminal/ConnectedTerminal.tsx`** — in the `attachCustomKeyEventHandler` registered on mount, added a case before the final `return true`:

- When `key === 'Enter'` with `shiftKey` and **no** other modifiers (ctrl/meta/alt) and not IME-composing → `event.preventDefault()`, write `\n` to the PTY via the existing `handleTerminalData` path, and `return false` (prevents xterm's default `\r`).

Behavior matrix:
- Plain Enter → unchanged (xterm sends `\r`, app submits).
- **Shift+Enter → sends `\n` (newline)** — matches the existing Ctrl+J workaround.
- Ctrl/Cmd+Shift+Enter, Alt+Enter, IME-composing Enter → unchanged (not intercepted).
- In a normal shell, `\n` is equivalent to Enter (ICRNL), so shell usage is unaffected.

**`src/renderer/components/terminal/ConnectedTerminal.test.tsx`** — two new tests:
- sends `\n` on Shift+Enter and prevents the default;
- does not remap Shift+Enter when another modifier is held.

## How It Was Tested

- [x] `bun run ci` (Biome strict)
- [x] `bun run typecheck`
- [x] `bun run test` (full suite green; +2 new tests)
- [ ] `cargo clippy --all-targets -- -D warnings` — N/A: frontend-only change, no Rust touched (CI runs the Rust gate on the unchanged baseline)
- [ ] `cargo test` — N/A: frontend-only
- [x] Manual verification completed — confirmed in the running app that Shift+Enter now inserts a newline in multiline TUI input (previously unresponsive).

## Screenshots or Recordings

N/A — keyboard input behavior; no visual UI change.

## CI & Review Gate

- [ ] All CI checks pass (PR Validation, Rust Checks, Build Verification, Security Scans)
- [ ] Code review comments from CodeRabbit / Claude have been addressed or resolved
- [ ] No unresolved review findings remain

(Awaiting CI + CodeRabbit after opening.)

## Checklist

- [x] My PR title follows the conventional commit format used by this repo
- [x] I linked the related issue or explained why none exists
- [x] I updated docs when needed (none needed)
- [x] I added or updated tests when needed (+2 tests)
- [x] I verified the change does not introduce unrelated modifications
- [x] I read AGENTS.md and followed the contributor guidelines
- [x] A human reviewed the complete diff before submission
