### PR TITLE
feat(editor): redesign markdown preview readability

### DIFF
--- a/src/renderer/components/editor/FrontmatterProperties.test.tsx
+++ b/src/renderer/components/editor/FrontmatterProperties.test.tsx
@@ -28,6 +28,19 @@ describe('FrontmatterProperties', () => {
     expect(onChange).not.toHaveBeenCalled()
   })
 
+  it('commits an edited scalar on blur without losing its accessible label', () => {
+    const onChange = vi.fn()
+    render(<FrontmatterProperties data={{ title: 'Doc' }} onChange={onChange} />)
+
+    const titleInput = screen.getByLabelText('title')
+    fireEvent.focus(titleInput)
+    fireEvent.change(titleInput, { target: { value: 'Readable Doc' } })
+    fireEvent.blur(titleInput)
+
+    expect(onChange).toHaveBeenCalledWith({ title: 'Readable Doc' })
+    expect(screen.getByLabelText('title')).toBe(titleInput)
+  })
+
   it('removeKey calls onChange with the key removed', () => {
     const onChange = vi.fn()
     render(<FrontmatterProperties data={{ title: 'Doc', status: 'draft' }} onChange={onChange} />)
@@ -42,9 +55,21 @@ describe('FrontmatterProperties', () => {
     const onChange = vi.fn()
     render(<FrontmatterProperties data={{ context: ['alpha', 'beta'] }} onChange={onChange} />)
 
-    fireEvent.click(screen.getByRole('button', { name: 'Remove alpha' }))
+    expect(screen.getByRole('group', { name: 'context' })).toBeTruthy()
+    fireEvent.click(screen.getByRole('button', { name: 'Remove alpha from context' }))
 
     expect(onChange).toHaveBeenCalledTimes(1)
     expect(onChange).toHaveBeenCalledWith({ context: ['beta'] })
+  })
+
+  it('labels nested read-only values by their property key', () => {
+    render(
+      <FrontmatterProperties
+        data={{ metadata: { kind: 'nested', display: 'path: /very/long/value' } }}
+        onChange={vi.fn()}
+      />
+    )
+
+    expect(screen.getByRole('group', { name: 'metadata' })).toBeTruthy()
   })
 })

