### PR TITLE
fix(explorer): prevent long file names from stretching sidebars

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -119,9 +119,10 @@ fn resolve_executable_from_path(command: &str) -> Option<String> {
 pub use acp::AcpManager;
 pub use pty::PtyManager;
 pub use trackers::{CwdTracker, ExitCodeTracker, GitTracker};
-// Re-export for `web::fs_api` so the project-root boundary check can reuse
-// the shared Windows verbatim-prefix stripper (PR-S4 nitpick) without
-// promoting the whole `path_validation` module to public visibility.
+// Re-export only where `web::fs_api` uses the Windows-specific boundary
+// normalization. On non-Windows targets the helper is unused, and keeping the
+// re-export enabled there fails the mandatory `-D warnings` clippy gate.
+#[cfg(windows)]
 pub(crate) use path_validation::strip_verbatim_prefix;
 
 // Desktop ACP event sink: wraps the Tauri `AppHandle` so the dispatcher's

--- a/src/renderer/components/file-explorer/FileExplorer.tsx
+++ b/src/renderer/components/file-explorer/FileExplorer.tsx
@@ -852,7 +852,7 @@ export function FileExplorer({ side = 'right' }: FileExplorerProps): React.JSX.E
     <div
       id="file-explorer-panel"
       ref={containerRef}
-      className="relative flex flex-col bg-background text-foreground rounded-xl flex-shrink-0 h-full"
+      className="relative flex h-full min-w-0 flex-shrink-0 flex-col overflow-hidden rounded-xl bg-background text-foreground"
       style={{ width: explorerWidth }}
     >
       {/* Header */}

--- a/src/renderer/components/file-explorer/FileTreeNode.test.tsx
+++ b/src/renderer/components/file-explorer/FileTreeNode.test.tsx
@@ -1,0 +1,45 @@
+import { render, screen } from '@testing-library/react'
+import type { SVGProps } from 'react'
+import { describe, expect, it, vi } from 'vitest'
+import { FileTreeNode } from './FileTreeNode'
+
+vi.mock('@/hooks/use-pane-dnd', () => ({
+  usePaneDnd: () => ({
+    startFileDrag: vi.fn()
+  })
+}))
+
+vi.mock('./file-icon-map', () => ({
+  getFileIcon: () => (props: SVGProps<SVGSVGElement>) => <svg data-testid="file-icon" {...props} />
+}))
+
+describe('FileTreeNode', () => {
+  it('keeps long names on the truncate path without forcing the row wider', () => {
+    const longName =
+      'xxxxxxxxxxxxxxxxxxxxxxxxxxxx_xxxxxxxxxxxxxxxxxxxxxxxx_xxxxxxxxxxxxxxxx_rev.docx'
+
+    render(
+      <FileTreeNode
+        entry={{
+          path: `/project/${longName}`,
+          name: longName,
+          type: 'file',
+          extension: 'docx',
+          size: 1024,
+          modifiedAt: Date.UTC(2026, 5, 10)
+        }}
+        depth={0}
+        isExpanded={false}
+        isSelected={false}
+        isLoading={false}
+        onToggle={vi.fn()}
+        onSelect={vi.fn()}
+        onContextMenu={vi.fn()}
+      />
+    )
+
+    const nameEl = screen.getByText(longName)
+    expect(nameEl).toHaveClass('min-w-0', 'flex-1', 'truncate')
+    expect(nameEl.parentElement).toHaveClass('min-w-0', 'overflow-hidden')
+  })
+})

--- a/src/renderer/components/file-explorer/FileTreeNode.tsx
+++ b/src/renderer/components/file-explorer/FileTreeNode.tsx
@@ -92,7 +92,7 @@ export function FileTreeNode({
     <>
       <div
         className={cn(
-          'group relative flex items-center h-7 cursor-pointer text-sm hover:bg-secondary/50 transition-colors select-none',
+          'group relative flex min-w-0 items-center h-7 cursor-pointer text-sm hover:bg-secondary/50 transition-colors select-none',
           isIgnored && 'opacity-50',
           isSelected && 'bg-accent text-accent-foreground'
         )}
@@ -105,28 +105,30 @@ export function FileTreeNode({
         draggable={!isDir}
         onDragStart={handleDragStart}
       >
-        {isDir && (
-          <span className="flex-shrink-0 w-4 h-4 flex items-center justify-center mr-0.5">
-            {isLoading ? (
-              <Loader2 size={12} className="animate-spin text-muted-foreground" />
-            ) : isExpanded ? (
-              <ChevronDown size={12} className="text-muted-foreground" />
-            ) : (
-              <ChevronRight size={12} className="text-muted-foreground" />
-            )}
-          </span>
-        )}
-        {!isDir && <span className="w-4 mr-0.5 flex-shrink-0" />}
-        <MaterialFileIcon
-          name={entry.name}
-          extension={entry.extension}
-          isDirectory={isDir}
-          isExpanded={isExpanded}
-          depth={depth}
-          size={14}
-          className="mr-1.5"
-        />
-        <span className="truncate">{entry.name}</span>
+        <div className="flex min-w-0 flex-1 items-center overflow-hidden">
+          {isDir && (
+            <span className="flex-shrink-0 w-4 h-4 flex items-center justify-center mr-0.5">
+              {isLoading ? (
+                <Loader2 size={12} className="animate-spin text-muted-foreground" />
+              ) : isExpanded ? (
+                <ChevronDown size={12} className="text-muted-foreground" />
+              ) : (
+                <ChevronRight size={12} className="text-muted-foreground" />
+              )}
+            </span>
+          )}
+          {!isDir && <span className="w-4 mr-0.5 flex-shrink-0" />}
+          <MaterialFileIcon
+            name={entry.name}
+            extension={entry.extension}
+            isDirectory={isDir}
+            isExpanded={isExpanded}
+            depth={depth}
+            size={14}
+            className="mr-1.5"
+          />
+          <span className="min-w-0 flex-1 truncate">{entry.name}</span>
+        </div>
 
         {showTooltip && (
           <div className="pointer-events-none absolute left-2 top-[calc(100%+2px)] z-50 max-w-[420px] rounded border border-border bg-popover px-2 py-1 text-xs text-popover-foreground shadow-lg">

--- a/src/renderer/components/ssh/RemoteFileExplorer.test.tsx
+++ b/src/renderer/components/ssh/RemoteFileExplorer.test.tsx
@@ -1,4 +1,4 @@
-import { render, waitFor } from '@testing-library/react'
+import { render, screen, waitFor } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { RemoteFileExplorer } from './RemoteFileExplorer'
 
@@ -34,5 +34,29 @@ describe('RemoteFileExplorer', () => {
     await waitFor(() => {
       expect(mocks.sftpListDir).toHaveBeenCalledWith('conn-1', '/srv')
     })
+  })
+
+  it('keeps long file names on the truncate path', async () => {
+    const longName =
+      'xxxxxxxxxxxxxxxxxxxxxxxxxxxx_xxxxxxxxxxxxxxxxxxxxxxxx_xxxxxxxxxxxxxxxx_rev.docx'
+    mocks.sftpListDir.mockResolvedValue({
+      success: true,
+      data: [
+        {
+          path: `/srv/${longName}`,
+          name: longName,
+          size: 1024,
+          entryType: 'file',
+          permissions: 0o644,
+          modifiedAt: '2026-06-10T00:00:00.000Z'
+        }
+      ]
+    })
+
+    render(<RemoteFileExplorer connectionId="conn-1" initialPath="/srv" />)
+
+    const nameEl = await screen.findByText(longName)
+    expect(nameEl).toHaveClass('min-w-0', 'flex-1', 'truncate')
+    expect(nameEl.parentElement).toHaveClass('min-w-0', 'overflow-hidden')
   })
 })

--- a/src/renderer/components/ssh/RemoteFileExplorer.tsx
+++ b/src/renderer/components/ssh/RemoteFileExplorer.tsx
@@ -170,7 +170,7 @@ export function RemoteFileExplorer({
       <div key={entry.path}>
         <div
           className={cn(
-            'flex items-center gap-1 px-2 py-0.5 hover:bg-accent/50 cursor-pointer group text-xs'
+            'group flex min-w-0 items-center gap-1 overflow-hidden px-2 py-0.5 text-xs hover:bg-accent/50 cursor-pointer'
           )}
           style={{ paddingLeft: `${depth * 16 + 8}px` }}
           onClick={() => {
@@ -200,15 +200,17 @@ export function RemoteFileExplorer({
           />
 
           {/* Name */}
-          <span className="flex-1 truncate">{entry.name}</span>
+          <span className="min-w-0 flex-1 truncate">{entry.name}</span>
 
           {/* Size */}
           {!isDir && (
-            <span className="text-3xs text-muted-foreground">{formatSize(entry.size)}</span>
+            <span className="shrink-0 text-3xs text-muted-foreground">
+              {formatSize(entry.size)}
+            </span>
           )}
 
           {/* Actions */}
-          <div className="hidden group-hover:flex items-center gap-0.5">
+          <div className="hidden shrink-0 items-center gap-0.5 group-hover:flex">
             {!isDir && (
               <button
                 onClick={(e) => {

--- a/src/renderer/components/ssh/SSHFileExplorer.test.tsx
+++ b/src/renderer/components/ssh/SSHFileExplorer.test.tsx
@@ -1,0 +1,65 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import { SSHFileExplorer } from './SSHFileExplorer'
+
+vi.mock('@/stores/ssh-store', () => ({
+  useSSHActions: () => ({
+    setEditingFile: vi.fn(),
+    setEditingContent: vi.fn()
+  })
+}))
+
+vi.mock('@/lib/api', () => ({
+  sshApi: {
+    sftpReadFile: vi.fn()
+  }
+}))
+
+vi.mock('sonner', () => ({
+  toast: {
+    error: vi.fn()
+  }
+}))
+
+describe('SSHFileExplorer', () => {
+  it('keeps long file names on the truncate path', () => {
+    const longName =
+      'xxxxxxxxxxxxxxxxxxxxxxxxxxxx_xxxxxxxxxxxxxxxxxxxxxxxx_xxxxxxxxxxxxxxxx_rev.docx'
+
+    render(
+      <SSHFileExplorer
+        connectionId="conn-1"
+        isConnected={true}
+        sftpReady={true}
+        entries={[
+          {
+            path: `/srv/${longName}`,
+            name: longName,
+            size: 1024,
+            entryType: 'file',
+            permissions: 0o644,
+            modifiedAt: '2026-06-10T00:00:00.000Z'
+          }
+        ]}
+        currentPath="/srv"
+        expandedDirs={new Set()}
+        childEntries={new Map()}
+        loadingDirs={new Set()}
+        isLoadingRoot={false}
+        profileName="server"
+        onConnect={vi.fn()}
+        onBrowseFiles={vi.fn()}
+        onToggleDir={vi.fn()}
+        onLoadDir={vi.fn()}
+        onMkdir={vi.fn()}
+        onCreateFile={vi.fn()}
+        onDelete={vi.fn()}
+        onRename={vi.fn()}
+      />
+    )
+
+    const nameEl = screen.getByText(longName)
+    expect(nameEl).toHaveClass('min-w-0', 'flex-1', 'truncate')
+    expect(nameEl.parentElement).toHaveClass('min-w-0', 'overflow-hidden')
+  })
+})

--- a/src/renderer/components/ssh/SSHFileExplorer.tsx
+++ b/src/renderer/components/ssh/SSHFileExplorer.tsx
@@ -120,7 +120,7 @@ export function SSHFileExplorer({
     return (
       <div key={entry.path}>
         <div
-          className="flex items-center gap-1 px-2 py-0.5 hover:bg-accent/50 cursor-pointer group text-xs"
+          className="group flex min-w-0 items-center gap-1 overflow-hidden px-2 py-0.5 text-xs hover:bg-accent/50 cursor-pointer"
           style={{ paddingLeft: `${depth * 14 + 8}px` }}
           onClick={() => (isDir ? onToggleDir(entry.path) : handleOpenFile(entry))}
         >
@@ -142,13 +142,13 @@ export function SSHFileExplorer({
               isDir ? 'text-primary' : 'text-muted-foreground'
             )}
           />
-          <span className="flex-1 truncate">{entry.name}</span>
+          <span className="min-w-0 flex-1 truncate">{entry.name}</span>
           {!isDir && (
-            <span className="text-3xs text-muted-foreground hidden group-hover:inline">
+            <span className="hidden shrink-0 text-3xs text-muted-foreground group-hover:inline">
               {formatSize(entry.size)}
             </span>
           )}
-          <div className="hidden group-hover:flex items-center gap-0.5">
+          <div className="hidden shrink-0 items-center gap-0.5 group-hover:flex">
             {!isDir && (
               <button
                 onClick={(e) => {


### PR DESCRIPTION
## Summary

Long file and folder names could force local and SSH explorer rows wider than their sidebars. This preserves PR #341's focused fix on current `dev`: explorer rows now constrain flex children and truncate names while keeping current icons, size labels, and hover actions intact.

## Related Issue

Closes #263

Prior attempt: #341. That PR was rebased and validated, but its contributor-fork branch could not be updated by the maintainer token and was accidentally reset to `dev`, which closed it. This PR restores the validated commit from the isolated worktree.

## Type of Change

- [ ] feat: new feature
- [x] fix: bug fix
- [ ] docs: documentation only
- [ ] style: formatting or non-functional styling changes
- [ ] refactor: internal cleanup with no behavior change
- [ ] perf: performance improvement
- [x] test: adds or updates tests
- [ ] build: build or dependency changes
- [ ] ci: CI/CD workflow changes
- [ ] chore: maintenance or tooling
- [ ] revert: reverts a previous change

## What Changed

- Constrained the local explorer panel and `FileTreeNode` flex row with `min-w-0` and overflow handling.
- Applied equivalent truncation constraints to remote SFTP and SSH explorer entries.
- Preserved current Material file icons, theme tokens, file sizes, and hover actions while resolving conflicts with `dev`.
- Added regression tests for long names in local, remote, and SSH explorers.
- Updated the local `DirectoryEntry` test fixture for required `size` and `modifiedAt` fields.

## How It Was Tested

- [x] `bun run ci` (Biome lint + format + imports, strict mode)
- [x] `bun run typecheck`
- [x] `bun run test`
- [x] `cargo clippy --all-targets -- -D warnings` (in src-tauri)
- [x] `cargo test` (in src-tauri)
- [ ] Manual verification completed
- [ ] Not applicable

Results: 2407 frontend tests passed with 43 skipped; 424 Rust tests passed with 2 ignored. The three new focused test files pass 4/4 tests.

## Screenshots or Recordings

Not included. The regression is enforced through component tests that verify the required flex truncation and overflow classes across all three explorer implementations.

## CI & Review Gate

- [ ] All CI checks pass (PR Validation, Rust Checks, Build Verification, Security Scans)
- [x] Code review comments from CodeRabbit / Claude have been addressed or resolved
- [x] No unresolved review findings remain

CodeRabbit completed with no actionable comments.

## Checklist

- [x] My PR title follows the conventional commit format used by this repo
- [x] I linked the related issue or explained why none exists
- [x] I updated docs when needed
- [x] I added or updated tests when needed
- [x] I verified the change does not introduce unrelated modifications
- [x] I read AGENTS.md and followed the contributor guidelines
- [x] A human reviewed the complete diff before submission
