### PR TITLE
fix(macos): harden distribution and restore Homebrew publication

### DIFF
--- a/.github/workflows/publish-homebrew.yml
+++ b/.github/workflows/publish-homebrew.yml
@@ -1,8 +1,15 @@
 name: Publish Homebrew
 
 on:
-  release:
-    types: [published]
+  workflow_call:
+    inputs:
+      version:
+        description: Version to publish, with or without leading v
+        required: true
+        type: string
+    secrets:
+      HOMEBREW_TAP_TOKEN:
+        required: false
   workflow_dispatch:
     inputs:
       version:
@@ -14,12 +21,55 @@ permissions:
   contents: read
 
 concurrency:
-  group: publish-homebrew-${{ github.event.release.tag_name || inputs.version }}
+  group: publish-homebrew-tap
   cancel-in-progress: false
 
 jobs:
+  release_metadata:
+    name: Resolve release metadata
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.metadata.outputs.version }}
+      tag: ${{ steps.metadata.outputs.tag }}
+      is_prerelease: ${{ steps.metadata.outputs.is_prerelease }}
+    steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2
+        with:
+          egress-policy: audit
+
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Resolve authoritative release metadata
+        id: metadata
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          INPUT_VERSION: ${{ inputs.version }}
+        run: |
+          source scripts/release/homebrew.sh
+          VERSION="$(normalize_release_version "$INPUT_VERSION")"
+          TAG="v$VERSION"
+          IS_PRERELEASE="$(gh release view "$TAG" \
+            --repo gnoviawan/termul \
+            --json isPrerelease \
+            --jq '.isPrerelease')"
+
+          if [[ "$IS_PRERELEASE" != "true" && "$IS_PRERELEASE" != "false" ]]; then
+            echo "Unable to determine prerelease metadata for $TAG" >&2
+            exit 1
+          fi
+
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "is_prerelease=$IS_PRERELEASE" >> "$GITHUB_OUTPUT"
+
   checksums:
     name: Generate SHA256SUMS
+    needs: release_metadata
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -29,33 +79,10 @@ jobs:
         with:
           egress-policy: audit
 
-      - name: Resolve version
-        id: version
-        shell: bash
-        env:
-          EVENT_NAME: ${{ github.event_name }}
-          INPUT_VERSION: ${{ inputs.version }}
-          RELEASE_TAG: ${{ github.event.release.tag_name }}
-        run: |
-          if [[ "$EVENT_NAME" == "workflow_dispatch" ]]; then
-            VERSION="$INPUT_VERSION"
-          else
-            VERSION="$RELEASE_TAG"
-          fi
-
-          VERSION="${VERSION#v}"
-          if [[ ! "$VERSION" =~ ^[0-9]+(\.[0-9]+){1,2}([._+-][0-9A-Za-z]+)?$ ]]; then
-            echo "Invalid version: $VERSION" >&2
-            exit 1
-          fi
-
-          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
-          echo "tag=v$VERSION" >> "$GITHUB_OUTPUT"
-
       - name: Download release assets
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TAG: ${{ steps.version.outputs.tag }}
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ needs.release_metadata.outputs.tag }}
         run: |
           mkdir -p release-assets
           gh release download "$TAG" \
@@ -66,28 +93,29 @@ jobs:
         shell: bash
         run: |
           cd release-assets
-          mapfile -d '' assets < <(
+          asset_count=0
+          : > ../SHA256SUMS.txt
+          while IFS= read -r -d '' asset; do
+            asset="${asset#./}"
+            sha256sum "$asset" >> ../SHA256SUMS.txt
+            asset_count=$((asset_count + 1))
+          done < <(
             find . -maxdepth 1 -type f \
               ! -name '*.sig' \
               ! -name 'latest.json' \
               ! -name 'SHA256SUMS.txt' \
-              -printf '%f\0' | sort -z
+              -print0 | sort -z
           )
 
-          if [[ "${#assets[@]}" -eq 0 ]]; then
+          if [[ "$asset_count" -eq 0 ]]; then
             echo "No binary release assets found to checksum." >&2
             exit 1
           fi
 
-          : > ../SHA256SUMS.txt
-          for asset in "${assets[@]}"; do
-            sha256sum "$asset" >> ../SHA256SUMS.txt
-          done
-
       - name: Upload SHA256SUMS
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TAG: ${{ steps.version.outputs.tag }}
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ needs.release_metadata.outputs.tag }}
         run: |
           gh release upload "$TAG" SHA256SUMS.txt \
             --repo gnoviawan/termul \
@@ -95,50 +123,34 @@ jobs:
 
   homebrew:
     name: Update Homebrew cask
-    needs: [checksums]
+    needs: [release_metadata, checksums]
+    if: needs.release_metadata.outputs.is_prerelease == 'false'
     runs-on: ubuntu-latest
-    if: github.event_name == 'workflow_dispatch' || github.event.release.prerelease == false
     steps:
       - name: Harden runner
         uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2
         with:
           egress-policy: audit
 
-      - name: Resolve version
-        id: version
+      - name: Require stable tap token
         shell: bash
         env:
-          EVENT_NAME: ${{ github.event_name }}
-          INPUT_VERSION: ${{ inputs.version }}
-          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
         run: |
-          if [[ "$EVENT_NAME" == "workflow_dispatch" ]]; then
-            VERSION="$INPUT_VERSION"
-          else
-            VERSION="$RELEASE_TAG"
-          fi
-
-          VERSION="${VERSION#v}"
-          if [[ ! "$VERSION" =~ ^[0-9]+(\.[0-9]+){1,2}([._+-][0-9A-Za-z]+)?$ ]]; then
-            echo "Invalid version: $VERSION" >&2
+          if [[ -z "$HOMEBREW_TAP_TOKEN" ]]; then
+            echo "HOMEBREW_TAP_TOKEN is required for stable Homebrew publication." >&2
             exit 1
           fi
 
-          if [[ "$VERSION" =~ (-[0-9A-Za-z]+|alpha|beta|rc) ]]; then
-            echo "Homebrew tap updates are skipped for prerelease version $VERSION."
-            echo "should_publish=false" >> "$GITHUB_OUTPUT"
-          else
-            echo "should_publish=true" >> "$GITHUB_OUTPUT"
-          fi
-
-          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
-          echo "tag=v$VERSION" >> "$GITHUB_OUTPUT"
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Download SHA256SUMS
-        if: steps.version.outputs.should_publish == 'true'
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TAG: ${{ steps.version.outputs.tag }}
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ needs.release_metadata.outputs.tag }}
         run: |
           mkdir -p release-assets
           gh release download "$TAG" \
@@ -147,97 +159,55 @@ jobs:
             --dir release-assets
 
       - name: Resolve DMG checksums
-        if: steps.version.outputs.should_publish == 'true'
         id: dmg
         shell: bash
         env:
-          VERSION: ${{ steps.version.outputs.version }}
+          VERSION: ${{ needs.release_metadata.outputs.version }}
         run: |
-          cd release-assets
-          ARM_DMG="Termul.Manager_${VERSION}_aarch64.dmg"
-          INTEL_DMG="Termul.Manager_${VERSION}_x64.dmg"
-
-          ARM_SHA256="$(awk -v file="$ARM_DMG" '$2 == file { print $1 }' SHA256SUMS.txt)"
-          INTEL_SHA256="$(awk -v file="$INTEL_DMG" '$2 == file { print $1 }' SHA256SUMS.txt)"
-
-          if [[ -z "$ARM_SHA256" ]]; then
-            echo "Missing checksum for $ARM_DMG" >&2
+          source scripts/release/homebrew.sh
+          checksum_count=0
+          while IFS= read -r checksum; do
+            checksum_count=$((checksum_count + 1))
+            case "$checksum_count" in
+              1) ARM_SHA256="$checksum" ;;
+              2) INTEL_SHA256="$checksum" ;;
+            esac
+          done < <(resolve_dmg_checksums release-assets/SHA256SUMS.txt "$VERSION")
+          if [[ "$checksum_count" -ne 2 ]]; then
+            echo "Expected exactly two DMG checksums, found $checksum_count" >&2
             exit 1
           fi
-
-          if [[ -z "$INTEL_SHA256" ]]; then
-            echo "Missing checksum for $INTEL_DMG" >&2
-            exit 1
-          fi
-
           echo "arm_sha256=$ARM_SHA256" >> "$GITHUB_OUTPUT"
           echo "intel_sha256=$INTEL_SHA256" >> "$GITHUB_OUTPUT"
 
       - name: Clone Homebrew tap
-        if: steps.version.outputs.should_publish == 'true'
         env:
           GH_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
         run: |
-          test -n "$GH_TOKEN"
           gh auth setup-git
           gh repo clone gnoviawan/homebrew-termul tap -- --depth 1
 
       - name: Configure Git
-        if: steps.version.outputs.should_publish == 'true'
         working-directory: tap
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
       - name: Write cask
-        if: steps.version.outputs.should_publish == 'true'
-        working-directory: tap
         env:
-          VERSION: ${{ steps.version.outputs.version }}
+          VERSION: ${{ needs.release_metadata.outputs.version }}
           ARM_SHA256: ${{ steps.dmg.outputs.arm_sha256 }}
           INTEL_SHA256: ${{ steps.dmg.outputs.intel_sha256 }}
         run: |
-          mkdir -p Casks
-          cat > Casks/termul.rb <<EOF
-          cask "termul" do
-            arch arm: "aarch64", intel: "x64"
-
-            version "$VERSION"
-            sha256 arm:   "$ARM_SHA256",
-                   intel: "$INTEL_SHA256"
-
-            url "https://github.com/gnoviawan/termul/releases/download/v#{version}/Termul.Manager_#{version}_#{arch}.dmg"
-            name "Termul Manager"
-            desc "Terminal-native workspace and CLI agent manager"
-            homepage "https://github.com/gnoviawan/termul"
-
-            auto_updates true
-            depends_on macos: :catalina
-
-            app "Termul Manager.app"
-
-            postflight do
-              system_command "/usr/bin/xattr",
-                             args: ["-dr", "com.apple.quarantine", "#{appdir}/Termul Manager.app"]
-            end
-
-            zap trash: [
-              "~/Library/Application Support/com.termul-manager.app",
-              "~/Library/Caches/com.termul-manager.app",
-              "~/Library/HTTPStorages/com.termul-manager.app",
-              "~/Library/Logs/com.termul-manager.app",
-              "~/Library/Preferences/com.termul-manager.app.plist",
-              "~/Library/Saved Application State/com.termul-manager.app.savedState",
-              "~/Library/WebKit/com.termul-manager.app",
-            ]
-          end
-          EOF
+          source scripts/release/homebrew.sh
+          write_homebrew_cask tap/Casks/termul.rb \
+            "$VERSION" "$ARM_SHA256" "$INTEL_SHA256"
 
       - name: Commit and push
-        if: steps.version.outputs.should_publish == 'true'
         working-directory: tap
         env:
-          VERSION: ${{ steps.version.outputs.version }}
+          VERSION: ${{ needs.release_metadata.outputs.version }}
+          GH_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
         run: |
           git add Casks/termul.rb
           if git diff --cached --quiet -- Casks/termul.rb; then
@@ -246,7 +216,7 @@ jobs:
           fi
 
           git commit -m "Update to $VERSION"
-          DEFAULT_BRANCH="$(git remote show origin | awk '/HEAD branch/ { print $NF }')"
+          DEFAULT_BRANCH="$(git remote show origin | awk '/HEAD branch/ { print $NF}')"
           git fetch origin "$DEFAULT_BRANCH"
           git rebase "origin/$DEFAULT_BRANCH"
           git push origin "HEAD:$DEFAULT_BRANCH"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,20 +41,16 @@ jobs:
         id: version
         shell: bash
         run: |
-          TAG="${GITHUB_REF#refs/tags/}"
-          VERSION="${TAG#v}"
-          if [[ -z "$VERSION" ]]; then
-            echo "Tag must include a version" >&2
-            exit 1
-          fi
+          source scripts/release/homebrew.sh
+          VERSION="$(normalize_release_version "$GITHUB_REF_NAME")"
           echo "normalized_version=$VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Check prerelease
         id: check
         shell: bash
         run: |
-          TAG="${GITHUB_REF#refs/tags/}"
-          if [[ "$TAG" =~ (-[0-9A-Za-z]+|alpha|beta|rc) ]]; then
+          source scripts/release/homebrew.sh
+          if is_release_prerelease "$GITHUB_REF_NAME"; then
             echo "is_prerelease=true" >> "$GITHUB_OUTPUT"
           else
             echo "is_prerelease=false" >> "$GITHUB_OUTPUT"
@@ -95,7 +91,6 @@ jobs:
                 repo: context.repo.repo,
                 tag: tagName,
               })
-
               release = await github.rest.repos.updateRelease({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
@@ -107,10 +102,7 @@ jobs:
                 prerelease,
               })
             } catch (error) {
-              if (error.status !== 404) {
-                throw error
-              }
-
+              if (error.status !== 404) throw error
               release = await github.rest.repos.createRelease({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
@@ -121,15 +113,12 @@ jobs:
                 prerelease,
               })
             }
-
             core.setOutput('releaseId', String(release.data.id))
 
   build:
     name: Build (${{ matrix.platform }})
-    needs: [changelog, create_release]
+    needs: changelog
     runs-on: ${{ matrix.runner }}
-    permissions:
-      contents: write
     strategy:
       fail-fast: false
       matrix:
@@ -138,22 +127,18 @@ jobs:
             runner: windows-latest
             rust_target: x86_64-pc-windows-msvc
             args: --target x86_64-pc-windows-msvc
-
           - platform: linux-x64
             runner: ubuntu-22.04
             rust_target: x86_64-unknown-linux-gnu
             args: --target x86_64-unknown-linux-gnu
-
           - platform: macos-aarch64
             runner: macos-latest
             rust_target: aarch64-apple-darwin
             args: --target aarch64-apple-darwin
-
           - platform: macos-x64
             runner: macos-15-intel
             rust_target: x86_64-apple-darwin
             args: --target x86_64-apple-darwin
-
     steps:
       - name: Harden runner
         if: matrix.runner == 'ubuntu-22.04'
