### PR TITLE
fix(terminal): add render-liveness watchdog for mid-use WebGL freezes

### DIFF
--- a/src/renderer/components/terminal/ConnectedTerminal.test.tsx
+++ b/src/renderer/components/terminal/ConnectedTerminal.test.tsx
@@ -1734,6 +1734,76 @@ describe('ConnectedTerminal', () => {
     })
   })
 
+  describe('Render-liveness watchdog', () => {
+    afterEach(() => {
+      vi.useRealTimers()
+    })
+
+    it('nudges recovery after PTY output while the pane is visible (WebGL)', async () => {
+      vi.useFakeTimers()
+      render(<ConnectedTerminal />)
+
+      await vi.waitFor(() => {
+        expect(vi.mocked(terminalApi).spawn).toHaveBeenCalledTimes(1)
+      })
+      // Flush post-spawn async (ptyId assignment).
+      await vi.advanceTimersByTimeAsync(50)
+      expect(capturedDataCallback).toBeTruthy()
+
+      const refreshBefore = mockTerminalInstance.refresh.mock.calls.length
+
+      // Feed PTY output — marks the pane as "live" for the watchdog.
+      capturedDataCallback!('terminal-123', new Uint8Array([0x68, 0x69]))
+
+      // Advance past the watchdog interval. performTerminalRecovery runs
+      // synchronously (the mocked container is 800x600, well above the
+      // collapsed-dimension guard) and issues a full repaint.
+      await vi.advanceTimersByTimeAsync(20100)
+
+      expect(mockTerminalInstance.refresh).toHaveBeenCalledWith(0, mockTerminalInstance.rows - 1)
+      expect(mockTerminalInstance.refresh.mock.calls.length).toBeGreaterThan(refreshBefore)
+    })
+
+    it('does nothing when no output was received since the last tick', async () => {
+      vi.useFakeTimers()
+      render(<ConnectedTerminal />)
+
+      await vi.waitFor(() => {
+        expect(vi.mocked(terminalApi).spawn).toHaveBeenCalledTimes(1)
+      })
+      await vi.advanceTimersByTimeAsync(50)
+
+      const refreshBefore = mockTerminalInstance.refresh.mock.calls.length
+
+      // No PTY output fed — the watchdog tick must bail out early, even across
+      // multiple intervals.
+      await vi.advanceTimersByTimeAsync(20100)
+      await vi.advanceTimersByTimeAsync(20100)
+
+      expect(mockTerminalInstance.refresh.mock.calls.length).toBe(refreshBefore)
+    })
+
+    it('is disabled when the renderer preference is dom', async () => {
+      vi.mocked(useTerminalRenderer).mockReturnValue('dom')
+
+      vi.useFakeTimers()
+      render(<ConnectedTerminal />)
+
+      await vi.waitFor(() => {
+        expect(vi.mocked(terminalApi).spawn).toHaveBeenCalledTimes(1)
+      })
+      await vi.advanceTimersByTimeAsync(50)
+      expect(capturedDataCallback).toBeTruthy()
+      capturedDataCallback!('terminal-123', new Uint8Array([0x68, 0x69]))
+
+      const refreshBefore = mockTerminalInstance.refresh.mock.calls.length
+      await vi.advanceTimersByTimeAsync(20100)
+
+      // No watchdog nudge for the DOM renderer (no canvas layer to stall).
+      expect(mockTerminalInstance.refresh.mock.calls.length).toBe(refreshBefore)
+    })
+  })
+
   describe('Visibility change recovery', () => {
     let originalVisibilityState: string
 

--- a/src/renderer/components/terminal/ConnectedTerminal.tsx
+++ b/src/renderer/components/terminal/ConnectedTerminal.tsx
@@ -118,6 +118,13 @@ const MAX_WEBGL_RECOVERY_ATTEMPTS = 3
 const WEBGL_CONTEXT_LOSS_RECOVERY_DELAY_MS = 100
 const VISIBILITY_RECOVERY_DELAY_MS = 150
 const POWER_RESUME_RECOVERY_DELAY_MS = 300
+// Render-liveness watchdog interval. The xterm 6.x WebGL renderer can stop
+// re-presenting its canvas mid-session even though the context is healthy and
+// the PTY keeps producing output (the "TUI stuck but process runs" symptom).
+// Existing recovery only fires on window visibility/focus/power events, so a
+// long-running tab that is never minimized never recovers. The watchdog nudges
+// recovery while the pane is visible AND has recently received output.
+const RENDER_WATCHDOG_INTERVAL_MS = 20000
 const ACTIVITY_DEBOUNCE_MS = 1000
 const CLIPBOARD_RATE_LIMIT_MS = 100
 
@@ -211,6 +218,10 @@ function ConnectedTerminalComponent({
   // fire close together; without this guard each would start its own
   // layout-wait RAF loop and overlapping fit + visibility-flip cycles.
   const recoveryInProgressRef = useRef<boolean>(false)
+  // Flipped true whenever PTY output is written to xterm; the render-liveness
+  // watchdog reads (and resets) it to decide whether the pane is actively
+  // streaming and may need a compositor re-present nudge.
+  const outputReceivedSinceTickRef = useRef<boolean>(false)
   // Track visibility prop for recovery path guards (tab-active, not window-visible).
   // Ref avoids stale closures in event listeners referencing isVisible directly.
   const isVisibleRef = useRef(isVisible)
@@ -784,6 +795,7 @@ function ConnectedTerminalComponent({
     cleanupDataListenerRef.current = terminalApi.onData((id: string, data: Uint8Array) => {
       if (id === ptyIdRef.current && terminalRef.current) {
         terminalRef.current.write(data)
+        outputReceivedSinceTickRef.current = true
         // Resolve terminal record ID (cached to avoid linear scan)
         if (!cachedTerminalId) {
           const terminalRecord = useTerminalStore.getState().findTerminalByPtyId(id)
@@ -1461,6 +1473,31 @@ function ConnectedTerminalComponent({
       }
       cleanup()
     }
+  }, [performTerminalRecovery])
+
+  // Render-liveness watchdog: mitigate the xterm 6.x WebGL compositor stall
+  // that freezes the pane mid-session (output flows but the canvas stops
+  // updating). Visibility/focus/power handlers only recover on window events,
+  // so an always-visible, never-minimized tab would stay frozen. Every
+  // RENDER_WATCHDOG_INTERVAL_MS, if the pane is visible and has received output
+  // since the last tick, nudge performTerminalRecovery (single-flight guarded,
+  // layout-aware). Skipped for the DOM renderer (no canvas to stall) and when
+  // the document is hidden.
+  useEffect(() => {
+    // The DOM renderer has no canvas layer to stall, so the watchdog only runs
+    // for the WebGL renderer.
+    if (!shouldUseWebglRenderer(rendererPreferenceRef.current)) return
+
+    const tick = (): void => {
+      if (document.visibilityState !== 'visible') return
+      if (!isVisibleRef.current) return
+      if (!outputReceivedSinceTickRef.current) return
+      outputReceivedSinceTickRef.current = false
+      performTerminalRecovery()
+    }
+
+    const intervalId = setInterval(tick, RENDER_WATCHDOG_INTERVAL_MS)
+    return () => clearInterval(intervalId)
   }, [performTerminalRecovery])
 
   const handleContainerClick = useCallback((): void => {


### PR DESCRIPTION
## Summary

The xterm 6.x WebGL renderer can **stop re-presenting its canvas mid-session** even though the GL context is healthy and the PTY keeps producing output (the **"TUI stuck but process runs"** symptom — our own `performTerminalRecovery` comments cite xterm.js issues #4841 / #5357). The existing recovery only fires on **window** events (`visibilitychange`, `focus`, power-resume), so a long-running tab that is **never minimized** never recovers and stays frozen until the user interacts with the window.

This adds a render-liveness watchdog: every `RENDER_WATCHDOG_INTERVAL_MS` (20s), if the pane is visible **and** has received PTY output since the last tick, it nudges `performTerminalRecovery` (single-flight guarded, layout-aware). This bounds the worst-case freeze to ~20s during active streaming without waiting for a window event. It is skipped for the DOM renderer (no canvas to stall) and when the document is hidden.

## Related Issue

No related issue — reported directly as a rendering-reliability pain. Searched open + closed PRs/issues for "render watchdog", "terminal frozen", "webgl stuck", "compositor" — no existing or duplicate work found.

## Type of Change

- [x] fix: bug fix

## What Changed

**`src/renderer/components/terminal/ConnectedTerminal.tsx`:**

- New constant `RENDER_WATCHDOG_INTERVAL_MS = 20000`.
- New `outputReceivedSinceTickRef` — flipped `true` in the PTY data listener whenever output is written to xterm.
- New `useEffect` watchdog: registers a `setInterval` (cleaned up on unmount). The tick bails out early unless (a) the renderer preference is WebGL, (b) `document.visibilityState === 'visible'`, (c) the pane `isVisible`, and (d) output was received since the last tick; otherwise it resets the flag and calls `performTerminalRecovery()`.
- Reuses the existing, well-tested `performTerminalRecovery` (which does the fit + `refresh` + 1-frame visibility re-composite under a single-flight guard and a collapsed-dimension guard), so no new rendering logic is introduced.

Behavior:
- Idle terminal (no output) → watchdog does nothing (no unnecessary repaints/flicker).
- Active streaming + WebGL + visible → a recovery nudge at most every 20s, only when the compositor may have stalled.
- DOM renderer or hidden document → watchdog disabled.

**`src/renderer/components/terminal/ConnectedTerminal.test.tsx`** — new `describe('Render-liveness watchdog')` with 3 tests:
- nudges recovery after PTY output while visible (WebGL);
- does nothing when no output was received since the last tick;
- is disabled when the renderer preference is `dom`.

## How It Was Tested

- [x] `bun run ci` (Biome strict)
- [x] `bun run typecheck`
- [x] `bun run test` (full suite green; +3 new tests)
- [ ] `cargo clippy --all-targets -- -D warnings` — N/A: frontend-only change, no Rust touched (CI runs the Rust gate on the unchanged baseline)
- [ ] `cargo test` — N/A: frontend-only
- [x] Manual verification completed — exercised in the running app with heavy TUI streaming; mid-use freezes now self-recover within ~20s instead of persisting.

## Screenshots or Recordings

N/A — renderer liveness behavior; no static visual UI change.

## CI & Review Gate

- [ ] All CI checks pass (PR Validation, Rust Checks, Build Verification, Security Scans)
- [ ] Code review comments from CodeRabbit / Claude have been addressed or resolved
- [ ] No unresolved review findings remain

(Awaiting CI + CodeRabbit after opening.)

## Checklist

- [x] My PR title follows the conventional commit format used by this repo
- [x] I linked the related issue or explained why none exists
- [x] I updated docs when needed (none needed)
- [x] I added or updated tests when needed (+3 tests)
- [x] I verified the change does not introduce unrelated modifications
- [x] I read AGENTS.md and followed the contributor guidelines
- [x] A human reviewed the complete diff before submission

## Notes

This is a mitigation for the xterm 6.x beta WebGL compositor stall, not a root-cause fix. The underlying cause (the beta renderer) is tracked separately as an investigation (a stable 6.0.0 spike builds clean with zero code changes but needs real-app validation). This watchdog is valuable defense-in-depth regardless of the xterm version.
