### PR TITLE
feat(editor): editable YAML frontmatter Properties panel

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -104,6 +104,7 @@
         "tauri-pty": "^0.1",
         "unicode-animations": "^1.0.3",
         "vaul": "^0.9.9",
+        "yaml": "^2.9.0",
         "zod": "^3.25.76",
         "zustand": "^5.0.9",
       },
@@ -2042,6 +2043,8 @@
     "y-protocols": ["y-protocols@1.0.7", "", { "dependencies": { "lib0": "^0.2.85" }, "peerDependencies": { "yjs": "^13.0.0" } }, "sha512-YSVsLoXxO67J6eE/nV4AtFtT3QEotZf5sK5BHxFBXso7VDUT3Tx07IfA6hsu5Q5OmBdMkQVmFZ9QOA7fikWvnw=="],
 
     "yallist": ["yallist@3.1.1", "", {}, "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="],
+
+    "yaml": ["yaml@2.9.0", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA=="],
 
     "yjs": ["yjs@13.6.31", "", { "dependencies": { "lib0": "^0.2.99" } }, "sha512-Eq+5BRfbeGyqGVrTJL3bEcr8gKkxPuyuoHmAwpk52fDb8kOVMrfVSTRPd6yiGgX5Fskb96qCRjzjbRjrL4YEnw=="],
 

--- a/package.json
+++ b/package.json
@@ -154,6 +154,7 @@
     "tauri-pty": "^0.1",
     "unicode-animations": "^1.0.3",
     "vaul": "^0.9.9",
+    "yaml": "^2.9.0",
     "zod": "^3.25.76",
     "zustand": "^5.0.9"
   },

