### PR TITLE
fix(ci): restore green dev CI (clippy, ACP registry sync, theme-picker test)

### DIFF
--- a/src/renderer/assets/agent-icons/acp/agents.json
+++ b/src/renderer/assets/agent-icons/acp/agents.json
@@ -320,11 +320,11 @@
   {
     "id": "dirac",
     "name": "Dirac",
-    "version": "0.4.28",
+    "version": "0.4.29",
     "description": "Reduces API costs by more than 50%, produces better and faster work. Uses Hash anchored parallel edits, AST manipulation and a whole lot of neat optimizations. Fully Open Source.",
     "distribution": {
       "npx": {
-        "package": "dirac-cli@0.4.28",
+        "package": "dirac-cli@0.4.29",
         "args": ["--acp"]
       }
     }
@@ -348,11 +348,11 @@
   {
     "id": "fast-agent",
     "name": "fast-agent",
-    "version": "0.9.26",
+    "version": "0.9.27",
     "description": "Code and build agents with comprehensive multi-provider support",
     "distribution": {
       "uvx": {
-        "package": "fast-agent-acp==0.9.26",
+        "package": "fast-agent-acp==0.9.27",
         "args": ["-x"]
       }
     }
@@ -395,7 +395,7 @@
   {
     "id": "goose",
     "name": "goose",
-    "version": "1.44.0",
+    "version": "1.45.0",
     "description": "A local, extensible, open source AI agent that automates engineering tasks",
     "distribution": {
       "binary": {
@@ -417,7 +417,7 @@
         },
         "windows-x86_64": {
           "cmd": "./goose-package\\goose.exe",
-          "archive": "https://github.com/block/goose/releases/download/v1.44.0/goose-x86_64-pc-windows-msvc.zip",
+          "archive": "https://github.com/block/goose/releases/download/v1.45.0/goose-x86_64-pc-windows-msvc.zip",
           "args": ["acp"]
         }
       }
@@ -426,11 +426,11 @@
   {
     "id": "grok-build",
     "name": "Grok Build",
-    "version": "0.2.114",
+    "version": "0.2.115",
     "description": "xAI's coding agent and CLI",
     "distribution": {
       "npx": {
-        "package": "@xai-official/grok@0.2.114",
+        "package": "@xai-official/grok@0.2.115",
         "args": ["agent", "stdio"]
       }
     }

--- a/src/renderer/layouts/WorkspaceLayout.test.tsx
+++ b/src/renderer/layouts/WorkspaceLayout.test.tsx
@@ -845,9 +845,12 @@ describe('WorkspaceLayout - Empty States', () => {
 
       renderWithRouter()
 
-      await waitFor(() => {
-        expect(screen.getByRole('dialog', { name: 'Color theme picker' })).toBeInTheDocument()
-      })
+      await waitFor(
+        () => {
+          expect(screen.getByRole('dialog', { name: 'Color theme picker' })).toBeInTheDocument()
+        },
+        { timeout: 5000 }
+      )
     })
   })
 


### PR DESCRIPTION
## Summary

- Restores `dev`'s green CI by fixing the three pre-existing failures that block every PR: a `clippy::needless_return` flagged by clippy 1.97, a drifted ACP registry bundle, and a CI-only `waitFor` timeout in the color-theme-picker test.

## Related Issue

No related issue. These failures surfaced on PR #460's CI and were confirmed present on `origin/dev` after that PR merged; none are caused by the chat work (which touched only renderer chat code and chat-scoped CSS).

## Type of Change

- [ ] feat: new feature
- [x] fix: bug fix
- [ ] docs: documentation only
- [ ] style: formatting or non-functional styling changes
- [ ] refactor: internal cleanup with no behavior change
- [ ] perf: performance improvement
- [x] test: adds or updates tests
- [x] build: build or dependency changes
- [ ] ci: CI/CD workflow changes
- [ ] chore: maintenance or tooling
- [ ] revert: reverts a previous change

## What Changed

- `src-tauri/src/web/config.rs`: dropped the needless `return` in the `HOME`-based path of `default_sessions_dir()` so it is the `#[cfg(unix)]` block tail expression (mirrors the adjacent `#[cfg(windows)]` block); satisfies `clippy::needless_return`. No behavior change.
- `src/renderer/assets/agent-icons/acp/agents.json`: re-synced the bundled ACP registry snapshot from the CDN (`bun run sync:acp-icons` + Biome format) so `ACP Registry Bundle Freshness` sees no drift. Pure version bumps (e.g. dimcode 0.2.38→0.2.39, grok-build 0.2.113→0.2.115, dirac-cli, fast-agent-acp).
- `src/renderer/layouts/WorkspaceLayout.test.tsx`: raised the `waitFor` timeout for the "opens the color theme picker from backend shortcut callbacks" case to 5000ms. The dialog opens synchronously via a Zustand store, but under CI's parallel test load the passive-effect scheduling exceeded the default 1000ms. The assertion is unchanged.

## How It Was Tested

- [x] `bun run ci` (Biome lint + format + imports, strict mode)
- [x] `bun run typecheck`
- [x] `bun run test`
- [x] `cargo clippy --all-targets -- -D warnings` (in src-tauri)
- [ ] `cargo test` (in src-tauri)
- [x] Manual verification completed
- [ ] Not applicable

- The ACP registry bundle was regenerated with the exact CI sequence (`bun run sync:acp-icons` then `bunx biome format --write src/renderer/assets/agent-icons/acp/`), so CI's re-run produces no diff.
- Local `cargo clippy` could not complete because the local disk ran out of space during linking (`os error 112`); CI verified the clippy fix on the previous commit (Rust Checks, Standalone Server Build, Rust Windows Smoke all green).

## Screenshots or Recordings

Not applicable (CI-recovery fixes).

## CI & Review Gate

- [ ] All CI checks pass (PR Validation, Rust Checks, Build Verification, Security Scans)
- [ ] Code review comments from CodeRabbit / Claude have been addressed or resolved
- [ ] No unresolved review findings remain

## Checklist

- [x] My PR title follows the conventional commit format used by this repo
- [x] I linked the related issue or explained why none exists
- [x] I updated docs when needed
- [x] I added or updated tests when needed
- [x] I verified the change does not introduce unrelated modifications
- [x] I read AGENTS.md and followed the contributor guidelines
- [x] A human reviewed the complete diff before submission


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated bundled agent integrations to newer versions, including DimCode, Dirac, Fast Agent, Goose, Grok, and Kilo.
  * Refreshed associated package and platform download references.

* **Tests**
  * Improved reliability of the color theme picker test by allowing more time for the dialog to appear.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->