--- a/src/renderer/components/editor/FrontmatterProperties.tsx
+++ b/src/renderer/components/editor/FrontmatterProperties.tsx
@@ -136,151 +136,162 @@ export function FrontmatterProperties({
   )
 
   return (
-    // Match BlockNote `.bn-editor { padding-inline: 54px }` so Properties align with body text.
-    <div className="border-b border-border px-[54px] py-3">
-      <div className="mb-2 text-xs font-medium uppercase tracking-wide text-muted-foreground">
-        Properties
-      </div>
+    <section className="frontmatter-properties border-b border-border/70" aria-label="Properties">
+      <div className="frontmatter-properties-inner py-5">
+        <div className="label-section mb-2.5 text-muted-foreground">Properties</div>
 
-      <div className="flex flex-col gap-1.5">
-        {entries.map(([key, value]) => {
-          const Icon = iconForKey(key)
-          return (
-            <div key={key} className="group flex items-start gap-2 rounded-md py-1">
-              <Icon className="mt-2 size-3.5 shrink-0 text-muted-foreground" aria-hidden="true" />
-              <label
-                htmlFor={`${baseId}-${key}`}
-                className="mt-1.5 w-28 shrink-0 truncate text-xs text-muted-foreground"
-                title={key}
-              >
-                {key}
-              </label>
-              <div className="min-w-0 flex-1">
-                {isFrontmatterNested(value) ? (
-                  <div
-                    id={`${baseId}-${key}`}
-                    className="rounded-md border border-border/60 bg-muted/40 px-2 py-1.5 font-mono text-xs text-muted-foreground"
-                    title="Nested value (read-only)"
-                  >
-                    {value.display}
-                  </div>
-                ) : Array.isArray(value) ? (
-                  <div className="flex flex-wrap items-center gap-1.5 py-0.5">
-                    {value.map((item, index) => (
-                      <Badge
-                        key={`${key}-${item}-${index}`}
-                        variant="secondary"
-                        className="gap-1 pr-1 font-normal"
-                      >
-                        <List className="size-3 opacity-60" aria-hidden="true" />
-                        <span>{item}</span>
-                        <button
-                          type="button"
-                          className="rounded-full p-0.5 text-muted-foreground hover:bg-destructive/10 hover:text-destructive"
-                          aria-label={`Remove ${item}`}
-                          onClick={() => removeArrayItem(key, index)}
+        <div className="frontmatter-properties-grid flex flex-col gap-1">
+          {entries.map(([key, value]) => {
+            const Icon = iconForKey(key)
+            const fieldId = `${baseId}-${key}`
+            const labelId = `${fieldId}-label`
+            return (
+              <div key={key} className="group flex min-w-0 items-start gap-2 rounded-md py-0.5">
+                <Icon className="mt-2 size-3.5 shrink-0 text-muted-foreground" aria-hidden="true" />
+                <label
+                  id={labelId}
+                  htmlFor={isFrontmatterNested(value) || Array.isArray(value) ? undefined : fieldId}
+                  className="mt-1.5 w-24 shrink-0 truncate text-xs text-muted-foreground"
+                  title={key}
+                >
+                  {key}
+                </label>
+                <div className="min-w-0 flex-1">
+                  {isFrontmatterNested(value) ? (
+                    <div
+                      id={fieldId}
+                      role="group"
+                      aria-labelledby={labelId}
+                      className="min-w-0 max-w-full break-words rounded-md border border-border/60 bg-muted/40 px-2 py-1.5 font-mono text-xs text-muted-foreground [overflow-wrap:anywhere]"
+                      title="Nested value (read-only)"
+                    >
+                      {value.display}
+                    </div>
+                  ) : Array.isArray(value) ? (
+                    <div
+                      id={fieldId}
+                      role="group"
+                      aria-labelledby={labelId}
+                      className="flex min-w-0 max-w-full flex-wrap items-center gap-1.5 py-0.5"
+                    >
+                      {value.map((item, index) => (
+                        <Badge
+                          key={`${key}-${item}-${index}`}
+                          variant="secondary"
+                          className="min-w-0 max-w-full gap-1 pr-1 font-normal"
                         >
-                          <X className="size-3" />
-                        </button>
-                      </Badge>
-                    ))}
-                    {value.length === 0 && (
-                      <span className="text-xs text-muted-foreground">[]</span>
-                    )}
-                  </div>
-                ) : (
-                  <Input
-                    id={`${baseId}-${key}`}
-                    className="h-8 border-transparent bg-transparent px-2 shadow-none hover:border-input focus-visible:border-input"
-                    value={
-                      draftScalars[key] !== undefined
-                        ? draftScalars[key]
-                        : formatFrontmatterValue(value)
-                    }
-                    onFocus={() => {
-                      setDraftScalars((prev) => ({
-                        ...prev,
-                        [key]: formatFrontmatterValue(value)
-                      }))
-                    }}
-                    onChange={(event) => {
-                      const nextText = event.target.value
-                      setDraftScalars((prev) => ({ ...prev, [key]: nextText }))
-                    }}
-                    onBlur={() => commitScalar(key)}
-                    onKeyDown={(event) => {
-                      if (event.key === 'Enter') {
-                        event.currentTarget.blur()
+                          <List className="size-3 shrink-0 opacity-60" aria-hidden="true" />
+                          <span className="min-w-0 break-words [overflow-wrap:anywhere]">
+                            {item}
+                          </span>
+                          <button
+                            type="button"
+                            className="inline-flex size-6 shrink-0 items-center justify-center rounded-full text-muted-foreground outline-none hover:bg-destructive/10 hover:text-destructive focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background"
+                            aria-label={`Remove ${item} from ${key}`}
+                            onClick={() => removeArrayItem(key, index)}
+                          >
+                            <X className="size-3" />
+                          </button>
+                        </Badge>
+                      ))}
+                      {value.length === 0 && (
+                        <span className="text-xs text-muted-foreground">[]</span>
+                      )}
+                    </div>
+                  ) : (
+                    <Input
+                      id={fieldId}
+                      className="h-8 border-transparent bg-transparent px-2 shadow-none hover:border-input focus-visible:border-input"
+                      value={
+                        draftScalars[key] !== undefined
+                          ? draftScalars[key]
+                          : formatFrontmatterValue(value)
                       }
-                    }}
-                  />
-                )}
+                      onFocus={() => {
+                        setDraftScalars((prev) => ({
+                          ...prev,
+                          [key]: formatFrontmatterValue(value)
+                        }))
+                      }}
+                      onChange={(event) => {
+                        const nextText = event.target.value
+                        setDraftScalars((prev) => ({ ...prev, [key]: nextText }))
+                      }}
+                      onBlur={() => commitScalar(key)}
+                      onKeyDown={(event) => {
+                        if (event.key === 'Enter') {
+                          event.currentTarget.blur()
+                        }
+                      }}
+                    />
+                  )}
+                </div>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon-xs"
+                  className={cn(
+                    'mt-1 shrink-0 text-muted-foreground transition-opacity',
+                    // Touch / no-hover: always visible. Fine pointer: reveal on row hover/focus.
+                    'opacity-50 [@media(hover:hover)]:opacity-0 [@media(hover:hover)]:group-hover:opacity-100',
+                    'focus-visible:opacity-100'
+                  )}
+                  aria-label={`Remove ${key}`}
+                  onClick={() => removeKey(key)}
+                >
+                  <Trash2 className="size-3.5" />
+                </Button>
               </div>
-              <Button
-                type="button"
-                variant="ghost"
-                size="icon-xs"
-                className={cn(
-                  'mt-1 shrink-0 text-muted-foreground transition-opacity',
-                  // Touch / no-hover: always visible. Fine pointer: reveal on row hover/focus.
-                  'opacity-50 [@media(hover:hover)]:opacity-0 [@media(hover:hover)]:group-hover:opacity-100',
-                  'focus-visible:opacity-100'
-                )}
-                aria-label={`Remove ${key}`}
-                onClick={() => removeKey(key)}
-              >
-                <Trash2 className="size-3.5" />
+            )
+          })}
+        </div>
+
+        {adding ? (
+          <div className="mt-2 flex flex-col gap-1.5">
+            <div className="flex items-center gap-2">
+              <Input
+                className="h-8"
+                placeholder="Property key"
+                value={draftKey}
+                autoFocus
+                aria-invalid={draftError !== null}
+                onChange={(event) => {
+                  setDraftKey(event.target.value)
+                  setDraftError(null)
+                }}
+                onKeyDown={(event) => {
+                  if (event.key === 'Enter') {
+                    event.preventDefault()
+                    commitAdd()
+                  }
+                  if (event.key === 'Escape') {
+                    event.preventDefault()
+                    cancelAdd()
+                  }
+                }}
+              />
+              <Button type="button" size="xs" onClick={commitAdd}>
+                Add
+              </Button>
+              <Button type="button" size="xs" variant="ghost" onClick={cancelAdd}>
+                Cancel
               </Button>
             </div>
-          )
-        })}
-      </div>
-
-      {adding ? (
-        <div className="mt-2 flex flex-col gap-1.5">
-          <div className="flex items-center gap-2">
-            <Input
-              className="h-8"
-              placeholder="Property key"
-              value={draftKey}
-              autoFocus
-              aria-invalid={draftError !== null}
-              onChange={(event) => {
-                setDraftKey(event.target.value)
-                setDraftError(null)
-              }}
-              onKeyDown={(event) => {
-                if (event.key === 'Enter') {
-                  event.preventDefault()
-                  commitAdd()
-                }
-                if (event.key === 'Escape') {
-                  event.preventDefault()
-                  cancelAdd()
-                }
-              }}
-            />
-            <Button type="button" size="xs" onClick={commitAdd}>
-              Add
-            </Button>
-            <Button type="button" size="xs" variant="ghost" onClick={cancelAdd}>
-              Cancel
-            </Button>
+            {draftError && <p className="text-xs text-destructive">{draftError}</p>}
           </div>
-          {draftError && <p className="text-xs text-destructive">{draftError}</p>}
-        </div>
-      ) : (
-        <Button
-          type="button"
-          variant="ghost"
-          size="xs"
-          className="mt-2 text-muted-foreground"
-          onClick={() => setAdding(true)}
-        >
-          <Plus className="size-3.5" />
-          Add property
-        </Button>
-      )}
-    </div>
+        ) : (
+          <Button
+            type="button"
+            variant="ghost"
+            size="xs"
+            className="mt-2 text-muted-foreground"
+            onClick={() => setAdding(true)}
+          >
+            <Plus className="size-3.5" />
+            Add property
+          </Button>
+        )}
+      </div>
+    </section>
   )
 }

--- a/src/renderer/components/editor/FrontmatterProperties.tsx
+++ b/src/renderer/components/editor/FrontmatterProperties.tsx
@@ -252,6 +252,7 @@ export function FrontmatterProperties({
               <Input
                 className="h-8"
                 placeholder="Property key"
+                aria-label="Property key"
                 value={draftKey}
                 autoFocus
                 aria-invalid={draftError !== null}

--- a/src/renderer/components/editor/MarkdownEditor.frontmatter.test.tsx
+++ b/src/renderer/components/editor/MarkdownEditor.frontmatter.test.tsx
@@ -5,7 +5,7 @@ import { flushEditorContent } from '@/lib/editor-content-flush'
 import { MarkdownEditor } from './MarkdownEditor'
 
 vi.mock('@blocknote/react', () => ({
-  BlockNoteViewRaw: () => null
+  BlockNoteViewRaw: () => <div data-testid="blocknote-view" />
 }))
 
 vi.mock('@/hooks/use-blocknote', () => ({
@@ -66,6 +66,21 @@ describe('MarkdownEditor frontmatter strip/rejoin/flush', () => {
         scrollToBlock: vi.fn()
       }
     })
+  })
+
+  it('keeps Properties and BlockNote inside the scoped document shell', () => {
+    const { getByLabelText, getByTestId } = render(
+      <MarkdownEditor filePath="/docs/spec.md" content={FM_CONTENT} isVisible onChange={vi.fn()} />
+    )
+
+    const scrollRoot = getByTestId('blocknote-view').closest('.markdown-editor')
+    const documentShell = getByTestId('blocknote-view').closest('.markdown-editor-document')
+
+    expect(scrollRoot).toBeTruthy()
+    expect(documentShell).toBeTruthy()
+    expect(documentShell?.classList.contains('flex')).toBe(true)
+    expect(documentShell?.classList.contains('flex-col')).toBe(true)
+    expect(documentShell?.contains(getByLabelText('Properties'))).toBe(true)
   })
 
   it('passes body-only into useBlockNote and rejoins FM on body onChange', () => {

--- a/src/renderer/components/editor/MarkdownEditor.tsx
+++ b/src/renderer/components/editor/MarkdownEditor.tsx
@@ -283,22 +283,27 @@ export function MarkdownEditor({
       <div ref={layoutRef} className="h-full w-full">
         <ResizablePanelGroup ref={panelGroupRef} direction="horizontal">
           <ResizablePanel defaultSize={canRenderToc ? 100 - tocPanelDefaultSize : 100} minSize={60}>
-            <div ref={blockNoteScrollRootRef} className="flex h-full flex-col overflow-auto">
-              {hasFrontmatter && (
-                <FrontmatterProperties data={frontmatter} onChange={handleFrontmatterChange} />
-              )}
-              <div className="min-h-0 flex-1">
-                <BlockNoteViewRaw
-                  editor={editor}
-                  theme={isDark ? 'dark' : 'light'}
-                  formattingToolbar={false}
-                  linkToolbar={false}
-                  slashMenu={false}
-                  emojiPicker={false}
-                  sideMenu={false}
-                  filePanel={false}
-                  tableHandles={false}
-                />
+            <div
+              ref={blockNoteScrollRootRef}
+              className="markdown-editor flex h-full flex-col overflow-auto"
+            >
+              <div className="markdown-editor-document flex min-h-full w-full flex-col">
+                {hasFrontmatter && (
+                  <FrontmatterProperties data={frontmatter} onChange={handleFrontmatterChange} />
+                )}
+                <div className="min-h-0 flex-1">
+                  <BlockNoteViewRaw
+                    editor={editor}
+                    theme={isDark ? 'dark' : 'light'}
+                    formattingToolbar={false}
+                    linkToolbar={false}
+                    slashMenu={false}
+                    emojiPicker={false}
+                    sideMenu={false}
+                    filePanel={false}
+                    tableHandles={false}
+                  />
+                </div>
               </div>
             </div>
           </ResizablePanel>

--- a/src/renderer/index.css
+++ b/src/renderer/index.css
@@ -803,3 +803,252 @@
     text-align: left;
   }
 }
+
+/* BlockNote ships unlayered defaults, so these locally scoped overrides remain
+   unlayered as well. This prevents the markdown document theme from leaking to
+   chat or any future BlockNote surfaces. */
+.markdown-editor {
+  container-name: markdown-editor;
+  container-type: inline-size;
+  --markdown-document-width: 48rem;
+  --markdown-document-gutter: clamp(1.25rem, 5cqi, 3.5rem);
+}
+
+.markdown-editor-document {
+  min-width: 0;
+  padding-bottom: 5rem;
+}
+
+.markdown-editor .frontmatter-properties-inner,
+.markdown-editor .bn-editor {
+  width: min(100%, calc(var(--markdown-document-width) + 2 * var(--markdown-document-gutter)));
+  margin-inline: auto;
+  padding-inline: var(--markdown-document-gutter);
+}
+
+.markdown-editor .frontmatter-properties-grid {
+  max-width: 40rem;
+}
+
+.markdown-editor .bn-container,
+.markdown-editor .bn-editor {
+  min-width: 0;
+  background: transparent;
+  color: hsl(var(--foreground));
+}
+
+.markdown-editor .bn-editor {
+  padding-top: 2.25rem;
+  padding-bottom: 1rem;
+  border-radius: 0;
+}
+
+.markdown-editor .bn-default-styles {
+  font-family: "Inter Variable", "Inter", system-ui, sans-serif;
+  font-size: 16px;
+  line-height: 1.72;
+}
+
+.markdown-editor .bn-block-outer {
+  line-height: inherit;
+}
+
+.markdown-editor .bn-block-content {
+  min-width: 0;
+  padding-block: 0.16rem;
+}
+
+.markdown-editor .bn-block-content[data-content-type="paragraph"] {
+  padding-block: 0.32rem;
+}
+
+.markdown-editor .bn-block-content[data-content-type="heading"],
+.markdown-editor .bn-block-outer[data-prev-type="heading"] > .bn-block > .bn-block-content {
+  line-height: 1.25;
+  font-weight: 650;
+  letter-spacing: -0.018em;
+  text-wrap: balance;
+}
+
+.markdown-editor .bn-block-content[data-content-type="heading"][data-level="1"],
+.markdown-editor
+  .bn-block-outer[data-prev-type="heading"][data-prev-level="1"]
+  > .bn-block
+  > .bn-block-content {
+  font-size: 2rem;
+}
+
+.markdown-editor .bn-block-content[data-content-type="heading"][data-level="2"],
+.markdown-editor
+  .bn-block-outer[data-prev-type="heading"][data-prev-level="2"]
+  > .bn-block
+  > .bn-block-content {
+  font-size: 1.5rem;
+}
+
+.markdown-editor .bn-block-content[data-content-type="heading"][data-level="3"],
+.markdown-editor
+  .bn-block-outer[data-prev-type="heading"][data-prev-level="3"]
+  > .bn-block
+  > .bn-block-content {
+  font-size: 1.2rem;
+}
+
+.markdown-editor .bn-block-content[data-content-type="heading"][data-level="4"],
+.markdown-editor .bn-block-content[data-content-type="heading"][data-level="5"],
+.markdown-editor .bn-block-content[data-content-type="heading"][data-level="6"],
+.markdown-editor
+  .bn-block-outer[data-prev-type="heading"]:is(
+    [data-prev-level="4"],
+    [data-prev-level="5"],
+    [data-prev-level="6"]
+  )
+  > .bn-block
+  > .bn-block-content {
+  font-size: 1rem;
+}
+
+.markdown-editor .bn-block-outer:has(> .bn-block > [data-content-type="heading"]) {
+  margin-top: 1.75rem;
+  margin-bottom: 0.35rem;
+}
+
+.markdown-editor
+  .bn-block-group
+  > .bn-block-outer:first-child:has(> .bn-block > [data-content-type="heading"]) {
+  margin-top: 0;
+}
+
+.markdown-editor
+  .bn-block-outer:has(
+    > .bn-block
+      > :is(
+        [data-content-type="bulletListItem"],
+        [data-content-type="numberedListItem"],
+        [data-content-type="checkListItem"]
+      )
+  ) {
+  margin-block: 0.08rem;
+}
+
+.markdown-editor
+  .bn-block-content:is(
+    [data-content-type="bulletListItem"],
+    [data-content-type="numberedListItem"],
+    [data-content-type="checkListItem"]
+  )::before {
+  color: hsl(var(--muted-foreground) / 0.85);
+}
+
+.markdown-editor .bn-block-group .bn-block-group {
+  margin-left: 1.25rem;
+}
+
+.markdown-editor [data-content-type="quote"] blockquote {
+  margin-block: 0.45rem;
+  padding: 0.15rem 0 0.15rem 1rem;
+  border-left-color: hsl(var(--primary) / 0.55);
+  color: hsl(var(--muted-foreground));
+}
+
+.markdown-editor [data-content-type="divider"] hr {
+  margin-block: 1.5rem;
+  border-top-color: hsl(var(--border) / 0.8);
+}
+
+.markdown-editor .bn-inline-content a {
+  color: hsl(var(--primary));
+  text-decoration: underline;
+  text-decoration-thickness: 1px;
+  text-underline-offset: 0.18em;
+}
+
+.markdown-editor .bn-inline-content code {
+  padding: 0.12em 0.38em;
+  border: 1px solid hsl(var(--border) / 0.55);
+  border-radius: 0.3rem;
+  background: hsl(var(--muted) / 0.55);
+  font-family: "JetBrains Mono Variable", "JetBrains Mono", ui-monospace, monospace;
+  font-size: 0.88em;
+}
+
+.markdown-editor .bn-block-content[data-content-type="codeBlock"] {
+  margin-block: 0.7rem;
+  overflow: hidden;
+  border: 1px solid hsl(var(--border) / 0.7);
+  border-radius: calc(var(--radius) + 0.125rem);
+  background: hsl(var(--card));
+  color: hsl(var(--card-foreground));
+}
+
+.markdown-editor .bn-block-content[data-content-type="codeBlock"] > pre {
+  padding: 1.1rem 1.25rem;
+  line-height: 1.62;
+  font-family: "JetBrains Mono Variable", "JetBrains Mono", ui-monospace, monospace;
+  font-size: 0.88rem;
+}
+
+.markdown-editor [data-content-type="table"] .tableWrapper {
+  max-width: 100%;
+  margin-block: 0.8rem;
+  overflow-x: auto;
+  padding: 0;
+  border: 1px solid hsl(var(--border) / 0.75);
+  border-radius: var(--radius);
+}
+
+.markdown-editor .bn-editor .bn-block-content[data-content-type="table"] table {
+  width: max-content !important;
+  min-width: 100%;
+  border-collapse: collapse;
+  font-size: 0.92rem;
+  line-height: 1.5;
+}
+
+.markdown-editor .bn-editor [data-content-type="table"] th,
+.markdown-editor .bn-editor [data-content-type="table"] td {
+  padding: 0.55rem 0.75rem;
+  border-color: hsl(var(--border) / 0.65);
+  vertical-align: top;
+}
+
+.markdown-editor .bn-editor [data-content-type="table"] th {
+  background: hsl(var(--muted) / 0.45);
+  font-weight: 600;
+}
+
+@container markdown-editor (max-width: 560px) {
+  .markdown-editor {
+    --markdown-document-gutter: 1rem;
+  }
+
+  .markdown-editor .frontmatter-properties-inner {
+    padding-top: 1rem;
+    padding-bottom: 1rem;
+  }
+
+  .markdown-editor .frontmatter-properties-grid > div {
+    flex-wrap: wrap;
+  }
+
+  .markdown-editor .frontmatter-properties-grid label {
+    width: calc(100% - 3.5rem);
+  }
+
+  .markdown-editor .frontmatter-properties-grid label + div {
+    flex-basis: calc(100% - 1.375rem);
+    margin-left: 1.375rem;
+  }
+
+  .markdown-editor .bn-editor {
+    padding-top: 1.5rem;
+  }
+
+  .markdown-editor .bn-block-content[data-content-type="heading"][data-level="1"],
+  .markdown-editor
+    .bn-block-outer[data-prev-type="heading"][data-prev-level="1"]
+    > .bn-block
+    > .bn-block-content {
+    font-size: 1.75rem;
+  }
+}

--- a/src/renderer/index.css
+++ b/src/renderer/index.css
@@ -844,7 +844,7 @@
 }
 
 .markdown-editor .bn-default-styles {
-  font-family: "Inter Variable", "Inter", system-ui, sans-serif;
+  font-family: "Inter Variable", Inter, system-ui, sans-serif;
   font-size: 16px;
   line-height: 1.72;
 }


### PR DESCRIPTION
## Summary

Redesigns the BlockNote markdown preview for comfortable reading. The current document view is visually dense: long unbroken lines span the full pane, paragraphs and lists have no breathing room, heading hierarchy is hard to scan, and the frontmatter Properties panel spreads labels and values too far apart. This PR introduces a centered, responsive reading measure with deliberate typographic rhythm and a more compact Properties panel — without changing editing, persistence, TOC scrolling, or wide-content overflow.

## Related Issue

No related issue — this is a direct user request to improve markdown preview readability. No existing open or closed PRs address this specific redesign.

## Type of Change

- [x] feat: new feature
- [ ] fix: bug fix
- [ ] docs: documentation only
- [ ] style: formatting or non-functional styling changes
- [ ] refactor: internal cleanup with no behavior change
- [ ] perf: performance improvement
- [ ] test: adds or updates tests
- [ ] build: build or dependency changes
- [ ] ci: CI/CD workflow changes
- [ ] chore: maintenance or tooling
- [ ] revert: reverts a previous change

## What Changed

### Document shell & scope
- Added a stable `.markdown-editor` scope class on the document scroll root so all styling is contained to the markdown editor (no leakage to chat or future BlockNote surfaces).
- Inserted a `.markdown-editor-document` flex-column wrapper between the scroll root and BlockNote, keeping `blockNoteScrollRootRef` as the TOC active-heading scroll ancestor and preserving full-height flex-fill for the editor.

### BlockNote typography & rhythm (scoped, unlayered CSS)
- **Reading measure:** centered 48rem max-width with responsive gutters (`clamp(1.25rem, 5cqi, 3.5rem)`).
- **Body:** line-height 1.72, 16px base (unchanged size, improved rhythm).
- **Headings:** moderate scale (2rem / 1.5rem / 1.2rem / 1rem for H4-H6), weight 650, `text-wrap: balance`, more space above than below. Complete `data-prev-*` selectors for H1-H6 prevent transition flicker.
- **Paragraphs/lists:** comfortable block spacing, muted list markers, reduced nested-list indent.
- **Quotes/dividers/links/code:** token-based styling using existing CSS variables.
- **Code blocks:** bordered card with preserved inner `pre` horizontal scrolling.
- **Tables:** `width: max-content !important` to beat BlockNote's vendor `width: auto !important`, tokenized borders/header, cell padding, horizontal scroll in wrapper.

### Responsive behavior (container query, not viewport)
- Made `.markdown-editor` an inline-size container (`container-type: inline-size`).
- Replaced the viewport `@media (max-width: 560px)` with `@container markdown-editor (max-width: 560px)` so the compact layout activates based on the **resizable editor pane**, not the app window — critical when the TOC panel is visible or the divider is resized.
- Gutters use `5cqi` (container query inline units) instead of `5vw`.

### Frontmatter Properties panel
- Tighter geometry: `w-24` labels (was `w-28`), `py-0.5` rows, `py-5` section padding.
- **Accessibility:** `role="group"` + `aria-labelledby` for nested and array values (previously `<label htmlFor>` targeted non-labelable divs); property key included in remove-item accessible names (`Remove alpha from context`); `aria-label` on new-property key input.
- **Long-value containment:** `min-w-0`, `max-w-full`, `break-words`, `overflow-wrap: anywhere` on nested values and badge text so long paths/hashes don't widen the pane.
- **Remove buttons:** larger `size-6` target with `focus-visible:ring` for keyboard accessibility.

### Tests
- `MarkdownEditor.frontmatter.test.tsx`: added scoped shell + flex-column assertion and Properties co-location test; BlockNote mock renders a testid element instead of `null`.
- `FrontmatterProperties.test.tsx`: added scalar blur keeps-accessible-name assertion, nested-value group labelling test, and updated array-removal test to match the new key-inclusive label.

### CodeRabbit review fixes
- Removed quotes around single-word `Inter` font name (stylelint `font-family-name-quotes`).
- Added `aria-label="Property key"` to the new-property key Input for consistent accessibility.

## How It Was Tested

- [x] `bun run ci` (Biome lint + format + imports, strict mode)
- [x] `bun run typecheck`
- [x] `bun run test`
- [ ] `cargo clippy --all-targets -- -D warnings` (in src-tauri)
- [ ] `cargo test` (in src-tauri)
- [x] Manual verification completed
- [ ] Not applicable

**Results:** Focused tests 11 passed · typecheck clean · biome ci 714 files no errors · full Vitest suite 2511 passed, 42 skipped.

## Screenshots or Recordings

Typography/density is perceptual — visual acceptance in the Tauri renderer is still required at wide and narrow pane sizes, with TOC shown/hidden, covering: H1-H6, paragraphs, nested ordered/unordered/check lists, inline code, code blocks, Mermaid, blockquotes, wide tables, and long frontmatter values.

## CI & Review Gate

- [ ] All CI checks pass (PR Validation, Rust Checks, Build Verification, Security Scans)
- [x] Code review comments from CodeRabbit / Claude have been addressed or resolved
- [ ] No unresolved review findings remain

CodeRabbit findings (2) have been addressed in commit `55485e3e`.

## Checklist

- [x] My PR title follows the conventional commit format used by this repo
- [x] I linked the related issue or explained why none exists
- [x] I updated docs when needed
- [x] I added or updated tests when needed
- [x] I verified the change does not introduce unrelated modifications
- [x] I read AGENTS.md and followed the contributor guidelines
- [ ] A human reviewed the complete diff before submission

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refreshed the Markdown editor look with improved typography, spacing, headings, tables, code blocks, and responsive adjustments.
  * Enhanced the frontmatter “Properties” section layout within the editor’s document shell.
* **Accessibility**
  * Improved labeling for nested/array frontmatter values and array controls.
  * Added clearer accessible text for property key and removal actions.
* **Bug Fixes**
  * Scalar frontmatter edits now commit reliably when the field loses focus.
* **Tests**
  * Expanded frontmatter and editor DOM/layout coverage, including nested labels and array removal behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->