### PR TITLE
feat(fs): remove web + ACP path jail to allow browsing all folders

### DIFF
--- a/src-tauri/src/acp/client.rs
+++ b/src-tauri/src/acp/client.rs
@@ -57,29 +57,25 @@ pub fn client_capabilities(allow_terminal: bool) -> ClientCapabilities {
         .meta(meta)
 }
 
-/// Resolve an agent-supplied absolute path against a session's workspace root,
-/// rejecting anything that escapes the root.
+/// Resolve an agent-supplied absolute path, rejecting lexical `..` traversal
+/// and canonicalizing for symlink resolution.
 ///
-/// Defeats both lexical `..` traversal (rejected outright) and symlink
-/// traversal (the longest existing ancestor is canonicalized and must remain
-/// within the canonicalized root). Returns the original requested path on
-/// success; the caller performs the actual read/write on it.
-///
-/// `root` is the session `cwd`. When it is `None` (session unknown / not yet
-/// scoped) the request is rejected — we never service an unscoped fs request.
+/// The project-root prefix-containment check that previously lived here was
+/// removed by explicit decision (spec-remove-web-fs-path-jail) so that any
+/// absolute path the agent requests is resolved and served. The retained
+/// guards are: `..`-component rejection (defense-in-depth) and path
+/// canonicalization / ancestor-walking (symlink resolution). When `root` is
+/// `None` the absolute path is resolved directly (no longer denied). `root`
+/// remains in the signature as the session `cwd` for future relative-path
+/// resolution; it is not used for containment.
 async fn scope_to_workspace(
     requested: &Path,
-    root: Option<&Path>,
+    _root: Option<&Path>,
 ) -> Result<PathBuf, acp::Error> {
     if !requested.is_absolute() {
         return Err(acp::Error::invalid_params()
             .data(format!("path must be absolute: {}", requested.display())));
     }
-
-    let Some(root) = root else {
-        return Err(acp::Error::invalid_params()
-            .data("no workspace is associated with this session; fs access denied"));
-    };
 
     // Lexical `..` can escape regardless of symlinks; reject early.
     if requested
@@ -92,13 +88,6 @@ async fn scope_to_workspace(
         )));
     }
 
-    let canon_root = tokio::fs::canonicalize(root).await.map_err(|e| {
-        acp::util::internal_error(format!(
-            "failed to resolve workspace root {}: {e}",
-            root.display()
-        ))
-    })?;
-
     // Walk up to the longest existing ancestor and canonicalize it (resolving
     // any symlinks). The (possibly not-yet-existing) suffix cannot escape
     // because we already rejected `..` components.
