### PR TITLE
fix(acp): dedupe duplicate Thinking selector (pi ACP modes + config)

### DIFF
--- a/src/renderer/components/agents/AgentLauncher.test.tsx
+++ b/src/renderer/components/agents/AgentLauncher.test.tsx
@@ -400,6 +400,59 @@ describe('AgentLauncher ACP new thread', () => {
     expect(mockSetConfigOption).not.toHaveBeenCalled()
   }, 10000)
 
+  it('hides ModeChip when session.modes duplicates thought_level (pi-acp)', async () => {
+    const key = 'acp-registry:claude-acp\0/work\0'
+    const session = preparedSession(ACP_CONFIG, [
+      { value: 'm1', name: 'Model One' },
+      { value: 'm2', name: 'Model Two' }
+    ])
+    session.modes = {
+      currentModeId: 'off',
+      availableModes: [
+        { id: 'off', name: 'Thinking: off' },
+        { id: 'low', name: 'Thinking: low' },
+        { id: 'medium', name: 'Thinking: medium' }
+      ]
+    }
+    session.configOptions = [
+      {
+        id: 'model',
+        name: 'Model',
+        category: 'model',
+        type: 'select',
+        currentValue: 'm1',
+        options: [
+          { value: 'm1', name: 'Model One' },
+          { value: 'm2', name: 'Model Two' }
+        ]
+      },
+      {
+        id: 'thought_level',
+        name: 'Thinking',
+        category: 'thought_level',
+        type: 'select',
+        currentValue: 'off',
+        options: [
+          { value: 'off', name: 'Thinking: off' },
+          { value: 'low', name: 'Thinking: low' },
+          { value: 'medium', name: 'Thinking: medium' }
+        ]
+      }
+    ]
+    acpStateRef.current.agentConfigs = [ACP_CONFIG]
+    mockPersistRead.mockResolvedValue({
+      success: true,
+      data: { agentId: 'acp-registry:claude-acp', mode: 'acp' }
+    })
+    acpStateRef.current.preparedSessions = { [key]: 'prepared-1' }
+    acpStateRef.current.sessions = { 'prepared-1': session }
+    renderLauncher()
+
+    expect(await screen.findByRole('button', { name: 'Thinking: off' })).toBeInTheDocument()
+    expect(screen.getAllByRole('button', { name: 'Thinking: off' })).toHaveLength(1)
+    expect(screen.queryByRole('button', { name: /^Agent$/ })).not.toBeInTheDocument()
+  }, 10000)
+
   it('shows optimistic model label and pending spinner while setConfigOption is in flight', async () => {
     const key = 'acp-registry:claude-acp\0/work\0'
     let resolveConfig!: () => void

--- a/src/renderer/components/agents/AgentLauncher.tsx
+++ b/src/renderer/components/agents/AgentLauncher.tsx
@@ -11,6 +11,7 @@ import { ComposerPill } from '@/components/chat/ComposerPill'
 import { attachmentToBlock } from '@/components/chat/chat-attachments'
 import {
   filterDuplicateModeConfigOptions,
+  modesRedundantWithThoughtLevel,
   partitionConfigOptions,
   resolveModelOption
 } from '@/components/chat/chat-input-bar-config'
@@ -190,10 +191,13 @@ export function AgentLauncher({ paneId, className }: AgentLauncherProps): React.
     model,
     draftSession?.models
   )
+  const draftModes = draftSession?.modes ?? null
   const visibleGenericConfigOptions = filterDuplicateModeConfigOptions(
     genericConfigOptions,
-    draftSession?.modes ?? null
+    draftModes
   )
+  const showModeChip =
+    Boolean(draftSession) && !modesRedundantWithThoughtLevel(draftModes, thoughtLevel)
   const menuOpen = isSlashTrigger(prompt)
   const {
     onInput,
@@ -715,7 +719,7 @@ export function AgentLauncher({ paneId, className }: AgentLauncherProps): React.
                     onSelect={(valueId) => handleSetConfig(option.id, valueId)}
                   />
                 ))}
