### PR TITLE
fix(build): embed fresh dist-web by building it in beforeBuildCommand

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -6,7 +6,7 @@
 	"build": {
 		"beforeDevCommand": "npx vite --config vite.config.tauri.ts",
 		"devUrl": "http://localhost:5180/tauri-index.html",
-		"beforeBuildCommand": "npx vite build --config vite.config.tauri.ts",
+		"beforeBuildCommand": "npx vite build --config vite.config.web.ts && npx vite build --config vite.config.tauri.ts",
 		"frontendDist": "../dist-tauri"
 	},
 	"app": {


### PR DESCRIPTION
## Summary

`bun run build:tauri` updated the desktop app but left the **remote web UI / chat preview stale**. Root cause: `beforeBuildCommand` only built `dist-tauri/` (the desktop webview); `dist-web/` (the remote web bundle served by the embedded ACP web server) was never rebuilt, so `rust-embed` embedded whatever stale `dist-web/` was on disk into the release binary. CI avoided this by running `bun run build:web` separately before the cargo build; local builds had no such guard, so a stale `dist-web/` (gitignored) silently embedded old content — desktop current, remote web UI lagging behind.

## Related Issue

No tracked issue — reported directly by the maintainer (stale remote web UI after a local `build:tauri`). Searched open + closed PRs for `dist-web` / `beforeBuildCommand` / `build:web` duplicates: none. PR #433 is the merged web-bootstrap feature that introduced the dual-build split, not a fix for this.

## Type of Change

- [ ] feat: new feature
- [x] fix: bug fix
- [ ] docs: documentation only
- [ ] style: formatting or non-functional styling changes
- [ ] refactor: internal cleanup with no behavior change
- [ ] perf: performance improvement
- [ ] test: adds or updates tests
- [x] build: build or dependency changes
- [ ] ci: CI/CD workflow changes
- [ ] chore: maintenance or tooling
- [ ] revert: reverts a previous change

## What Changed

`src-tauri/tauri.conf.json` — `build.beforeBuildCommand` now builds **both** frontends:

```diff
  "build": {
    "beforeDevCommand": "npx vite --config vite.config.tauri.ts",
    "devUrl": "http://localhost:5180/tauri-index.html",
-   "beforeBuildCommand": "npx vite build --config vite.config.tauri.ts",
+   "beforeBuildCommand": "npx vite build --config vite.config.web.ts && npx vite build --config vite.config.tauri.ts",
    "frontendDist": "../dist-tauri"
  },
```

Web builds first so a web-build failure aborts before the heavier tauri/cargo step; by the time cargo compiles, `dist-web/` is guaranteed fresh and `rust-embed` embeds the current web bundle into the desktop binary. One source of truth covering every `build:tauri*` npm script, direct `tauri build`, and CI's `tauri-action`.

**Dev mode is unaffected** — it uses `beforeDevCommand` (the vite dev server) and serves the remote web UI from disk via `ServeDir`. For a *live* web UI in dev, run `bun run dev:web`; for a refreshed static web UI, `bun run build:web`.

CI's explicit `bun run build:web` step (`release.yml` / `pr-validation.yml`) is now redundant but harmless and defensive — left as-is.

## How It Was Tested

- [x] `bun run ci` (Biome lint + format + imports, strict mode) — 714 files, no fixes
- [x] `bun run typecheck` — clean
- [x] `bun run test` — 2511 passed, 42 skipped
- [x] `cargo clippy --all-targets -- -D warnings` (in src-tauri) — clean (build.rs parses `tauri.conf.json` via `tauri_build::build()`)
- [x] `cargo test` (in src-tauri) — 487 passed, 0 failed
- [ ] Manual verification completed
- [ ] Not applicable

## Screenshots or Recordings

N/A — build-config change, no UI delta.

## CI & Review Gate

- [ ] All CI checks pass (PR Validation, Rust Checks, Build Verification, Security Scans)
- [ ] Code review comments from CodeRabbit / Claude have been addressed or resolved
- [ ] No unresolved review findings remain

## Checklist

- [x] My PR title follows the conventional commit format used by this repo
- [x] I linked the related issue or explained why none exists
- [x] I updated docs when needed (no doc change needed — `build:tauri*` commands now work without a hidden `build:web` prerequisite)
- [x] I added or updated tests when needed (config-only; existing `cargo test` exercises `build.rs` → `tauri_build::build()` parsing the config)
- [x] I verified the change does not introduce unrelated modifications (1 file, 1 line)
- [x] I read AGENTS.md and followed the contributor guidelines
- [x] A human reviewed the complete diff before submission


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the application build process to run both web and desktop build steps, improving build consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->