### PR TITLE
chore(acp): re-sync bundled ACP agent registry

### DIFF
--- a/src/renderer/assets/agent-icons/acp/agents.json
+++ b/src/renderer/assets/agent-icons/acp/agents.json
@@ -320,11 +320,11 @@
   {
     "id": "dirac",
     "name": "Dirac",
-    "version": "0.4.18",
+    "version": "0.4.19",
     "description": "Reduces API costs by more than 50%, produces better and faster work. Uses Hash anchored parallel edits, AST manipulation and a whole lot of neat optimizations. Fully Open Source.",
     "distribution": {
       "npx": {
-        "package": "dirac-cli@0.4.18",
+        "package": "dirac-cli@0.4.19",
         "args": ["--acp"]
       }
     }
@@ -348,11 +348,11 @@
   {
     "id": "fast-agent",
     "name": "fast-agent",
-    "version": "0.9.14",
+    "version": "0.9.15",
     "description": "Code and build agents with comprehensive multi-provider support",
     "distribution": {
       "uvx": {
-        "package": "fast-agent-acp==0.9.14",
+        "package": "fast-agent-acp==0.9.15",
         "args": ["-x"]
       }
     }
@@ -384,11 +384,11 @@
   {
     "id": "glm-acp-agent",
     "name": "GLM Agent",
-    "version": "1.1.4",
+    "version": "1.2.0",
     "description": "ACP agent powered by Zhipu AI's GLM Coding Plan models (glm-5.1, glm-5-turbo, glm-4.7, glm-4.5-air). Supports streaming, tool calls, mid-session model switching, image input via Z.AI Coding Plan Vision MCP, and session load/fork/resume with on-disk persistence.",
     "distribution": {
       "npx": {
-        "package": "glm-acp-agent@1.1.4"
+        "package": "glm-acp-agent@1.2.0"
       }
     }
   },
@@ -426,11 +426,11 @@
   {
     "id": "grok-build",
     "name": "Grok Build",
-    "version": "0.2.104",
+    "version": "0.2.105",
     "description": "xAI's coding agent and CLI",
     "distribution": {
       "npx": {
-        "package": "@xai-official/grok@0.2.104",
+        "package": "@xai-official/grok@0.2.105",
         "args": ["agent", "stdio"]
       }
     }
@@ -438,33 +438,33 @@
   {
     "id": "harn",
     "name": "Harn",
-    "version": "0.10.23",
+    "version": "0.10.24",
     "description": "Harn runs .harn agent pipelines as a native ACP coding agent over stdio.",
     "distribution": {
       "binary": {
         "darwin-aarch64": {
           "cmd": "./harn",
-          "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.23/harn-aarch64-apple-darwin.tar.gz",
+          "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.24/harn-aarch64-apple-darwin.tar.gz",
           "args": ["serve", "acp"]
         },
         "darwin-x86_64": {
           "cmd": "./harn",
-          "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.23/harn-x86_64-apple-darwin.tar.gz",
+          "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.24/harn-x86_64-apple-darwin.tar.gz",
           "args": ["serve", "acp"]
         },
         "linux-aarch64": {
           "cmd": "./harn",
-          "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.23/harn-aarch64-unknown-linux-gnu.tar.gz",
+          "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.24/harn-aarch64-unknown-linux-gnu.tar.gz",
           "args": ["serve", "acp"]
         },
         "linux-x86_64": {
           "cmd": "./harn",
-          "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.23/harn-x86_64-unknown-linux-gnu.tar.gz",
+          "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.24/harn-x86_64-unknown-linux-gnu.tar.gz",
           "args": ["serve", "acp"]
         },
         "windows-x86_64": {
           "cmd": "harn.exe",
-          "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.23/harn-x86_64-pc-windows-msvc.zip",
+          "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.24/harn-x86_64-pc-windows-msvc.zip",
           "args": ["serve", "acp"]
         }
       }
@@ -739,11 +739,11 @@
   {
     "id": "qwen-code",
     "name": "Qwen Code",
-    "version": "0.19.11",
+    "version": "0.19.12",
     "description": "Alibaba's Qwen coding assistant",
     "distribution": {
       "npx": {
-        "package": "@qwen-code/qwen-code@0.19.11",
+        "package": "@qwen-code/qwen-code@0.19.12",
         "args": ["--acp", "--experimental-skills"]
       }
     }


### PR DESCRIPTION
## Summary

The bundled ACP agent registry snapshot at `src/renderer/assets/agent-icons/acp/agents.json` had drifted from the upstream ACP CDN registry since the last sync on 2026-07-18. The `acp-registry-bundle` (ACP Registry Bundle Freshness) CI job regenerates the snapshot from the CDN and fails the build when the committed copy no longer matches. This PR re-syncs the bundled snapshot so that freshness check passes again.

## Related Issue

No related issue — this is a recurring maintenance chore performed via the maintainer-only `bun run sync:acp-icons` script. Searched open and closed PRs for "acp sync" / "registry" / "agents.json" and found no duplicate.

## Type of Change

- [x] chore: maintenance or tooling

## What Changed

Regenerated `src/renderer/assets/agent-icons/acp/agents.json` via `bun run sync:acp-icons` followed by `bunx biome format --write src/renderer/assets/agent-icons/acp/` — the exact pipeline CI's `acp-registry-bundle` job runs. Six agents had version bumps in the upstream registry; the snapshot now reflects them:

| Agent | Old | New |
|---|---|---|
| dirac | 0.4.18 | 0.4.19 |
| fast-agent | 0.9.14 | 0.9.15 |
| glm-acp-agent | 1.1.4 | 1.2.0 |
| grok-build | 0.2.104 | 0.2.105 |
| harn | 0.10.23 | 0.10.24 (5 binary archives) |
| qwen-code | 0.19.11 | 0.19.12 |

Net: 1 file changed, 16 insertions(+), 16 deletions(-). Still 38 agents, no new/removed agents, no icon SVG or `manifest.json` changes, no code or Rust changes. The runtime snapshot fetcher `src-tauri/src/acp_registry_snapshot.rs` pulls live from the CDN and is unaffected by this bundled snapshot.

## How It Was Tested

- [x] `bun run ci` (Biome lint + format + imports, strict mode) — passed (635 files, no fixes)
- [x] `bun run typecheck` — passed (node + web + test configs)
- [x] `bun run test` — passed (2159 passed, 42 skipped, 0 failed)
- [ ] `cargo clippy --all-targets -- -D warnings` — N/A (no Rust changes)
- [ ] `cargo test` — N/A (no Rust changes)
- [x] Manual verification — re-ran `bun run sync:acp-icons` + local `biome format` (v2.4.16, matching CI's pinned version); `git diff --exit-code -- src/renderer/assets/agent-icons/acp/` is empty against this commit, proving the `acp-registry-bundle` freshness job passes.

## Screenshots or Recordings

N/A — data-only asset change, no UI impact.

## CI & Review Gate

- [ ] All CI checks pass — to be confirmed after push
- [ ] Code review comments from CodeRabbit / Claude addressed — to be confirmed
- [ ] No unresolved review findings remain — to be confirmed

## Checklist

- [x] PR title follows conventional commit format (`chore(acp): re-sync bundled ACP agent registry`)
- [x] Linked related issue or explained why none exists
- [x] Updated docs when needed — N/A
- [x] Added/updated tests when needed — N/A
- [x] No unrelated modifications (single file, scoped to `src/renderer/assets/agent-icons/acp/agents.json`)
- [x] Read AGENTS.md and followed contributor guidelines
- [ ] A human reviewed the complete diff before submission — pending human review