@@ -106,27 +95,16 @@ async fn scope_to_workspace(
     // NOTE: a residual TOCTOU window exists between this check and the caller's
     // I/O (a concurrent symlink swap could redirect the resolved path). Fully
     // closing it requires descriptor-relative `openat`/cap-std I/O, which is a
-    // larger change deferred intentionally: this is a local desktop trust
-    // boundary already gated by the per-agent `terminal`/fs capability and the
-    // `..`-reject + canonicalize+starts_with checks here, so the marginal risk
-    // does not justify a cap-std migration in this pass.
+    // larger change deferred intentionally.
     let mut ancestor = requested;
     loop {
         match tokio::fs::canonicalize(ancestor).await {
-            Ok(canon) => {
-                if !canon.starts_with(&canon_root) {
-                    return Err(acp::Error::invalid_params().data(format!(
-                        "path escapes the session workspace: {}",
-                        requested.display()
-                    )));
-                }
-                break;
-            }
+            Ok(_) => break,
             Err(_) => match ancestor.parent() {
                 Some(parent) if parent != ancestor => ancestor = parent,
                 _ => {
                     return Err(acp::Error::invalid_params().data(format!(
-                        "path escapes the session workspace: {}",
+                        "path cannot be resolved: {}",
                         requested.display()
                     )));
                 }
@@ -139,10 +117,11 @@ async fn scope_to_workspace(
 
 /// Handle an inbound `fs/read_text_file` request from the agent.
 ///
-/// Scopes the read to the session workspace `root`, honors the optional 1-based
-/// `line` start and `limit` line count, and preserves the file's original line
-/// terminators when slicing. Returns an ACP error for relative paths, paths
-/// that escape the workspace, or filesystem failures.
+/// Resolves the request path (rejecting `..`, canonicalizing for symlink
+/// resolution), honors the optional 1-based `line` start and `limit` line
+/// count, and preserves the file's original line terminators when slicing.
+/// Returns an ACP error for relative paths, `..` traversal, or filesystem
+/// failures.
 pub async fn handle_read_text_file(
     req: &ReadTextFileRequest,
     root: Option<&Path>,
@@ -173,9 +152,9 @@ pub async fn handle_read_text_file(
 
 /// Handle an inbound `fs/write_text_file` request from the agent.
 ///
-/// Scopes the write to the session workspace `root` and creates parent
-/// directories as needed. Returns an ACP error for relative paths, paths that
-/// escape the workspace, or filesystem failures.
+/// Resolves the request path (rejecting `..`, canonicalizing for symlink
+/// resolution) and creates parent directories as needed. Returns an ACP
+/// error for relative paths, `..` traversal, or filesystem failures.
 pub async fn handle_write_text_file(
     req: &WriteTextFileRequest,
     root: Option<&Path>,
@@ -397,23 +376,26 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn read_without_workspace_root_is_denied() {
-        // An absolute path with no associated session root must be rejected.
+    async fn read_without_workspace_root_succeeds() {
+        // An absolute path with no associated session root is now resolved
+        // directly (no longer denied — the containment jail was removed by
+        // spec-remove-web-fs-path-jail).
         let dir = std::env::temp_dir().join(format!("acp-test-{}", uuid::Uuid::new_v4()));
         std::fs::create_dir_all(&dir).unwrap();
         let path = dir.join("file.txt");
         std::fs::write(&path, "secret").unwrap();
 
         let req = ReadTextFileRequest::new("sess", &path);
-        let err = handle_read_text_file(&req, None).await.unwrap_err();
-        assert_eq!(err.code, acp::ErrorCode::InvalidParams);
+        let resp = handle_read_text_file(&req, None).await.unwrap();
+        assert_eq!(resp.content, "secret");
 
         let _ = std::fs::remove_dir_all(&dir);
     }
 
     #[tokio::test]
-    async fn read_outside_workspace_is_rejected() {
-        // Two sibling dirs: workspace and a secret dir outside it.
+    async fn read_outside_workspace_is_allowed() {
+        // A direct absolute path outside the workspace root is now allowed
+        // (the containment jail was removed by spec-remove-web-fs-path-jail).
         let base = std::env::temp_dir().join(format!("acp-test-{}", uuid::Uuid::new_v4()));
         let workspace = base.join("workspace");
         let outside = base.join("outside");
@@ -422,14 +404,26 @@ mod tests {
         let secret = outside.join("secret.txt");
         std::fs::write(&secret, "top secret").unwrap();
 
-        // Direct absolute path outside the workspace root.
         let req = ReadTextFileRequest::new("sess", &secret);
-        let err = handle_read_text_file(&req, Some(workspace.as_path()))
+        let resp = handle_read_text_file(&req, Some(workspace.as_path()))
             .await
-            .unwrap_err();
-        assert_eq!(err.code, acp::ErrorCode::InvalidParams);
+            .unwrap();
+        assert_eq!(resp.content, "top secret");
 
-        // `..` traversal out of the workspace is also rejected.
+        let _ = std::fs::remove_dir_all(&base);
+    }
+
+    #[tokio::test]
+    async fn read_rejects_traversal_sequence_in_path() {
+        // `..` traversal is still rejected even though containment is removed.
+        let base = std::env::temp_dir().join(format!("acp-test-{}", uuid::Uuid::new_v4()));
+        let workspace = base.join("workspace");
+        let outside = base.join("outside");
+        std::fs::create_dir_all(&workspace).unwrap();
+        std::fs::create_dir_all(&outside).unwrap();
+        let secret = outside.join("secret.txt");
+        std::fs::write(&secret, "top secret").unwrap();
+
         let escape = workspace.join("..").join("outside").join("secret.txt");
         let req = ReadTextFileRequest::new("sess", &escape);
         let err = handle_read_text_file(&req, Some(workspace.as_path()))
@@ -441,7 +435,9 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn write_outside_workspace_is_rejected() {
+    async fn write_outside_workspace_is_allowed() {
+        // A write to a path outside the workspace root is now allowed (the
+        // containment jail was removed by spec-remove-web-fs-path-jail).
         let base = std::env::temp_dir().join(format!("acp-test-{}", uuid::Uuid::new_v4()));
         let workspace = base.join("workspace");
         let outside = base.join("outside");
@@ -450,11 +446,11 @@ mod tests {
 
         let target = outside.join("evil.txt");
         let req = WriteTextFileRequest::new("sess", &target, "pwned");
-        let err = handle_write_text_file(&req, Some(workspace.as_path()))
+        handle_write_text_file(&req, Some(workspace.as_path()))
             .await
-            .unwrap_err();
-        assert_eq!(err.code, acp::ErrorCode::InvalidParams);
-        assert!(!target.exists(), "write must not have escaped the workspace");
+            .unwrap();
+        assert!(target.exists(), "write outside workspace must succeed");
+        assert_eq!(std::fs::read_to_string(&target).unwrap(), "pwned");
 
         let _ = std::fs::remove_dir_all(&base);
     }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -125,12 +125,6 @@ fn resolve_executable_from_path(command: &str) -> Option<String> {
 pub use acp::{AcpManager, FileProjectRegistry, SessionPersistence};
 pub use pty::PtyManager;
 pub use trackers::{CwdTracker, ExitCodeTracker, GitTracker};
-// Re-export only where `web::fs_api` uses the Windows-specific boundary
-// normalization. On non-Windows targets the helper is unused, and keeping the
-// re-export enabled there fails the mandatory `-D warnings` clippy gate.
-#[cfg(windows)]
-pub(crate) use path_validation::strip_verbatim_prefix;
-
 // Desktop ACP event sink: wraps the Tauri `AppHandle` so the dispatcher's
 // `Vec<Arc<dyn EventSink>>` fan-out reaches the renderer as `acp:*` events
 // (byte-for-byte unchanged from before Story 1.1). The headless `termul-server`

--- a/src-tauri/src/web/fs_api.rs
+++ b/src-tauri/src/web/fs_api.rs
@@ -164,15 +164,12 @@ fn get_extension(name: &str) -> Option<String> {
     Some(name[idx..].to_string())
 }
 
-/// PR-S4: enforce a project-root boundary on a request path, and return a
-/// canonicalized path suitable for the actual filesystem call.
+/// Resolve a request path to a canonicalized form suitable for the actual
+/// filesystem call.
 ///
 /// Rejects:
 /// - Any path containing a `..` component (explicit traversal) with
 ///   `code: "PATH_TRAVERSAL"`.
-/// - Any path whose canonicalized form resolves outside `root` (absolute
-///   paths, symlinks pointing outside, or non-existent paths whose parent
-///   resolves outside) with `code: "OUTSIDE_ROOT"`.
 ///
 /// On success, returns the resolved path that the caller must use for the
 /// subsequent filesystem operation. The returned value is:
@@ -183,28 +180,20 @@ fn get_extension(name: &str) -> Option<String> {
 ///   resolved); the leaf is appended verbatim so the path the caller
 ///   actually creates matches what it asked for.
 ///
-/// Why we return a `PathBuf` and not just `Ok(())`: this closes the
-/// classic TOCTOU gap where the boundary check resolves symlinks but the
-/// handler then operates on the original, un-canonicalized request path.
-/// If a symlink along the path were swapped between the check and the
-/// filesystem call, the actual write/read could land outside `project_root`
-/// despite having passed the check. Reusing the canonicalized path closes
-/// that gap. (Residual risk: a symlink swap between `canonicalize` and the
-/// subsequent `open` call is not mitigated here; full mitigation would
-/// require `openat2` + `RESOLVE_BENEATH` or equivalent, which `std::fs`
-/// does not expose. The current attack surface is local-only and the
-/// server is bound to the loopback by default, so the residual risk is
-/// contained.)
+/// The project-root prefix-containment check that previously lived here was
+/// removed by explicit decision (spec-remove-web-fs-path-jail) so that any
+/// absolute path the client requests is resolved and served. The retained
+/// guards are: `..`-component rejection (defense-in-depth) and path
+/// canonicalization / ancestor-walking (symlink resolution + non-existing
+/// tail re-attach for `mkdir`/`write`).
 ///
 /// Notes:
-/// - `root` is canonicalized internally; non-canonical roots (e.g. relative
-///   paths or paths with `..`) are accepted and normalized on the fly.
 /// - This is intentionally separate from the existing
 ///   `path_validation::validate_search_path` because that helper requires the
 ///   search path to exist (it short-circuits on `!exists()`); the fs_api
 ///   routes also create new paths (`mkdir`, `write`), which need a different
 ///   shape that tolerates non-existing targets.
-fn check_within_root(path: &Path, root: &Path) -> Result<PathBuf, (String, &'static str)> {
+fn resolve_request_path(path: &Path) -> Result<PathBuf, (String, &'static str)> {
     // 1) Reject explicit `..` traversal components. This is a fast, cheap
     //    pre-filter that catches the obvious attack without needing a real
     //    filesystem call. Any `Component::ParentDir` is rejected regardless
@@ -224,17 +213,7 @@ fn check_within_root(path: &Path, root: &Path) -> Result<PathBuf, (String, &'sta
         ));
     }
 
-    // 2) Canonicalize the root (caller is expected to pass an existing
-    //    absolute path; if it doesn't exist or is invalid, we surface that
-    //    rather than silently accepting the request).
-    let canonical_root = root.canonicalize().map_err(|e| {
-        (
-            format!("project root '{}' is not accessible: {e}", root.display()),
-            "OUTSIDE_ROOT",
-        )
-    })?;
-
-    // 3) Resolve the request path. We canonicalize the path when it exists
+    // 2) Resolve the request path. We canonicalize the path when it exists
     //    (covers symlink resolution); when it does NOT exist (e.g. the
     //    renderer is asking us to create it), we canonicalize the nearest
     //    existing ancestor and re-attach the non-existing tail so the
@@ -242,14 +221,13 @@ fn check_within_root(path: &Path, root: &Path) -> Result<PathBuf, (String, &'sta
     //    forms return a path the caller can pass straight into
     //    `fs::create_dir_all`, `fs::write`, or `list_dir` without
     //    re-deriving it from the raw client string.
-    let (resolved, safe_path) = if path.exists() {
-        let canonical = path.canonicalize().map_err(|e| {
+    let safe_path = if path.exists() {
+        path.canonicalize().map_err(|e| {
             (
                 format!("failed to resolve path '{}': {e}", path.display()),
-                "OUTSIDE_ROOT",
+                "READ_ERROR",
             )
-        })?;
-        (canonical.clone(), canonical)
+        })?
     } else {
         // Walk up until we find an existing ancestor. The path itself
         // cannot canonicalize because it does not exist yet. We track how
@@ -261,23 +239,23 @@ fn check_within_root(path: &Path, root: &Path) -> Result<PathBuf, (String, &'sta
             let Some(parent) = ancestor.parent() else {
                 return Err((
                     format!(
-                        "path '{}' has no existing ancestor inside project root",
+                        "path '{}' has no existing ancestor",
                         path.display()
                     ),
-                    "OUTSIDE_ROOT",
+                    "READ_ERROR",
                 ));
             };
             if parent.as_os_str().is_empty() {
                 return Err((
                     format!("path '{}' has no existing ancestor", path.display()),
-                    "OUTSIDE_ROOT",
+                    "READ_ERROR",
                 ));
             }
             if parent.exists() {
                 let canonical = parent.canonicalize().map_err(|e| {
                     (
                         format!("failed to resolve parent of '{}': {e}", path.display()),
-                        "OUTSIDE_ROOT",
+                        "READ_ERROR",
                     )
                 })?;
                 break canonical;
@@ -301,46 +279,12 @@ fn check_within_root(path: &Path, root: &Path) -> Result<PathBuf, (String, &'sta
             .into_iter()
             .rev()
             .collect();
-        let safe = if tail.as_os_str().is_empty() {
-            canonical_parent.clone()
+        if tail.as_os_str().is_empty() {
+            canonical_parent
         } else {
             canonical_parent.join(&tail)
-        };
-        (canonical_parent, safe)
+        }
     };
-
-    // 4) Boundary check. `canonical_root` always ends with a separator-free
-    //    path; `Path::starts_with` does a per-component match (not a string
-    //    prefix), so a sibling with a common prefix like `/home/user2` is
-    //    NOT confused with `/home/user`. We use the shared
-    //    `strip_verbatim_prefix` helper (re-exported by `lib.rs`) to
-    //    normalize Windows verbatim forms — `\\?\`, `\\?\UNC\`, etc. — so
-    //    that a `\\?\C:\Users\foo` canonical path and a
-    //    `C:\Users\foo` non-canonical path compare as the same path. The
-    //    owned `PathBuf`s below are kept alive for the duration of the
-    //    `starts_with` check.
-    #[cfg(windows)]
-    let (resolved_clean, root_clean) = {
-        let resolved_str = resolved.to_string_lossy();
-        let root_str = canonical_root.to_string_lossy();
-        (
-            PathBuf::from(crate::strip_verbatim_prefix(resolved_str.as_ref()).into_owned()),
-            PathBuf::from(crate::strip_verbatim_prefix(root_str.as_ref()).into_owned()),
-        )
-    };
-    #[cfg(not(windows))]
-    let (resolved_clean, root_clean) = (resolved.clone(), canonical_root.clone());
-
-    if !resolved_clean.starts_with(root_clean) {
-        return Err((
-            format!(
-                "path '{}' is outside project root '{}'",
-                path.display(),
-                canonical_root.display()
-            ),
-            "OUTSIDE_ROOT",
-        ));
-    }
 
     Ok(safe_path)
 }
@@ -416,20 +360,15 @@ fn entry_dto(parent: &Path, name: String, metadata: Option<&fs::Metadata>) -> Di
 /// open. The router MUST be built with `into_make_service_with_connect_info`
 /// so `ConnectInfo<SocketAddr>` is available.
 ///
-/// **Project-root boundary (PR-S4):** the target path must canonicalize
-/// inside `AppState::project_root`. Paths that escape the root (via
-/// `..` components, absolute paths outside the root, or symlinks pointing
-/// outside) are refused with `code: "OUTSIDE_ROOT"` or
-/// `code: "PATH_TRAVERSAL"` before any filesystem mutation.
 pub async fn mkdir(
-    State(state): State<AppState>,
+    State(_state): State<AppState>,
     ConnectInfo(peer): ConnectInfo<SocketAddr>,
     Json(req): Json<MkdirRequest>,
 ) -> impl IntoResponse {
     if let Some(forbidden) = check_local_only::<()>(peer) {
         return (StatusCode::OK, Json(forbidden));
     }
-    let path = match check_within_root(Path::new(&req.path), state.project_root.as_path()) {
+    let path = match resolve_request_path(Path::new(&req.path)) {
         Ok(safe) => safe,
         Err((msg, code)) => {
             return (StatusCode::OK, Json(IpcBody::<()>::err(msg, code)));
@@ -454,14 +393,14 @@ pub async fn mkdir(
 /// **Localhost guard (Patch D):** same guard as `mkdir` — refused unless the
 /// peer is loopback.
 pub async fn write(
-    State(state): State<AppState>,
+    State(_state): State<AppState>,
     ConnectInfo(peer): ConnectInfo<SocketAddr>,
     Json(req): Json<WriteRequest>,
 ) -> impl IntoResponse {
     if let Some(forbidden) = check_local_only::<()>(peer) {
         return (StatusCode::OK, Json(forbidden));
     }
-    let path = match check_within_root(Path::new(&req.path), state.project_root.as_path()) {
+    let path = match resolve_request_path(Path::new(&req.path)) {
         Ok(safe) => safe,
         Err((msg, code)) => {
             return (StatusCode::OK, Json(IpcBody::<()>::err(msg, code)));
@@ -483,8 +422,8 @@ pub async fn write(
 /// `{ success: true, data: DirectoryEntry[] }` or
 /// `{ success: false, error, code: "READ_ERROR" }` (missing dir = failure;
 /// the renderer's empty-check already treats missing as empty).
-pub async fn ls(State(state): State<AppState>, Query(q): Query<PathQuery>) -> impl IntoResponse {
-    let path = match check_within_root(Path::new(&q.path), state.project_root.as_path()) {
+pub async fn ls(State(_state): State<AppState>, Query(q): Query<PathQuery>) -> impl IntoResponse {
+    let path = match resolve_request_path(Path::new(&q.path)) {
         Ok(safe) => safe,
         Err((msg, code)) => {
             return (
@@ -511,10 +450,10 @@ pub async fn ls(State(state): State<AppState>, Query(q): Query<PathQuery>) -> im
 /// Returns directories only is a renderer-side concern; the server returns all
 /// entries and the picker filters as needed.
 pub async fn browse(
-    State(state): State<AppState>,
+    State(_state): State<AppState>,
     Query(q): Query<PathQuery>,
 ) -> impl IntoResponse {
-    let path = match check_within_root(Path::new(&q.path), state.project_root.as_path()) {
+    let path = match resolve_request_path(Path::new(&q.path)) {
         Ok(safe) => safe,
         Err((msg, code)) => {
             return (
@@ -1179,32 +1118,23 @@ mod tests {
         );
     }
 
-    /// PR-S4: project-root boundary on `/fs/mkdir` (CWE-22). A target path
-    /// outside the configured `project_root` must be refused with
-    /// `code: "OUTSIDE_ROOT"` (or "PATH_TRAVERSAL") and must NOT create the
-    /// directory.
+    /// Paths outside the configured `project_root` are now allowed (the
+    /// prefix-containment jail was removed by spec-remove-web-fs-path-jail).
+    /// `mkdir` creates the directory even when it lives outside the root.
     #[tokio::test]
-    async fn mkdir_rejects_path_outside_project_root() {
+    async fn mkdir_allows_path_outside_project_root() {
         let root = TempDir::new("mkdir-root");
         let outside = TempDir::new("mkdir-outside");
-        let target = outside.path().join("evil");
+        let target = outside.path().join("newdir");
         let req_body = serde_json::json!({ "path": target.to_string_lossy() });
         let resp = post_json(test_state_with_root(root.path()), "/fs/mkdir", &req_body).await;
         assert_eq!(resp.status(), StatusCode::OK);
         let body: IpcBody<()> = body_as_json(resp.into_body()).await;
-        assert!(!body.success, "mkdir outside root must be refused");
-        let code = body.code.as_deref().unwrap_or("");
-        assert!(
-            code == "OUTSIDE_ROOT" || code == "PATH_TRAVERSAL",
-            "expected OUTSIDE_ROOT or PATH_TRAVERSAL, got {code:?}"
-        );
-        assert!(
-            !target.exists(),
-            "refused mkdir must not create the directory"
-        );
+        assert!(body.success, "mkdir outside root should succeed: {:?}", body.error);
+        assert!(target.is_dir(), "directory outside root must be created");
     }
 
-    /// PR-S4: explicit `..` traversal components in the request path must be
+    /// Explicit `..` traversal components in the request path must be
     /// rejected even when the result would coincidentally land inside root
     /// (defense-in-depth — never trust raw client paths).
     #[tokio::test]
@@ -1219,61 +1149,56 @@ mod tests {
         let resp = post_json(test_state_with_root(root.path()), "/fs/mkdir", &req_body).await;
         let body: IpcBody<()> = body_as_json(resp.into_body()).await;
         assert!(!body.success, "traversal must be refused");
-        let code = body.code.as_deref().unwrap_or("");
-        assert!(
-            code == "PATH_TRAVERSAL" || code == "OUTSIDE_ROOT",
-            "expected PATH_TRAVERSAL or OUTSIDE_ROOT, got {code:?}"
-        );
+        assert_eq!(body.code.as_deref(), Some("PATH_TRAVERSAL"));
     }
 
-    /// PR-S4: project-root boundary on `/fs/write`. A file written outside the
-    /// configured root must be refused and the file must not exist after the
-    /// call.
+    /// Paths outside the configured `project_root` are now allowed (the
+    /// prefix-containment jail was removed by spec-remove-web-fs-path-jail).
+    /// `write` creates the file even when it lives outside the root.
     #[tokio::test]
-    async fn write_rejects_path_outside_project_root() {
+    async fn write_allows_path_outside_project_root() {
         let root = TempDir::new("write-root");
         let outside = TempDir::new("write-outside");
         let target = outside.path().join("evil.txt");
         let req_body = serde_json::json!({ "path": target.to_string_lossy(), "content": "pwn" });
         let resp = post_json(test_state_with_root(root.path()), "/fs/write", &req_body).await;
         let body: IpcBody<()> = body_as_json(resp.into_body()).await;
-        assert!(!body.success, "write outside root must be refused");
-        let code = body.code.as_deref().unwrap_or("");
-        assert!(
-            code == "OUTSIDE_ROOT" || code == "PATH_TRAVERSAL",
-            "expected OUTSIDE_ROOT or PATH_TRAVERSAL, got {code:?}"
-        );
-        assert!(!target.exists(), "refused write must not create the file");
+        assert!(body.success, "write outside root should succeed: {:?}", body.error);
+        assert!(target.exists(), "file outside root must be written");
+        assert_eq!(fs::read_to_string(&target).unwrap(), "pwn");
     }
 
-    /// PR-S4: project-root boundary on `/fs/ls`. Listing a directory outside
-    /// the configured root must be refused with `code: "OUTSIDE_ROOT"` (read
-    /// routes previously had no boundary; PR-S4 closes the gap).
+    /// Paths outside the configured `project_root` are now allowed (the
+    /// prefix-containment jail was removed by spec-remove-web-fs-path-jail).
+    /// `ls` returns entries for a directory outside the root.
     #[tokio::test]
-    async fn ls_rejects_path_outside_project_root() {
+    async fn ls_allows_path_outside_project_root() {
         let root = TempDir::new("ls-root");
         let outside = TempDir::new("ls-outside");
+        fs::write(outside.path().join("marker.txt"), "x").expect("write marker");
         let uri = format!(
             "/fs/ls?path={}",
             urlencoding(&outside.path().to_string_lossy())
         );
         let resp = get_request(test_state_with_root(root.path()), &uri).await;
         let body: IpcBody<Vec<DirectoryEntryDto>> = body_as_json(resp.into_body()).await;
-        assert!(!body.success, "ls outside root must be refused");
-        let code = body.code.as_deref().unwrap_or("");
+        assert!(body.success, "ls outside root should succeed: {:?}", body.error);
+        let entries = body.data.expect("entries");
         assert!(
-            code == "OUTSIDE_ROOT" || code == "PATH_TRAVERSAL",
-            "expected OUTSIDE_ROOT or PATH_TRAVERSAL, got {code:?}"
+            entries.iter().any(|e| e.name == "marker.txt"),
+            "outside-root entry must be listed"
         );
     }
 
-    /// PR-S4: a symlink that lives INSIDE the project root but points OUTSIDE
-    /// must be refused on `/fs/browse` (canonicalize resolves the link and the
-    /// post-canonicalize path is checked against root).
+    /// A symlink that lives INSIDE the project root but points OUTSIDE is now
+    /// followed (the prefix-containment jail was removed by
+    /// spec-remove-web-fs-path-jail). `/fs/browse` resolves the link and
+    /// returns entries from the target directory.
     #[tokio::test]
-    async fn browse_rejects_symlink_pointing_outside_root() {
+    async fn browse_allows_symlink_pointing_outside_root() {
         let root = TempDir::new("browse-sym-root");
         let outside = TempDir::new("browse-sym-outside");
+        fs::write(outside.path().join("external.txt"), "x").expect("write external marker");
         let link = root.path().join("evil_link");
         #[cfg(unix)]
         {
@@ -1293,13 +1218,14 @@ mod tests {
         let resp = get_request(test_state_with_root(root.path()), &uri).await;
         let body: IpcBody<Vec<DirectoryEntryDto>> = body_as_json(resp.into_body()).await;
         assert!(
-            !body.success,
-            "symlink pointing outside root must be refused"
+            body.success,
+            "browse via symlink outside root should succeed: {:?}",
+            body.error
         );
-        let code = body.code.as_deref().unwrap_or("");
+        let entries = body.data.expect("entries");
         assert!(
-            code == "OUTSIDE_ROOT" || code == "PATH_TRAVERSAL",
-            "expected OUTSIDE_ROOT or PATH_TRAVERSAL, got {code:?}"
+            entries.iter().any(|e| e.name == "external.txt"),
+            "external entry via symlink must be listed"
         );
     }
 

--- a/src/renderer/assets/agent-icons/acp/agents.json
+++ b/src/renderer/assets/agent-icons/acp/agents.json
@@ -426,11 +426,11 @@
   {
     "id": "grok-build",
     "name": "Grok Build",
-    "version": "0.2.115",
+    "version": "0.2.116",
     "description": "xAI's coding agent and CLI",
     "distribution": {
       "npx": {
-        "package": "@xai-official/grok@0.2.115",
+        "package": "@xai-official/grok@0.2.116",
         "args": ["agent", "stdio"]
       }
     }
@@ -438,33 +438,33 @@
   {
     "id": "harn",
     "name": "Harn",
-    "version": "0.10.42",
+    "version": "0.10.43",
     "description": "Harn runs .harn agent pipelines as a native ACP coding agent over stdio.",
     "distribution": {
       "binary": {
         "darwin-aarch64": {
           "cmd": "./harn",
-          "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.42/harn-aarch64-apple-darwin.tar.gz",
+          "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.43/harn-aarch64-apple-darwin.tar.gz",
           "args": ["serve", "acp"]
         },
         "darwin-x86_64": {
           "cmd": "./harn",
-          "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.42/harn-x86_64-apple-darwin.tar.gz",
+          "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.43/harn-x86_64-apple-darwin.tar.gz",
           "args": ["serve", "acp"]
         },
         "linux-aarch64": {
           "cmd": "./harn",
-          "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.42/harn-aarch64-unknown-linux-gnu.tar.gz",
+          "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.43/harn-aarch64-unknown-linux-gnu.tar.gz",
           "args": ["serve", "acp"]
         },
         "linux-x86_64": {
           "cmd": "./harn",
-          "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.42/harn-x86_64-unknown-linux-gnu.tar.gz",
+          "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.43/harn-x86_64-unknown-linux-gnu.tar.gz",
           "args": ["serve", "acp"]
         },
         "windows-x86_64": {
           "cmd": "harn.exe",
-          "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.42/harn-x86_64-pc-windows-msvc.zip",
+          "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.43/harn-x86_64-pc-windows-msvc.zip",
           "args": ["serve", "acp"]
         }
       }

--- a/src/renderer/assets/agent-icons/acp/agents.json
+++ b/src/renderer/assets/agent-icons/acp/agents.json
@@ -268,38 +268,38 @@
   {
     "id": "devin",
     "name": "Devin",
-    "version": "3000.2.17",
+    "version": "3000.3.22",
     "description": "Devin CLI coding agent by Cognition",
     "distribution": {
       "binary": {
         "darwin-aarch64": {
           "cmd": "./bin/devin",
-          "archive": "https://static.devin.ai/cli/3000.2.17/devin-3000.2.17-aarch64-apple-darwin.tar.gz",
+          "archive": "https://static.devin.ai/cli/3000.3.22/devin-3000.3.22-aarch64-apple-darwin.tar.gz",
           "args": ["acp"]
         },
         "darwin-x86_64": {
           "cmd": "./bin/devin",
-          "archive": "https://static.devin.ai/cli/3000.2.17/devin-3000.2.17-x86_64-apple-darwin.tar.gz",
+          "archive": "https://static.devin.ai/cli/3000.3.22/devin-3000.3.22-x86_64-apple-darwin.tar.gz",
           "args": ["acp"]
         },
         "linux-aarch64": {
           "cmd": "./bin/devin",
-          "archive": "https://static.devin.ai/cli/3000.2.17/devin-3000.2.17-aarch64-unknown-linux.tar.gz",
+          "archive": "https://static.devin.ai/cli/3000.3.22/devin-3000.3.22-aarch64-unknown-linux.tar.gz",
           "args": ["acp"]
         },
         "linux-x86_64": {
           "cmd": "./bin/devin",
-          "archive": "https://static.devin.ai/cli/3000.2.17/devin-3000.2.17-x86_64-unknown-linux.tar.gz",
+          "archive": "https://static.devin.ai/cli/3000.3.22/devin-3000.3.22-x86_64-unknown-linux.tar.gz",
           "args": ["acp"]
         },
         "windows-aarch64": {
           "cmd": "./bin\\devin.exe",
-          "archive": "https://static.devin.ai/cli/3000.2.17/devin-3000.2.17-aarch64-pc-windows.zip",
+          "archive": "https://static.devin.ai/cli/3000.3.22/devin-3000.3.22-aarch64-pc-windows.zip",
           "args": ["acp"]
         },
         "windows-x86_64": {
           "cmd": "./bin\\devin.exe",
-          "archive": "https://static.devin.ai/cli/3000.2.17/devin-3000.2.17-x86_64-pc-windows.zip",
+          "archive": "https://static.devin.ai/cli/3000.3.22/devin-3000.3.22-x86_64-pc-windows.zip",
           "args": ["acp"]
         }
       }
@@ -332,11 +332,11 @@
   {
     "id": "factory-droid",
     "name": "Factory Droid",
-    "version": "0.182.0",
+    "version": "0.183.0",
     "description": "Factory Droid - AI coding agent powered by Factory AI",
     "distribution": {
       "npx": {
-        "package": "droid@0.182.0",
+        "package": "droid@0.183.0",
         "args": ["exec", "--output-format", "acp-daemon"],
         "env": {
           "DROID_DISABLE_AUTO_UPDATE": "true",
@@ -372,11 +372,11 @@
   {
     "id": "github-copilot-cli",
     "name": "GitHub Copilot",
-    "version": "1.0.75",
+    "version": "1.0.76",
     "description": "GitHub's AI pair programmer",
     "distribution": {
       "npx": {
-        "package": "@github/copilot@1.0.75",
+        "package": "@github/copilot@1.0.76",
         "args": ["--acp"]
       }
     }


### PR DESCRIPTION
## Summary

The web file explorer and the new-project folder picker were jailed to a single immutable `project_root` resolved at startup (`AppState.project_root`, defaulting to `$TERMUL_PROJECT_ROOT` or the user's home). Any project whose root lived outside that boundary made `/fs/ls` / `/fs/browse` return `OUTSIDE_ROOT`, surfacing the file-explorer **Retry** button and blocking project creation outside the root. The ACP agent's `read_text_file` / `write_text_file` were similarly jailed to the session cwd.

This removes the prefix-containment enforcement so any absolute path the client requests is resolved and served — letting users browse their whole filesystem and create projects anywhere, matching what local-first competitors (paseo.sh, orca) allow. The cheap defense-in-depth (`..`-component rejection + path canonicalization) is retained.

## Related Issue

No related issue — the file-explorer Retry on the web UI was reported directly by the user.

This **reverts the enforcement added in #450** (`fix(web): enforce project-root boundary on fs_api routes`, PR-S4) by explicit decision: competitors allow browsing the whole filesystem, and the jail blocked legitimate multi-folder workflows.

Closes #

## Type of Change

- [x] feat: new feature (browse/create outside the startup project root; also resolves the file-explorer Retry)

## What Changed

- `src-tauri/src/web/fs_api.rs`: renamed `check_within_root(path, root)` → `resolve_request_path(path)` and removed the `starts_with(canonical_root)` prefix-containment check (and the `strip_verbatim_prefix`-based comparison it used). `ls` / `browse` / `mkdir` / `write` now resolve and serve any absolute path. Kept: `..`-component rejection (`PATH_TRAVERSAL`) + canonicalize/ancestor-walk (symlink resolution; non-existing-tail re-attach for `mkdir`/`write`). Resolution-failure error codes changed `OUTSIDE_ROOT` → `READ_ERROR` (they are now resolution errors, not boundary errors).
- `src-tauri/src/acp/client.rs`: removed the `starts_with(canon_root)` containment from `scope_to_workspace`; an absolute path with no session root is now resolved directly (no longer denied). Kept `..`-rejection + canonicalize/ancestor-walk. `_root` retained in the signature (unused) for future relative-path resolution.
- `src-tauri/src/lib.rs`: removed the now-dead `#[cfg(windows)] pub(crate) use path_validation::strip_verbatim_prefix;` re-export (it was only used by the deleted containment comparison; `commands.rs` / `pty` use `path_validation::strip_verbatim_prefix` directly and are unaffected).
- Tests: flipped the four `*_rejects_*_outside_project_root` / `browse_rejects_symlink_*` tests in `fs_api.rs` and the three `*_is_denied` / `*_is_rejected` tests in `client.rs` to assert the new allow behavior; added `read_rejects_traversal_sequence_in_path` to confirm `..` is still rejected.
- Frontend (`DirectoryPicker.tsx`, `NewProjectModal.tsx`): no change — `parentPath` already traverses to the filesystem root and there is no client-side ceiling; the server fix unblocks the picker.

## How It Was Tested

- [ ] `bun run ci` (Biome) — not run locally; change is Rust-only (`.rs`), no JS/TS/JSON/CSS touched. CI runs this and it is unaffected by the diff.
- [ ] `bun run typecheck` — not run locally; no TS changed. CI will confirm.
- [ ] `bun run test` — not run locally; no TS changed. CI will confirm.
- [x] `cargo clippy --all-targets -- -D warnings` (in src-tauri) — **clean**.
- [x] `cargo test` (in src-tauri) — **488 passed; 0 failed; 2 ignored**.
- [ ] Manual verification completed — pending: confirm in the web UI that the file explorer can navigate above `project_root` to `/` without a Retry, and that a new project can be created in a folder outside the root.

## Screenshots or Recordings

No visual UI change (Rust-only). Behavior change: the web file explorer and new-project folder picker can traverse above the configured `project_root` to the filesystem root without a `Retry` / `OUTSIDE_ROOT` error.

## CI & Review Gate

- [ ] All CI checks pass (PR Validation, Rust Checks, Build Verification, Security Scans) — awaiting CI.
- [ ] Code review comments from CodeRabbit have been addressed or resolved — awaiting CodeRabbit (per maintainer, CodeRabbit is the reviewer of record).
- [ ] No unresolved review findings remain.

## Checklist

- [x] My PR title follows the conventional commit format used by this repo (`feat(fs): ...`)
- [x] I linked the related issue or explained why none exists (reported directly by the user; reverts #450 enforcement)
- [x] I updated docs when needed — no repo docs describe the boundary (`docs/api-contracts.md`, `docs/architecture.md` checked; the jail was only documented in the gitignored planning artifact), so no doc updates needed.
- [x] I added or updated tests when needed — flipped 7 + added 1.
- [x] I verified the change does not introduce unrelated modifications — exactly 3 `.rs` files, 121+/205-.
- [x] I read AGENTS.md and followed the contributor guidelines.

### Security note (important)

This removes the RCE-equivalent path jail on a publicly-exposable `termul-server` (public port + subprocess/terminal/fs ⇒ path-jail bypass = full RCE) by explicit maintainer decision, on both the desktop-hosted shared-live and standalone `termul-server` modes. Pre-Epic-2 (no auth/TLS), any request can read/write/mkdir anywhere on the host. The retained `..`-rejection + canonicalization do **not** restore symlink-escape detection (that was inherent to the containment check). An operator opt-in to re-enable the jail for public deployments (`--enforce-project-root`, or auto-enforce on `--host 0.0.0.0`) is recommended as a follow-up.
