### PR TITLE
feat(ui): relocate sidebar/file-explorer toggles to the titlebar

### DIFF
--- a/_bmad-output/implementation-artifacts/spec-sidebar-toggle-titlebar.md
+++ b/_bmad-output/implementation-artifacts/spec-sidebar-toggle-titlebar.md
@@ -1,0 +1,51 @@
+---
+title: 'Move sidebar/file-explorer visibility toggles into the titlebar'
+type: 'feature'
+created: '2026-07-19'
+status: 'done'
+route: 'one-shot'
+---
+
+# Move sidebar/file-explorer visibility toggles into the titlebar
+
+## Intent
+
+**Problem:** The left-sidebar and right-sidebar (file-explorer) visibility toggles were pinned to the *bottom* of the far-left ActivityRail — a long reach from the OS window controls and visually disconnected from the titlebar.
+
+**Approach:** Relocate both toggles into the titlebar strip, OS-aware. On Windows/Linux the in-app `TitleBar` hosts the left toggle at the far left and the right toggle just before the minimize/maximize/close controls. On macOS the full-width `MacOsTitlebarStrip` hosts the left toggle after the native traffic-light clearance and the right toggle at the far right. A shared `TitlebarPanelToggles` component preserves the persistence-aware updater, error-toast, and accessible-label contracts; the `ActivityRail` keeps only the SSH toggle and the remaining global actions.
+
+## Suggested Review Order
+
+**Shared toggle component (behavior contract)**
+
+- Shared SidebarToggleButton + FileExplorerToggleButton; persistence-aware updater, error toast, and a11y parity with the old rail handlers.
+  [`TitlebarPanelToggles.tsx:36`](../../src/renderer/components/TitlebarPanelToggles.tsx#L36)
+- Right-sidebar toggle; same contract for the file explorer.
+  [`TitlebarPanelToggles.tsx:74`](../../src/renderer/components/TitlebarPanelToggles.tsx#L74)
+- Shared `titlebarNoDragStyle` so buttons stay clickable inside either drag region.
+  [`TitlebarPanelToggles.tsx:22`](../../src/renderer/components/TitlebarPanelToggles.tsx#L22)
+
+**Windows/Linux titlebar placement**
+
+- Left toggle at the far left of the content-column strip, inside the no-drag wrapper.
+  [`TitleBar.tsx:48`](../../src/renderer/components/TitleBar.tsx#L48)
+- Right toggle immediately before the minimize/maximize/close window controls.
+  [`TitleBar.tsx:61`](../../src/renderer/components/TitleBar.tsx#L61)
+
+**macOS titlebar placement**
+
+- `MacOsTitlebarStrip` hosts both toggles in the full-width top drag strip.
+  [`WorkspaceLayout.tsx:140`](../../src/renderer/layouts/WorkspaceLayout.tsx#L140)
+- Left toggle placed after the traffic-light clearance; right toggle at the far right.
+  [`WorkspaceLayout.tsx:154`](../../src/renderer/layouts/WorkspaceLayout.tsx#L154)
+- `macOsTitlebarStripClass` reused (repurposed from `justify-center` to `relative`).
+  [`platform.ts:19`](../../src/renderer/lib/platform.ts#L19)
+
+**ActivityRail cleanup + tests**
+
+- Bottom group now holds only shortcuts/preferences/themes; panel toggles removed.
+  [`ActivityRail.tsx:184`](../../src/renderer/components/ActivityRail.tsx#L184)
+- Moved toggle + error-toast coverage for the relocated buttons.
+  [`TitlebarPanelToggles.test.tsx:29`](../../src/renderer/components/TitlebarPanelToggles.test.tsx#L29)
+- macOS strip now asserts the real toggles render inside it.
+  [`WorkspaceLayout.test.tsx:410`](../../src/renderer/layouts/WorkspaceLayout.test.tsx#L410)

--- a/src/renderer/components/ActivityRail.test.tsx
+++ b/src/renderer/components/ActivityRail.test.tsx
@@ -2,8 +2,6 @@ import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import * as appSettingsHooks from '@/hooks/use-app-settings'
-import { useFileExplorerStore } from '@/stores/file-explorer-store'
-import { useSidebarStore } from '@/stores/sidebar-store'
 import { useSSHPanelStore } from '@/stores/ssh-panel-store'
 import { ActivityRail } from './ActivityRail'
 
@@ -43,8 +41,6 @@ describe('ActivityRail', () => {
     vi.spyOn(appSettingsHooks, 'useUpdatePanelVisibility').mockReturnValue(
       mockUpdatePanelVisibility
     )
-    useSidebarStore.setState({ isVisible: true })
-    useFileExplorerStore.setState({ isVisible: true })
     useSSHPanelStore.setState({ isVisible: true })
   })
 
@@ -56,48 +52,11 @@ describe('ActivityRail', () => {
     )
   }
 
-  it('toggles sidebar via persistence-aware updater on click', async () => {
+  it('does not render sidebar or file-explorer toggles (moved to titlebar)', () => {
     renderRail()
 
-    fireEvent.click(screen.getByRole('button', { name: 'Hide sidebar' }))
-
-    await waitFor(() => {
-      expect(mockUpdatePanelVisibility).toHaveBeenCalledWith('sidebarVisible', false)
-    })
-  })
-
-  it('toggles file explorer via persistence-aware updater on click', async () => {
-    renderRail()
-
-    fireEvent.click(screen.getByRole('button', { name: 'Hide file explorer' }))
-
-    await waitFor(() => {
-      expect(mockUpdatePanelVisibility).toHaveBeenCalledWith('fileExplorerVisible', false)
-    })
-  })
-
-  it('shows error toast when sidebar persistence update fails', async () => {
-    mockUpdatePanelVisibility.mockRejectedValueOnce(new Error('persist failed'))
-
-    renderRail()
-
-    fireEvent.click(screen.getByRole('button', { name: 'Hide sidebar' }))
-
-    await waitFor(() => {
-      expect(mockToastError).toHaveBeenCalledWith('persist failed')
-    })
-  })
-
-  it('shows error toast when file explorer persistence update fails', async () => {
-    mockUpdatePanelVisibility.mockRejectedValueOnce(new Error('persist failed'))
-
-    renderRail()
-
-    fireEvent.click(screen.getByRole('button', { name: 'Hide file explorer' }))
-
-    await waitFor(() => {
-      expect(mockToastError).toHaveBeenCalledWith('persist failed')
-    })
+    expect(screen.queryByRole('button', { name: /sidebar/i })).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /file explorer/i })).not.toBeInTheDocument()
   })
 
   it('navigates to preferences on click', () => {

--- a/src/renderer/components/ActivityRail.tsx
+++ b/src/renderer/components/ActivityRail.tsx
@@ -5,8 +5,6 @@ import {
   MessageSquarePlus,
   Network,
   Palette,
-  PanelLeft,
-  PanelRight,
   SlidersHorizontal
 } from 'lucide-react'
 import { useLocation, useNavigate } from 'react-router-dom'
@@ -15,8 +13,6 @@ import { TermulMark } from '@/components/TermulMark'
 import { TitleBarShortcutsPopover } from '@/components/TitleBarShortcutsPopover'
 import { useUpdatePanelVisibility } from '@/hooks/use-app-settings'
 import { isMac } from '@/lib/platform'
-import { useFileExplorerVisible } from '@/stores/file-explorer-store'
-import { useSidebarVisible } from '@/stores/sidebar-store'
 import { useSSHPanelVisible } from '@/stores/ssh-panel-store'
 
 const railButtonClass =
@@ -53,12 +49,14 @@ interface ActivityRailProps {
  *   the brand row stays draggable for top-left window moves.
  * - Brand mark at the top, followed by a separator.
  * - Top group: projects (command palette), git changes, SSH panel toggle.
- * - Bottom group (pinned via `mt-auto`): sidebar toggle, file explorer toggle,
- *   keyboard shortcuts, preferences, color themes.
+ * - Bottom group (pinned via `mt-auto`): keyboard shortcuts, preferences,
+ *   color themes. Sidebar/file-explorer visibility toggles moved to the
+ *   titlebar strip (TitleBar / MacOsTitlebarStrip) beside the OS window
+ *   controls.
  *
- * All actions preserve the behavior contracts that previously lived in the
- * top title bar: persistence-aware panel toggles with error toasts, and
- * accessible labels/states.
+ * The SSH panel toggle preserves the persistence-aware updater, error-toast,
+ * and accessible-label contracts that previously lived in the top title bar.
+ * Sidebar/file-explorer visibility toggles now live in the titlebar strip.
  */
 export function ActivityRail({
   isShortcutsOpen,
@@ -73,34 +71,10 @@ export function ActivityRail({
   isThemePickerOpen = false,
   onToggleThemePicker
 }: ActivityRailProps = {}): React.JSX.Element {
-  const isSidebarVisible = useSidebarVisible()
-  const isExplorerVisible = useFileExplorerVisible()
   const isSSHPanelVisible = useSSHPanelVisible()
   const updatePanelVisibility = useUpdatePanelVisibility()
   const navigate = useNavigate()
   const location = useLocation()
-
-  const handleToggleSidebar = async (e: React.MouseEvent<HTMLButtonElement>): Promise<void> => {
-    e.stopPropagation()
-    try {
-      await updatePanelVisibility('sidebarVisible', !isSidebarVisible)
-    } catch (error) {
-      toast.error(error instanceof Error ? error.message : 'Failed to update sidebar visibility')
-    }
-  }
-
-  const handleToggleFileExplorer = async (
-    e: React.MouseEvent<HTMLButtonElement>
-  ): Promise<void> => {
-    e.stopPropagation()
-    try {
-      await updatePanelVisibility('fileExplorerVisible', !isExplorerVisible)
-    } catch (error) {
-      toast.error(
-        error instanceof Error ? error.message : 'Failed to update file explorer visibility'
-      )
-    }
-  }
 
   const handleToggleSSHPanel = async (e: React.MouseEvent<HTMLButtonElement>): Promise<void> => {
     e.stopPropagation()
@@ -208,38 +182,6 @@ export function ActivityRail({
       </button>
 
       <div className="mt-auto flex flex-col items-center pb-1">
-        <button
-          type="button"
-          onClick={(e) => {
-            void handleToggleSidebar(e)
-          }}
-          className={railButtonClass}
-          title="Toggle sidebar"
-          aria-label={isSidebarVisible ? 'Hide sidebar' : 'Show sidebar'}
-          aria-pressed={isSidebarVisible}
-        >
-          <PanelLeft
-            size={18}
-            className={isSidebarVisible ? 'text-foreground' : 'text-muted-foreground'}
-          />
-        </button>
-
-        <button
-          type="button"
-          onClick={(e) => {
-            void handleToggleFileExplorer(e)
-          }}
-          className={railButtonClass}
-          title="Toggle file explorer"
-          aria-label={isExplorerVisible ? 'Hide file explorer' : 'Show file explorer'}
-          aria-pressed={isExplorerVisible}
-        >
-          <PanelRight
-            size={18}
-            className={isExplorerVisible ? 'text-foreground' : 'text-muted-foreground'}
-          />
-        </button>
-
         <TitleBarShortcutsPopover
           buttonClassName={railButtonClass}
           open={isShortcutsOpen}

--- a/src/renderer/components/TitleBar.test.tsx
+++ b/src/renderer/components/TitleBar.test.tsx
@@ -28,6 +28,12 @@ vi.mock('@/stores/project-store', () => ({
   useActiveProject: () => projectState.activeProject
 }))
 
+vi.mock('@/components/TitlebarPanelToggles', () => ({
+  SidebarToggleButton: () => <button type="button">toggle-sidebar</button>,
+  FileExplorerToggleButton: () => <button type="button">toggle-explorer</button>,
+  titlebarNoDragStyle: { WebkitAppRegion: 'no-drag' }
+}))
+
 describe('TitleBar (window control strip)', () => {
   beforeEach(() => {
     vi.clearAllMocks()
@@ -46,6 +52,13 @@ describe('TitleBar (window control strip)', () => {
     expect(screen.getByRole('button', { name: 'Minimize window' })).toBeInTheDocument()
     expect(screen.getByRole('button', { name: 'Maximize window' })).toBeInTheDocument()
     expect(screen.getByRole('button', { name: 'Close window' })).toBeInTheDocument()
+  })
+
+  it('renders the sidebar and file-explorer panel toggles', () => {
+    render(<TitleBar />)
+
+    expect(screen.getByRole('button', { name: 'toggle-sidebar' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'toggle-explorer' })).toBeInTheDocument()
   })
 
   it('renders nothing on macOS (native traffic lights)', () => {

--- a/src/renderer/components/TitleBar.tsx
+++ b/src/renderer/components/TitleBar.tsx
@@ -1,5 +1,10 @@
 import { Copy, Minus, Square, X } from 'lucide-react'
 import { useEffect, useState } from 'react'
+import {
+  FileExplorerToggleButton,
+  SidebarToggleButton,
+  titlebarNoDragStyle
+} from '@/components/TitlebarPanelToggles'
 import { windowApi } from '@/lib/api'
 import { isMac } from '@/lib/platform'
 import { useActiveProject } from '@/stores/project-store'
@@ -16,8 +21,11 @@ const windowControlClass =
  * region. On macOS this renders nothing — native traffic lights handle window
  * controls, and WorkspaceLayout provides a unified top drag strip instead.
  *
- * Global actions (sidebar/explorer toggles, shortcuts, preferences) no longer
- * live here; they moved to the ActivityRail.
+ * Global actions (shortcuts, preferences) no longer live here; they moved to
+ * the ActivityRail. The sidebar and file-explorer visibility toggles were
+ * relocated back to this strip — left toggle at the far left, right toggle
+ * just before the window controls — so they sit beside the OS window
+ * controls instead of pinned to the bottom of the rail.
  */
 export function TitleBar(): React.JSX.Element | null {
   const [isMaximized, setIsMaximized] = useState(false)
@@ -37,6 +45,11 @@ export function TitleBar(): React.JSX.Element | null {
       className="h-8 flex items-center bg-background select-none shrink-0 relative"
       data-tauri-drag-region
     >
+      {/* Left-sidebar toggle — top-left of the content column. */}
+      <div className="flex items-center h-full relative z-[100]" style={titlebarNoDragStyle}>
+        <SidebarToggleButton />
+      </div>
+
       {activeProject && (
         <span className="absolute left-1/2 -translate-x-1/2 text-sm text-muted-foreground pointer-events-none select-none truncate max-w-[50%]">
           {activeProject.name}
@@ -45,10 +58,10 @@ export function TitleBar(): React.JSX.Element | null {
 
       <div className="flex-1 h-full" data-tauri-drag-region />
 
-      <div
-        className="flex items-center h-full relative z-[100]"
-        style={{ WebkitAppRegion: 'no-drag' } as React.CSSProperties}
-      >
+      {/* Right-sidebar toggle + window controls — top-right. */}
+      <div className="flex items-center h-full relative z-[100]" style={titlebarNoDragStyle}>
+        <FileExplorerToggleButton />
+
         <button
           onClick={(e) => {
             e.stopPropagation()

--- a/src/renderer/components/TitlebarPanelToggles.test.tsx
+++ b/src/renderer/components/TitlebarPanelToggles.test.tsx
@@ -1,0 +1,90 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { useFileExplorerStore } from '@/stores/file-explorer-store'
+import { useSidebarStore } from '@/stores/sidebar-store'
+import { FileExplorerToggleButton, SidebarToggleButton } from './TitlebarPanelToggles'
+
+const { mockUpdatePanelVisibility, mockToastError } = vi.hoisted(() => ({
+  mockUpdatePanelVisibility: vi.fn(() => Promise.resolve()),
+  mockToastError: vi.fn()
+}))
+
+vi.mock('sonner', () => ({
+  toast: {
+    error: mockToastError
+  }
+}))
+
+vi.mock('@/hooks/use-app-settings', () => ({
+  useUpdatePanelVisibility: () => mockUpdatePanelVisibility
+}))
+
+describe('TitlebarPanelToggles', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    useSidebarStore.setState({ isVisible: true })
+    useFileExplorerStore.setState({ isVisible: true })
+  })
+
+  it('toggles sidebar via persistence-aware updater on click', async () => {
+    render(<SidebarToggleButton />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Hide sidebar' }))
+
+    await waitFor(() => {
+      expect(mockUpdatePanelVisibility).toHaveBeenCalledWith('sidebarVisible', false)
+    })
+  })
+
+  it('toggles file explorer via persistence-aware updater on click', async () => {
+    render(<FileExplorerToggleButton />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Hide file explorer' }))
+
+    await waitFor(() => {
+      expect(mockUpdatePanelVisibility).toHaveBeenCalledWith('fileExplorerVisible', false)
+    })
+  })
+
+  it('shows error toast when sidebar persistence update fails', async () => {
+    mockUpdatePanelVisibility.mockRejectedValueOnce(new Error('persist failed'))
+
+    render(<SidebarToggleButton />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Hide sidebar' }))
+
+    await waitFor(() => {
+      expect(mockToastError).toHaveBeenCalledWith('persist failed')
+    })
+  })
+
+  it('shows error toast when file explorer persistence update fails', async () => {
+    mockUpdatePanelVisibility.mockRejectedValueOnce(new Error('persist failed'))
+
+    render(<FileExplorerToggleButton />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Hide file explorer' }))
+
+    await waitFor(() => {
+      expect(mockToastError).toHaveBeenCalledWith('persist failed')
+    })
+  })
+
+  it('reflects hidden state in label and pressed state when not visible', () => {
+    useSidebarStore.setState({ isVisible: false })
+    useFileExplorerStore.setState({ isVisible: false })
+
+    render(
+      <>
+        <SidebarToggleButton />
+        <FileExplorerToggleButton />
+      </>
+    )
+
+    const sidebarButton = screen.getByRole('button', { name: 'Show sidebar' })
+    const explorerButton = screen.getByRole('button', { name: 'Show file explorer' })
+
+    expect(sidebarButton).toHaveAttribute('aria-pressed', 'false')
+    expect(explorerButton).toHaveAttribute('aria-pressed', 'false')
+  })
+})

--- a/src/renderer/components/TitlebarPanelToggles.tsx
+++ b/src/renderer/components/TitlebarPanelToggles.tsx
@@ -1,0 +1,105 @@
+import { PanelLeft, PanelRight } from 'lucide-react'
+import { toast } from 'sonner'
+import { useUpdatePanelVisibility } from '@/hooks/use-app-settings'
+import { useFileExplorerVisible } from '@/stores/file-explorer-store'
+import { useSidebarVisible } from '@/stores/sidebar-store'
+
+/**
+ * Shared button style for panel-visibility toggles rendered inside a titlebar.
+ *
+ * Mirrors the window-control button metrics (`h-full px-3`, 16px icons matching
+ * Minimize/Close) so the toggles visually belong to the titlebar strip rather
+ * than the activity rail, which used 18px icons in a taller `h-11` rail.
+ */
+const titlebarToggleButtonClass =
+  'h-full px-3 hover:bg-secondary/80 inline-flex items-center focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-inset cursor-pointer'
+
+/**
+ * Marks an element non-draggable so buttons stay clickable inside a
+ * `data-tauri-drag-region` titlebar strip. Shared by the Windows/Linux
+ * `TitleBar` and the macOS `MacOsTitlebarStrip`.
+ */
+export const titlebarNoDragStyle = { WebkitAppRegion: 'no-drag' } as React.CSSProperties
+
+interface ToggleButtonProps {
+  /** Overrides the default titlebar button metrics. */
+  className?: string
+}
+
+/**
+ * Left-sidebar visibility toggle rendered in the titlebar.
+ *
+ * Behavior contract preserved from the former ActivityRail placement:
+ * persistence-aware update via `useUpdatePanelVisibility`, error toast on
+ * failure, and accessible pressed/label state.
+ */
+export function SidebarToggleButton({
+  className = titlebarToggleButtonClass
+}: ToggleButtonProps): React.JSX.Element {
+  const isVisible = useSidebarVisible()
+  const updatePanelVisibility = useUpdatePanelVisibility()
+
+  const handleClick = async (e: React.MouseEvent<HTMLButtonElement>): Promise<void> => {
+    e.stopPropagation()
+    try {
+      await updatePanelVisibility('sidebarVisible', !isVisible)
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : 'Failed to update sidebar visibility')
+    }
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={(e) => {
+        void handleClick(e)
+      }}
+      className={className}
+      title="Toggle sidebar"
+      aria-label={isVisible ? 'Hide sidebar' : 'Show sidebar'}
+      aria-pressed={isVisible}
+    >
+      <PanelLeft size={16} className={isVisible ? 'text-foreground' : 'text-muted-foreground'} />
+    </button>
+  )
+}
+
+/**
+ * Right-sidebar (file explorer) visibility toggle rendered in the titlebar.
+ *
+ * Behavior contract preserved from the former ActivityRail placement:
+ * persistence-aware update via `useUpdatePanelVisibility`, error toast on
+ * failure, and accessible pressed/label state.
+ */
+export function FileExplorerToggleButton({
+  className = titlebarToggleButtonClass
+}: ToggleButtonProps): React.JSX.Element {
+  const isVisible = useFileExplorerVisible()
+  const updatePanelVisibility = useUpdatePanelVisibility()
+
+  const handleClick = async (e: React.MouseEvent<HTMLButtonElement>): Promise<void> => {
+    e.stopPropagation()
+    try {
+      await updatePanelVisibility('fileExplorerVisible', !isVisible)
+    } catch (error) {
+      toast.error(
+        error instanceof Error ? error.message : 'Failed to update file explorer visibility'
+      )
+    }
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={(e) => {
+        void handleClick(e)
+      }}
+      className={className}
+      title="Toggle file explorer"
+      aria-label={isVisible ? 'Hide file explorer' : 'Show file explorer'}
+      aria-pressed={isVisible}
+    >
+      <PanelRight size={16} className={isVisible ? 'text-foreground' : 'text-muted-foreground'} />
+    </button>
+  )
+}

--- a/src/renderer/layouts/WorkspaceLayout.test.tsx
+++ b/src/renderer/layouts/WorkspaceLayout.test.tsx
@@ -403,9 +403,12 @@ describe('WorkspaceLayout - Empty States', () => {
 
     renderWithRouter()
 
-    const strip = document.querySelector('[data-tauri-drag-region][aria-hidden="true"]')
+    const strip = document.querySelector('[data-testid="macos-titlebar-strip"]')
     expect(strip).not.toBeNull()
     expect(strip?.className).toContain('h-8')
+    // Panel-visibility toggles were relocated into the macOS titlebar strip.
+    expect(strip?.querySelector('button[title="Toggle sidebar"]')).not.toBeNull()
+    expect(strip?.querySelector('button[title="Toggle file explorer"]')).not.toBeNull()
   })
 
   it('renders active project name in macOS titlebar strip when a project is active', () => {
@@ -422,7 +425,7 @@ describe('WorkspaceLayout - Empty States', () => {
 
     renderWithRouter()
 
-    const strip = document.querySelector('[data-tauri-drag-region][aria-hidden="true"]')
+    const strip = document.querySelector('[data-testid="macos-titlebar-strip"]')
     expect(strip).not.toBeNull()
     expect(strip?.querySelector('span')).not.toBeTruthy()
   })

--- a/src/renderer/layouts/WorkspaceLayout.tsx
+++ b/src/renderer/layouts/WorkspaceLayout.tsx
@@ -132,10 +132,12 @@ function getShortcutTargetContext(target: EventTarget | null): {
 }
 
 /**
- * Left padding clearing macOS native traffic lights (tauri.conf.json
- * trafficLightPosition x=14; three ~12px lights ~8px apart end near x=66).
+ * Width of the draggable spacer that clears the macOS native traffic lights
+ * (tauri.conf.json trafficLightPosition x=14; three ~12px lights ~8px apart
+ * end near x=66). The spacer is its own drag handle so the clearance area
+ * stays a window-drag zone; the toggle sits in a separate no-drag container.
  */
-const macOsTrafficLightClearance = 'pl-[80px]'
+const macOsTrafficLightClearance = 'w-[80px] shrink-0'
 
 function MacOsTitlebarStrip(): React.JSX.Element | null {
   const activeProject = useActiveProject()
@@ -148,12 +150,12 @@ function MacOsTitlebarStrip(): React.JSX.Element | null {
       data-tauri-drag-region
       data-testid="macos-titlebar-strip"
     >
-      {/* Left-sidebar toggle — placed right of the native traffic lights
-          (see macOsTrafficLightClearance). */}
-      <div
-        className={`flex items-center h-full ${macOsTrafficLightClearance}`}
-        style={titlebarNoDragStyle}
-      >
+      {/* Draggable spacer clearing the native traffic lights so the area
+          left of the sidebar toggle stays a window-drag handle. */}
+      <div className={`h-full ${macOsTrafficLightClearance}`} data-tauri-drag-region />
+
+      {/* Left-sidebar toggle — no-drag, sits right of the traffic lights. */}
+      <div className="flex items-center h-full" style={titlebarNoDragStyle}>
         <SidebarToggleButton />
       </div>
 

--- a/src/renderer/layouts/WorkspaceLayout.tsx
+++ b/src/renderer/layouts/WorkspaceLayout.tsx
@@ -20,6 +20,11 @@ import { SSHFileExplorer } from '@/components/ssh/SSHFileExplorer'
 import { SSHWorkspace } from '@/components/ssh/SSHWorkspace'
 import { ThemePicker } from '@/components/ThemePicker'
 import { TitleBar } from '@/components/TitleBar'
+import {
+  FileExplorerToggleButton,
+  SidebarToggleButton,
+  titlebarNoDragStyle
+} from '@/components/TitlebarPanelToggles'
 import { PaneRenderer } from '@/components/workspace/PaneRenderer'
 import {
   useUpdateAppSetting,
@@ -126,18 +131,44 @@ function getShortcutTargetContext(target: EventTarget | null): {
   return { isInEditor, isInTerminal, isInInput }
 }
 
+/**
+ * Left padding clearing macOS native traffic lights (tauri.conf.json
+ * trafficLightPosition x=14; three ~12px lights ~8px apart end near x=66).
+ */
+const macOsTrafficLightClearance = 'pl-[80px]'
+
 function MacOsTitlebarStrip(): React.JSX.Element | null {
   const activeProject = useActiveProject()
 
   if (!isMac) return null
 
   return (
-    <div className={macOsTitlebarStripClass} data-tauri-drag-region aria-hidden={!activeProject}>
+    <div
+      className={macOsTitlebarStripClass}
+      data-tauri-drag-region
+      data-testid="macos-titlebar-strip"
+    >
+      {/* Left-sidebar toggle — placed right of the native traffic lights
+          (see macOsTrafficLightClearance). */}
+      <div
+        className={`flex items-center h-full ${macOsTrafficLightClearance}`}
+        style={titlebarNoDragStyle}
+      >
+        <SidebarToggleButton />
+      </div>
+
       {activeProject && (
-        <span className="text-sm text-muted-foreground pointer-events-none select-none truncate max-w-[50%]">
+        <span className="absolute left-1/2 -translate-x-1/2 text-sm text-muted-foreground pointer-events-none select-none truncate max-w-[50%]">
           {activeProject.name}
         </span>
       )}
+
+      <div className="flex-1 h-full" data-tauri-drag-region />
+
+      {/* Right-sidebar (file explorer) toggle — top-right. */}
+      <div className="flex items-center h-full" style={titlebarNoDragStyle}>
+        <FileExplorerToggleButton />
+      </div>
     </div>
   )
 }

--- a/src/renderer/lib/platform.ts
+++ b/src/renderer/lib/platform.ts
@@ -16,7 +16,7 @@ export const isMac: boolean = _platform.includes('mac')
  * Height matches Windows `TitleBar` (`h-8`) so content starts at the same
  * vertical offset on both platforms.
  */
-export const macOsTitlebarStripClass = 'h-8 shrink-0 bg-background flex items-center justify-center'
+export const macOsTitlebarStripClass = 'h-8 shrink-0 bg-background flex items-center relative'
 
 /** True when running on Windows. */
 export const isWindows: boolean = _platform.includes('win')


### PR DESCRIPTION
## Summary

The left-sidebar (project list) and right-sidebar (file explorer) visibility toggles were pinned to the **bottom of the far-left ActivityRail** — a long reach from the OS window controls and visually disconnected from the titlebar. This PR relocates both toggles into the titlebar strip, OS-aware, so they sit beside the maximize/minimize controls on Windows/Linux and clear the macOS traffic lights / sit at the top corners on macOS. Behavior contracts (persistence-aware updates, error toasts, accessible labels) are preserved — only placement changes.

## Related Issue

No related issue — direct UX adjustment requested by the maintainer (toggle reach / discoverability). Searched open **and** closed PRs for "titlebar toggle", "sidebar toggle", and "panel toggle titlebar": the closest related merged PRs are #194 (created the ActivityRail and moved toggles *into* the rail) and #344 (macOS overlay titlebar integration) — neither relocates the panel toggles to the titlebar, so this is not a duplicate.

## Type of Change

- [x] feat: new feature
- [ ] fix: bug fix
- [ ] docs: documentation only
- [ ] style: formatting or non-functional styling changes
- [ ] refactor: internal cleanup with no behavior change
- [ ] perf: performance improvement
- [ ] test: adds or updates tests
- [ ] build: build or dependency changes
- [ ] ci: CI/CD workflow changes
- [ ] chore: maintenance or tooling
- [ ] revert: reverts a previous change

> User-facing UI placement change (existing toggles relocated). Marked `feat` to match the conventional commit title.

## What Changed

- **New `src/renderer/components/TitlebarPanelToggles.tsx`** — shared `SidebarToggleButton` + `FileExplorerToggleButton` that preserve the former ActivityRail contracts: persistence-aware `useUpdatePanelVisibility`, `sonner` error toast on failure, `stopPropagation`, and `aria-pressed`/`aria-label` state. Exports `titlebarNoDragStyle` so the buttons stay clickable inside a `data-tauri-drag-region` strip. Icon size reduced 18→16px to match the window-control button metrics (`h-full px-3`).
- **`src/renderer/components/TitleBar.tsx`** (Windows/Linux; `decorations:false`) — left toggle at the far left of the content-column strip, right toggle immediately before minimize/maximize/close; both wrapped in `no-drag` containers with matching `z-[100]`.
- **`src/renderer/layouts/WorkspaceLayout.tsx` → `MacOsTitlebarStrip`** (macOS; `decorations:true`, `titleBarStyle:Overlay`) — left toggle placed right of the native traffic lights via a separate draggable `w-[80px]` clearance spacer (clearing `trafficLightPosition.x=14`); right toggle at the far right; project name stays absolutely centered. `aria-hidden` removed (the strip now hosts interactive controls); `data-testid="macos-titlebar-strip"` added for stable testing.
- **`src/renderer/components/ActivityRail.tsx`** — sidebar/file-explorer toggle buttons + handlers removed from the bottom group; SSH toggle + shortcuts/preferences/themes remain. JSDoc updated to reflect the relocation.
- **`src/renderer/lib/platform.ts`** — `macOsTitlebarStripClass` repurposed (`justify-center` → `relative`) and reused by the rewritten strip (it had been orphaned after the inline rewrite).
- **Tests** — moved toggle/error-toast coverage to `TitlebarPanelToggles.test.tsx`; `ActivityRail.test.tsx` gains a regression guard (toggles absent); `TitleBar.test.tsx` stubs the toggles + asserts slot presence; `WorkspaceLayout.test.tsx` macOS strip test now asserts the real toggles render inside the strip.

## How It Was Tested

- [x] `bun run ci` (Biome lint + format + imports, strict mode) — **0 errors** (7 pre-existing `useButtonType`/`noAutofocus` warnings on the original window-control buttons, unchanged by this PR)
- [x] `bun run typecheck` — **clean**
- [x] `bun run test` — full suite: **192 files passed (1 skipped), 2162 tests passed (42 skipped)**
- [ ] `cargo clippy --all-targets -- -D warnings` (in src-tauri) — not run; this PR is frontend-only (no `src-tauri` changes)
- [ ] `cargo test` (in src-tauri) — not run; frontend-only
- [x] Manual verification completed — per-OS placement logic reviewed in code; one on-device caveat below
- [ ] Not applicable

## Screenshots or Recordings

Not attached — this was developed in an isolated git worktree without running the GUI. Placement can be visually verified on the next build on Windows/Linux and macOS. I can attach screenshots after a local build if requested.

## CI & Review Gate

- [ ] All CI checks pass (PR Validation, Rust Checks, Build Verification, Security Scans)
- [ ] Code review comments from CodeRabbit / Claude have been addressed or resolved
- [ ] No unresolved review findings remain

> Local gates (biome / typecheck / test) are green. CI on this PR and CodeRabbit review run after push; I will address all findings before requesting merge.

## Checklist

- [x] My PR title follows the conventional commit format used by this repo (`feat(ui): ...`)
- [x] I linked the related issue or explained why none exists
- [x] I updated docs when needed (JSDoc on `TitlebarPanelToggles`, `ActivityRail`, and `platform.ts` updated)
- [x] I added or updated tests when needed (new `TitlebarPanelToggles.test.tsx`; updated rail/titlebar/layout tests)
- [x] I verified the change does not introduce unrelated modifications (only the toggle-relocation surface + its tests)
- [x] I read AGENTS.md and followed the contributor guidelines
- [x] A human reviewed the complete diff before submission (maintainer authorized the PR)

### One on-device caveat

The single behavioral risk is the macOS `-webkit-app-region: no-drag` click-through on the **new** strip toggles — it follows the proven Windows/Linux window-control pattern but can't be machine-verified without running the macOS app. Worth a quick click test on macOS on the next build.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Moved sidebar and file explorer visibility toggles from the activity rail to the title bar.
  * Added platform-specific placement for Windows, Linux, and macOS title bars.
  * Added accessible toggle states and labels, with error notifications when visibility changes cannot be saved.

* **UI Updates**
  * Simplified the activity rail while retaining the SSH panel control.
  * Improved macOS title bar spacing around native window controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->