### PR TITLE
fix(acp): evict closed-session transcripts to curb WebView2 memory growth

### DIFF
--- a/src-tauri/src/acp/client.rs
+++ b/src-tauri/src/acp/client.rs
@@ -231,7 +231,7 @@ pub fn emit_session_update(app: &AppHandle, agent_id: &AgentId, notification: Se
                 }
                 other => format!("{other:?}"),
             };
-            log::info!(
+            log::debug!(
                 "[acp] agent {agent_id} session {} agent_message_chunk: {preview}",
                 session_id.0
             );

--- a/src/renderer/stores/acp-store.test.ts
+++ b/src/renderer/stores/acp-store.test.ts
@@ -2885,6 +2885,9 @@ describe('acp-store transcript eviction (WebView memory)', () => {
 
   it('closeSession drops messages/toolCalls/commands/sessionUsage', async () => {
     seedTranscript('sess-mem')
+    useAcpStore.setState({
+      plans: { 'sess-mem': [{ content: 'plan', status: 'pending' }] }
+    })
     vi.mocked(invoke).mockResolvedValue(undefined)
     await useAcpStore.getState().closeSession('sess-mem')
     const st = useAcpStore.getState()
@@ -2893,6 +2896,7 @@ describe('acp-store transcript eviction (WebView memory)', () => {
     expect(st.toolCalls['sess-mem']).toBeUndefined()
     expect(st.commands['sess-mem']).toBeUndefined()
     expect(st.sessionUsage['sess-mem']).toBeUndefined()
+    expect(st.plans['sess-mem']).toBeUndefined()
   })
 
   it('deleteHistorySession drops in-memory transcript maps', async () => {

--- a/src/renderer/stores/acp-store.test.ts
+++ b/src/renderer/stores/acp-store.test.ts
@@ -1803,11 +1803,9 @@ describe('acp-store', () => {
     expect(session.status).toBe('closed')
     expect(session.lastError).toBeNull()
     expect(session.replaying).toBeNull()
-    // Partial replay must not be overwritten by the failure restore path.
-    const messages = useAcpStore.getState().messages['s-del-fail']
-    expect(
-      messages.some((m) => m.blocks.some((b) => b.type === 'text' && b.text === 'partial replay'))
-    ).toBe(true)
+    // Delete frees transcript maps; the failure path must not resurrect them
+    // or leave a partial mid-load replay resident in the WebView heap.
+    expect(useAcpStore.getState().messages['s-del-fail']).toBeUndefined()
     vi.mocked(invoke).mockReset()
   })
 
@@ -2807,6 +2805,7 @@ describe('ACP agent plan store', () => {
   })
 
   it('_onPlanUpdate replaces entries and empty update clears plan', () => {
+    seedSession('sess-1', 'agent-1', false)
     useAcpStore.getState()._onPlanUpdate({
       agentId: 'agent-1',
       sessionId: 'sess-1',
@@ -2845,6 +2844,171 @@ describe('ACP agent plan store', () => {
     })
     useAcpStore.getState()._onSessionClosed({ agentId: 'agent-1', sessionId: 'sess-1' })
     expect(useAcpStore.getState().plans['sess-1']).toBeUndefined()
+  })
+})
+
+describe('acp-store transcript eviction (WebView memory)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    useAcpStore.setState(FRESH)
+  })
+
+  function seedTranscript(sessionId: string): void {
+    seedSession(sessionId, 'agent-1', false)
+    useAcpStore.setState({
+      messages: {
+        [sessionId]: [
+          {
+            id: 'm1',
+            role: 'user',
+            blocks: [{ type: 'text', text: 'hello' }],
+            streaming: false,
+            timestamp: 1
+          }
+        ]
+      },
+      toolCalls: {
+        [sessionId]: [{ toolCallId: 'tc-1', title: 'read', status: 'completed', seq: 1 }]
+      },
+      commands: { [sessionId]: [{ name: 'help', description: 'help' }] },
+      sessionUsage: {
+        [sessionId]: {
+          used: 10,
+          size: 100,
+          baselineUsed: 0,
+          updatedAt: 1,
+          source: 'reported'
+        }
+      }
+    })
+  }
+
+  it('closeSession drops messages/toolCalls/commands/sessionUsage', async () => {
+    seedTranscript('sess-mem')
+    vi.mocked(invoke).mockResolvedValue(undefined)
+    await useAcpStore.getState().closeSession('sess-mem')
+    const st = useAcpStore.getState()
+    expect(st.sessions['sess-mem']?.status).toBe('closed')
+    expect(st.messages['sess-mem']).toBeUndefined()
+    expect(st.toolCalls['sess-mem']).toBeUndefined()
+    expect(st.commands['sess-mem']).toBeUndefined()
+    expect(st.sessionUsage['sess-mem']).toBeUndefined()
+  })
+
+  it('deleteHistorySession drops in-memory transcript maps', async () => {
+    seedTranscript('sess-del')
+    useAcpStore.setState({
+      sessionIndex: [
+        {
+          id: 'sess-del',
+          agentId: 'agent-1',
+          title: 'T',
+          cwd: '/work',
+          projectId: 'p1',
+          createdAt: 0,
+          lastActivityAt: 0,
+          messageCount: 1,
+          status: 'active'
+        }
+      ]
+    })
+    await useAcpStore.getState().deleteHistorySession('sess-del')
+    const st = useAcpStore.getState()
+    expect(st.messages['sess-del']).toBeUndefined()
+    expect(st.toolCalls['sess-del']).toBeUndefined()
+    expect(st.commands['sess-del']).toBeUndefined()
+    expect(st.sessionUsage['sess-del']).toBeUndefined()
+  })
+
+  it('_onSessionClosed drops transcript maps after persist', () => {
+    seedTranscript('sess-closed')
+    useAcpStore.getState()._onSessionClosed({ agentId: 'agent-1', sessionId: 'sess-closed' })
+    const st = useAcpStore.getState()
+    expect(st.sessions['sess-closed']?.status).toBe('closed')
+    expect(st.messages['sess-closed']).toBeUndefined()
+    expect(st.toolCalls['sess-closed']).toBeUndefined()
+  })
+
+  it('late _onToolCall for closed session does not recreate toolCalls', async () => {
+    seedTranscript('sess-late')
+    vi.mocked(invoke).mockResolvedValue(undefined)
+    await useAcpStore.getState().closeSession('sess-late')
+    useAcpStore.getState()._onToolCall({
+      agentId: 'agent-1',
+      sessionId: 'sess-late',
+      toolCall: { toolCallId: 'late-1', title: 'write', status: 'pending' }
+    })
+    expect(useAcpStore.getState().toolCalls['sess-late']).toBeUndefined()
+  })
+
+  it('late commands/usage/plan updates do not recreate maps after close', async () => {
+    seedTranscript('sess-late-maps')
+    vi.mocked(invoke).mockResolvedValue(undefined)
+    await useAcpStore.getState().closeSession('sess-late-maps')
+    useAcpStore.getState()._onCommandsUpdate({
+      agentId: 'agent-1',
+      sessionId: 'sess-late-maps',
+      availableCommands: [{ name: 'x' }]
+    })
+    useAcpStore.getState()._onUsageUpdate({
+      agentId: 'agent-1',
+      sessionId: 'sess-late-maps',
+      used: 50,
+      size: 100
+    })
+    useAcpStore.getState()._onPlanUpdate({
+      agentId: 'agent-1',
+      sessionId: 'sess-late-maps',
+      plan: { entries: [{ content: 'step', status: 'pending' }] }
+    })
+    const st = useAcpStore.getState()
+    expect(st.commands['sess-late-maps']).toBeUndefined()
+    expect(st.sessionUsage['sess-late-maps']).toBeUndefined()
+    expect(st.plans['sess-late-maps']).toBeUndefined()
+  })
+
+  it('second close after eviction does not persist empty messages', async () => {
+    const { saveSessionPayload } = await import('@/lib/acp-history-persistence')
+    seedTranscript('sess-twice')
+    vi.mocked(invoke).mockResolvedValue(undefined)
+    await useAcpStore.getState().closeSession('sess-twice')
+    vi.mocked(saveSessionPayload).mockClear()
+    await useAcpStore.getState().closeSession('sess-twice')
+    expect(saveSessionPayload).not.toHaveBeenCalled()
+  })
+
+  it('openHistorySession reloads messages after prior close eviction', async () => {
+    const { loadSessionPayload } = await import('@/lib/acp-history-persistence')
+    seedTranscript('sess-reopen')
+    vi.mocked(invoke).mockResolvedValue(undefined)
+    await useAcpStore.getState().closeSession('sess-reopen')
+    expect(useAcpStore.getState().messages['sess-reopen']).toBeUndefined()
+
+    vi.mocked(loadSessionPayload).mockResolvedValueOnce({
+      metadata: {
+        id: 'sess-reopen',
+        agentId: 'agent-1',
+        title: 'Reopen',
+        cwd: '/work',
+        projectId: 'p1',
+        createdAt: 1,
+        lastActivityAt: 2,
+        messageCount: 1,
+        status: 'closed'
+      },
+      messages: [
+        {
+          id: 'm-disk',
+          role: 'user',
+          blocks: [{ type: 'text', text: 'from disk' }],
+          streaming: false,
+          timestamp: 1
+        }
+      ]
+    })
+    ;(invoke as ReturnType<typeof vi.fn>).mockResolvedValueOnce(undefined)
+    await useAcpStore.getState().openHistorySession('sess-reopen')
+    expect(useAcpStore.getState().messages['sess-reopen']?.[0]?.id).toBe('m-disk')
   })
 })
 

--- a/src/renderer/stores/acp-store.ts
+++ b/src/renderer/stores/acp-store.ts
@@ -574,6 +574,28 @@ function dropRecordKey<T>(
   return next
 }
 
+/**
+ * Free per-session transcript maps held in the WebView heap.
+ * Disk history is untouched — reopen lazy-loads via `openHistorySession`.
+ * Call only after any needed `persistSession` so the last mirror is flushed.
+ */
+function dropSessionTranscriptState(
+  state: Pick<AcpState, 'messages' | 'toolCalls' | 'commands' | 'sessionUsage'>,
+  sessionId: SessionId
+): Pick<AcpState, 'messages' | 'toolCalls' | 'commands' | 'sessionUsage'> {
+  return {
+    messages: dropRecordKey(state.messages, sessionId),
+    toolCalls: dropRecordKey(state.toolCalls, sessionId),
+    commands: dropRecordKey(state.commands, sessionId),
+    sessionUsage: dropRecordKey(state.sessionUsage, sessionId)
+  }
+}
+
+/** True when live (or mid-replay) session updates may mutate transcript maps. */
+function acceptsSessionTranscriptEvents(session: AcpSession | undefined): session is AcpSession {
+  return Boolean(session && (session.status !== 'closed' || session.replaying))
+}
+
 /** Move a failed optimistic send into the queue when the backend is still busy. */
 function recoverPromptToQueue(
   set: TurnEndSetter,
@@ -742,6 +764,9 @@ function persistSession(
   // title update streamed as part of the replay) would truncate the on-disk
   // history if the app quits before the next full persist.
   if (session.replaying) return
+  // After WebView transcript eviction the map key is absent. Never rewrite
+  // disk with `[]` from a second close / late prompt-complete / title event.
+  if (!(sessionId in state.messages)) return
   // `streaming` is transient UI state; persisting it would restore a message
   // stuck in its shimmer state after a restart.
   const messages = (state.messages[sessionId] ?? []).map((m) =>
@@ -1492,6 +1517,13 @@ export const useAcpStore = create<AcpState>((set, get) => ({
         suppressQueueFlush: dropRecordKey(s.suppressQueueFlush, sessionId)
       }
     })
+    // Flush closed status + last transcript to disk while maps still hold it,
+    // then drop in-memory maps so WebView2 can reclaim heap. Ephemeral (warm
+    // pool) sessions are never mirrored.
+    if (!ephemeralSessionIds.has(sessionId) && get().sessions[sessionId]) {
+      persistSession(get(), sessionId, (entries) => set({ sessionIndex: entries }))
+    }
+    set((s) => dropSessionTranscriptState(s, sessionId))
   },
 
   setActiveSession: (sessionId) => set({ activeSessionId: sessionId }),
@@ -1823,7 +1855,11 @@ export const useAcpStore = create<AcpState>((set, get) => ({
           replaying: null
         }
       }
-      return { sessionIndex: next, sessions }
+      return {
+        sessionIndex: next,
+        sessions,
+        ...dropSessionTranscriptState(s, id)
+      }
     })
     // Reclaim any app-owned temp files staged for this session.
     void deleteSessionTempFiles(id)
@@ -2288,6 +2324,8 @@ export const useAcpStore = create<AcpState>((set, get) => ({
 
   _onToolCall: (e) =>
     set((s) => {
+      // Same guard as message chunks: never grow maps for unknown/closed sessions.
+      if (!acceptsSessionTranscriptEvents(s.sessions[e.sessionId])) return {}
       // Stamp arrival time + monotonic seq (unless already present) so the UI
       // can interleave tool calls with messages on one chronological timeline.
       const stamped: ToolCall = {
@@ -2305,6 +2343,7 @@ export const useAcpStore = create<AcpState>((set, get) => ({
 
   _onToolCallUpdate: (e) =>
     set((s) => {
+      if (!acceptsSessionTranscriptEvents(s.sessions[e.sessionId])) return {}
       const list = s.toolCalls[e.sessionId] ?? []
       const idx = list.findIndex((t) => t.toolCallId === e.update.toolCallId)
       if (idx === -1) return {}
@@ -2320,11 +2359,16 @@ export const useAcpStore = create<AcpState>((set, get) => ({
       if (entries.length === 0) {
         return { plans: dropPlanForSession(s.plans, e.sessionId) }
       }
+      // Do not re-grow plan cache for closed/unknown sessions after eviction.
+      if (!acceptsSessionTranscriptEvents(s.sessions[e.sessionId])) return {}
       return { plans: { ...s.plans, [e.sessionId]: entries } }
     }),
 
   _onCommandsUpdate: (e) =>
-    set((s) => ({ commands: { ...s.commands, [e.sessionId]: e.availableCommands ?? [] } })),
+    set((s) => {
+      if (!acceptsSessionTranscriptEvents(s.sessions[e.sessionId])) return {}
+      return { commands: { ...s.commands, [e.sessionId]: e.availableCommands ?? [] } }
+    }),
 
   _onModeUpdate: (e) =>
     set((s) => {
@@ -2383,7 +2427,8 @@ export const useAcpStore = create<AcpState>((set, get) => ({
       return
     }
     set((s) => {
-      if (!s.sessions[e.sessionId]) return {}
+      // Closed shells remain in `sessions` after eviction — still reject usage.
+      if (!acceptsSessionTranscriptEvents(s.sessions[e.sessionId])) return {}
       const prev = s.sessionUsage[e.sessionId]
       const baselineUsed = prev?.baselineUsed ?? e.used
       const next: SessionUsage = {
@@ -2501,6 +2546,7 @@ export const useAcpStore = create<AcpState>((set, get) => ({
 
   _onAgentDisconnected: (e) => {
     const affected: SessionId[] = []
+    const dropTranscriptIds: SessionId[] = []
     set((s) => {
       const agentStatus = { ...s.agentStatus, [e.agentId]: 'error' as AgentStatus }
       const sessions = { ...s.sessions }
@@ -2512,6 +2558,7 @@ export const useAcpStore = create<AcpState>((set, get) => ({
             // Chat" survives in the history index on agent disconnect.
             delete sessions[id]
             ephemeralSessionIds.delete(id)
+            dropTranscriptIds.push(id)
           } else {
             sessions[id] = {
               ...sessions[id],
@@ -2521,6 +2568,7 @@ export const useAcpStore = create<AcpState>((set, get) => ({
               replaying: null
             }
             affected.push(id)
+            dropTranscriptIds.push(id)
           }
         }
       }
@@ -2547,10 +2595,19 @@ export const useAcpStore = create<AcpState>((set, get) => ({
         preparedSessions
       }
     })
-    // Persist the closed status for each session the disconnect affected, so the
-    // history index reflects it across restarts (mirrors _onSessionClosed).
+    // Persist closed status + transcript while maps still hold content, then
+    // free WebView heap for every session this disconnect retired.
     for (const id of affected) {
       persistSession(get(), id, (entries) => set({ sessionIndex: entries }))
+    }
+    if (dropTranscriptIds.length > 0) {
+      set((s) => {
+        let next: Pick<AcpState, 'messages' | 'toolCalls' | 'commands' | 'sessionUsage'> = s
+        for (const id of dropTranscriptIds) {
+          next = dropSessionTranscriptState(next, id)
+        }
+        return next
+      })
     }
   },
 
@@ -2575,7 +2632,8 @@ export const useAcpStore = create<AcpState>((set, get) => ({
           sessions,
           preparedSessions,
           pendingPermissions: dropPermissionsForSession(s.pendingPermissions, e.sessionId),
-          plans: dropPlanForSession(s.plans, e.sessionId)
+          plans: dropPlanForSession(s.plans, e.sessionId),
+          ...dropSessionTranscriptState(s, e.sessionId)
         }
       })
       return
@@ -2583,7 +2641,13 @@ export const useAcpStore = create<AcpState>((set, get) => ({
     set((s) => {
       const session = s.sessions[e.sessionId]
       const pendingPermissions = dropPermissionsForSession(s.pendingPermissions, e.sessionId)
-      if (!session) return { pendingPermissions, plans: dropPlanForSession(s.plans, e.sessionId) }
+      if (!session) {
+        return {
+          pendingPermissions,
+          plans: dropPlanForSession(s.plans, e.sessionId),
+          ...dropSessionTranscriptState(s, e.sessionId)
+        }
+      }
       return {
         pendingPermissions,
         plans: dropPlanForSession(s.plans, e.sessionId),
@@ -2599,9 +2663,11 @@ export const useAcpStore = create<AcpState>((set, get) => ({
         }
       }
     })
+    // Persist while transcript maps still hold content, then free WebView heap.
     if (get().sessions[e.sessionId]) {
       persistSession(get(), e.sessionId, (entries) => set({ sessionIndex: entries }))
     }
+    set((s) => dropSessionTranscriptState(s, e.sessionId))
   }
 }))
 

--- a/src/renderer/stores/acp-store.ts
+++ b/src/renderer/stores/acp-store.ts
@@ -580,14 +580,15 @@ function dropRecordKey<T>(
  * Call only after any needed `persistSession` so the last mirror is flushed.
  */
 function dropSessionTranscriptState(
-  state: Pick<AcpState, 'messages' | 'toolCalls' | 'commands' | 'sessionUsage'>,
+  state: Pick<AcpState, 'messages' | 'toolCalls' | 'commands' | 'sessionUsage' | 'plans'>,
   sessionId: SessionId
-): Pick<AcpState, 'messages' | 'toolCalls' | 'commands' | 'sessionUsage'> {
+): Pick<AcpState, 'messages' | 'toolCalls' | 'commands' | 'sessionUsage' | 'plans'> {
   return {
     messages: dropRecordKey(state.messages, sessionId),
     toolCalls: dropRecordKey(state.toolCalls, sessionId),
     commands: dropRecordKey(state.commands, sessionId),
-    sessionUsage: dropRecordKey(state.sessionUsage, sessionId)
+    sessionUsage: dropRecordKey(state.sessionUsage, sessionId),
+    plans: dropRecordKey(state.plans, sessionId)
   }
 }
 
@@ -1511,7 +1512,6 @@ export const useAcpStore = create<AcpState>((set, get) => ({
       }
       return {
         sessions,
-        plans: dropPlanForSession(s.plans, sessionId),
         pendingPermissions: dropPermissionsForSession(s.pendingPermissions, sessionId),
         promptQueues: dropPromptQueueForSession(s.promptQueues, sessionId),
         suppressQueueFlush: dropRecordKey(s.suppressQueueFlush, sessionId)
@@ -2602,7 +2602,8 @@ export const useAcpStore = create<AcpState>((set, get) => ({
     }
     if (dropTranscriptIds.length > 0) {
       set((s) => {
-        let next: Pick<AcpState, 'messages' | 'toolCalls' | 'commands' | 'sessionUsage'> = s
+        let next: Pick<AcpState, 'messages' | 'toolCalls' | 'commands' | 'sessionUsage' | 'plans'> =
+          s
         for (const id of dropTranscriptIds) {
           next = dropSessionTranscriptState(next, id)
         }
@@ -2632,7 +2633,6 @@ export const useAcpStore = create<AcpState>((set, get) => ({
           sessions,
           preparedSessions,
           pendingPermissions: dropPermissionsForSession(s.pendingPermissions, e.sessionId),
-          plans: dropPlanForSession(s.plans, e.sessionId),
           ...dropSessionTranscriptState(s, e.sessionId)
         }
       })
@@ -2644,13 +2644,11 @@ export const useAcpStore = create<AcpState>((set, get) => ({
       if (!session) {
         return {
           pendingPermissions,
-          plans: dropPlanForSession(s.plans, e.sessionId),
           ...dropSessionTranscriptState(s, e.sessionId)
         }
       }
       return {
         pendingPermissions,
-        plans: dropPlanForSession(s.plans, e.sessionId),
         sessions: {
           ...s.sessions,
           [e.sessionId]: {


### PR DESCRIPTION
## Summary

After 1–3 ACP agent turns on the same agent, Task Manager showed **WebView2: Termul Manager ~1.9GB** while the Rust host stayed ~16MB. Closed chats kept uncapped Zustand `messages` / `toolCalls` (and related maps) for the app lifetime, so the renderer heap never shrank.

This PR persists the last transcript to disk, then **evicts** per-session in-memory transcript maps on close / delete / session-closed / disconnect; ignores late events for dead sessions; refuses empty disk overwrites after eviction; and demotes per-chunk ACP logging from `info` to `debug`. Disk history stays intact for lazy reopen.

## Related Issue

No related issue — reproduced locally (WebView2 ~1.9GB after ACP use; logs under `%LOCALAPPDATA%\com.termul-manager.app\logs\termul.log` were ~97% `agent_message_chunk` INFO lines). Searched open/closed PRs for ACP/WebView memory eviction — no duplicate found.

## Type of Change

- [ ] feat: new feature
- [x] fix: bug fix
- [ ] docs: documentation only
- [ ] style: formatting or non-functional styling changes
- [ ] refactor: internal cleanup with no behavior change
- [ ] perf: performance improvement
- [ ] test: adds or updates tests
- [ ] build: build or dependency changes
- [ ] ci: CI/CD workflow changes
- [ ] chore: maintenance or tooling
- [ ] revert: reverts a previous change

## What Changed

- `src/renderer/stores/acp-store.ts`: `dropSessionTranscriptState` (messages/toolCalls/commands/sessionUsage/plans) + `acceptsSessionTranscriptEvents`; persist-then-drop on `closeSession`, `deleteHistorySession`, `_onSessionClosed`, `_onAgentDisconnected`; gate late tool/commands/usage/plan handlers; `persistSession` no-ops when the messages key was already evicted (prevents empty overwrite).
- `src-tauri/src/acp/client.rs`: `agent_message_chunk` log level `info` → `debug`.
- `src/renderer/stores/acp-store.test.ts`: eviction, late-event, reopen-from-disk, and empty-persist regression tests.

## How It Was Tested

- [x] `bun run ci` (Biome lint + format + imports, strict mode)
- [x] `bun run typecheck`
- [x] `bun run test` (`src/renderer/stores/acp-store.test.ts`)
- [ ] `cargo clippy --all-targets -- -D warnings` (in src-tauri) — not re-run locally; Rust change is a one-line log level swap
- [ ] `cargo test` (in src-tauri) — not re-run locally for the same reason
- [ ] Manual verification completed — awaiting Task Manager check after install/build of this branch (close chats after 1–3 ACP turns; reopen via history/Reconnect)
- [ ] Not applicable

## Screenshots or Recordings

Pre-fix Task Manager: WebView2 ~1937.8 MB vs Termul Manager host ~16 MB after ACP use. No UI chrome change; closed chat still shows existing “Chat disconnected / Reconnect” banner and reloads from disk.

## CI & Review Gate

- [ ] All CI checks pass (PR Validation, Rust Checks, Build Verification, Security Scans)
- [ ] Code review comments from CodeRabbit / Claude have been addressed or resolved
- [ ] No unresolved review findings remain

## Checklist

- [x] My PR title follows the conventional commit format used by this repo
- [x] I linked the related issue or explained why none exists
- [x] I updated docs when needed (N/A — behavior is store/log only; reopen path unchanged)
- [x] I added or updated tests when needed
- [x] I verified the change does not introduce unrelated modifications
- [x] I read AGENTS.md and followed the contributor guidelines
- [x] A human reviewed the complete diff before submission

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Reduced memory usage by evicting closed or deleted session transcripts from the application’s in-memory state.
  * Prevented late-arriving session events from recreating discarded transcript data.
  * Ensured reopening a history session reloads its transcript correctly.

* **Bug Fixes**
  * Prevented empty transcript data from overwriting saved session history.
  * Improved cleanup when sessions disconnect or fail during history loading.
  * Reduced log verbosity for routine agent message updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->