### PR TITLE
fix(terminal): force fallback renderer repaint when WebGL recovery exhausts

### DIFF
--- a/src/renderer/components/terminal/ConnectedTerminal.test.tsx
+++ b/src/renderer/components/terminal/ConnectedTerminal.test.tsx
@@ -1614,6 +1614,36 @@ describe('ConnectedTerminal', () => {
       }
     })
 
+    it('should force a fallback repaint once WebGL recovery is exhausted', async () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+      try {
+        render(<ConnectedTerminal />)
+
+        await vi.waitFor(() => {
+          expect(vi.mocked(terminalApi).spawn).toHaveBeenCalled()
+        })
+
+        vi.useFakeTimers()
+
+        // Exhaust all recovery attempts: init load + 2 recoveries bring the
+        // counter to MAX, then the 3rd context loss pins the exhaustion flag.
+        for (let i = 0; i < 3; i++) {
+          capturedContextLossCallback!()
+          await vi.advanceTimersByTimeAsync(150)
+        }
+
+        // The exhausted path forces a full repaint so xterm's built-in renderer
+        // redraws instead of leaving the pane blank while the PTY keeps running.
+        expect(mockTerminalInstance.refresh).toHaveBeenCalledWith(0, mockTerminalInstance.rows - 1)
+
+        // No further WebGL addon is created once exhausted.
+        expect(webglAddonCreateCount).toBe(3)
+      } finally {
+        warnSpy.mockRestore()
+      }
+    })
+
     it.skip('should dispose WebGL and skip recovery after switching renderer preference to canvas', async () => {
       vi.useFakeTimers()
       const { rerender } = render(<ConnectedTerminal className="renderer-auto" />)

--- a/src/renderer/components/terminal/ConnectedTerminal.tsx
+++ b/src/renderer/components/terminal/ConnectedTerminal.tsx
@@ -203,6 +203,10 @@ function ConnectedTerminalComponent({
   const webglAddonRef = useRef<WebglAddon | null>(null)
   const fileLinkProviderDisposableRef = useRef<IDisposable | null>(null)
   const webglRecoveryAttemptsRef = useRef<number>(0)
+  // Pinned to true once WebGL recovery is exhausted for this terminal, so we
+  // permanently use xterm's built-in renderer instead of re-entering a failing
+  // WebGL path. Reset only when the user manually toggles the renderer setting.
+  const webglExhaustedRef = useRef<boolean>(false)
   const webglRecoveryTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const loadWebglAddonRef = useRef<((term: Terminal, isRecovery?: boolean) => void) | null>(null)
   const webglContextLostRef = useRef<boolean>(false)
@@ -668,7 +672,7 @@ function ConnectedTerminalComponent({
 
     // WebGL addon loading with context loss recovery
     const loadWebglAddon = (term: Terminal, isRecovery: boolean = false): void => {
-      if (!shouldUseWebglRenderer(rendererPreferenceRef.current)) {
+      if (!shouldUseWebglRenderer(rendererPreferenceRef.current) || webglExhaustedRef.current) {
         webglAddonRef.current = null
         return
       }
@@ -686,6 +690,14 @@ function ConnectedTerminalComponent({
             isRecovery
           }
         })
+        // Finalize the fallback. The last WebGL addon was already disposed in
+        // onContextLoss, so xterm has reverted to its built-in renderer. Pin
+        // the exhaustion flag so we never re-enter the failing WebGL path
+        // (settings changes, visibility recovery), and force a full repaint so
+        // the fallback renderer redraws immediately instead of leaving the pane
+        // blank until the next PTY-driven render.
+        webglExhaustedRef.current = true
+        term.refresh(0, term.rows - 1)
         return
       }
       try {
@@ -1259,6 +1271,9 @@ function ConnectedTerminalComponent({
     }
 
     if (terminalRef.current && loadWebglAddonRef.current && !webglAddonRef.current) {
+      // Manual retry path: toggling the renderer preference (dom → webgl)
+      // clears the exhaustion flag and gives WebGL a fresh attempt.
+      webglExhaustedRef.current = false
       webglRecoveryAttemptsRef.current = 0
       loadWebglAddonRef.current(terminalRef.current)
     }


### PR DESCRIPTION
## Summary

When the WebGL renderer's context-loss recovery hits `MAX_WEBGL_RECOVERY_ATTEMPTS` (3), the last `WebglAddon` was already disposed in the `onContextLoss` handler but **nothing forced xterm's built-in renderer to repaint**. The pane could stay blank while the PTY kept producing output — one concrete manifestation of the **"TUI stuck but process runs"** symptom.

The existing code even logged `"falling back to DOM renderer"` but never actually finalized that fallback. This change pins an exhaustion flag so the failing WebGL path is never re-entered (settings changes, visibility recovery), and forces a full `refresh(0, rows - 1)` so the fallback renderer redraws immediately.

## Related Issue

No related issue — reported directly as a rendering-reliability pain. Searched open + closed PRs/issues for "webgl fallback", "renderer exhausted", "terminal stuck", "context loss" — no existing or duplicate work found.

## Type of Change

- [x] fix: bug fix

## What Changed

**`src/renderer/components/terminal/ConnectedTerminal.tsx`:**

- New `webglExhaustedRef` (boolean) — pinned `true` once recovery is exhausted for this terminal, so we permanently use xterm's built-in renderer instead of re-entering a failing WebGL path.
- `loadWebglAddon` top guard now also short-circuits when `webglExhaustedRef.current` is set.
- The exhausted branch (`webglRecoveryAttemptsRef >= MAX`) now sets `webglExhaustedRef.current = true` and calls `term.refresh(0, term.rows - 1)` to force the fallback renderer to repaint immediately, instead of silently returning.
- The renderer-preference `useEffect` resets `webglExhaustedRef.current = false` when the user toggles back to WebGL (dom → webgl) — a manual retry path, matching the existing `webglRecoveryAttemptsRef` reset.

Behavior:
- Normal WebGL context loss/recovery → unchanged (still retries up to MAX).
- After MAX is reached → pane repaints via the built-in renderer instead of going blank; no further WebGL attempts until the user manually toggles the renderer preference.

**`src/renderer/components/terminal/ConnectedTerminal.test.tsx`** — new test:
- forces a fallback repaint once WebGL recovery is exhausted (asserts `refresh` is called with `0, rows - 1` and no further WebGL addon is created).

## How It Was Tested

- [x] `bun run ci` (Biome strict)
- [x] `bun run typecheck`
- [x] `bun run test` (full suite green; +1 new test)
- [ ] `cargo clippy --all-targets -- -D warnings` — N/A: frontend-only change, no Rust touched (CI runs the Rust gate on the unchanged baseline)
- [ ] `cargo test` — N/A: frontend-only
- [x] Manual verification completed — exercised in the running app alongside the render-watchdog fix; pane no longer stays blank after repeated WebGL context loss.

## Screenshots or Recordings

N/A — renderer fallback behavior; no static visual UI change.

## CI & Review Gate

- [ ] All CI checks pass (PR Validation, Rust Checks, Build Verification, Security Scans)
- [ ] Code review comments from CodeRabbit / Claude have been addressed or resolved
- [ ] No unresolved review findings remain

(Awaiting CI + CodeRabbit after opening.)

## Checklist

- [x] My PR title follows the conventional commit format used by this repo
- [x] I linked the related issue or explained why none exists
- [x] I updated docs when needed (none needed)
- [x] I added or updated tests when needed (+1 test)
- [x] I verified the change does not introduce unrelated modifications
- [x] I read AGENTS.md and followed the contributor guidelines
- [x] A human reviewed the complete diff before submission