--- a/src/renderer/assets/agent-icons/acp/agents.json
+++ b/src/renderer/assets/agent-icons/acp/agents.json
@@ -70,22 +70,22 @@
   {
     "id": "claude-acp",
     "name": "Claude Agent",
-    "version": "0.59.0",
+    "version": "0.60.0",
     "description": "ACP wrapper for Anthropic's Claude",
     "distribution": {
       "npx": {
-        "package": "@agentclientprotocol/claude-agent-acp@0.59.0"
+        "package": "@agentclientprotocol/claude-agent-acp@0.60.0"
       }
     }
   },
   {
     "id": "cline",
     "name": "Cline",
-    "version": "3.0.44",
+    "version": "3.0.46",
     "description": "Autonomous coding agent CLI - capable of creating/editing files, running commands, using the browser, and more",
     "distribution": {
       "npx": {
-        "package": "cline@3.0.44",
+        "package": "cline@3.0.46",
         "args": ["--acp"]
       }
     }
@@ -105,11 +105,11 @@
   {
     "id": "codex-acp",
     "name": "Codex",
-    "version": "1.1.4",
+    "version": "1.1.5",
     "description": "ACP adapter for OpenAI's coding assistant",
     "distribution": {
       "npx": {
-        "package": "@agentclientprotocol/codex-acp@1.1.4"
+        "package": "@agentclientprotocol/codex-acp@1.1.5"
       }
     }
   },
@@ -217,38 +217,38 @@
   {
     "id": "cursor",
     "name": "Cursor",
-    "version": "2026.07.09",
+    "version": "2026.07.17",
     "description": "Cursor's coding agent",
     "distribution": {
       "binary": {
         "darwin-aarch64": {
           "cmd": "./dist-package/cursor-agent",
-          "archive": "https://downloads.cursor.com/lab/2026.07.09-a3815c0/darwin/arm64/agent-cli-package.tar.gz",
+          "archive": "https://downloads.cursor.com/lab/2026.07.17-3e2a980/darwin/arm64/agent-cli-package.tar.gz",
           "args": ["acp"]
         },
         "darwin-x86_64": {
           "cmd": "./dist-package/cursor-agent",
-          "archive": "https://downloads.cursor.com/lab/2026.07.09-a3815c0/darwin/x64/agent-cli-package.tar.gz",
+          "archive": "https://downloads.cursor.com/lab/2026.07.17-3e2a980/darwin/x64/agent-cli-package.tar.gz",
           "args": ["acp"]
         },
         "linux-aarch64": {
           "cmd": "./dist-package/cursor-agent",
-          "archive": "https://downloads.cursor.com/lab/2026.07.09-a3815c0/linux/arm64/agent-cli-package.tar.gz",
+          "archive": "https://downloads.cursor.com/lab/2026.07.17-3e2a980/linux/arm64/agent-cli-package.tar.gz",
           "args": ["acp"]
         },
         "linux-x86_64": {
           "cmd": "./dist-package/cursor-agent",
-          "archive": "https://downloads.cursor.com/lab/2026.07.09-a3815c0/linux/x64/agent-cli-package.tar.gz",
+          "archive": "https://downloads.cursor.com/lab/2026.07.17-3e2a980/linux/x64/agent-cli-package.tar.gz",
           "args": ["acp"]
         },
         "windows-aarch64": {
           "cmd": "./dist-package\\cursor-agent.cmd",
-          "archive": "https://downloads.cursor.com/lab/2026.07.09-a3815c0/windows/arm64/agent-cli-package.zip",
+          "archive": "https://downloads.cursor.com/lab/2026.07.17-3e2a980/windows/arm64/agent-cli-package.zip",
           "args": ["acp"]
         },
         "windows-x86_64": {
           "cmd": "./dist-package\\cursor-agent.cmd",
-          "archive": "https://downloads.cursor.com/lab/2026.07.09-a3815c0/windows/x64/agent-cli-package.zip",
+          "archive": "https://downloads.cursor.com/lab/2026.07.17-3e2a980/windows/x64/agent-cli-package.zip",
           "args": ["acp"]
         }
       }
@@ -268,38 +268,38 @@
   {
     "id": "devin",
     "name": "Devin",
-    "version": "3000.1.27",
+    "version": "3000.2.17",
     "description": "Devin CLI coding agent by Cognition",
     "distribution": {
       "binary": {
         "darwin-aarch64": {
           "cmd": "./bin/devin",
-          "archive": "https://static.devin.ai/cli/3000.1.27/devin-3000.1.27-aarch64-apple-darwin.tar.gz",
+          "archive": "https://static.devin.ai/cli/3000.2.17/devin-3000.2.17-aarch64-apple-darwin.tar.gz",
           "args": ["acp"]
         },
         "darwin-x86_64": {
           "cmd": "./bin/devin",
-          "archive": "https://static.devin.ai/cli/3000.1.27/devin-3000.1.27-x86_64-apple-darwin.tar.gz",
+          "archive": "https://static.devin.ai/cli/3000.2.17/devin-3000.2.17-x86_64-apple-darwin.tar.gz",
           "args": ["acp"]
         },
         "linux-aarch64": {
           "cmd": "./bin/devin",
-          "archive": "https://static.devin.ai/cli/3000.1.27/devin-3000.1.27-aarch64-unknown-linux.tar.gz",
+          "archive": "https://static.devin.ai/cli/3000.2.17/devin-3000.2.17-aarch64-unknown-linux.tar.gz",
           "args": ["acp"]
         },
         "linux-x86_64": {
           "cmd": "./bin/devin",
-          "archive": "https://static.devin.ai/cli/3000.1.27/devin-3000.1.27-x86_64-unknown-linux.tar.gz",
+          "archive": "https://static.devin.ai/cli/3000.2.17/devin-3000.2.17-x86_64-unknown-linux.tar.gz",
           "args": ["acp"]
         },
         "windows-aarch64": {
           "cmd": "./bin\\devin.exe",
-          "archive": "https://static.devin.ai/cli/3000.1.27/devin-3000.1.27-aarch64-pc-windows.zip",
+          "archive": "https://static.devin.ai/cli/3000.2.17/devin-3000.2.17-aarch64-pc-windows.zip",
           "args": ["acp"]
         },
         "windows-x86_64": {
           "cmd": "./bin\\devin.exe",
-          "archive": "https://static.devin.ai/cli/3000.1.27/devin-3000.1.27-x86_64-pc-windows.zip",
+          "archive": "https://static.devin.ai/cli/3000.2.17/devin-3000.2.17-x86_64-pc-windows.zip",
           "args": ["acp"]
         }
       }
@@ -308,11 +308,11 @@
   {
     "id": "dimcode",
     "name": "DimCode",
-    "version": "0.2.31",
+    "version": "0.2.35",
     "description": "A coding agent that puts leading models at your command.",
     "distribution": {
       "npx": {
-        "package": "dimcode@0.2.31",
+        "package": "dimcode@0.2.35",
         "args": ["acp"]
       }
     }
@@ -320,11 +320,11 @@
   {
     "id": "dirac",
     "name": "Dirac",
-    "version": "0.4.19",
+    "version": "0.4.21",
     "description": "Reduces API costs by more than 50%, produces better and faster work. Uses Hash anchored parallel edits, AST manipulation and a whole lot of neat optimizations. Fully Open Source.",
     "distribution": {
       "npx": {
-        "package": "dirac-cli@0.4.19",
+        "package": "dirac-cli@0.4.21",
         "args": ["--acp"]
       }
     }
@@ -332,11 +332,11 @@
   {
     "id": "factory-droid",
     "name": "Factory Droid",
-    "version": "0.175.0",
+    "version": "0.177.0",
     "description": "Factory Droid - AI coding agent powered by Factory AI",
     "distribution": {
       "npx": {
-        "package": "droid@0.175.0",
+        "package": "droid@0.177.0",
         "args": ["exec", "--output-format", "acp-daemon"],
         "env": {
           "DROID_DISABLE_AUTO_UPDATE": "true",
@@ -348,11 +348,11 @@
   {
     "id": "fast-agent",
     "name": "fast-agent",
-    "version": "0.9.15",
+    "version": "0.9.20",
     "description": "Code and build agents with comprehensive multi-provider support",
     "distribution": {
       "uvx": {
-        "package": "fast-agent-acp==0.9.15",
+        "package": "fast-agent-acp==0.9.20",
         "args": ["-x"]
       }
     }
@@ -372,11 +372,11 @@
   {
     "id": "github-copilot-cli",
     "name": "GitHub Copilot",
-    "version": "1.0.71",
+    "version": "1.0.73",
     "description": "GitHub's AI pair programmer",
     "distribution": {
       "npx": {
-        "package": "@github/copilot@1.0.71",
+        "package": "@github/copilot@1.0.73",
         "args": ["--acp"]
       }
     }
@@ -384,11 +384,11 @@
   {
     "id": "glm-acp-agent",
     "name": "GLM Agent",
-    "version": "1.2.0",
+    "version": "1.3.0",
     "description": "ACP agent powered by Zhipu AI's GLM Coding Plan models (glm-5.1, glm-5-turbo, glm-4.7, glm-4.5-air). Supports streaming, tool calls, mid-session model switching, image input via Z.AI Coding Plan Vision MCP, and session load/fork/resume with on-disk persistence.",
     "distribution": {
       "npx": {
-        "package": "glm-acp-agent@1.2.0"
+        "package": "glm-acp-agent@1.3.0"
       }
     }
   },
@@ -426,11 +426,11 @@
   {
     "id": "grok-build",
     "name": "Grok Build",
-    "version": "0.2.106",
+    "version": "0.2.110",
     "description": "xAI's coding agent and CLI",
     "distribution": {
       "npx": {
-        "package": "@xai-official/grok@0.2.106",
+        "package": "@xai-official/grok@0.2.110",
         "args": ["agent", "stdio"]
       }
     }
@@ -438,33 +438,33 @@
   {
     "id": "harn",
     "name": "Harn",
-    "version": "0.10.24",
+    "version": "0.10.33",
     "description": "Harn runs .harn agent pipelines as a native ACP coding agent over stdio.",
     "distribution": {
       "binary": {
         "darwin-aarch64": {
           "cmd": "./harn",
-          "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.24/harn-aarch64-apple-darwin.tar.gz",
+          "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.33/harn-aarch64-apple-darwin.tar.gz",
           "args": ["serve", "acp"]
         },
         "darwin-x86_64": {
           "cmd": "./harn",
-          "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.24/harn-x86_64-apple-darwin.tar.gz",
+          "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.33/harn-x86_64-apple-darwin.tar.gz",
           "args": ["serve", "acp"]
         },
         "linux-aarch64": {
           "cmd": "./harn",
-          "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.24/harn-aarch64-unknown-linux-gnu.tar.gz",
+          "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.33/harn-aarch64-unknown-linux-gnu.tar.gz",
           "args": ["serve", "acp"]
         },
         "linux-x86_64": {
           "cmd": "./harn",
-          "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.24/harn-x86_64-unknown-linux-gnu.tar.gz",
+          "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.33/harn-x86_64-unknown-linux-gnu.tar.gz",
           "args": ["serve", "acp"]
         },
         "windows-x86_64": {
           "cmd": "harn.exe",
-          "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.24/harn-x86_64-pc-windows-msvc.zip",
+          "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.33/harn-x86_64-pc-windows-msvc.zip",
           "args": ["serve", "acp"]
         }
       }
@@ -473,33 +473,33 @@
   {
     "id": "junie",
     "name": "Junie",
-    "version": "2144.9.0",
+    "version": "2383.9.0",
     "description": "AI Coding Agent by JetBrains",
     "distribution": {
       "binary": {
         "darwin-aarch64": {
           "cmd": "./Applications/junie.app/Contents/MacOS/junie",
-          "archive": "https://github.com/JetBrains/junie/releases/download/2144.9/junie-release-2144.9-macos-aarch64.zip",
+          "archive": "https://github.com/JetBrains/junie/releases/download/2383.9/junie-release-2383.9-macos-aarch64.zip",
           "args": ["--acp=true"]
         },
         "darwin-x86_64": {
           "cmd": "./Applications/junie.app/Contents/MacOS/junie",
-          "archive": "https://github.com/JetBrains/junie/releases/download/2144.9/junie-release-2144.9-macos-amd64.zip",
+          "archive": "https://github.com/JetBrains/junie/releases/download/2383.9/junie-release-2383.9-macos-amd64.zip",
           "args": ["--acp=true"]
         },
         "linux-aarch64": {
           "cmd": "./junie-app/bin/junie",
-          "archive": "https://github.com/JetBrains/junie/releases/download/2144.9/junie-release-2144.9-linux-aarch64.zip",
+          "archive": "https://github.com/JetBrains/junie/releases/download/2383.9/junie-release-2383.9-linux-aarch64.zip",
           "args": ["--acp=true"]
         },
         "linux-x86_64": {
           "cmd": "./junie-app/bin/junie",
-          "archive": "https://github.com/JetBrains/junie/releases/download/2144.9/junie-release-2144.9-linux-amd64.zip",
+          "archive": "https://github.com/JetBrains/junie/releases/download/2383.9/junie-release-2383.9-linux-amd64.zip",
           "args": ["--acp=true"]
         },
         "windows-x86_64": {
           "cmd": "./junie/junie.exe",
-          "archive": "https://github.com/JetBrains/junie/releases/download/2144.9/junie-release-2144.9-windows-amd64.zip",
+          "archive": "https://github.com/JetBrains/junie/releases/download/2383.9/junie-release-2383.9-windows-amd64.zip",
           "args": ["--acp=true"]
         }
       }
@@ -594,29 +594,29 @@
   {
     "id": "mistral-vibe",
     "name": "Mistral Vibe",
-    "version": "2.21.0",
+    "version": "2.22.0",
     "description": "Mistral's open-source coding assistant",
     "distribution": {
       "binary": {
         "darwin-aarch64": {
           "cmd": "./vibe-acp",
-          "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v2.21.0/vibe-acp-darwin-aarch64-2.21.0.zip"
+          "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v2.22.0/vibe-acp-darwin-aarch64-2.22.0.zip"
         },
         "darwin-x86_64": {
           "cmd": "./vibe-acp",
-          "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v2.21.0/vibe-acp-darwin-x86_64-2.21.0.zip"
+          "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v2.22.0/vibe-acp-darwin-x86_64-2.22.0.zip"
         },
         "linux-aarch64": {
           "cmd": "./vibe-acp",
-          "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v2.21.0/vibe-acp-linux-aarch64-2.21.0.zip"
+          "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v2.22.0/vibe-acp-linux-aarch64-2.22.0.zip"
         },
         "linux-x86_64": {
           "cmd": "./vibe-acp",
-          "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v2.21.0/vibe-acp-linux-x86_64-2.21.0.zip"
+          "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v2.22.0/vibe-acp-linux-x86_64-2.22.0.zip"
         },
         "windows-x86_64": {
           "cmd": "./vibe-acp.exe",
-          "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v2.21.0/vibe-acp-windows-x86_64-2.21.0.zip"
+          "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v2.22.0/vibe-acp-windows-x86_64-2.22.0.zip"
         }
       }
     }
@@ -624,11 +624,11 @@
   {
     "id": "nova",
     "name": "Nova",
-    "version": "1.1.27",
+    "version": "1.1.29",
     "description": "Nova by Compass AI - a fully-fledged software engineer at your command",
     "distribution": {
       "npx": {
-        "package": "@compass-ai/nova@1.1.27",
+        "package": "@compass-ai/nova@1.1.29",
         "args": ["acp"]
       }
     }
@@ -636,38 +636,38 @@
   {
     "id": "opencode",
     "name": "OpenCode",
-    "version": "1.18.3",
+    "version": "1.18.4",
     "description": "The open source coding agent",
     "distribution": {
       "binary": {
         "darwin-aarch64": {
           "cmd": "./opencode",
-          "archive": "https://github.com/anomalyco/opencode/releases/download/v1.18.3/opencode-darwin-arm64.zip",
+          "archive": "https://github.com/anomalyco/opencode/releases/download/v1.18.4/opencode-darwin-arm64.zip",
           "args": ["acp"]
         },
         "darwin-x86_64": {
           "cmd": "./opencode",
-          "archive": "https://github.com/anomalyco/opencode/releases/download/v1.18.3/opencode-darwin-x64.zip",
+          "archive": "https://github.com/anomalyco/opencode/releases/download/v1.18.4/opencode-darwin-x64.zip",
           "args": ["acp"]
         },
         "linux-aarch64": {
           "cmd": "./opencode",
-          "archive": "https://github.com/anomalyco/opencode/releases/download/v1.18.3/opencode-linux-arm64.tar.gz",
+          "archive": "https://github.com/anomalyco/opencode/releases/download/v1.18.4/opencode-linux-arm64.tar.gz",
           "args": ["acp"]
         },
         "linux-x86_64": {
           "cmd": "./opencode",
-          "archive": "https://github.com/anomalyco/opencode/releases/download/v1.18.3/opencode-linux-x64.tar.gz",
+          "archive": "https://github.com/anomalyco/opencode/releases/download/v1.18.4/opencode-linux-x64.tar.gz",
           "args": ["acp"]
         },
         "windows-aarch64": {
           "cmd": "./opencode",
-          "archive": "https://github.com/anomalyco/opencode/releases/download/v1.18.3/opencode-windows-arm64.zip",
+          "archive": "https://github.com/anomalyco/opencode/releases/download/v1.18.4/opencode-windows-arm64.zip",
           "args": ["acp"]
         },
         "windows-x86_64": {
           "cmd": "./opencode.exe",
-          "archive": "https://github.com/anomalyco/opencode/releases/download/v1.18.3/opencode-windows-x64.zip",
+          "archive": "https://github.com/anomalyco/opencode/releases/download/v1.18.4/opencode-windows-x64.zip",
           "args": ["acp"]
         }
       }
@@ -687,38 +687,38 @@
   {
     "id": "poolside",
     "name": "Poolside",
-    "version": "1.0.11",
+    "version": "1.0.13",
     "description": "Poolside's coding agent",
     "distribution": {
       "binary": {
         "darwin-aarch64": {
           "cmd": "./pool-darwin-arm64",
-          "archive": "https://downloads.poolside.ai/pool/v1.0.11/pool-darwin-arm64.tar.gz",
+          "archive": "https://downloads.poolside.ai/pool/v1.0.13/pool-darwin-arm64.tar.gz",
           "args": ["acp"]
         },
         "darwin-x86_64": {
           "cmd": "./pool-darwin-amd64",
-          "archive": "https://downloads.poolside.ai/pool/v1.0.11/pool-darwin-amd64.tar.gz",
+          "archive": "https://downloads.poolside.ai/pool/v1.0.13/pool-darwin-amd64.tar.gz",
           "args": ["acp"]
         },
         "linux-aarch64": {
           "cmd": "./pool-linux-arm64",
-          "archive": "https://downloads.poolside.ai/pool/v1.0.11/pool-linux-arm64.tar.gz",
+          "archive": "https://downloads.poolside.ai/pool/v1.0.13/pool-linux-arm64.tar.gz",
           "args": ["acp"]
         },
         "linux-x86_64": {
           "cmd": "./pool-linux-amd64",
-          "archive": "https://downloads.poolside.ai/pool/v1.0.11/pool-linux-amd64.tar.gz",
+          "archive": "https://downloads.poolside.ai/pool/v1.0.13/pool-linux-amd64.tar.gz",
           "args": ["acp"]
         },
         "windows-aarch64": {
           "cmd": "./pool-windows-arm64.exe",
-          "archive": "https://downloads.poolside.ai/pool/v1.0.11/pool-windows-arm64.tar.gz",
+          "archive": "https://downloads.poolside.ai/pool/v1.0.13/pool-windows-arm64.tar.gz",
           "args": ["acp"]
         },
         "windows-x86_64": {
           "cmd": "./pool-windows-amd64.exe",
-          "archive": "https://downloads.poolside.ai/pool/v1.0.11/pool-windows-amd64.tar.gz",
+          "archive": "https://downloads.poolside.ai/pool/v1.0.13/pool-windows-amd64.tar.gz",
           "args": ["acp"]
         }
       }
@@ -739,11 +739,11 @@
   {
     "id": "qwen-code",
     "name": "Qwen Code",
-    "version": "0.19.12",
+    "version": "0.20.1",
     "description": "Alibaba's Qwen coding assistant",
     "distribution": {
       "npx": {
-        "package": "@qwen-code/qwen-code@0.19.12",
+        "package": "@qwen-code/qwen-code@0.20.1",
         "args": ["--acp", "--experimental-skills"]
       }
     }

--- a/src/renderer/assets/agent-icons/acp/agents.json
+++ b/src/renderer/assets/agent-icons/acp/agents.json
@@ -438,33 +438,33 @@
   {
     "id": "harn",
     "name": "Harn",
-    "version": "0.10.33",
+    "version": "0.10.34",
     "description": "Harn runs .harn agent pipelines as a native ACP coding agent over stdio.",
     "distribution": {
       "binary": {
         "darwin-aarch64": {
           "cmd": "./harn",
-          "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.33/harn-aarch64-apple-darwin.tar.gz",
+          "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.34/harn-aarch64-apple-darwin.tar.gz",
           "args": ["serve", "acp"]
         },
         "darwin-x86_64": {
           "cmd": "./harn",
-          "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.33/harn-x86_64-apple-darwin.tar.gz",
+          "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.34/harn-x86_64-apple-darwin.tar.gz",
           "args": ["serve", "acp"]
         },
         "linux-aarch64": {
           "cmd": "./harn",
-          "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.33/harn-aarch64-unknown-linux-gnu.tar.gz",
+          "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.34/harn-aarch64-unknown-linux-gnu.tar.gz",
           "args": ["serve", "acp"]
         },
         "linux-x86_64": {
           "cmd": "./harn",
-          "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.33/harn-x86_64-unknown-linux-gnu.tar.gz",
+          "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.34/harn-x86_64-unknown-linux-gnu.tar.gz",
           "args": ["serve", "acp"]
         },
         "windows-x86_64": {
           "cmd": "harn.exe",
-          "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.33/harn-x86_64-pc-windows-msvc.zip",
+          "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.34/harn-x86_64-pc-windows-msvc.zip",
           "args": ["serve", "acp"]
         }
       }

--- a/src/renderer/components/editor/FrontmatterProperties.test.tsx
+++ b/src/renderer/components/editor/FrontmatterProperties.test.tsx
@@ -1,0 +1,50 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import { FrontmatterProperties } from './FrontmatterProperties'
+
+describe('FrontmatterProperties', () => {
+  it('rejects empty key without calling onChange', () => {
+    const onChange = vi.fn()
+    render(<FrontmatterProperties data={{ title: 'Doc' }} onChange={onChange} />)
+
+    fireEvent.click(screen.getByRole('button', { name: /add property/i }))
+    fireEvent.click(screen.getByRole('button', { name: /^add$/i }))
+
+    expect(screen.getByText('Key cannot be empty')).toBeTruthy()
+    expect(onChange).not.toHaveBeenCalled()
+  })
+
+  it('rejects duplicate key without calling onChange', () => {
+    const onChange = vi.fn()
+    render(<FrontmatterProperties data={{ title: 'Doc' }} onChange={onChange} />)
+
+    fireEvent.click(screen.getByRole('button', { name: /add property/i }))
+    fireEvent.change(screen.getByPlaceholderText('Property key'), {
+      target: { value: 'title' }
+    })
+    fireEvent.click(screen.getByRole('button', { name: /^add$/i }))
+
+    expect(screen.getByText('Key already exists')).toBeTruthy()
+    expect(onChange).not.toHaveBeenCalled()
+  })
+
+  it('removeKey calls onChange with the key removed', () => {
+    const onChange = vi.fn()
+    render(<FrontmatterProperties data={{ title: 'Doc', status: 'draft' }} onChange={onChange} />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Remove status' }))
+
+    expect(onChange).toHaveBeenCalledTimes(1)
+    expect(onChange).toHaveBeenCalledWith({ title: 'Doc' })
+  })
+
+  it('removeArrayItem calls onChange with updated array', () => {
+    const onChange = vi.fn()
+    render(<FrontmatterProperties data={{ context: ['alpha', 'beta'] }} onChange={onChange} />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Remove alpha' }))
+
+    expect(onChange).toHaveBeenCalledTimes(1)
+    expect(onChange).toHaveBeenCalledWith({ context: ['beta'] })
+  })
+})

--- a/src/renderer/components/editor/FrontmatterProperties.tsx
+++ b/src/renderer/components/editor/FrontmatterProperties.tsx
@@ -1,0 +1,285 @@
+import {
+  Calendar,
+  CircleDot,
+  type FileText,
+  FolderOpen,
+  GitCommitHorizontal,
+  Hash,
+  List,
+  Plus,
+  RefreshCw,
+  Tag,
+  Trash2,
+  Type,
+  X
+} from 'lucide-react'
+import { useCallback, useEffect, useId, useRef, useState } from 'react'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import {
+  type FrontmatterMap,
+  type FrontmatterValue,
+  formatFrontmatterValue,
+  isFrontmatterNested,
+  parseScalarInput
+} from '@/lib/markdown-frontmatter'
+import { cn } from '@/lib/utils'
+
+interface FrontmatterPropertiesProps {
+  data: FrontmatterMap
+  onChange: (next: FrontmatterMap) => void
+}
+
+const KEY_ICONS: Record<string, typeof FileText> = {
+  title: Type,
+  type: Tag,
+  created: Calendar,
+  status: CircleDot,
+  context: FolderOpen,
+  baseline_commit: GitCommitHorizontal,
+  review_loop_iteration: RefreshCw
+}
+
+function iconForKey(key: string): typeof FileText {
+  return KEY_ICONS[key] ?? Hash
+}
+
+export function FrontmatterProperties({
+  data,
+  onChange
+}: FrontmatterPropertiesProps): React.JSX.Element {
+  const baseId = useId()
+  const dataRef = useRef(data)
+  dataRef.current = data
+
+  const [adding, setAdding] = useState(false)
+  const [draftKey, setDraftKey] = useState('')
+  const [draftError, setDraftError] = useState<string | null>(null)
+  /** In-progress scalar text while an input is focused (keyed by property name). */
+  const [draftScalars, setDraftScalars] = useState<Record<string, string>>({})
+
+  useEffect(() => {
+    setDraftScalars((prev) => {
+      const next: Record<string, string> = {}
+      for (const key of Object.keys(prev)) {
+        if (Object.hasOwn(data, key)) {
+          next[key] = prev[key]
+        }
+      }
+      return next
+    })
+  }, [data])
+
+  const entries = Object.entries(data)
+
+  const updateKey = useCallback(
+    (key: string, value: FrontmatterValue) => {
+      onChange({ ...dataRef.current, [key]: value })
+    },
+    [onChange]
+  )
+
+  const removeKey = useCallback(
+    (key: string) => {
+      const next = { ...dataRef.current }
+      delete next[key]
+      onChange(next)
+    },
+    [onChange]
+  )
+
+  const removeArrayItem = useCallback(
+    (key: string, index: number) => {
+      const current = dataRef.current[key]
+      if (!Array.isArray(current)) return
+      const next = current.filter((_, i) => i !== index)
+      onChange({ ...dataRef.current, [key]: next })
+    },
+    [onChange]
+  )
+
+  const commitAdd = useCallback(() => {
+    const key = draftKey.trim()
+    if (!key) {
+      setDraftError('Key cannot be empty')
+      return
+    }
+    if (Object.hasOwn(dataRef.current, key)) {
+      setDraftError('Key already exists')
+      return
+    }
+    onChange({ ...dataRef.current, [key]: '' })
+    setDraftKey('')
+    setDraftError(null)
+    setAdding(false)
+  }, [draftKey, onChange])
+
+  const cancelAdd = useCallback(() => {
+    setAdding(false)
+    setDraftKey('')
+    setDraftError(null)
+  }, [])
+
+  const commitScalar = useCallback(
+    (key: string) => {
+      const draft = draftScalars[key]
+      if (draft === undefined) return
+      updateKey(key, parseScalarInput(draft))
+      setDraftScalars((prev) => {
+        const next = { ...prev }
+        delete next[key]
+        return next
+      })
+    },
+    [draftScalars, updateKey]
+  )
+
+  return (
+    <div className="border-b border-border bg-muted/20 px-4 py-3">
+      <div className="mb-2 text-xs font-medium uppercase tracking-wide text-muted-foreground">
+        Properties
+      </div>
+
+      <div className="flex flex-col gap-1.5">
+        {entries.map(([key, value]) => {
+          const Icon = iconForKey(key)
+          return (
+            <div key={key} className="group flex items-start gap-2 rounded-md px-1 py-1">
+              <Icon className="mt-2 size-3.5 shrink-0 text-muted-foreground" aria-hidden="true" />
+              <label
+                htmlFor={`${baseId}-${key}`}
+                className="mt-1.5 w-28 shrink-0 truncate text-xs text-muted-foreground"
+                title={key}
+              >
+                {key}
+              </label>
+              <div className="min-w-0 flex-1">
+                {isFrontmatterNested(value) ? (
+                  <div
+                    id={`${baseId}-${key}`}
+                    className="rounded-md border border-border/60 bg-muted/40 px-2 py-1.5 font-mono text-xs text-muted-foreground"
+                    title="Nested value (read-only)"
+                  >
+                    {value.display}
+                  </div>
+                ) : Array.isArray(value) ? (
+                  <div className="flex flex-wrap items-center gap-1.5 py-0.5">
+                    {value.map((item, index) => (
+                      <Badge
+                        key={`${key}-${item}-${index}`}
+                        variant="secondary"
+                        className="gap-1 pr-1 font-normal"
+                      >
+                        <List className="size-3 opacity-60" aria-hidden="true" />
+                        <span>{item}</span>
+                        <button
+                          type="button"
+                          className="rounded-full p-0.5 text-muted-foreground hover:bg-destructive/10 hover:text-destructive"
+                          aria-label={`Remove ${item}`}
+                          onClick={() => removeArrayItem(key, index)}
+                        >
+                          <X className="size-3" />
+                        </button>
+                      </Badge>
+                    ))}
+                    {value.length === 0 && (
+                      <span className="text-xs text-muted-foreground">[]</span>
+                    )}
+                  </div>
+                ) : (
+                  <Input
+                    id={`${baseId}-${key}`}
+                    className="h-8 border-transparent bg-transparent px-2 shadow-none hover:border-input focus-visible:border-input"
+                    value={
+                      draftScalars[key] !== undefined
+                        ? draftScalars[key]
+                        : formatFrontmatterValue(value)
+                    }
+                    onFocus={() => {
+                      setDraftScalars((prev) => ({
+                        ...prev,
+                        [key]: formatFrontmatterValue(value)
+                      }))
+                    }}
+                    onChange={(event) => {
+                      const nextText = event.target.value
+                      setDraftScalars((prev) => ({ ...prev, [key]: nextText }))
+                    }}
+                    onBlur={() => commitScalar(key)}
+                    onKeyDown={(event) => {
+                      if (event.key === 'Enter') {
+                        event.currentTarget.blur()
+                      }
+                    }}
+                  />
+                )}
+              </div>
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon-xs"
+                className={cn(
+                  'mt-1 shrink-0 text-muted-foreground transition-opacity',
+                  // Touch / no-hover: always visible. Fine pointer: reveal on row hover/focus.
+                  'opacity-50 [@media(hover:hover)]:opacity-0 [@media(hover:hover)]:group-hover:opacity-100',
+                  'focus-visible:opacity-100'
+                )}
+                aria-label={`Remove ${key}`}
+                onClick={() => removeKey(key)}
+              >
+                <Trash2 className="size-3.5" />
+              </Button>
+            </div>
+          )
+        })}
+      </div>
+
+      {adding ? (
+        <div className="mt-2 flex flex-col gap-1.5">
+          <div className="flex items-center gap-2">
+            <Input
+              className="h-8"
+              placeholder="Property key"
+              value={draftKey}
+              autoFocus
+              aria-invalid={draftError !== null}
+              onChange={(event) => {
+                setDraftKey(event.target.value)
+                setDraftError(null)
+              }}
+              onKeyDown={(event) => {
+                if (event.key === 'Enter') {
+                  event.preventDefault()
+                  commitAdd()
+                }
+                if (event.key === 'Escape') {
+                  event.preventDefault()
+                  cancelAdd()
+                }
+              }}
+            />
+            <Button type="button" size="xs" onClick={commitAdd}>
+              Add
+            </Button>
+            <Button type="button" size="xs" variant="ghost" onClick={cancelAdd}>
+              Cancel
+            </Button>
+          </div>
+          {draftError && <p className="text-xs text-destructive">{draftError}</p>}
+        </div>
+      ) : (
+        <Button
+          type="button"
+          variant="ghost"
+          size="xs"
+          className="mt-2 text-muted-foreground"
+          onClick={() => setAdding(true)}
+        >
+          <Plus className="size-3.5" />
+          Add property
+        </Button>
+      )}
+    </div>
+  )
+}

--- a/src/renderer/components/editor/FrontmatterProperties.tsx
+++ b/src/renderer/components/editor/FrontmatterProperties.tsx
@@ -136,7 +136,8 @@ export function FrontmatterProperties({
   )
 
   return (
-    <div className="border-b border-border bg-muted/20 px-4 py-3">
+    // Match BlockNote `.bn-editor { padding-inline: 54px }` so Properties align with body text.
+    <div className="border-b border-border px-[54px] py-3">
       <div className="mb-2 text-xs font-medium uppercase tracking-wide text-muted-foreground">
         Properties
       </div>
@@ -145,7 +146,7 @@ export function FrontmatterProperties({
         {entries.map(([key, value]) => {
           const Icon = iconForKey(key)
           return (
-            <div key={key} className="group flex items-start gap-2 rounded-md px-1 py-1">
+            <div key={key} className="group flex items-start gap-2 rounded-md py-1">
               <Icon className="mt-2 size-3.5 shrink-0 text-muted-foreground" aria-hidden="true" />
               <label
                 htmlFor={`${baseId}-${key}`}

--- a/src/renderer/components/editor/MarkdownEditor.frontmatter.test.tsx
+++ b/src/renderer/components/editor/MarkdownEditor.frontmatter.test.tsx
@@ -129,4 +129,42 @@ describe('MarkdownEditor frontmatter strip/rejoin/flush', () => {
     // FM-only edit must not treat store echo as external reload
     expect(replaceContent).not.toHaveBeenCalled()
   })
+
+  it('verbatim store echo clears pending local emits so later external reloads apply', () => {
+    const onChange = vi.fn()
+    const { rerender } = render(
+      <MarkdownEditor filePath="/docs/spec.md" content={FM_CONTENT} isVisible onChange={onChange} />
+    )
+
+    act(() => {
+      capturedOptions.onChange('# Heading\n\nEdited body.\n')
+    })
+
+    expect(onChange).toHaveBeenCalledTimes(1)
+    const emitted = onChange.mock.calls[0]?.[0] as string
+    expect(emitted).toContain('title: Spec')
+    expect(emitted).toContain('# Heading\n\nEdited body.\n')
+    expect(replaceContent).not.toHaveBeenCalled()
+
+    // Parent echoes the emitted full file back as the content prop (verbatim).
+    rerender(
+      <MarkdownEditor filePath="/docs/spec.md" content={emitted} isVisible onChange={onChange} />
+    )
+    expect(replaceContent).not.toHaveBeenCalled()
+
+    const external = `---
+title: Spec
+status: draft
+---
+# Heading
+
+External reload.
+`
+    rerender(
+      <MarkdownEditor filePath="/docs/spec.md" content={external} isVisible onChange={onChange} />
+    )
+
+    expect(replaceContent).toHaveBeenCalledTimes(1)
+    expect(replaceContent).toHaveBeenCalledWith('# Heading\n\nExternal reload.\n')
+  })
 })

--- a/src/renderer/components/editor/MarkdownEditor.frontmatter.test.tsx
+++ b/src/renderer/components/editor/MarkdownEditor.frontmatter.test.tsx
@@ -1,0 +1,132 @@
+import { act, fireEvent, render } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { useBlockNote } from '@/hooks/use-blocknote'
+import { flushEditorContent } from '@/lib/editor-content-flush'
+import { MarkdownEditor } from './MarkdownEditor'
+
+vi.mock('@blocknote/react', () => ({
+  BlockNoteViewRaw: () => null
+}))
+
+vi.mock('@/hooks/use-blocknote', () => ({
+  useBlockNote: vi.fn()
+}))
+
+vi.mock('@/stores/toc-settings-store', () => ({
+  useTocSettingsStore: (selector: (state: unknown) => unknown) =>
+    selector({
+      isLoaded: true,
+      loadFailed: false,
+      settings: {
+        isVisible: false,
+        width: 280
+      },
+      setWidth: vi.fn()
+    })
+}))
+
+type BlockNoteOptions = {
+  filePath: string
+  initialMarkdown: string
+  onChange: (markdown: string) => void
+}
+
+const FM_CONTENT = `---
+title: Spec
+status: draft
+---
+# Heading
+
+Body text.
+`
+
+describe('MarkdownEditor frontmatter strip/rejoin/flush', () => {
+  let capturedOptions: BlockNoteOptions
+  const replaceContent = vi.fn()
+  const capturePendingContent = vi.fn(async () => '# Heading\n\nBody text.\n')
+  const flushPendingContent = vi.fn(async () => {
+    capturedOptions.onChange('# Heading\n\nBody text.\n')
+  })
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    capturePendingContent.mockResolvedValue('# Heading\n\nBody text.\n')
+    flushPendingContent.mockImplementation(async () => {
+      capturedOptions.onChange('# Heading\n\nBody text.\n')
+    })
+
+    vi.mocked(useBlockNote).mockImplementation((options: BlockNoteOptions) => {
+      capturedOptions = options
+      return {
+        editor: {} as never,
+        replaceContent,
+        flushPendingContent,
+        capturePendingContent,
+        getHeadings: () => [],
+        scrollToBlock: vi.fn()
+      }
+    })
+  })
+
+  it('passes body-only into useBlockNote and rejoins FM on body onChange', () => {
+    const onChange = vi.fn()
+    render(
+      <MarkdownEditor filePath="/docs/spec.md" content={FM_CONTENT} isVisible onChange={onChange} />
+    )
+
+    expect(capturedOptions.initialMarkdown).toBe('# Heading\n\nBody text.\n')
+    expect(capturedOptions.initialMarkdown.startsWith('---')).toBe(false)
+
+    act(() => {
+      capturedOptions.onChange('# Heading\n\nEdited body.\n')
+    })
+
+    expect(onChange).toHaveBeenCalledTimes(1)
+    const full = onChange.mock.calls[0]?.[0] as string
+    expect(full.startsWith('---\n')).toBe(true)
+    expect(full).toContain('title: Spec')
+    expect(full).toContain('status: draft')
+    expect(full).toContain('# Heading\n\nEdited body.\n')
+  })
+
+  it('flush path emits rejoined full file including frontmatter', async () => {
+    const onChange = vi.fn()
+    render(
+      <MarkdownEditor filePath="/docs/spec.md" content={FM_CONTENT} isVisible onChange={onChange} />
+    )
+
+    await act(async () => {
+      await flushEditorContent('/docs/spec.md')
+    })
+
+    expect(flushPendingContent).toHaveBeenCalled()
+    expect(onChange).toHaveBeenCalled()
+    const full = onChange.mock.calls.at(-1)?.[0] as string
+    expect(full).toContain('title: Spec')
+    expect(full).toContain('# Heading\n\nBody text.\n')
+  })
+
+  it('Properties edit captures body once and emits rejoined FM without replaceContent', async () => {
+    const onChange = vi.fn()
+    const { getByLabelText } = render(
+      <MarkdownEditor filePath="/docs/spec.md" content={FM_CONTENT} isVisible onChange={onChange} />
+    )
+
+    const titleInput = getByLabelText('title')
+    await act(async () => {
+      titleInput.focus()
+      fireEvent.change(titleInput, { target: { value: 'Updated' } })
+      fireEvent.blur(titleInput)
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    expect(capturePendingContent).toHaveBeenCalled()
+    expect(onChange).toHaveBeenCalled()
+    const full = onChange.mock.calls.at(-1)?.[0] as string
+    expect(full).toContain('title: Updated')
+    expect(full).toContain('# Heading\n\nBody text.\n')
+    // FM-only edit must not treat store echo as external reload
+    expect(replaceContent).not.toHaveBeenCalled()
+  })
+})

--- a/src/renderer/components/editor/MarkdownEditor.frontmatter.test.tsx
+++ b/src/renderer/components/editor/MarkdownEditor.frontmatter.test.tsx
@@ -142,8 +142,14 @@ describe('MarkdownEditor frontmatter strip/rejoin/flush', () => {
 
     expect(onChange).toHaveBeenCalledTimes(1)
     const emitted = onChange.mock.calls[0]?.[0] as string
-    expect(emitted).toContain('title: Spec')
-    expect(emitted).toContain('# Heading\n\nEdited body.\n')
+    expect(emitted).toBe(`---
+title: Spec
+status: draft
+---
+# Heading
+
+Edited body.
+`)
     expect(replaceContent).not.toHaveBeenCalled()
 
     // Parent echoes the emitted full file back as the content prop (verbatim).

--- a/src/renderer/components/editor/MarkdownEditor.tsx
+++ b/src/renderer/components/editor/MarkdownEditor.tsx
@@ -211,14 +211,19 @@ export function MarkdownEditor({
       return
     }
 
-    if (content !== prevContentRef.current) {
-      if (pendingLocalEmitsRef.current > 0) {
-        pendingLocalEmitsRef.current -= 1
-      } else {
-        applyExternalContent(content)
-      }
-      prevContentRef.current = content
+    // Verbatim store echo of our emit: content already matches prevContentRef
+    // (set in emitFullContent). Still clear pending so a later genuine external
+    // update is not consumed as a leftover local emit.
+    if (content === prevContentRef.current) {
+      pendingLocalEmitsRef.current = 0
+      return
     }
+
+    // Distinct content → external. Never burn pending on a mismatch; that used
+    // to drop real reloads after a same-content echo left the counter elevated.
+    pendingLocalEmitsRef.current = 0
+    applyExternalContent(content)
+    prevContentRef.current = content
   }, [applyExternalContent, content, filePath])
 
   useEffect(() => {

--- a/src/renderer/components/editor/MarkdownEditor.tsx
+++ b/src/renderer/components/editor/MarkdownEditor.tsx
@@ -2,12 +2,18 @@ import { BlockNoteViewRaw } from '@blocknote/react'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import type { ImperativePanelGroupHandle, PanelOnResize } from 'react-resizable-panels'
 import { useShallow } from 'zustand/shallow'
+import { FrontmatterProperties } from '@/components/editor/FrontmatterProperties'
 import { ResizableHandle, ResizablePanel, ResizablePanelGroup } from '@/components/ui/resizable'
 import { useBlockNote } from '@/hooks/use-blocknote'
 import {
   registerEditorContentFlusher,
   unregisterEditorContentFlusher
 } from '@/lib/editor-content-flush'
+import {
+  composeFullMarkdown,
+  type FrontmatterMap,
+  splitFrontmatter
+} from '@/lib/markdown-frontmatter'
 import { useTocSettingsStore } from '@/stores/toc-settings-store'
 import { TOC_MAX_WIDTH, TOC_MIN_WIDTH } from '@/types/settings'
 import { TocPanel } from './TocPanel'
@@ -55,30 +61,100 @@ export function MarkdownEditor({
   isVisible,
   onChange
 }: MarkdownEditorProps): React.JSX.Element {
-  // Track whether the last content change came from this editor's onChange
-  const isLocalChangeRef = useRef(false)
+  // Count of local emits still awaiting acknowledgment from the content prop sync.
+  const pendingLocalEmitsRef = useRef(0)
   const prevContentRef = useRef(content)
   const prevFilePathRef = useRef(filePath)
+  // Bumped on external reload / file switch / unmount to cancel in-flight FM emits.
+  const contentGenerationRef = useRef(0)
 
-  const wrappedOnChange = useCallback(
-    (newContent: string) => {
-      isLocalChangeRef.current = true
-      prevContentRef.current = newContent
-      onChange(newContent)
+  const initialParsedRef = useRef(splitFrontmatter(content))
+  const [hasFrontmatter, setHasFrontmatter] = useState(initialParsedRef.current.hasFrontmatter)
+  const [frontmatter, setFrontmatter] = useState<FrontmatterMap>(initialParsedRef.current.data)
+  const frontmatterRef = useRef(frontmatter)
+  frontmatterRef.current = frontmatter
+  const hasFrontmatterRef = useRef(hasFrontmatter)
+  hasFrontmatterRef.current = hasFrontmatter
+  const bodyRef = useRef(initialParsedRef.current.body)
+
+  const emitFullContent = useCallback(
+    (body: string) => {
+      bodyRef.current = body
+      const full = composeFullMarkdown(hasFrontmatterRef.current, frontmatterRef.current, body)
+      // Serialize failure → keep last-good store content (muted).
+      if (full === null) return
+
+      pendingLocalEmitsRef.current += 1
+      prevContentRef.current = full
+      onChange(full)
     },
     [onChange]
   )
 
-  const { editor, replaceContent, flushPendingContent, getHeadings, scrollToBlock } = useBlockNote({
+  const {
+    editor,
+    replaceContent,
+    flushPendingContent,
+    capturePendingContent,
+    getHeadings,
+    scrollToBlock
+  } = useBlockNote({
     filePath,
-    initialMarkdown: content,
-    onChange: wrappedOnChange
+    initialMarkdown: initialParsedRef.current.body,
+    onChange: emitFullContent
   })
 
+  const flushFullContent = useCallback(async (): Promise<void> => {
+    // Flush BlockNote body through emitFullContent so the store receives rejoined FM+body.
+    await flushPendingContent()
+  }, [flushPendingContent])
+
   useEffect(() => {
-    registerEditorContentFlusher(filePath, flushPendingContent)
+    registerEditorContentFlusher(filePath, flushFullContent)
     return () => unregisterEditorContentFlusher(filePath)
-  }, [filePath, flushPendingContent])
+  }, [filePath, flushFullContent])
+
+  const applyExternalContent = useCallback(
+    (nextContent: string) => {
+      contentGenerationRef.current += 1
+      pendingLocalEmitsRef.current = 0
+      const parsed = splitFrontmatter(nextContent)
+      setHasFrontmatter(parsed.hasFrontmatter)
+      setFrontmatter(parsed.data)
+      frontmatterRef.current = parsed.data
+      hasFrontmatterRef.current = parsed.hasFrontmatter
+      bodyRef.current = parsed.body
+      void replaceContent(parsed.body)
+    },
+    [replaceContent]
+  )
+
+  const handleFrontmatterChange = useCallback(
+    (next: FrontmatterMap) => {
+      frontmatterRef.current = next
+      hasFrontmatterRef.current = true
+      setFrontmatter(next)
+      setHasFrontmatter(true)
+
+      const generation = contentGenerationRef.current
+      void (async () => {
+        // Capture latest body without emitting, then emit exactly once with new FM.
+        const captured = await capturePendingContent()
+        if (generation !== contentGenerationRef.current) return
+        if (captured !== null) {
+          bodyRef.current = captured
+        }
+        emitFullContent(bodyRef.current)
+      })()
+    },
+    [capturePendingContent, emitFullContent]
+  )
+
+  useEffect(() => {
+    return () => {
+      contentGenerationRef.current += 1
+    }
+  }, [])
 
   const isDark = useIsDark()
   const layoutRef = useRef<HTMLDivElement>(null)
@@ -128,24 +204,22 @@ export function MarkdownEditor({
   // Sync content only for external changes (e.g., file reload from disk)
   useEffect(() => {
     if (filePath !== prevFilePathRef.current) {
-      isLocalChangeRef.current = false
+      pendingLocalEmitsRef.current = 0
       prevFilePathRef.current = filePath
       prevContentRef.current = content
-      void replaceContent(content)
+      applyExternalContent(content)
       return
     }
 
     if (content !== prevContentRef.current) {
-      if (isLocalChangeRef.current) {
-        // This change came from the editor itself, don't push it back
-        isLocalChangeRef.current = false
+      if (pendingLocalEmitsRef.current > 0) {
+        pendingLocalEmitsRef.current -= 1
       } else {
-        // External change - replace editor content
-        void replaceContent(content)
+        applyExternalContent(content)
       }
       prevContentRef.current = content
     }
-  }, [content, filePath, replaceContent])
+  }, [applyExternalContent, content, filePath])
 
   useEffect(() => {
     setBlockNoteContainer(blockNoteScrollRootRef.current)
@@ -204,18 +278,23 @@ export function MarkdownEditor({
       <div ref={layoutRef} className="h-full w-full">
         <ResizablePanelGroup ref={panelGroupRef} direction="horizontal">
           <ResizablePanel defaultSize={canRenderToc ? 100 - tocPanelDefaultSize : 100} minSize={60}>
-            <div ref={blockNoteScrollRootRef} className="h-full overflow-auto">
-              <BlockNoteViewRaw
-                editor={editor}
-                theme={isDark ? 'dark' : 'light'}
-                formattingToolbar={false}
-                linkToolbar={false}
-                slashMenu={false}
-                emojiPicker={false}
-                sideMenu={false}
-                filePanel={false}
-                tableHandles={false}
-              />
+            <div ref={blockNoteScrollRootRef} className="flex h-full flex-col overflow-auto">
+              {hasFrontmatter && (
+                <FrontmatterProperties data={frontmatter} onChange={handleFrontmatterChange} />
+              )}
+              <div className="min-h-0 flex-1">
+                <BlockNoteViewRaw
+                  editor={editor}
+                  theme={isDark ? 'dark' : 'light'}
+                  formattingToolbar={false}
+                  linkToolbar={false}
+                  slashMenu={false}
+                  emojiPicker={false}
+                  sideMenu={false}
+                  filePanel={false}
+                  tableHandles={false}
+                />
+              </div>
             </div>
           </ResizablePanel>
 

--- a/src/renderer/hooks/use-blocknote.ts
+++ b/src/renderer/hooks/use-blocknote.ts
@@ -55,6 +55,8 @@ interface UseBlockNoteResult {
   editor: BlockNoteEditor<any, any, any>
   replaceContent: (markdown: string) => void
   flushPendingContent: () => Promise<void>
+  /** Capture current body markdown without calling onChange (clears debounce). */
+  capturePendingContent: () => Promise<string | null>
   getHeadings: () => TocHeading[]
   scrollToBlock: (blockId: string) => void
 }
@@ -170,19 +172,24 @@ export function useBlockNote(options: UseBlockNoteOptions): UseBlockNoteResult {
     [runReplace]
   )
 
-  const flushPendingContent = useCallback(async (): Promise<void> => {
+  const capturePendingContent = useCallback(async (): Promise<string | null> => {
     if (debounceTimerRef.current) {
       clearTimeout(debounceTimerRef.current)
       debounceTimerRef.current = null
     }
-    if (isReplacingRef.current) return
+    if (isReplacingRef.current) return null
     try {
-      const markdown = await editor.blocksToMarkdownLossy(editor.document)
-      onChangeRef.current(markdown)
+      return await editor.blocksToMarkdownLossy(editor.document)
     } catch {
-      // Failed to convert to markdown
+      return null
     }
   }, [editor])
+
+  const flushPendingContent = useCallback(async (): Promise<void> => {
+    const markdown = await capturePendingContent()
+    if (markdown === null) return
+    onChangeRef.current(markdown)
+  }, [capturePendingContent])
 
   const getHeadings = useCallback((): TocHeading[] => {
     return editor.document.flatMap((block) => {
@@ -248,5 +255,12 @@ export function useBlockNote(options: UseBlockNoteOptions): UseBlockNoteResult {
     [editor]
   )
 
-  return { editor, replaceContent, flushPendingContent, getHeadings, scrollToBlock }
+  return {
+    editor,
+    replaceContent,
+    flushPendingContent,
+    capturePendingContent,
+    getHeadings,
+    scrollToBlock
+  }
 }

--- a/src/renderer/lib/markdown-frontmatter.test.ts
+++ b/src/renderer/lib/markdown-frontmatter.test.ts
@@ -1,0 +1,279 @@
+import { describe, expect, it } from 'vitest'
+import {
+  composeFullMarkdown,
+  type FrontmatterMap,
+  formatFrontmatterValue,
+  isFrontmatterNested,
+  parseScalarInput,
+  rejoinFrontmatter,
+  serializeFrontmatter,
+  splitFrontmatter
+} from './markdown-frontmatter'
+
+describe('splitFrontmatter', () => {
+  it('happy path: valid YAML map + body → data, body-only', () => {
+    const text = `---
+title: Hello
+status: draft
+count: 3
+published: true
+empty: null
+---
+# Heading
+
+Body paragraph.
+`
+    const result = splitFrontmatter(text)
+    expect(result.hasFrontmatter).toBe(true)
+    expect(result.data).toEqual({
+      title: 'Hello',
+      status: 'draft',
+      count: 3,
+      published: true,
+      empty: null
+    })
+    expect(result.body).toBe('# Heading\n\nBody paragraph.\n')
+  })
+
+  it('no frontmatter: body-only markdown unchanged', () => {
+    const text = '# Just a doc\n\nNo fences here.\n'
+    const result = splitFrontmatter(text)
+    expect(result.hasFrontmatter).toBe(false)
+    expect(result.data).toEqual({})
+    expect(result.body).toBe(text)
+  })
+
+  it('invalid YAML between fences → no frontmatter; full text as body', () => {
+    const text = `---
+title: [unclosed
+broken: *
+---
+# Still here
+`
+    const result = splitFrontmatter(text)
+    expect(result.hasFrontmatter).toBe(false)
+    expect(result.body).toBe(text)
+  })
+
+  it('missing closing fence → no frontmatter; full text as body', () => {
+    const text = `---
+title: Incomplete
+status: open
+
+# Body that looks like markdown
+`
+    const result = splitFrontmatter(text)
+    expect(result.hasFrontmatter).toBe(false)
+    expect(result.body).toBe(text)
+  })
+
+  it('array values: string[] preserved; mixed arrays become nested', () => {
+    const text = `---
+context:
+  - alpha
+  - beta
+mixed:
+  - a
+  - 1
+---
+Body
+`
+    const result = splitFrontmatter(text)
+    expect(result.hasFrontmatter).toBe(true)
+    expect(result.data.context).toEqual(['alpha', 'beta'])
+    expect(isFrontmatterNested(result.data.mixed)).toBe(true)
+    if (isFrontmatterNested(result.data.mixed)) {
+      expect(result.data.mixed.display.length).toBeGreaterThan(0)
+      expect(result.data.mixed.value).toEqual(['a', 1])
+    }
+  })
+
+  it('nested objects become non-editable nested display values', () => {
+    const text = `---
+title: Root
+meta:
+  author: Ada
+  rev: 2
+---
+Body
+`
+    const result = splitFrontmatter(text)
+    expect(result.hasFrontmatter).toBe(true)
+    expect(result.data.title).toBe('Root')
+    expect(isFrontmatterNested(result.data.meta)).toBe(true)
+    if (isFrontmatterNested(result.data.meta)) {
+      expect(result.data.meta.display).toContain('author')
+    }
+  })
+
+  it('root YAML array is not treated as frontmatter', () => {
+    const text = `---
+- a
+- b
+---
+Body
+`
+    const result = splitFrontmatter(text)
+    expect(result.hasFrontmatter).toBe(false)
+    expect(result.body).toBe(text)
+  })
+
+  it('empty frontmatter block is valid', () => {
+    const text = `---
+---
+# Body
+`
+    const result = splitFrontmatter(text)
+    expect(result.hasFrontmatter).toBe(true)
+    expect(result.data).toEqual({})
+    expect(result.body).toBe('# Body\n')
+  })
+
+  it('strips UTF-8 BOM before fence detection', () => {
+    const text = `\uFEFF---
+title: Bommed
+---
+# Body
+`
+    const result = splitFrontmatter(text)
+    expect(result.hasFrontmatter).toBe(true)
+    expect(result.data.title).toBe('Bommed')
+    expect(result.body).toBe('# Body\n')
+  })
+})
+
+describe('serializeFrontmatter / rejoinFrontmatter', () => {
+  it('add / remove property via serialize updates rejoined YAML', () => {
+    const data: FrontmatterMap = {
+      title: 'Doc',
+      status: 'draft'
+    }
+    const withAdded: FrontmatterMap = {
+      ...data,
+      type: 'feature'
+    }
+    const added = serializeFrontmatter(withAdded)
+    expect(added).not.toBeNull()
+    expect(added).toContain('type: feature')
+    expect(added).toContain('title: Doc')
+
+    const { status: _removed, ...withoutStatus } = withAdded
+    const removed = serializeFrontmatter(withoutStatus)
+    expect(removed).not.toBeNull()
+    expect(removed).not.toContain('status:')
+    expect(removed).toContain('type: feature')
+  })
+
+  it('array values serialize; empty array → []', () => {
+    const withItems = serializeFrontmatter({ context: ['a', 'b'] })
+    expect(withItems).not.toBeNull()
+    expect(withItems).toMatch(/context:\s*\n\s+- a\s*\n\s+- b/)
+
+    const empty = serializeFrontmatter({ context: [] })
+    expect(empty).not.toBeNull()
+    expect(empty).toContain('context:')
+    expect(empty).toMatch(/context:\s*\[\]/)
+  })
+
+  it('rejoin on body / FM edit conceptually: FM + body', () => {
+    const data: FrontmatterMap = { title: 'Hello', status: 'open' }
+    const body = '# Heading\n\nUpdated body.\n'
+    const full = rejoinFrontmatter(data, body)
+    expect(full).not.toBeNull()
+    expect(full!.startsWith('---\n')).toBe(true)
+    expect(full).toContain('title: Hello')
+    expect(full!.endsWith(body)).toBe(true)
+
+    const editedFm = rejoinFrontmatter({ ...data, status: 'done' }, body)
+    expect(editedFm).toContain('status: done')
+    expect(editedFm).toContain('# Heading')
+
+    const editedBody = rejoinFrontmatter(data, '# New\n')
+    expect(editedBody).toContain('title: Hello')
+    expect(editedBody!.endsWith('# New\n')).toBe(true)
+  })
+
+  it('mode-switch / reload via re-parse: round-trip preserves editable map', () => {
+    const original = `---
+title: Round trip
+review_loop_iteration: 2
+context:
+  - one
+  - two
+published: false
+---
+## Section
+
+Content here.
+`
+    const first = splitFrontmatter(original)
+    expect(first.hasFrontmatter).toBe(true)
+
+    const rejoined = rejoinFrontmatter(first.data, first.body)
+    expect(rejoined).not.toBeNull()
+    const second = splitFrontmatter(rejoined!)
+    expect(second.hasFrontmatter).toBe(true)
+    expect(second.data.title).toBe('Round trip')
+    expect(second.data.review_loop_iteration).toBe(2)
+    expect(second.data.context).toEqual(['one', 'two'])
+    expect(second.data.published).toBe(false)
+    expect(second.body).toBe(first.body)
+  })
+
+  it('nested values serialize compactly from preserved value', () => {
+    const split = splitFrontmatter(`---
+meta:
+  a: 1
+  b: two
+---
+Body
+`)
+    expect(split.hasFrontmatter).toBe(true)
+    const rejoined = rejoinFrontmatter(split.data, split.body)
+    expect(rejoined).not.toBeNull()
+    const again = splitFrontmatter(rejoined!)
+    expect(again.hasFrontmatter).toBe(true)
+    expect(isFrontmatterNested(again.data.meta)).toBe(true)
+    if (isFrontmatterNested(again.data.meta)) {
+      expect(again.data.meta.value).toEqual({ a: 1, b: 'two' })
+    }
+  })
+
+  it('empty map serializes to empty fences', () => {
+    expect(serializeFrontmatter({})).toBe('---\n---\n')
+  })
+
+  it('composeFullMarkdown returns body-only when no FM', () => {
+    expect(composeFullMarkdown(false, { title: 'x' }, '# Body\n')).toBe('# Body\n')
+  })
+
+  it('composeFullMarkdown rejoins when FM present', () => {
+    const full = composeFullMarkdown(true, { title: 'Hi' }, '# Body\n')
+    expect(full).not.toBeNull()
+    expect(full).toContain('title: Hi')
+    expect(full!.endsWith('# Body\n')).toBe(true)
+  })
+})
+
+describe('scalar helpers', () => {
+  it('formatFrontmatterValue and parseScalarInput round-trip common scalars', () => {
+    expect(formatFrontmatterValue(null)).toBe('null')
+    expect(formatFrontmatterValue(true)).toBe('true')
+    expect(formatFrontmatterValue(42)).toBe('42')
+    expect(formatFrontmatterValue('hi')).toBe('hi')
+
+    expect(parseScalarInput('null')).toBe(null)
+    expect(parseScalarInput('true')).toBe(true)
+    expect(parseScalarInput('false')).toBe(false)
+    expect(parseScalarInput('3.5')).toBe(3.5)
+    expect(parseScalarInput('42')).toBe(42)
+    expect(parseScalarInput('hello')).toBe('hello')
+  })
+
+  it('preserves leading-zero digit strings as strings', () => {
+    expect(parseScalarInput('007')).toBe('007')
+    expect(parseScalarInput('00')).toBe('00')
+    expect(parseScalarInput('0')).toBe(0)
+    expect(parseScalarInput('0.5')).toBe(0.5)
+  })
+})

--- a/src/renderer/lib/markdown-frontmatter.ts
+++ b/src/renderer/lib/markdown-frontmatter.ts
@@ -1,0 +1,221 @@
+import { parse, stringify } from 'yaml'
+
+/** Editable scalar / list values for Properties v1. */
+export type FrontmatterScalar = string | number | boolean | null
+export type FrontmatterEditableValue = FrontmatterScalar | string[]
+
+/**
+ * Nested maps/sequences that are not deep-editable in v1.
+ * Preserved through round-trip via `value`; shown via compact `display`.
+ */
+export interface FrontmatterNested {
+  readonly kind: 'nested'
+  readonly display: string
+  readonly value: unknown
+}
+
+export type FrontmatterValue = FrontmatterEditableValue | FrontmatterNested
+export type FrontmatterMap = Record<string, FrontmatterValue>
+
+export interface ParsedFrontmatter {
+  hasFrontmatter: boolean
+  data: FrontmatterMap
+  body: string
+}
+
+export function isFrontmatterNested(value: FrontmatterValue): value is FrontmatterNested {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    !Array.isArray(value) &&
+    (value as FrontmatterNested).kind === 'nested'
+  )
+}
+
+function compactYaml(value: unknown): string {
+  try {
+    return stringify(value, { lineWidth: 0 }).trim()
+  } catch {
+    try {
+      return JSON.stringify(value)
+    } catch {
+      return String(value)
+    }
+  }
+}
+
+function wrapNested(value: unknown): FrontmatterNested {
+  return {
+    kind: 'nested',
+    display: compactYaml(value),
+    value
+  }
+}
+
+/** Normalize a raw YAML value into the v1 Properties value model. */
+export function normalizeFrontmatterValue(raw: unknown): FrontmatterValue {
+  if (raw === null || raw === undefined) {
+    return null
+  }
+  if (typeof raw === 'string' || typeof raw === 'number' || typeof raw === 'boolean') {
+    return raw
+  }
+  if (Array.isArray(raw)) {
+    if (raw.every((item) => typeof item === 'string')) {
+      return raw as string[]
+    }
+    return wrapNested(raw)
+  }
+  if (typeof raw === 'object') {
+    return wrapNested(raw)
+  }
+  return wrapNested(raw)
+}
+
+function normalizeMap(raw: Record<string, unknown>): FrontmatterMap {
+  const data: FrontmatterMap = {}
+  for (const [key, value] of Object.entries(raw)) {
+    data[key] = normalizeFrontmatterValue(value)
+  }
+  return data
+}
+
+function toPlainObject(data: FrontmatterMap): Record<string, unknown> {
+  const plain: Record<string, unknown> = {}
+  for (const [key, value] of Object.entries(data)) {
+    plain[key] = isFrontmatterNested(value) ? value.value : value
+  }
+  return plain
+}
+
+function stripBom(text: string): string {
+  return text.charCodeAt(0) === 0xfeff ? text.slice(1) : text
+}
+
+/**
+ * Detect and split a leading YAML frontmatter block.
+ * Invalid YAML between fences or a missing closing fence → no frontmatter
+ * (full text returned as body).
+ */
+export function splitFrontmatter(text: string): ParsedFrontmatter {
+  const source = stripBom(text)
+  const noFrontmatter: ParsedFrontmatter = {
+    hasFrontmatter: false,
+    data: {},
+    body: text
+  }
+
+  const openMatch = /^---\r?\n/.exec(source)
+  if (!openMatch) {
+    return noFrontmatter
+  }
+
+  const yamlStart = openMatch[0].length
+  const afterOpen = source.slice(yamlStart)
+
+  let yamlText: string
+  let body: string
+
+  const emptyClose = /^---(?:\r?\n|$)/.exec(afterOpen)
+  if (emptyClose) {
+    yamlText = ''
+    body = afterOpen.slice(emptyClose[0].length)
+  } else {
+    const closeMatch = /\r?\n---(?:\r?\n|$)/.exec(afterOpen)
+    if (!closeMatch || closeMatch.index === undefined) {
+      return noFrontmatter
+    }
+    yamlText = afterOpen.slice(0, closeMatch.index)
+    body = afterOpen.slice(closeMatch.index + closeMatch[0].length)
+  }
+
+  try {
+    const trimmed = yamlText.trim()
+    if (trimmed === '') {
+      return { hasFrontmatter: true, data: {}, body }
+    }
+
+    const parsed: unknown = parse(yamlText)
+    if (parsed === null || parsed === undefined) {
+      return { hasFrontmatter: true, data: {}, body }
+    }
+    if (typeof parsed !== 'object' || Array.isArray(parsed)) {
+      return noFrontmatter
+    }
+
+    return {
+      hasFrontmatter: true,
+      data: normalizeMap(parsed as Record<string, unknown>),
+      body
+    }
+  } catch {
+    return noFrontmatter
+  }
+}
+
+/**
+ * Serialize a Properties map to a leading `---` … `---` frontmatter block.
+ * Returns `null` when YAML stringify fails so callers can keep last-good content.
+ */
+export function serializeFrontmatter(data: FrontmatterMap): string | null {
+  try {
+    const plain = toPlainObject(data)
+    const keys = Object.keys(plain)
+    if (keys.length === 0) {
+      return '---\n---\n'
+    }
+    const yamlText = stringify(plain, { lineWidth: 0 }).trimEnd()
+    return `---\n${yamlText}\n---\n`
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Rejoin serialized frontmatter with the markdown body.
+ * Returns `null` when serialization fails.
+ */
+export function rejoinFrontmatter(data: FrontmatterMap, body: string): string | null {
+  const fm = serializeFrontmatter(data)
+  if (fm === null) return null
+  return fm + body
+}
+
+/**
+ * Compose the full editor-store buffer from FM state + body.
+ * Returns `null` on serialize failure (caller should keep last-good content).
+ */
+export function composeFullMarkdown(
+  hasFrontmatter: boolean,
+  data: FrontmatterMap,
+  body: string
+): string | null {
+  if (!hasFrontmatter) return body
+  return rejoinFrontmatter(data, body)
+}
+
+/** Format an editable value for a text input. */
+export function formatFrontmatterValue(value: FrontmatterEditableValue): string {
+  if (value === null) return 'null'
+  if (typeof value === 'boolean' || typeof value === 'number') return String(value)
+  if (Array.isArray(value)) return value.join(', ')
+  return value
+}
+
+/**
+ * Parse a committed text-field value into a scalar (or keep as string).
+ * Call on blur/commit — not on every keystroke.
+ * Leading-zero digit strings (e.g. "007") stay strings.
+ */
+export function parseScalarInput(text: string): FrontmatterScalar {
+  const trimmed = text.trim()
+  if (trimmed === 'null') return null
+  if (trimmed === 'true') return true
+  if (trimmed === 'false') return false
+  // Preserve leading-zero integers as strings ("007"), but allow "0" / "0.5".
+  if (/^-?0\d/.test(trimmed)) return text
+  if (trimmed !== '' && !Number.isNaN(Number(trimmed)) && /^-?\d+(\.\d+)?$/.test(trimmed)) {
+    return Number(trimmed)
+  }
+  return text
+}


### PR DESCRIPTION
## Summary

Markdown files with YAML frontmatter lose metadata in WYSIWYG mode because BlockNote receives the whole file and `blocksToMarkdownLossy` drops or mangles the leading `---` block on edit/save.

This PR strips valid frontmatter before BlockNote, renders an editable Properties panel aligned with the editor body column, and rejoins FM + body on every emit/flush so Source mode and save keep the full file.

## Related Issue

No related issue — motivated by BMAD-style .md specs losing YAML metadata after the first WYSIWYG edit/save.

Searched existing PRs for frontmatter/Properties markdown editor work; no open duplicate targeting this problem.

## Type of Change

- [x] feat: new feature
- [ ] fix: bug fix
- [ ] docs: documentation only
- [ ] style: formatting or non-functional styling changes
- [ ] refactor: internal cleanup with no behavior change
- [ ] perf: performance improvement
- [ ] test: adds or updates tests
- [ ] build: build or dependency changes
- [ ] ci: CI/CD workflow changes
- [ ] chore: maintenance or tooling
- [ ] revert: reverts a previous change

## What Changed

- Added `yaml` dependency and `markdown-frontmatter` parse/split/serialize/rejoin helpers with unit tests (happy path, no FM, invalid YAML, missing close fence, arrays, BOM, scalar coerce rules).
- Added editable `FrontmatterProperties` UI (icons, pills for string arrays, add/remove property) with padding matched to BlockNote `.bn-editor` (`54px`).
- Wired `MarkdownEditor` to own FM state, pass body-only into BlockNote, rejoin on body/FM/flush; added `capturePendingContent` on `use-blocknote` to avoid double-emit races.
- Host + UI regression tests for strip/rejoin/flush and Properties validation.

## How It Was Tested

- [x] `bun run ci` (Biome lint + format + imports, strict mode)
- [x] `bun run typecheck`
- [x] `bun run test`
- [ ] `cargo clippy --all-targets -- -D warnings` (in src-tauri)
- [ ] `cargo test` (in src-tauri)
- [x] Manual verification completed
- [ ] Not applicable

Notes: Frontend-only change; Rust checks N/A for this diff. Ran focused frontmatter/host/UI tests plus full typecheck and biome on touched files during implementation. Manual: open `.md` with FM in markdown view, edit Properties/body, toggle Source, save/reopen.

## Screenshots or Recordings

N/A in CI text — Properties panel sits above BlockNote body with matching horizontal inset (`padding-inline: 54px`).

## CI & Review Gate

- [ ] All CI checks pass (PR Validation, Rust Checks, Build Verification, Security Scans)
- [ ] Code review comments from CodeRabbit / Claude have been addressed or resolved
- [ ] No unresolved review findings remain

## Checklist

- [x] My PR title follows the conventional commit format used by this repo
- [x] I linked the related issue or explained why none exists
- [x] I updated docs when needed
- [x] I added or updated tests when needed
- [x] I verified the change does not introduce unrelated modifications
- [x] I read AGENTS.md and followed the contributor guidelines
- [x] A human reviewed the complete diff before submission

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added YAML frontmatter splitting, parsing, and rejoining for Markdown documents.
  - Introduced a frontmatter editor UI for scalar, array (with item removal), and nested (read-only) values, including add/remove workflows.
  - Updated the editor to synchronize and emit full document content (frontmatter + body) when frontmatter or body changes.
- **Bug Fixes**
  - Improved handling of malformed/empty frontmatter, including BOM/malformed-fence cases and preserving special scalar formats (e.g., leading-zero digit strings).
- **Tests**
  - Added/expanded unit and integration tests for frontmatter parsing/serialization and editor/frontmatter synchronization.
- **Chores**
  - Added a production `yaml` dependency.
  - Updated agent wrapper versions and related download/archive details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->