### PR TITLE
feat(remote): scan-to-connect QR via built-in cloudflared tunnel

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -89,6 +89,7 @@
         "material-icon-theme": "^5.35.0",
         "mermaid": "^11.14.0",
         "next-themes": "^0.3.0",
+        "qrcode.react": "^4.2.0",
         "react": "^18.3.1",
         "react-day-picker": "^8.10.1",
         "react-dom": "^18.3.1",
@@ -1719,6 +1720,8 @@
     "proxy-addr": ["proxy-addr@2.0.7", "", { "dependencies": { "forwarded": "0.2.0", "ipaddr.js": "1.9.1" } }, "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg=="],
 
     "punycode": ["punycode@2.3.1", "", {}, "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="],
+
+    "qrcode.react": ["qrcode.react@4.2.0", "", { "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-QpgqWi8rD9DsS9EP3z7BT+5lY5SFhsqGjpgW5DY/i3mK4M9DTBNz3ErMi8BWYEfI3L0d8GIbGmcdFAS1uIRGjA=="],
 
     "qs": ["qs@6.15.3", "", { "dependencies": { "es-define-property": "^1.0.1", "side-channel": "^1.1.1" } }, "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A=="],
 

--- a/package.json
+++ b/package.json
@@ -141,6 +141,7 @@
     "material-icon-theme": "^5.35.0",
     "mermaid": "^11.14.0",
     "next-themes": "^0.3.0",
+    "qrcode.react": "^4.2.0",
     "react": "^18.3.1",
     "react-day-picker": "^8.10.1",
     "react-dom": "^18.3.1",

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -2987,9 +2987,14 @@ pub async fn sftp_create_file(
 
 /// Start the desktop-hosted shared-live web server.
 ///
-/// Shares the desktop's live `AcpManager` sessions with a browser/phone client
-/// over the LAN (the same server the standalone `termul-server` binary uses).
-/// Bind mode defaults to localhost; `all` exposes it on the LAN.
+/// Shares the desktop's live `AcpManager` sessions with a phone/browser client.
+///
+/// Starts the in-process localhost web server (the same one the standalone
+/// `termul-server` binary uses), then brings up a built-in cloudflared
+/// quick-tunnel so the phone can reach it on any network — the popover renders
+/// the ephemeral `https://*.trycloudflare.com` URL as a QR. The `bind_mode`
+/// param is accepted for API stability but ignored (the tunnel targets
+/// localhost). App auth / token-gating land in Epic 2.
 #[tauri::command]
 pub async fn remote_server_start(
     acp_manager: State<'_, Arc<crate::acp::AcpManager>>,
@@ -3002,7 +3007,7 @@ pub async fn remote_server_start(
     // Default to localhost only when the caller omits the bind mode; an
     // explicit-but-unrecognized value (e.g. a typo of "all") is an error — do
     // not silently downgrade to localhost (the phone would silently fail to
-    // connect on the LAN).
+    // connect).
     let bind_mode = match bind_mode.as_deref() {
         None => remote::RemoteBindMode::Localhost,
         Some(s) => remote::RemoteBindMode::parse(s).ok_or_else(|| {
@@ -3011,7 +3016,7 @@ pub async fn remote_server_start(
             )
         })?,
     };
-    match remote_state
+    let started = remote_state
         .start(
             acp_manager.inner().clone(),
             ws_relay.inner().clone(),
@@ -3019,9 +3024,38 @@ pub async fn remote_server_start(
             chat_history_cache.inner().clone(),
             bind_mode,
         )
-        .await
-    {
-        Ok(status) => Ok(IpcResult::success(status)),
+        .await;
+    match started {
+        Ok(status) => {
+            // Server is up on localhost. Bring up the cloudflared quick-tunnel so
+            // the phone can reach it on any network — the QR encodes the resulting
+            // ephemeral HTTPS URL (edge TLS via cloudflared; app auth is Epic 2).
+            // On tunnel failure, drain the server and surface the error so the
+            // popover never holds a localhost-only server + a stale toggle.
+            let port = match status.port {
+                Some(p) => p,
+                None => {
+                    return Ok(IpcResult::error(
+                        "started remote server reported no port".to_string(),
+                        "REMOTE_START_FAILED",
+                    ))
+                }
+            };
+            match remote::cloudflared::start_quick_tunnel(port).await {
+                Ok(tunnel) => {
+                    if let Err(e) = remote_state.attach_tunnel(tunnel.url, tunnel.child) {
+                        // Server stopped between start and attach; attach already
+                        // killed the orphan child. Surface the error.
+                        return Ok(IpcResult::error(e, "REMOTE_TUNNEL_FAILED"));
+                    }
+                    Ok(IpcResult::success(remote_state.status()))
+                }
+                Err(e) => {
+                    let _ = remote_state.stop().await;
+                    Ok(IpcResult::error(e, "REMOTE_TUNNEL_FAILED"))
+                }
+            }
+        }
         Err(e) => Ok(IpcResult::error(e, "REMOTE_START_FAILED")),
     }
 }

--- a/src-tauri/src/remote/cloudflared.rs
+++ b/src-tauri/src/remote/cloudflared.rs
@@ -1,0 +1,310 @@
+//! Built-in `cloudflared` quick-tunnel sidecar for the desktop-hosted
+//! shared-live server.
+//!
+//! Spawns `cloudflared tunnel --url http://localhost:{port}` so the desktop's
+//! live agent sessions become reachable from a phone on any network via an
+//! ephemeral `https://*.trycloudflare.com` URL (edge TLS, no account). The
+//! StatusBar popover encodes that URL as a QR — scan to open.
+//!
+//! ## Sidecar resolution
+//!
+//! Mirrors the `rg` sidecar convention (`resolve_rg_path` in
+//! `crate::commands`): per-target binary name + an env override
+//! (`TERMUL_CLOUDFLARED_PATH`) + the same candidate dirs (`src-tauri/bin`,
+//! `bin`, the running exe's dir, `../Resources`, `../lib`) + a `OnceLock`
+//! cache. In dev/cloudflare-installed setups the bare `cloudflared` on PATH is
+//! the last-resort fallback (`source = "path"`); production bundles resolve via
+//! the `sidecar` candidate once the license-gated release step ships the binary
+//! (see `spec-remote-qr-cloudflared-tunnel.md` Ask First).
+//!
+//! ## URL detection
+//!
+//! cloudflared prints the random trycloudflare hostname to stdout **or**
+//! stderr (varies across versions). We regex-match the URL shape
+//! `https://[a-z0-9-]+\.trycloudflare\.com` from both streams — the URL is the
+//! invariant, not the surrounding human sentence ("Your quick Tunnel…").
+//!
+//! ## Lifecycle
+//!
+//! The spawned [`tokio::process::Child`] is returned to the caller
+//! ([`RemoteServerState`]) so `stop()` can kill it alongside the Axum drain,
+//! and `kill_on_drop(true)` is a safety net for the panic/abort path.
+//! cloudflared provides edge TLS; application-level auth lands in Epic 2 —
+//! until then the random ephemeral URL is the only gate.
+
+use std::path::PathBuf;
+use std::sync::OnceLock;
+
+use lazy_static::lazy_static;
+use regex::Regex;
+use tokio::process::{Child, Command};
+use tokio::sync::{oneshot, Mutex};
+
+/// Spawn → URL deadline. cloudflared usually prints the URL within a few
+/// seconds; 25s tolerates slow cold starts / sluggish networks. Beyond this we
+/// give up, kill the child, and surface an error so the popover never hangs.
+const TUNNEL_URL_TIMEOUT_SECS: u64 = 25;
+
+lazy_static! {
+    static ref TRY_TUNNEL_URL_RE: Regex =
+        Regex::new(r"https://[a-z0-9-]+\.trycloudflare\.com").expect("valid static regex");
+}
+
+static CLOUDFLARED_PATH_CACHE: OnceLock<String> = OnceLock::new();
+
+#[cfg(target_os = "windows")]
+fn cloudflared_sidecar_name() -> &'static str {
+    "cloudflared-x86_64-pc-windows-msvc.exe"
+}
+#[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+fn cloudflared_sidecar_name() -> &'static str {
+    "cloudflared-aarch64-apple-darwin"
+}
+#[cfg(all(target_os = "macos", not(target_arch = "aarch64")))]
+fn cloudflared_sidecar_name() -> &'static str {
+    "cloudflared-x86_64-apple-darwin"
+}
+#[cfg(all(target_os = "linux", target_arch = "aarch64"))]
+fn cloudflared_sidecar_name() -> &'static str {
+    "cloudflared-aarch64-unknown-linux-gnu"
+}
+#[cfg(all(target_os = "linux", not(target_arch = "aarch64")))]
+fn cloudflared_sidecar_name() -> &'static str {
+    "cloudflared-x86_64-unknown-linux-musl"
+}
+#[cfg(not(any(target_os = "windows", target_os = "macos", target_os = "linux")))]
+fn cloudflared_sidecar_name() -> &'static str {
+    "cloudflared"
+}
+
+/// Resolve the cloudflared binary path. Mirrors `resolve_rg_path`:
+/// env override `TERMUL_CLOUDFLARED_PATH` (absolute, or relative to cwd /
+/// `src-tauri`), then the bundled sidecar under the same candidate dirs as
+/// `rg`. Returns `(path, source)`; `source = "path"` is the bare-name
+/// last-resort fallback (resolved via PATH at spawn time).
+///
+/// Keep this function pure / side-effect-free so it can be unit-tested without
+/// spawning processes.
+pub fn resolve_cloudflared_path() -> (String, String) {
+    if let Ok(env_val) = std::env::var("TERMUL_CLOUDFLARED_PATH") {
+        let trimmed = env_val.trim();
+        if !trimmed.is_empty() {
+            let env_path = PathBuf::from(trimmed);
+            if env_path.is_absolute() {
+                return (trimmed.to_string(), "env".to_string());
+            }
+            if let Ok(cwd) = std::env::current_dir() {
+                let direct = cwd.join(&env_path);
+                if direct.exists() && direct.is_file() {
+                    return (direct.to_string_lossy().to_string(), "env".to_string());
+                }
+                let from_src_tauri = cwd.join("src-tauri").join(&env_path);
+                if from_src_tauri.exists() && from_src_tauri.is_file() {
+                    return (
+                        from_src_tauri.to_string_lossy().to_string(),
+                        "env".to_string(),
+                    );
+                }
+            }
+            return (trimmed.to_string(), "env".to_string());
+        }
+    }
+
+    let binary = cloudflared_sidecar_name();
+    let mut candidates: Vec<PathBuf> = Vec::new();
+    if let Ok(cwd) = std::env::current_dir() {
+        candidates.push(cwd.join("src-tauri").join("bin").join(binary));
+        candidates.push(cwd.join("bin").join(binary));
+    }
+    if let Ok(exe) = std::env::current_exe() {
+        if let Some(exe_dir) = exe.parent() {
+            candidates.push(exe_dir.join(binary));
+            candidates.push(exe_dir.join("../Resources").join(binary));
+            candidates.push(exe_dir.join("../lib").join(binary));
+        }
+    }
+    if let Some(found) = candidates.into_iter().find(|p| p.exists() && p.is_file()) {
+        return (found.to_string_lossy().to_string(), "sidecar".to_string());
+    }
+    ("cloudflared".to_string(), "path".to_string())
+}
+
+/// Cached resolved path (first call wins; mirrors `detect_rg_path`).
+pub fn detect_cloudflared_path() -> String {
+    if let Some(cached) = CLOUDFLARED_PATH_CACHE.get() {
+        return cached.clone();
+    }
+    let (detected, _source) = resolve_cloudflared_path();
+    let _ = CLOUDFLARED_PATH_CACHE.set(detected.clone());
+    detected
+}
+
+#[cfg(target_os = "windows")]
+fn configure_background_command(command: &mut Command) {
+    // Reuse the same CREATE_NO_WINDOW flag (0x08000000) as the rg sidecar so
+    // spawning cloudflared never flashes a console window on Windows. tokio's
+    // `Command` exposes `creation_flags` as an inherent method on Windows.
+    command.creation_flags(0x0800_0000);
+}
+#[cfg(not(target_os = "windows"))]
+fn configure_background_command(_command: &mut Command) {}
+
+/// A started quick tunnel: the public URL to expose (e.g. as a QR) and the live
+/// child handle to kill on server stop / app exit.
+pub struct QuickTunnel {
+    pub url: String,
+    pub child: Child,
+}
+
+/// Spawn `cloudflared tunnel --url http://localhost:{port}` and wait (up to
+/// [`TUNNEL_URL_TIMEOUT_SECS`]) for the ephemeral trycloudflare URL.
+///
+/// # Errors
+/// - `cloudflared binary not found at <path>: <io>` — spawn failed (binary
+///   not installed / not bundled / PATH miss).
+/// - `cloudflared exited before producing a tunnel URL` — the process died
+///   without printing the URL.
+/// - `tunnel URL not received within <N>s` — cloudflared ran but never
+///   printed the URL (no internet, registration rejected, slow cold start).
+///
+/// On any error the child is killed before returning — no orphaned process.
+pub async fn start_quick_tunnel(port: u16) -> Result<QuickTunnel, String> {
+    let path = detect_cloudflared_path();
+    let mut command = Command::new(&path);
+    command
+        .args(["tunnel", "--url", &format!("http://localhost:{port}")])
+        .stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .kill_on_drop(true);
+    configure_background_command(&mut command);
+
+    let mut child = command
+        .spawn()
+        .map_err(|e| format!("cloudflared binary not found at {path}: {e}"))?;
+
+    let stdout = child
+        .stdout
+        .take()
+        .ok_or_else(|| "cloudflared stdout pipe missing".to_string())?;
+    let stderr = child
+        .stderr
+        .take()
+        .ok_or_else(|| "cloudflared stderr pipe missing".to_string())?;
+
+    let (url_tx, url_rx) = oneshot::channel::<String>();
+    let url_tx = std::sync::Arc::new(Mutex::new(Some(url_tx)));
+
+    spawn_line_scanner(stdout, url_tx.clone());
+    spawn_line_scanner(stderr, url_tx);
+
+    match tokio::time::timeout(
+        std::time::Duration::from_secs(TUNNEL_URL_TIMEOUT_SECS),
+        url_rx,
+    )
+    .await
+    {
+        Ok(Ok(url)) => Ok(QuickTunnel { url, child }),
+        // Sender dropped without sending → cloudflared exited before printing.
+        Ok(Err(_)) => {
+            let _ = child.kill().await;
+            Err("cloudflared exited before producing a tunnel URL".to_string())
+        }
+        Err(_) => {
+            let _ = child.kill().await;
+            Err(format!(
+                "tunnel URL not received within {TUNNEL_URL_TIMEOUT_SECS}s"
+            ))
+        }
+    }
+}
+
+/// Read lines from `reader` and fire the first trycloudflare URL match through
+/// `url_tx`. On EOF without a match it drops the sender so the caller's oneshot
+/// resolves with `Err` (→ "exited before producing a URL").
+fn spawn_line_scanner<R>(reader: R, url_tx: std::sync::Arc<Mutex<Option<oneshot::Sender<String>>>>)
+where
+    R: tokio::io::AsyncRead + Unpin + Send + 'static,
+{
+    use tokio::io::{AsyncBufReadExt, BufReader};
+
+    tokio::spawn(async move {
+        let mut reader = BufReader::new(reader);
+        let mut line = String::new();
+        loop {
+            line.clear();
+            match reader.read_line(&mut line).await {
+                Ok(0) => break, // EOF
+                Ok(_) => {
+                    if let Some(m) = TRY_TUNNEL_URL_RE.find(&line) {
+                        if let Some(tx) = url_tx.lock().await.take() {
+                            let _ = tx.send(m.as_str().to_string());
+                        }
+                        return;
+                    }
+                }
+                Err(_) => break,
+            }
+        }
+        // EOF without a URL — drop the sender so the caller resolves Err.
+        url_tx.lock().await.take();
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sidecar_name_is_nonempty() {
+        assert!(!cloudflared_sidecar_name().is_empty());
+    }
+
+    #[test]
+    fn resolve_path_returns_a_string_and_known_source() {
+        let (path, source) = resolve_cloudflared_path();
+        assert!(!path.is_empty());
+        // "env" only with the env var set; "sidecar" when a bundled file is
+        // found; "path" is the bare-name fallback (dev/CI without the binary).
+        assert!(
+            matches!(source.as_str(), "env" | "sidecar" | "path"),
+            "unexpected source: {source}"
+        );
+    }
+
+    #[test]
+    fn detect_caches_first_resolution() {
+        let a = detect_cloudflared_path();
+        let b = detect_cloudflared_path();
+        assert_eq!(a, b, "detect_cloudflared_path must be idempotent");
+    }
+
+    #[test]
+    fn url_regex_matches_trycloudflare_hostnames() {
+        let line = "2026-07-30 INF Your quick Tunnel has been created! Visit it at: https://foo-bar-baz.trycloudflare.com";
+        let m = TRY_TUNNEL_URL_RE.find(line).expect("must match");
+        assert_eq!(m.as_str(), "https://foo-bar-baz.trycloudflare.com");
+    }
+
+    #[test]
+    fn url_regex_matches_inside_json_logs() {
+        let line = "{\"level\":\"info\",\"url\":\"https://random-words-1234.trycloudflare.com\"}";
+        let m = TRY_TUNNEL_URL_RE.find(line).expect("must match");
+        assert_eq!(m.as_str(), "https://random-words-1234.trycloudflare.com");
+    }
+
+    #[test]
+    fn url_regex_ignores_localhost_urls() {
+        // The QR must encode the PUBLIC tunnel URL, never the local one.
+        assert!(TRY_TUNNEL_URL_RE
+            .find("listening on http://localhost:5123")
+            .is_none());
+    }
+
+    #[test]
+    fn url_regex_ignores_arbitrary_https_urls() {
+        assert!(TRY_TUNNEL_URL_RE
+            .find("redirect to https://example.com/path")
+            .is_none());
+    }
+}

--- a/src-tauri/src/remote/host.rs
+++ b/src-tauri/src/remote/host.rs
@@ -30,6 +30,7 @@ use std::net::SocketAddr;
 use std::sync::Arc;
 
 use serde::Serialize;
+use tokio::process::Child;
 use tokio::sync::oneshot;
 use tracing::{info, warn};
 
@@ -80,6 +81,13 @@ impl RemoteBindMode {
     }
 
     /// `true` when bound to all interfaces (LAN-exposed).
+    ///
+    /// Currently unused: the desktop-hosted server always binds localhost
+    /// because the cloudflared quick-tunnel targets it (the LAN `all` mode is
+    /// removed from the popover and deferred — see
+    /// `spec-remote-qr-cloudflared-tunnel`). Retained + tested for the
+    /// deferred LAN-only connect mode.
+    #[allow(dead_code)]
     pub fn is_lan_exposed(self) -> bool {
         matches!(self, Self::All)
     }
@@ -99,6 +107,10 @@ pub struct RemoteStatus {
     pub bind_mode: Option<String>,
     /// Bind host shown in the UI (`127.0.0.1` or `0.0.0.0`).
     pub bind_host: Option<String>,
+    /// Ephemeral `https://*.trycloudflare.com` tunnel URL when the built-in
+    /// cloudflared quick-tunnel is up; `None` when stopped or before the URL
+    /// arrives. The StatusBar QR encodes this (never the local `url`).
+    pub tunnel_url: Option<String>,
 }
 
 impl RemoteStatus {
@@ -109,15 +121,15 @@ impl RemoteStatus {
             port: None,
             bind_mode: None,
             bind_host: None,
+            tunnel_url: None,
         }
     }
 
-    fn running(addr: SocketAddr, bind_mode: RemoteBindMode) -> Self {
-        // When bound to 0.0.0.0 (LAN-exposed), the host's LAN IP can't be known
-        // from the bind address alone, so don't fabricate a loopback URL the
-        // phone can't reach — leave `url` empty and let the status-bar UI show
-        // "connect via this machine's LAN IP:{port}". On localhost the URL is
-        // concrete and useful.
+    fn running(addr: SocketAddr, bind_mode: RemoteBindMode, tunnel_url: Option<String>) -> Self {
+        // The desktop-hosted server always binds localhost (the cloudflared
+        // quick-tunnel targets it), so `url` is a concrete loopback URL — kept
+        // for "open on this machine" diagnostics. The phone-reachable address
+        // is `tunnel_url`, which the popover renders as a QR.
         let url = if addr.ip().is_unspecified() {
             None
         } else {
@@ -129,6 +141,7 @@ impl RemoteStatus {
             port: Some(addr.port()),
             bind_mode: Some(bind_mode.as_str().to_string()),
             bind_host: Some(bind_mode.display_host().to_string()),
+            tunnel_url,
         }
     }
 }
@@ -142,6 +155,11 @@ struct RemoteServer {
     serve_handle: Option<tokio::task::JoinHandle<()>>,
     addr: SocketAddr,
     bind_mode: RemoteBindMode,
+    /// Ephemeral trycloudflare URL (set when the quick-tunnel came up).
+    tunnel_url: Option<String>,
+    /// Live `cloudflared` child. Killed in `stop()`; `kill_on_drop(true)` is
+    /// the safety net for the panic/abort path where `stop()` never runs.
+    tunnel_child: Option<Child>,
 }
 
 impl RemoteServer {
@@ -158,7 +176,9 @@ impl Drop for RemoteServer {
     fn drop(&mut self) {
         // Best-effort graceful shutdown on drop (e.g. app exit). Signal the
         // serve task to drain; the JoinHandle is left to the runtime to reap
-        // (awaiting it in `Drop` isn't possible — `Drop` is sync).
+        // (awaiting it in `Drop` isn't possible — `Drop` is sync). The
+        // cloudflared `tunnel_child` is dropped here too — its `kill_on_drop`
+        // guarantees the process is reaped even when `stop()` never ran.
         if let Some(tx) = self.shutdown_tx.take() {
             let _ = tx.send(());
         }
@@ -194,20 +214,20 @@ impl RemoteServerState {
         ws_relay: Arc<WsRelaySink>,
         registry: Arc<ProjectRegistry>,
         chat_history_cache: Arc<ChatHistoryCache>,
-        bind_mode: RemoteBindMode,
+        _bind_mode: RemoteBindMode,
     ) -> Result<RemoteStatus, String> {
+        // The built-in cloudflared quick-tunnel forwards to localhost, so the
+        // desktop-hosted server always binds localhost regardless of the
+        // caller's bind mode — the LAN `all` mode is removed from the popover
+        // and deferred (see spec-remote-qr-cloudflared-tunnel). The param stays
+        // for API stability / the standalone binary's parity path; it is
+        // ignored here (`_bind_mode`) to avoid churning every caller.
+        let bind_mode = RemoteBindMode::Localhost;
         {
             let slot = self.inner.lock().unwrap();
             if slot.is_some() {
                 return Err("Remote server is already running".to_string());
             }
-        }
-
-        if bind_mode.is_lan_exposed() {
-            warn!(
-                "Binding shared-live server to 0.0.0.0 — LAN exposure without auth \
-                 (Epic 2). Anyone on the network can drive the live agent sessions."
-            );
         }
 
         // PR-S4: resolve the project-root boundary for the fs_api routes.
@@ -272,7 +292,7 @@ impl RemoteServerState {
         .await
         .map_err(|e| format!("Failed to start remote server: {}", e))?;
 
-        let status = RemoteStatus::running(addr, bind_mode);
+        let status = RemoteStatus::running(addr, bind_mode, None);
         info!(
             "Shared-live web server sharing desktop AcpManager on http://{}",
             addr
@@ -293,6 +313,11 @@ impl RemoteServerState {
             serve_handle: Some(serve_handle),
             addr,
             bind_mode,
+            // Tunnel URL + child are attached after `cloudflared::start_quick_tunnel`
+            // resolves in `remote_server_start` — keeps this method testable without
+            // a real cloudflared binary (the lifecycle tests bind/stop/status here).
+            tunnel_url: None,
+            tunnel_child: None,
         });
         Ok(status)
     }
@@ -307,6 +332,16 @@ impl RemoteServerState {
         let server = { self.inner.lock().unwrap().take() };
         match server {
             Some(mut server) => {
+                // Kill the cloudflared child first so the public tunnel stops
+                // forwarding new traffic before Axum drains existing conns.
+                // (kill_on_drop would also reap it on Drop, but an explicit
+                // kill here lets us await + log failures, and the child stays
+                // owned until this call so Drop can't race us.)
+                if let Some(mut child) = server.tunnel_child.take() {
+                    if let Err(e) = child.kill().await {
+                        warn!("cloudflared child kill failed during stop: {e}");
+                    }
+                }
                 // Signal drain, then await the serve task so Axum finishes
                 // flushing before the caller proceeds (e.g. app exit →
                 // `kill_all`). `Drop` would only signal; awaiting here enforces
@@ -336,11 +371,41 @@ impl RemoteServerState {
             // If the spawned serve task has exited (error/panic), don't keep
             // reporting `running` with a dead listener — surface stopped so the
             // UI doesn't lie about a server the phone can't reach.
-            Some(server) if !server.task_finished() => {
-                RemoteStatus::running(server.addr, server.bind_mode)
-            }
+            Some(server) if !server.task_finished() => RemoteStatus::running(
+                server.addr,
+                server.bind_mode,
+                server.tunnel_url.clone(),
+            ),
             Some(_) => RemoteStatus::stopped(),
             None => RemoteStatus::stopped(),
+        }
+    }
+
+    /// Attach a started cloudflared quick-tunnel (URL + live child) to the
+    /// running server so [`status`](Self::status) reports the tunnel URL and
+    /// [`stop`](Self::stop) kills the child. Called by `remote_server_start`
+    /// after the server binds and `cloudflared::start_quick_tunnel` resolves.
+    ///
+    /// If the server stopped/died between `start` and this call, the orphaned
+    /// child is killed (sync `start_kill`) so no cloudflared lingers. Keeping
+    /// this out of `start` lets the server-lifecycle unit tests run without a
+    /// real cloudflared binary.
+    pub fn attach_tunnel(&self, url: String, child: Child) -> Result<(), String> {
+        let mut child = Some(child);
+        let mut slot = self.inner.lock().unwrap();
+        match slot.as_mut() {
+            Some(server) if !server.task_finished() => {
+                server.tunnel_url = Some(url);
+                server.tunnel_child = child.take();
+                Ok(())
+            }
+            _ => {
+                // Server gone — kill the orphan we still hold (sync).
+                if let Some(c) = child.as_mut() {
+                    let _ = c.start_kill();
+                }
+                Err("remote server stopped before tunnel attached".to_string())
+            }
         }
     }
 }
@@ -393,17 +458,33 @@ mod tests {
         assert_eq!(s.port, None);
         assert_eq!(s.bind_mode, None);
         assert_eq!(s.bind_host, None);
+        assert_eq!(s.tunnel_url, None);
     }
 
     #[test]
     fn remote_status_running_localhost_uses_loopback_url() {
         let addr: SocketAddr = "127.0.0.1:5123".parse().unwrap();
-        let s = RemoteStatus::running(addr, RemoteBindMode::Localhost);
+        let s = RemoteStatus::running(addr, RemoteBindMode::Localhost, None);
         assert!(s.running);
         assert_eq!(s.url.as_deref(), Some("http://127.0.0.1:5123"));
         assert_eq!(s.port, Some(5123));
         assert_eq!(s.bind_mode.as_deref(), Some("localhost"));
         assert_eq!(s.bind_host.as_deref(), Some("127.0.0.1"));
+        assert_eq!(s.tunnel_url, None);
+    }
+
+    #[test]
+    fn remote_status_running_carries_tunnel_url() {
+        let addr: SocketAddr = "127.0.0.1:5123".parse().unwrap();
+        let s = RemoteStatus::running(
+            addr,
+            RemoteBindMode::Localhost,
+            Some("https://foo-bar.trycloudflare.com".to_string()),
+        );
+        assert_eq!(
+            s.tunnel_url.as_deref(),
+            Some("https://foo-bar.trycloudflare.com")
+        );
     }
 
     #[test]
@@ -412,7 +493,7 @@ mod tests {
         // address, so `url` is `None` (the UI shows "use this machine's LAN
         // IP:{port}"). Don't fabricate a loopback URL the phone can't reach.
         let addr: SocketAddr = "0.0.0.0:8080".parse().unwrap();
-        let s = RemoteStatus::running(addr, RemoteBindMode::All);
+        let s = RemoteStatus::running(addr, RemoteBindMode::All, None);
         assert!(s.running);
         assert_eq!(s.url, None, "0.0.0.0 must not fabricate a loopback URL");
         assert_eq!(s.port, Some(8080));

--- a/src-tauri/src/remote/mod.rs
+++ b/src-tauri/src/remote/mod.rs
@@ -10,6 +10,7 @@
 //! web server has no `/api/projects` or `/api/spawn` routes — the phone connects
 //! directly to a session via the WS URL. Auth / token-gating land in Epic 2.
 
+pub mod cloudflared;
 pub mod host;
 
 pub use host::{RemoteBindMode, RemoteServerState, RemoteStatus};

--- a/src/renderer/components/RemoteAccessPopover.test.tsx
+++ b/src/renderer/components/RemoteAccessPopover.test.tsx
@@ -1,0 +1,150 @@
+import type { RemoteStatus } from '@shared/types/ipc.types'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { TooltipProvider } from '@/components/ui/tooltip'
+import { RemoteAccessPopover } from './RemoteAccessPopover'
+
+// QR mock: expose the encoded value so tests assert the URL the QR would draw,
+// without depending on qrcode.react's SVG internals under jsdom.
+vi.mock('qrcode.react', () => ({
+  QRCodeSVG: ({ value }: { value: string }) => <div data-testid="qr" data-value={value} />
+}))
+
+// Remote status store: `useRemoteStatus` is configurable per test; `getState`
+// is used only on the toggle-success path.
+const setStatus = vi.fn()
+vi.mock('@/stores/remote-status-store', () => ({
+  useRemoteStatus: vi.fn((): RemoteStatus | null => null),
+  useRemoteStatusStore: { getState: () => ({ setStatus }) }
+}))
+
+const startMock = vi.fn()
+const stopMock = vi.fn()
+vi.mock('@/lib/api', () => ({
+  remoteServerApi: {
+    start: (...args: unknown[]) => startMock(...args),
+    stop: () => stopMock(),
+    status: vi.fn()
+  },
+  syncProjects: vi.fn(() => Promise.resolve({ success: true, data: undefined })),
+  syncChatHistory: vi.fn(() => Promise.resolve({ success: true, data: undefined }))
+}))
+
+vi.mock('@/stores/project-store', () => ({
+  useProjectStore: {
+    getState: () => ({ projects: [], activeProjectId: null })
+  }
+}))
+
+vi.mock('@/stores/acp-store', () => ({
+  useAcpStore: {
+    getState: () => ({
+      loadSessionIndex: vi.fn(async () => {}),
+      sessionIndex: [],
+      messages: {}
+    })
+  }
+}))
+
+vi.mock('@/hooks/use-projects-persistence', () => ({
+  toProjectSummaries: vi.fn(() => [])
+}))
+
+vi.mock('@/lib/acp-history-persistence', () => ({
+  toPersistedSessionSummaries: vi.fn(() => [])
+}))
+
+// Silence sonner toasts in test output.
+vi.mock('sonner', () => ({ toast: { error: vi.fn() } }))
+
+import { syncChatHistory, syncProjects } from '@/lib/api'
+import { useRemoteStatus } from '@/stores/remote-status-store'
+
+const RUNNING: RemoteStatus = {
+  running: true,
+  url: 'http://127.0.0.1:5123',
+  port: 5123,
+  bindMode: 'localhost',
+  bindHost: '127.0.0.1',
+  tunnelUrl: 'https://foo-bar.trycloudflare.com'
+}
+
+function renderPopover(): ReturnType<typeof render> {
+  return render(
+    <TooltipProvider>
+      <RemoteAccessPopover />
+    </TooltipProvider>
+  )
+}
+
+/** Click the StatusBar trigger to open the Radix popover, then wait for the
+ * toggle switch to mount (the content is portalled into document.body). */
+async function openPopover(): Promise<HTMLElement> {
+  const trigger = screen.getByLabelText('Remote terminal access')
+  await fireEvent.click(trigger)
+  return screen.findByRole('switch')
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  vi.mocked(useRemoteStatus).mockReturnValue(null)
+})
+
+afterEach(() => {
+  vi.mocked(useRemoteStatus).mockReturnValue(null)
+})
+
+describe('RemoteAccessPopover', () => {
+  it('shows the globe trigger with the toggle off when no status', () => {
+    renderPopover()
+    const trigger = screen.getByLabelText('Remote terminal access')
+    expect(trigger.getAttribute('aria-pressed')).toBe('false')
+    // Popover is closed → no QR / copy-link in the DOM yet.
+    expect(screen.queryByTestId('qr')).toBeNull()
+    expect(screen.queryByText('Copy link')).toBeNull()
+  })
+
+  it('renders a QR from tunnelUrl when running (no bind selector, no URL row)', async () => {
+    vi.mocked(useRemoteStatus).mockReturnValue(RUNNING)
+    renderPopover()
+    await openPopover()
+
+    const qr = screen.getByTestId('qr')
+    expect(qr.getAttribute('data-value')).toBe(RUNNING.tunnelUrl)
+    // The simplify goal: no bind selector, no open-in-browser text row.
+    expect(screen.queryByText('Listen on')).toBeNull()
+    expect(screen.queryByText('Open in browser')).toBeNull()
+    expect(screen.getByText('Copy link')).toBeDefined()
+  })
+
+  it('shows an inline error when start fails (no QR)', async () => {
+    startMock.mockResolvedValueOnce({ success: false, error: 'tunnel down' })
+    renderPopover()
+
+    const toggle = await openPopover()
+    await fireEvent.click(toggle)
+
+    expect(await screen.findByText('tunnel down')).toBeDefined()
+    expect(screen.queryByTestId('qr')).toBeNull()
+  })
+
+  it('starts remote access with no bind-mode arg on toggle on and seeds the web client', async () => {
+    startMock.mockResolvedValueOnce({ success: true, data: RUNNING })
+    renderPopover()
+
+    const toggle = await openPopover()
+    await fireEvent.click(toggle)
+
+    // start() is called with no bindMode — the tunnel forces localhost.
+    await waitFor(() => {
+      expect(startMock).toHaveBeenCalledTimes(1)
+    })
+    expect(startMock).toHaveBeenCalledWith()
+    expect(setStatus).toHaveBeenCalledWith(RUNNING)
+    // Epic-4 bridge: project list + chat-history seeded on success.
+    await waitFor(() => {
+      expect(syncProjects).toHaveBeenCalledTimes(1)
+      expect(syncChatHistory).toHaveBeenCalledTimes(1)
+    })
+  })
+})

--- a/src/renderer/components/RemoteAccessPopover.tsx
+++ b/src/renderer/components/RemoteAccessPopover.tsx
@@ -1,42 +1,47 @@
-import { AlertCircle, Check, Copy, ExternalLink, Monitor, ShieldAlert } from 'lucide-react'
+import { AlertCircle, Check, Copy, Monitor, ShieldAlert } from 'lucide-react'
+import { QRCodeSVG } from 'qrcode.react'
 import { useState } from 'react'
 import { toast } from 'sonner'
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
 import { Switch } from '@/components/ui/switch'
-import { useUpdateAppSetting } from '@/hooks/use-app-settings'
 import { toProjectSummaries } from '@/hooks/use-projects-persistence'
 import { toPersistedSessionSummaries } from '@/lib/acp-history-persistence'
-import { openerApi, remoteServerApi, syncChatHistory, syncProjects } from '@/lib/api'
+import { remoteServerApi, syncChatHistory, syncProjects } from '@/lib/api'
 import { cn } from '@/lib/utils'
 import { useAcpStore } from '@/stores/acp-store'
-import { useAppSettingsStore } from '@/stores/app-settings-store'
 import { useProjectStore } from '@/stores/project-store'
 import { useRemoteStatus, useRemoteStatusStore } from '@/stores/remote-status-store'
-import { REMOTE_BIND_MODE_OPTIONS, type RemoteBindMode } from '@/types/settings'
 
 const statusBarTriggerClass =
   'flex items-center hover:bg-white/10 px-2 py-0.5 rounded cursor-pointer transition-colors'
 
+/**
+ * StatusBar popover for remote agent access.
+ *
+ * Enabling starts the in-process localhost web server + a built-in cloudflared
+ * quick-tunnel, producing an ephemeral `https://*.trycloudflare.com` URL the
+ * phone can reach on any network. That URL is rendered as a QR — scan to open.
+ * No bind selector, no URL text row: the QR is the connect UI.
+ *
+ * Security posture (until Epic 2 ships a real token): cloudflared provides edge
+ * TLS; the random ephemeral URL is the only gate. The warning below makes that
+ * explicit and tells the user to toggle off to rotate.
+ */
 export function RemoteAccessPopover(): React.JSX.Element {
   const remoteStatus = useRemoteStatus()
-  const remoteBindMode = useAppSettingsStore((s) => s.settings.remoteBindMode)
-  const updateSetting = useUpdateAppSetting()
   const [remoteBusy, setRemoteBusy] = useState(false)
   const [remoteError, setRemoteError] = useState<string | null>(null)
   const [copiedUrl, setCopiedUrl] = useState(false)
-  const [openError, setOpenError] = useState<string | null>(null)
 
   const isRunning = remoteStatus?.running ?? false
-  const url = remoteStatus?.url ?? null
+  // The QR encodes the public tunnel URL only — never the localhost `url`.
+  const tunnelUrl = remoteStatus?.tunnelUrl ?? null
 
   const handleRemoteToggle = async (enable: boolean): Promise<void> => {
     setRemoteBusy(true)
     setRemoteError(null)
-    setOpenError(null)
     try {
-      const result = enable
-        ? await remoteServerApi.start({ bindMode: remoteBindMode })
-        : await remoteServerApi.stop()
+      const result = enable ? await remoteServerApi.start() : await remoteServerApi.stop()
       if (result.success) {
         useRemoteStatusStore.getState().setStatus(result.data)
         // Epic-4 bridge: seed the in-memory project registry so the web/remote
@@ -55,8 +60,8 @@ export function RemoteAccessPopover(): React.JSX.Element {
             toast.error(`Failed to seed remote project list: ${syncResult.error}`)
           }
           // Seed the chat-history cache (index + visible payloads) so the web
-          // sidebar shows the desktop's chats immediately (the live-push path in
-          // `useAcpHistorySync` + `persistSession` keeps it in sync).
+          // sidebar shows the desktop's chats immediately (the live-push path
+          // in `useAcpHistorySync` + `persistSession` keeps it in sync).
           // Await the session-index load first so the seed is not empty (the
           // app-mount load in `useAcpHistory` may race with server-start).
           await useAcpStore.getState().loadSessionIndex()
@@ -89,24 +94,14 @@ export function RemoteAccessPopover(): React.JSX.Element {
     }
   }
 
-  const handleCopyRemote = async (value: string): Promise<void> => {
+  const handleCopyLink = async (): Promise<void> => {
+    if (!tunnelUrl) return
     try {
-      await navigator.clipboard.writeText(value)
+      await navigator.clipboard.writeText(tunnelUrl)
       setCopiedUrl(true)
       setTimeout(() => setCopiedUrl(false), 1500)
     } catch {
       // Clipboard unavailable; ignore.
-    }
-  }
-
-  const handleOpenInBrowser = async (): Promise<void> => {
-    if (!url) return
-    setOpenError(null)
-    const result = await openerApi.openUrlWithSystemBrowser(url)
-    if (!result.success) {
-      const message = result.error ?? 'Failed to open URL in browser'
-      setOpenError(message)
-      toast.error(message)
     }
   }
 
@@ -123,34 +118,12 @@ export function RemoteAccessPopover(): React.JSX.Element {
           {isRunning && <span className="sr-only">Remote access enabled</span>}
         </button>
       </PopoverTrigger>
-      <PopoverContent side="top" align="end" className="w-96 p-4">
-        <div className="space-y-4">
+      <PopoverContent side="top" align="end" className="w-72 p-4">
+        <div className="space-y-3">
           <div>
             <h4 className="font-medium text-sm text-foreground">Remote Agent Access</h4>
             <p className="text-xs text-muted-foreground mt-1">
-              Share your live agent sessions with a browser or phone over HTTP + WebSocket.
-            </p>
-          </div>
-
-          <div>
-            <label className="block text-sm font-medium text-secondary-foreground mb-2">
-              Listen on
-            </label>
-            <select
-              value={remoteBindMode}
-              onChange={(e) => updateSetting('remoteBindMode', e.target.value as RemoteBindMode)}
-              disabled={isRunning}
-              className="w-full bg-secondary/50 border border-border rounded-lg px-3 py-2 text-sm text-foreground focus:ring-2 focus:ring-primary focus:border-transparent outline-none transition-shadow disabled:opacity-50 disabled:cursor-not-allowed"
-            >
-              {REMOTE_BIND_MODE_OPTIONS.map((option) => (
-                <option key={option.value} value={option.value}>
-                  {option.label}
-                </option>
-              ))}
-            </select>
-            <p className="text-xs text-muted-foreground mt-1">
-              {REMOTE_BIND_MODE_OPTIONS.find((o) => o.value === remoteBindMode)?.description}
-              {isRunning && <> Stop the server to change the bind address.</>}
+              Scan the QR to open your live agent sessions on a phone, on any network.
             </p>
           </div>
 
@@ -158,9 +131,7 @@ export function RemoteAccessPopover(): React.JSX.Element {
             <div className="flex-1 min-w-0">
               <div className="text-sm text-foreground">Enable remote access</div>
               <div className="text-xs text-muted-foreground mt-0.5">
-                {remoteBindMode === 'all'
-                  ? 'Starts a server on 0.0.0.0 (all network interfaces)'
-                  : 'Starts a server on 127.0.0.1 (this machine only)'}
+                Starts a local server + a cloudflared tunnel.
               </div>
             </div>
             <Switch
@@ -178,94 +149,36 @@ export function RemoteAccessPopover(): React.JSX.Element {
             </div>
           )}
 
-          {isRunning && url && (
-            <div className="space-y-3">
+          {isRunning && tunnelUrl && (
+            <div className="space-y-2">
+              {/* White pad so the black QR modules are legible in dark themes. */}
+              <div className="flex justify-center">
+                <div className="rounded-lg bg-white p-2">
+                  <QRCodeSVG value={tunnelUrl} size={160} level="M" />
+                </div>
+              </div>
               <div className="flex items-start gap-2 text-xs text-amber-600 dark:text-amber-400 bg-amber-500/10 border border-amber-500/30 rounded-md px-3 py-2">
                 <ShieldAlert className="w-4 h-4 mt-0.5 shrink-0" />
                 <span>
-                  Anyone who can reach this address can drive your live agent sessions. There is no
-                  auth token yet — full auth + TLS land in a later release.{' '}
-                  {remoteStatus?.bindMode === 'all' ? (
-                    <>
-                      The server listens on <strong>all interfaces</strong>; devices on your LAN can
-                      connect using this machine&apos;s IP and the port below. Exposing it on the
-                      LAN before auth ships is your explicit decision.
-                    </>
-                  ) : (
-                    <>
-                      The server listens on <strong>localhost only</strong>. To reach it from
-                      another device, use a tunnel (e.g.{' '}
-                      <code className="text-2xs">cloudflared</code>) or switch to &quot;All
-                      interfaces&quot; and restart.
-                    </>
-                  )}
+                  No auth yet — anyone with this link can drive your live agent. The link is random
+                  and shown only to you. Toggle off to rotate.
                 </span>
               </div>
+              <button
+                type="button"
+                onClick={() => void handleCopyLink()}
+                className="w-full inline-flex items-center justify-center gap-2 text-xs bg-secondary hover:bg-secondary/80 border border-border rounded-md px-3 py-1.5 transition-colors"
+                aria-label="Copy tunnel link"
+              >
+                {copiedUrl ? <Check className="w-3.5 h-3.5" /> : <Copy className="w-3.5 h-3.5" />}
+                {copiedUrl ? 'Copied' : 'Copy link'}
+              </button>
+            </div>
+          )}
 
-              <div className="grid grid-cols-2 gap-3">
-                <div>
-                  <div className="text-xs text-muted-foreground mb-1">Bind host</div>
-                  <div className="text-sm font-mono text-foreground bg-secondary/50 border border-border rounded-md px-3 py-2">
-                    {remoteStatus?.bindHost ?? '—'}
-                  </div>
-                </div>
-                <div>
-                  <div className="text-xs text-muted-foreground mb-1">Port</div>
-                  <div className="text-sm font-mono text-foreground bg-secondary/50 border border-border rounded-md px-3 py-2">
-                    {remoteStatus?.port ?? '—'}
-                  </div>
-                </div>
-                <div className="col-span-2">
-                  <div className="text-xs text-muted-foreground mb-1">Open on this machine</div>
-                  <div className="text-sm font-mono text-foreground bg-secondary/50 border border-border rounded-md px-3 py-2 truncate">
-                    {url.replace(/^https?:\/\//, '')}
-                  </div>
-                </div>
-              </div>
-
-              {remoteStatus?.bindMode === 'all' && (
-                <p className="text-xs text-muted-foreground">
-                  On other devices, open{' '}
-                  <span className="font-mono">
-                    http://&lt;this-machine-ip&gt;:{remoteStatus.port}
-                  </span>{' '}
-                  (replace with your LAN IP).
-                </p>
-              )}
-
-              <div>
-                <div className="text-xs text-muted-foreground mb-1">Open in browser</div>
-                <div className="flex items-center gap-2">
-                  <input
-                    readOnly
-                    value={url}
-                    className="flex-1 min-w-0 text-sm font-mono text-foreground bg-secondary/50 border border-border rounded-md px-3 py-2 outline-none select-all"
-                    onFocus={(e) => e.currentTarget.select()}
-                  />
-                  <button
-                    type="button"
-                    onClick={() => void handleCopyRemote(url)}
-                    className="shrink-0 inline-flex items-center gap-1 text-sm bg-secondary hover:bg-secondary/80 border border-border rounded-md px-3 py-2 transition-colors"
-                    aria-label="Copy URL"
-                  >
-                    {copiedUrl ? <Check className="w-4 h-4" /> : <Copy className="w-4 h-4" />}
-                    {copiedUrl ? 'Copied' : 'Copy'}
-                  </button>
-                </div>
-                <button
-                  type="button"
-                  onClick={() => void handleOpenInBrowser()}
-                  className="mt-2 w-full inline-flex items-center justify-center gap-2 text-sm bg-primary text-primary-foreground hover:bg-primary/90 rounded-md px-3 py-2 transition-colors"
-                >
-                  <ExternalLink className="w-4 h-4" />
-                  Open in browser
-                </button>
-                {openError && <p className="text-xs text-destructive mt-1">{openError}</p>}
-                <p className="text-xs text-muted-foreground mt-1">
-                  Open this URL in a browser to follow your live agent sessions. No token required
-                  yet.
-                </p>
-              </div>
+          {isRunning && !tunnelUrl && (
+            <div className="flex items-center justify-center text-xs text-muted-foreground py-2">
+              Starting tunnel…
             </div>
           )}
         </div>

--- a/src/shared/types/ipc.types.ts
+++ b/src/shared/types/ipc.types.ts
@@ -335,6 +335,8 @@ export interface RemoteStatus {
   bindMode: RemoteBindMode | null
   /** `127.0.0.1` or `0.0.0.0` while running. */
   bindHost: string | null
+  /** Ephemeral `https://*.trycloudflare.com` tunnel URL (QR-encoded). */
+  tunnelUrl: string | null
 }
 
 // Remote terminal server control API


### PR DESCRIPTION
## Summary

Getting the desktop's live agent sessions onto a phone was clunky: the `RemoteAccessPopover` forced the user to pick a bind mode, find their LAN IP (or run an external `cloudflared` by hand), then copy/type a URL — text-heavy and phone-hostile.

This PR makes it scan-to-connect. Enabling remote access now starts the in-process localhost web server **and** spawns a built-in `cloudflared` quick-tunnel, producing an ephemeral `https://*.trycloudflare.com` URL. The popover's bind selector + URL/Open-in-browser/Copy row is replaced by a single **QR** encoding that URL — scan to open on any phone, on any network.

## Related Issue

No related issue. Feature work is specified in `_bmad-output/implementation-artifacts/spec-remote-qr-cloudflared-tunnel.md`. No existing open/closed PRs address this (searched `remote`, `qr`, `tunnel`).

## Type of Change

- [x] feat: new feature

## What Changed

- **`src-tauri/src/remote/cloudflared.rs` (new)** — Sidecar name + path resolution mirroring the existing `rg` sidecar (`TERMUL_CLOUDFLARED_PATH` env override + the same candidate dirs + `OnceLock` cache), async spawn of `cloudflared tunnel --url http://localhost:{port}`, URL regex (`https://[a-z0-9-]+\.trycloudflare\.com`) parsed from **both** stdout and stderr, `Child` handle with `kill_on_drop(true)`. Unit-tested (path resolution + URL regex).
- **`src-tauri/src/remote/host.rs`** — `RemoteServerState` gains `tunnel_url` + `tunnel_child`; `start()` stays server-only (so the lifecycle unit tests run **without** a real cloudflared binary — CI-safe); new `attach_tunnel(url, child)` registers the URL + child; `stop()` kills the child before draining Axum; `status()` reports `tunnel_url`. `RemoteStatus` gains `tunnel_url` (`tunnelUrl` over the wire).
- **`src-tauri/src/commands.rs`** — `remote_server_start` orchestrates `start → cloudflared::start_quick_tunnel → attach_tunnel`; on tunnel failure it `stop()`s the server and returns `REMOTE_TUNNEL_FAILED` (no localhost-only server + stale toggle). The `ExitRequested` cleanup already calls `stop()`, so the tunnel child is reaped on app quit — no orphaned `cloudflared`.
- **`src/shared/types/ipc.types.ts`** — `tunnelUrl: string | null` on `RemoteStatus`.
- **`src/renderer/components/RemoteAccessPopover.tsx`** — Dropped the "Listen on" selector, the bind host/port grid, and the URL/Open-in-browser/Copy row; renders a `QRCodeSVG` (white-padded for dark themes) from `status.tunnelUrl`; compact "no auth yet" warning + small "Copy link" ghost. The project/chat-history seed on enable is unchanged.
- **`src/renderer/components/RemoteAccessPopover.test.tsx` (new)** — QR-from-`tunnelUrl`, no URL text row, error/off states, and asserts `start()` is called with **no** bind-mode arg.
- **`package.json`** — add `qrcode.react` (ISC; `QRCodeSVG` renders inline SVG, jsdom-safe).

### Security posture (important)

- **TLS:** cloudflared terminates TLS at the edge, so the tunneled path is HTTPS end-to-end to the tunnel edge. This effectively covers Epic 2 story `2-2` (TLS termination) for the tunnel path.
- **Auth:** there is **no application auth token yet** (Epic 2 story `2-1` is backlog). The random ephemeral `trycloudflare.com` URL is the only gate, distributed solely via the QR. The popover keeps a prominent warning stating this and that toggling off rotates the URL. This is the same "no auth yet" philosophy as the current LAN mode, raised from LAN to internet.
- **cloudflared is NOT bundled in this PR.** `cloudflared` is source-available but **not** standard OSS — redistribution in signed installers requires a license sign-off (the spec's frozen Ask-First boundary). The runtime resolves cloudflared via `TERMUL_CLOUDFLARED_PATH` or PATH, so the feature works in dev / when the user has cloudflared installed. Bundling + per-target binaries + license review are the explicit gated follow-up, tracked in `_bmad-output/implementation-artifacts/deferred-work.md` ("remote-qr-cloudflared-tunnel — bundle + license the cloudflared sidecar for releases"). **Do not ship a release bundle including cloudflared until that license review is done.**

### Notes for review

- `start()` is intentionally kept cloudflared-free so the existing server-lifecycle tests (`start_then_stop`, `double_start`, `start_stop_does_not_kill_agents`) don't depend on a real cloudflared binary. The tunnel orchestration lives in the `remote_server_start` command; `stop()` is the single kill path (also reached by `ExitRequested`).
- The `bind_mode` param on `remote_server_start` is kept for API stability / standalone-binary parity but is now ignored (the tunnel targets localhost). The LAN `all` mode is removed from the popover and deferred (re-adding it is an Ask-First in the spec).

## How It Was Tested

- [x] `bun run typecheck` — 0 errors
- [ ] `bun run ci` (Biome strict) — not run directly; Biome ran on the changed files (clean) and the **pre-commit hook ran `biome check` on staged files and passed**. The repo's pre-existing 285 lint warnings are unchanged by this PR.
- [x] `bun run test` — 2519 passed, 0 failed (incl. new `RemoteAccessPopover.test.tsx` 4/4 and `StatusBar.test.tsx` 13/13)
- [x] `cargo clippy --all-targets -- -D warnings` (in src-tauri) — clean
- [x] `cargo test` (in src-tauri) — 495 passed, 0 failed
- [x] `bun run build:web` (Tauri frontend build) — built (qrcode.react bundles cleanly)
- [ ] Manual verification completed — **pending**: end-to-end "scan QR with a phone" needs a real cloudflared + the desktop app running; deferred to the human. Local test path: `TERMUL_CLOUDFLARED_PATH=/path/to/cloudflared bun run tauri dev` → toggle remote on → QR appears → scan with a phone on cellular.

## Screenshots or Recordings

None yet — UI change; a screenshot of the compact QR popover will be added once cloudflared is wired for an end-to-end run.

## CI & Review Gate

- [ ] All CI checks pass (PR Validation, Rust Checks, Build Verification, Security Scans) — awaiting CI on this PR.
- [ ] Code review comments from CodeRabbit have been addressed or resolved — **delegated to CodeRabbit** (BMAD subagent review intentionally skipped per maintainer; this PR is the review surface).
- [ ] No unresolved review findings remain — pending CodeRabbit.

## Checklist

- [x] My PR title follows the conventional commit format used by this repo
- [x] I linked the related issue or explained why none exists (spec + deferred-work referenced)
- [x] I updated docs when needed (spec change log + deferred-work record the cloudflared-not-bundled decision and the start/attach decoupling)
- [x] I added or updated tests when needed (new cloudflared.rs unit tests + new RemoteAccessPopover.test.tsx + extended host.rs tests)
- [x] I verified the change does not introduce unrelated modifications
- [x] I read AGENTS.md and followed the contributor guidelines
- [x] A human reviewed the complete diff before submission — maintainer-directed; CodeRabbit will review on this PR.
