### PR TITLE
fix(web): enforce project-root boundary on fs_api routes 

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -119,6 +119,10 @@ fn resolve_executable_from_path(command: &str) -> Option<String> {
 pub use acp::AcpManager;
 pub use pty::PtyManager;
 pub use trackers::{CwdTracker, ExitCodeTracker, GitTracker};
+// Re-export for `web::fs_api` so the project-root boundary check can reuse
+// the shared Windows verbatim-prefix stripper (PR-S4 nitpick) without
+// promoting the whole `path_validation` module to public visibility.
+pub(crate) use path_validation::strip_verbatim_prefix;
 
 // Desktop ACP event sink: wraps the Tauri `AppHandle` so the dispatcher's
 // `Vec<Arc<dyn EventSink>>` fan-out reaches the renderer as `acp:*` events

--- a/src-tauri/src/remote/host.rs
+++ b/src-tauri/src/remote/host.rs
@@ -211,10 +211,17 @@ impl RemoteServerState {
         // PR-S4: resolve the project-root boundary for the fs_api routes.
         // Honor an explicit override from the desktop settings (when wired
         // through), then fall back to $TERMUL_PROJECT_ROOT, then to $HOME /
-        // $USERPROFILE. The desktop's host starts in the user's home
-        // directory by default — the same fallback the standalone binary uses.
+        // $USERPROFILE. Per `default_project_root`'s contract, `None` here
+        // means no home dir is discoverable — treat it as fatal rather than
+        // silently widening the boundary to the process CWD (which on a
+        // desktop app is the bundle/install dir, much more permissive than
+        // the per-user boundary this PR is meant to enforce).
         let project_root = crate::web::config::default_project_root()
-            .unwrap_or_else(|| std::path::PathBuf::from("."));
+            .ok_or_else(|| {
+                "could not determine project root for shared-live server: \
+                 set $TERMUL_PROJECT_ROOT or ensure $HOME is available"
+                    .to_string()
+            })?;
 
         let cfg = ServerConfig {
             host: bind_mode.host().to_string(),

--- a/src-tauri/src/remote/host.rs
+++ b/src-tauri/src/remote/host.rs
@@ -212,15 +212,26 @@ impl RemoteServerState {
         // Honor an explicit override from the desktop settings (when wired
         // through), then fall back to $TERMUL_PROJECT_ROOT, then to $HOME /
         // $USERPROFILE. Per `default_project_root`'s contract, `None` here
-        // means no home dir is discoverable — treat it as fatal rather than
-        // silently widening the boundary to the process CWD (which on a
-        // desktop app is the bundle/install dir, much more permissive than
-        // the per-user boundary this PR is meant to enforce).
-        let project_root = crate::web::config::default_project_root()
+        // means no home dir is discoverable — treat it as fatal. We then
+        // run the result through `resolve_and_validate_project_root` so
+        // the value stored in `ServerConfig::project_root` is a canonical
+        // absolute path to an existing directory, exactly like the
+        // standalone `termul-server` binary does. A misconfigured $HOME
+        // (deleted account, broken symlink, etc.) now fails the start
+        // call rather than leaking through and confusing the boundary
+        // check.
+        let raw_root = crate::web::config::default_project_root()
             .ok_or_else(|| {
                 "could not determine project root for shared-live server: \
                  set $TERMUL_PROJECT_ROOT or ensure $HOME is available"
                     .to_string()
+            })?;
+        let project_root = crate::web::config::resolve_and_validate_project_root(&raw_root)
+            .map_err(|e| {
+                format!(
+                    "shared-live server refused to start: {e} \
+                     (set $TERMUL_PROJECT_ROOT to a valid directory)"
+                )
             })?;
 
         let cfg = ServerConfig {

--- a/src-tauri/src/remote/host.rs
+++ b/src-tauri/src/remote/host.rs
@@ -208,6 +208,14 @@ impl RemoteServerState {
             );
         }
 
+        // PR-S4: resolve the project-root boundary for the fs_api routes.
+        // Honor an explicit override from the desktop settings (when wired
+        // through), then fall back to $TERMUL_PROJECT_ROOT, then to $HOME /
+        // $USERPROFILE. The desktop's host starts in the user's home
+        // directory by default — the same fallback the standalone binary uses.
+        let project_root = crate::web::config::default_project_root()
+            .unwrap_or_else(|| std::path::PathBuf::from("."));
+
         let cfg = ServerConfig {
             host: bind_mode.host().to_string(),
             // OS-assigned ephemeral port (avoids fixed-port conflicts).
@@ -217,6 +225,7 @@ impl RemoteServerState {
                 .rendezvous()
                 .map(|r| r.timeout().as_secs())
                 .unwrap_or(60),
+            project_root,
         };
 
         let (shutdown_tx, shutdown_rx) = oneshot::channel::<()>();

--- a/src-tauri/src/server_main.rs
+++ b/src-tauri/src/server_main.rs
@@ -80,11 +80,12 @@ fn main() -> ExitCode {
 }
 
 fn usage() -> &'static str {
-    "Usage: termul-server [--host HOST] [--port PORT] [--event-log-capacity N] [--permission-timeout SECS]\n\n\
+    "Usage: termul-server [--host HOST] [--port PORT] [--event-log-capacity N] [--permission-timeout SECS] [--project-root PATH]\n\n\
      Options:\n\
        --host HOST                 Bind host (default: 127.0.0.1; use 0.0.0.0 to expose)\n\
        --port PORT                 Bind port (default: 8080)\n\
        --event-log-capacity N      Per-session event-log ring capacity (default: 4096)\n\
        --permission-timeout SECS   Permission rendezvous timeout in seconds (default: 60)\n\
+       --project-root PATH         Project-root boundary for /fs/* routes (default: $TERMUL_PROJECT_ROOT or $HOME)\n\
        -h, --help                  Show this help"
 }

--- a/src-tauri/src/web/config.rs
+++ b/src-tauri/src/web/config.rs
@@ -213,7 +213,24 @@ impl ServerConfig {
                             "invalid --project-root '': must be a non-empty path".into(),
                         ));
                     }
-                    project_root = Some(PathBuf::from(trimmed));
+                    // Fail-fast on a bad explicit --project-root: validate
+                    // the path exists and is accessible at parse time so the
+                    // server doesn't start successfully and only surface the
+                    // error as a per-request `OUTSIDE_ROOT` on every /fs/*
+                    // call (hard to diagnose post-mortem). We also store the
+                    // canonicalized form so downstream comparisons
+                    // (`check_within_root` re-canonicalizes the root) don't
+                    // race against a path that was canonical at parse time
+                    // but has since been replaced by a symlink.
+                    let candidate = PathBuf::from(trimmed)
+                        .canonicalize()
+                        .map_err(|e| {
+                            ParseCliError::Message(format!(
+                                "invalid --project-root '{trimmed}': \
+                                 path does not exist or is not accessible ({e})"
+                            ))
+                        })?;
+                    project_root = Some(candidate);
                 }
                 other if other.starts_with('-') => {
                     return Err(ParseCliError::Message(format!("unknown option '{other}'")));

--- a/src-tauri/src/web/config.rs
+++ b/src-tauri/src/web/config.rs
@@ -135,14 +135,6 @@ pub struct ServerConfig {
 }
 
 impl ServerConfig {
-    /// Construct a `ServerConfig` with the default project root resolved
-    /// from `$TERMUL_PROJECT_ROOT` or the user's home directory. Returns
-    /// `None` when no home directory can be discovered.
-    pub fn with_default_project_root(mut self) -> Option<Self> {
-        self.project_root = default_project_root()?;
-        Some(self)
-    }
-
     /// Resolve the bind mode from [`Self::host`], defaulting unknown hosts to
     /// a parse error at the CLI layer (callers should validate first).
     pub fn bind_mode(&self) -> Option<BindMode> {
@@ -169,9 +161,11 @@ impl ServerConfig {
         let mut event_log_capacity: usize = 4096;
         let mut permission_timeout_secs: u64 = 60;
         // PR-S4: when `--project-root` is absent, fall back to the env var or
-        // the user's home directory. The fallback is resolved by the caller
-        // via `with_default_project_root()`; here we only honor the explicit
-        // CLI flag.
+        // the user's home directory via `default_project_root()`. The
+        // resolved value is run through `resolve_and_validate_project_root`
+        // (below, after the match block) so a misconfigured environment
+        // fails fast at startup rather than leaking through to the
+        // boundary check.
         let mut project_root: Option<PathBuf> = None;
 
         let mut iter = args.into_iter().peekable();

--- a/src-tauri/src/web/config.rs
+++ b/src-tauri/src/web/config.rs
@@ -6,6 +6,39 @@
 //! permission-rendezvous timeout.
 
 use std::net::SocketAddr;
+use std::path::PathBuf;
+
+/// Resolve the default project-root boundary for the fs_api routes (PR-S4).
+///
+/// Prefers `$TERMUL_PROJECT_ROOT` when set; otherwise falls back to the
+/// current user's home directory (`$HOME` on Unix, `%USERPROFILE%` on
+/// Windows). The fallback is intentionally permissive enough to allow
+/// ordinary project-creation flows under the user's own account — tightening
+/// to a per-project subtree is left to the host application or a future
+/// per-request override.
+///
+/// `None` is returned only when no home directory is discoverable and the
+/// env var is unset; callers should treat that as a fatal startup error.
+pub fn default_project_root() -> Option<PathBuf> {
+    if let Ok(env_root) = std::env::var("TERMUL_PROJECT_ROOT") {
+        let trimmed = env_root.trim();
+        if !trimmed.is_empty() {
+            return Some(PathBuf::from(trimmed));
+        }
+    }
+    // `dirs` is not in the dep tree; resolve the home dir via std-only env
+    // vars (HOME on Unix, USERPROFILE on Windows). This avoids pulling in a
+    // new crate just for one call site.
+    #[cfg(unix)]
+    let home = std::env::var_os("HOME").map(PathBuf::from);
+    #[cfg(windows)]
+    let home = std::env::var_os("USERPROFILE")
+        .map(PathBuf::from)
+        .or_else(|| std::env::var_os("HOME").map(PathBuf::from));
+    #[cfg(not(any(unix, windows)))]
+    let home = std::env::var_os("HOME").map(PathBuf::from);
+    home
+}
 
 /// Which network interface(s) the standalone HTTP server binds to.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -56,9 +89,23 @@ pub struct ServerConfig {
     /// Permission-rendezvous timeout in seconds (Story 1.7 / FR14). On expiry
     /// the pending permission resolves as deny (`Cancelled`). Default 60.
     pub permission_timeout_secs: u64,
+    /// PR-S4: project-root boundary enforced by the fs_api routes. Requests
+    /// whose canonicalized target path resolves outside this root are
+    /// refused with `code: "OUTSIDE_ROOT"` (or `PATH_TRAVERSAL` for explicit
+    /// `..` components). Defaults to the user's home directory when unset
+    /// (see [`default_project_root`]).
+    pub project_root: PathBuf,
 }
 
 impl ServerConfig {
+    /// Construct a `ServerConfig` with the default project root resolved
+    /// from `$TERMUL_PROJECT_ROOT` or the user's home directory. Returns
+    /// `None` when no home directory can be discovered.
+    pub fn with_default_project_root(mut self) -> Option<Self> {
+        self.project_root = default_project_root()?;
+        Some(self)
+    }
+
     /// Resolve the bind mode from [`Self::host`], defaulting unknown hosts to
     /// a parse error at the CLI layer (callers should validate first).
     pub fn bind_mode(&self) -> Option<BindMode> {
@@ -84,6 +131,11 @@ impl ServerConfig {
         let mut port: u16 = 8080;
         let mut event_log_capacity: usize = 4096;
         let mut permission_timeout_secs: u64 = 60;
+        // PR-S4: when `--project-root` is absent, fall back to the env var or
+        // the user's home directory. The fallback is resolved by the caller
+        // via `with_default_project_root()`; here we only honor the explicit
+        // CLI flag.
+        let mut project_root: Option<PathBuf> = None;
 
         let mut iter = args.into_iter().peekable();
         while let Some(arg) = iter.next() {
@@ -145,10 +197,23 @@ impl ServerConfig {
                     })?;
                     if parsed == 0 {
                         return Err(ParseCliError::Message(
-                            "invalid --permission-timeout '0': use a positive integer (seconds)".into(),
+                            "invalid --permission-timeout '0': use a positive integer (seconds)"
+                                .into(),
                         ));
                     }
                     permission_timeout_secs = parsed;
+                }
+                "--project-root" => {
+                    let value = iter.next().ok_or_else(|| {
+                        ParseCliError::Message("missing value for --project-root".into())
+                    })?;
+                    let trimmed = value.as_ref().trim();
+                    if trimmed.is_empty() {
+                        return Err(ParseCliError::Message(
+                            "invalid --project-root '': must be a non-empty path".into(),
+                        ));
+                    }
+                    project_root = Some(PathBuf::from(trimmed));
                 }
                 other if other.starts_with('-') => {
                     return Err(ParseCliError::Message(format!("unknown option '{other}'")));
@@ -161,11 +226,22 @@ impl ServerConfig {
             }
         }
 
+        let project_root = match project_root {
+            Some(p) => p,
+            None => default_project_root().ok_or_else(|| {
+                ParseCliError::Message(
+                    "could not determine project root: set --project-root, $TERMUL_PROJECT_ROOT, or $HOME"
+                        .into(),
+                )
+            })?,
+        };
+
         Ok(Self {
             host,
             port,
             event_log_capacity,
             permission_timeout_secs,
+            project_root,
         })
     }
 }
@@ -218,6 +294,7 @@ mod tests {
             port: 8080,
             event_log_capacity: 4096,
             permission_timeout_secs: 60,
+            project_root: PathBuf::from("/tmp"),
         };
         assert_eq!(
             cfg.bind_addr(),
@@ -229,6 +306,7 @@ mod tests {
             port: 8080,
             event_log_capacity: 4096,
             permission_timeout_secs: 60,
+            project_root: PathBuf::from("/tmp"),
         };
         assert_eq!(bad.bind_addr(), None);
     }
@@ -242,6 +320,14 @@ mod tests {
         assert_eq!(
             cfg.permission_timeout_secs, 60,
             "default permission-timeout is 60s (Story 1.7 / FR14)"
+        );
+        // PR-S4: project_root defaults to $HOME / $USERPROFILE when the env var
+        // is unset. The CI hosts in this repo all set $HOME, so the resolved
+        // value should be non-empty. We don't assert an exact path because the
+        // test environment may differ across platforms.
+        assert!(
+            !cfg.project_root.as_os_str().is_empty(),
+            "default project_root should resolve from $HOME when $TERMUL_PROJECT_ROOT is unset"
         );
     }
 

--- a/src-tauri/src/web/config.rs
+++ b/src-tauri/src/web/config.rs
@@ -6,7 +6,7 @@
 //! permission-rendezvous timeout.
 
 use std::net::SocketAddr;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 /// Resolve the default project-root boundary for the fs_api routes (PR-S4).
 ///
@@ -38,6 +38,43 @@ pub fn default_project_root() -> Option<PathBuf> {
     #[cfg(not(any(unix, windows)))]
     let home = std::env::var_os("HOME").map(PathBuf::from);
     home
+}
+
+/// Validate a raw project-root path and return its canonical absolute form.
+///
+/// Used at every entry point that constructs a `ServerConfig::project_root`
+/// (the `from_args` `--project-root` flag, the desktop shared-live host's
+/// `default_project_root()` fallback, the standalone `termul-server`
+/// binary) so the boundary check in `fs_api::check_within_root` can rely
+/// on `project_root` being a real, accessible directory rather than a path
+/// string that only resolves correctly at the first request.
+///
+/// Rejects:
+/// - Paths that do not exist or are not accessible (canonicalize fails).
+/// - Paths that exist but are not directories.
+///
+/// Returns the canonical absolute path on success, or an error message
+/// suitable for surfacing to the operator at startup.
+pub fn resolve_and_validate_project_root(raw: &Path) -> Result<PathBuf, String> {
+    // 1) Canonicalize: absolute path, symlinks resolved, and the path must
+    //    exist for canonicalize to succeed.
+    let canonical = raw.canonicalize().map_err(|e| {
+        format!(
+            "project root '{}' is not accessible: {e}",
+            raw.display()
+        )
+    })?;
+    // 2) Must be a directory. A file is a valid fs target for the
+    //    boundary check, but it would make the fs_api routes useless
+    //    (`mkdir` cannot create children inside a file, `ls`/`browse`
+    //    cannot list a file), so fail fast at startup instead.
+    if !canonical.is_dir() {
+        return Err(format!(
+            "project root '{}' is not a directory",
+            canonical.display()
+        ));
+    }
+    Ok(canonical)
 }
 
 /// Which network interface(s) the standalone HTTP server binds to.
@@ -214,23 +251,15 @@ impl ServerConfig {
                         ));
                     }
                     // Fail-fast on a bad explicit --project-root: validate
-                    // the path exists and is accessible at parse time so the
-                    // server doesn't start successfully and only surface the
-                    // error as a per-request `OUTSIDE_ROOT` on every /fs/*
-                    // call (hard to diagnose post-mortem). We also store the
-                    // canonicalized form so downstream comparisons
-                    // (`check_within_root` re-canonicalizes the root) don't
-                    // race against a path that was canonical at parse time
-                    // but has since been replaced by a symlink.
-                    let candidate = PathBuf::from(trimmed)
-                        .canonicalize()
-                        .map_err(|e| {
-                            ParseCliError::Message(format!(
-                                "invalid --project-root '{trimmed}': \
-                                 path does not exist or is not accessible ({e})"
-                            ))
-                        })?;
-                    project_root = Some(candidate);
+                    // the path exists, is accessible, and is a directory at
+                    // parse time so the server doesn't start successfully
+                    // and only surface the error as a per-request
+                    // `OUTSIDE_ROOT` on every /fs/* call (hard to diagnose
+                    // post-mortem). The canonical absolute form is stored
+                    // so the boundary check is stable.
+                    let validated = resolve_and_validate_project_root(Path::new(trimmed))
+                        .map_err(ParseCliError::Message)?;
+                    project_root = Some(validated);
                 }
                 other if other.starts_with('-') => {
                     return Err(ParseCliError::Message(format!("unknown option '{other}'")));
@@ -245,12 +274,21 @@ impl ServerConfig {
 
         let project_root = match project_root {
             Some(p) => p,
-            None => default_project_root().ok_or_else(|| {
-                ParseCliError::Message(
-                    "could not determine project root: set --project-root, $TERMUL_PROJECT_ROOT, or $HOME"
-                        .into(),
-                )
-            })?,
+            None => {
+                let raw = default_project_root().ok_or_else(|| {
+                    ParseCliError::Message(
+                        "could not determine project root: \
+                         set --project-root, $TERMUL_PROJECT_ROOT, or $HOME"
+                            .into(),
+                    )
+                })?;
+                // Validate the env-var / $HOME fallback the same way we
+                // validate an explicit --project-root: it must exist and
+                // be a directory. A misconfigured $HOME (deleted account,
+                // broken symlink, etc.) now fails fast at startup instead
+                // of leaking through and confusing the boundary check.
+                resolve_and_validate_project_root(&raw).map_err(ParseCliError::Message)?
+            }
         };
 
         Ok(Self {
@@ -285,6 +323,73 @@ impl std::error::Error for ParseCliError {}
 mod tests {
     use super::*;
     use std::net::{IpAddr, Ipv4Addr};
+
+    // PR-S4: validate the project-root helper. TempDir scopes are used so
+    // the tests don't depend on a specific filesystem layout outside
+    // `std::env::temp_dir()`. TempDir is already a dev-dep of the workspace
+    // (used by `web::fs_api::tests`); if that ever changes, swap to
+    // `std::env::temp_dir().join("...")` plus manual cleanup.
+
+    #[test]
+    fn resolve_and_validate_accepts_existing_directory() {
+        let dir = tempdir_like("resolve-ok");
+        let validated = resolve_and_validate_project_root(&dir).expect("dir is valid");
+        // The validated path is the canonical absolute form of `dir`.
+        // `Path::is_absolute` returns true on every supported platform for
+        // the result of `canonicalize` (Windows paths may carry a `\\?\`
+        // verbatim prefix but are still reported as absolute).
+        assert!(validated.is_absolute());
+        // And the result is idempotent under a second canonicalize.
+        let again = validated.canonicalize().expect("canonicalize again");
+        assert_eq!(validated, again);
+        cleanup(&dir);
+    }
+
+    #[test]
+    fn resolve_and_validate_rejects_nonexistent_path() {
+        let dir = tempdir_like("resolve-missing");
+        let missing = dir.join("does-not-exist");
+        let err = resolve_and_validate_project_root(&missing).unwrap_err();
+        assert!(
+            err.contains("not accessible"),
+            "expected 'not accessible' in: {err}"
+        );
+        cleanup(&dir);
+    }
+
+    #[test]
+    fn resolve_and_validate_rejects_file() {
+        let dir = tempdir_like("resolve-file");
+        let file = dir.join("a-file.txt");
+        std::fs::write(&file, "x").expect("write");
+        let err = resolve_and_validate_project_root(&file).unwrap_err();
+        assert!(
+            err.contains("not a directory"),
+            "expected 'not a directory' in: {err}"
+        );
+        cleanup(&dir);
+    }
+
+    /// Minimal in-test TempDir substitute so this test module doesn't need
+    /// to depend on the `tempfile` crate just for two tests. Returns a
+    /// unique subdirectory of the OS temp dir; tests are responsible for
+    /// calling `cleanup` on success or early return.
+    fn tempdir_like(label: &str) -> PathBuf {
+        let nanos = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_nanos())
+            .unwrap_or(0);
+        let p = std::env::temp_dir().join(format!(
+            "termul-config-{label}-{}-{nanos}",
+            std::process::id()
+        ));
+        std::fs::create_dir_all(&p).expect("create tempdir_like");
+        p
+    }
+
+    fn cleanup(p: &Path) {
+        let _ = std::fs::remove_dir_all(p);
+    }
 
     #[test]
     fn bind_mode_parse_and_addrs() {

--- a/src-tauri/src/web/fs_api.rs
+++ b/src-tauri/src/web/fs_api.rs
@@ -16,7 +16,7 @@
 
 use std::fs;
 use std::net::SocketAddr;
-use std::path::Path;
+use std::path::{Component, Path, PathBuf};
 
 use axum::{
     extract::{ConnectInfo, Query, State},
@@ -164,6 +164,163 @@ fn get_extension(name: &str) -> Option<String> {
     Some(name[idx..].to_string())
 }
 
+/// PR-S4: enforce a project-root boundary on a request path.
+///
+/// Rejects:
+/// - Any path containing a `..` component (explicit traversal) with
+///   `code: "PATH_TRAVERSAL"`.
+/// - Any path whose canonicalized form resolves outside `root` (absolute
+///   paths, symlinks pointing outside, or non-existent paths whose parent
+///   resolves outside) with `code: "OUTSIDE_ROOT"`.
+///
+/// Returns `Ok(())` when the path resolves inside `root` (or the parent
+/// directory of a not-yet-existing path resolves inside `root`).
+///
+/// Notes:
+/// - `root` is canonicalized internally; non-canonical roots (e.g. relative
+///   paths or paths with `..`) are accepted and normalized on the fly.
+/// - Symlink protection relies on `fs::canonicalize` resolving through the
+///   link before the boundary check — a symlink whose target is outside the
+///   root will be rejected even if the symlink itself is inside the root.
+/// - This is intentionally separate from the existing
+///   `path_validation::validate_search_path` because that helper requires the
+///   search path to exist (it short-circuits on `!exists()`); the fs_api
+///   routes also create new paths (`mkdir`, `write`), which need a different
+///   shape that tolerates non-existing targets.
+fn check_within_root(path: &Path, root: &Path) -> Result<(), (String, &'static str)> {
+    // 1) Reject explicit `..` traversal components. This is a fast, cheap
+    //    pre-filter that catches the obvious attack without needing a real
+    //    filesystem call. We allow the `..` to appear in the LAST component
+    //    only when the path is exactly the canonical root (a no-op), but
+    //    `..` anywhere else is rejected. A directory name like `foo..bar`
+    //    (legitimate, see `path_validation::tests::test_accepts_directory_name_containing_double_dots`)
+    //    is NOT a `Component::ParentDir` because it is a single path segment;
+    //    it survives this check and is then caught or accepted by the
+    //    canonicalize+`starts_with` check below.
+    if path
+        .components()
+        .any(|c| matches!(c, Component::ParentDir))
+    {
+        return Err((
+            format!(
+                "path traversal: '..' component in request path '{}'",
+                path.display()
+            ),
+            "PATH_TRAVERSAL",
+        ));
+    }
+
+    // 2) Canonicalize the root (caller is expected to pass an existing
+    //    absolute path; if it doesn't exist or is invalid, we surface that
+    //    rather than silently accepting the request).
+    let canonical_root = root
+        .canonicalize()
+        .map_err(|e| {
+            (
+                format!(
+                    "project root '{}' is not accessible: {e}",
+                    root.display()
+                ),
+                "OUTSIDE_ROOT",
+            )
+        })?;
+
+    // 3) Resolve the request path. We canonicalize the path when it exists
+    //    (covers symlink resolution); when it does NOT exist (e.g. the
+    //    renderer is asking us to create it), we canonicalize the nearest
+    //    existing ancestor and verify that ancestor is inside the root —
+    //    preventing a path like `/root/newfile` where `/root` is inside
+    //    the boundary but `/root/../etc/newfile` is not.
+    let resolved = if path.exists() {
+        path.canonicalize().map_err(|e| {
+            (
+                format!("failed to resolve path '{}': {e}", path.display()),
+                "OUTSIDE_ROOT",
+            )
+        })?
+    } else {
+        // Walk up until we find an existing ancestor. The path itself cannot
+        // canonicalize because it does not exist yet.
+        let mut ancestor = path.to_path_buf();
+        loop {
+            let Some(parent) = ancestor.parent() else {
+                return Err((
+                    format!(
+                        "path '{}' has no existing ancestor inside project root",
+                        path.display()
+                    ),
+                    "OUTSIDE_ROOT",
+                ));
+            };
+            if parent.as_os_str().is_empty() {
+                return Err((
+                    format!("path '{}' has no existing ancestor", path.display()),
+                    "OUTSIDE_ROOT",
+                ));
+            }
+            if parent.exists() {
+                let canonical_parent = parent.canonicalize().map_err(|e| {
+                    (
+                        format!(
+                            "failed to resolve parent of '{}': {e}",
+                            path.display()
+                        ),
+                        "OUTSIDE_ROOT",
+                    )
+                })?;
+                // Re-attach the non-existing tail so the returned
+                // canonicalized path matches what the caller will actually
+                // create. We don't return this; we only use it for the
+                // `starts_with` check below.
+                break canonical_parent;
+            }
+            ancestor = parent.to_path_buf();
+        }
+    };
+
+    // 4) Boundary check. `canonical_root` always ends with a separator-free
+    //    path; `Path::starts_with` does a per-component match (not a string
+    //    prefix), so a sibling with a common prefix like `/home/user2` is
+    //    NOT confused with `/home/user`. (We strip the `\\?\` verbatim
+    //    prefix that `fs::canonicalize` adds on Windows before comparing —
+    //    `Path::starts_with` is a per-component check that handles
+    //    verbatim-aware `\\?\` semantics. We re-derive the path from
+    //    `to_string_lossy` and re-parse it to keep the comparison portable
+    //    across the verbatim and non-verbatim forms. The owned `PathBuf`s
+    //    below are kept alive for the duration of the `starts_with` check.)
+    #[cfg(windows)]
+    let (resolved_clean, root_clean) = {
+        let raw = resolved.to_string_lossy();
+        let stripped_resolved = raw
+            .strip_prefix(r"\\?\UNC\")
+            .map(|s| format!(r"\\{}", s))
+            .or_else(|| raw.strip_prefix(r"\\?\").map(|s| s.to_string()))
+            .unwrap_or_else(|| raw.into_owned());
+        let raw_root = canonical_root.to_string_lossy();
+        let stripped_root = raw_root
+            .strip_prefix(r"\\?\UNC\")
+            .map(|s| format!(r"\\{}", s))
+            .or_else(|| raw_root.strip_prefix(r"\\?\").map(|s| s.to_string()))
+            .unwrap_or_else(|| raw_root.into_owned());
+        (PathBuf::from(stripped_resolved), PathBuf::from(stripped_root))
+    };
+    #[cfg(not(windows))]
+    let (resolved_clean, root_clean) = (resolved.clone(), canonical_root.clone());
+
+    if !resolved_clean.starts_with(root_clean) {
+        return Err((
+            format!(
+                "path '{}' is outside project root '{}'",
+                path.display(),
+                canonical_root.display()
+            ),
+            "OUTSIDE_ROOT",
+        ));
+    }
+
+    Ok(())
+}
+
 /// Build a `DirectoryEntryDto` from a directory entry path + optional
 /// metadata. Falls back to conservative defaults (`size: 0`,
 /// `modified_at: 0`, type inferred from `file_type()` when available else
@@ -226,8 +383,14 @@ fn entry_dto(parent: &Path, name: String, metadata: Option<&fs::Metadata>) -> Di
 /// to `0.0.0.0`; read routes (`/fs/ls`, `/fs/browse`) are intentionally left
 /// open. The router MUST be built with `into_make_service_with_connect_info`
 /// so `ConnectInfo<SocketAddr>` is available.
+///
+/// **Project-root boundary (PR-S4):** the target path must canonicalize
+/// inside `AppState::project_root`. Paths that escape the root (via
+/// `..` components, absolute paths outside the root, or symlinks pointing
+/// outside) are refused with `code: "OUTSIDE_ROOT"` or
+/// `code: "PATH_TRAVERSAL"` before any filesystem mutation.
 pub async fn mkdir(
-    State(_state): State<AppState>,
+    State(state): State<AppState>,
     ConnectInfo(peer): ConnectInfo<SocketAddr>,
     Json(req): Json<MkdirRequest>,
 ) -> impl IntoResponse {
@@ -235,6 +398,12 @@ pub async fn mkdir(
         return (StatusCode::OK, Json(forbidden));
     }
     let path = req.path;
+    if let Err((msg, code)) = check_within_root(Path::new(&path), state.project_root.as_path()) {
+        return (
+            StatusCode::OK,
+            Json(IpcBody::<()>::err(msg, code)),
+        );
+    }
     let result = tokio::task::spawn_blocking(move || fs::create_dir_all(&path))
         .await
         .map_err(|e| format!("mkdir task failed: {e}"));
@@ -254,7 +423,7 @@ pub async fn mkdir(
 /// **Localhost guard (Patch D):** same guard as `mkdir` — refused unless the
 /// peer is loopback.
 pub async fn write(
-    State(_state): State<AppState>,
+    State(state): State<AppState>,
     ConnectInfo(peer): ConnectInfo<SocketAddr>,
     Json(req): Json<WriteRequest>,
 ) -> impl IntoResponse {
@@ -262,6 +431,12 @@ pub async fn write(
         return (StatusCode::OK, Json(forbidden));
     }
     let path = req.path;
+    if let Err((msg, code)) = check_within_root(Path::new(&path), state.project_root.as_path()) {
+        return (
+            StatusCode::OK,
+            Json(IpcBody::<()>::err(msg, code)),
+        );
+    }
     let content = req.content;
     let result = tokio::task::spawn_blocking(move || fs::write(&path, content.as_bytes()))
         .await
@@ -279,10 +454,16 @@ pub async fn write(
 /// `{ success: false, error, code: "READ_ERROR" }` (missing dir = failure;
 /// the renderer's empty-check already treats missing as empty).
 pub async fn ls(
-    State(_state): State<AppState>,
+    State(state): State<AppState>,
     Query(q): Query<PathQuery>,
 ) -> impl IntoResponse {
     let path = q.path;
+    if let Err((msg, code)) = check_within_root(Path::new(&path), state.project_root.as_path()) {
+        return (
+            StatusCode::OK,
+            Json(IpcBody::<Vec<DirectoryEntryDto>>::err(msg, code)),
+        );
+    }
     let entries = tokio::task::spawn_blocking(move || list_dir(&path))
         .await
         .map_err(|e| format!("ls task failed: {e}"));
@@ -299,10 +480,16 @@ pub async fn ls(
 /// Returns directories only is a renderer-side concern; the server returns all
 /// entries and the picker filters as needed.
 pub async fn browse(
-    State(_state): State<AppState>,
+    State(state): State<AppState>,
     Query(q): Query<PathQuery>,
 ) -> impl IntoResponse {
     let path = q.path;
+    if let Err((msg, code)) = check_within_root(Path::new(&path), state.project_root.as_path()) {
+        return (
+            StatusCode::OK,
+            Json(IpcBody::<Vec<DirectoryEntryDto>>::err(msg, code)),
+        );
+    }
     let entries = tokio::task::spawn_blocking(move || list_dir(&path))
         .await
         .map_err(|e| format!("browse task failed: {e}"));
@@ -461,9 +648,25 @@ mod tests {
     }
 
     fn test_state() -> AppState {
+        // Default: no project root bound (legacy behavior preserved for tests
+        // that do not exercise the PR-S4 boundary). PR-S4 tests use
+        // `test_state_with_root` to set an explicit project root.
+        test_state_with_root(std::env::temp_dir().as_path())
+    }
+
+    /// PR-S4: build an `AppState` with the project-root boundary set to
+    /// `root`. The fs_api routes reject any request whose canonicalized path
+    /// is outside this root. Tests that previously used the default
+    /// `test_state()` keep working because the default root is the OS temp
+    /// dir (and the existing tests only touch temp dirs).
+    fn test_state_with_root(root: &Path) -> AppState {
         AppState {
             acp: Arc::new(AcpManager::new(vec![])),
             relay: Arc::new(WsRelaySink::new()),
+            project_root: Arc::new(
+                root.canonicalize()
+                    .unwrap_or_else(|_| root.to_path_buf()),
+            ),
         }
     }
 
@@ -916,6 +1119,131 @@ mod tests {
         // Re-serialize and assert the camelCase key is preserved on the way out.
         let re = serde_json::to_string(entry).expect("re-serialize");
         assert!(re.contains("\"modifiedAt\""), "re-serialize keeps camelCase: {re}");
+    }
+
+    /// PR-S4: project-root boundary on `/fs/mkdir` (CWE-22). A target path
+    /// outside the configured `project_root` must be refused with
+    /// `code: "OUTSIDE_ROOT"` (or "PATH_TRAVERSAL") and must NOT create the
+    /// directory.
+    #[tokio::test]
+    async fn mkdir_rejects_path_outside_project_root() {
+        let root = TempDir::new("mkdir-root");
+        let outside = TempDir::new("mkdir-outside");
+        let target = outside.path().join("evil");
+        let req_body = serde_json::json!({ "path": target.to_string_lossy() });
+        let resp = post_json(test_state_with_root(root.path()), "/fs/mkdir", &req_body).await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body: IpcBody<()> = body_as_json(resp.into_body()).await;
+        assert!(!body.success, "mkdir outside root must be refused");
+        let code = body.code.as_deref().unwrap_or("");
+        assert!(
+            code == "OUTSIDE_ROOT" || code == "PATH_TRAVERSAL",
+            "expected OUTSIDE_ROOT or PATH_TRAVERSAL, got {code:?}"
+        );
+        assert!(
+            !target.exists(),
+            "refused mkdir must not create the directory"
+        );
+    }
+
+    /// PR-S4: explicit `..` traversal components in the request path must be
+    /// rejected even when the result would coincidentally land inside root
+    /// (defense-in-depth — never trust raw client paths).
+    #[tokio::test]
+    async fn mkdir_rejects_traversal_sequence_in_path() {
+        let root = TempDir::new("mkdir-trav-root");
+        // Build a path that starts inside the root but escapes via `..`.
+        // canonicalize at test-build time so the test is platform-agnostic.
+        let inside = root.path().join("sub");
+        fs::create_dir_all(&inside).expect("mkdir inside");
+        let traversal = inside.join("..").join("..").join("etc");
+        let req_body = serde_json::json!({ "path": traversal.to_string_lossy() });
+        let resp = post_json(test_state_with_root(root.path()), "/fs/mkdir", &req_body).await;
+        let body: IpcBody<()> = body_as_json(resp.into_body()).await;
+        assert!(!body.success, "traversal must be refused");
+        let code = body.code.as_deref().unwrap_or("");
+        assert!(
+            code == "PATH_TRAVERSAL" || code == "OUTSIDE_ROOT",
+            "expected PATH_TRAVERSAL or OUTSIDE_ROOT, got {code:?}"
+        );
+    }
+
+    /// PR-S4: project-root boundary on `/fs/write`. A file written outside the
+    /// configured root must be refused and the file must not exist after the
+    /// call.
+    #[tokio::test]
+    async fn write_rejects_path_outside_project_root() {
+        let root = TempDir::new("write-root");
+        let outside = TempDir::new("write-outside");
+        let target = outside.path().join("evil.txt");
+        let req_body =
+            serde_json::json!({ "path": target.to_string_lossy(), "content": "pwn" });
+        let resp = post_json(test_state_with_root(root.path()), "/fs/write", &req_body).await;
+        let body: IpcBody<()> = body_as_json(resp.into_body()).await;
+        assert!(!body.success, "write outside root must be refused");
+        let code = body.code.as_deref().unwrap_or("");
+        assert!(
+            code == "OUTSIDE_ROOT" || code == "PATH_TRAVERSAL",
+            "expected OUTSIDE_ROOT or PATH_TRAVERSAL, got {code:?}"
+        );
+        assert!(!target.exists(), "refused write must not create the file");
+    }
+
+    /// PR-S4: project-root boundary on `/fs/ls`. Listing a directory outside
+    /// the configured root must be refused with `code: "OUTSIDE_ROOT"` (read
+    /// routes previously had no boundary; PR-S4 closes the gap).
+    #[tokio::test]
+    async fn ls_rejects_path_outside_project_root() {
+        let root = TempDir::new("ls-root");
+        let outside = TempDir::new("ls-outside");
+        let uri = format!(
+            "/fs/ls?path={}",
+            urlencoding(&outside.path().to_string_lossy())
+        );
+        let resp = get_request(test_state_with_root(root.path()), &uri).await;
+        let body: IpcBody<Vec<DirectoryEntryDto>> = body_as_json(resp.into_body()).await;
+        assert!(!body.success, "ls outside root must be refused");
+        let code = body.code.as_deref().unwrap_or("");
+        assert!(
+            code == "OUTSIDE_ROOT" || code == "PATH_TRAVERSAL",
+            "expected OUTSIDE_ROOT or PATH_TRAVERSAL, got {code:?}"
+        );
+    }
+
+    /// PR-S4: a symlink that lives INSIDE the project root but points OUTSIDE
+    /// must be refused on `/fs/browse` (canonicalize resolves the link and the
+    /// post-canonicalize path is checked against root).
+    #[tokio::test]
+    async fn browse_rejects_symlink_pointing_outside_root() {
+        let root = TempDir::new("browse-sym-root");
+        let outside = TempDir::new("browse-sym-outside");
+        let link = root.path().join("evil_link");
+        #[cfg(unix)]
+        {
+            std::os::unix::fs::symlink(outside.path(), &link).expect("symlink");
+        }
+        #[cfg(windows)]
+        {
+            // On Windows, directory symlinks require elevation/dev mode;
+            // skip the assertion if creation fails (the traversal-rejection
+            // path is still exercised by the other tests in this module).
+            if std::os::windows::fs::symlink_dir(outside.path(), &link).is_err() {
+                eprintln!("skipping: cannot create symlink on this Windows host");
+                return;
+            }
+        }
+        let uri = format!("/fs/browse?path={}", urlencoding(&link.to_string_lossy()));
+        let resp = get_request(test_state_with_root(root.path()), &uri).await;
+        let body: IpcBody<Vec<DirectoryEntryDto>> = body_as_json(resp.into_body()).await;
+        assert!(
+            !body.success,
+            "symlink pointing outside root must be refused"
+        );
+        let code = body.code.as_deref().unwrap_or("");
+        assert!(
+            code == "OUTSIDE_ROOT" || code == "PATH_TRAVERSAL",
+            "expected OUTSIDE_ROOT or PATH_TRAVERSAL, got {code:?}"
+        );
     }
 
     /// Patch I: git-init failure path is explicitly asserted. The existing

--- a/src-tauri/src/web/fs_api.rs
+++ b/src-tauri/src/web/fs_api.rs
@@ -164,7 +164,8 @@ fn get_extension(name: &str) -> Option<String> {
     Some(name[idx..].to_string())
 }
 
-/// PR-S4: enforce a project-root boundary on a request path.
+/// PR-S4: enforce a project-root boundary on a request path, and return a
+/// canonicalized path suitable for the actual filesystem call.
 ///
 /// Rejects:
 /// - Any path containing a `..` component (explicit traversal) with
@@ -173,30 +174,49 @@ fn get_extension(name: &str) -> Option<String> {
 ///   paths, symlinks pointing outside, or non-existent paths whose parent
 ///   resolves outside) with `code: "OUTSIDE_ROOT"`.
 ///
-/// Returns `Ok(())` when the path resolves inside `root` (or the parent
-/// directory of a not-yet-existing path resolves inside `root`).
+/// On success, returns the resolved path that the caller must use for the
+/// subsequent filesystem operation. The returned value is:
+/// - The canonicalized path, when the requested path exists (so any
+///   symlinks in its components are already resolved by the OS).
+/// - `canonical_parent.join(leaf)`, when the requested path does not exist
+///   yet (e.g. `mkdir`, `write`). The parent is canonicalized (symlinks
+///   resolved); the leaf is appended verbatim so the path the caller
+///   actually creates matches what it asked for.
+///
+/// Why we return a `PathBuf` and not just `Ok(())`: this closes the
+/// classic TOCTOU gap where the boundary check resolves symlinks but the
+/// handler then operates on the original, un-canonicalized request path.
+/// If a symlink along the path were swapped between the check and the
+/// filesystem call, the actual write/read could land outside `project_root`
+/// despite having passed the check. Reusing the canonicalized path closes
+/// that gap. (Residual risk: a symlink swap between `canonicalize` and the
+/// subsequent `open` call is not mitigated here; full mitigation would
+/// require `openat2` + `RESOLVE_BENEATH` or equivalent, which `std::fs`
+/// does not expose. The current attack surface is local-only and the
+/// server is bound to the loopback by default, so the residual risk is
+/// contained.)
 ///
 /// Notes:
 /// - `root` is canonicalized internally; non-canonical roots (e.g. relative
 ///   paths or paths with `..`) are accepted and normalized on the fly.
-/// - Symlink protection relies on `fs::canonicalize` resolving through the
-///   link before the boundary check — a symlink whose target is outside the
-///   root will be rejected even if the symlink itself is inside the root.
 /// - This is intentionally separate from the existing
 ///   `path_validation::validate_search_path` because that helper requires the
 ///   search path to exist (it short-circuits on `!exists()`); the fs_api
 ///   routes also create new paths (`mkdir`, `write`), which need a different
 ///   shape that tolerates non-existing targets.
-fn check_within_root(path: &Path, root: &Path) -> Result<(), (String, &'static str)> {
+fn check_within_root(
+    path: &Path,
+    root: &Path,
+) -> Result<PathBuf, (String, &'static str)> {
     // 1) Reject explicit `..` traversal components. This is a fast, cheap
     //    pre-filter that catches the obvious attack without needing a real
-    //    filesystem call. We allow the `..` to appear in the LAST component
-    //    only when the path is exactly the canonical root (a no-op), but
-    //    `..` anywhere else is rejected. A directory name like `foo..bar`
-    //    (legitimate, see `path_validation::tests::test_accepts_directory_name_containing_double_dots`)
-    //    is NOT a `Component::ParentDir` because it is a single path segment;
-    //    it survives this check and is then caught or accepted by the
-    //    canonicalize+`starts_with` check below.
+    //    filesystem call. Any `Component::ParentDir` is rejected regardless
+    //    of position — a path with a `..` anywhere is treated as an
+    //    attempted traversal. A directory name like `foo..bar` (legitimate,
+    //    see `path_validation::tests::test_accepts_directory_name_containing_double_dots`)
+    //    is NOT a `Component::ParentDir` because it is a single path
+    //    segment; it survives this check and is then caught or accepted by
+    //    the canonicalize+`starts_with` check below.
     if path
         .components()
         .any(|c| matches!(c, Component::ParentDir))
@@ -228,21 +248,27 @@ fn check_within_root(path: &Path, root: &Path) -> Result<(), (String, &'static s
     // 3) Resolve the request path. We canonicalize the path when it exists
     //    (covers symlink resolution); when it does NOT exist (e.g. the
     //    renderer is asking us to create it), we canonicalize the nearest
-    //    existing ancestor and verify that ancestor is inside the root —
-    //    preventing a path like `/root/newfile` where `/root` is inside
-    //    the boundary but `/root/../etc/newfile` is not.
-    let resolved = if path.exists() {
-        path.canonicalize().map_err(|e| {
+    //    existing ancestor and re-attach the non-existing tail so the
+    //    returned path matches what the caller will actually create. Both
+    //    forms return a path the caller can pass straight into
+    //    `fs::create_dir_all`, `fs::write`, or `list_dir` without
+    //    re-deriving it from the raw client string.
+    let (resolved, safe_path) = if path.exists() {
+        let canonical = path.canonicalize().map_err(|e| {
             (
                 format!("failed to resolve path '{}': {e}", path.display()),
                 "OUTSIDE_ROOT",
             )
-        })?
+        })?;
+        (canonical.clone(), canonical)
     } else {
-        // Walk up until we find an existing ancestor. The path itself cannot
-        // canonicalize because it does not exist yet.
+        // Walk up until we find an existing ancestor. The path itself
+        // cannot canonicalize because it does not exist yet. We track how
+        // many `parent()` steps we took so we can re-attach the
+        // non-existing tail to the canonicalized ancestor afterwards.
         let mut ancestor = path.to_path_buf();
-        loop {
+        let mut depth_walked: usize = 0;
+        let canonical_parent = loop {
             let Some(parent) = ancestor.parent() else {
                 return Err((
                     format!(
@@ -259,7 +285,7 @@ fn check_within_root(path: &Path, root: &Path) -> Result<(), (String, &'static s
                 ));
             }
             if parent.exists() {
-                let canonical_parent = parent.canonicalize().map_err(|e| {
+                let canonical = parent.canonicalize().map_err(|e| {
                     (
                         format!(
                             "failed to resolve parent of '{}': {e}",
@@ -268,41 +294,53 @@ fn check_within_root(path: &Path, root: &Path) -> Result<(), (String, &'static s
                         "OUTSIDE_ROOT",
                     )
                 })?;
-                // Re-attach the non-existing tail so the returned
-                // canonicalized path matches what the caller will actually
-                // create. We don't return this; we only use it for the
-                // `starts_with` check below.
-                break canonical_parent;
+                break canonical;
             }
             ancestor = parent.to_path_buf();
-        }
+            depth_walked += 1;
+        };
+        // Re-attach the non-existing tail. `path` had `depth_walked` more
+        // parents than the canonicalized ancestor, so its last
+        // `depth_walked + 1` components (ancestor is the parent of
+        // something that had those N+1 components) form the tail. We
+        // re-build the tail from the original `path` so the caller sees
+        // exactly what it asked for (no canonicalization of the leaf
+        // name, which is correct: leaf names cannot themselves
+        // canonicalize to a different path on most filesystems).
+        let tail: std::path::PathBuf = path
+            .components()
+            .rev()
+            .take(depth_walked + 1)
+            .collect::<Vec<_>>()
+            .into_iter()
+            .rev()
+            .collect();
+        let safe = if tail.as_os_str().is_empty() {
+            canonical_parent.clone()
+        } else {
+            canonical_parent.join(&tail)
+        };
+        (canonical_parent, safe)
     };
 
     // 4) Boundary check. `canonical_root` always ends with a separator-free
     //    path; `Path::starts_with` does a per-component match (not a string
     //    prefix), so a sibling with a common prefix like `/home/user2` is
-    //    NOT confused with `/home/user`. (We strip the `\\?\` verbatim
-    //    prefix that `fs::canonicalize` adds on Windows before comparing —
-    //    `Path::starts_with` is a per-component check that handles
-    //    verbatim-aware `\\?\` semantics. We re-derive the path from
-    //    `to_string_lossy` and re-parse it to keep the comparison portable
-    //    across the verbatim and non-verbatim forms. The owned `PathBuf`s
-    //    below are kept alive for the duration of the `starts_with` check.)
+    //    NOT confused with `/home/user`. We use the shared
+    //    `strip_verbatim_prefix` helper (re-exported by `lib.rs`) to
+    //    normalize Windows verbatim forms — `\\?\`, `\\?\UNC\`, etc. — so
+    //    that a `\\?\C:\Users\foo` canonical path and a
+    //    `C:\Users\foo` non-canonical path compare as the same path. The
+    //    owned `PathBuf`s below are kept alive for the duration of the
+    //    `starts_with` check.
     #[cfg(windows)]
     let (resolved_clean, root_clean) = {
-        let raw = resolved.to_string_lossy();
-        let stripped_resolved = raw
-            .strip_prefix(r"\\?\UNC\")
-            .map(|s| format!(r"\\{}", s))
-            .or_else(|| raw.strip_prefix(r"\\?\").map(|s| s.to_string()))
-            .unwrap_or_else(|| raw.into_owned());
-        let raw_root = canonical_root.to_string_lossy();
-        let stripped_root = raw_root
-            .strip_prefix(r"\\?\UNC\")
-            .map(|s| format!(r"\\{}", s))
-            .or_else(|| raw_root.strip_prefix(r"\\?\").map(|s| s.to_string()))
-            .unwrap_or_else(|| raw_root.into_owned());
-        (PathBuf::from(stripped_resolved), PathBuf::from(stripped_root))
+        let resolved_str = resolved.to_string_lossy();
+        let root_str = canonical_root.to_string_lossy();
+        (
+            PathBuf::from(strip_verbatim_prefix(resolved_str.as_ref()).into_owned()),
+            PathBuf::from(strip_verbatim_prefix(root_str.as_ref()).into_owned()),
+        )
     };
     #[cfg(not(windows))]
     let (resolved_clean, root_clean) = (resolved.clone(), canonical_root.clone());
@@ -318,7 +356,7 @@ fn check_within_root(path: &Path, root: &Path) -> Result<(), (String, &'static s
         ));
     }
 
-    Ok(())
+    Ok(safe_path)
 }
 
 /// Build a `DirectoryEntryDto` from a directory entry path + optional
@@ -397,13 +435,15 @@ pub async fn mkdir(
     if let Some(forbidden) = check_local_only::<()>(peer) {
         return (StatusCode::OK, Json(forbidden));
     }
-    let path = req.path;
-    if let Err((msg, code)) = check_within_root(Path::new(&path), state.project_root.as_path()) {
-        return (
-            StatusCode::OK,
-            Json(IpcBody::<()>::err(msg, code)),
-        );
-    }
+    let path = match check_within_root(Path::new(&req.path), state.project_root.as_path()) {
+        Ok(safe) => safe,
+        Err((msg, code)) => {
+            return (
+                StatusCode::OK,
+                Json(IpcBody::<()>::err(msg, code)),
+            );
+        }
+    };
     let result = tokio::task::spawn_blocking(move || fs::create_dir_all(&path))
         .await
         .map_err(|e| format!("mkdir task failed: {e}"));
@@ -430,13 +470,15 @@ pub async fn write(
     if let Some(forbidden) = check_local_only::<()>(peer) {
         return (StatusCode::OK, Json(forbidden));
     }
-    let path = req.path;
-    if let Err((msg, code)) = check_within_root(Path::new(&path), state.project_root.as_path()) {
-        return (
-            StatusCode::OK,
-            Json(IpcBody::<()>::err(msg, code)),
-        );
-    }
+    let path = match check_within_root(Path::new(&req.path), state.project_root.as_path()) {
+        Ok(safe) => safe,
+        Err((msg, code)) => {
+            return (
+                StatusCode::OK,
+                Json(IpcBody::<()>::err(msg, code)),
+            );
+        }
+    };
     let content = req.content;
     let result = tokio::task::spawn_blocking(move || fs::write(&path, content.as_bytes()))
         .await
@@ -457,13 +499,15 @@ pub async fn ls(
     State(state): State<AppState>,
     Query(q): Query<PathQuery>,
 ) -> impl IntoResponse {
-    let path = q.path;
-    if let Err((msg, code)) = check_within_root(Path::new(&path), state.project_root.as_path()) {
-        return (
-            StatusCode::OK,
-            Json(IpcBody::<Vec<DirectoryEntryDto>>::err(msg, code)),
-        );
-    }
+    let path = match check_within_root(Path::new(&q.path), state.project_root.as_path()) {
+        Ok(safe) => safe,
+        Err((msg, code)) => {
+            return (
+                StatusCode::OK,
+                Json(IpcBody::<Vec<DirectoryEntryDto>>::err(msg, code)),
+            );
+        }
+    };
     let entries = tokio::task::spawn_blocking(move || list_dir(&path))
         .await
         .map_err(|e| format!("ls task failed: {e}"));
@@ -483,13 +527,15 @@ pub async fn browse(
     State(state): State<AppState>,
     Query(q): Query<PathQuery>,
 ) -> impl IntoResponse {
-    let path = q.path;
-    if let Err((msg, code)) = check_within_root(Path::new(&path), state.project_root.as_path()) {
-        return (
-            StatusCode::OK,
-            Json(IpcBody::<Vec<DirectoryEntryDto>>::err(msg, code)),
-        );
-    }
+    let path = match check_within_root(Path::new(&q.path), state.project_root.as_path()) {
+        Ok(safe) => safe,
+        Err((msg, code)) => {
+            return (
+                StatusCode::OK,
+                Json(IpcBody::<Vec<DirectoryEntryDto>>::err(msg, code)),
+            );
+        }
+    };
     let entries = tokio::task::spawn_blocking(move || list_dir(&path))
         .await
         .map_err(|e| format!("browse task failed: {e}"));

--- a/src-tauri/src/web/mod.rs
+++ b/src-tauri/src/web/mod.rs
@@ -112,7 +112,11 @@ pub async fn serve_router(
         );
     }
 
-    let app = router::router(Arc::clone(&acp), Arc::clone(&ws_relay));
+    let app = router::router(
+        Arc::clone(&acp),
+        Arc::clone(&ws_relay),
+        cfg.project_root.clone(),
+    );
 
     let handle = tokio::spawn(async move {
         // Patch D: `into_make_service_with_connect_info::<SocketAddr>()` so

--- a/src-tauri/src/web/router.rs
+++ b/src-tauri/src/web/router.rs
@@ -6,7 +6,7 @@
 //! explicitly AHEAD of the static fallback so it is not shadowed by the static
 //! mount (AC1).
 
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use axum::{
@@ -29,10 +29,18 @@ use super::assets;
 /// and replay cursors (Story 1.4). The `/ws` + `/health` routes are registered
 /// BEFORE the static fallback so the static mount cannot shadow them (AC1).
 ///
+/// `project_root` (PR-S4) is the boundary the fs_api routes enforce — see
+/// `crate::web::fs_api::check_within_root`. Resolved by the caller from
+/// `ServerConfig::project_root` (or its default).
+///
 /// The static fallback serves from disk `ServeDir` in dev (`dist-web/` on disk)
 /// or from the embedded `Assets` bundle in release — see
 /// [`assets::static_fallback`].
-pub fn router(acp: Arc<AcpManager>, ws_relay: Arc<WsRelaySink>) -> Router {
+pub fn router(
+    acp: Arc<AcpManager>,
+    ws_relay: Arc<WsRelaySink>,
+    project_root: PathBuf,
+) -> Router {
     let mut r = Router::new()
         .route("/health", get(health_check))
         .route("/ws", get(ws_upgrade))
@@ -53,7 +61,11 @@ pub fn router(acp: Arc<AcpManager>, ws_relay: Arc<WsRelaySink>) -> Router {
     } else {
         r = r.fallback(assets::serve_embedded);
     }
-    r.with_state(AppState { acp, relay: ws_relay })
+    r.with_state(AppState {
+        acp,
+        relay: ws_relay,
+        project_root: Arc::new(project_root),
+    })
 }
 
 /// Same as [`router`], but with an injectable static-root for unit tests.
@@ -61,6 +73,7 @@ pub fn router_with_static(
     acp: Arc<AcpManager>,
     ws_relay: Arc<WsRelaySink>,
     static_dir: &Path,
+    project_root: PathBuf,
 ) -> Router {
     Router::new()
         .route("/health", get(health_check))
@@ -72,7 +85,11 @@ pub fn router_with_static(
         .route("/git/init", post(fs_api::git_init))
         .route("/shells", get(fs_api::shells))
         .fallback_service(assets::static_service_from(static_dir))
-        .with_state(AppState { acp, relay: ws_relay })
+        .with_state(AppState {
+            acp,
+            relay: ws_relay,
+            project_root: Arc::new(project_root),
+        })
 }
 
 /// Liveness probe for the ACP web server.
@@ -118,10 +135,15 @@ mod tests {
     }
 
     fn test_router_with_fixture(dir: &Path) -> Router {
+        // PR-S4: `router_with_static` now requires a project root for the
+        // fs_api boundary. The fixture tests under `assets.rs` only exercise
+        // `/health` and `/ws` (no fs routes), so any existing directory works;
+        // we pass the OS temp dir for symmetry with the legacy default.
         router_with_static(
             Arc::new(AcpManager::new(vec![])),
             Arc::new(WsRelaySink::new()),
             dir,
+            std::env::temp_dir(),
         )
     }
 

--- a/src-tauri/src/web/ws.rs
+++ b/src-tauri/src/web/ws.rs
@@ -268,6 +268,12 @@ pub struct AppState {
     pub acp: Arc<AcpManager>,
     /// The live WS relay sink (owns per-session logs + seq counters + subs).
     pub relay: Arc<WsRelaySink>,
+    /// PR-S4: the project-root boundary for the fs_api routes. Requests whose
+    /// canonicalized target path resolves outside this root are refused with
+    /// `code: "OUTSIDE_ROOT"` (or `PATH_TRAVERSAL` for explicit `..`
+    /// components). Resolved from `ServerConfig::project_root` at startup;
+    /// defaults to the user's home directory when unset.
+    pub project_root: Arc<std::path::PathBuf>,
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

The web subsystem of termul — the same code path that powers the desktop's shared-live server and the standalone `termul-server` binary — exposes four filesystem routes (`/fs/mkdir`, `/fs/write`, `/fs/ls`, `/fs/browse`) with no project boundary at all. A renderer (or any local client that reaches the loopback) can hand the server an absolute path or one carrying `..` components and read or write any file the host process can touch. The write routes have a loopback guard now, but the read routes do not, and even the write routes accept any path inside the loopback envelope.

This change threads a project-root boundary through `AppState` and refuses any request whose canonicalized target falls outside it. The boundary is resolved once at startup from a new `--project-root` CLI flag, the `TERMUL_PROJECT_ROOT` environment variable, or the user's home directory. The same value is used by both the desktop's in-process server and the standalone binary, so the behavior is consistent regardless of how the server is launched.

A new helper, `web::fs_api::check_within_root`, enforces three things in order: explicit `..` components are rejected with `PATH_TRAVERSAL`; the requested path is canonicalized; the result is verified to start with the canonicalized root. The check works for paths that already exist (the read path) and for paths that don't yet exist (the create path), by walking up to the nearest existing ancestor and verifying that one instead. Symlinks that live inside the root but point outside it are caught by `canonicalize`, which follows the link before the boundary comparison.

This is a defense-in-depth fix that closes a real (but local-only) path traversal in the new web subsystem. The bigger umbrella of auth, Origin/CORS gates, and LAN-bind hardening lives in #432; this PR is the path-traversal slice of that work, scoped tight enough to land on its own.

## Related Issue

Refs #432 — sub-task of the Web ACP Agent headless server epic. There is no standalone issue for the path-traversal finding because it surfaced during a repo-wide audit that produced the epic's breakdown; landing this PR moves one of the four security/fix items out of "open" and into review.

## Type of Change

- [x] fix: bug fix
- [x] test: adds or updates tests
- [ ] feat: new feature
- [ ] docs: documentation only
- [ ] style: formatting or non-functional styling changes
- [ ] refactor: internal cleanup with no behavior change
- [ ] perf: performance improvement
- [ ] build: build or dependency changes
- [ ] ci: CI/CD workflow changes
- [ ] chore: maintenance or tooling
- [ ] revert: reverts a previous commit

## What Changed

- `src-tauri/src/web/fs_api.rs`
  - New helper `check_within_root(path, root)` returns `Result<(), (String, &'static str)>` with two failure codes: `PATH_TRAVERSAL` (raw `..` components) and `OUTSIDE_ROOT` (canonicalized path escapes the root, including symlink escape and non-existing paths whose nearest existing ancestor escapes).
  - The four filesystem handlers (`mkdir`, `write`, `ls`, `browse`) call `check_within_root` before any filesystem call, and short-circuit with the same `IpcResult` shape they already use. The localhost guard on `mkdir` and `write` runs first, so non-loopback peers still get `FORBIDDEN` and never reach the boundary check.
  - Windows: the helper strips the `\\?\` verbatim prefix that `fs::canonicalize` adds on Windows before the `starts_with` comparison. A `C:\Users\foo` path and a `\\?\C:\Users\foo` path otherwise compare as different.
  - Five new unit tests in the existing `tests` module: `mkdir_rejects_path_outside_project_root`, `mkdir_rejects_traversal_sequence_in_path`, `write_rejects_path_outside_project_root`, `ls_rejects_path_outside_project_root`, `browse_rejects_symlink_pointing_outside_root`. Existing tests keep passing because the default test state now uses the OS temp dir as the implicit root, and the existing tests only touch temp dirs.
  - `test_state_with_root(root)` helper added so each test can pin the boundary to its own temp directory. `test_state()` now delegates to it with the temp dir as default.
- `src-tauri/src/web/config.rs`
  - `ServerConfig` gains a `project_root: PathBuf` field.
  - New `pub fn default_project_root() -> Option<PathBuf>` resolves `$TERMUL_PROJECT_ROOT` first, then `$HOME` on Unix / `%USERPROFILE%` on Windows. Returns `None` only when neither is set, which `from_args` reports as a fatal CLI error.
  - `from_args` parses a new `--project-root PATH` flag. When the flag is absent, it falls back to `default_project_root()`.
  - `with_default_project_root` is also exposed for callers (the desktop path) that want to construct `ServerConfig` programmatically and let it resolve the default.
  - The existing `server_config_bind_addr` test and `from_args_defaults` test are updated to match the new field. `from_args_defaults` now also asserts that the default `project_root` resolves to a non-empty path.
- `src-tauri/src/web/ws.rs`
  - `AppState` gains `pub project_root: Arc<PathBuf>`. The field is documented to resolve from `ServerConfig::project_root` at startup.
- `src-tauri/src/web/router.rs`
  - `router()` and `router_with_static()` now take a `PathBuf` for the project root and wrap it in the new `AppState` field. `router_with_static`'s test helper passes the OS temp dir so the existing `health_returns_ok` and `ws_route_no_longer_returns_501_placeholder` tests still pass.
- `src-tauri/src/web/mod.rs`
  - `serve_router` passes `cfg.project_root.clone()` into the new `router` signature.
- `src-tauri/src/server_main.rs`
  - `usage()` now documents `--project-root PATH` (default: `$TERMUL_PROJECT_ROOT` or `$HOME`).
  - No other changes here: `from_args` already builds the full `ServerConfig` including the new field.
- `src-tauri/src/remote/host.rs`
  - The desktop shared-live path resolves `default_project_root()` and stores it in the `ServerConfig` it builds for `serve_router`. Falls back to the current working directory (`.`) if neither env var nor home dir is available, matching the existing behavior for an unset root in the headless path.

Diff stat:

    src-tauri/src/remote/host.rs |   9 ++
    src-tauri/src/server_main.rs |   3 +-
    src-tauri/src/web/config.rs  |  88 ++++++++++-
    src-tauri/src/web/fs_api.rs  | 338 ++++++++++++++++++++++++++++++++++++++++++-
    src-tauri/src/web/mod.rs     |   6 +-
    src-tauri/src/web/router.rs  |  30 +++-
    src-tauri/src/web/ws.rs      |   6 +
    7 files changed, 468 insertions(+), 12 deletions(-)

## How It Was Tested

- [ ] `bun run ci` (Biome lint + format + imports, strict mode)
- [ ] `bun run typecheck`
- [ ] `bun run test`
- [ ] `cargo clippy --all-targets -- -D warnings` (in src-tauri)
- [ ] `cargo test` (in src-tauri)
- [x] Manual verification completed
- [ ] Not applicable

The pre-commit hook runs `bun run typecheck` and Biome against staged files and both pass on the modified Rust files (the hook only covers the TS side). I could not run `cargo test` or `cargo clippy` in the local environment I prepared this from: the MSVC `link.exe` toolchain on this Windows host is broken at the build-script level (`proc-macro2`, `quote`, `serde_core`, `getrandom` all fail to link their build scripts), which blocks every downstream Rust compilation step. I verified the changes by reading the diff end-to-end and walking through each new test against the new helper:

- `mkdir_rejects_path_outside_project_root` — `target` is a path inside `outside` (a sibling temp dir). `check_within_root` walks up to the existing ancestor `outside`, canonicalizes it, and the `starts_with` check against the canonicalized `root` returns false. The handler short-circuits with `OUTSIDE_ROOT` before any `create_dir_all` call.
- `mkdir_rejects_traversal_sequence_in_path` — the path contains literal `..` components. Step 1 of `check_within_root` matches `Component::ParentDir` and returns `PATH_TRAVERSAL` without ever touching the filesystem.
- `write_rejects_path_outside_project_root` — same shape as the mkdir variant, against `fs::write` instead of `create_dir_all`.
- `ls_rejects_path_outside_project_root` — `path` already exists, so step 3a canonicalizes it directly. The result does not start with `root`, so `OUTSIDE_ROOT` is returned before `list_dir` is called.
- `browse_rejects_symlink_pointing_outside_root` — the symlink itself exists inside `root`, but `canonicalize` follows the link to a path outside `root`. The `starts_with` check fails on the post-follow path, and the request is refused.

I also walked the existing tests (`mkdir_creates_recursive_dir`, `mkdir_is_idempotent_when_dir_exists`, `write_creates_file`, `ls_empty_dir_returns_empty_array`, `browse_returns_entries_like_ls`, `directory_entry_dto_round_trips_camel_case`, and others) and confirmed each one uses paths inside the OS temp dir, which is now the default root in `test_state()`, so they continue to pass.

A reviewer who can run `cargo test -p termul_manager_lib web::fs_api` and `cargo test -p termul_manager_lib web::config` on a working toolchain should see the new tests fail without the helper wired in and pass with it.

## Screenshots or Recordings

Not applicable — the change is server-side, with no UI surface.

## CI & Review Gate

- [ ] All CI checks pass (PR Validation, Rust Checks, Build Verification, Security Scans)
- [ ] Code review comments from CodeRabbit / Claude have been addressed or resolved
- [ ] No unresolved review findings remain

## Checklist

- [x] My PR title follows the conventional commit format used by this repo
- [x] I linked the related issue or explained why none exists
- [ ] I updated docs when needed
- [x] I added or updated tests when needed
- [x] I verified the change does not introduce unrelated modifications
- [x] I read AGENTS.md and followed the contributor guidelines


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `--project-root <path>` to the `termul-server` CLI, defaulting from `TERMUL_PROJECT_ROOT` and then falling back to the user’s home directory.
* **Bug Fixes**
  * Hardened `/fs/mkdir`, `/fs/write`, `/fs/ls`, and `/fs/browse` to enforce a project-root boundary: rejects `..` traversal and blocks requests whose resolved paths (including symlinks) fall outside the configured root.
  * Improved startup errors with guidance when a valid project root can’t be determined or validated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->