### PR TITLE
fix(pty): kill child before joining reader on cleanup to stop exit leak (#390)

### DIFF
--- a/src-tauri/src/pty/manager.rs
+++ b/src-tauri/src/pty/manager.rs
@@ -780,23 +780,49 @@ impl PtyManager {
         // a) Drop writer first to close PTY input stream cleanly.
         let _ = instance.writer.blocking_lock().take();
 
-        // b) Wait flusher thread to finish naturally (max 2s)
+        // b) Kill the child FIRST and wait briefly for it to exit. Once the
+        //    child exits, the OS closes the PTY slave end and the reader
+        //    thread's blocking `reader.read()` returns Ok(0) (EOF), so it
+        //    exits naturally and the joins below complete fast.
+        //
+        //    The previous order (join reader, THEN kill child) left the reader
+        //    blocked because the child was still alive holding the PTY open.
+        //    Every cleanup hit the 3s join timeout, leaking the detached
+        //    watcher thread spawned by `join_reader_with_timeout` plus the
+        //    stuck reader thread. With N terminals, those leaked threads kept
+        //    the process alive in the task manager and spinning CPU after the
+        //    window was closed (issue #390).
+        if let Some(mut child) = instance.child.blocking_lock().take() {
+            let _ = child.kill();
+            // Best-effort wait: give the child up to ~2s to exit so the PTY
+            // EOF propagates to the reader before we join. If it doesn't exit
+            // (stubborn grandchild / ConPTY edge case), proceed anyway — the
+            // join timeout below is the safety net.
+            let deadline = Instant::now() + Duration::from_secs(2);
+            while Instant::now() < deadline {
+                match child.try_wait() {
+                    Ok(Some(_)) => break,
+                    Ok(None) => std::thread::sleep(Duration::from_millis(50)),
+                    Err(_) => break,
+                }
+            }
+        }
+
+        // c) Wait flusher thread to finish naturally (max 2s). It observes the
+        //    reader's done_flag, which is set once the reader exits on EOF.
         if let Some(flusher_handle) = instance.flusher_handle.blocking_lock().take() {
             if wait_reader_thread {
                 Self::join_reader_with_timeout(flusher_handle, Duration::from_secs(2));
             }
         }
 
-        // c) Wait reader thread to finish naturally (max 3s)
+        // d) Wait reader thread to finish naturally (max 3s). With the child
+        //    already killed above, the reader should have hit EOF and exited;
+        //    this join is a safety net for slow/edge-case exits.
         if let Some(reader_handle) = instance.reader_handle.blocking_lock().take() {
             if wait_reader_thread {
                 Self::join_reader_with_timeout(reader_handle, Duration::from_secs(3));
             }
-        }
-
-        // d) Kill child process
-        if let Some(mut child) = instance.child.blocking_lock().take() {
-            let _ = child.kill();
         }
 
         // e) Drop ConPTY handles last


### PR DESCRIPTION
## Summary

Quitting the app (Cmd+Q / Quit) while terminals were running left the Termul process alive in the task manager, still consuming CPU. The root cause is in `PtyManager::cleanup_terminal_resources_sync`: it joined the reader thread **before** killing the child, so the reader stayed blocked on `reader.read()` while the child was still alive holding the PTY open. Every cleanup hit its 3s join timeout, leaking the detached watcher thread spawned by `join_reader_with_timeout` plus the stuck reader thread. With N terminals, those leaked threads kept the process alive and spinning CPU after quit.

## Related Issue

Closes #390

Prior PTY-related PRs reviewed for overlap — none address this exit/quit leak:
- #292 (conPTY tree kill via Job Object on Windows) — different scope (kill semantics, not exit cleanup ordering)
- #309 (protect open-project terminals from orphan reaping) — different scope
- #369 (closed — PTY slot limit RAII) — different scope

## Type of Change

- [x] fix: bug fix

## What Changed

`src-tauri/src/pty/manager.rs` — `cleanup_terminal_resources_sync`:

Reordered cleanup so the child is killed and waited on **first** (up to ~2s via `try_wait`), then the flusher and reader threads are joined. Once the child exits, the OS closes the PTY slave end and the reader's blocking `read()` returns `Ok(0)` (EOF), so the reader thread exits naturally and the joins complete fast instead of timing out.

`join_reader_with_timeout` is left in place as a best-effort safety net for slow/edge-case exits; in the normal path it no longer hits its timeout, so it stops spawning watcher threads that outlive cleanup.

This path is exercised on every terminal kill (`kill()` and `kill_all()`), not just app exit, so individual terminal close benefits too.

## How It Was Tested

- [x] `bun run ci` (Biome lint + format + imports, strict mode) — 642 files, no error
- [x] `bun run typecheck` — tsc node/web/test all pass
- [x] `bun run test` — 195 files, 2202 tests passed (42 skipped)
- [x] `cargo clippy --all-targets -- -D warnings` (in src-tauri) — 0 warnings
- [x] `cargo test` (in src-tauri) — 249 passed. Note: `trackers::cwd_tracker::tests::test_detect_cwd_unix` fails, but it fails **identically on clean HEAD** (`git stash && cargo test test_detect_cwd_unix`), so it is a pre-existing macOS environment failure unrelated to this change.
- [x] Manual verification completed — see below.

### Manual repro (macOS)

1. `bun run tauri dev`, create a terminal, run a long-lived command that holds the PTY (e.g. `top`, `npm run dev`).
2. Quit the app via **Cmd+Q** (not the window close button — on macOS closing the window intentionally keeps the app running in the dock).
3. Check Activity Monitor / `pgrep -fl Termul`.
   - Before fix: Termul process stays alive with CPU > 0 after quit.
   - After fix: process exits cleanly.

## Notes for reviewers

- **Windows verification requested.** The ConPTY path (`src-tauri/src/pty/windows.rs`, `conpty_handles`) differs from Unix and is the most likely place a child still holds the PTY open after `kill()`. I cannot test on Windows locally; please confirm via the Windows smoke CI that quit-with-running-terminal exits cleanly. The `try_wait` loop has a 2s cap so a stubborn grandchild will not block exit — it falls through to the join timeout safety net, same as before, just no longer the common path.
- Residual edge case (out of scope here): if a grandchild process keeps the ConPTY slave handle open on Windows, the reader may still not receive EOF. That would require force-closing `conpty_handles` — left for a follow-up if the Windows smoke check surfaces it.

## CI & Review Gate

- [ ] All CI checks pass (PR Validation, Rust Checks, Build Verification, Security Scans)
- [ ] Code review comments from CodeRabbit / Claude have been addressed or resolved
- [ ] No unresolved review findings remain

## Checklist

- [x] My PR title follows the conventional commit format used by this repo
- [x] I linked the related issue or explained why none exists
- [x] I updated docs when needed (N/A — internal fix)
- [ ] I added or updated tests when needed — no regression test added; this is an OS-thread lifecycle fix not easily unit-testable. Happy to add one if maintainers want.
- [x] I verified the change does not introduce unrelated modifications (1 file changed)
- [x] I read AGENTS.md and followed the contributor guidelines
- [x] A human reviewed the complete diff before submission

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved terminal shutdown reliability by stopping the underlying process before completing cleanup.
  * Reduced delays and prevented lingering background resources when closing terminal sessions.
  * Added a brief wait to allow terminal processes to exit cleanly before final cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->