### PR TITLE
feat(acp): redesign chat tool activity

### DIFF
--- a/src/renderer/components/chat/ChatMessage.test.tsx
+++ b/src/renderer/components/chat/ChatMessage.test.tsx
@@ -29,18 +29,28 @@ vi.mock('streamdown', async () => {
     children,
     isAnimating,
     caret,
-    linkSafety
+    linkSafety,
+    components
   }: {
     children: ReactNode
     isAnimating?: boolean
     caret?: string
     linkSafety?: LinkSafety
+    components?: Record<string, unknown>
   }): React.JSX.Element {
     const [open, setOpen] = React.useState(false)
     const url = 'https://example.com/docs'
+    const markdown = typeof children === 'string' ? children : ''
+    const CustomTable = components?.table as React.ElementType | undefined
+    const semanticFixture = markdown.startsWith('# Compact heading')
 
     return (
-      <div data-testid="streamdown" data-animating={isAnimating} data-caret={caret}>
+      <div
+        data-testid="streamdown"
+        data-animating={isAnimating}
+        data-caret={caret}
+        data-custom-table={Boolean(CustomTable)}
+      >
         <button
           type="button"
           data-testid="streamdown-link"
@@ -53,7 +63,40 @@ vi.mock('streamdown', async () => {
         >
           docs
         </button>
-        {children}
+        {semanticFixture ? (
+          <>
+            <h1 data-streamdown="heading-1">Compact heading</h1>
+            <ul data-streamdown="unordered-list">
+              <li data-streamdown="list-item">First item</li>
+              <li data-streamdown="list-item">Second item</li>
+            </ul>
+            <p>
+              Use <code>inline()</code> here.
+            </p>
+            <div data-streamdown="code-block-body">
+              <pre>
+                <code>const compact = true</code>
+              </pre>
+            </div>
+            <blockquote data-streamdown="blockquote">A concise quote</blockquote>
+            {CustomTable ? (
+              <CustomTable>
+                <thead>
+                  <tr>
+                    <th>Column</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr>
+                    <td>Value</td>
+                  </tr>
+                </tbody>
+              </CustomTable>
+            ) : null}
+          </>
+        ) : (
+          children
+        )}
         {linkSafety?.renderModal?.({
           isOpen: open,
           url,
@@ -64,7 +107,13 @@ vi.mock('streamdown', async () => {
     )
   }
 
-  return { Streamdown: MockStreamdown }
+  const StreamdownContext = React.createContext({ controls: false, isAnimating: false })
+  return {
+    Streamdown: MockStreamdown,
+    StreamdownContext,
+    TableCopyDropdown: ({ children }: { children: ReactNode }) => <>{children}</>,
+    TableDownloadDropdown: ({ children }: { children: ReactNode }) => <>{children}</>
+  }
 })
 
 vi.mock('framer-motion', async () => {
@@ -95,6 +144,65 @@ describe('ChatMessage', () => {
 
     expect(screen.getByTestId('streamdown')).toHaveAttribute('data-animating', 'true')
     expect(screen.getByTestId('streamdown')).toHaveAttribute('data-caret', 'block')
+  })
+
+  it('renders compact markdown semantics for headings, lists, code, quotes, and tables', () => {
+    const message: ChatMessageType = {
+      ...agentMessage(false),
+      blocks: [
+        {
+          type: 'text',
+          text: [
+            '# Compact heading',
+            '',
+            '- First item',
+            '- Second item',
+            '',
+            'Use `inline()` here.',
+            '',
+            '```ts',
+            'const compact = true',
+            '```',
+            '',
+            '> A concise quote',
+            '',
+            '| Column |',
+            '| --- |',
+            '| Value |'
+          ].join('\n')
+        }
+      ]
+    }
+    const { container } = render(<ChatMessage message={message} isLast />)
+
+    const heading = screen.getByRole('heading', { level: 1, name: 'Compact heading' })
+    expect(heading).toHaveAttribute('data-streamdown', 'heading-1')
+
+    const list = screen.getByRole('list')
+    expect(list.tagName).toBe('UL')
+    expect(list).toHaveAttribute('data-streamdown', 'unordered-list')
+    expect(screen.getAllByRole('listitem')).toHaveLength(2)
+
+    const inlineCode = screen.getByText('inline()')
+    expect(inlineCode.tagName).toBe('CODE')
+    expect(inlineCode.closest('pre')).toBeNull()
+
+    const codeBlock = screen.getByText('const compact = true')
+    expect(codeBlock.closest('[data-streamdown="code-block-body"]')).toBeInTheDocument()
+    expect(codeBlock.closest('pre')).toBeInTheDocument()
+
+    const quote = screen.getByText('A concise quote')
+    expect(quote.tagName).toBe('BLOCKQUOTE')
+    expect(quote).toHaveAttribute('data-streamdown', 'blockquote')
+
+    const table = screen.getByRole('table')
+    expect(table).toHaveAttribute('data-streamdown', 'table')
+    expect(table.closest('[data-streamdown="table-wrapper"]')).toHaveClass(
+      'min-w-0',
+      'overflow-hidden'
+    )
+    expect(table.parentElement).toHaveClass('max-w-full', 'overflow-x-auto')
+    expect(container.querySelector('.chat-streamdown')).toHaveClass('leading-normal', 'min-w-0')
   })
 
   it('stops the Streamdown caret when the live agent message finishes', () => {

--- a/src/renderer/components/chat/ChatMessage.tsx
+++ b/src/renderer/components/chat/ChatMessage.tsx
@@ -210,7 +210,7 @@ function AgentProse({
   reduced: boolean
 }): React.JSX.Element {
   return (
-    <div className="chat-streamdown text-sm leading-relaxed text-foreground">
+    <div className="chat-streamdown min-w-0 text-sm leading-normal text-foreground">
       <Streamdown
         mode="streaming"
         isAnimating={streaming}

--- a/src/renderer/components/chat/ChatMessageList.test.tsx
+++ b/src/renderer/components/chat/ChatMessageList.test.tsx
@@ -154,7 +154,10 @@ describe('ChatMessageList', () => {
     const trigger = screen.getByRole('button', { name: 'Worked for 3s' })
     expect(trigger).toHaveAttribute('aria-expanded', 'false')
     trigger.focus()
-    // Native buttons dispatch a click with detail=0 when activated by keyboard.
+    // jsdom does not synthesize the click a real browser fires on Enter, so
+    // dispatch the key sequence then the keyboard-generated click (detail 0).
+    fireEvent.keyDown(trigger, { key: 'Enter' })
+    fireEvent.keyUp(trigger, { key: 'Enter' })
     fireEvent.click(trigger, { detail: 0 })
     expect(trigger).toHaveAttribute('aria-expanded', 'true')
   })

--- a/src/renderer/components/chat/ChatMessageList.test.tsx
+++ b/src/renderer/components/chat/ChatMessageList.test.tsx
@@ -1,11 +1,32 @@
-import { render, screen, waitFor } from '@testing-library/react'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { describe, expect, it, vi } from 'vitest'
 import { ChatMessageList } from './ChatMessageList'
 import type { TimelineItem } from './chat-timeline'
 
 vi.mock('./ChatMessage', () => ({
-  ChatMessage: () => <div>Agent response</div>
+  ChatMessage: ({
+    message
+  }: {
+    message: { id: string; blocks: Array<{ type: string; text?: string; name?: string }> }
+  }) => (
+    <div data-testid={`message-${message.id}`}>
+      {message.blocks.map((block) => block.text ?? block.name ?? block.type).join('')}
+    </div>
+  )
 }))
+
+const userItem: TimelineItem = {
+  kind: 'message',
+  key: 'user-1',
+  message: {
+    id: 'user-1',
+    role: 'user',
+    blocks: [{ type: 'text', text: 'Please investigate' }],
+    streaming: false,
+    timestamp: 1_000,
+    seq: 1
+  }
+}
 
 const streamingAgentItem: TimelineItem = {
   kind: 'message',
@@ -15,7 +36,21 @@ const streamingAgentItem: TimelineItem = {
     role: 'agent',
     blocks: [{ type: 'text', text: 'Working on it' }],
     streaming: true,
-    timestamp: 0
+    timestamp: 2_000,
+    seq: 3
+  }
+}
+
+const finalAgentItem: TimelineItem = {
+  kind: 'message',
+  key: 'agent-final',
+  message: {
+    id: 'agent-final',
+    role: 'agent',
+    blocks: [{ type: 'text', text: 'Final response' }],
+    streaming: false,
+    timestamp: 4_200,
+    seq: 4
   }
 }
 
@@ -26,7 +61,25 @@ const toolItem: TimelineItem = {
     toolCallId: 'tool-1',
     title: 'Reading files',
     status: 'in_progress',
-    timestamp: 0
+    timestamp: 1_500,
+    seq: 2
+  }
+}
+
+const completedToolItem: TimelineItem = {
+  ...toolItem,
+  tool: { ...toolItem.tool, status: 'completed' }
+}
+
+const failedToolItem: TimelineItem = {
+  kind: 'tool',
+  key: 'tool-failed',
+  tool: {
+    toolCallId: 'tool-failed',
+    title: 'Run checks',
+    status: 'failed',
+    timestamp: 2_000,
+    seq: 2
   }
 }
 
@@ -39,40 +92,40 @@ const thoughtItem: TimelineItem = {
       role: 'thought',
       blocks: [{ type: 'text', text: 'Considering options' }],
       streaming: true,
-      timestamp: 0
+      timestamp: 1_200,
+      seq: 2
     }
   ]
 }
 
 describe('ChatMessageList', () => {
   it.each([
-    ['before content arrives', []],
-    ['while a thought streams', [thoughtItem]],
-    ['while a tool runs', [toolItem]],
-    ['while an agent response streams', [streamingAgentItem]]
-  ] satisfies Array<[string, TimelineItem[]]>)('shows the running indicator %s', (_, items) => {
+    ['before content arrives', [userItem]],
+    ['while a thought streams', [userItem, thoughtItem]],
+    ['while a tool runs', [userItem, toolItem]],
+    ['while an agent response streams', [userItem, streamingAgentItem]]
+  ] satisfies Array<[string, TimelineItem[]]>)('shows open Working activity %s', (_, items) => {
     render(
       <ChatMessageList items={items} sessionId="session-1" agentId="agent-1" showRunningIndicator />
     )
 
-    expect(screen.getByRole('status', { name: 'Agent is working' })).toBeInTheDocument()
+    const trigger = screen.getByRole('button', { name: /Working/ })
+    expect(trigger).toHaveAttribute('aria-expanded', 'true')
   })
 
-  it('removes the running indicator after the turn finishes', async () => {
+  it('collapses completed activity while keeping the final response visible', async () => {
     const { rerender } = render(
       <ChatMessageList
-        items={[streamingAgentItem]}
+        items={[userItem, toolItem, streamingAgentItem]}
         sessionId="session-1"
         agentId="agent-1"
         showRunningIndicator
       />
     )
 
-    expect(screen.getByRole('status', { name: 'Agent is working' })).toBeInTheDocument()
-
     rerender(
       <ChatMessageList
-        items={[streamingAgentItem]}
+        items={[userItem, completedToolItem, streamingAgentItem, finalAgentItem]}
         sessionId="session-1"
         agentId="agent-1"
         showRunningIndicator={false}
@@ -80,7 +133,114 @@ describe('ChatMessageList', () => {
     )
 
     await waitFor(() => {
-      expect(screen.queryByRole('status', { name: 'Agent is working' })).not.toBeInTheDocument()
+      expect(screen.getByRole('button', { name: 'Worked for 3s' })).toHaveAttribute(
+        'aria-expanded',
+        'false'
+      )
     })
+    expect(screen.getByText('Final response')).toBeInTheDocument()
+  })
+
+  it('allows keyboard-accessible reopening after completion', () => {
+    render(
+      <ChatMessageList
+        items={[userItem, completedToolItem, finalAgentItem]}
+        sessionId="session-1"
+        agentId="agent-1"
+        showRunningIndicator={false}
+      />
+    )
+
+    const trigger = screen.getByRole('button', { name: 'Worked for 3s' })
+    expect(trigger).toHaveAttribute('aria-expanded', 'false')
+    trigger.focus()
+    // Native buttons dispatch a click with detail=0 when activated by keyboard.
+    fireEvent.click(trigger, { detail: 0 })
+    expect(trigger).toHaveAttribute('aria-expanded', 'true')
+  })
+
+  it('keeps attachment responses visible when later text and an empty tail arrive', async () => {
+    const attachmentItem: TimelineItem = {
+      kind: 'message',
+      key: 'agent-attachment',
+      message: {
+        id: 'agent-attachment',
+        role: 'agent',
+        blocks: [{ type: 'resource_link', name: 'report.pdf', uri: 'file:///tmp/report.pdf' }],
+        streaming: false,
+        timestamp: 2_200,
+        seq: 3
+      }
+    }
+    const emptyTailItem: TimelineItem = {
+      kind: 'message',
+      key: 'agent-empty',
+      message: {
+        id: 'agent-empty',
+        role: 'agent',
+        blocks: [{ type: 'text', text: '  ' }],
+        streaming: false,
+        timestamp: 4_300,
+        seq: 5
+      }
+    }
+
+    render(
+      <ChatMessageList
+        items={[userItem, completedToolItem, attachmentItem, finalAgentItem, emptyTailItem]}
+        sessionId="session-1"
+        agentId="agent-1"
+        showRunningIndicator={false}
+      />
+    )
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Worked for 3s' })).toHaveAttribute(
+        'aria-expanded',
+        'false'
+      )
+    })
+    expect(screen.getByTestId('message-agent-attachment')).toHaveTextContent('report.pdf')
+    expect(screen.getByTestId('message-agent-final')).toHaveTextContent('Final response')
+    expect(screen.queryByTestId('message-agent-empty')).not.toBeInTheDocument()
+  })
+
+  it('keeps the live response DOM node stable when later activity arrives', () => {
+    const { rerender } = render(
+      <ChatMessageList
+        items={[userItem, streamingAgentItem]}
+        sessionId="session-1"
+        agentId="agent-1"
+        showRunningIndicator
+      />
+    )
+    const liveNode = screen.getByTestId('message-agent-1')
+
+    rerender(
+      <ChatMessageList
+        items={[userItem, streamingAgentItem, toolItem]}
+        sessionId="session-1"
+        agentId="agent-1"
+        showRunningIndicator
+      />
+    )
+
+    expect(screen.getByTestId('message-agent-1')).toBe(liveNode)
+    expect(screen.getByText('Reading files')).toBeInTheDocument()
+  })
+
+  it('keeps a failed tool-only turn open and visible', () => {
+    render(
+      <ChatMessageList
+        items={[userItem, failedToolItem]}
+        sessionId="session-1"
+        agentId="agent-1"
+        showRunningIndicator={false}
+      />
+    )
+
+    const trigger = screen.getByRole('button', { name: /Worked.*needs attention/ })
+    expect(trigger).toHaveAttribute('aria-expanded', 'true')
+    expect(screen.getByText('Run checks')).toBeInTheDocument()
   })
 })

--- a/src/renderer/components/chat/ChatMessageList.tsx
+++ b/src/renderer/components/chat/ChatMessageList.tsx
@@ -1,4 +1,3 @@
-import { AnimatePresence, motion, useReducedMotion } from 'framer-motion'
 import { useEffect, useMemo, useRef } from 'react'
 import {
   MessageScroller,
@@ -9,15 +8,15 @@ import {
   MessageScrollerViewport,
   useMessageScroller
 } from '@/components/ui/message-scroller'
-import { MonochromeSpinner } from '@/components/ui/monochrome-spinner'
 import type { AgentId, SessionId } from '@/lib/acp-api'
 import { cn } from '@/lib/utils'
 import { ChatEmptyState } from './ChatEmptyState'
 import { ChatMessage } from './ChatMessage'
 import { CHAT_GUTTER_X } from './chat-layout'
-import { agentTurnMeta, type TimelineItem } from './chat-timeline'
+import { groupTurnActivity, type TimelineItem, type TurnTimelineItem } from './chat-timeline'
 import { ThoughtGroup } from './ThoughtGroup'
 import { ToolCallCard } from './ToolCallCard'
+import { TurnActivity } from './TurnActivity'
 
 /** Reports the live item count to the scroller so the jump button can badge unread. */
 function ItemCountReporter({ count }: { count: number }): null {
@@ -42,23 +41,15 @@ interface ChatMessageListProps {
   onRetry?: () => void
 }
 
-/** Hide the agent header when the previous timeline entry is also an agent reply. */
-function isGroupedReply(items: TimelineItem[], index: number): boolean {
-  const it = items[index]
-  if (it.kind !== 'message' || it.message.role !== 'agent') return false
-  const prev = items[index - 1]
-  return prev?.kind === 'message' && prev.message.role === 'agent'
-}
-
-/** Index of the last message item in the timeline (skips trailing tool cards). */
-function lastMessageIndex(items: TimelineItem[]): number {
+/** Index of the last visible message item in the turn-grouped timeline. */
+function lastMessageIndex(items: TurnTimelineItem[]): number {
   for (let i = items.length - 1; i >= 0; i--) {
     if (items[i].kind === 'message') return i
   }
   return -1
 }
 
-/** Stable id for animate-enter tracking across message, tool, and thought rows. */
+/** Stable id for animate-enter tracking across message, tool, thought, and activity rows. */
 function timelineItemId(it: TimelineItem): string {
   if (it.kind === 'message') return it.message.id
   if (it.kind === 'tool') return it.tool.toolCallId
@@ -88,9 +79,9 @@ function useAnimateEnter(sessionId: SessionId, items: TimelineItem[]): (id: stri
 }
 
 /**
- * Scrollable message thread built on the MessageScroller engine. Auto-follows
- * the live edge only while the reader is pinned to the bottom; a jump-to-latest
- * control appears otherwise. New user turns anchor the scroll position.
+ * Scrollable message thread built on the MessageScroller engine. Agent process
+ * output is grouped into one turn-level disclosure; the final reply remains a
+ * normal message below it.
  */
 export function ChatMessageList({
   items,
@@ -100,8 +91,11 @@ export function ChatMessageList({
   onEditMessage,
   onRetry
 }: ChatMessageListProps): React.JSX.Element {
-  const turnMeta = useMemo(() => agentTurnMeta(items), [items])
-  const lastMsgIndex = useMemo(() => lastMessageIndex(items), [items])
+  const groupedItems = useMemo(
+    () => groupTurnActivity(items, showRunningIndicator),
+    [items, showRunningIndicator]
+  )
+  const lastMsgIndex = useMemo(() => lastMessageIndex(groupedItems), [groupedItems])
   const shouldAnimateEnter = useAnimateEnter(sessionId, items)
 
   if (items.length === 0 && !showRunningIndicator) {
@@ -114,62 +108,52 @@ export function ChatMessageList({
       <div className="pointer-events-none absolute inset-x-0 top-0 z-10 h-6 bg-gradient-to-b from-background to-transparent" />
       <div className="pointer-events-none absolute inset-x-0 bottom-0 z-10 h-6 bg-gradient-to-t from-background to-transparent" />
       <MessageScrollerProvider autoScroll>
-        <ItemCountReporter count={items.length} />
+        <ItemCountReporter count={groupedItems.length} />
         <MessageScroller>
           <MessageScrollerViewport className={cn(CHAT_GUTTER_X, 'py-4')}>
             <MessageScrollerContent className="mx-auto w-full max-w-3xl">
-              {items.map((it, i) => (
+              {groupedItems.map((item, index) => (
                 <MessageScrollerItem
-                  key={it.key}
-                  messageId={it.key}
-                  scrollAnchor={it.kind === 'message' && it.message.role === 'user'}
+                  key={item.key}
+                  messageId={item.key}
+                  scrollAnchor={item.kind === 'message' && item.message.role === 'user'}
                 >
-                  {it.kind === 'tool' ? (
-                    <ToolCallCard
-                      toolCall={it.tool}
-                      animateEnter={shouldAnimateEnter(it.tool.toolCallId)}
+                  {item.kind === 'activity' ? (
+                    <TurnActivity
+                      items={item.items}
+                      active={item.active}
+                      durationMs={item.durationMs}
+                      attentionRequired={item.attentionRequired}
+                      hasFinalResponse={item.hasFinalResponse}
+                      shouldAnimateEnter={shouldAnimateEnter}
                     />
-                  ) : it.kind === 'thought-group' ? (
-                    <ThoughtGroup messages={it.messages} isLiveTail={i === items.length - 1} />
+                  ) : item.kind === 'tool' ? (
+                    <ToolCallCard
+                      toolCall={item.tool}
+                      animateEnter={shouldAnimateEnter(item.tool.toolCallId)}
+                    />
+                  ) : item.kind === 'thought-group' ? (
+                    <ThoughtGroup messages={item.messages} isLiveTail={false} />
                   ) : (
                     <ChatMessage
-                      message={it.message}
-                      showHeader={!isGroupedReply(items, i)}
-                      isLast={i === items.length - 1}
-                      isTurnTail={turnMeta.tail.has(it.message.id)}
-                      turnText={turnMeta.text.get(it.message.id)}
-                      actionsPinned={i === lastMsgIndex}
-                      animateEnter={shouldAnimateEnter(it.message.id)}
+                      message={item.message}
+                      showHeader
+                      isLast={index === groupedItems.length - 1}
+                      isTurnTail={item.isTurnTail}
+                      turnText={item.turnText}
+                      actionsPinned={index === lastMsgIndex}
+                      animateEnter={shouldAnimateEnter(item.message.id)}
                       onEdit={onEditMessage}
                       onRetry={onRetry}
                     />
                   )}
                 </MessageScrollerItem>
               ))}
-              <AnimatePresence initial={false}>
-                {showRunningIndicator && <TurnRunningIndicator key="running" />}
-              </AnimatePresence>
             </MessageScrollerContent>
           </MessageScrollerViewport>
           <MessageScrollerButton />
         </MessageScroller>
       </MessageScrollerProvider>
     </div>
-  )
-}
-
-/** Persistent turn-running cue — gradient matrix spin (no visible text label). */
-function TurnRunningIndicator(): React.JSX.Element {
-  const reduced = useReducedMotion() ?? false
-  return (
-    <motion.div
-      className="min-w-0 shrink-0 px-1 py-2"
-      initial={reduced ? { opacity: 0 } : { opacity: 0, y: 6 }}
-      animate={reduced ? { opacity: 1 } : { opacity: 1, y: 0 }}
-      exit={reduced ? { opacity: 0 } : { opacity: 0, y: -4 }}
-      transition={{ duration: 0.18, ease: 'easeOut' }}
-    >
-      <MonochromeSpinner pattern="diagonal" label="Agent is working" />
-    </motion.div>
   )
 }

--- a/src/renderer/components/chat/ToolCallCard.test.tsx
+++ b/src/renderer/components/chat/ToolCallCard.test.tsx
@@ -29,6 +29,11 @@ describe('ToolCallCard', () => {
     expect(card).toHaveClass('tool-call-card-running')
     expect(card).toHaveAttribute('aria-busy', 'true')
     expect(container.querySelector('.animate-spin')).not.toBeInTheDocument()
+    expect(card).not.toHaveClass(
+      'rounded-lg',
+      'bg-card/30',
+      'shadow-[0_1px_2px_hsl(var(--foreground)/0.04)]'
+    )
 
     rerender(<ToolCallCard toolCall={toolCall('pending')} />)
     expect(container.firstElementChild).not.toHaveClass('tool-call-card-running')

--- a/src/renderer/components/chat/ToolCallCard.test.tsx
+++ b/src/renderer/components/chat/ToolCallCard.test.tsx
@@ -29,11 +29,13 @@ describe('ToolCallCard', () => {
     expect(card).toHaveClass('tool-call-card-running')
     expect(card).toHaveAttribute('aria-busy', 'true')
     expect(container.querySelector('.animate-spin')).not.toBeInTheDocument()
-    expect(card).not.toHaveClass(
+    for (const cls of [
       'rounded-lg',
       'bg-card/30',
       'shadow-[0_1px_2px_hsl(var(--foreground)/0.04)]'
-    )
+    ]) {
+      expect(card).not.toHaveClass(cls)
+    }
 
     rerender(<ToolCallCard toolCall={toolCall('pending')} />)
     expect(container.firstElementChild).not.toHaveClass('tool-call-card-running')

--- a/src/renderer/components/chat/ToolCallCard.tsx
+++ b/src/renderer/components/chat/ToolCallCard.tsx
@@ -226,7 +226,7 @@ function ToolCallCardComponent({
       aria-busy={inProgress || undefined}
       data-status={status}
       className={cn(
-        'group/tool relative my-1.5 w-full overflow-hidden rounded-lg bg-card/30 shadow-[0_1px_2px_hsl(var(--foreground)/0.04)] ring-1 ring-border/50',
+        'group/tool relative my-0.5 w-full overflow-hidden',
         inProgress && 'tool-call-card-running'
       )}
       initial={animateEnter ? enter.initial : false}
@@ -240,16 +240,16 @@ function ToolCallCardComponent({
             onClick={() => setOpen((v) => !v)}
             aria-expanded={open}
             data-press-feedback="off"
-            className="flex w-full items-center gap-2 px-3 py-2 text-left text-xs transition-colors hover:bg-card/60"
+            className="flex min-h-7 w-full items-center gap-2 px-1 py-1 text-left text-xs outline-none transition-colors hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
           >
             {row}
           </button>
         ) : (
-          <div className="flex items-center gap-2 px-3 py-2 text-xs">{row}</div>
+          <div className="flex min-h-7 items-center gap-2 px-1 py-1 text-xs">{row}</div>
         )}
         {hasDetail && (
           <CollapseExpandMotion open={open}>
-            <div className="flex flex-col gap-1.5 border-t border-border/50 bg-background/30 px-2.5 pb-2.5 pt-2">
+            <div className="ml-4 flex flex-col gap-1.5 border-l border-border/50 px-2 pb-2 pt-1.5">
               {hasContent
                 ? content.map((item, i) => renderContentItem(item, i))
                 : resultText && <ResultBlock text={resultText} />}

--- a/src/renderer/components/chat/ToolCallCard.tsx
+++ b/src/renderer/components/chat/ToolCallCard.tsx
@@ -240,7 +240,7 @@ function ToolCallCardComponent({
             onClick={() => setOpen((v) => !v)}
             aria-expanded={open}
             data-press-feedback="off"
-            className="flex min-h-7 w-full items-center gap-2 px-1 py-1 text-left text-xs outline-none transition-colors hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+            className="flex min-h-7 w-full items-center gap-2 px-1 py-1 text-left text-xs outline-none transition-colors hover:text-foreground focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring"
           >
             {row}
           </button>

--- a/src/renderer/components/chat/TurnActivity.tsx
+++ b/src/renderer/components/chat/TurnActivity.tsx
@@ -1,0 +1,114 @@
+import { motion, useReducedMotion } from 'framer-motion'
+import { ChevronRight } from 'lucide-react'
+import { useEffect, useRef, useState } from 'react'
+import { CollapseExpandMotion } from '@/components/ui/collapse-expand-motion'
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible'
+import { ShimmerText } from '@/components/ui/shimmer-text'
+import { cn } from '@/lib/utils'
+import { ChatMessage } from './ChatMessage'
+import { CHAT_SPRING } from './chat-motion'
+import type { TimelineItem } from './chat-timeline'
+import { ThoughtGroup } from './ThoughtGroup'
+import { ToolCallCard } from './ToolCallCard'
+
+interface TurnActivityProps {
+  items: TimelineItem[]
+  active: boolean
+  durationMs: number | null
+  attentionRequired: boolean
+  hasFinalResponse: boolean
+  shouldAnimateEnter: (id: string) => boolean
+}
+
+/** Whole-second duration without implying precision the available timestamps do not have. */
+function formatTurnDuration(durationMs: number | null): string | null {
+  if (durationMs === null) return null
+  const seconds = Math.max(1, Math.round(durationMs / 1000))
+  return `${seconds}s`
+}
+
+/** Borderless, turn-level disclosure for reasoning, tools, and intermediate narration. */
+export function TurnActivity({
+  items,
+  active,
+  durationMs,
+  attentionRequired,
+  hasFinalResponse,
+  shouldAnimateEnter
+}: TurnActivityProps): React.JSX.Element {
+  const reduced = useReducedMotion() ?? false
+  const [open, setOpen] = useState(active || attentionRequired || !hasFinalResponse)
+  const wasActive = useRef(active)
+
+  useEffect(() => {
+    if (active) {
+      setOpen(true)
+    } else if (wasActive.current && !attentionRequired && hasFinalResponse) {
+      setOpen(false)
+    }
+    wasActive.current = active
+  }, [active, attentionRequired, hasFinalResponse])
+
+  const duration = formatTurnDuration(durationMs)
+  const label = active ? 'Working…' : duration ? `Worked for ${duration}` : 'Worked'
+
+  return (
+    <Collapsible open={open} onOpenChange={setOpen} className="my-1 min-w-0">
+      <CollapsibleTrigger
+        data-press-feedback="off"
+        className={cn(
+          'flex min-h-8 w-full cursor-pointer items-center gap-1.5 text-left text-xs text-muted-foreground outline-none transition-colors hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background',
+          attentionRequired && !active && 'text-red-400'
+        )}
+      >
+        <motion.span
+          aria-hidden="true"
+          className="shrink-0"
+          animate={{ rotate: open ? 90 : 0 }}
+          transition={reduced ? { duration: 0 } : CHAT_SPRING}
+        >
+          <ChevronRight size={13} />
+        </motion.span>
+        <span className="font-medium">{active ? <ShimmerText text={label} /> : label}</span>
+        {attentionRequired && !active ? <span>· needs attention</span> : null}
+      </CollapsibleTrigger>
+      <CollapsibleContent forceMount>
+        <CollapseExpandMotion open={open}>
+          <div className="min-w-0 pb-1 pl-4">
+            {items.map((item, index) => {
+              if (item.kind === 'tool') {
+                return (
+                  <ToolCallCard
+                    key={item.key}
+                    toolCall={item.tool}
+                    animateEnter={shouldAnimateEnter(item.tool.toolCallId)}
+                  />
+                )
+              }
+              if (item.kind === 'thought-group') {
+                return (
+                  <ThoughtGroup
+                    key={item.key}
+                    messages={item.messages}
+                    isLiveTail={active && index === items.length - 1}
+                  />
+                )
+              }
+              return (
+                <ChatMessage
+                  key={item.key}
+                  message={item.message}
+                  showHeader={false}
+                  isLast={false}
+                  animateEnter={shouldAnimateEnter(item.message.id)}
+                />
+              )
+            })}
+          </div>
+        </CollapseExpandMotion>
+      </CollapsibleContent>
+    </Collapsible>
+  )
+}
+
+export { formatTurnDuration }

--- a/src/renderer/components/chat/chat-markdown-table.test.tsx
+++ b/src/renderer/components/chat/chat-markdown-table.test.tsx
@@ -1,0 +1,59 @@
+import { render, screen } from '@testing-library/react'
+import { createContext } from 'react'
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('streamdown', () => {
+  const StreamdownContext = createContext({ controls: false, isAnimating: false })
+  return {
+    StreamdownContext,
+    TableCopyDropdown: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+    TableDownloadDropdown: ({ children }: { children: React.ReactNode }) => <>{children}</>
+  }
+})
+
+import { ChatMarkdownTable } from './chat-markdown-table'
+
+describe('ChatMarkdownTable', () => {
+  it('rerenders growing streamed children even when the class name is unchanged', () => {
+    const { rerender } = render(
+      <ChatMarkdownTable className="same-table">
+        <tbody>
+          <tr>
+            <td>row one</td>
+          </tr>
+        </tbody>
+      </ChatMarkdownTable>
+    )
+
+    rerender(
+      <ChatMarkdownTable className="same-table">
+        <tbody>
+          <tr>
+            <td>row one</td>
+          </tr>
+          <tr>
+            <td>row two</td>
+          </tr>
+        </tbody>
+      </ChatMarkdownTable>
+    )
+
+    expect(screen.getByText('row two')).toBeInTheDocument()
+  })
+
+  it('keeps one lightweight boundary and a horizontal overflow region', () => {
+    const { container } = render(
+      <ChatMarkdownTable>
+        <tbody>
+          <tr>
+            <td>cell</td>
+          </tr>
+        </tbody>
+      </ChatMarkdownTable>
+    )
+
+    const wrapper = container.querySelector('[data-streamdown="table-wrapper"]')
+    expect(wrapper).toHaveClass('overflow-hidden', 'border')
+    expect(wrapper?.querySelector('.overflow-x-auto')).toBeInTheDocument()
+  })
+})

--- a/src/renderer/components/chat/chat-markdown-table.test.tsx
+++ b/src/renderer/components/chat/chat-markdown-table.test.tsx
@@ -56,4 +56,21 @@ describe('ChatMarkdownTable', () => {
     expect(wrapper).toHaveClass('overflow-hidden', 'border')
     expect(wrapper?.querySelector('.overflow-x-auto')).toBeInTheDocument()
   })
+
+  it('exposes a keyboard-focusable scroll region for wide tables', () => {
+    const { container } = render(
+      <ChatMarkdownTable>
+        <tbody>
+          <tr>
+            <td>cell</td>
+          </tr>
+        </tbody>
+      </ChatMarkdownTable>
+    )
+
+    const scrollRegion = container.querySelector('.overflow-x-auto')
+    expect(scrollRegion?.tagName).toBe('SECTION')
+    expect(scrollRegion).toHaveAttribute('tabindex', '0')
+    expect(scrollRegion).toHaveAttribute('aria-label', 'Markdown table')
+  })
 })

--- a/src/renderer/components/chat/chat-markdown-table.tsx
+++ b/src/renderer/components/chat/chat-markdown-table.tsx
@@ -135,11 +135,14 @@ function ChatMarkdownTableComponent({
 
   return (
     <div
-      className="my-4 flex flex-col gap-2 rounded-xl border border-border/50 bg-card/30 p-2 shadow-[0_1px_2px_hsl(var(--foreground)/0.04)]"
+      className="my-2 min-w-0 overflow-hidden rounded-md border border-border/50"
       data-streamdown="table-wrapper"
     >
       {toolbar ? (
-        <div className="flex justify-end" data-streamdown="table-toolbar">
+        <div
+          className="flex justify-end border-b border-border/40 px-1 py-0.5"
+          data-streamdown="table-toolbar"
+        >
           <IconActionGroup className="gap-0.5 px-1 py-0.5">
             {showCopy ? (
               <TableCopyDropdown>
@@ -163,7 +166,7 @@ function ChatMarkdownTableComponent({
           </IconActionGroup>
         </div>
       ) : null}
-      <div className="overflow-x-auto rounded-lg border border-border/50 bg-background">
+      <div className="max-w-full overflow-x-auto bg-background">
         <table
           className={cn('w-full divide-y divide-border text-sm', className)}
           data-streamdown="table"
@@ -176,7 +179,4 @@ function ChatMarkdownTableComponent({
   )
 }
 
-export const ChatMarkdownTable = memo(
-  ChatMarkdownTableComponent,
-  (prev, next) => prev.className === next.className
-)
+export const ChatMarkdownTable = memo(ChatMarkdownTableComponent)

--- a/src/renderer/components/chat/chat-markdown-table.tsx
+++ b/src/renderer/components/chat/chat-markdown-table.tsx
@@ -166,7 +166,12 @@ function ChatMarkdownTableComponent({
           </IconActionGroup>
         </div>
       ) : null}
-      <div className="max-w-full overflow-x-auto bg-background">
+      <section
+        className="max-w-full overflow-x-auto bg-background"
+        aria-label="Markdown table"
+        // biome-ignore lint/a11y/noNoninteractiveTabindex: scrollable table region is intentionally focusable so keyboard users can scroll wide tables (WAI-ARIA scrollable-region pattern)
+        tabIndex={0}
+      >
         <table
           className={cn('w-full divide-y divide-border text-sm', className)}
           data-streamdown="table"
@@ -174,7 +179,7 @@ function ChatMarkdownTableComponent({
         >
           {children}
         </table>
-      </div>
+      </section>
     </div>
   )
 }

--- a/src/renderer/components/chat/chat-timeline.test.ts
+++ b/src/renderer/components/chat/chat-timeline.test.ts
@@ -1,14 +1,35 @@
 import { describe, expect, it } from 'vitest'
-import type { ToolCall } from '@/lib/acp-api'
+import type { ContentBlock, ToolCall } from '@/lib/acp-api'
 import type { ChatMessage } from '@/stores/acp-store'
-import { buildTimeline, consolidateThoughtGroups } from './chat-timeline'
+import { buildTimeline, consolidateThoughtGroups, groupTurnActivity } from './chat-timeline'
 
-function msg(id: string, role: ChatMessage['role'], timestamp: number, seq?: number): ChatMessage {
-  return { id, role, blocks: [{ type: 'text', text: id }], streaming: false, timestamp, seq }
+function msg(
+  id: string,
+  role: ChatMessage['role'],
+  timestamp: number,
+  seq?: number,
+  text = id
+): ChatMessage {
+  return { id, role, blocks: [{ type: 'text', text }], streaming: false, timestamp, seq }
 }
 
-function tool(id: string, timestamp: number, seq?: number): ToolCall {
-  return { toolCallId: id, title: id, status: 'completed', timestamp, seq }
+function agentBlocks(
+  id: string,
+  timestamp: number,
+  seq: number,
+  blocks: ContentBlock[],
+  streaming = false
+): ChatMessage {
+  return { id, role: 'agent', blocks, streaming, timestamp, seq }
+}
+
+function tool(
+  id: string,
+  timestamp: number,
+  seq?: number,
+  status: ToolCall['status'] = 'completed'
+): ToolCall {
+  return { toolCallId: id, title: id, status, timestamp, seq }
 }
 
 function timelineItemId(i: ReturnType<typeof buildTimeline>[number]): string {
@@ -19,7 +40,6 @@ function timelineItemId(i: ReturnType<typeof buildTimeline>[number]): string {
 
 describe('buildTimeline', () => {
   it('interleaves text and tool calls in arrival (seq) order', () => {
-    // Agent emits: text → tool → tool → text, all within one turn.
     const messages = [
       msg('user', 'user', 100, 1),
       msg('a1', 'agent', 110, 2),
@@ -54,7 +74,6 @@ describe('buildTimeline', () => {
   })
 
   it('sorts seqless history before seq-stamped items, by timestamp', () => {
-    // Legacy persisted messages have no seq; live tools do.
     const messages = [msg('h1', 'user', 10), msg('h2', 'agent', 20)]
     const tools = [tool('t1', 5, 1)]
     const order = buildTimeline(messages, tools).map(timelineItemId)
@@ -83,8 +102,6 @@ describe('consolidateThoughtGroups', () => {
     expect(group.kind).toBe('thought-group')
     if (group.kind === 'thought-group') {
       expect(group.messages.map((m) => m.id)).toEqual(['t1', 't2'])
-      // Stable key: the first message id of the run (not the joined ids, which
-      // would change as new chunks arrive and remount the ThoughtGroup).
       expect(group.key).toBe('t1')
     }
   })
@@ -101,5 +118,153 @@ describe('consolidateThoughtGroups', () => {
   it('passes non-thought items through unchanged', () => {
     const items = buildTimeline([msg('user', 'user', 100, 1), msg('a1', 'agent', 110, 2)], [])
     expect(consolidateThoughtGroups(items)).toEqual(items)
+  })
+})
+
+describe('groupTurnActivity', () => {
+  it('groups each user turn and leaves the final substantive reply outside activity', () => {
+    const items = consolidateThoughtGroups(
+      buildTimeline(
+        [
+          msg('u1', 'user', 1_000, 1),
+          msg('thought', 'thought', 1_200, 2),
+          msg('narration', 'agent', 1_500, 3, 'Checking files'),
+          msg('final', 'agent', 4_200, 5, 'Final answer'),
+          msg('u2', 'user', 5_000, 6),
+          msg('final-2', 'agent', 6_000, 7, 'Second answer')
+        ],
+        [tool('read', 2_000, 4)]
+      )
+    )
+
+    const grouped = groupTurnActivity(items, false)
+    expect(grouped.map((item) => item.kind)).toEqual([
+      'message',
+      'activity',
+      'message',
+      'message',
+      'message'
+    ])
+    const activity = grouped[1]
+    expect(activity.kind).toBe('activity')
+    if (activity.kind === 'activity') {
+      expect(activity.items.map(timelineItemId)).toEqual(['thought', 'narration', 'read'])
+      expect(activity.durationMs).toBe(3_200)
+    }
+    const final = grouped[2]
+    expect(final.kind).toBe('message')
+    if (final.kind === 'message') {
+      expect(final.message.id).toBe('final')
+      expect(final.turnText).toBe('Checking files\n\nFinal answer')
+    }
+  })
+
+  it('moves narration into activity when a later tool means it is not final', () => {
+    const items = buildTimeline(
+      [msg('user', 'user', 100, 1), msg('narration', 'agent', 110, 2, 'Trying this')],
+      [tool('failed', 120, 3, 'failed')]
+    )
+    const grouped = groupTurnActivity(items, false)
+    expect(grouped.map((item) => item.kind)).toEqual(['message', 'activity'])
+    const activity = grouped[1]
+    expect(activity.kind).toBe('activity')
+    if (activity.kind === 'activity') {
+      expect(activity.attentionRequired).toBe(true)
+      expect(activity.hasFinalResponse).toBe(false)
+      expect(activity.items.map(timelineItemId)).toEqual(['narration', 'failed'])
+    }
+  })
+
+  it('keeps every media-bearing reply visible when later text and an empty tail arrive', () => {
+    const items = buildTimeline(
+      [
+        msg('user', 'user', 100, 1),
+        agentBlocks('attachment-only', 110, 2, [
+          { type: 'resource_link', uri: 'file:///tmp/report.pdf', name: 'report.pdf' }
+        ]),
+        msg('narration', 'agent', 120, 3, 'Preparing the summary'),
+        agentBlocks('image-and-caption', 130, 4, [
+          { type: 'image', data: 'base64-image', mimeType: 'image/png' },
+          { type: 'text', text: 'Chart preview' }
+        ]),
+        msg('final', 'agent', 150, 6, 'Final answer'),
+        msg('empty-tail', 'agent', 160, 7, '   ')
+      ],
+      [tool('read', 140, 5)]
+    )
+
+    const grouped = groupTurnActivity(items, false)
+    expect(grouped.map((item) => item.kind)).toEqual([
+      'message',
+      'activity',
+      'message',
+      'message',
+      'message'
+    ])
+    const activity = grouped[1]
+    expect(activity.kind).toBe('activity')
+    if (activity.kind === 'activity') {
+      expect(activity.items.map(timelineItemId)).toEqual(['narration', 'read'])
+      expect(activity.hasFinalResponse).toBe(true)
+    }
+    expect(
+      grouped
+        .filter((item) => item.kind === 'message' && item.message.role === 'agent')
+        .map((item) => (item.kind === 'message' ? item.message.id : ''))
+    ).toEqual(['attachment-only', 'image-and-caption', 'final'])
+    expect(grouped.some((item) => item.key === 'empty-tail')).toBe(false)
+  })
+
+  it('keeps the last substantive text visible when a media-only response follows it', () => {
+    const items = buildTimeline(
+      [
+        msg('user', 'user', 100, 1),
+        msg('final-text', 'agent', 120, 2, 'Final answer'),
+        agentBlocks('attachment-tail', 130, 3, [
+          { type: 'resource_link', uri: 'file:///tmp/report.pdf', name: 'report.pdf' }
+        ])
+      ],
+      []
+    )
+
+    const grouped = groupTurnActivity(items, false)
+    expect(
+      grouped
+        .filter((item) => item.kind === 'message' && item.message.role === 'agent')
+        .map((item) => (item.kind === 'message' ? item.message.id : ''))
+    ).toEqual(['final-text', 'attachment-tail'])
+  })
+
+  it('keeps a live response at a stable key when later activity arrives', () => {
+    const liveResponse = msg('live-response', 'agent', 120, 2, 'Readable live answer')
+    liveResponse.streaming = true
+    const beforeTool = groupTurnActivity(
+      buildTimeline([msg('user', 'user', 100, 1), liveResponse], []),
+      true
+    )
+    const afterTool = groupTurnActivity(
+      buildTimeline([msg('user', 'user', 100, 1), liveResponse], [tool('read', 130, 3)]),
+      true
+    )
+
+    expect(beforeTool.map((item) => item.key)).toEqual(['user', 'activity:user', 'live-response'])
+    expect(afterTool.map((item) => item.key)).toEqual(['user', 'activity:user', 'live-response'])
+    const activity = afterTool[1]
+    expect(activity.kind).toBe('activity')
+    if (activity.kind === 'activity') {
+      expect(activity.items.map(timelineItemId)).toEqual(['read'])
+    }
+  })
+
+  it('keeps an active empty turn represented and omits duration without timestamps', () => {
+    const source = buildTimeline([msg('user', 'user', 0, 1)], [])
+    const grouped = groupTurnActivity(source, true)
+    expect(grouped.map((item) => item.kind)).toEqual(['message', 'activity'])
+    const activity = grouped[1]
+    expect(activity.kind).toBe('activity')
+    if (activity.kind === 'activity') {
+      expect(activity.active).toBe(true)
+      expect(activity.durationMs).toBeNull()
+    }
   })
 })

--- a/src/renderer/components/chat/chat-timeline.test.ts
+++ b/src/renderer/components/chat/chat-timeline.test.ts
@@ -233,6 +233,23 @@ describe('groupTurnActivity', () => {
         .filter((item) => item.kind === 'message' && item.message.role === 'agent')
         .map((item) => (item.kind === 'message' ? item.message.id : ''))
     ).toEqual(['final-text', 'attachment-tail'])
+
+    const finalTextItem = grouped.find(
+      (item) => item.kind === 'message' && item.message.id === 'final-text'
+    )
+    expect(finalTextItem?.kind).toBe('message')
+    if (finalTextItem?.kind === 'message') {
+      expect(finalTextItem.isTurnTail).toBe(true)
+      expect(finalTextItem.turnText).toBe('Final answer')
+    }
+    const attachmentItem = grouped.find(
+      (item) => item.kind === 'message' && item.message.id === 'attachment-tail'
+    )
+    expect(attachmentItem?.kind).toBe('message')
+    if (attachmentItem?.kind === 'message') {
+      expect(attachmentItem.isTurnTail).toBe(false)
+      expect(attachmentItem.turnText).toBeUndefined()
+    }
   })
 
   it('keeps a live response at a stable key when later activity arrives', () => {

--- a/src/renderer/components/chat/chat-timeline.ts
+++ b/src/renderer/components/chat/chat-timeline.ts
@@ -2,9 +2,29 @@ import type { ToolCall } from '@/lib/acp-api'
 import type { ChatMessage } from '@/stores/acp-store'
 
 export type TimelineItem =
-  | { kind: 'message'; key: string; message: ChatMessage }
+  | {
+      kind: 'message'
+      key: string
+      message: ChatMessage
+      /** True when this visible reply ends its turn. */
+      isTurnTail?: boolean
+      /** All agent narration in the turn, used by the turn-level copy action. */
+      turnText?: string
+    }
   | { kind: 'tool'; key: string; tool: ToolCall }
   | { kind: 'thought-group'; key: string; messages: ChatMessage[] }
+
+export interface TurnActivityItem {
+  kind: 'activity'
+  key: string
+  items: TimelineItem[]
+  active: boolean
+  durationMs: number | null
+  attentionRequired: boolean
+  hasFinalResponse: boolean
+}
+
+export type TurnTimelineItem = TimelineItem | TurnActivityItem
 
 interface Stamped {
   item: TimelineItem
@@ -113,12 +133,178 @@ function agentText(message: ChatMessage): string {
     .join('')
 }
 
+function hasSubstantiveText(message: ChatMessage): boolean {
+  return message.blocks.some(
+    (block) => block.type === 'text' && (block.text ?? '').trim().length > 0
+  )
+}
+
+function hasMediaContent(message: ChatMessage): boolean {
+  return message.blocks.some((block) => block.type !== 'text')
+}
+
+function itemTimestamp(item: TimelineItem | undefined): number | null {
+  if (!item) return null
+  if (item.kind === 'tool') {
+    return typeof item.tool.timestamp === 'number' && item.tool.timestamp > 0
+      ? item.tool.timestamp
+      : null
+  }
+  if (item.kind === 'thought-group') {
+    const timestamps = item.messages.map((message) => message.timestamp).filter((ts) => ts > 0)
+    return timestamps.length > 0 ? Math.max(...timestamps) : null
+  }
+  if (item.kind === 'message') {
+    return item.message.timestamp > 0 ? item.message.timestamp : null
+  }
+  return null
+}
+
+function activityNeedsAttention(items: TimelineItem[]): boolean {
+  return items.some(
+    (item) =>
+      item.kind === 'tool' &&
+      (item.tool.status === 'failed' ||
+        item.tool.status === 'pending' ||
+        item.tool.status === 'in_progress')
+  )
+}
+
 /**
- * Group consecutive agent replies into turns. A turn is the run of agent
- * messages following a user message; intervening tool calls and thoughts don't
- * break it. Only the last agent reply of each turn is marked as the `tail`, and
- * carries the concatenated text of every agent reply in that turn — so a single
- * turn-level Copy yields the whole response, not one bubble.
+ * Partition user-to-user turns into one activity disclosure plus visible
+ * assistant response content. Media-bearing agent messages always remain
+ * outside completed activity. While a turn is live, substantive agent messages
+ * also stay outside so later tools update the stable activity row instead of
+ * moving/remounting the readable response; completion performs the one final
+ * partition of text-only narration.
+ */
+export function groupTurnActivity(items: TimelineItem[], activeTurn: boolean): TurnTimelineItem[] {
+  const out: TurnTimelineItem[] = []
+  let user: TimelineItem | null = null
+  let turn: TimelineItem[] = []
+  let turnIndex = 0
+
+  const flush = (active: boolean): void => {
+    if (!user && turn.length === 0 && !active) return
+
+    let finalTextIndex = -1
+    if (!active) {
+      for (let i = turn.length - 1; i >= 0; i--) {
+        const item = turn[i]!
+        if (item.kind !== 'message' || item.message.role !== 'agent') break
+        if (hasSubstantiveText(item.message)) {
+          finalTextIndex = i
+          break
+        }
+        // Empty text-only tails are ignored. Attachment-only replies remain
+        // visible independently and do not disqualify the preceding final text.
+        if (hasMediaContent(item.message)) continue
+      }
+    }
+
+    const visibleResponseIndices = new Set<number>()
+    turn.forEach((item, index) => {
+      if (item.kind !== 'message' || item.message.role !== 'agent') return
+      if (hasMediaContent(item.message)) visibleResponseIndices.add(index)
+      if (active && hasSubstantiveText(item.message)) visibleResponseIndices.add(index)
+    })
+    if (finalTextIndex >= 0) visibleResponseIndices.add(finalTextIndex)
+
+    if (active && visibleResponseIndices.size === 0) {
+      let emptyStreamingIndex = -1
+      for (let index = turn.length - 1; index >= 0; index--) {
+        const item = turn[index]!
+        if (item.kind === 'message' && item.message.role === 'agent' && item.message.streaming) {
+          emptyStreamingIndex = index
+          break
+        }
+      }
+      if (emptyStreamingIndex >= 0) visibleResponseIndices.add(emptyStreamingIndex)
+    }
+
+    const visibleResponses = turn.filter(
+      (item, index): item is Extract<TimelineItem, { kind: 'message' }> =>
+        visibleResponseIndices.has(index) && item.kind === 'message'
+    )
+    const activityItems = turn.filter((item, index) => {
+      if (visibleResponseIndices.has(index)) return false
+      return !(
+        item.kind === 'message' &&
+        item.message.role === 'agent' &&
+        !hasSubstantiveText(item.message) &&
+        !hasMediaContent(item.message)
+      )
+    })
+    const allAgentText = turn
+      .filter((item) => item.kind === 'message' && item.message.role === 'agent')
+      .map((item) => (item.kind === 'message' ? agentText(item.message) : ''))
+      .filter((text) => text.length > 0)
+      .join('\n\n')
+
+    if (user) out.push(user)
+
+    if (activityItems.length > 0 || active) {
+      const startedAt =
+        user?.kind === 'message' && user.message.timestamp > 0 ? user.message.timestamp : null
+      const endTimestamps = turn
+        .map((turnItem) => itemTimestamp(turnItem))
+        .filter((timestamp): timestamp is number => timestamp !== null)
+      const endedAt = endTimestamps.length > 0 ? Math.max(...endTimestamps) : null
+      const durationMs =
+        !active && startedAt !== null && endedAt !== null && endedAt > startedAt
+          ? endedAt - startedAt
+          : null
+
+      out.push({
+        kind: 'activity',
+        key: `activity:${user?.key ?? turn[0]?.key ?? turnIndex}`,
+        items: activityItems,
+        active,
+        durationMs,
+        attentionRequired: activityNeedsAttention(activityItems),
+        hasFinalResponse: visibleResponses.length > 0
+      })
+    }
+
+    visibleResponses.forEach((response, index) => {
+      const isTurnTail = index === visibleResponses.length - 1
+      out.push({
+        ...response,
+        isTurnTail,
+        turnText: isTurnTail ? allAgentText : undefined
+      })
+    })
+
+    user = null
+    turn = []
+    turnIndex += 1
+  }
+
+  const lastUserIndex = items.reduce(
+    (last, item, index) => (item.kind === 'message' && item.message.role === 'user' ? index : last),
+    -1
+  )
+
+  for (let i = 0; i < items.length; i++) {
+    const item = items[i]!
+    if (item.kind === 'message' && item.message.role === 'user') {
+      if (user || turn.length > 0) flush(false)
+      user = item
+    } else {
+      turn.push(item)
+    }
+
+    if (i === items.length - 1) flush(activeTurn && lastUserIndex <= i)
+  }
+
+  if (items.length === 0 && activeTurn) flush(true)
+
+  return out
+}
+
+/**
+ * Group consecutive agent replies into turns. Retained for callers that only
+ * need action metadata without the activity presentation grouping.
  */
 export function agentTurnMeta(items: TimelineItem[]): AgentTurnMeta {
   const tail = new Set<string>()
@@ -146,7 +332,6 @@ export function agentTurnMeta(items: TimelineItem[]): AgentTurnMeta {
       lastAgentId = it.message.id
       turnTexts.push(agentText(it.message))
     }
-    // thoughts: ignore, don't break the turn
   }
   flush()
 

--- a/src/renderer/components/chat/chat-timeline.ts
+++ b/src/renderer/components/chat/chat-timeline.ts
@@ -196,9 +196,8 @@ export function groupTurnActivity(items: TimelineItem[], activeTurn: boolean): T
           finalTextIndex = i
           break
         }
-        // Empty text-only tails are ignored. Attachment-only replies remain
-        // visible independently and do not disqualify the preceding final text.
-        if (hasMediaContent(item.message)) continue
+        // Empty text-only tails and attachment-only replies are skipped: they
+        // stay visible independently and don't disqualify the preceding final text.
       }
     }
 
@@ -266,12 +265,23 @@ export function groupTurnActivity(items: TimelineItem[], activeTurn: boolean): T
       })
     }
 
+    // The turn tail carries the turn-level copy action. Prefer the last visible
+    // response with substantive text so attachment-only positional tails don't
+    // receive copy text; fall back to the final positional response when none of
+    // the visible responses contain text.
+    let turnTailIndex = visibleResponses.length - 1
+    for (let i = visibleResponses.length - 1; i >= 0; i--) {
+      if (hasSubstantiveText(visibleResponses[i]!.message)) {
+        turnTailIndex = i
+        break
+      }
+    }
     visibleResponses.forEach((response, index) => {
-      const isTurnTail = index === visibleResponses.length - 1
+      const isTurnTail = index === turnTailIndex
       out.push({
         ...response,
         isTurnTail,
-        turnText: isTurnTail ? allAgentText : undefined
+        turnText: isTurnTail && allAgentText.length > 0 ? allAgentText : undefined
       })
     })
 
@@ -279,11 +289,6 @@ export function groupTurnActivity(items: TimelineItem[], activeTurn: boolean): T
     turn = []
     turnIndex += 1
   }
-
-  const lastUserIndex = items.reduce(
-    (last, item, index) => (item.kind === 'message' && item.message.role === 'user' ? index : last),
-    -1
-  )
 
   for (let i = 0; i < items.length; i++) {
     const item = items[i]!
@@ -294,7 +299,7 @@ export function groupTurnActivity(items: TimelineItem[], activeTurn: boolean): T
       turn.push(item)
     }
 
-    if (i === items.length - 1) flush(activeTurn && lastUserIndex <= i)
+    if (i === items.length - 1) flush(activeTurn)
   }
 
   if (items.length === 0 && activeTurn) flush(true)

--- a/src/renderer/index.css
+++ b/src/renderer/index.css
@@ -703,8 +703,55 @@
     }
   }
 
+  .chat-streamdown {
+    min-width: 0;
+    overflow-wrap: anywhere;
+    text-wrap: pretty;
+  }
+  .chat-streamdown > :first-child {
+    margin-top: 0;
+  }
+  .chat-streamdown > :last-child {
+    margin-bottom: 0;
+  }
+  .chat-streamdown [data-streamdown^="heading-"] {
+    margin-block: 0.75em 0.3em;
+    font-size: 1em;
+    font-weight: 600;
+    line-height: 1.25;
+  }
+  .chat-streamdown [data-streamdown="heading-1"] {
+    font-size: 1.08em;
+  }
+  .chat-streamdown p,
+  .chat-streamdown [data-streamdown="ordered-list"],
+  .chat-streamdown [data-streamdown="unordered-list"],
+  .chat-streamdown [data-streamdown="blockquote"],
+  .chat-streamdown pre {
+    margin-block: 0 0.55em;
+  }
+  .chat-streamdown [data-streamdown="ordered-list"],
+  .chat-streamdown [data-streamdown="unordered-list"] {
+    padding-left: 1.25rem;
+  }
+  .chat-streamdown [data-streamdown="list-item"] {
+    padding-block: 0.08em;
+  }
+  .chat-streamdown [data-streamdown="blockquote"] {
+    border-left-width: 2px;
+    padding-left: 0.65rem;
+  }
+  .chat-streamdown [data-streamdown="horizontal-rule"] {
+    margin-block: 0.8rem;
+  }
+  .chat-streamdown :not(pre) > code {
+    border-radius: 0.25rem;
+    background: hsl(var(--muted) / 0.55);
+    padding: 0.08em 0.3em;
+    font-size: 0.88em;
+  }
   .chat-streamdown [data-streamdown="code-block-body"] {
-    line-height: 1.65;
+    line-height: 1.55;
   }
   .chat-streamdown [data-streamdown="code-block-body"] pre,
   .chat-streamdown [data-streamdown="code-block-body"] code {
@@ -741,13 +788,18 @@
     height: 0.875rem;
     flex-shrink: 0;
   }
+  .chat-streamdown [data-streamdown="table"] {
+    min-width: max-content;
+    font-size: 0.875rem;
+  }
   .chat-streamdown [data-streamdown="table"] th {
-    background: hsl(var(--muted) / 0.5);
+    background: hsl(var(--muted) / 0.35);
     font-weight: 600;
   }
   .chat-streamdown [data-streamdown="table"] th,
   .chat-streamdown [data-streamdown="table"] td {
-    padding: 0.35rem 0.6rem;
+    border-color: hsl(var(--border) / 0.45);
+    padding: 0.3rem 0.5rem;
     text-align: left;
   }
 }


### PR DESCRIPTION
## Summary

- Redesigns ACP chat process activity so reasoning, intermediate narration, and tool calls appear in one subtle `Working…` disclosure and collapse to `Worked for Xs` after completion.
- Keeps the final assistant response and all media/attachment responses visible, reducing process noise without losing response content.
- Simplifies conversational Markdown typography and fixes streamed GFM tables that could stop rerendering when their children changed.

## Related Issue

No related issue. This addresses a directly observed ACP chat UX problem: bordered tool cards and persistent reasoning/tool rows overwhelmed the final response, Markdown felt visually heavy, and some streamed tables did not update. Existing open and closed PRs were searched before submission; no duplicate PR was found.

## Type of Change

- [x] feat: new feature
- [x] fix: bug fix
- [ ] docs: documentation only
- [ ] style: formatting or non-functional styling changes
- [ ] refactor: internal cleanup with no behavior change
- [ ] perf: performance improvement
- [x] test: adds or updates tests
- [ ] build: build or dependency changes
- [ ] ci: CI/CD workflow changes
- [ ] chore: maintenance or tooling
- [ ] revert: reverts a previous change

## What Changed

- Added turn-aware timeline grouping that separates process activity from visible response content.
- Added an accessible `TurnActivity` disclosure that stays open while active and collapses successful completed work by default.
- Converted tool calls from bordered cards to compact, borderless rows while retaining expandable results, diffs, durations, and failure states.
- Preserved all media-bearing agent messages outside activity, including attachment-only tails after a textual final response.
- Prevented empty trailing agent messages from replacing the last substantive response.
- Selected the last substantive-text response as the turn tail for copy actions, so attachment-only positional tails do not receive copy text.
- Tightened Streamdown heading, paragraph, list, blockquote, inline-code, fenced-code, and table spacing.
- Removed the table memo comparator that ignored changed children and froze streamed row updates.
- Made wide tables keyboard-focusable scroll regions.
- Added regression coverage for grouping, active/completed behavior, keyboard reopening, failures, tool-only turns, attachments, live DOM stability, Markdown semantics, turn-tail copy assignment, and growing tables.

## How It Was Tested

- [x] `bun run ci` (Biome lint + format + imports, strict mode)
- [x] `bun run typecheck`
- [x] `bun run test`
- [ ] `cargo clippy --all-targets -- -D warnings` (in src-tauri)
- [ ] `cargo test` (in src-tauri)
- [x] Manual verification completed
- [ ] Not applicable

Frontend validation results:

- Full Vitest suite: 224 passed files, 2,488 passed tests; 1 file/43 tests skipped by the existing suite.
- Focused ACP chat suite: 34 files, 281 tests passed.
- TypeScript node/web/test configs passed.
- Biome CI checked 712 files with no errors.
- Tauri dev app launched successfully from the isolated worktree and displayed the desktop window.

Rust checks were attempted but the local drive ran out of space during compilation/linking (`os error 112`, `LNK1180`). No Rust files are changed by this PR; the mandatory Rust gates are left for CI's clean environment rather than reported as passing locally.

## Screenshots or Recordings

Manual Tauri verification was completed from the isolated worktree. No screenshot is attached yet; the reviewer can reproduce with `bun run tauri dev` and trigger a multi-tool ACP turn.

## CI & Review Gate

- [ ] All CI checks pass (PR Validation, Rust Checks, Build Verification, Security Scans)
- [ ] Code review comments from CodeRabbit / Claude have been addressed or resolved
- [ ] No unresolved review findings remain

## Checklist

- [x] My PR title follows the conventional commit format used by this repo
- [x] I linked the related issue or explained why none exists
- [x] I updated docs when needed
- [x] I added or updated tests when needed
- [x] I verified the change does not introduce unrelated modifications
- [x] I read AGENTS.md and followed the contributor guidelines
- [x] A human reviewed the complete diff before submission


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added collapsible activity sections for tool calls, reasoning, and in-progress work.
  * Activity sections show elapsed time and highlight items requiring attention.
  * Added keyboard-accessible horizontal scrolling for wide markdown tables.

* **Improvements**
  * Improved chat markdown readability for headings, lists, code, blockquotes, and tables.
  * Refined table layout, spacing, and overflow behavior.
  * Simplified tool call cards and expanded-detail presentation.
  * Preserved visible responses and attachments more reliably during ongoing activity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->