### PR TITLE
fix(settings): auto-detect project env file

### DIFF
--- a/src/renderer/lib/env-parser.test.ts
+++ b/src/renderer/lib/env-parser.test.ts
@@ -1,8 +1,26 @@
 import { describe, expect, it } from 'vitest'
 import type { EnvVariable } from '@/types/project'
-import { mergeEnvVars, parseEnvFile, resolveEnvForSpawn } from './env-parser'
+import { mergeEnvVars, parseEnvFile, resolveEnvForSpawn, resolveProjectEnvPath } from './env-parser'
 
 describe('env-parser', () => {
+  describe('resolveProjectEnvPath', () => {
+    it.each([
+      ['/workspace/app', '/workspace/app/.env'],
+      ['/workspace/app/', '/workspace/app/.env'],
+      ['/workspace/app///', '/workspace/app/.env'],
+      ['C:\\workspace\\app', 'C:\\workspace\\app\\.env'],
+      ['C:\\workspace\\app\\', 'C:\\workspace\\app\\.env'],
+      ['C:/workspace/app/', 'C:/workspace/app/.env'],
+      ['\\\\server\\share\\app', '\\\\server\\share\\app\\.env'],
+      ['\\\\server\\share\\app\\\\', '\\\\server\\share\\app\\.env'],
+      ['/', '/.env'],
+      ['/workspace/project\\name', '/workspace/project\\name/.env'],
+      ['C:\\', 'C:\\.env']
+    ])('resolves %s to %s', (rootPath, expected) => {
+      expect(resolveProjectEnvPath(rootPath)).toBe(expected)
+    })
+  })
+
   describe('parseEnvFile', () => {
     it('should parse simple KEY=value pairs', () => {
       const content = 'NODE_ENV=development\nAPI_KEY=test123'

--- a/src/renderer/lib/env-parser.ts
+++ b/src/renderer/lib/env-parser.ts
@@ -1,6 +1,24 @@
 import type { EnvVariable } from '@/types/project'
 
 /**
+ * Resolve the exact .env file beneath a project root without relying on
+ * platform-specific path APIs in the renderer.
+ */
+export function resolveProjectEnvPath(rootPath: string): string {
+  const isWindowsPath = /^[A-Za-z]:[\\/]/.test(rootPath) || rootPath.startsWith('\\\\')
+  const separator = isWindowsPath && rootPath.includes('\\') ? '\\' : '/'
+  const rootWithoutTrailingSeparators = isWindowsPath
+    ? rootPath.replace(/[\\/]+$/, '')
+    : rootPath.replace(/\/+$/, '')
+
+  if (rootWithoutTrailingSeparators === '') {
+    return `${separator}.env`
+  }
+
+  return `${rootWithoutTrailingSeparators}${separator}.env`
+}
+
+/**
  * Result of parsing a .env file
  */
 export interface EnvParseResult {

--- a/src/renderer/pages/ProjectSettings.test.tsx
+++ b/src/renderer/pages/ProjectSettings.test.tsx
@@ -1,0 +1,296 @@
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { useProjectStore } from '@/stores/project-store'
+import type { Project } from '@/types/project'
+import ProjectSettings from './ProjectSettings'
+
+const apiMocks = vi.hoisted(() => ({
+  selectFile: vi.fn(),
+  selectDirectory: vi.fn(),
+  readFile: vi.fn(),
+  getAvailableShells: vi.fn(),
+  parseGitignore: vi.fn()
+}))
+
+vi.mock('@/lib/api', () => ({
+  dialogApi: {
+    selectFile: apiMocks.selectFile,
+    selectDirectory: apiMocks.selectDirectory
+  },
+  filesystemApi: { readFile: apiMocks.readFile },
+  shellApi: { getAvailableShells: apiMocks.getAvailableShells },
+  worktreeApi: { parseGitignore: apiMocks.parseGitignore }
+}))
+
+vi.mock('@/components/settings/SettingsLayout', () => ({
+  SettingsLayout: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  SettingsSection: ({ children }: { children: React.ReactNode }) => <section>{children}</section>
+}))
+
+vi.mock('@/components/NewProjectModal', () => ({ NewProjectModal: () => null }))
+vi.mock('@/components/ConfirmDialog', () => ({ ConfirmDialog: () => null }))
+
+const firstProject: Project = {
+  id: 'project-1',
+  name: 'First Project',
+  color: 'blue',
+  path: '/workspace/app',
+  defaultShell: 'bash',
+  envVars: [
+    { key: 'KEEP', value: 'unchanged' },
+    { key: 'OVERWRITE', value: 'old' }
+  ]
+}
+
+const secondProject: Project = {
+  id: 'project-2',
+  name: 'Second Project',
+  color: 'green',
+  path: '/workspace/second',
+  defaultShell: 'bash',
+  envVars: [{ key: 'SECOND', value: 'saved' }]
+}
+
+function renderSettings(projects: Project[] = [firstProject], activeProjectId = firstProject.id) {
+  useProjectStore.setState({
+    projects,
+    groups: [],
+    activeProjectId,
+    isLoaded: true,
+    isWorktreeOperationLocked: false
+  })
+
+  return render(
+    <MemoryRouter>
+      <ProjectSettings />
+    </MemoryRouter>
+  )
+}
+
+function importEnv() {
+  fireEvent.click(screen.getByRole('button', { name: /import from \.env/i }))
+}
+
+describe('ProjectSettings .env import', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    apiMocks.getAvailableShells.mockResolvedValue({
+      success: true,
+      data: {
+        available: [{ name: 'bash', path: '/bin/bash', displayName: 'Bash' }],
+        default: { name: 'bash', path: '/bin/bash', displayName: 'Bash' }
+      }
+    })
+    apiMocks.parseGitignore.mockResolvedValue({ success: true, data: [] })
+    apiMocks.selectDirectory.mockResolvedValue({
+      success: false,
+      error: 'cancelled',
+      code: 'DIALOG_CANCELED'
+    })
+  })
+
+  it('reads the current form root .env directly, merges values, and keeps them unsaved', async () => {
+    apiMocks.readFile.mockResolvedValue({
+      success: true,
+      data: { content: 'OVERWRITE=new\nADDED=value', path: '/workspace/app/.env' }
+    })
+    renderSettings()
+
+    importEnv()
+
+    await waitFor(() => expect(apiMocks.readFile).toHaveBeenCalledWith('/workspace/app/.env'))
+    expect(apiMocks.selectFile).not.toHaveBeenCalled()
+    expect(await screen.findByDisplayValue('new')).toBeInTheDocument()
+    expect(screen.getByDisplayValue('unchanged')).toBeInTheDocument()
+    expect(screen.getByDisplayValue('value')).toBeInTheDocument()
+    expect(screen.getByText('You have unsaved changes')).toBeInTheDocument()
+    expect(useProjectStore.getState().projects[0].envVars).toEqual(firstProject.envVars)
+  })
+
+  it('uses an edited root path and normalizes trailing separators', async () => {
+    apiMocks.readFile.mockResolvedValue({
+      success: true,
+      data: { content: 'KEY=value', path: 'C:\\workspace\\edited\\.env' }
+    })
+    renderSettings()
+
+    fireEvent.change(screen.getByDisplayValue('/workspace/app'), {
+      target: { value: 'C:\\workspace\\edited\\\\' }
+    })
+    importEnv()
+
+    await waitFor(() =>
+      expect(apiMocks.readFile).toHaveBeenCalledWith('C:\\workspace\\edited\\.env')
+    )
+    expect(apiMocks.selectFile).not.toHaveBeenCalled()
+  })
+
+  it('trims surrounding whitespace from the edited root before reading', async () => {
+    apiMocks.readFile.mockResolvedValue({
+      success: true,
+      data: { content: 'KEY=value', path: '/workspace/edited/.env' }
+    })
+    renderSettings()
+
+    fireEvent.change(screen.getByDisplayValue('/workspace/app'), {
+      target: { value: '  /workspace/edited/  ' }
+    })
+    importEnv()
+
+    await waitFor(() => expect(apiMocks.readFile).toHaveBeenCalledWith('/workspace/edited/.env'))
+  })
+
+  it('requires a configured form root without reading or opening a dialog', async () => {
+    renderSettings([{ ...firstProject, path: undefined }])
+
+    importEnv()
+
+    expect(await screen.findByText('Project root is required to import .env.')).toBeInTheDocument()
+    expect(apiMocks.readFile).not.toHaveBeenCalled()
+    expect(apiMocks.selectFile).not.toHaveBeenCalled()
+  })
+
+  it('keeps existing values unchanged and reports adapter read failures', async () => {
+    apiMocks.readFile.mockResolvedValue({
+      success: false,
+      error: 'File not found',
+      code: 'FILE_NOT_FOUND'
+    })
+    renderSettings()
+
+    importEnv()
+
+    expect(await screen.findByText('Failed to read .env: File not found')).toBeInTheDocument()
+    expect(screen.getByDisplayValue('old')).toBeInTheDocument()
+    expect(screen.queryByText('You have unsaved changes')).not.toBeInTheDocument()
+    expect(apiMocks.selectFile).not.toHaveBeenCalled()
+  })
+
+  it('keeps values unchanged for an empty or comment-only file', async () => {
+    apiMocks.readFile.mockResolvedValue({
+      success: true,
+      data: { content: '# comment\n\n', path: '/workspace/app/.env' }
+    })
+    renderSettings()
+
+    importEnv()
+
+    expect(await screen.findByText('The .env file is empty.')).toBeInTheDocument()
+    expect(screen.getByDisplayValue('old')).toBeInTheDocument()
+    expect(screen.queryByText('You have unsaved changes')).not.toBeInTheDocument()
+  })
+
+  it('reports invalid-only files without marking the form changed', async () => {
+    apiMocks.readFile.mockResolvedValue({
+      success: true,
+      data: { content: 'INVALID LINE', path: '/workspace/app/.env' }
+    })
+    renderSettings()
+
+    importEnv()
+
+    expect(await screen.findByText(/Imported 0 variables/)).toBeInTheDocument()
+    expect(screen.getByText(/Line 1: INVALID LINE/)).toBeInTheDocument()
+    expect(screen.queryByText('You have unsaved changes')).not.toBeInTheDocument()
+  })
+
+  it('imports valid variables and warns about invalid lines', async () => {
+    apiMocks.readFile.mockResolvedValue({
+      success: true,
+      data: { content: 'VALID=value\nINVALID LINE', path: '/workspace/app/.env' }
+    })
+    renderSettings()
+
+    importEnv()
+
+    expect(await screen.findByDisplayValue('value')).toBeInTheDocument()
+    expect(screen.getByText(/Imported 1 variables/)).toBeInTheDocument()
+    expect(screen.getByText(/Line 2: INVALID LINE/)).toBeInTheDocument()
+  })
+
+  it('discards a completed read after the active project switches', async () => {
+    let resolveRead: ((result: unknown) => void) | undefined
+    apiMocks.readFile.mockReturnValue(
+      new Promise((resolve) => {
+        resolveRead = resolve
+      })
+    )
+    renderSettings([firstProject, secondProject])
+
+    importEnv()
+    await waitFor(() => expect(apiMocks.readFile).toHaveBeenCalledWith('/workspace/app/.env'))
+
+    act(() => {
+      useProjectStore.getState().selectProject(secondProject.id)
+    })
+    await screen.findByText('Second Project')
+
+    await act(async () => {
+      resolveRead?.({
+        success: true,
+        data: { content: 'STALE=ignored', path: '/workspace/app/.env' }
+      })
+      await Promise.resolve()
+    })
+
+    expect(screen.queryByDisplayValue('ignored')).not.toBeInTheDocument()
+    expect(screen.getByDisplayValue('saved')).toBeInTheDocument()
+    expect(screen.queryByText('You have unsaved changes')).not.toBeInTheDocument()
+    expect(apiMocks.selectFile).not.toHaveBeenCalled()
+  })
+
+  it('discards a pending read after the edited root changes', async () => {
+    let resolveRead: ((result: unknown) => void) | undefined
+    apiMocks.readFile.mockReturnValue(
+      new Promise((resolve) => {
+        resolveRead = resolve
+      })
+    )
+    renderSettings()
+
+    importEnv()
+    await waitFor(() => expect(apiMocks.readFile).toHaveBeenCalledWith('/workspace/app/.env'))
+    fireEvent.change(screen.getByDisplayValue('/workspace/app'), {
+      target: { value: '/workspace/changed' }
+    })
+
+    await act(async () => {
+      resolveRead?.({
+        success: true,
+        data: { content: 'STALE=ignored', path: '/workspace/app/.env' }
+      })
+      await Promise.resolve()
+    })
+
+    expect(screen.queryByDisplayValue('ignored')).not.toBeInTheDocument()
+  })
+
+  it('allows only the latest overlapping import to update the form', async () => {
+    const resolvers: Array<(result: unknown) => void> = []
+    apiMocks.readFile.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolvers.push(resolve)
+        })
+    )
+    renderSettings()
+
+    importEnv()
+    importEnv()
+    await waitFor(() => expect(apiMocks.readFile).toHaveBeenCalledTimes(2))
+
+    await act(async () => {
+      resolvers[1]({ success: true, data: { content: 'ORDER=new', path: '/workspace/app/.env' } })
+      await Promise.resolve()
+    })
+    expect(await screen.findByDisplayValue('new')).toBeInTheDocument()
+
+    await act(async () => {
+      resolvers[0]({ success: true, data: { content: 'ORDER=old', path: '/workspace/app/.env' } })
+      await Promise.resolve()
+    })
+    expect(screen.getByDisplayValue('new')).toBeInTheDocument()
+    expect(screen.getByDisplayValue('ORDER')).toBeInTheDocument()
+  })
+})

--- a/src/renderer/pages/ProjectSettings.tsx
+++ b/src/renderer/pages/ProjectSettings.tsx
@@ -25,10 +25,15 @@ import {
 import { Skeleton } from '@/components/ui/skeleton'
 import { dialogApi, filesystemApi, shellApi, worktreeApi } from '@/lib/api'
 import { availableColors, getColorClasses } from '@/lib/colors'
-import { mergeEnvVars, parseEnvFile } from '@/lib/env-parser'
+import { mergeEnvVars, parseEnvFile, resolveProjectEnvPath } from '@/lib/env-parser'
 import type { SettingsSearchEntry } from '@/lib/settings-search'
 import { cn } from '@/lib/utils'
-import { useActiveProject, useActiveProjectId, useProjectActions } from '@/stores/project-store'
+import {
+  useActiveProject,
+  useActiveProjectId,
+  useProjectActions,
+  useProjectStore
+} from '@/stores/project-store'
 import type { EnvVariable, ProjectColor } from '@/types/project'
 
 const PROJECT_SETTINGS_CATEGORIES: SettingsCategory[] = [
@@ -113,6 +118,8 @@ export default function ProjectSettings() {
   const [projectName, setProjectName] = useState(activeProject?.name || '')
   const [selectedColor, setSelectedColor] = useState<ProjectColor>(activeProject?.color || 'blue')
   const [rootPath, setRootPath] = useState(activeProject?.path || '')
+  const rootPathRef = useRef(rootPath)
+  rootPathRef.current = rootPath
   const [envVars, setEnvVars] = useState<EnvVariable[]>(activeProject?.envVars || [])
   const [shell, setShell] = useState(activeProject?.defaultShell || '')
   const [hasChanges, setHasChanges] = useState(false)
@@ -153,6 +160,7 @@ export default function ProjectSettings() {
   // user — or the D5 auto-fill — has since changed.
   const symlinkInitProjectRef = useRef<string | null>(null)
   const autoFilledSymlinkRef = useRef<string | null>(null)
+  const envImportRequestRef = useRef(0)
 
   // Sync state when activeProject changes
   useEffect(() => {
@@ -169,8 +177,11 @@ export default function ProjectSettings() {
         setProjectName(activeProject.name)
         setSelectedColor(activeProject.color)
         setRootPath(activeProject.path || '')
+        envImportRequestRef.current += 1
         setEnvVars(activeProject.envVars || [])
         setSymlinkDirs(activeProject.symlinkDirs ?? [])
+        setImportError(null)
+        setImportWarnings(null)
         setHasChanges(false)
       }
     }
@@ -294,61 +305,80 @@ export default function ProjectSettings() {
   }
 
   const handleImportEnvFile = async () => {
-    // Capture the current project ID to detect concurrent project switches
+    // Capture enough form identity to reject stale and out-of-order reads.
     const projectIdAtStart = activeProjectId
+    const normalizedRoot = rootPath.trim()
+    const requestId = envImportRequestRef.current + 1
+    envImportRequestRef.current = requestId
 
     setImportError(null)
     setImportWarnings(null)
 
-    const fileResult = await dialogApi.selectFile({
-      filters: [{ name: 'Environment Files', extensions: ['env'] }],
-      title: 'Select .env File'
-    })
-
-    // Check if project switched during dialog
-    if (projectIdAtStart !== activeProjectId) {
+    if (normalizedRoot === '') {
+      setImportError('Project root is required to import .env.')
       return
     }
 
-    if (!fileResult.success) {
-      // User cancelled - not an error
-      return
-    }
+    const envPath = resolveProjectEnvPath(normalizedRoot)
 
-    const readResult = await filesystemApi.readFile(fileResult.data)
+    try {
+      const readResult = await filesystemApi.readFile(envPath)
 
-    // Check if project switched during file read
-    if (projectIdAtStart !== activeProjectId) {
-      return
-    }
+      // Read the store directly because this async callback retains values from
+      // the render in which it started. The request/root checks also reject
+      // overlapping reads and edits made while the adapter call is pending.
+      if (
+        requestId !== envImportRequestRef.current ||
+        projectIdAtStart !== useProjectStore.getState().activeProjectId ||
+        normalizedRoot !== rootPathRef.current.trim()
+      ) {
+        return
+      }
 
-    if (!readResult.success) {
-      setImportError(`Failed to read file: ${readResult.error}`)
-      return
-    }
+      if (!readResult.success) {
+        setImportError(`Failed to read .env: ${readResult.error}`)
+        return
+      }
 
-    const parseResult = parseEnvFile(readResult.data.content)
+      const parseResult = parseEnvFile(readResult.data.content)
 
-    if (parseResult.vars.length === 0 && parseResult.invalidLines.length === 0) {
-      setImportError('The .env file is empty.')
-      return
-    }
+      if (parseResult.vars.length === 0 && parseResult.invalidLines.length === 0) {
+        setImportError('The .env file is empty.')
+        return
+      }
 
-    // Merge with existing env vars using functional update to avoid stale state
-    setEnvVars((prevEnvVars) => mergeEnvVars(prevEnvVars, parseResult.vars))
-    setHasChanges(true)
+      // Merge only when at least one variable parsed successfully. An invalid-only
+      // file should report its skipped lines without claiming unsaved changes.
+      if (parseResult.vars.length > 0) {
+        setEnvVars((prevEnvVars) => mergeEnvVars(prevEnvVars, parseResult.vars))
+        setHasChanges(true)
+      }
 
-    // Show warnings for invalid lines if any
-    if (parseResult.invalidLines.length > 0) {
-      const warningDetails = parseResult.invalidLines
-        .slice(0, 3)
-        .map((l) => `Line ${l.line}: ${l.content}`)
-        .join('\n')
-      const moreCount =
-        parseResult.invalidLines.length > 3 ? ` (+${parseResult.invalidLines.length - 3} more)` : ''
-      setImportWarnings(
-        `Imported ${parseResult.vars.length} variables.\nSkipped ${parseResult.invalidLines.length} invalid line(s):\n${warningDetails}${moreCount}`
-      )
+      // Show warnings for invalid lines if any.
+      if (parseResult.invalidLines.length > 0) {
+        const warningDetails = parseResult.invalidLines
+          .slice(0, 3)
+          .map((l) => `Line ${l.line}: ${l.content}`)
+          .join('\n')
+        const moreCount =
+          parseResult.invalidLines.length > 3
+            ? ` (+${parseResult.invalidLines.length - 3} more)`
+            : ''
+        setImportWarnings(
+          `Imported ${parseResult.vars.length} variables.\nSkipped ${parseResult.invalidLines.length} invalid line(s):\n${warningDetails}${moreCount}`
+        )
+      }
+    } catch (error) {
+      if (
+        requestId !== envImportRequestRef.current ||
+        projectIdAtStart !== useProjectStore.getState().activeProjectId ||
+        normalizedRoot !== rootPathRef.current.trim()
+      ) {
+        return
+      }
+
+      const message = error instanceof Error ? error.message : String(error)
+      setImportError(`Failed to read .env: ${message}`)
     }
   }
 


### PR DESCRIPTION
## Summary

- Fixes the broken `.env` import flow reported on macOS, where the native picker renders dotfiles unselectable.
- Imports the exact `.env` file from the current Project Settings root path automatically, avoiding a file picker or browser entirely.
- Preserves existing parsing, merge, warning, secure-persistence, and unsaved-form behavior while rejecting stale or out-of-order reads.

## Related Issue

Closes #323

No open or closed pull request was found that already addresses issue #323.

## Type of Change

- [ ] feat: new feature
- [x] fix: bug fix
- [ ] docs: documentation only
- [ ] style: formatting or non-functional styling changes
- [ ] refactor: internal cleanup with no behavior change
- [ ] perf: performance improvement
- [x] test: adds or updates tests
- [ ] build: build or dependency changes
- [ ] ci: CI/CD workflow changes
- [ ] chore: maintenance or tooling
- [ ] revert: reverts a previous change

## What Changed

- Replaced `dialogApi.selectFile()` in Project Settings with deterministic `<current-root>/.env` resolution through `filesystemApi`.
- Added cross-platform resolution for POSIX, Windows drive, forward-slash Windows, and UNC paths without misclassifying literal POSIX backslashes.
- Added generation, project-ID, and root-path guards so project switches, root edits, and overlapping reads cannot apply stale environment values.
- Added regression coverage for success, no-dialog behavior, whitespace/trailing separators, missing and unreadable files, empty and invalid content, warnings, project switches, changed roots, and out-of-order imports.

## How It Was Tested

- [x] `bun run ci` (Biome lint + format + imports, strict mode)
- [x] `bun run typecheck`
- [x] `bun run test`
- [x] `cargo clippy --all-targets -- -D warnings` (in src-tauri)
- [x] `cargo test` (in src-tauri)
- [ ] Manual verification completed
- [ ] Not applicable

Local results:

- Vitest: 217 files passed, 1 skipped; 2,426 tests passed, 43 skipped.
- Rust tests: 424 passed, 2 ignored.
- Three-angle adversarial review completed; all actionable findings were fixed before submission.

## Screenshots or Recordings

No visual layout change. This changes the import action from opening an OS picker to reading the active project root `.env` directly.

## CI & Review Gate

- [ ] All CI checks pass (PR Validation, Rust Checks, Build Verification, Security Scans)
- [ ] Code review comments from CodeRabbit / Claude have been addressed or resolved
- [ ] No unresolved review findings remain

## Checklist

- [x] My PR title follows the conventional commit format used by this repo
- [x] I linked the related issue or explained why none exists
- [x] I updated docs when needed
- [x] I added or updated tests when needed
- [x] I verified the change does not introduce unrelated modifications
- [x] I read AGENTS.md and followed the contributor guidelines
- [x] A human reviewed the complete diff before submission
