### PR TITLE
fix(chat): keep live agent text inside the Working collapsible while live

### DIFF
--- a/src/renderer/components/chat/ChatMessageList.tsx
+++ b/src/renderer/components/chat/ChatMessageList.tsx
@@ -142,7 +142,7 @@ export function ChatMessageList({
                       isTurnTail={item.isTurnTail}
                       turnText={item.turnText}
                       actionsPinned={index === lastMsgIndex}
-                      animateEnter={shouldAnimateEnter(item.message.id)}
+                      animateEnter={item.isTurnTail ? false : shouldAnimateEnter(item.message.id)}
                       onEdit={onEditMessage}
                       onRetry={onRetry}
                     />

--- a/src/renderer/components/chat/TurnActivity.tsx
+++ b/src/renderer/components/chat/TurnActivity.tsx
@@ -99,7 +99,7 @@ export function TurnActivity({
                   key={item.key}
                   message={item.message}
                   showHeader={false}
-                  isLast={false}
+                  isLast={active && index === items.length - 1}
                   animateEnter={shouldAnimateEnter(item.message.id)}
                 />
               )

--- a/src/renderer/components/chat/chat-timeline.test.ts
+++ b/src/renderer/components/chat/chat-timeline.test.ts
@@ -264,12 +264,56 @@ describe('groupTurnActivity', () => {
       true
     )
 
-    expect(beforeTool.map((item) => item.key)).toEqual(['user', 'activity:user', 'live-response'])
-    expect(afterTool.map((item) => item.key)).toEqual(['user', 'activity:user', 'live-response'])
-    const activity = afterTool[1]
-    expect(activity.kind).toBe('activity')
-    if (activity.kind === 'activity') {
-      expect(activity.items.map(timelineItemId)).toEqual(['read'])
+    // While the turn is live, the response renders INSIDE the activity
+    // collapsible (not as a top-level row), at a stable key that survives the
+    // arrival of later activity without remounting.
+    expect(beforeTool.map((item) => item.key)).toEqual(['user', 'activity:user'])
+    expect(afterTool.map((item) => item.key)).toEqual(['user', 'activity:user'])
+    const beforeActivity = beforeTool[1]
+    const afterActivity = afterTool[1]
+    expect(beforeActivity?.kind).toBe('activity')
+    expect(afterActivity?.kind).toBe('activity')
+    if (beforeActivity?.kind === 'activity' && afterActivity?.kind === 'activity') {
+      expect(beforeActivity.items.map(timelineItemId)).toEqual(['live-response'])
+      expect(afterActivity.items.map(timelineItemId)).toEqual(['live-response', 'read'])
+    }
+  })
+
+  it('keeps the empty streaming live tail inside the activity, not outside', () => {
+    const emptyStreaming = msg('empty-tail', 'agent', 120, 2, '')
+    emptyStreaming.streaming = true
+    const grouped = groupTurnActivity(
+      buildTimeline([msg('user', 'user', 100, 1), emptyStreaming], []),
+      true
+    )
+    // The pre-text streaming tail stays inside the activity (not a top-level
+    // row) so the caret renders inside the open collapsible while the turn is
+    // live.
+    expect(grouped.map((item) => item.key)).toEqual(['user', 'activity:user'])
+    const activity = grouped[1]
+    expect(activity?.kind).toBe('activity')
+    if (activity?.kind === 'activity') {
+      expect(activity.items.map(timelineItemId)).toEqual(['empty-tail'])
+    }
+  })
+
+  it('drops a non-trailing empty streaming message instead of rendering a blank bubble', () => {
+    const whitespaceStreaming = msg('ws-tail', 'agent', 120, 2, '   ')
+    whitespaceStreaming.streaming = true
+    const grouped = groupTurnActivity(
+      buildTimeline(
+        [msg('user', 'user', 100, 1), whitespaceStreaming, msg('final', 'agent', 140, 4, 'Done')],
+        [tool('read', 130, 3)]
+      ),
+      true
+    )
+    // A non-trailing empty/whitespace streaming message is dropped entirely
+    // (no blank bubble); only the trailing live tail is kept for the caret.
+    expect(grouped.some((item) => item.key === 'ws-tail')).toBe(false)
+    const activity = grouped.find((item) => item.kind === 'activity')
+    expect(activity?.kind).toBe('activity')
+    if (activity?.kind === 'activity') {
+      expect(activity.items.map(timelineItemId)).toEqual(['read', 'final'])
     }
   })
 

--- a/src/renderer/components/chat/chat-timeline.ts
+++ b/src/renderer/components/chat/chat-timeline.ts
@@ -205,21 +205,10 @@ export function groupTurnActivity(items: TimelineItem[], activeTurn: boolean): T
     turn.forEach((item, index) => {
       if (item.kind !== 'message' || item.message.role !== 'agent') return
       if (hasMediaContent(item.message)) visibleResponseIndices.add(index)
-      if (active && hasSubstantiveText(item.message)) visibleResponseIndices.add(index)
+      // Live intermediate + streaming text renders INSIDE the activity collapsible;
+      // only the final response (finalTextIndex, computed when !active) stays outside.
     })
     if (finalTextIndex >= 0) visibleResponseIndices.add(finalTextIndex)
-
-    if (active && visibleResponseIndices.size === 0) {
-      let emptyStreamingIndex = -1
-      for (let index = turn.length - 1; index >= 0; index--) {
-        const item = turn[index]!
-        if (item.kind === 'message' && item.message.role === 'agent' && item.message.streaming) {
-          emptyStreamingIndex = index
-          break
-        }
-      }
-      if (emptyStreamingIndex >= 0) visibleResponseIndices.add(emptyStreamingIndex)
-    }
 
     const visibleResponses = turn.filter(
       (item, index): item is Extract<TimelineItem, { kind: 'message' }> =>
@@ -227,11 +216,16 @@ export function groupTurnActivity(items: TimelineItem[], activeTurn: boolean): T
     )
     const activityItems = turn.filter((item, index) => {
       if (visibleResponseIndices.has(index)) return false
+      // Keep only the TRAILING empty streaming live tail inside the collapsible
+      // (so the caret renders there); non-trailing empty streaming messages are
+      // dropped to avoid spurious blank bubbles. finalizeStreaming clears
+      // `streaming` when activeTurn flips false, so this only applies while live.
       return !(
         item.kind === 'message' &&
         item.message.role === 'agent' &&
         !hasSubstantiveText(item.message) &&
-        !hasMediaContent(item.message)
+        !hasMediaContent(item.message) &&
+        !(index === turn.length - 1 && item.message.streaming)
       )
     })
     const allAgentText = turn


### PR DESCRIPTION
## Summary

While an agent turn is live, every intermediate agent text response rendered **outside** the "Working…" `TurnActivity` collapsible as a standalone bubble, then "jumped" inside when the final response arrived — the partition only ran at turn completion (`groupTurnActivity` added all live substantive text to `visibleResponseIndices`). This caused a visible, jarring relocation of short non-final responses the moment the turn ended.

This PR keeps live intermediate agent text — including the currently-streaming message and the pre-text empty streaming tail — **inside** the open "Working…" collapsible; only the final response emerges outside at turn completion (via the existing `finalTextIndex` partition).

## Related Issue

No issue — reported directly. No prior PR addresses this specific bug: searched open + closed PRs; the closest, #460 (redesign chat tool activity), is the broader redesign that *introduced* the collapsible, not this fix.

## Type of Change

- [x] fix: bug fix

## What Changed

- `src/renderer/components/chat/chat-timeline.ts` — in `groupTurnActivity`, removed the `active && hasSubstantiveText` add to `visibleResponseIndices` (which put all live text outside) and removed the empty-streaming-outside placeholder block. The `activityItems` filter now keeps only the **trailing** empty streaming tail (`index === turn.length - 1 && item.message.streaming`) so the caret renders inside without leaking non-trailing blank bubbles. (`finalizeStreaming` clears `streaming` in the same deferred `set` that flips `activeTurn:false`, so a streaming message only exists while the turn is live — no leak into completed turns.)
- `src/renderer/components/chat/TurnActivity.tsx` — the message branch passes `isLast={active && index === items.length - 1}` (mirroring `ThoughtGroup.isLiveTail`) so the existing `ChatMessage` streaming caret renders on the last item inside the collapsible.
- `src/renderer/components/chat/ChatMessageList.tsx` — the standalone `ChatMessage` passes `animateEnter={item.isTurnTail ? false : shouldAnimateEnter(...)}` to suppress the re-animation flash when the final response remounts from inside the activity's item map to a top-level row at completion (different parent lists → React remounts → would otherwise re-trigger the enter animation and flicker the final answer).
- `src/renderer/components/chat/chat-timeline.test.ts` — rewrote "keeps a live response at a stable key when later activity arrives" to assert the live response is inside `activityItems`; added "keeps the empty streaming live tail inside the activity, not outside" and "drops a non-trailing empty streaming message instead of rendering a blank bubble".

`ChatMessage.tsx` (caret logic) and `acp-store.ts` (streaming flag lifecycle) are intentionally untouched.

## How It Was Tested

- [x] `bun run ci` (Biome lint + format + imports, strict mode) — clean; 286 warnings / 108 infos identical to baseline (the diff adds zero)
- [x] `bun run typecheck` — clean (node + web + test configs)
- [x] `bun run test` — 2512 passed / 43 skipped / 0 failed
- [ ] `cargo clippy --all-targets -- -D warnings` (in src-tauri) — N/A (no Rust changes)
- [ ] `cargo test` (in src-tauri) — N/A (no Rust changes)
- [x] Manual verification completed — traced: active↔completed transition (no flash), pre-text empty streaming tail (caret inside), text→tool→text→tool→text (only trailing chunk gets the caret), single-response turn, media-bearing reply (unchanged — still always outside), and history load (unchanged).

## CI & Review Gate

- [ ] All CI checks pass (PR Validation, Rust Checks, Build Verification, Security Scans)
- [ ] Code review comments from CodeRabbit / Claude have been addressed or resolved
- [ ] No unresolved review findings remain

Will be confirmed after CI + CodeRabbit run on this PR.

## Checklist

- [x] My PR title follows the conventional commit format used by this repo
- [x] I linked the related issue or explained why none exists
- [x] I updated docs when needed (no user-facing docs change; behavior matches the existing "Working…" disclosure design)
- [x] I added or updated tests when needed
- [x] I verified the change does not introduce unrelated modifications (only 4 chat files; the `src-tauri/tauri.conf.json` build change from #465 is the base, not part of this PR)
- [x] I read AGENTS.md and followed the contributor guidelines
- [ ] A human reviewed the complete diff before submission


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved live response rendering during active turns by keeping streaming content within the activity row.
  * Prevented blank or duplicate message bubbles from appearing during streaming.
  * Preserved caret display for the trailing live response.
  * Corrected final-message handling so live activity renders consistently.

* **Tests**
  * Added coverage for live responses, tool activity, and empty or whitespace-only streaming messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->