@@ -165,6 +150,41 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
+
+      - name: Preflight Apple and updater credentials
+        if: startsWith(matrix.platform, 'macos-')
+        shell: bash
+        env:
+          APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
+          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+          APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          TAURI_SIGNING_PUBLIC_KEY: ${{ secrets.TAURI_SIGNING_PUBLIC_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+        run: |
+          missing=()
+          for name in \
+            APPLE_CERTIFICATE \
+            APPLE_CERTIFICATE_PASSWORD \
+            APPLE_SIGNING_IDENTITY \
+            APPLE_ID \
+            APPLE_PASSWORD \
+            APPLE_TEAM_ID \
+            TAURI_SIGNING_PUBLIC_KEY \
+            TAURI_SIGNING_PRIVATE_KEY \
+            TAURI_SIGNING_PRIVATE_KEY_PASSWORD; do
+            if [[ -z "${!name:-}" ]]; then
+              missing+=("$name")
+            fi
+          done
+          if [[ "${#missing[@]}" -ne 0 ]]; then
+            printf 'Missing required macOS release credential categories:\n' >&2
+            printf '  - %s\n' "${missing[@]}" >&2
+            exit 1
+          fi
 
       - name: Install Linux dependencies
         if: matrix.runner == 'ubuntu-22.04'
@@ -216,24 +236,42 @@ jobs:
         shell: bash
         run: test -f dist-web/index.html && test -s dist-web/index.html
 
-      - name: Build and publish release artifacts
+      - name: Build platform artifacts locally
+        id: tauri
         uses: tauri-apps/tauri-action@fce9c6108b31ea247710505d3aaaa893ee6768d4 # v0
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAURI_SIGNING_PUBLIC_KEY: ${{ secrets.TAURI_SIGNING_PUBLIC_KEY }}
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+          APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
+          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+          APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
         with:
-          tagName: ${{ github.ref_name }}
-          releaseName: 'Termul Manager ${{ github.ref_name }}'
-          releaseBody: ${{ needs.changelog.outputs.changelog }}
-          releaseId: ${{ needs.create_release.outputs.release_id }}
-          releaseDraft: true
-          prerelease: ${{ needs.changelog.outputs.is_prerelease }}
           tauriScript: bun run tauri
           args: ${{ matrix.args }} --config src-tauri/tauri.conf.prod.json
 
-      - name: Verify macOS bundle library portability
+      - name: Persist Tauri artifact paths
+        shell: bash
+        env:
+          ARTIFACT_PATHS: ${{ steps.tauri.outputs.artifactPaths }}
+        run: printf '%s\n' "$ARTIFACT_PATHS" > tauri-artifact-paths.json
+
+      - name: Require updater signatures
+        shell: bash
+        env:
+          ARTIFACT_PATHS: ${{ steps.tauri.outputs.artifactPaths }}
+        run: |
+          node - <<'NODE'
+          const paths = JSON.parse(process.env.ARTIFACT_PATHS || '[]')
+          if (!Array.isArray(paths) || !paths.some((path) => path.endsWith('.sig'))) {
+            throw new Error('Tauri produced no updater signatures; check the updater signing secrets.')
+          }
+          NODE
+
+      - name: Verify macOS bundle library portability and signing
         if: startsWith(matrix.platform, 'macos-')
         shell: bash
         env:
@@ -242,29 +280,25 @@ jobs:
           set -euo pipefail
           shopt -s nullglob
 
-          bundle_dir="src-tauri/target/${RUST_TARGET}/release/bundle/macos"
-          app_bundles=("${bundle_dir}"/*.app)
-          if [[ ${#app_bundles[@]} -ne 1 ]]; then
-            printf 'Expected exactly one .app in %s, found %d\n' \
-              "$bundle_dir" "${#app_bundles[@]}" >&2
-            printf 'Found: %s\n' "${app_bundles[*]:-none}" >&2
+          bundle_dir="src-tauri/target/$RUST_TARGET/release/bundle"
+          app_bundles=("$bundle_dir/macos"/*.app)
+          dmgs=("$bundle_dir/dmg"/*.dmg)
+          if [[ "${#app_bundles[@]}" -ne 1 || "${#dmgs[@]}" -ne 1 ]]; then
+            echo "Expected exactly one macOS app and one DMG before verification." >&2
             exit 1
           fi
 
-          app_bundle="${app_bundles[0]}"
-          info_plist="${app_bundle}/Contents/Info.plist"
-          executable_name="$(/usr/libexec/PlistBuddy \
-            -c 'Print :CFBundleExecutable' "$info_plist")"
+          app="${app_bundles[0]}"
+          dmg="${dmgs[0]}"
+          info_plist="$app/Contents/Info.plist"
+          executable_name="$(/usr/libexec/PlistBuddy -c 'Print :CFBundleExecutable' "$info_plist")"
           if [[ -z "$executable_name" || "$executable_name" == */* ]]; then
-            printf 'Invalid CFBundleExecutable in %s: %s\n' \
-              "$info_plist" "${executable_name:-empty}" >&2
+            echo "Invalid CFBundleExecutable in $info_plist: ${executable_name:-empty}" >&2
             exit 1
           fi
-
-          executable="${app_bundle}/Contents/MacOS/${executable_name}"
+          executable="$app/Contents/MacOS/$executable_name"
           if [[ ! -f "$executable" || ! -x "$executable" ]]; then
-            printf 'Declared bundle executable is missing or not executable: %s\n' \
-              "$executable" >&2
+            echo "Declared bundle executable is missing or not executable: $executable" >&2
             exit 1
           fi
 
@@ -280,17 +314,13 @@ jobs:
           while IFS= read -r dependency; do
             [[ -z "$dependency" ]] && continue
             case "$dependency" in
-              /System/Library/*|/usr/lib/*|@rpath/*|@loader_path/*|@executable_path/*)
-                ;;
+              /System/Library/*|/usr/lib/*|@rpath/*|@loader_path/*|@executable_path/*) ;;
               /usr/local/*|/opt/homebrew/*)
-                forbidden+=("$dependency (Homebrew/local prefix)")
-                ;;
+                forbidden+=("$dependency (Homebrew/local prefix)") ;;
               /*)
-                forbidden+=("$dependency (runner-local absolute path)")
-                ;;
+                forbidden+=("$dependency (runner-local absolute path)") ;;
               *)
-                forbidden+=("$dependency (unexpected relative load path)")
-                ;;
+                forbidden+=("$dependency (unexpected relative load path)") ;;
             esac
           done < <(
             printf '%s\n' "$dependencies" |
@@ -301,35 +331,55 @@ jobs:
           while IFS= read -r rpath; do
             [[ -z "$rpath" ]] && continue
             case "$rpath" in
-              /System/Library/*|/usr/lib/*|@loader_path/*|@executable_path/*)
-                ;;
+              /System/Library/*|/usr/lib/*|@loader_path/*|@executable_path/*) ;;
               /usr/local/*|/opt/homebrew/*)
-                forbidden+=("$rpath (Homebrew/local LC_RPATH)")
-                ;;
+                forbidden+=("$rpath (Homebrew/local LC_RPATH)") ;;
               *)
-                forbidden+=("$rpath (non-portable LC_RPATH)")
-                ;;
+                forbidden+=("$rpath (non-portable LC_RPATH)") ;;
             esac
           done <<< "$rpaths"
 
-          if [[ ${#forbidden[@]} -ne 0 ]]; then
+          if [[ "${#forbidden[@]}" -ne 0 ]]; then
             printf 'Forbidden Mach-O paths in %s:\n' "$executable" >&2
             printf '  %s\n' "${forbidden[@]}" >&2
             exit 1
           fi
 
+          codesign --verify --deep --strict --verbose=2 "$app"
+          spctl --assess --type execute --verbose=4 "$app"
+          xcrun stapler validate "$app"
+          codesign --verify --strict --verbose=2 "$dmg"
+          spctl --assess --type open --context context:primary-signature --verbose=4 "$dmg"
+          xcrun stapler validate "$dmg"
+
+      - name: Collect platform release assets and updater manifest
+        shell: bash
+        run: |
+          node scripts/release/prepare-platform-artifacts.mjs \
+            --platform "${{ matrix.platform }}" \
+            --version "${{ needs.changelog.outputs.normalized_version }}" \
+            --tag "${{ github.ref_name }}" \
+            --artifacts tauri-artifact-paths.json \
+            --output collected
+
+      - name: Upload platform workflow artifact
+        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
+        with:
+          name: release-${{ matrix.platform }}
+          path: collected/
+          if-no-files-found: error
+          retention-days: 1
+
   # Standalone headless server for VPS deploy (Story 1.2 scaffold).
   # Build sequencing: bun run build:web MUST run before the cargo release
-  # build so rust-embed embeds dist-web/ into the binary (Story 1.11 — a
+  # build so rust-embed embeds dist-web/ into the binary (Story 1.11 - a
   # missing/stale dist-web/ now fails the release build clearly via the
   # web_embed_missing compile_error in assets.rs; the ordering here keeps the
   # embed non-empty).
   standalone-server:
     name: Build termul-server (linux-x64)
-    needs: [changelog, create_release]
+    needs: changelog
     runs-on: ubuntu-22.04
-    permissions:
-      contents: write
     steps:
       - name: Harden runner
         uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2
@@ -342,7 +392,6 @@ jobs:
           persist-credentials: false
 
       - name: Install Linux dependencies
-        shell: bash
         run: |
           sudo apt-get update
           sudo apt-get install -y \
@@ -393,20 +442,13 @@ jobs:
       - name: Upload termul-server workflow artifact
         uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
         with:
-          name: termul-server-x86_64-unknown-linux-gnu
+          name: release-standalone-server
           path: src-tauri/target/x86_64-unknown-linux-gnu/release/termul-server
           if-no-files-found: error
-
-      - name: Attach termul-server to draft release
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: >
-          gh release upload "${{ github.ref_name }}"
-          src-tauri/target/x86_64-unknown-linux-gnu/release/termul-server
-          --clobber
+          retention-days: 1
 
   publish_release:
-    name: Publish Release
+    name: Validate, upload, and publish release
     needs: [changelog, create_release, build, standalone-server]
     runs-on: ubuntu-latest
     permissions:
@@ -417,65 +459,69 @@ jobs:
         with:
           egress-policy: audit
 
-      - name: Verify updater assets before publish
-        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
-        env:
-          IS_PRERELEASE: ${{ needs.changelog.outputs.is_prerelease }}
-          RELEASE_ID: ${{ needs.create_release.outputs.release_id }}
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            const releaseId = Number(process.env.RELEASE_ID)
-            const isPrerelease = process.env.IS_PRERELEASE === 'true'
-            const stableManifestPath =
-              '/releases/latest/download/latest.json'
-            const channelPolicy = isPrerelease
-              ? 'stable clients intentionally ignore prerelease tags'
-              : 'stable clients consume the stable latest.json manifest'
+          persist-credentials: false
 
-            core.info(`Updater channel policy: ${channelPolicy}`)
+      - name: Download all platform workflow artifacts
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
+        with:
+          pattern: release-*
+          path: release-inputs
 
-            const { data: assets } = await github.rest.repos.listReleaseAssets({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              release_id: releaseId,
-              per_page: 100,
-            })
+      - name: Validate and merge release inputs
+        env:
+          VERSION: ${{ needs.changelog.outputs.normalized_version }}
+          RELEASE_BODY: ${{ needs.changelog.outputs.changelog }}
+        run: |
+          expected=(windows-x64 linux-x64 macos-aarch64 macos-x64)
+          manifests=()
+          mkdir -p release-assets
+          printf '%s' "$RELEASE_BODY" > release-notes.md
 
-            const assetNames = assets.map((asset) => asset.name)
-            core.info(`Draft release assets: ${assetNames.join(', ')}`)
+          for platform in "${expected[@]}"; do
+            root="release-inputs/release-$platform"
+            manifest="$root/platform-manifest.json"
+            if [[ ! -s "$manifest" || ! -d "$root/assets" ]]; then
+              echo "Missing collected release input for $platform" >&2
+              exit 1
+            fi
+            manifests+=("$manifest")
+            while IFS= read -r -d '' asset; do
+              name="$(basename "$asset")"
+              if [[ -e "release-assets/$name" ]] && ! cmp -s "$asset" "release-assets/$name"; then
+                echo "Conflicting duplicate release asset: $name" >&2
+                exit 1
+              fi
+              cp "$asset" "release-assets/$name"
+            done < <(find "$root/assets" -maxdepth 1 -type f -print0)
+          done
 
-            if (isPrerelease) {
-              core.notice(
-                [
-                  'This tag is marked as a prerelease.',
-                  'Stable clients intentionally ignore prerelease tags',
-                  `because they only check ${stableManifestPath}.`,
-                ].join(' ')
-              )
-              return
-            }
+          cp release-inputs/release-standalone-server/termul-server release-assets/termul-server
+          PUB_DATE="$(date -u +'%Y-%m-%dT%H:%M:%S.000Z')"
+          node scripts/release/merge-updater-manifests.mjs \
+            latest.json "$VERSION" release-notes.md "$PUB_DATE" "${manifests[@]}"
 
-            const hasLatestJson = assetNames.includes('latest.json')
-            const hasSigFiles = assetNames.some((name) => name.endsWith('.sig'))
+          release_file_count=0
+          while IFS= read -r -d '' _release_file; do
+            release_file_count=$((release_file_count + 1))
+          done < <(find release-assets -maxdepth 1 -type f -print0)
+          if [[ "$release_file_count" -eq 0 ]]; then
+            echo "No validated release assets were collected." >&2
+            exit 1
+          fi
 
-            if (!hasLatestJson || !hasSigFiles) {
-              const publishedAssets = assetNames.join(', ')
-              core.setFailed(
-                [
-                  `Stable release is missing required updater assets.`,
-                  `  - latest.json present: ${hasLatestJson}`,
-                  `  - .sig files present: ${hasSigFiles}`,
-                  `Draft assets: ${publishedAssets}`,
-                  ``,
-                  `To fix this, ensure:`,
-                  `  1. 'bundle.createUpdaterArtifacts' is true in tauri.conf.json`,
-                  `  2. TAURI_SIGNING_PRIVATE_KEY is configured in GitHub secrets`,
-                  `  3. The tauri-action build step receives the signing env vars.`,
-                ].join('\n')
-              )
-              return
-            }
+      - name: Upload all validated release assets and updater manifest once
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          assets=()
+          while IFS= read -r -d '' asset; do
+            assets+=("$asset")
+          done < <(find release-assets -maxdepth 1 -type f -print0 | sort -z)
+          assets+=(latest.json)
+          gh release upload "${{ github.ref_name }}" "${assets[@]}" --clobber
 
       - name: Publish draft release
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
@@ -486,19 +532,25 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            const releaseId = Number(process.env.RELEASE_ID)
             const tagName = context.ref.replace('refs/tags/', '')
-            const releaseName = `Termul Manager ${tagName}`
-            const releaseBody = process.env.RELEASE_BODY || ''
-            const prerelease = process.env.IS_PRERELEASE === 'true'
-
             await github.rest.repos.updateRelease({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              release_id: releaseId,
+              release_id: Number(process.env.RELEASE_ID),
               tag_name: tagName,
-              name: releaseName,
-              body: releaseBody,
+              name: `Termul Manager ${tagName}`,
+              body: process.env.RELEASE_BODY || '',
               draft: false,
-              prerelease,
+              prerelease: process.env.IS_PRERELEASE === 'true',
             })
+
+  publish_homebrew:
+    name: Publish checksums and Homebrew metadata
+    needs: [changelog, publish_release]
+    permissions:
+      contents: write
+    uses: ./.github/workflows/publish-homebrew.yml
+    with:
+      version: ${{ needs.changelog.outputs.normalized_version }}
+    secrets:
+      HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -354,11 +354,15 @@ jobs:
 
       - name: Collect platform release assets and updater manifest
         shell: bash
+        env:
+          PLATFORM: ${{ matrix.platform }}
+          VERSION: ${{ needs.changelog.outputs.normalized_version }}
+          TAG: ${{ github.ref_name }}
         run: |
           node scripts/release/prepare-platform-artifacts.mjs \
-            --platform "${{ matrix.platform }}" \
-            --version "${{ needs.changelog.outputs.normalized_version }}" \
-            --tag "${{ github.ref_name }}" \
+            --platform "$PLATFORM" \
+            --version "$VERSION" \
+            --tag "$TAG" \
             --artifacts tauri-artifact-paths.json \
             --output collected
 
@@ -515,13 +519,14 @@ jobs:
       - name: Upload all validated release assets and updater manifest once
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ github.ref_name }}
         run: |
           assets=()
           while IFS= read -r -d '' asset; do
             assets+=("$asset")
           done < <(find release-assets -maxdepth 1 -type f -print0 | sort -z)
           assets+=(latest.json)
-          gh release upload "${{ github.ref_name }}" "${assets[@]}" --clobber
+          gh release upload "$TAG" "${assets[@]}" --clobber
 
       - name: Publish draft release
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7

--- a/docs/deployment-guide.md
+++ b/docs/deployment-guide.md
@@ -1,201 +1,167 @@
 # Termul Manager - Deployment Guide
 
-**Date:** 2026-05-09
+**Date:** 2026-07-28
 
 ## Overview
 
-Termul Manager is distributed as a packaged Tauri desktop application. Deployment is release-driven and centered on GitHub Actions workflows that build platform artifacts, sign updater packages, validate release metadata, and publish release assets.
+Termul Manager is distributed as a packaged Tauri desktop application. Releases are built on GitHub Actions, updater artifacts are signed with the existing Tauri minisign key, macOS bundles are additionally Developer ID signed and notarized, and one publish job owns every GitHub Release upload.
 
 ## Packaging Model
 
-The app is bundled through Tauri with:
-
-- desktop binaries and installers for supported platforms
-- updater artifacts enabled via `createUpdaterArtifacts: true`
-- platform icons and bundle metadata defined in `src-tauri/tauri.conf.json`
-
-Build output is documented as:
-
-- `src-tauri/target/release/bundle/`
-
-## Runtime Configuration
-
-Key runtime/deployment settings live in:
+The app is bundled through Tauri with updater artifacts enabled by `createUpdaterArtifacts: true`. Runtime and production bundle settings live in:
 
 - `src-tauri/tauri.conf.json`
 - `src-tauri/tauri.conf.prod.json`
 
-Important configured values include:
+The stable updater endpoint is:
 
-- `frontendDist: ../dist-tauri`
-- hidden startup window (`visible: false`) until renderer readiness
-- updater endpoint: `https://github.com/gnoviawan/termul/releases/latest/download/latest.json`
-- updater public key embedded in app config
-- bundle targets: `all`
+- `https://github.com/gnoviawan/termul/releases/latest/download/latest.json`
 
-## Local Production Build
+The desktop release build also creates `dist-web/` before compiling so the embedded browser client is present in both desktop binaries and the standalone Linux server.
 
-```bash
-bun run build
-```
+## Required Release Secrets
 
-Additional targeted builds:
+All platform builds require the updater signing contract:
 
-```bash
-bun run build:tauri:debug
-bun run build:tauri:win
-bun run build:tauri:mac-arm
-bun run build:tauri:mac-x64
-bun run build:tauri:linux
-```
+- `TAURI_SIGNING_PUBLIC_KEY`
+- `TAURI_SIGNING_PRIVATE_KEY`
+- `TAURI_SIGNING_PRIVATE_KEY_PASSWORD`
+
+Both macOS architecture jobs also require:
+
+- `APPLE_CERTIFICATE` — base64 Developer ID Application certificate (`.p12`)
+- `APPLE_CERTIFICATE_PASSWORD`
+- `APPLE_SIGNING_IDENTITY`
+- `APPLE_ID`
+- `APPLE_PASSWORD` — app-specific password
+- `APPLE_TEAM_ID`
+
+The macOS jobs check these categories immediately after checkout, before dependency installation. Missing values fail with names only; values are never printed.
+
+Stable Homebrew publication additionally requires:
+
+- `HOMEBREW_TAP_TOKEN` — write access to `gnoviawan/homebrew-termul`
+
+The reusable Homebrew workflow resolves authoritative GitHub release metadata before this token is checked. Prereleases therefore still receive `SHA256SUMS.txt`, skip the tap update, and do not require the tap token.
 
 ## Release Workflow
 
-The main release pipeline is `.github/workflows/release.yml`.
+`.github/workflows/release.yml` is triggered by `v*` tags. Tags must be full SemVer and may contain dotted prerelease/build identifiers, for example `v1.2.3-beta.1+macos.7`.
 
-### Trigger
+The workflow order is:
 
-- Push a git tag matching `v*`
+1. Generate the changelog, normalize the tag, and create/update a draft release.
+2. Build Windows x64, Linux x64, macOS arm64, and macOS Intel locally with `tauri-action` **without** `tagName`, `releaseId`, or other upload identifiers.
+3. Verify both macOS `.app` bundles and DMGs with `codesign`, `spctl`, and `stapler`, and reject non-portable Mach-O dependency or `LC_RPATH` entries before collecting them.
+4. Convert each platform's Tauri artifact output into an isolated workflow artifact containing release assets and a platform updater manifest.
+5. Build the standalone Linux server as a workflow artifact after creating the embedded browser bundle.
+6. In one publish job, download every workflow artifact, reject conflicting asset names, deeply validate each updater `{url, signature}` record, reject conflicting duplicate platform records, require every supported Tauri updater key, and authoritatively create `latest.json`.
+7. Upload all release assets and `latest.json` once, then publish the draft.
+8. Invoke the reusable Homebrew workflow for every release channel. It always generates `SHA256SUMS.txt`; only stable releases update the tap.
 
-### Main Stages
+No matrix/platform build job or standalone-server job is permitted to upload GitHub Release assets or write a shared `latest.json`.
 
-1. **Generate changelog**
-   - uses `git-cliff`
-   - normalizes the version from the tag
-   - detects prerelease status
+## Required Updater Platforms
 
-2. **Create or update draft release**
-   - creates a GitHub draft release if needed
-   - updates body/name when rerun
+The centralized merge validates the conventions used by Tauri and the historical v0.4.8 manifest:
 
-3. **Build platform artifacts**
-   - Windows x64
-   - Linux x64
-   - macOS arm64
-   - macOS x64 / Intel
+- `windows-x86_64`
+- `windows-x86_64-msi`
+- `windows-x86_64-nsis`
+- `linux-x86_64`
+- `linux-x86_64-appimage`
+- `linux-x86_64-deb`
+- `linux-x86_64-rpm`
+- `darwin-aarch64`
+- `darwin-aarch64-app`
+- `darwin-x86_64`
+- `darwin-x86_64-app`
 
-4. **Validate versions**
-   - `package.json`
-   - `src-tauri/Cargo.toml`
-   - `src-tauri/tauri.conf.json`
-     must all match the tag version
+Every record must have a nonempty URL and minisign signature. Missing keys, malformed records, version mismatches, and conflicting duplicate records fail before upload.
 
-5. **Publish via Tauri action**
-   - builds bundles
-   - signs updater artifacts
-   - uploads to the draft release
+## Platform Notes
 
-6. **Verify updater assets**
-   - checks `latest.json`
-   - checks `.sig` files
-   - blocks stable publish if required updater assets are missing
+### Linux and Browser Bundle
 
-7. **Publish draft release**
-   - finalizes the GitHub release
-
-## CI / Validation Before Release
-
-PR and branch validation are handled separately in `.github/workflows/pr-validation.yml`, which runs:
-
-- lint
-- typecheck
-- tests
-- cargo check
-- cargo test
-- cargo clippy
-- Tauri frontend build verification
-
-## Signing and Auto-Update
-
-Auto-update is enabled in Tauri config and relies on:
-
-- embedded minisign public key in `src-tauri/tauri.conf.json`
-- GitHub secrets:
-  - `TAURI_SIGNING_PUBLIC_KEY`
-  - `TAURI_SIGNING_PRIVATE_KEY`
-  - `TAURI_SIGNING_PRIVATE_KEY_PASSWORD`
-
-The app expects stable clients to consume `latest.json` from the GitHub releases latest-download path.
-
-## Release Version Procedure
-
-Per `CONTRIBUTING.md`, maintainers should ensure matching versions in:
-
-- `package.json`
-- `src-tauri/Cargo.toml`
-- `src-tauri/tauri.conf.json`
-
-Then create and push a tag, for example:
-
-```bash
-git tag v0.3.7
-git push origin v0.3.7
-```
-
-## Platform-Specific Notes
-
-### Linux
-
-The release workflow installs Linux build dependencies such as:
-
-- `libwebkit2gtk-4.1-dev`
-- `libappindicator3-dev`
-- `librsvg2-dev`
-- `patchelf`
+Linux desktop and standalone-server builds preserve the current `ubuntu-22.04` dependency setup, including WebKitGTK, appindicator, SVG, D-Bus, and `patchelf`. Both build paths create and validate `dist-web/index.html` before Rust compilation so the in-process browser client is embedded rather than relying on files outside the installation.
 
 ### Windows
 
-Windows builds target:
+Windows releases target `x86_64-pc-windows-msvc` and collect both MSI and NSIS updater records and signatures.
 
-- `x86_64-pc-windows-msvc`
+### macOS Portability, Signing, and Notarization
 
-### macOS
+Both `aarch64-apple-darwin` and `x86_64-apple-darwin` are built. For these targets, the SSH dependency vendors OpenSSL so the packaged app does not require Homebrew OpenSSL on user systems.
 
-Release workflow currently targets:
+The macOS collection gate requires exactly one `.app` and one DMG, resolves the app's declared `CFBundleExecutable`, and inspects that executable with `otool -L` and `otool -l`. It permits system libraries and relocatable `@rpath`, `@loader_path`, and `@executable_path` dependencies, but rejects Homebrew/local prefixes, runner-local absolute paths, unexpected relative load paths, and non-portable `LC_RPATH` entries. It then runs:
 
-- `aarch64-apple-darwin`
-- `x86_64-apple-darwin`
+```bash
+codesign --verify --deep --strict --verbose=2 "Termul Manager.app"
+spctl --assess --type execute --verbose=4 "Termul Manager.app"
+xcrun stapler validate "Termul Manager.app"
+codesign --verify --strict --verbose=2 Termul.Manager_*.dmg
+spctl --assess --type open --context context:primary-signature --verbose=4 Termul.Manager_*.dmg
+xcrun stapler validate Termul.Manager_*.dmg
+```
 
-For these targets, the SSH dependency vendors OpenSSL so the packaged app does not require Homebrew OpenSSL on user systems. After each macOS bundle is built, the release workflow requires exactly one `.app`, resolves its declared `CFBundleExecutable`, prints that executable's `otool -L` dependencies and `LC_RPATH` entries, and fails on Homebrew, unexpected relative, or other non-portable build-runner paths.
+After maintainers provision the Apple secrets, repeat these checks against both architectures on a real release. Existing v0.4.8 GitHub assets cannot be retroactively notarized.
 
-Repository scripts also support Intel macOS builds locally.
+## Homebrew and Checksums
+
+`.github/workflows/publish-homebrew.yml` is both reusable and manually dispatchable. It:
+
+1. validates full SemVer input;
+2. queries the GitHub release's `isPrerelease` metadata;
+3. downloads all release assets and uploads `SHA256SUMS.txt` for stable and prerelease channels;
+4. skips the tap job for prereleases without evaluating `HOMEBREW_TAP_TOKEN`;
+5. for stable releases, strictly resolves exactly one checksum for each macOS DMG and updates the cask idempotently;
+6. serializes reusable workflow runs with tap-wide concurrency so different release versions cannot race while pushing the cask.
+
+Version `0.4.8` is a narrow historical exception. Its unsigned/unnotarized DMGs retain the cask `xattr -dr com.apple.quarantine` postflight. The cask generator omits that workaround for every other version, including all future signed/notarized releases.
 
 ## Additional Distribution Workflow
 
-The repository also contains `.github/workflows/publish-aur.yml`, which updates the Arch Linux AUR package `termul-manager` by:
+`.github/workflows/publish-aur.yml` remains the separate Arch Linux AUR publication workflow. It is not part of the centralized GitHub Release asset upload path.
 
-- resolving the version from tag or workflow input
-- cloning the AUR repo
-- updating `PKGBUILD`
-- regenerating checksums and `.SRCINFO`
-- pushing the updated package metadata
+## Operational Risks and Release Checklist
 
-## Operational Risks
+- Version mismatches across JS, Rust, and Tauri configuration fail the release.
+- Missing updater or Apple signing credentials block the affected build before publication.
+- Missing signatures, missing updater keys, malformed URLs, conflicting manifests, or conflicting duplicate asset names fail the centralized publish job.
+- Updater key rotation must be coordinated carefully to avoid breaking existing clients.
 
-- version mismatches across JS/Rust/Tauri config will fail release
-- missing signing secrets will block updater artifact creation
-- missing `latest.json` or signature files will prevent stable release publish
-- updater key rotation must be performed carefully to avoid breaking existing clients
+Recommended release checks:
 
-## Recommended Release Checklist
+1. Run focused release validation and normal repository CI validation.
+2. Confirm version parity in `package.json`, `src-tauri/Cargo.toml`, and `src-tauri/tauri.conf.json`.
+3. Confirm updater, Apple, and stable Homebrew secrets are provisioned for the intended channel.
+4. Push the release tag.
+5. Confirm both macOS portability/signing/notarization gates pass.
+6. Confirm the centralized publish job reports every required updater platform and uploads installers, updater archives, `.sig` files, `termul-server`, and `latest.json` exactly once.
+7. Confirm `SHA256SUMS.txt` exists; for stable releases, confirm the Homebrew cask update succeeds.
 
-1. Run local validation (`bun run lint`, `bun run typecheck`, `bun run test`)
-2. Run Rust validation in `src-tauri/`
-3. Confirm version parity in all three version files
-4. Confirm signing secrets are available in GitHub
-5. Push release tag
-6. For both macOS targets, confirm the bundle portability gate reports only system or dyld-relative dependencies and portable system/bundle-relative `LC_RPATH` entries
-7. Verify draft release assets include installers, `.sig`, and `latest.json`
-8. Publish the release
+## Local Validation
+
+Focused release validation does not require broad application builds:
+
+```bash
+actionlint .github/workflows/release.yml .github/workflows/publish-homebrew.yml
+bun run test -- scripts/release/prepare-platform-artifacts.test.ts scripts/release/merge-updater-manifests.test.ts
+npx bats scripts/tests/homebrew-release.bats
+node --check scripts/release/prepare-platform-artifacts.mjs
+node --check scripts/release/merge-updater-manifests.mjs
+bash -n scripts/release/homebrew.sh
+```
+
+Normal pre-PR validation remains `bun run ci`, `bun run typecheck`, `bun run test`, Rust clippy/tests, and the repository's CI/CodeRabbit gates.
 
 ## Related Files
 
-- `src-tauri/tauri.conf.json`
 - `.github/workflows/release.yml`
+- `.github/workflows/publish-homebrew.yml`
 - `.github/workflows/publish-aur.yml`
-- `docs/auto-update-release-verification.md`
-- `CONTRIBUTING.md`
-
----
-
-_Generated using BMAD Method `document-project` workflow_
+- `scripts/release/prepare-platform-artifacts.mjs`
+- `scripts/release/merge-updater-manifests.mjs`
+- `scripts/release/homebrew.sh`
+- `src-tauri/tauri.conf.json`
+- `src-tauri/tauri.conf.prod.json`

--- a/scripts/release/homebrew.sh
+++ b/scripts/release/homebrew.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+
+normalize_release_version() {
+  local version="${1#v}"
+  local core prerelease identifier
+  local semver='^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$'
+
+  if [[ ! "$version" =~ $semver ]]; then
+    echo "Invalid SemVer release version: $version" >&2
+    return 1
+  fi
+
+  core="${version%%[-+]*}"
+  while IFS= read -r identifier; do
+    if [[ "$identifier" != "0" && "$identifier" == 0* ]]; then
+      echo "Invalid SemVer release version: $version" >&2
+      return 1
+    fi
+  done < <(printf '%s\n' "$core" | tr '.' '\n')
+
+  prerelease="${version%%+*}"
+  if [[ "$prerelease" == *-* ]]; then
+    prerelease="${prerelease#*-}"
+    while IFS= read -r identifier; do
+      if [[ "$identifier" =~ ^[0-9]+$ && "$identifier" != "0" && "$identifier" == 0* ]]; then
+        echo "Invalid SemVer release version: $version" >&2
+        return 1
+      fi
+    done < <(printf '%s\n' "$prerelease" | tr '.' '\n')
+  fi
+
+  printf '%s\n' "$version"
+}
+
+is_release_prerelease() {
+  local version
+  version="$(normalize_release_version "$1")" || return 1
+  version="${version%%+*}"
+  [[ "$version" == *-* ]]
+}
+
+resolve_dmg_checksums() {
+  local checksum_file="$1"
+  local version="$2"
+  local arm_dmg="Termul.Manager_${version}_aarch64.dmg"
+  local intel_dmg="Termul.Manager_${version}_x64.dmg"
+  local arm_sha256 intel_sha256
+
+  arm_sha256="$(awk -v file="$arm_dmg" '$2 == file || $2 == "*" file { print $1 }' "$checksum_file")"
+  intel_sha256="$(awk -v file="$intel_dmg" '$2 == file || $2 == "*" file { print $1 }' "$checksum_file")"
+
+  if [[ "$(printf '%s\n' "$arm_sha256" | sed '/^$/d' | wc -l)" -ne 1 || ! "$arm_sha256" =~ ^[0-9a-fA-F]{64}$ ]]; then
+    echo "Missing, duplicate, or invalid checksum for $arm_dmg" >&2
+    return 1
+  fi
+
+  if [[ "$(printf '%s\n' "$intel_sha256" | sed '/^$/d' | wc -l)" -ne 1 || ! "$intel_sha256" =~ ^[0-9a-fA-F]{64}$ ]]; then
+    echo "Missing, duplicate, or invalid checksum for $intel_dmg" >&2
+    return 1
+  fi
+
+  printf '%s\n%s\n' "$arm_sha256" "$intel_sha256"
+}
+
+write_homebrew_cask() {
+  local output_file="$1"
+  local version="$2"
+  local arm_sha256="$3"
+  local intel_sha256="$4"
+
+  mkdir -p "$(dirname "$output_file")"
+  cat >"$output_file" <<EOF
+cask "termul" do
+  arch arm: "aarch64", intel: "x64"
+
+  version "$version"
+  sha256 arm:   "$arm_sha256",
+         intel: "$intel_sha256"
+
+  url "https://github.com/gnoviawan/termul/releases/download/v#{version}/Termul.Manager_#{version}_#{arch}.dmg"
+  name "Termul Manager"
+  desc "Terminal-native workspace and CLI agent manager"
+  homepage "https://github.com/gnoviawan/termul"
+
+  auto_updates true
+  depends_on macos: :catalina
+
+  app "Termul Manager.app"
+EOF
+
+  if [[ "$version" == "0.4.8" ]]; then
+    cat >>"$output_file" <<'EOF'
+
+  # v0.4.8 predates Developer ID signing and notarization. Do not copy this
+  # narrowly scoped compatibility exception to later casks.
+  postflight do
+    system_command "/usr/bin/xattr",
+                   args: ["-dr", "com.apple.quarantine", "#{appdir}/Termul Manager.app"]
+  end
+EOF
+  fi
+
+  cat >>"$output_file" <<'EOF'
+
+  zap trash: [
+    "~/Library/Application Support/com.termul-manager.app",
+    "~/Library/Caches/com.termul-manager.app",
+    "~/Library/HTTPStorages/com.termul-manager.app",
+    "~/Library/Logs/com.termul-manager.app",
+    "~/Library/Preferences/com.termul-manager.app.plist",
+    "~/Library/Saved Application State/com.termul-manager.app.savedState",
+    "~/Library/WebKit/com.termul-manager.app",
+  ]
+end
+EOF
+}

--- a/scripts/release/merge-updater-manifests.mjs
+++ b/scripts/release/merge-updater-manifests.mjs
@@ -1,152 +1,148 @@
 #!/usr/bin/env node
 
-import { readFile, writeFile } from "node:fs/promises";
-import { basename } from "node:path";
-import process from "node:process";
-import { pathToFileURL } from "node:url";
+import { readFile, writeFile } from 'node:fs/promises'
+import { basename } from 'node:path'
+import process from 'node:process'
+import { pathToFileURL } from 'node:url'
 
 export const requiredPlatformKeys = [
-	"windows-x86_64",
-	"windows-x86_64-msi",
-	"windows-x86_64-nsis",
-	"linux-x86_64",
-	"linux-x86_64-appimage",
-	"linux-x86_64-deb",
-	"linux-x86_64-rpm",
-	"darwin-aarch64",
-	"darwin-aarch64-app",
-	"darwin-x86_64",
-	"darwin-x86_64-app",
-];
+  'windows-x86_64',
+  'windows-x86_64-msi',
+  'windows-x86_64-nsis',
+  'linux-x86_64',
+  'linux-x86_64-appimage',
+  'linux-x86_64-deb',
+  'linux-x86_64-rpm',
+  'darwin-aarch64',
+  'darwin-aarch64-app',
+  'darwin-x86_64',
+  'darwin-x86_64-app'
+]
 
 function assertNonEmptyString(value, description) {
-	if (typeof value !== "string" || value.trim() === "") {
-		throw new Error(`${description} must be a nonempty string`);
-	}
+  if (typeof value !== 'string' || value.trim() === '') {
+    throw new Error(`${description} must be a nonempty string`)
+  }
 }
 
 function assertPlainObject(value, description) {
-	if (typeof value !== "object" || value === null || Array.isArray(value)) {
-		throw new Error(`${description} must be an object`);
-	}
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    throw new Error(`${description} must be an object`)
+  }
 }
 
 function assertStringArray(value, description) {
-	if (!Array.isArray(value) || value.some((entry) => typeof entry !== "string" || entry === "")) {
-		throw new Error(`${description} must be an array of nonempty strings`);
-	}
+  if (!Array.isArray(value) || value.some((entry) => typeof entry !== 'string' || entry === '')) {
+    throw new Error(`${description} must be an array of nonempty strings`)
+  }
 }
 
 function releaseUrlAssetName(url, version, description) {
-	let parsed;
-	try {
-		parsed = new URL(url);
-	} catch {
-		throw new Error(`${description} must be a valid URL`);
-	}
-	const expectedPrefix = `/gnoviawan/termul/releases/download/${encodeURIComponent(`v${version}`)}/`;
-	if (parsed.protocol !== "https:" || parsed.hostname !== "github.com" || !parsed.pathname.startsWith(expectedPrefix)) {
-		throw new Error(`${description} must target the current v${version} GitHub release`);
-	}
-	const encodedName = parsed.pathname.slice(expectedPrefix.length);
-	if (!encodedName || encodedName.includes("/")) {
-		throw new Error(`${description} must identify one release asset`);
-	}
-	try {
-		return decodeURIComponent(encodedName);
-	} catch {
-		throw new Error(`${description} contains an invalid encoded asset name`);
-	}
+  let parsed
+  try {
+    parsed = new URL(url)
+  } catch {
+    throw new Error(`${description} must be a valid URL`)
+  }
+  const expectedPrefix = `/gnoviawan/termul/releases/download/${encodeURIComponent(`v${version}`)}/`
+  if (
+    parsed.protocol !== 'https:' ||
+    parsed.hostname !== 'github.com' ||
+    !parsed.pathname.startsWith(expectedPrefix)
+  ) {
+    throw new Error(`${description} must target the current v${version} GitHub release`)
+  }
+  const encodedName = parsed.pathname.slice(expectedPrefix.length)
+  if (!encodedName || encodedName.includes('/')) {
+    throw new Error(`${description} must identify one release asset`)
+  }
+  try {
+    return decodeURIComponent(encodedName)
+  } catch {
+    throw new Error(`${description} contains an invalid encoded asset name`)
+  }
 }
 
-export async function mergeUpdaterManifests({
-	inputPaths,
-	outputPath,
-	version,
-	notes,
-	pubDate,
-}) {
-	assertNonEmptyString(version, "version");
-	assertNonEmptyString(pubDate, "pub_date");
-	if (typeof notes !== "string") throw new Error("notes must be a string");
-	if (!Array.isArray(inputPaths) || inputPaths.length === 0) {
-		throw new Error("At least one updater manifest is required");
-	}
+export async function mergeUpdaterManifests({ inputPaths, outputPath, version, notes, pubDate }) {
+  assertNonEmptyString(version, 'version')
+  assertNonEmptyString(pubDate, 'pub_date')
+  if (typeof notes !== 'string') throw new Error('notes must be a string')
+  if (!Array.isArray(inputPaths) || inputPaths.length === 0) {
+    throw new Error('At least one updater manifest is required')
+  }
 
-	const platforms = {};
-	for (const inputPath of inputPaths) {
-		const manifest = JSON.parse(await readFile(inputPath, "utf8"));
-		assertPlainObject(manifest, `Updater manifest ${inputPath}`);
-		if (manifest.version !== version) {
-			throw new Error(
-				`Updater manifest version mismatch: ${inputPath} has ${String(manifest.version)}, expected ${version}`,
-			);
-		}
-		assertStringArray(manifest.assetNames, `Updater manifest assetNames in ${inputPath}`);
-		const assetNames = new Set(manifest.assetNames);
-		assertPlainObject(manifest.platforms, `Updater manifest platforms in ${inputPath}`);
+  const platforms = {}
+  for (const inputPath of inputPaths) {
+    const manifest = JSON.parse(await readFile(inputPath, 'utf8'))
+    assertPlainObject(manifest, `Updater manifest ${inputPath}`)
+    if (manifest.version !== version) {
+      throw new Error(
+        `Updater manifest version mismatch: ${inputPath} has ${String(manifest.version)}, expected ${version}`
+      )
+    }
+    assertStringArray(manifest.assetNames, `Updater manifest assetNames in ${inputPath}`)
+    const assetNames = new Set(manifest.assetNames)
+    assertPlainObject(manifest.platforms, `Updater manifest platforms in ${inputPath}`)
 
-		for (const [key, record] of Object.entries(manifest.platforms)) {
-			assertPlainObject(record, `Updater record ${key} in ${inputPath}`);
-			assertNonEmptyString(record.url, `Updater record ${key} url`);
-			assertNonEmptyString(record.signature, `Updater record ${key} signature`);
-			const normalized = { url: record.url.trim(), signature: record.signature.trim() };
-			const assetName = releaseUrlAssetName(
-				normalized.url,
-				version,
-				`Updater record ${key} url`,
-			);
-			if (!assetNames.has(assetName)) {
-				throw new Error(`Updater record ${key} references uncollected release asset ${assetName}`);
-			}
-			if (!assetNames.has(`${assetName}.sig`)) {
-				throw new Error(`Updater record ${key} is missing collected signature asset ${assetName}.sig`);
-			}
-			if (basename(assetName) !== assetName) {
-				throw new Error(`Updater record ${key} asset name must not contain a path`);
-			}
-			if (platforms[key]) {
-				if (
-					platforms[key].url !== normalized.url ||
-					platforms[key].signature !== normalized.signature
-				) {
-					throw new Error(`Conflicting duplicate updater record for ${key}`);
-				}
-				continue;
-			}
-			platforms[key] = normalized;
-		}
-	}
+    for (const [key, record] of Object.entries(manifest.platforms)) {
+      assertPlainObject(record, `Updater record ${key} in ${inputPath}`)
+      assertNonEmptyString(record.url, `Updater record ${key} url`)
+      assertNonEmptyString(record.signature, `Updater record ${key} signature`)
+      const normalized = { url: record.url.trim(), signature: record.signature.trim() }
+      const assetName = releaseUrlAssetName(normalized.url, version, `Updater record ${key} url`)
+      if (!assetNames.has(assetName)) {
+        throw new Error(`Updater record ${key} references uncollected release asset ${assetName}`)
+      }
+      if (!assetNames.has(`${assetName}.sig`)) {
+        throw new Error(
+          `Updater record ${key} is missing collected signature asset ${assetName}.sig`
+        )
+      }
+      if (basename(assetName) !== assetName) {
+        throw new Error(`Updater record ${key} asset name must not contain a path`)
+      }
+      if (platforms[key]) {
+        if (
+          platforms[key].url !== normalized.url ||
+          platforms[key].signature !== normalized.signature
+        ) {
+          throw new Error(`Conflicting duplicate updater record for ${key}`)
+        }
+        continue
+      }
+      platforms[key] = normalized
+    }
+  }
 
-	const missing = requiredPlatformKeys.filter((key) => !platforms[key]);
-	if (missing.length > 0) {
-		throw new Error(`Missing required updater platforms: ${missing.join(", ")}`);
-	}
+  const missing = requiredPlatformKeys.filter((key) => !platforms[key])
+  if (missing.length > 0) {
+    throw new Error(`Missing required updater platforms: ${missing.join(', ')}`)
+  }
 
-	const output = { version, notes, pub_date: pubDate, platforms };
-	await writeFile(outputPath, `${JSON.stringify(output, null, 2)}\n`);
-	return output;
+  const output = { version, notes, pub_date: pubDate, platforms }
+  await writeFile(outputPath, `${JSON.stringify(output, null, 2)}\n`)
+  return output
 }
 
 async function runCli() {
-	const [outputPath, version, notesPath, pubDate, ...inputPaths] = process.argv.slice(2);
-	if (!outputPath || !version || !notesPath || !pubDate || inputPaths.length === 0) {
-		throw new Error(
-			"Usage: merge-updater-manifests.mjs <output> <version> <notes-file> <pub-date> <manifest> [manifest...]",
-		);
-	}
-	await mergeUpdaterManifests({
-		inputPaths,
-		outputPath,
-		version,
-		notes: await readFile(notesPath, "utf8"),
-		pubDate,
-	});
+  const [outputPath, version, notesPath, pubDate, ...inputPaths] = process.argv.slice(2)
+  if (!outputPath || !version || !notesPath || !pubDate || inputPaths.length === 0) {
+    throw new Error(
+      'Usage: merge-updater-manifests.mjs <output> <version> <notes-file> <pub-date> <manifest> [manifest...]'
+    )
+  }
+  await mergeUpdaterManifests({
+    inputPaths,
+    outputPath,
+    version,
+    notes: await readFile(notesPath, 'utf8'),
+    pubDate
+  })
 }
 
 if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
-	runCli().catch((error) => {
-		console.error(error instanceof Error ? error.message : String(error));
-		process.exit(1);
-	});
+  runCli().catch((error) => {
+    console.error(error instanceof Error ? error.message : String(error))
+    process.exit(1)
+  })
 }

--- a/scripts/release/merge-updater-manifests.mjs
+++ b/scripts/release/merge-updater-manifests.mjs
@@ -1,0 +1,152 @@
+#!/usr/bin/env node
+
+import { readFile, writeFile } from "node:fs/promises";
+import { basename } from "node:path";
+import process from "node:process";
+import { pathToFileURL } from "node:url";
+
+export const requiredPlatformKeys = [
+	"windows-x86_64",
+	"windows-x86_64-msi",
+	"windows-x86_64-nsis",
+	"linux-x86_64",
+	"linux-x86_64-appimage",
+	"linux-x86_64-deb",
+	"linux-x86_64-rpm",
+	"darwin-aarch64",
+	"darwin-aarch64-app",
+	"darwin-x86_64",
+	"darwin-x86_64-app",
+];
+
+function assertNonEmptyString(value, description) {
+	if (typeof value !== "string" || value.trim() === "") {
+		throw new Error(`${description} must be a nonempty string`);
+	}
+}
+
+function assertPlainObject(value, description) {
+	if (typeof value !== "object" || value === null || Array.isArray(value)) {
+		throw new Error(`${description} must be an object`);
+	}
+}
+
+function assertStringArray(value, description) {
+	if (!Array.isArray(value) || value.some((entry) => typeof entry !== "string" || entry === "")) {
+		throw new Error(`${description} must be an array of nonempty strings`);
+	}
+}
+
+function releaseUrlAssetName(url, version, description) {
+	let parsed;
+	try {
+		parsed = new URL(url);
+	} catch {
+		throw new Error(`${description} must be a valid URL`);
+	}
+	const expectedPrefix = `/gnoviawan/termul/releases/download/${encodeURIComponent(`v${version}`)}/`;
+	if (parsed.protocol !== "https:" || parsed.hostname !== "github.com" || !parsed.pathname.startsWith(expectedPrefix)) {
+		throw new Error(`${description} must target the current v${version} GitHub release`);
+	}
+	const encodedName = parsed.pathname.slice(expectedPrefix.length);
+	if (!encodedName || encodedName.includes("/")) {
+		throw new Error(`${description} must identify one release asset`);
+	}
+	try {
+		return decodeURIComponent(encodedName);
+	} catch {
+		throw new Error(`${description} contains an invalid encoded asset name`);
+	}
+}
+
+export async function mergeUpdaterManifests({
+	inputPaths,
+	outputPath,
+	version,
+	notes,
+	pubDate,
+}) {
+	assertNonEmptyString(version, "version");
+	assertNonEmptyString(pubDate, "pub_date");
+	if (typeof notes !== "string") throw new Error("notes must be a string");
+	if (!Array.isArray(inputPaths) || inputPaths.length === 0) {
+		throw new Error("At least one updater manifest is required");
+	}
+
+	const platforms = {};
+	for (const inputPath of inputPaths) {
+		const manifest = JSON.parse(await readFile(inputPath, "utf8"));
+		assertPlainObject(manifest, `Updater manifest ${inputPath}`);
+		if (manifest.version !== version) {
+			throw new Error(
+				`Updater manifest version mismatch: ${inputPath} has ${String(manifest.version)}, expected ${version}`,
+			);
+		}
+		assertStringArray(manifest.assetNames, `Updater manifest assetNames in ${inputPath}`);
+		const assetNames = new Set(manifest.assetNames);
+		assertPlainObject(manifest.platforms, `Updater manifest platforms in ${inputPath}`);
+
+		for (const [key, record] of Object.entries(manifest.platforms)) {
+			assertPlainObject(record, `Updater record ${key} in ${inputPath}`);
+			assertNonEmptyString(record.url, `Updater record ${key} url`);
+			assertNonEmptyString(record.signature, `Updater record ${key} signature`);
+			const normalized = { url: record.url.trim(), signature: record.signature.trim() };
+			const assetName = releaseUrlAssetName(
+				normalized.url,
+				version,
+				`Updater record ${key} url`,
+			);
+			if (!assetNames.has(assetName)) {
+				throw new Error(`Updater record ${key} references uncollected release asset ${assetName}`);
+			}
+			if (!assetNames.has(`${assetName}.sig`)) {
+				throw new Error(`Updater record ${key} is missing collected signature asset ${assetName}.sig`);
+			}
+			if (basename(assetName) !== assetName) {
+				throw new Error(`Updater record ${key} asset name must not contain a path`);
+			}
+			if (platforms[key]) {
+				if (
+					platforms[key].url !== normalized.url ||
+					platforms[key].signature !== normalized.signature
+				) {
+					throw new Error(`Conflicting duplicate updater record for ${key}`);
+				}
+				continue;
+			}
+			platforms[key] = normalized;
+		}
+	}
+
+	const missing = requiredPlatformKeys.filter((key) => !platforms[key]);
+	if (missing.length > 0) {
+		throw new Error(`Missing required updater platforms: ${missing.join(", ")}`);
+	}
+
+	const output = { version, notes, pub_date: pubDate, platforms };
+	await writeFile(outputPath, `${JSON.stringify(output, null, 2)}\n`);
+	return output;
+}
+
+async function runCli() {
+	const [outputPath, version, notesPath, pubDate, ...inputPaths] = process.argv.slice(2);
+	if (!outputPath || !version || !notesPath || !pubDate || inputPaths.length === 0) {
+		throw new Error(
+			"Usage: merge-updater-manifests.mjs <output> <version> <notes-file> <pub-date> <manifest> [manifest...]",
+		);
+	}
+	await mergeUpdaterManifests({
+		inputPaths,
+		outputPath,
+		version,
+		notes: await readFile(notesPath, "utf8"),
+		pubDate,
+	});
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+	runCli().catch((error) => {
+		console.error(error instanceof Error ? error.message : String(error));
+		process.exit(1);
+	});
+}

--- a/scripts/release/merge-updater-manifests.test.ts
+++ b/scripts/release/merge-updater-manifests.test.ts
@@ -1,0 +1,174 @@
+// @ts-expect-error The production helper is intentionally plain ESM for direct workflow use.
+import {
+	mergeUpdaterManifests,
+	requiredPlatformKeys,
+} from "./merge-updater-manifests.mjs";
+import { mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, test } from "vitest";
+
+const version = "1.2.3";
+const assetName = (suffix: string) => `Termul-${version}-${suffix}.bin`;
+const record = (suffix: string) => ({
+	url: `https://github.com/gnoviawan/termul/releases/download/v${version}/${assetName(suffix)}`,
+	signature: `signature-${suffix}`,
+});
+
+async function fixtureDir() {
+	return mkdtemp(join(tmpdir(), "termul-updater-manifest-"));
+}
+
+async function writeManifest(
+	path: string,
+	platforms: Record<string, unknown>,
+	manifestVersion = version,
+	assetNames = Object.keys(platforms).flatMap((key) => [assetName(key), `${assetName(key)}.sig`]),
+) {
+	await writeFile(path, JSON.stringify({ version: manifestVersion, assetNames, platforms }));
+}
+
+function completePlatforms() {
+	return Object.fromEntries(requiredPlatformKeys.map((key) => [key, record(key)]));
+}
+
+function completeAssetNames() {
+	return requiredPlatformKeys.flatMap((key) => [assetName(key), `${assetName(key)}.sig`]);
+}
+
+describe("mergeUpdaterManifests", () => {
+	test("authoritatively merges all historical Tauri platform keys", async () => {
+		const dir = await fixtureDir();
+		const inputs = await Promise.all(
+			Object.entries(completePlatforms()).map(async ([key, value], index) => {
+				const path = join(dir, `${index}.json`);
+				await writeManifest(path, { [key]: value });
+				return path;
+			}),
+		);
+		const outputPath = join(dir, "latest.json");
+
+		const merged = await mergeUpdaterManifests({
+			inputPaths: inputs,
+			outputPath,
+			version,
+			notes: "notes",
+			pubDate: "2026-01-01T00:00:00.000Z",
+		});
+
+		expect(Object.keys(merged.platforms).sort()).toEqual(
+			[...requiredPlatformKeys].sort(),
+		);
+		expect(JSON.parse(await readFile(outputPath, "utf8"))).toEqual(merged);
+	});
+
+	test("rejects a missing updater platform", async () => {
+		const dir = await fixtureDir();
+		const platforms = completePlatforms();
+		delete platforms["darwin-x86_64-app"];
+		const input = join(dir, "manifest.json");
+		await writeManifest(input, platforms);
+
+		await expect(
+			mergeUpdaterManifests({
+				inputPaths: [input],
+				outputPath: join(dir, "latest.json"),
+				version,
+				notes: "notes",
+				pubDate: "2026-01-01T00:00:00.000Z",
+			}),
+		).rejects.toThrow("Missing required updater platforms: darwin-x86_64-app");
+	});
+
+	test.each([
+		["empty url", { url: "", signature: "signature" }, "url must be a nonempty string"],
+		["missing signature", { url: record("linux-x86_64").url }, "signature must be a nonempty string"],
+		["non-object record", "broken", "must be an object"],
+	])("rejects malformed updater entries: %s", async (_name, malformed, error) => {
+		const dir = await fixtureDir();
+		const platforms = completePlatforms();
+		platforms["linux-x86_64"] = malformed as never;
+		const input = join(dir, "manifest.json");
+		await writeManifest(input, platforms, version, completeAssetNames());
+
+		await expect(
+			mergeUpdaterManifests({
+				inputPaths: [input],
+				outputPath: join(dir, "latest.json"),
+				version,
+				notes: "notes",
+				pubDate: "2026-01-01T00:00:00.000Z",
+			}),
+		).rejects.toThrow(error);
+	});
+
+	test("rejects conflicting duplicate updater records", async () => {
+		const dir = await fixtureDir();
+		const first = join(dir, "first.json");
+		const second = join(dir, "second.json");
+		await writeManifest(first, completePlatforms(), version, completeAssetNames());
+		await writeManifest(second, {
+			"windows-x86_64": record("different"),
+		});
+
+		await expect(
+			mergeUpdaterManifests({
+				inputPaths: [first, second],
+				outputPath: join(dir, "latest.json"),
+				version,
+				notes: "notes",
+				pubDate: "2026-01-01T00:00:00.000Z",
+			}),
+		).rejects.toThrow("Conflicting duplicate updater record for windows-x86_64");
+	});
+
+	test.each([
+		[
+			"a different release tag",
+			`https://github.com/gnoviawan/termul/releases/download/v9.9.9/${assetName("linux-x86_64")}`,
+			"must target the current v1.2.3 GitHub release",
+		],
+		[
+			"an uncollected asset",
+			`https://github.com/gnoviawan/termul/releases/download/v${version}/uncollected.bin`,
+			"references uncollected release asset uncollected.bin",
+		],
+	])("rejects updater URLs referencing %s", async (_name, url, error) => {
+		const dir = await fixtureDir();
+		const platforms = completePlatforms();
+		platforms["linux-x86_64"] = { ...record("linux-x86_64"), url };
+		const input = join(dir, "manifest.json");
+		await writeManifest(input, platforms, version, completeAssetNames());
+
+		await expect(
+			mergeUpdaterManifests({
+				inputPaths: [input],
+				outputPath: join(dir, "latest.json"),
+				version,
+				notes: "notes",
+				pubDate: "2026-01-01T00:00:00.000Z",
+			}),
+		).rejects.toThrow(error);
+	});
+
+	test("rejects a manifest without the collected signature asset", async () => {
+		const dir = await fixtureDir();
+		const input = join(dir, "manifest.json");
+		const assets = completeAssetNames().filter(
+			(name) => name !== `${assetName("linux-x86_64")}.sig`,
+		);
+		await writeManifest(input, completePlatforms(), version, assets);
+
+		await expect(
+			mergeUpdaterManifests({
+				inputPaths: [input],
+				outputPath: join(dir, "latest.json"),
+				version,
+				notes: "notes",
+				pubDate: "2026-01-01T00:00:00.000Z",
+			}),
+		).rejects.toThrow(
+			`Updater record linux-x86_64 is missing collected signature asset ${assetName("linux-x86_64")}.sig`,
+		);
+	});
+});

--- a/scripts/release/merge-updater-manifests.test.ts
+++ b/scripts/release/merge-updater-manifests.test.ts
@@ -1,174 +1,174 @@
+import { mkdtemp, readFile, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { describe, expect, test } from 'vitest'
 // @ts-expect-error The production helper is intentionally plain ESM for direct workflow use.
-import {
-	mergeUpdaterManifests,
-	requiredPlatformKeys,
-} from "./merge-updater-manifests.mjs";
-import { mkdtemp, readFile, writeFile } from "node:fs/promises";
-import { tmpdir } from "node:os";
-import { join } from "node:path";
-import { describe, expect, test } from "vitest";
+import { mergeUpdaterManifests, requiredPlatformKeys } from './merge-updater-manifests.mjs'
 
-const version = "1.2.3";
-const assetName = (suffix: string) => `Termul-${version}-${suffix}.bin`;
+const version = '1.2.3'
+const assetName = (suffix: string) => `Termul-${version}-${suffix}.bin`
 const record = (suffix: string) => ({
-	url: `https://github.com/gnoviawan/termul/releases/download/v${version}/${assetName(suffix)}`,
-	signature: `signature-${suffix}`,
-});
+  url: `https://github.com/gnoviawan/termul/releases/download/v${version}/${assetName(suffix)}`,
+  signature: `signature-${suffix}`
+})
 
 async function fixtureDir() {
-	return mkdtemp(join(tmpdir(), "termul-updater-manifest-"));
+  return mkdtemp(join(tmpdir(), 'termul-updater-manifest-'))
 }
 
 async function writeManifest(
-	path: string,
-	platforms: Record<string, unknown>,
-	manifestVersion = version,
-	assetNames = Object.keys(platforms).flatMap((key) => [assetName(key), `${assetName(key)}.sig`]),
+  path: string,
+  platforms: Record<string, unknown>,
+  manifestVersion = version,
+  assetNames = Object.keys(platforms).flatMap((key) => [assetName(key), `${assetName(key)}.sig`])
 ) {
-	await writeFile(path, JSON.stringify({ version: manifestVersion, assetNames, platforms }));
+  await writeFile(path, JSON.stringify({ version: manifestVersion, assetNames, platforms }))
 }
 
 function completePlatforms() {
-	return Object.fromEntries(requiredPlatformKeys.map((key) => [key, record(key)]));
+  return Object.fromEntries(requiredPlatformKeys.map((key) => [key, record(key)]))
 }
 
 function completeAssetNames() {
-	return requiredPlatformKeys.flatMap((key) => [assetName(key), `${assetName(key)}.sig`]);
+  return requiredPlatformKeys.flatMap((key) => [assetName(key), `${assetName(key)}.sig`])
 }
 
-describe("mergeUpdaterManifests", () => {
-	test("authoritatively merges all historical Tauri platform keys", async () => {
-		const dir = await fixtureDir();
-		const inputs = await Promise.all(
-			Object.entries(completePlatforms()).map(async ([key, value], index) => {
-				const path = join(dir, `${index}.json`);
-				await writeManifest(path, { [key]: value });
-				return path;
-			}),
-		);
-		const outputPath = join(dir, "latest.json");
+describe('mergeUpdaterManifests', () => {
+  test('authoritatively merges all historical Tauri platform keys', async () => {
+    const dir = await fixtureDir()
+    const inputs = await Promise.all(
+      Object.entries(completePlatforms()).map(async ([key, value], index) => {
+        const path = join(dir, `${index}.json`)
+        await writeManifest(path, { [key]: value })
+        return path
+      })
+    )
+    const outputPath = join(dir, 'latest.json')
 
-		const merged = await mergeUpdaterManifests({
-			inputPaths: inputs,
-			outputPath,
-			version,
-			notes: "notes",
-			pubDate: "2026-01-01T00:00:00.000Z",
-		});
+    const merged = await mergeUpdaterManifests({
+      inputPaths: inputs,
+      outputPath,
+      version,
+      notes: 'notes',
+      pubDate: '2026-01-01T00:00:00.000Z'
+    })
 
-		expect(Object.keys(merged.platforms).sort()).toEqual(
-			[...requiredPlatformKeys].sort(),
-		);
-		expect(JSON.parse(await readFile(outputPath, "utf8"))).toEqual(merged);
-	});
+    expect(Object.keys(merged.platforms).sort()).toEqual([...requiredPlatformKeys].sort())
+    expect(JSON.parse(await readFile(outputPath, 'utf8'))).toEqual(merged)
+  })
 
-	test("rejects a missing updater platform", async () => {
-		const dir = await fixtureDir();
-		const platforms = completePlatforms();
-		delete platforms["darwin-x86_64-app"];
-		const input = join(dir, "manifest.json");
-		await writeManifest(input, platforms);
+  test('rejects a missing updater platform', async () => {
+    const dir = await fixtureDir()
+    const platforms = completePlatforms()
+    delete platforms['darwin-x86_64-app']
+    const input = join(dir, 'manifest.json')
+    await writeManifest(input, platforms)
 
-		await expect(
-			mergeUpdaterManifests({
-				inputPaths: [input],
-				outputPath: join(dir, "latest.json"),
-				version,
-				notes: "notes",
-				pubDate: "2026-01-01T00:00:00.000Z",
-			}),
-		).rejects.toThrow("Missing required updater platforms: darwin-x86_64-app");
-	});
+    await expect(
+      mergeUpdaterManifests({
+        inputPaths: [input],
+        outputPath: join(dir, 'latest.json'),
+        version,
+        notes: 'notes',
+        pubDate: '2026-01-01T00:00:00.000Z'
+      })
+    ).rejects.toThrow('Missing required updater platforms: darwin-x86_64-app')
+  })
 
-	test.each([
-		["empty url", { url: "", signature: "signature" }, "url must be a nonempty string"],
-		["missing signature", { url: record("linux-x86_64").url }, "signature must be a nonempty string"],
-		["non-object record", "broken", "must be an object"],
-	])("rejects malformed updater entries: %s", async (_name, malformed, error) => {
-		const dir = await fixtureDir();
-		const platforms = completePlatforms();
-		platforms["linux-x86_64"] = malformed as never;
-		const input = join(dir, "manifest.json");
-		await writeManifest(input, platforms, version, completeAssetNames());
+  test.each([
+    ['empty url', { url: '', signature: 'signature' }, 'url must be a nonempty string'],
+    [
+      'missing signature',
+      { url: record('linux-x86_64').url },
+      'signature must be a nonempty string'
+    ],
+    ['non-object record', 'broken', 'must be an object']
+  ])('rejects malformed updater entries: %s', async (_name, malformed, error) => {
+    const dir = await fixtureDir()
+    const platforms = completePlatforms()
+    platforms['linux-x86_64'] = malformed as never
+    const input = join(dir, 'manifest.json')
+    await writeManifest(input, platforms, version, completeAssetNames())
 
-		await expect(
-			mergeUpdaterManifests({
-				inputPaths: [input],
-				outputPath: join(dir, "latest.json"),
-				version,
-				notes: "notes",
-				pubDate: "2026-01-01T00:00:00.000Z",
-			}),
-		).rejects.toThrow(error);
-	});
+    await expect(
+      mergeUpdaterManifests({
+        inputPaths: [input],
+        outputPath: join(dir, 'latest.json'),
+        version,
+        notes: 'notes',
+        pubDate: '2026-01-01T00:00:00.000Z'
+      })
+    ).rejects.toThrow(error)
+  })
 
-	test("rejects conflicting duplicate updater records", async () => {
-		const dir = await fixtureDir();
-		const first = join(dir, "first.json");
-		const second = join(dir, "second.json");
-		await writeManifest(first, completePlatforms(), version, completeAssetNames());
-		await writeManifest(second, {
-			"windows-x86_64": record("different"),
-		});
+  test('rejects conflicting duplicate updater records', async () => {
+    const dir = await fixtureDir()
+    const first = join(dir, 'first.json')
+    const second = join(dir, 'second.json')
+    await writeManifest(first, completePlatforms(), version, completeAssetNames())
+    await writeManifest(second, { 'windows-x86_64': record('different') }, version, [
+      assetName('different'),
+      `${assetName('different')}.sig`
+    ])
 
-		await expect(
-			mergeUpdaterManifests({
-				inputPaths: [first, second],
-				outputPath: join(dir, "latest.json"),
-				version,
-				notes: "notes",
-				pubDate: "2026-01-01T00:00:00.000Z",
-			}),
-		).rejects.toThrow("Conflicting duplicate updater record for windows-x86_64");
-	});
+    await expect(
+      mergeUpdaterManifests({
+        inputPaths: [first, second],
+        outputPath: join(dir, 'latest.json'),
+        version,
+        notes: 'notes',
+        pubDate: '2026-01-01T00:00:00.000Z'
+      })
+    ).rejects.toThrow('Conflicting duplicate updater record for windows-x86_64')
+  })
 
-	test.each([
-		[
-			"a different release tag",
-			`https://github.com/gnoviawan/termul/releases/download/v9.9.9/${assetName("linux-x86_64")}`,
-			"must target the current v1.2.3 GitHub release",
-		],
-		[
-			"an uncollected asset",
-			`https://github.com/gnoviawan/termul/releases/download/v${version}/uncollected.bin`,
-			"references uncollected release asset uncollected.bin",
-		],
-	])("rejects updater URLs referencing %s", async (_name, url, error) => {
-		const dir = await fixtureDir();
-		const platforms = completePlatforms();
-		platforms["linux-x86_64"] = { ...record("linux-x86_64"), url };
-		const input = join(dir, "manifest.json");
-		await writeManifest(input, platforms, version, completeAssetNames());
+  test.each([
+    [
+      'a different release tag',
+      `https://github.com/gnoviawan/termul/releases/download/v9.9.9/${assetName('linux-x86_64')}`,
+      'must target the current v1.2.3 GitHub release'
+    ],
+    [
+      'an uncollected asset',
+      `https://github.com/gnoviawan/termul/releases/download/v${version}/uncollected.bin`,
+      'references uncollected release asset uncollected.bin'
+    ]
+  ])('rejects updater URLs referencing %s', async (_name, url, error) => {
+    const dir = await fixtureDir()
+    const platforms = completePlatforms()
+    platforms['linux-x86_64'] = { ...record('linux-x86_64'), url }
+    const input = join(dir, 'manifest.json')
+    await writeManifest(input, platforms, version, completeAssetNames())
 
-		await expect(
-			mergeUpdaterManifests({
-				inputPaths: [input],
-				outputPath: join(dir, "latest.json"),
-				version,
-				notes: "notes",
-				pubDate: "2026-01-01T00:00:00.000Z",
-			}),
-		).rejects.toThrow(error);
-	});
+    await expect(
+      mergeUpdaterManifests({
+        inputPaths: [input],
+        outputPath: join(dir, 'latest.json'),
+        version,
+        notes: 'notes',
+        pubDate: '2026-01-01T00:00:00.000Z'
+      })
+    ).rejects.toThrow(error)
+  })
 
-	test("rejects a manifest without the collected signature asset", async () => {
-		const dir = await fixtureDir();
-		const input = join(dir, "manifest.json");
-		const assets = completeAssetNames().filter(
-			(name) => name !== `${assetName("linux-x86_64")}.sig`,
-		);
-		await writeManifest(input, completePlatforms(), version, assets);
+  test('rejects a manifest without the collected signature asset', async () => {
+    const dir = await fixtureDir()
+    const input = join(dir, 'manifest.json')
+    const assets = completeAssetNames().filter(
+      (name) => name !== `${assetName('linux-x86_64')}.sig`
+    )
+    await writeManifest(input, completePlatforms(), version, assets)
 
-		await expect(
-			mergeUpdaterManifests({
-				inputPaths: [input],
-				outputPath: join(dir, "latest.json"),
-				version,
-				notes: "notes",
-				pubDate: "2026-01-01T00:00:00.000Z",
-			}),
-		).rejects.toThrow(
-			`Updater record linux-x86_64 is missing collected signature asset ${assetName("linux-x86_64")}.sig`,
-		);
-	});
-});
+    await expect(
+      mergeUpdaterManifests({
+        inputPaths: [input],
+        outputPath: join(dir, 'latest.json'),
+        version,
+        notes: 'notes',
+        pubDate: '2026-01-01T00:00:00.000Z'
+      })
+    ).rejects.toThrow(
+      `Updater record linux-x86_64 is missing collected signature asset ${assetName('linux-x86_64')}.sig`
+    )
+  })
+})

--- a/scripts/release/merge-updater-manifests.test.ts
+++ b/scripts/release/merge-updater-manifests.test.ts
@@ -26,11 +26,11 @@ async function writeManifest(
 }
 
 function completePlatforms() {
-  return Object.fromEntries(requiredPlatformKeys.map((key) => [key, record(key)]))
+  return Object.fromEntries(requiredPlatformKeys.map((key: string) => [key, record(key)]))
 }
 
 function completeAssetNames() {
-  return requiredPlatformKeys.flatMap((key) => [assetName(key), `${assetName(key)}.sig`])
+  return requiredPlatformKeys.flatMap((key: string) => [assetName(key), `${assetName(key)}.sig`])
 }
 
 describe('mergeUpdaterManifests', () => {
@@ -155,7 +155,7 @@ describe('mergeUpdaterManifests', () => {
     const dir = await fixtureDir()
     const input = join(dir, 'manifest.json')
     const assets = completeAssetNames().filter(
-      (name) => name !== `${assetName('linux-x86_64')}.sig`
+      (name: string) => name !== `${assetName('linux-x86_64')}.sig`
     )
     await writeManifest(input, completePlatforms(), version, assets)
 

--- a/scripts/release/prepare-platform-artifacts.mjs
+++ b/scripts/release/prepare-platform-artifacts.mjs
@@ -1,215 +1,210 @@
 #!/usr/bin/env node
 
-import { copyFile, mkdir, readFile, stat, writeFile } from "node:fs/promises";
-import { basename, join } from "node:path";
-import process from "node:process";
-import { pathToFileURL } from "node:url";
+import { copyFile, mkdir, readFile, stat, writeFile } from 'node:fs/promises'
+import { basename, join } from 'node:path'
+import process from 'node:process'
+import { pathToFileURL } from 'node:url'
 
 const platformDefinitions = {
-	"windows-x64": {
-		requiredKeys: [
-			"windows-x86_64",
-			"windows-x86_64-msi",
-			"windows-x86_64-nsis",
-		],
-		primaryBundle: "msi",
-	},
-	"linux-x64": {
-		requiredKeys: [
-			"linux-x86_64",
-			"linux-x86_64-appimage",
-			"linux-x86_64-deb",
-			"linux-x86_64-rpm",
-		],
-		primaryBundle: "appimage",
-	},
-	"macos-aarch64": {
-		requiredKeys: ["darwin-aarch64", "darwin-aarch64-app"],
-		primaryBundle: "app",
-		arch: "aarch64",
-	},
-	"macos-x64": {
-		requiredKeys: ["darwin-x86_64", "darwin-x86_64-app"],
-		primaryBundle: "app",
-		arch: "x64",
-	},
-};
+  'windows-x64': {
+    requiredKeys: ['windows-x86_64', 'windows-x86_64-msi', 'windows-x86_64-nsis'],
+    primaryBundle: 'msi'
+  },
+  'linux-x64': {
+    requiredKeys: ['linux-x86_64', 'linux-x86_64-appimage', 'linux-x86_64-deb', 'linux-x86_64-rpm'],
+    primaryBundle: 'appimage'
+  },
+  'macos-aarch64': {
+    requiredKeys: ['darwin-aarch64', 'darwin-aarch64-app'],
+    primaryBundle: 'app',
+    arch: 'aarch64'
+  },
+  'macos-x64': {
+    requiredKeys: ['darwin-x86_64', 'darwin-x86_64-app'],
+    primaryBundle: 'app',
+    arch: 'x64'
+  }
+}
 
 function fail(message) {
-	throw new Error(message);
+  throw new Error(message)
 }
 
 function readArguments(argv) {
-	const options = {};
-	for (let index = 0; index < argv.length; index += 2) {
-		const name = argv[index];
-		const value = argv[index + 1];
-		if (!name?.startsWith("--") || value === undefined) {
-			fail(`Invalid arguments: ${argv.join(" ")}`);
-		}
-		options[name.slice(2)] = value;
-	}
-	return options;
+  const options = {}
+  for (let index = 0; index < argv.length; index += 2) {
+    const name = argv[index]
+    const value = argv[index + 1]
+    if (!name?.startsWith('--') || value === undefined) {
+      fail(`Invalid arguments: ${argv.join(' ')}`)
+    }
+    options[name.slice(2)] = value
+  }
+  return options
 }
 
 function normalizeArch(arch) {
-	if (["amd64", "x86_64", "x64"].includes(arch)) return "x86_64";
-	if (["aarch64", "arm64"].includes(arch)) return "aarch64";
-	if (["x86", "i386", "i686"].includes(arch)) return "i686";
-	return arch;
+  if (['amd64', 'x86_64', 'x64'].includes(arch)) return 'x86_64'
+  if (['aarch64', 'arm64'].includes(arch)) return 'aarch64'
+  if (['x86', 'i386', 'i686'].includes(arch)) return 'i686'
+  return arch
 }
 
 function detectExtension(name) {
-	for (const extension of [
-		".app.tar.gz.sig",
-		".app.tar.gz",
-		".AppImage.tar.gz.sig",
-		".AppImage.tar.gz",
-		".sig",
-	]) {
-		if (name.endsWith(extension)) return extension;
-	}
-	return "";
+  for (const extension of [
+    '.app.tar.gz.sig',
+    '.app.tar.gz',
+    '.AppImage.tar.gz.sig',
+    '.AppImage.tar.gz',
+    '.sig'
+  ]) {
+    if (name.endsWith(extension)) return extension
+  }
+  return ''
 }
 
 function detectBundle(path) {
-	if (path.includes("/msi/") || path.includes("\\msi\\")) return "msi";
-	if (path.includes("/nsis/") || path.includes("\\nsis\\")) return "nsis";
-	if (path.includes("/appimage/") || path.includes("\\appimage\\")) return "appimage";
-	if (path.includes("/deb/") || path.includes("\\deb\\")) return "deb";
-	if (path.includes("/rpm/") || path.includes("\\rpm\\")) return "rpm";
-	if (path.includes("/macos/") || path.includes("\\macos\\")) return "app";
-	return "";
+  if (path.includes('/msi/') || path.includes('\\msi\\')) return 'msi'
+  if (path.includes('/nsis/') || path.includes('\\nsis\\')) return 'nsis'
+  if (path.includes('/appimage/') || path.includes('\\appimage\\')) return 'appimage'
+  if (path.includes('/deb/') || path.includes('\\deb\\')) return 'deb'
+  if (path.includes('/rpm/') || path.includes('\\rpm\\')) return 'rpm'
+  if (path.includes('/macos/') || path.includes('\\macos\\')) return 'app'
+  return ''
 }
 
 function releaseAssetName(artifact) {
-	if ([".app.tar.gz", ".app.tar.gz.sig"].includes(artifact.ext)) {
-		const appName = basename(artifact.path, artifact.ext).replaceAll(" ", ".");
-		return `${appName}_${artifact.arch}${artifact.ext}`;
-	}
-	return basename(artifact.path);
+  if (['.app.tar.gz', '.app.tar.gz.sig'].includes(artifact.ext)) {
+    const appName = basename(artifact.path, artifact.ext).replaceAll(' ', '.')
+    return `${appName}_${artifact.arch}${artifact.ext}`
+  }
+  return basename(artifact.path)
 }
 
 function assertNonEmptyString(value, description) {
-	if (typeof value !== "string" || value.trim() === "") {
-		fail(`${description} must be a nonempty string`);
-	}
+  if (typeof value !== 'string' || value.trim() === '') {
+    fail(`${description} must be a nonempty string`)
+  }
 }
 
 export async function preparePlatformArtifacts({
-	platform,
-	version,
-	tag,
-	artifactsPath,
-	outputPath,
+  platform,
+  version,
+  tag,
+  artifactsPath,
+  outputPath
 }) {
-	const definition = platformDefinitions[platform];
-	if (!definition) fail(`Unsupported platform: ${platform}`);
-	assertNonEmptyString(version, "version");
-	assertNonEmptyString(tag, "tag");
-	assertNonEmptyString(artifactsPath, "artifacts path");
-	assertNonEmptyString(outputPath, "output path");
+  const definition = platformDefinitions[platform]
+  if (!definition) fail(`Unsupported platform: ${platform}`)
+  assertNonEmptyString(version, 'version')
+  assertNonEmptyString(tag, 'tag')
+  assertNonEmptyString(artifactsPath, 'artifacts path')
+  assertNonEmptyString(outputPath, 'output path')
 
-	const artifactPaths = JSON.parse(await readFile(artifactsPath, "utf8"));
-	if (!Array.isArray(artifactPaths) || artifactPaths.length === 0) {
-		fail(`${platform} artifact list is empty`);
-	}
+  const artifactPaths = JSON.parse(await readFile(artifactsPath, 'utf8'))
+  if (!Array.isArray(artifactPaths) || artifactPaths.length === 0) {
+    fail(`${platform} artifact list is empty`)
+  }
 
-	const filePaths = [];
-	for (const path of artifactPaths) {
-		assertNonEmptyString(path, `${platform} artifact path`);
-		if ((await stat(path)).isFile()) filePaths.push(path);
-	}
-	if (filePaths.length === 0) fail(`${platform} artifact list contains no files`);
+  const filePaths = []
+  for (const path of artifactPaths) {
+    assertNonEmptyString(path, `${platform} artifact path`)
+    let artifactStat
+    try {
+      artifactStat = await stat(path)
+    } catch (error) {
+      fail(`${platform} artifact path is unavailable: ${path} (${error.message})`)
+    }
+    if (artifactStat.isFile()) filePaths.push(path)
+  }
+  if (filePaths.length === 0) fail(`${platform} artifact list contains no files`)
 
-	const artifacts = filePaths.map((path) => ({
-		path,
-		ext: detectExtension(basename(path)),
-		bundle: detectBundle(path),
-		arch: definition.arch ?? "",
-		assetName: "",
-	}));
+  const artifacts = filePaths.map((path) => ({
+    path,
+    ext: detectExtension(basename(path)),
+    bundle: detectBundle(path),
+    arch: definition.arch ?? '',
+    assetName: ''
+  }))
 
-	const assetSources = new Map();
-	for (const artifact of artifacts) {
-		artifact.assetName = releaseAssetName(artifact);
-		const existingPath = assetSources.get(artifact.assetName);
-		if (existingPath) {
-			fail(`${platform} has duplicate release asset ${artifact.assetName}`);
-		}
-		assetSources.set(artifact.assetName, artifact.path);
-	}
+  const assetSources = new Map()
+  for (const artifact of artifacts) {
+    artifact.assetName = releaseAssetName(artifact)
+    const existingPath = assetSources.get(artifact.assetName)
+    if (existingPath) {
+      fail(`${platform} has duplicate release asset ${artifact.assetName}`)
+    }
+    assetSources.set(artifact.assetName, artifact.path)
+  }
 
-	await mkdir(join(outputPath, "assets"), { recursive: true });
-	for (const artifact of artifacts) {
-		await copyFile(artifact.path, join(outputPath, "assets", artifact.assetName));
-	}
+  await mkdir(join(outputPath, 'assets'), { recursive: true })
+  for (const artifact of artifacts) {
+    await copyFile(artifact.path, join(outputPath, 'assets', artifact.assetName))
+  }
 
-	const signatures = artifacts.filter((artifact) => artifact.assetName.endsWith(".sig"));
-	const platforms = {};
-	const entryForBundle = async (bundle) => {
-		const matchingSignatures = signatures.filter((artifact) => artifact.bundle === bundle);
-		if (matchingSignatures.length !== 1) {
-			fail(`${platform} must have exactly one ${bundle} updater signature`);
-		}
-		const signatureArtifact = matchingSignatures[0];
-		const updaterAssetName = signatureArtifact.assetName.slice(0, -4);
-		const matchingAssets = artifacts.filter(
-			(artifact) => artifact.assetName === updaterAssetName,
-		);
-		if (matchingAssets.length !== 1) {
-			fail(`${platform} signature has no unique matching updater asset: ${updaterAssetName}`);
-		}
-		const signature = (await readFile(signatureArtifact.path, "utf8")).trim();
-		assertNonEmptyString(signature, `${platform} ${bundle} signature`);
-		return {
-			url: `https://github.com/gnoviawan/termul/releases/download/${encodeURIComponent(tag)}/${encodeURIComponent(updaterAssetName)}`,
-			signature,
-		};
-	};
+  const signatures = artifacts.filter((artifact) => artifact.assetName.endsWith('.sig'))
+  const platforms = {}
+  const entryForBundle = async (bundle) => {
+    const matchingSignatures = signatures.filter((artifact) => artifact.bundle === bundle)
+    if (matchingSignatures.length !== 1) {
+      fail(`${platform} must have exactly one ${bundle} updater signature`)
+    }
+    const signatureArtifact = matchingSignatures[0]
+    const updaterAssetName = signatureArtifact.assetName.slice(0, -4)
+    const matchingAssets = artifacts.filter((artifact) => artifact.assetName === updaterAssetName)
+    if (matchingAssets.length !== 1) {
+      fail(`${platform} signature has no unique matching updater asset: ${updaterAssetName}`)
+    }
+    const signature = (await readFile(signatureArtifact.path, 'utf8')).trim()
+    assertNonEmptyString(signature, `${platform} ${bundle} signature`)
+    return {
+      url: `https://github.com/gnoviawan/termul/releases/download/${encodeURIComponent(tag)}/${encodeURIComponent(updaterAssetName)}`,
+      signature
+    }
+  }
 
-	if (platform === "windows-x64") {
-		platforms["windows-x86_64"] = await entryForBundle(definition.primaryBundle);
-		platforms["windows-x86_64-msi"] = await entryForBundle("msi");
-		platforms["windows-x86_64-nsis"] = await entryForBundle("nsis");
-	} else if (platform === "linux-x64") {
-		platforms["linux-x86_64"] = await entryForBundle(definition.primaryBundle);
-		platforms["linux-x86_64-appimage"] = await entryForBundle("appimage");
-		platforms["linux-x86_64-deb"] = await entryForBundle("deb");
-		platforms["linux-x86_64-rpm"] = await entryForBundle("rpm");
-	} else {
-		const arch = normalizeArch(definition.arch);
-		const entry = await entryForBundle("app");
-		platforms[`darwin-${arch}`] = entry;
-		platforms[`darwin-${arch}-app`] = entry;
-	}
+  if (platform === 'windows-x64') {
+    platforms['windows-x86_64'] = await entryForBundle(definition.primaryBundle)
+    platforms['windows-x86_64-msi'] = await entryForBundle('msi')
+    platforms['windows-x86_64-nsis'] = await entryForBundle('nsis')
+  } else if (platform === 'linux-x64') {
+    platforms['linux-x86_64'] = await entryForBundle(definition.primaryBundle)
+    platforms['linux-x86_64-appimage'] = await entryForBundle('appimage')
+    platforms['linux-x86_64-deb'] = await entryForBundle('deb')
+    platforms['linux-x86_64-rpm'] = await entryForBundle('rpm')
+  } else {
+    const arch = normalizeArch(definition.arch)
+    const entry = await entryForBundle('app')
+    platforms[`darwin-${arch}`] = entry
+    platforms[`darwin-${arch}-app`] = entry
+  }
 
-	for (const key of definition.requiredKeys) {
-		if (!platforms[key]) fail(`${platform} did not produce required updater platform ${key}`);
-	}
+  for (const key of definition.requiredKeys) {
+    if (!platforms[key]) fail(`${platform} did not produce required updater platform ${key}`)
+  }
 
-	const manifest = { platform, version, assetNames: [...assetSources.keys()], platforms };
-	await writeFile(
-		join(outputPath, "platform-manifest.json"),
-		`${JSON.stringify(manifest, null, 2)}\n`,
-	);
-	return manifest;
+  const manifest = { platform, version, assetNames: [...assetSources.keys()], platforms }
+  await writeFile(
+    join(outputPath, 'platform-manifest.json'),
+    `${JSON.stringify(manifest, null, 2)}\n`
+  )
+  return manifest
 }
 
 async function runCli() {
-	const options = readArguments(process.argv.slice(2));
-	await preparePlatformArtifacts({
-		platform: options.platform,
-		version: options.version,
-		tag: options.tag,
-		artifactsPath: options.artifacts,
-		outputPath: options.output,
-	});
+  const options = readArguments(process.argv.slice(2))
+  await preparePlatformArtifacts({
+    platform: options.platform,
+    version: options.version,
+    tag: options.tag,
+    artifactsPath: options.artifacts,
+    outputPath: options.output
+  })
 }
 
 if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
-	runCli().catch((error) => {
-		console.error(error instanceof Error ? error.message : String(error));
-		process.exit(1);
-	});
+  runCli().catch((error) => {
+    console.error(error instanceof Error ? error.message : String(error))
+    process.exit(1)
+  })
 }

--- a/scripts/release/prepare-platform-artifacts.mjs
+++ b/scripts/release/prepare-platform-artifacts.mjs
@@ -1,0 +1,215 @@
+#!/usr/bin/env node
+
+import { copyFile, mkdir, readFile, stat, writeFile } from "node:fs/promises";
+import { basename, join } from "node:path";
+import process from "node:process";
+import { pathToFileURL } from "node:url";
+
+const platformDefinitions = {
+	"windows-x64": {
+		requiredKeys: [
+			"windows-x86_64",
+			"windows-x86_64-msi",
+			"windows-x86_64-nsis",
+		],
+		primaryBundle: "msi",
+	},
+	"linux-x64": {
+		requiredKeys: [
+			"linux-x86_64",
+			"linux-x86_64-appimage",
+			"linux-x86_64-deb",
+			"linux-x86_64-rpm",
+		],
+		primaryBundle: "appimage",
+	},
+	"macos-aarch64": {
+		requiredKeys: ["darwin-aarch64", "darwin-aarch64-app"],
+		primaryBundle: "app",
+		arch: "aarch64",
+	},
+	"macos-x64": {
+		requiredKeys: ["darwin-x86_64", "darwin-x86_64-app"],
+		primaryBundle: "app",
+		arch: "x64",
+	},
+};
+
+function fail(message) {
+	throw new Error(message);
+}
+
+function readArguments(argv) {
+	const options = {};
+	for (let index = 0; index < argv.length; index += 2) {
+		const name = argv[index];
+		const value = argv[index + 1];
+		if (!name?.startsWith("--") || value === undefined) {
+			fail(`Invalid arguments: ${argv.join(" ")}`);
+		}
+		options[name.slice(2)] = value;
+	}
+	return options;
+}
+
+function normalizeArch(arch) {
+	if (["amd64", "x86_64", "x64"].includes(arch)) return "x86_64";
+	if (["aarch64", "arm64"].includes(arch)) return "aarch64";
+	if (["x86", "i386", "i686"].includes(arch)) return "i686";
+	return arch;
+}
+
+function detectExtension(name) {
+	for (const extension of [
+		".app.tar.gz.sig",
+		".app.tar.gz",
+		".AppImage.tar.gz.sig",
+		".AppImage.tar.gz",
+		".sig",
+	]) {
+		if (name.endsWith(extension)) return extension;
+	}
+	return "";
+}
+
+function detectBundle(path) {
+	if (path.includes("/msi/") || path.includes("\\msi\\")) return "msi";
+	if (path.includes("/nsis/") || path.includes("\\nsis\\")) return "nsis";
+	if (path.includes("/appimage/") || path.includes("\\appimage\\")) return "appimage";
+	if (path.includes("/deb/") || path.includes("\\deb\\")) return "deb";
+	if (path.includes("/rpm/") || path.includes("\\rpm\\")) return "rpm";
+	if (path.includes("/macos/") || path.includes("\\macos\\")) return "app";
+	return "";
+}
+
+function releaseAssetName(artifact) {
+	if ([".app.tar.gz", ".app.tar.gz.sig"].includes(artifact.ext)) {
+		const appName = basename(artifact.path, artifact.ext).replaceAll(" ", ".");
+		return `${appName}_${artifact.arch}${artifact.ext}`;
+	}
+	return basename(artifact.path);
+}
+
+function assertNonEmptyString(value, description) {
+	if (typeof value !== "string" || value.trim() === "") {
+		fail(`${description} must be a nonempty string`);
+	}
+}
+
+export async function preparePlatformArtifacts({
+	platform,
+	version,
+	tag,
+	artifactsPath,
+	outputPath,
+}) {
+	const definition = platformDefinitions[platform];
+	if (!definition) fail(`Unsupported platform: ${platform}`);
+	assertNonEmptyString(version, "version");
+	assertNonEmptyString(tag, "tag");
+	assertNonEmptyString(artifactsPath, "artifacts path");
+	assertNonEmptyString(outputPath, "output path");
+
+	const artifactPaths = JSON.parse(await readFile(artifactsPath, "utf8"));
+	if (!Array.isArray(artifactPaths) || artifactPaths.length === 0) {
+		fail(`${platform} artifact list is empty`);
+	}
+
+	const filePaths = [];
+	for (const path of artifactPaths) {
+		assertNonEmptyString(path, `${platform} artifact path`);
+		if ((await stat(path)).isFile()) filePaths.push(path);
+	}
+	if (filePaths.length === 0) fail(`${platform} artifact list contains no files`);
+
+	const artifacts = filePaths.map((path) => ({
+		path,
+		ext: detectExtension(basename(path)),
+		bundle: detectBundle(path),
+		arch: definition.arch ?? "",
+		assetName: "",
+	}));
+
+	const assetSources = new Map();
+	for (const artifact of artifacts) {
+		artifact.assetName = releaseAssetName(artifact);
+		const existingPath = assetSources.get(artifact.assetName);
+		if (existingPath) {
+			fail(`${platform} has duplicate release asset ${artifact.assetName}`);
+		}
+		assetSources.set(artifact.assetName, artifact.path);
+	}
+
+	await mkdir(join(outputPath, "assets"), { recursive: true });
+	for (const artifact of artifacts) {
+		await copyFile(artifact.path, join(outputPath, "assets", artifact.assetName));
+	}
+
+	const signatures = artifacts.filter((artifact) => artifact.assetName.endsWith(".sig"));
+	const platforms = {};
+	const entryForBundle = async (bundle) => {
+		const matchingSignatures = signatures.filter((artifact) => artifact.bundle === bundle);
+		if (matchingSignatures.length !== 1) {
+			fail(`${platform} must have exactly one ${bundle} updater signature`);
+		}
+		const signatureArtifact = matchingSignatures[0];
+		const updaterAssetName = signatureArtifact.assetName.slice(0, -4);
+		const matchingAssets = artifacts.filter(
+			(artifact) => artifact.assetName === updaterAssetName,
+		);
+		if (matchingAssets.length !== 1) {
+			fail(`${platform} signature has no unique matching updater asset: ${updaterAssetName}`);
+		}
+		const signature = (await readFile(signatureArtifact.path, "utf8")).trim();
+		assertNonEmptyString(signature, `${platform} ${bundle} signature`);
+		return {
+			url: `https://github.com/gnoviawan/termul/releases/download/${encodeURIComponent(tag)}/${encodeURIComponent(updaterAssetName)}`,
+			signature,
+		};
+	};
+
+	if (platform === "windows-x64") {
+		platforms["windows-x86_64"] = await entryForBundle(definition.primaryBundle);
+		platforms["windows-x86_64-msi"] = await entryForBundle("msi");
+		platforms["windows-x86_64-nsis"] = await entryForBundle("nsis");
+	} else if (platform === "linux-x64") {
+		platforms["linux-x86_64"] = await entryForBundle(definition.primaryBundle);
+		platforms["linux-x86_64-appimage"] = await entryForBundle("appimage");
+		platforms["linux-x86_64-deb"] = await entryForBundle("deb");
+		platforms["linux-x86_64-rpm"] = await entryForBundle("rpm");
+	} else {
+		const arch = normalizeArch(definition.arch);
+		const entry = await entryForBundle("app");
+		platforms[`darwin-${arch}`] = entry;
+		platforms[`darwin-${arch}-app`] = entry;
+	}
+
+	for (const key of definition.requiredKeys) {
+		if (!platforms[key]) fail(`${platform} did not produce required updater platform ${key}`);
+	}
+
+	const manifest = { platform, version, assetNames: [...assetSources.keys()], platforms };
+	await writeFile(
+		join(outputPath, "platform-manifest.json"),
+		`${JSON.stringify(manifest, null, 2)}\n`,
+	);
+	return manifest;
+}
+
+async function runCli() {
+	const options = readArguments(process.argv.slice(2));
+	await preparePlatformArtifacts({
+		platform: options.platform,
+		version: options.version,
+		tag: options.tag,
+		artifactsPath: options.artifacts,
+		outputPath: options.output,
+	});
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+	runCli().catch((error) => {
+		console.error(error instanceof Error ? error.message : String(error));
+		process.exit(1);
+	});
+}

--- a/scripts/release/prepare-platform-artifacts.test.ts
+++ b/scripts/release/prepare-platform-artifacts.test.ts
@@ -1,127 +1,125 @@
+import { mkdir, mkdtemp, readFile, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { dirname, join } from 'node:path'
+import { describe, expect, test } from 'vitest'
 // @ts-expect-error The production helper is intentionally plain ESM for direct workflow use.
-import { preparePlatformArtifacts } from "./prepare-platform-artifacts.mjs";
-import { mkdtemp, mkdir, readFile, writeFile } from "node:fs/promises";
-import { tmpdir } from "node:os";
-import { dirname, join } from "node:path";
-import { describe, expect, test } from "vitest";
+import { preparePlatformArtifacts } from './prepare-platform-artifacts.mjs'
 
 async function fixtureDir() {
-	return mkdtemp(join(tmpdir(), "termul-platform-artifacts-"));
+  return mkdtemp(join(tmpdir(), 'termul-platform-artifacts-'))
 }
 
-async function fixtureFile(root: string, relativePath: string, content = "artifact") {
-	const path = join(root, ...relativePath.split("/"));
-	await mkdir(dirname(path), { recursive: true });
-	await writeFile(path, content);
-	return path;
+async function fixtureFile(root: string, relativePath: string, content = 'artifact') {
+  const path = join(root, ...relativePath.split('/'))
+  await mkdir(dirname(path), { recursive: true })
+  await writeFile(path, content)
+  return path
 }
 
 async function prepare(platform: string, paths: string[], root: string) {
-	const artifactsPath = join(root, `${platform}-paths.json`);
-	const outputPath = join(root, `${platform}-output`);
-	await writeFile(artifactsPath, JSON.stringify(paths));
-	const manifest = await preparePlatformArtifacts({
-		platform,
-		version: "1.2.3",
-		tag: "v1.2.3",
-		artifactsPath,
-		outputPath,
-	});
-	return { manifest, outputPath };
+  const artifactsPath = join(root, `${platform}-paths.json`)
+  const outputPath = join(root, `${platform}-output`)
+  await writeFile(artifactsPath, JSON.stringify(paths))
+  const manifest = await preparePlatformArtifacts({
+    platform,
+    version: '1.2.3',
+    tag: 'v1.2.3',
+    artifactsPath,
+    outputPath
+  })
+  return { manifest, outputPath }
 }
 
-describe("preparePlatformArtifacts", () => {
-	test.each([
-		["macos-aarch64", "aarch64", "darwin-aarch64"],
-		["macos-x64", "x64", "darwin-x86_64"],
-	])("renames %s updater assets and preserves signature association", async (platform, arch, key) => {
-		const root = await fixtureDir();
-		const archive = await fixtureFile(root, "bundle/macos/Termul Manager.app.tar.gz");
-		const signature = await fixtureFile(
-			root,
-			"bundle/macos/Termul Manager.app.tar.gz.sig",
-			`signature-${arch}\n`,
-		);
-		const dmg = await fixtureFile(root, `bundle/dmg/Termul.Manager_1.2.3_${arch}.dmg`);
+describe('preparePlatformArtifacts', () => {
+  test.each([
+    ['macos-aarch64', 'aarch64', 'darwin-aarch64'],
+    ['macos-x64', 'x64', 'darwin-x86_64']
+  ])('renames %s updater assets and preserves signature association', async (platform, arch, key) => {
+    const root = await fixtureDir()
+    const archive = await fixtureFile(root, 'bundle/macos/Termul Manager.app.tar.gz')
+    const signature = await fixtureFile(
+      root,
+      'bundle/macos/Termul Manager.app.tar.gz.sig',
+      `signature-${arch}\n`
+    )
+    const dmg = await fixtureFile(root, `bundle/dmg/Termul.Manager_1.2.3_${arch}.dmg`)
 
-		const { manifest, outputPath } = await prepare(platform, [archive, signature, dmg], root);
-		const updaterName = `Termul.Manager_${arch}.app.tar.gz`;
+    const { manifest, outputPath } = await prepare(platform, [archive, signature, dmg], root)
+    const updaterName = `Termul.Manager_${arch}.app.tar.gz`
 
-		expect(manifest.assetNames).toContain(updaterName);
-		expect(manifest.assetNames).toContain(`${updaterName}.sig`);
-		expect(manifest.platforms[key]).toEqual({
-			url: `https://github.com/gnoviawan/termul/releases/download/v1.2.3/${updaterName}`,
-			signature: `signature-${arch}`,
-		});
-		expect(await readFile(join(outputPath, "assets", `${updaterName}.sig`), "utf8")).toBe(
-			`signature-${arch}\n`,
-		);
-	});
+    expect(manifest.assetNames).toContain(updaterName)
+    expect(manifest.assetNames).toContain(`${updaterName}.sig`)
+    expect(manifest.platforms[key]).toEqual({
+      url: `https://github.com/gnoviawan/termul/releases/download/v1.2.3/${updaterName}`,
+      signature: `signature-${arch}`
+    })
+    expect(await readFile(join(outputPath, 'assets', `${updaterName}.sig`), 'utf8')).toBe(
+      `signature-${arch}\n`
+    )
+  })
 
-	test("collects Windows MSI and NSIS paths", async () => {
-		const root = await fixtureDir();
-		const msi = await fixtureFile(root, "bundle/msi/Termul.Manager_1.2.3_x64_en-US.msi");
-		const msiSig = await fixtureFile(
-			root,
-			"bundle/msi/Termul.Manager_1.2.3_x64_en-US.msi.sig",
-			"msi-signature",
-		);
-		const exe = await fixtureFile(root, "bundle/nsis/Termul.Manager_1.2.3_x64-setup.exe");
-		const exeSig = await fixtureFile(
-			root,
-			"bundle/nsis/Termul.Manager_1.2.3_x64-setup.exe.sig",
-			"nsis-signature",
-		);
+  test('collects Windows MSI and NSIS paths', async () => {
+    const root = await fixtureDir()
+    const msi = await fixtureFile(root, 'bundle/msi/Termul.Manager_1.2.3_x64_en-US.msi')
+    const msiSig = await fixtureFile(
+      root,
+      'bundle/msi/Termul.Manager_1.2.3_x64_en-US.msi.sig',
+      'msi-signature'
+    )
+    const exe = await fixtureFile(root, 'bundle/nsis/Termul.Manager_1.2.3_x64-setup.exe')
+    const exeSig = await fixtureFile(
+      root,
+      'bundle/nsis/Termul.Manager_1.2.3_x64-setup.exe.sig',
+      'nsis-signature'
+    )
 
-		const { manifest } = await prepare("windows-x64", [msi, msiSig, exe, exeSig], root);
-		expect(manifest.platforms["windows-x86_64"].url).toMatch(/_x64_en-US\.msi$/);
-		expect(manifest.platforms["windows-x86_64-msi"].signature).toBe("msi-signature");
-		expect(manifest.platforms["windows-x86_64-nsis"].url).toMatch(/_x64-setup\.exe$/);
-	});
+    const { manifest } = await prepare('windows-x64', [msi, msiSig, exe, exeSig], root)
+    expect(manifest.platforms['windows-x86_64'].url).toMatch(/_x64_en-US\.msi$/)
+    expect(manifest.platforms['windows-x86_64-msi'].signature).toBe('msi-signature')
+    expect(manifest.platforms['windows-x86_64-nsis'].url).toMatch(/_x64-setup\.exe$/)
+  })
 
-	test("collects Linux AppImage, deb, and rpm paths", async () => {
-		const root = await fixtureDir();
-		const paths = [];
-		for (const [bundle, name] of [
-			["appimage", "Termul.Manager_1.2.3_amd64.AppImage"],
-			["deb", "Termul.Manager_1.2.3_amd64.deb"],
-			["rpm", "Termul.Manager-1.2.3-1.x86_64.rpm"],
-		]) {
-			paths.push(await fixtureFile(root, `bundle/${bundle}/${name}`));
-			paths.push(await fixtureFile(root, `bundle/${bundle}/${name}.sig`, `${bundle}-signature`));
-		}
+  test('collects Linux AppImage, deb, and rpm paths', async () => {
+    const root = await fixtureDir()
+    const paths = []
+    for (const [bundle, name] of [
+      ['appimage', 'Termul.Manager_1.2.3_amd64.AppImage'],
+      ['deb', 'Termul.Manager_1.2.3_amd64.deb'],
+      ['rpm', 'Termul.Manager-1.2.3-1.x86_64.rpm']
+    ]) {
+      paths.push(await fixtureFile(root, `bundle/${bundle}/${name}`))
+      paths.push(await fixtureFile(root, `bundle/${bundle}/${name}.sig`, `${bundle}-signature`))
+    }
 
-		const { manifest } = await prepare("linux-x64", paths, root);
-		expect(manifest.platforms["linux-x86_64"].url).toMatch(/\.AppImage$/);
-		expect(manifest.platforms["linux-x86_64-appimage"].signature).toBe(
-			"appimage-signature",
-		);
-		expect(manifest.platforms["linux-x86_64-deb"].url).toMatch(/\.deb$/);
-		expect(manifest.platforms["linux-x86_64-rpm"].url).toMatch(/\.rpm$/);
-	});
+    const { manifest } = await prepare('linux-x64', paths, root)
+    expect(manifest.platforms['linux-x86_64'].url).toMatch(/\.AppImage$/)
+    expect(manifest.platforms['linux-x86_64-appimage'].signature).toBe('appimage-signature')
+    expect(manifest.platforms['linux-x86_64-deb'].url).toMatch(/\.deb$/)
+    expect(manifest.platforms['linux-x86_64-rpm'].url).toMatch(/\.rpm$/)
+  })
 
-	test("rejects duplicate collected asset names even when paths are identical", async () => {
-		const root = await fixtureDir();
-		const msi = await fixtureFile(root, "bundle/msi/Termul.Manager_1.2.3_x64_en-US.msi");
-		const msiSig = await fixtureFile(
-			root,
-			"bundle/msi/Termul.Manager_1.2.3_x64_en-US.msi.sig",
-			"signature",
-		);
+  test('rejects duplicate collected asset names even when paths are identical', async () => {
+    const root = await fixtureDir()
+    const msi = await fixtureFile(root, 'bundle/msi/Termul.Manager_1.2.3_x64_en-US.msi')
+    const msiSig = await fixtureFile(
+      root,
+      'bundle/msi/Termul.Manager_1.2.3_x64_en-US.msi.sig',
+      'signature'
+    )
 
-		await expect(prepare("windows-x64", [msi, msi, msiSig], root)).rejects.toThrow(
-			"windows-x64 has duplicate release asset Termul.Manager_1.2.3_x64_en-US.msi",
-		);
-	});
+    await expect(prepare('windows-x64', [msi, msi, msiSig], root)).rejects.toThrow(
+      'windows-x64 has duplicate release asset Termul.Manager_1.2.3_x64_en-US.msi'
+    )
+  })
 
-	test("rejects multiple signatures for one updater bundle", async () => {
-		const root = await fixtureDir();
-		const first = await fixtureFile(root, "one/msi/Termul.Manager_1.2.3_x64_en-US.msi.sig", "one");
-		const second = await fixtureFile(root, "two/msi/Other_1.2.3_x64_en-US.msi.sig", "two");
-		const msi = await fixtureFile(root, "one/msi/Termul.Manager_1.2.3_x64_en-US.msi");
+  test('rejects multiple signatures for one updater bundle', async () => {
+    const root = await fixtureDir()
+    const first = await fixtureFile(root, 'one/msi/Termul.Manager_1.2.3_x64_en-US.msi.sig', 'one')
+    const second = await fixtureFile(root, 'two/msi/Other_1.2.3_x64_en-US.msi.sig', 'two')
+    const msi = await fixtureFile(root, 'one/msi/Termul.Manager_1.2.3_x64_en-US.msi')
 
-		await expect(prepare("windows-x64", [msi, first, second], root)).rejects.toThrow(
-			"windows-x64 must have exactly one msi updater signature",
-		);
-	});
-});
+    await expect(prepare('windows-x64', [msi, first, second], root)).rejects.toThrow(
+      'windows-x64 must have exactly one msi updater signature'
+    )
+  })
+})

--- a/scripts/release/prepare-platform-artifacts.test.ts
+++ b/scripts/release/prepare-platform-artifacts.test.ts
@@ -1,0 +1,127 @@
+// @ts-expect-error The production helper is intentionally plain ESM for direct workflow use.
+import { preparePlatformArtifacts } from "./prepare-platform-artifacts.mjs";
+import { mkdtemp, mkdir, readFile, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { describe, expect, test } from "vitest";
+
+async function fixtureDir() {
+	return mkdtemp(join(tmpdir(), "termul-platform-artifacts-"));
+}
+
+async function fixtureFile(root: string, relativePath: string, content = "artifact") {
+	const path = join(root, ...relativePath.split("/"));
+	await mkdir(dirname(path), { recursive: true });
+	await writeFile(path, content);
+	return path;
+}
+
+async function prepare(platform: string, paths: string[], root: string) {
+	const artifactsPath = join(root, `${platform}-paths.json`);
+	const outputPath = join(root, `${platform}-output`);
+	await writeFile(artifactsPath, JSON.stringify(paths));
+	const manifest = await preparePlatformArtifacts({
+		platform,
+		version: "1.2.3",
+		tag: "v1.2.3",
+		artifactsPath,
+		outputPath,
+	});
+	return { manifest, outputPath };
+}
+
+describe("preparePlatformArtifacts", () => {
+	test.each([
+		["macos-aarch64", "aarch64", "darwin-aarch64"],
+		["macos-x64", "x64", "darwin-x86_64"],
+	])("renames %s updater assets and preserves signature association", async (platform, arch, key) => {
+		const root = await fixtureDir();
+		const archive = await fixtureFile(root, "bundle/macos/Termul Manager.app.tar.gz");
+		const signature = await fixtureFile(
+			root,
+			"bundle/macos/Termul Manager.app.tar.gz.sig",
+			`signature-${arch}\n`,
+		);
+		const dmg = await fixtureFile(root, `bundle/dmg/Termul.Manager_1.2.3_${arch}.dmg`);
+
+		const { manifest, outputPath } = await prepare(platform, [archive, signature, dmg], root);
+		const updaterName = `Termul.Manager_${arch}.app.tar.gz`;
+
+		expect(manifest.assetNames).toContain(updaterName);
+		expect(manifest.assetNames).toContain(`${updaterName}.sig`);
+		expect(manifest.platforms[key]).toEqual({
+			url: `https://github.com/gnoviawan/termul/releases/download/v1.2.3/${updaterName}`,
+			signature: `signature-${arch}`,
+		});
+		expect(await readFile(join(outputPath, "assets", `${updaterName}.sig`), "utf8")).toBe(
+			`signature-${arch}\n`,
+		);
+	});
+
+	test("collects Windows MSI and NSIS paths", async () => {
+		const root = await fixtureDir();
+		const msi = await fixtureFile(root, "bundle/msi/Termul.Manager_1.2.3_x64_en-US.msi");
+		const msiSig = await fixtureFile(
+			root,
+			"bundle/msi/Termul.Manager_1.2.3_x64_en-US.msi.sig",
+			"msi-signature",
+		);
+		const exe = await fixtureFile(root, "bundle/nsis/Termul.Manager_1.2.3_x64-setup.exe");
+		const exeSig = await fixtureFile(
+			root,
+			"bundle/nsis/Termul.Manager_1.2.3_x64-setup.exe.sig",
+			"nsis-signature",
+		);
+
+		const { manifest } = await prepare("windows-x64", [msi, msiSig, exe, exeSig], root);
+		expect(manifest.platforms["windows-x86_64"].url).toMatch(/_x64_en-US\.msi$/);
+		expect(manifest.platforms["windows-x86_64-msi"].signature).toBe("msi-signature");
+		expect(manifest.platforms["windows-x86_64-nsis"].url).toMatch(/_x64-setup\.exe$/);
+	});
+
+	test("collects Linux AppImage, deb, and rpm paths", async () => {
+		const root = await fixtureDir();
+		const paths = [];
+		for (const [bundle, name] of [
+			["appimage", "Termul.Manager_1.2.3_amd64.AppImage"],
+			["deb", "Termul.Manager_1.2.3_amd64.deb"],
+			["rpm", "Termul.Manager-1.2.3-1.x86_64.rpm"],
+		]) {
+			paths.push(await fixtureFile(root, `bundle/${bundle}/${name}`));
+			paths.push(await fixtureFile(root, `bundle/${bundle}/${name}.sig`, `${bundle}-signature`));
+		}
+
+		const { manifest } = await prepare("linux-x64", paths, root);
+		expect(manifest.platforms["linux-x86_64"].url).toMatch(/\.AppImage$/);
+		expect(manifest.platforms["linux-x86_64-appimage"].signature).toBe(
+			"appimage-signature",
+		);
+		expect(manifest.platforms["linux-x86_64-deb"].url).toMatch(/\.deb$/);
+		expect(manifest.platforms["linux-x86_64-rpm"].url).toMatch(/\.rpm$/);
+	});
+
+	test("rejects duplicate collected asset names even when paths are identical", async () => {
+		const root = await fixtureDir();
+		const msi = await fixtureFile(root, "bundle/msi/Termul.Manager_1.2.3_x64_en-US.msi");
+		const msiSig = await fixtureFile(
+			root,
+			"bundle/msi/Termul.Manager_1.2.3_x64_en-US.msi.sig",
+			"signature",
+		);
+
+		await expect(prepare("windows-x64", [msi, msi, msiSig], root)).rejects.toThrow(
+			"windows-x64 has duplicate release asset Termul.Manager_1.2.3_x64_en-US.msi",
+		);
+	});
+
+	test("rejects multiple signatures for one updater bundle", async () => {
+		const root = await fixtureDir();
+		const first = await fixtureFile(root, "one/msi/Termul.Manager_1.2.3_x64_en-US.msi.sig", "one");
+		const second = await fixtureFile(root, "two/msi/Other_1.2.3_x64_en-US.msi.sig", "two");
+		const msi = await fixtureFile(root, "one/msi/Termul.Manager_1.2.3_x64_en-US.msi");
+
+		await expect(prepare("windows-x64", [msi, first, second], root)).rejects.toThrow(
+			"windows-x64 must have exactly one msi updater signature",
+		);
+	});
+});

--- a/scripts/tests/homebrew-release.bats
+++ b/scripts/tests/homebrew-release.bats
@@ -1,0 +1,125 @@
+#!/usr/bin/env bats
+
+load "helpers.bash"
+
+setup() {
+  make_tmp
+  source "$TERMUL_TEST_REPO_ROOT/scripts/release/homebrew.sh"
+}
+
+teardown() {
+  cleanup_tmp
+}
+
+@test "normalizes full SemVer tags with dotted prerelease and build identifiers" {
+  run normalize_release_version "v1.2.3-beta.1"
+  [ "$status" -eq 0 ]
+  [ "$output" = "1.2.3-beta.1" ]
+
+  run normalize_release_version "1.2.3-beta.1+macos.7"
+  [ "$status" -eq 0 ]
+  [ "$output" = "1.2.3-beta.1+macos.7" ]
+
+  run normalize_release_version "1.2.3+signed-macos.7"
+  [ "$status" -eq 0 ]
+  [ "$output" = "1.2.3+signed-macos.7" ]
+}
+
+@test "rejects incomplete unsafe and leading-zero versions" {
+  for invalid in \
+    "1.2" \
+    "1.2.3/../../tap" \
+    "01.2.3" \
+    "1.02.3" \
+    "1.2.03" \
+    "1.2.3-01" \
+    "1.2.3-beta.01"; do
+    run normalize_release_version "$invalid"
+    [ "$status" -ne 0 ]
+  done
+}
+
+@test "classifies prerelease before build metadata only" {
+  run is_release_prerelease "1.2.3-beta.1+signed-macos.7"
+  [ "$status" -eq 0 ]
+
+  run is_release_prerelease "1.2.3+signed-macos.7"
+  [ "$status" -ne 0 ]
+}
+
+@test "resolves exact DMG checksums" {
+  local checksums="$TERMUL_TEST_TMP_DIR/SHA256SUMS.txt"
+  local arm_sha="$(printf 'a%.0s' {1..64})"
+  local intel_sha="$(printf 'b%.0s' {1..64})"
+  cat >"$checksums" <<EOF
+$arm_sha  Termul.Manager_0.4.8_aarch64.dmg
+$intel_sha *Termul.Manager_0.4.8_x64.dmg
+EOF
+
+  run resolve_dmg_checksums "$checksums" "0.4.8"
+  [ "$status" -eq 0 ]
+  [ "${lines[0]}" = "$arm_sha" ]
+  [ "${lines[1]}" = "$intel_sha" ]
+}
+
+@test "checksum resolution propagates missing malformed and duplicate errors" {
+  local checksums="$TERMUL_TEST_TMP_DIR/SHA256SUMS.txt"
+  local arm_sha="$(printf 'a%.0s' {1..64})"
+  local intel_sha="$(printf 'b%.0s' {1..64})"
+
+  printf '%s  %s\n' "$arm_sha" "Termul.Manager_0.4.8_aarch64.dmg" >"$checksums"
+  run resolve_dmg_checksums "$checksums" "0.4.8"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"x64.dmg"* ]]
+
+  cat >"$checksums" <<EOF
+not-a-hash  Termul.Manager_0.4.8_aarch64.dmg
+$intel_sha  Termul.Manager_0.4.8_x64.dmg
+EOF
+  run resolve_dmg_checksums "$checksums" "0.4.8"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"aarch64.dmg"* ]]
+
+  cat >"$checksums" <<EOF
+$arm_sha  Termul.Manager_0.4.8_aarch64.dmg
+$arm_sha  Termul.Manager_0.4.8_aarch64.dmg
+$intel_sha  Termul.Manager_0.4.8_x64.dmg
+EOF
+  run resolve_dmg_checksums "$checksums" "0.4.8"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"aarch64.dmg"* ]]
+}
+
+@test "generates the exact v0.4.8 xattr exception and omits it for future releases" {
+  local legacy="$TERMUL_TEST_TMP_DIR/termul-0.4.8.rb"
+  local future="$TERMUL_TEST_TMP_DIR/termul-0.4.9.rb"
+  local arm_sha="6be298c2c2c8562b340b069357e8b5d6c3838791ac77c089114004db6a663e69"
+  local intel_sha="72b1d5ab617dcc72c021ec4524ec90a8607870d2011fa83686c4ccda185854c8"
+
+  write_homebrew_cask "$legacy" "0.4.8" "$arm_sha" "$intel_sha"
+  [ "$(grep -Fc 'com.apple.quarantine' "$legacy")" -eq 1 ]
+  grep -Fq 'args: ["-dr", "com.apple.quarantine", "#{appdir}/Termul Manager.app"]' "$legacy"
+
+  write_homebrew_cask "$future" "0.4.9" "$arm_sha" "$intel_sha"
+  ! grep -Fq 'com.apple.quarantine' "$future"
+}
+
+@test "prerelease metadata path does not require a Homebrew token" {
+  local workflow="$TERMUL_TEST_REPO_ROOT/.github/workflows/publish-homebrew.yml"
+  grep -Fq "if: needs.release_metadata.outputs.is_prerelease == 'false'" "$workflow"
+  ! sed -n '/release_metadata:/,/checksums:/p' "$workflow" | grep -q 'HOMEBREW_TAP_TOKEN'
+  ! sed -n '/checksums:/,/homebrew:/p' "$workflow" | grep -q 'HOMEBREW_TAP_TOKEN'
+}
+
+@test "release workflows preserve permissions token flow portability and tap serialization" {
+  local release_workflow="$TERMUL_TEST_REPO_ROOT/.github/workflows/release.yml"
+  local homebrew_workflow="$TERMUL_TEST_REPO_ROOT/.github/workflows/publish-homebrew.yml"
+
+  grep -Fq 'group: publish-homebrew-tap' "$homebrew_workflow"
+  grep -Fq 'GH_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}' "$homebrew_workflow"
+  grep -Fq 'contents: write' "${release_workflow}"
+  grep -Fq 'source scripts/release/homebrew.sh' "$release_workflow"
+  grep -Fq 'otool -L "$executable"' "$release_workflow"
+  grep -Fq 'LC_RPATH' "$release_workflow"
+  ! sed -n '/Verify macOS bundle library portability and signing/,/Collect platform release assets/p' "$release_workflow" | grep -q 'mapfile'
+}

--- a/scripts/tests/homebrew-release.bats
+++ b/scripts/tests/homebrew-release.bats
@@ -106,9 +106,16 @@ EOF
 
 @test "prerelease metadata path does not require a Homebrew token" {
   local workflow="$TERMUL_TEST_REPO_ROOT/.github/workflows/publish-homebrew.yml"
+  local metadata_section
+  local checksums_section
+  metadata_section="$(sed -n '/release_metadata:/,/checksums:/p' "$workflow")"
+  checksums_section="$(sed -n '/checksums:/,/homebrew:/p' "$workflow")"
+
   grep -Fq "if: needs.release_metadata.outputs.is_prerelease == 'false'" "$workflow"
-  ! sed -n '/release_metadata:/,/checksums:/p' "$workflow" | grep -q 'HOMEBREW_TAP_TOKEN'
-  ! sed -n '/checksums:/,/homebrew:/p' "$workflow" | grep -q 'HOMEBREW_TAP_TOKEN'
+  [ -n "$metadata_section" ]
+  [ -n "$checksums_section" ]
+  ! grep -q 'HOMEBREW_TAP_TOKEN' <<<"$metadata_section"
+  ! grep -q 'HOMEBREW_TAP_TOKEN' <<<"$checksums_section"
 }
 
 @test "release workflows preserve permissions token flow portability and tap serialization" {
@@ -121,5 +128,8 @@ EOF
   grep -Fq 'source scripts/release/homebrew.sh' "$release_workflow"
   grep -Fq 'otool -L "$executable"' "$release_workflow"
   grep -Fq 'LC_RPATH' "$release_workflow"
-  ! sed -n '/Verify macOS bundle library portability and signing/,/Collect platform release assets/p' "$release_workflow" | grep -q 'mapfile'
+  local macos_verification_section
+  macos_verification_section="$(sed -n '/Verify macOS bundle library portability and signing/,/Collect platform release assets/p' "$release_workflow")"
+  [ -n "$macos_verification_section" ]
+  ! grep -q 'mapfile' <<<"$macos_verification_section"
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -540,15 +540,8 @@ fn open_external_url(url: &str) -> Result<(), String> {
 fn build_app_menu<R: tauri::Runtime>(
     app: &tauri::AppHandle<R>,
 ) -> tauri::Result<tauri::menu::Menu<R>> {
-    let file_menu = {
-        #[cfg(target_os = "macos")]
-        let builder = SubmenuBuilder::new(app, "File");
-
-        #[cfg(not(target_os = "macos"))]
-        let builder = SubmenuBuilder::new(app, "File").quit();
-
-        builder.build()?
-    };
+    #[cfg(not(target_os = "macos"))]
+    let file_menu = SubmenuBuilder::new(app, "File").quit().build()?;
 
     let edit_menu = SubmenuBuilder::new(app, "Edit")
         .undo()
@@ -640,7 +633,7 @@ fn build_app_menu<R: tauri::Runtime>(
         .build()?;
 
     #[cfg(target_os = "macos")]
-    let menu = {
+    {
         let app_menu = SubmenuBuilder::new(app, app.package_info().name.clone())
             .about(None)
             .separator()
@@ -653,13 +646,18 @@ fn build_app_menu<R: tauri::Runtime>(
             .quit()
             .build()?;
 
-        MenuBuilder::new(app).item(&app_menu)
-    };
+        return MenuBuilder::new(app)
+            .item(&app_menu)
+            .item(&edit_menu)
+            .item(&view_menu)
+            .item(&window_menu)
+            .item(&help_menu)
+            .build();
+    }
 
     #[cfg(not(target_os = "macos"))]
-    let menu = MenuBuilder::new(app);
-
-    menu.item(&file_menu)
+    MenuBuilder::new(app)
+        .item(&file_menu)
         .item(&edit_menu)
         .item(&view_menu)
         .item(&window_menu)

--- a/src/renderer/assets/agent-icons/acp/agents.json
+++ b/src/renderer/assets/agent-icons/acp/agents.json
@@ -308,11 +308,11 @@
   {
     "id": "dimcode",
     "name": "DimCode",
-    "version": "0.2.37",
+    "version": "0.2.38",
     "description": "A coding agent that puts leading models at your command.",
     "distribution": {
       "npx": {
-        "package": "dimcode@0.2.37",
+        "package": "dimcode@0.2.38",
         "args": ["acp"]
       }
     }
@@ -641,38 +641,38 @@
   {
     "id": "opencode",
     "name": "OpenCode",
-    "version": "1.18.7",
+    "version": "1.18.8",
     "description": "The open source coding agent",
     "distribution": {
       "binary": {
         "darwin-aarch64": {
           "cmd": "./opencode",
-          "archive": "https://github.com/anomalyco/opencode/releases/download/v1.18.7/opencode-darwin-arm64.zip",
+          "archive": "https://github.com/anomalyco/opencode/releases/download/v1.18.8/opencode-darwin-arm64.zip",
           "args": ["acp"]
         },
         "darwin-x86_64": {
           "cmd": "./opencode",
-          "archive": "https://github.com/anomalyco/opencode/releases/download/v1.18.7/opencode-darwin-x64.zip",
+          "archive": "https://github.com/anomalyco/opencode/releases/download/v1.18.8/opencode-darwin-x64.zip",
           "args": ["acp"]
         },
         "linux-aarch64": {
           "cmd": "./opencode",
-          "archive": "https://github.com/anomalyco/opencode/releases/download/v1.18.7/opencode-linux-arm64.tar.gz",
+          "archive": "https://github.com/anomalyco/opencode/releases/download/v1.18.8/opencode-linux-arm64.tar.gz",
           "args": ["acp"]
         },
         "linux-x86_64": {
           "cmd": "./opencode",
-          "archive": "https://github.com/anomalyco/opencode/releases/download/v1.18.7/opencode-linux-x64.tar.gz",
+          "archive": "https://github.com/anomalyco/opencode/releases/download/v1.18.8/opencode-linux-x64.tar.gz",
           "args": ["acp"]
         },
         "windows-aarch64": {
           "cmd": "./opencode",
-          "archive": "https://github.com/anomalyco/opencode/releases/download/v1.18.7/opencode-windows-arm64.zip",
+          "archive": "https://github.com/anomalyco/opencode/releases/download/v1.18.8/opencode-windows-arm64.zip",
           "args": ["acp"]
         },
         "windows-x86_64": {
           "cmd": "./opencode.exe",
-          "archive": "https://github.com/anomalyco/opencode/releases/download/v1.18.7/opencode-windows-x64.zip",
+          "archive": "https://github.com/anomalyco/opencode/releases/download/v1.18.8/opencode-windows-x64.zip",
           "args": ["acp"]
         }
       }
@@ -756,20 +756,20 @@
   {
     "id": "sigit",
     "name": "siGit Code",
-    "version": "1.5.0",
+    "version": "1.5.1",
     "description": "Local-first coding agent. Runs entirely on your machine with optional on-device LLM inference via Onde.",
     "distribution": {
       "npx": {
-        "package": "@smbcloud/sigit@1.5.0"
+        "package": "@smbcloud/sigit@1.5.1"
       },
       "binary": {
         "darwin-aarch64": {
           "cmd": "./sigit",
-          "archive": "https://github.com/getsigit/sigit/releases/download/v1.5.0/sigit-macos-arm64.tar.gz"
+          "archive": "https://github.com/getsigit/sigit/releases/download/v1.5.1/sigit-macos-arm64.tar.gz"
         },
         "darwin-x86_64": {
           "cmd": "./sigit",
-          "archive": "https://github.com/getsigit/sigit/releases/download/v1.5.0/sigit-macos-amd64.tar.gz"
+          "archive": "https://github.com/getsigit/sigit/releases/download/v1.5.1/sigit-macos-amd64.tar.gz"
         },
         "linux-aarch64": {
           "cmd": "./sigit-linux-arm64"


### PR DESCRIPTION
## Summary

- Fixes the macOS distribution path reported in #418 by requiring Developer ID signing, notarization, stapling, Gatekeeper validation, and Mach-O portability checks before any macOS asset reaches a GitHub Release.
- Prevents concurrent or incomplete updater metadata publication by collecting each platform's artifacts independently, validating every historical Tauri updater platform record, and producing one authoritative `latest.json` in the release publication job.
- Restores Homebrew publication without relying on a suppressed `release: published` event, and removes the empty macOS File menu while preserving the functional application, Edit, View, Window, and Help menus.

## Related Issue

Closes #418

No open or closed PR matching issue #418 or the macOS notarization/Homebrew/File-menu scope was found before submission.

## Type of Change

- [ ] feat: new feature
- [x] fix: bug fix
- [ ] docs: documentation only
- [ ] style: formatting or non-functional styling changes
- [ ] refactor: internal cleanup with no behavior change
- [ ] perf: performance improvement
- [x] test: adds or updates tests
- [x] build: build or dependency changes
- [x] ci: CI/CD workflow changes
- [ ] chore: maintenance or tooling
- [ ] revert: reverts a previous change

## What Changed

- Builds platform artifacts without direct release upload, then centrally downloads and validates all platform manifests and release assets before publishing the draft release.
- Adds macOS Apple-secret preflight, Developer ID/notarization checks, Gatekeeper assessment, stapler validation, and portable Mach-O dependency/RPATH validation for both Apple Silicon and Intel builds.
- Preserves updater minisign artifacts while ensuring Windows, Linux, macOS ARM, and macOS Intel updater entries are complete and conflict-free.
- Makes the Homebrew workflow reusable and manually dispatchable, uses authoritative GitHub release metadata for prerelease behavior, generates `SHA256SUMS.txt` on every channel, and updates the tap only for stable releases.
- Adds strict SemVer, checksum-cardinality, cask-generation, artifact-collection, and updater-merge regression tests.
- Documents Apple and Homebrew secret requirements, activation behavior, verification gates, and the historical unsigned v0.4.8 limitation.
- Omits the empty File submenu only on macOS; non-macOS menu behavior is unchanged.

## How It Was Tested

- [ ] `bun run ci` (Biome lint + format + imports, strict mode)
- [ ] `bun run typecheck`
- [ ] `bun run test`
- [ ] `cargo clippy --all-targets -- -D warnings` (in src-tauri)
- [ ] `cargo test` (in src-tauri)
- [x] Manual verification completed
- [ ] Not applicable

Manual/static validation completed:

- `actionlint .github/workflows/release.yml .github/workflows/publish-homebrew.yml`
- YAML parsing for both changed workflows
- `node --check` for both release helper modules
- `bash -n` for the release shell helper and Bats suite
- Focused direct assertions for release helpers and exact v0.4.8 DMG checksum verification
- `git diff --check`
- Three-layer adversarial review plus a post-rebase review against current `dev`, with no blocker or high-severity findings

The full local commands could not be rerun in this isolated worktree because dependencies are not installed (`bun run ci` reports `biome` missing); required GitHub CI remains the authoritative gate. macOS-only signing, notarization, Gatekeeper, stapler, native-menu, and Homebrew audit checks require GitHub/macOS runners and configured repository credentials.

## Screenshots or Recordings

No screenshot is included: this removes an empty native macOS menu rather than changing rendered web UI. Native menu behavior is covered by the cfg-scoped construction change and remains subject to macOS CI/manual verification.

## CI & Review Gate

- [x] All CI checks pass (PR Validation, Rust Checks, Build Verification, Security Scans)
- [x] Code review comments from CodeRabbit / Claude have been addressed or resolved
- [x] No unresolved review findings remain

All required GitHub CI checks now pass, and all actionable CodeRabbit threads have been fixed, replied to, and resolved.

## Checklist

- [x] My PR title follows the conventional commit format used by this repo
- [x] I linked the related issue or explained why none exists
- [x] I updated docs when needed
- [x] I added or updated tests when needed
- [x] I verified the change does not introduce unrelated modifications
- [x] I read AGENTS.md and followed the contributor guidelines
- [x] A human reviewed the complete diff before submission


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * More robust release packaging across macOS, Windows, and Linux with merged updater manifests, stricter asset validation, and generation of the consolidated `latest.json`.
  * Automated Homebrew cask creation plus checksum publishing for stable releases, with dedicated prerelease handling and tap updates.
  * Added special legacy handling for version 0.4.8 to support macOS quarantine cleanup.

* **Bug Fixes**
  * Improved signature, version, and platform-download validation during release publishing.
  * Simplified the macOS app menu by removing the nonessential File menu.

* **Documentation**
  * Rewrote the deployment guide with clearer signing requirements, release checklist, and local validation steps.

* **Tests**
  * Added/expanded automated tests for release preparation, Homebrew cask/checksum logic, and manifest merging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->