### PR TITLE
fix(macos): vendor OpenSSL for portable app bundles

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -233,6 +233,91 @@ jobs:
           tauriScript: bun run tauri
           args: ${{ matrix.args }} --config src-tauri/tauri.conf.prod.json
 
+      - name: Verify macOS bundle library portability
+        if: startsWith(matrix.platform, 'macos-')
+        shell: bash
+        env:
+          RUST_TARGET: ${{ matrix.rust_target }}
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+
+          bundle_dir="src-tauri/target/${RUST_TARGET}/release/bundle/macos"
+          app_bundles=("${bundle_dir}"/*.app)
+          if [[ ${#app_bundles[@]} -ne 1 ]]; then
+            printf 'Expected exactly one .app in %s, found %d\n' \
+              "$bundle_dir" "${#app_bundles[@]}" >&2
+            printf 'Found: %s\n' "${app_bundles[*]:-none}" >&2
+            exit 1
+          fi
+
+          app_bundle="${app_bundles[0]}"
+          info_plist="${app_bundle}/Contents/Info.plist"
+          executable_name="$(/usr/libexec/PlistBuddy \
+            -c 'Print :CFBundleExecutable' "$info_plist")"
+          if [[ -z "$executable_name" || "$executable_name" == */* ]]; then
+            printf 'Invalid CFBundleExecutable in %s: %s\n' \
+              "$info_plist" "${executable_name:-empty}" >&2
+            exit 1
+          fi
+
+          executable="${app_bundle}/Contents/MacOS/${executable_name}"
+          if [[ ! -f "$executable" || ! -x "$executable" ]]; then
+            printf 'Declared bundle executable is missing or not executable: %s\n' \
+              "$executable" >&2
+            exit 1
+          fi
+
+          dependencies="$(otool -L "$executable")"
+          rpaths="$(otool -l "$executable" | awk '
+            $1 == "cmd" && $2 == "LC_RPATH" { in_rpath = 1; next }
+            in_rpath && $1 == "path" { print $2; in_rpath = 0 }
+          ')"
+          printf '%s\n' "$dependencies"
+          printf 'LC_RPATH entries:\n%s\n' "${rpaths:-  (none)}"
+
+          forbidden=()
+          while IFS= read -r dependency; do
+            [[ -z "$dependency" ]] && continue
+            case "$dependency" in
+              /System/Library/*|/usr/lib/*|@rpath/*|@loader_path/*|@executable_path/*)
+                ;;
+              /usr/local/*|/opt/homebrew/*)
+                forbidden+=("$dependency (Homebrew/local prefix)")
+                ;;
+              /*)
+                forbidden+=("$dependency (runner-local absolute path)")
+                ;;
+              *)
+                forbidden+=("$dependency (unexpected relative load path)")
+                ;;
+            esac
+          done < <(
+            printf '%s\n' "$dependencies" |
+              tail -n +2 |
+              sed -E 's/^[[:space:]]*([^[:space:]]+).*/\1/'
+          )
+
+          while IFS= read -r rpath; do
+            [[ -z "$rpath" ]] && continue
+            case "$rpath" in
+              /System/Library/*|/usr/lib/*|@loader_path/*|@executable_path/*)
+                ;;
+              /usr/local/*|/opt/homebrew/*)
+                forbidden+=("$rpath (Homebrew/local LC_RPATH)")
+                ;;
+              *)
+                forbidden+=("$rpath (non-portable LC_RPATH)")
+                ;;
+            esac
+          done <<< "$rpaths"
+
+          if [[ ${#forbidden[@]} -ne 0 ]]; then
+            printf 'Forbidden Mach-O paths in %s:\n' "$executable" >&2
+            printf '  %s\n' "${forbidden[@]}" >&2
+            exit 1
+          fi
+
   # Standalone headless server for VPS deploy (Story 1.2 scaffold).
   # Build sequencing: bun run build:web MUST run before the cargo release
   # build so rust-embed embeds dist-web/ into the binary (Story 1.11 — a

--- a/README.md
+++ b/README.md
@@ -323,7 +323,8 @@ bun run tauri <command>  # Direct Tauri CLI access
 - Active SSH sessions may retain the relevant secret in process memory only to support automatic reconnect; use SSH agent authentication to avoid runtime secret retention.
 - Interactive SSH terminals use OpenSSH's default known-hosts file with `StrictHostKeyChecking=accept-new`; do not override `UserKnownHostsFile` to `/dev/null`/`NUL` because that disables persistent host-key verification.
 - Local port forwarding uses `ssh2` `channel_direct_tcpip` over the active SSH session; remote/reverse forwarding is not supported by the MVP command path yet.
-- `ssh2` intentionally stays on system OpenSSL for now. Enabling `vendored-openssl` forces a local OpenSSL source build that can fail in Windows/MSYS environments without a complete Perl module setup.
+- `ssh2` vendors OpenSSL only for macOS targets so packaged `.app` bundles do not depend on Homebrew or build-runner library paths.
+- Windows and Linux retain `ssh2`'s system/default OpenSSL behavior. Do not enable `vendored-openssl` globally: its local source build can fail in common Windows/MSYS environments without a complete Perl module setup.
 
 ## ⭐ Star History
 

--- a/docs/deployment-guide.md
+++ b/docs/deployment-guide.md
@@ -156,6 +156,8 @@ Release workflow currently targets:
 - `aarch64-apple-darwin`
 - `x86_64-apple-darwin`
 
+For these targets, the SSH dependency vendors OpenSSL so the packaged app does not require Homebrew OpenSSL on user systems. After each macOS bundle is built, the release workflow requires exactly one `.app`, resolves its declared `CFBundleExecutable`, prints that executable's `otool -L` dependencies and `LC_RPATH` entries, and fails on Homebrew, unexpected relative, or other non-portable build-runner paths.
+
 Repository scripts also support Intel macOS builds locally.
 
 ## Additional Distribution Workflow
@@ -182,8 +184,9 @@ The repository also contains `.github/workflows/publish-aur.yml`, which updates 
 3. Confirm version parity in all three version files
 4. Confirm signing secrets are available in GitHub
 5. Push release tag
-6. Verify draft release assets include installers, `.sig`, and `latest.json`
-7. Publish the release
+6. For both macOS targets, confirm the bundle portability gate reports only system or dyld-relative dependencies and portable system/bundle-relative `LC_RPATH` entries
+7. Verify draft release assets include installers, `.sig`, and `latest.json`
+8. Publish the release
 
 ## Related Files
 

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3706,6 +3706,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
+name = "openssl-src"
+version = "300.6.1+3.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46eb8fb9fb3b61ce1c0f8a026c4c1a0714d3a9e138e7fbde78753ce2babc3846"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "openssl-sys"
 version = "0.9.116"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3713,6 +3722,7 @@ checksum = "f28a22dc7140cda5f096e5e7724a6962ca81a7f8bfd2979f9b18c11af56318c4"
 dependencies = [
  "cc",
  "libc",
+ "openssl-src",
  "pkg-config",
  "vcpkg",
 ]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -89,11 +89,8 @@ lazy_static = "1.4"
 # UUID generation
 uuid = { version = "1", features = ["v4", "serde"] }
 
-# SSH
-# Keep ssh2 on system OpenSSL for now. Enabling ssh2/vendored-openssl forces a
-# local OpenSSL source build that fails in common Windows/MSYS dev environments
-# without a full Perl module setup; see README SSH development notes.
-ssh2 = "0.9"
+# SSH linkage is selected per target below: macOS vendors OpenSSL for portable
+# app bundles, while Windows/Linux retain the system/default behavior.
 
 # Secure storage (OS keychain for secure credential storage).
 # IMPORTANT: keyring selects its backend at COMPILE TIME via cargo features.
@@ -134,9 +131,15 @@ tower = { version = "0.5", features = ["util"] }
 [target.'cfg(target_os = "windows")'.dependencies]
 keyring = { version = "3.6", features = ["windows-native"] }
 
-# macOS Keychain
+# macOS Keychain and self-contained SSH/OpenSSL linkage for packaged apps
 [target.'cfg(target_os = "macos")'.dependencies]
 keyring = { version = "3.6", features = ["apple-native"] }
+ssh2 = { version = "0.9", features = ["vendored-openssl"] }
+
+# Preserve the existing system/default SSH native dependency behavior outside
+# macOS. Global vendoring breaks common Windows/MSYS development environments.
+[target.'cfg(not(target_os = "macos"))'.dependencies]
+ssh2 = "0.9"
 
 # Linux Secret Service (persistent across reboots) with pure-Rust crypto so we
 # don't require a system OpenSSL/Perl build toolchain.


### PR DESCRIPTION
## Summary

- Fixes the macOS launch crash reported in #377 by making the `ssh2` dependency vendor OpenSSL only for Apple targets.
- Keeps Windows and Linux on their existing default native dependency behavior, avoiding the Windows/MSYS vendored-OpenSSL toolchain problem.
- Adds a release-time Mach-O portability gate for both macOS architectures so Homebrew or build-runner library paths cannot silently reach a published release.

## Related Issue

Closes #377

Searched open and closed pull requests for issue 377, the reported force-close behavior, Apple Silicon launch crashes, and macOS OpenSSL linkage. No duplicate fix was found.

## Type of Change

- [ ] feat: new feature
- [x] fix: bug fix
- [x] docs: documentation only
- [ ] style: formatting or non-functional styling changes
- [ ] refactor: internal cleanup with no behavior change
- [ ] perf: performance improvement
- [ ] test: adds or updates tests
- [x] build: build or dependency changes
- [x] ci: CI/CD workflow changes
- [ ] chore: maintenance or tooling
- [ ] revert: reverts a previous change

## What Changed

- Moved `ssh2` into target-specific Cargo dependency tables and enabled `vendored-openssl` only for `target_os = "macos"`.
- Updated `Cargo.lock` with `openssl-src 300.6.1+3.6.3` and its `openssl-sys` dependency edge, without unrelated package upgrades.
- Added a macOS release check that:
  - requires exactly one generated `.app`,
  - resolves its declared `CFBundleExecutable`,
  - prints `otool -L` dependencies and all `LC_RPATH` entries,
  - rejects Homebrew, unexpected relative, and other non-portable absolute paths.
- Updated README and deployment guidance to document target-specific OpenSSL linkage and the release gate.

## How It Was Tested

- [x] `bun run ci` (Biome lint + format + imports, strict mode)
- [x] `bun run typecheck`
- [x] `bun run test`
- [x] `cargo clippy --all-targets -- -D warnings` (in src-tauri)
- [x] `cargo test` (in src-tauri)
- [x] Manual verification completed
- [ ] Not applicable

Manual/target verification:

- `cargo tree --locked -e features -i openssl-sys --target aarch64-apple-darwin` includes `ssh2/vendored-openssl` and `openssl-sys/vendored`.
- `cargo tree --locked -e features -i openssl-sys --target x86_64-apple-darwin` includes `ssh2/vendored-openssl` and `openssl-sys/vendored`.
- `cargo tree --locked -e features -i openssl-sys --target x86_64-pc-windows-msvc` reports no OpenSSL dependency, confirming macOS vendoring does not leak into Windows.
- The workflow shell block passed Bash syntax/YAML review and synthetic `otool` dependency/`LC_RPATH` parsing checks during adversarial review.
- A clean-machine macOS launch cannot be performed from the Windows development host; both native release matrix jobs now validate the actual packaged executable.

## Screenshots or Recordings

No UI changes. The reported failure happens before the application window opens, so screenshots are not applicable.

## CI & Review Gate

- [x] All CI checks pass (PR Validation, Rust Checks, Build Verification, Security Scans)
- [x] Code review comments from CodeRabbit / Claude have been addressed or resolved
- [x] No unresolved review findings remain

All required checks passed. CodeRabbit completed with no actionable findings.

## Checklist

- [x] My PR title follows the conventional commit format used by this repo
- [x] I linked the related issue or explained why none exists
- [x] I updated docs when needed
- [x] I added or updated tests when needed
- [x] I verified the change does not introduce unrelated modifications
- [x] I read AGENTS.md and followed the contributor guidelines
- [x] A human reviewed the complete diff before submission