-                {draftSession && (
+                {showModeChip && draftSession && (
                   <ModeChip
                     session={draftSession}
                     disabled={false}

--- a/src/renderer/components/chat/ChatInputBar.tsx
+++ b/src/renderer/components/chat/ChatInputBar.tsx
@@ -34,6 +34,7 @@ import { ContextUsageIndicator } from './ContextUsageIndicator'
 import { attachmentToBlock, dedupeAttachmentBlocks } from './chat-attachments'
 import {
   filterDuplicateModeConfigOptions,
+  modesRedundantWithThoughtLevel,
   partitionConfigOptions,
   resolveModelOption
 } from './chat-input-bar-config'
@@ -129,6 +130,7 @@ export function ChatInputBar({
   } = partitionConfigOptions(usableConfigOptions)
   const { option: modelOption, source: modelSource } = resolveModelOption(model, session.models)
   const visibleGenericConfigOptions = filterDuplicateModeConfigOptions(genericConfigOptions, modes)
+  const showModeChip = !modesRedundantWithThoughtLevel(modes, thoughtLevel)
   const { skills } = useAgentSkills(projectRoot ?? session.cwd)
   const sessionUsage = useSessionUsage(session.id)
   const messages = useAcpMessages(session.id)
@@ -484,12 +486,14 @@ export function ChatInputBar({
                     ))}
                   </>
                 ) : null}
-                <ModeChip
-                  session={session}
-                  disabled={disabled}
-                  onSelect={onSetMode}
-                  label="Agent"
-                />
+                {showModeChip ? (
+                  <ModeChip
+                    session={session}
+                    disabled={disabled}
+                    onSelect={onSetMode}
+                    label="Agent"
+                  />
+                ) : null}
               </div>
               <div className="flex shrink-0 items-center gap-2">
                 <ContextUsageIndicator usage={sessionUsage} messages={messages} />

--- a/src/renderer/components/chat/chat-input-bar-config.test.ts
+++ b/src/renderer/components/chat/chat-input-bar-config.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from 'vitest'
 import type { SessionConfigOption, SessionModeState } from '@/lib/acp-api'
-import { filterDuplicateModeConfigOptions, partitionConfigOptions } from './chat-input-bar-config'
+import {
+  filterDuplicateModeConfigOptions,
+  partitionConfigOptions,
+  shouldAdvertiseConfigOption
+} from './chat-input-bar-config'
 
 function opt(id: string, category: string | null): SessionConfigOption {
   return {
@@ -57,22 +61,50 @@ describe('partitionConfigOptions', () => {
     expect(result.rest).toEqual([custom])
   })
 
-  it('promotes only the first thought_level option, rest keeps the others', () => {
+  it('promotes only the first thought_level option and discards later duplicates', () => {
     const tl1 = opt('reasoning1', 'thought_level')
     const tl2 = opt('reasoning2', 'thought_level')
     const result = partitionConfigOptions([tl1, tl2])
     expect(result.model).toBeNull()
     expect(result.thoughtLevel).toBe(tl1)
-    expect(result.rest).toEqual([tl2])
+    expect(result.rest).toEqual([])
   })
 
-  it('promotes only the first model option, rest keeps the others', () => {
+  it('promotes only the first model option and discards later duplicates', () => {
     const model1 = opt('model1', 'model')
     const model2 = opt('model2', 'model')
     const result = partitionConfigOptions([model1, model2])
     expect(result.model).toBe(model1)
     expect(result.thoughtLevel).toBeNull()
-    expect(result.rest).toEqual([model2])
+    expect(result.rest).toEqual([])
+  })
+
+  it('keeps non-singleton categories in rest alongside promoted chips', () => {
+    const model1 = opt('model1', 'model')
+    const model2 = opt('model2', 'model')
+    const tl1 = opt('reasoning1', 'thought_level')
+    const tl2 = opt('reasoning2', 'thought_level')
+    const custom = opt('custom', 'something-new')
+    const result = partitionConfigOptions([model1, tl1, custom, model2, tl2])
+    expect(result.model).toBe(model1)
+    expect(result.thoughtLevel).toBe(tl1)
+    expect(result.rest).toEqual([custom])
+  })
+})
+
+describe('shouldAdvertiseConfigOption', () => {
+  it('accepts the first promoted singleton and rejects later ones', () => {
+    const seen = new Set<string>()
+    expect(shouldAdvertiseConfigOption(opt('tl1', 'thought_level'), seen)).toBe(true)
+    expect(shouldAdvertiseConfigOption(opt('tl2', 'thought_level'), seen)).toBe(false)
+    expect(shouldAdvertiseConfigOption(opt('model1', 'model'), seen)).toBe(true)
+    expect(shouldAdvertiseConfigOption(opt('model2', 'model'), seen)).toBe(false)
+  })
+
+  it('always accepts uncategorized and non-singleton options', () => {
+    const seen = new Set<string>(['thought_level'])
+    expect(shouldAdvertiseConfigOption(opt('mode', 'mode'), seen)).toBe(true)
+    expect(shouldAdvertiseConfigOption(opt('custom', null), seen)).toBe(true)
   })
 })
 

--- a/src/renderer/components/chat/chat-input-bar-config.test.ts
+++ b/src/renderer/components/chat/chat-input-bar-config.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest'
 import type { SessionConfigOption, SessionModeState } from '@/lib/acp-api'
 import {
   filterDuplicateModeConfigOptions,
+  modesRedundantWithThoughtLevel,
   partitionConfigOptions,
   shouldAdvertiseConfigOption
 } from './chat-input-bar-config'
@@ -126,5 +127,54 @@ describe('filterDuplicateModeConfigOptions', () => {
     const mode = opt('mode', 'mode')
     const custom = opt('custom', 'custom')
     expect(filterDuplicateModeConfigOptions([mode, custom], modes)).toEqual([custom])
+  })
+})
+
+describe('modesRedundantWithThoughtLevel', () => {
+  const thoughtLevel: SessionConfigOption = {
+    id: 'thought_level',
+    name: 'Thinking',
+    category: 'thought_level',
+    type: 'select',
+    currentValue: 'off',
+    description: null,
+    options: [
+      { value: 'off', name: 'Thinking: off', description: null },
+      { value: 'low', name: 'Thinking: low', description: null },
+      { value: 'medium', name: 'Thinking: medium', description: null }
+    ]
+  }
+
+  it('detects pi-acp dual-published thinking modes', () => {
+    const modes: SessionModeState = {
+      currentModeId: 'off',
+      availableModes: [
+        { id: 'off', name: 'Thinking: off' },
+        { id: 'low', name: 'Thinking: low' },
+        { id: 'medium', name: 'Thinking: medium' }
+      ]
+    }
+    expect(modesRedundantWithThoughtLevel(modes, thoughtLevel)).toBe(true)
+  })
+
+  it('keeps real agent/plan modes alongside thought_level', () => {
+    const modes: SessionModeState = {
+      currentModeId: 'agent',
+      availableModes: [
+        { id: 'agent', name: 'Agent' },
+        { id: 'plan', name: 'Plan' }
+      ]
+    }
+    expect(modesRedundantWithThoughtLevel(modes, thoughtLevel)).toBe(false)
+  })
+
+  it('returns false when either side is missing', () => {
+    expect(modesRedundantWithThoughtLevel(null, thoughtLevel)).toBe(false)
+    expect(
+      modesRedundantWithThoughtLevel(
+        { currentModeId: 'off', availableModes: [{ id: 'off', name: 'Thinking: off' }] },
+        null
+      )
+    ).toBe(false)
   })
 })

--- a/src/renderer/components/chat/chat-input-bar-config.ts
+++ b/src/renderer/components/chat/chat-input-bar-config.ts
@@ -120,3 +120,19 @@ export function filterDuplicateModeConfigOptions(
   if (!modes || modes.availableModes.length === 0) return options
   return options.filter((option) => option.category !== MODE_CATEGORY)
 }
+
+/**
+ * True when `session.modes` is the same control as a `thought_level` config
+ * option (every mode id is also a thought_level value). pi-acp dual-publishes
+ * thinking this way — prefer the promoted Thinking chip and hide ModeChip
+ * (issue #444). Real agent/plan/ask modes do not match and still render.
+ */
+export function modesRedundantWithThoughtLevel(
+  modes: SessionModeState | null | undefined,
+  thoughtLevel: SessionConfigOption | null
+): boolean {
+  if (!modes || modes.availableModes.length === 0 || !thoughtLevel) return false
+  if (thoughtLevel.options.length === 0) return false
+  const thoughtValues = new Set(thoughtLevel.options.map((option) => option.value))
+  return modes.availableModes.every((mode) => thoughtValues.has(mode.id))
+}

--- a/src/renderer/components/chat/chat-input-bar-config.ts
+++ b/src/renderer/components/chat/chat-input-bar-config.ts
@@ -14,6 +14,17 @@ export const MODEL_CATEGORY = 'model'
 /** ACP semantic category for session mode config options. */
 export const MODE_CATEGORY = 'mode'
 
+/**
+ * Categories that map to a single promoted UI control. Agents may advertise
+ * multiple options with the same category; clients keep the first (ACP array
+ * order) and discard the rest so the composer does not show duplicate chips
+ * (issue #444).
+ */
+export const PROMOTED_SINGLETON_CATEGORIES = new Set<string>([
+  MODEL_CATEGORY,
+  THOUGHT_LEVEL_CATEGORY
+])
+
 export interface PartitionedConfigOptions {
   /** The first `model` option, if the agent advertises one. */
   model: SessionConfigOption | null
@@ -29,16 +40,35 @@ export interface ResolvedModelOption {
 }
 
 /**
+ * First-wins gate for promoted singleton categories (`model`, `thought_level`).
+ * Mutates `seenPromotedCategories` when accepting the first option of a
+ * category. Non-singleton / uncategorized options always pass through.
+ */
+export function shouldAdvertiseConfigOption(
+  option: Pick<SessionConfigOption, 'category'>,
+  seenPromotedCategories: Set<string>
+): boolean {
+  const category = option.category
+  if (!category || !PROMOTED_SINGLETON_CATEGORIES.has(category)) return true
+  if (seenPromotedCategories.has(category)) return false
+  seenPromotedCategories.add(category)
+  return true
+}
+
+/**
  * Split usable config options into promoted `model` / `thought_level` options
  * (first match wins for each) and the rest, preserving the rest's original
- * order. Options with an unknown/other category fall through to `rest` and
- * render as plain chips.
+ * order. Later options that share a promoted singleton category are discarded
+ * rather than falling through to `rest`. Unknown/other categories still render
+ * as plain chips.
  */
 export function partitionConfigOptions(options: SessionConfigOption[]): PartitionedConfigOptions {
   let model: SessionConfigOption | null = null
   let thoughtLevel: SessionConfigOption | null = null
   const rest: SessionConfigOption[] = []
+  const seenPromotedCategories = new Set<string>()
   for (const option of options) {
+    if (!shouldAdvertiseConfigOption(option, seenPromotedCategories)) continue
     if (model === null && option.category === MODEL_CATEGORY) {
       model = option
     } else if (thoughtLevel === null && option.category === THOUGHT_LEVEL_CATEGORY) {

--- a/src/renderer/components/chat/slash-menu-model.test.ts
+++ b/src/renderer/components/chat/slash-menu-model.test.ts
@@ -139,4 +139,64 @@ describe('buildSlashSections', () => {
       buildSlashSections({ commands: [], configOptions: [], modes: null, filter: '' })
     ).toEqual([])
   })
+
+  it('keeps only the first model and thought_level config sections', () => {
+    const duplicateOptions: SessionConfigOption[] = [
+      {
+        id: 'model-a',
+        name: 'Model A',
+        category: 'model',
+        type: 'select',
+        currentValue: 'm1',
+        description: null,
+        options: [{ value: 'm1', name: 'Sonnet', description: null }]
+      },
+      {
+        id: 'thinking-a',
+        name: 'Thinking A',
+        category: 'thought_level',
+        type: 'select',
+        currentValue: 'off',
+        description: null,
+        options: [{ value: 'off', name: 'off', description: null }]
+      },
+      {
+        id: 'model-b',
+        name: 'Model B',
+        category: 'model',
+        type: 'select',
+        currentValue: 'm2',
+        description: null,
+        options: [{ value: 'm2', name: 'Opus', description: null }]
+      },
+      {
+        id: 'thinking-b',
+        name: 'Thinking B',
+        category: 'thought_level',
+        type: 'select',
+        currentValue: 'off',
+        description: null,
+        options: [{ value: 'off', name: 'off', description: null }]
+      },
+      {
+        id: 'custom',
+        name: 'Custom',
+        category: 'something-new',
+        type: 'select',
+        currentValue: 'x',
+        description: null,
+        options: [{ value: 'x', name: 'X', description: null }]
+      }
+    ]
+    const sections = buildSlashSections({
+      commands: [],
+      configOptions: duplicateOptions,
+      modes: null,
+      filter: ''
+    })
+    const ids = sections.map((s) => s.id)
+    expect(ids).toEqual(['config:model-a', 'config:thinking-a', 'config:custom'])
+    expect(ids).not.toContain('config:model-b')
+    expect(ids).not.toContain('config:thinking-b')
+  })
 })

--- a/src/renderer/components/chat/slash-menu-model.ts
+++ b/src/renderer/components/chat/slash-menu-model.ts
@@ -11,6 +11,7 @@ import type {
   SessionModeState
 } from '@/lib/acp-api'
 import type { AgentSkillSummary } from '@/lib/skills-api'
+import { shouldAdvertiseConfigOption } from './chat-input-bar-config'
 
 export interface SlashCommandItem {
   kind: 'command'
@@ -111,7 +112,11 @@ export function buildSlashSections(input: SlashMenuInput): SlashSection[] {
   }
 
   if (configOptions.length > 0) {
+    const seenPromotedCategories = new Set<string>()
     for (const option of configOptions) {
+      // Keep slash sections aligned with the composer chip row: one section per
+      // promoted singleton category (`model` / `thought_level`), first-wins.
+      if (!shouldAdvertiseConfigOption(option, seenPromotedCategories)) continue
       const items: SlashItem[] = option.options
         .filter((v) => matches(filter, v.name, v.description, option.name))
         .map((v) => ({

--- a/src/renderer/stores/acp-store.test.ts
+++ b/src/renderer/stores/acp-store.test.ts
@@ -239,6 +239,182 @@ describe('acp-store', () => {
     expect(useAcpStore.getState().sessions['s1'].models?.currentModelId).toBe('openrouter/gpt-5.5')
   })
 
+  it('setConfigOption dual-writes set_mode when modes duplicate thought_level (pi-acp)', async () => {
+    const thoughtOptions = [
+      { value: 'off', name: 'Thinking: off', description: null },
+      { value: 'low', name: 'Thinking: low', description: null },
+      { value: 'xhigh', name: 'Thinking: xhigh', description: null }
+    ]
+    seedSession('s1', 'agent-1', false)
+    useAcpStore.setState((s) => ({
+      sessions: {
+        ...s.sessions,
+        s1: {
+          ...s.sessions['s1'],
+          modes: {
+            currentModeId: 'off',
+            availableModes: [
+              { id: 'off', name: 'Thinking: off' },
+              { id: 'low', name: 'Thinking: low' },
+              { id: 'xhigh', name: 'Thinking: xhigh' }
+            ]
+          },
+          configOptions: [
+            {
+              id: 'thought_level',
+              name: 'Thinking',
+              category: 'thought_level',
+              type: 'select',
+              currentValue: 'off',
+              description: null,
+              options: thoughtOptions
+            }
+          ]
+        }
+      }
+    }))
+    ;(invoke as ReturnType<typeof vi.fn>).mockImplementation(async (cmd: string) => {
+      if (cmd === 'acp_set_config_option') {
+        return [
+          {
+            id: 'thought_level',
+            name: 'Thinking',
+            category: 'thought_level',
+            type: 'select',
+            currentValue: 'xhigh',
+            description: null,
+            options: thoughtOptions
+          }
+        ]
+      }
+      if (cmd === 'acp_set_mode') return undefined
+      throw new Error(`unexpected invoke: ${cmd}`)
+    })
+
+    await useAcpStore.getState().setConfigOption('s1', 'thought_level', 'xhigh')
+
+    expect(invoke).toHaveBeenCalledWith('acp_set_config_option', {
+      agentId: 'agent-1',
+      sessionId: 's1',
+      configId: 'thought_level',
+      valueId: 'xhigh'
+    })
+    expect(invoke).toHaveBeenCalledWith('acp_set_mode', {
+      agentId: 'agent-1',
+      sessionId: 's1',
+      modeId: 'xhigh'
+    })
+    const session = useAcpStore.getState().sessions['s1']
+    expect(session.configOptions[0]?.currentValue).toBe('xhigh')
+    expect(session.modes?.currentModeId).toBe('xhigh')
+  })
+
+  it('setConfigOption does not call set_mode for real agent/plan modes', async () => {
+    const thoughtOptions = [
+      { value: 'off', name: 'Thinking: off', description: null },
+      { value: 'xhigh', name: 'Thinking: xhigh', description: null }
+    ]
+    seedSession('s1', 'agent-1', false)
+    useAcpStore.setState((s) => ({
+      sessions: {
+        ...s.sessions,
+        s1: {
+          ...s.sessions['s1'],
+          modes: {
+            currentModeId: 'agent',
+            availableModes: [
+              { id: 'agent', name: 'Agent' },
+              { id: 'plan', name: 'Plan' }
+            ]
+          },
+          configOptions: [
+            {
+              id: 'thought_level',
+              name: 'Thinking',
+              category: 'thought_level',
+              type: 'select',
+              currentValue: 'off',
+              description: null,
+              options: thoughtOptions
+            }
+          ]
+        }
+      }
+    }))
+    ;(invoke as ReturnType<typeof vi.fn>).mockImplementation(async (cmd: string) => {
+      if (cmd === 'acp_set_config_option') {
+        return [
+          {
+            id: 'thought_level',
+            name: 'Thinking',
+            category: 'thought_level',
+            type: 'select',
+            currentValue: 'xhigh',
+            description: null,
+            options: thoughtOptions
+          }
+        ]
+      }
+      throw new Error(`unexpected invoke: ${cmd}`)
+    })
+
+    await useAcpStore.getState().setConfigOption('s1', 'thought_level', 'xhigh')
+
+    expect(invoke).toHaveBeenCalledWith('acp_set_config_option', {
+      agentId: 'agent-1',
+      sessionId: 's1',
+      configId: 'thought_level',
+      valueId: 'xhigh'
+    })
+    expect(invoke).not.toHaveBeenCalledWith('acp_set_mode', expect.anything())
+    expect(useAcpStore.getState().sessions['s1'].modes?.currentModeId).toBe('agent')
+  })
+
+  it('setMode patches thought_level when modes duplicate thinking (pi-acp)', async () => {
+    seedSession('s1', 'agent-1', false)
+    useAcpStore.setState((s) => ({
+      sessions: {
+        ...s.sessions,
+        s1: {
+          ...s.sessions['s1'],
+          modes: {
+            currentModeId: 'off',
+            availableModes: [
+              { id: 'off', name: 'Thinking: off' },
+              { id: 'xhigh', name: 'Thinking: xhigh' }
+            ]
+          },
+          configOptions: [
+            {
+              id: 'thought_level',
+              name: 'Thinking',
+              category: 'thought_level',
+              type: 'select',
+              currentValue: 'off',
+              description: null,
+              options: [
+                { value: 'off', name: 'Thinking: off', description: null },
+                { value: 'xhigh', name: 'Thinking: xhigh', description: null }
+              ]
+            }
+          ]
+        }
+      }
+    }))
+    ;(invoke as ReturnType<typeof vi.fn>).mockResolvedValue(undefined)
+
+    await useAcpStore.getState().setMode('s1', 'xhigh')
+
+    expect(invoke).toHaveBeenCalledWith('acp_set_mode', {
+      agentId: 'agent-1',
+      sessionId: 's1',
+      modeId: 'xhigh'
+    })
+    const session = useAcpStore.getState().sessions['s1']
+    expect(session.modes?.currentModeId).toBe('xhigh')
+    expect(session.configOptions[0]?.currentValue).toBe('xhigh')
+  })
+
   it('sendPrompt appends a user message and marks the turn active', async () => {
     seedSession('s1', 'agent-1', false)
     // never resolve, so the turn stays active for the assertion

--- a/src/renderer/stores/acp-store.ts
+++ b/src/renderer/stores/acp-store.ts
@@ -14,6 +14,10 @@ import { toast } from 'sonner'
 import { create } from 'zustand'
 import { useShallow } from 'zustand/shallow'
 import {
+  modesRedundantWithThoughtLevel,
+  THOUGHT_LEVEL_CATEGORY
+} from '@/components/chat/chat-input-bar-config'
+import {
   loadAgentConfigs as loadAgentConfigsFromDisk,
   type StoredAgentConfig,
   saveAgentConfigs as saveAgentConfigsToDisk
@@ -2139,9 +2143,47 @@ export const useAcpStore = create<AcpState>((set, get) => ({
     const session = get().sessions[sessionId]
     if (!session) throw new Error(`unknown session ${sessionId}`)
     const updated = await acpApi.setConfigOption(session.agentId, sessionId, configId, valueId)
-    set((s) => ({
-      sessions: { ...s.sessions, [sessionId]: { ...s.sessions[sessionId], configOptions: updated } }
-    }))
+
+    // pi-acp dual-publishes thinking as thought_level + session.modes. After we
+    // hide ModeChip, Thinking only writes set_config_option — keep modes in
+    // sync so a later agent rebuild from modes does not snap the chip back to
+    // "off" (e.g. launcher xhigh → running ChatInputBar shows off).
+    const thoughtLevel =
+      updated.find((option) => option.category === THOUGHT_LEVEL_CATEGORY) ??
+      session.configOptions.find((option) => option.category === THOUGHT_LEVEL_CATEGORY) ??
+      null
+    const shouldSyncMode =
+      thoughtLevel?.id === configId &&
+      modesRedundantWithThoughtLevel(session.modes, thoughtLevel) &&
+      Boolean(session.modes?.availableModes.some((mode) => mode.id === valueId))
+
+    let modeSynced = false
+    if (shouldSyncMode) {
+      try {
+        await acpApi.setMode(session.agentId, sessionId, valueId)
+        modeSynced = true
+      } catch {
+        // Config write already succeeded; do not fail the Thinking chip on
+        // set_mode errors.
+      }
+    }
+
+    set((s) => {
+      const current = s.sessions[sessionId]
+      if (!current) return {}
+      return {
+        sessions: {
+          ...s.sessions,
+          [sessionId]: {
+            ...current,
+            configOptions: updated,
+            ...(modeSynced && current.modes
+              ? { modes: { ...current.modes, currentModeId: valueId } }
+              : {})
+          }
+        }
+      }
+    })
   },
 
   setMode: async (sessionId, modeId) => {
@@ -2151,12 +2193,24 @@ export const useAcpStore = create<AcpState>((set, get) => ({
     set((s) => {
       const current = s.sessions[sessionId]
       if (!current?.modes) return {}
+      const thoughtLevel =
+        current.configOptions.find((option) => option.category === THOUGHT_LEVEL_CATEGORY) ?? null
+      const syncThought =
+        modesRedundantWithThoughtLevel(current.modes, thoughtLevel) &&
+        Boolean(thoughtLevel?.options.some((option) => option.value === modeId))
       return {
         sessions: {
           ...s.sessions,
           [sessionId]: {
             ...current,
-            modes: { ...current.modes, currentModeId: modeId }
+            modes: { ...current.modes, currentModeId: modeId },
+            ...(syncThought && thoughtLevel
+              ? {
+                  configOptions: current.configOptions.map((option) =>
+                    option.id === thoughtLevel.id ? { ...option, currentValue: modeId } : option
+                  )
+                }
+              : {})
           }
         }
       }


### PR DESCRIPTION
## Summary

- On pi ACP, Agent Chat showed **two** "Thinking: …" chips: the promoted `thought_level` ConfigChip (brain icon) and ModeChip, because pi dual-publishes thinking as both a config option and `session.modes` with the same value IDs/names.
- Prefer the promoted Thinking chip and hide ModeChip when every mode id is also a `thought_level` option value. Real Agent/Plan/Ask modes are unchanged.
- Also first-wins-dedupe duplicate `model` / `thought_level` config options in the composer chip row and `/` slash menu so a second generic chip cannot appear.

## Related Issue

Closes #444

Prior related work (not duplicates of this bug): #286 / #302 (initial thought_level promotion). Closed PR attempt earlier today was incomplete until the ModeChip root cause was identified; this reopens that branch with both commits.

## Type of Change

- [x] fix: bug fix
- [ ] feat: new feature
- [ ] docs: documentation only
- [ ] style: formatting or non-functional styling changes
- [ ] refactor: internal cleanup with no behavior change
- [ ] perf: performance improvement
- [x] test: adds or updates tests
- [ ] build: build or dependency changes
- [ ] ci: CI/CD workflow changes
- [ ] chore: maintenance or tooling
- [ ] revert: reverts a previous change

## What Changed

- `modesRedundantWithThoughtLevel` in `chat-input-bar-config.ts` — detect when `session.modes` is the same control as `thought_level`
- `ChatInputBar` + `AgentLauncher` gate `ModeChip` behind `showModeChip` so pi ACP no longer renders a second Thinking pill
- `shouldAdvertiseConfigOption` + `partitionConfigOptions` — first `model` / `thought_level` wins; later same-category options discarded from `rest`
- `buildSlashSections` applies the same first-wins filter so `/` does not expose a second Thinking/Model section
- Unit tests: `modesRedundantWithThoughtLevel`, partition/slash dedupe, AgentLauncher pi-acp regression (`getAllByRole` length 1 for "Thinking: off")

## How It Was Tested

- [x] `bun run ci` (Biome lint + format + imports, strict mode)
- [x] `bun run typecheck`
- [x] `bun run test` (2210 passed)
- [ ] `cargo clippy --all-targets -- -D warnings` (in src-tauri)
- [ ] `cargo test` (in src-tauri)
- [x] Manual verification completed (UI-level AgentLauncher regression + modesRedundantWithThoughtLevel cases for pi dual-publish vs real agent/plan modes)
- [x] Not applicable (frontend-only; no Rust changes)

## Screenshots or Recordings

Before: two "Thinking: off" chips in the composer toolbar (one with brain icon, one without) when pi ACP is selected.
After: a single promoted Thinking chip; ModeChip suppressed only when modes are redundant with thought_level.

## CI & Review Gate

- [ ] All CI checks pass (PR Validation, Rust Checks, Build Verification, Security Scans)
- [ ] Code review comments from CodeRabbit / Claude have been addressed or resolved
- [ ] No unresolved review findings remain

## Checklist

- [x] My PR title follows the conventional commit format used by this repo
- [x] I linked the related issue or explained why none exists
- [x] I updated docs when needed (N/A — no doc changes required)
- [x] I added or updated tests when needed
- [x] I verified the change does not introduce unrelated modifications
- [x] I read AGENTS.md and followed the contributor guidelines
- [ ] A human reviewed the complete diff before submission

## Test plan

- [ ] Connect pi ACP and confirm only one Thinking chip in empty-state (AgentLauncher) and in-session (ChatInputBar) composers
- [ ] Confirm ModeChip still appears for agents that advertise real Agent/Plan/Ask modes alongside thought_level
- [ ] Confirm model picker still works when only one `model` option is advertised
- [ ] Open `/` and confirm a single Thinking Level / Model section when duplicate config options are present
- [ ] Confirm custom/non-singleton config chips still appear
- [ ] Confirm existing mode-config dedupe (`filterDuplicateModeConfigOptions`) is unchanged for true mode options