### PR TITLE
fix(remote): gate tunnel QR on edge reachability + clear stale URL on cloudflared exit

### DIFF
--- a/src-tauri/src/remote/cloudflared.rs
+++ b/src-tauri/src/remote/cloudflared.rs
@@ -190,19 +190,27 @@ async fn probe_tunnel_ready_with(
     timeout: std::time::Duration,
     interval: std::time::Duration,
 ) -> Result<(), String> {
-    // A per-request timeout bounds each GET so a hung edge (no response) can't
-    // stall the loop past the deadline — without it reqwest has no default
-    // timeout and a hung send() would never yield the retry.
+    // No global client timeout — each request is capped to the *remaining*
+    // deadline budget inside the loop, so a straggler near the deadline can't
+    // push total wait past `timeout`. A hung send() still yields: reqwest errors
+    // on the per-request timeout → reachable=false → the loop re-checks the
+    // deadline + exits.
     let client = reqwest::Client::builder()
-        .timeout(std::time::Duration::from_secs(3))
         .build()
         .map_err(|e| format!("tunnel probe client build failed: {e}"))?;
     let deadline = std::time::Instant::now() + timeout;
     while std::time::Instant::now() < deadline {
+        // Cap each GET to the remaining budget (≤3s) so the probe can't
+        // overshoot the documented `timeout` bound by a full request's duration.
+        let per_request_timeout = deadline
+            .saturating_duration_since(std::time::Instant::now())
+            .min(std::time::Duration::from_secs(3));
         // Any 2xx means the edge is routing to the origin. Non-2xx / network
-        // errors (edge not yet routing, NXDOMAIN, origin refused) → retry.
+        // errors (edge not yet routing, NXDOMAIN, origin refused, per-request
+        // timeout) → retry until the deadline.
         let reachable = client
             .get(url)
+            .timeout(per_request_timeout)
             .send()
             .await
             .map(|resp| resp.status().is_success())

--- a/src-tauri/src/remote/cloudflared.rs
+++ b/src-tauri/src/remote/cloudflared.rs
@@ -218,7 +218,10 @@ async fn probe_tunnel_ready_with(
         if reachable {
             return Ok(());
         }
-        tokio::time::sleep(interval).await;
+        // Cap the retry sleep by the remaining deadline so a sleep started near
+        // the deadline can't push total wait past `timeout` by a full interval.
+        let remaining = deadline.saturating_duration_since(std::time::Instant::now());
+        tokio::time::sleep(interval.min(remaining)).await;
     }
     Err(format!(
         "tunnel URL not reachable within {}s",
@@ -415,10 +418,58 @@ mod tests {
         )
         .await;
         assert!(result.is_err(), "unreachable URL must not be reported ready");
+        // Tight bound: the deadline + capped retry sleep can't overshoot by a
+        // full interval, so ~2s + small epsilon — well under 3s.
         assert!(
-            start.elapsed() < std::time::Duration::from_secs(5),
-            "probe must give up near the deadline, not hang"
+            start.elapsed() < std::time::Duration::from_secs(3),
+            "probe must give up near the deadline, not hang; took {:?}",
+            start.elapsed()
         );
         assert!(result.unwrap_err().contains("not reachable within 2s"));
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn probe_bounded_by_deadline_against_hanging_listener() {
+        // A listener that accepts the TCP connection but never sends an HTTP
+        // response — so the only thing that unblocks each GET is the probe's
+        // per-request timeout. This exercises the timeout + capped-retry-sleep
+        // path the port-1 (instant-refuse) test can't.
+        let addr = spawn_hanging_listener().await;
+        let url = format!("http://{addr}/");
+        let start = std::time::Instant::now();
+        let result = probe_tunnel_ready_with(
+            &url,
+            std::time::Duration::from_secs(2),
+            std::time::Duration::from_millis(500),
+        )
+        .await;
+        assert!(result.is_err(), "hanging listener must not be reported ready");
+        // The per-request timeout is capped to the remaining deadline, so total
+        // wait must hug the 2s bound — not the 3s per-request default.
+        assert!(
+            start.elapsed() < std::time::Duration::from_secs(3),
+            "probe overshot the deadline: {:?}",
+            start.elapsed()
+        );
+    }
+
+    /// A local TCP listener that accepts connections but never sends an HTTP
+    /// response, so a probe client's per-request timeout is the only unblock.
+    async fn spawn_hanging_listener() -> std::net::SocketAddr {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind hanging listener");
+        let addr = listener.local_addr().expect("local addr");
+        tokio::spawn(async move {
+            // Accept connections but never send an HTTP response — a probe
+            // client's per-request timeout is the only unblock.
+            while let Ok((stream, _)) = listener.accept().await {
+                tokio::spawn(async move {
+                    let _ = tokio::time::sleep(std::time::Duration::from_secs(120)).await;
+                    drop(stream);
+                });
+            }
+        });
+        addr
     }
 }

--- a/src-tauri/src/remote/cloudflared.rs
+++ b/src-tauri/src/remote/cloudflared.rs
@@ -156,6 +156,68 @@ pub struct QuickTunnel {
     pub child: Child,
 }
 
+/// Deadline for the post-URL reachability probe (see [`probe_tunnel_ready`]).
+/// cloudflared prints the trycloudflare URL *before* the edge route is live;
+/// this bounds how long we wait for the edge → origin path to return 2xx before
+/// giving up + surfacing a "not reachable" error so the popover never offers a
+/// dead QR.
+const TUNNEL_READY_PROBE_TIMEOUT_SECS: u64 = 10;
+/// Probe interval — balances responsiveness against edge/request load.
+const TUNNEL_READY_PROBE_INTERVAL_MS: u64 = 500;
+
+/// HTTP-probe the public trycloudflare URL until the edge routes to the origin
+/// (2xx) or [`TUNNEL_READY_PROBE_TIMEOUT_SECS`] elapses. The probe round-trips
+/// desktop → trycloudflare edge → cloudflared → localhost origin, exercising
+/// the full path the phone will use — so a 2xx here is the only signal that the
+/// QR will actually load (vs. cloudflared's "URL created" log line, which
+/// fires before the edge route + phone-DNS converge and yields "This site
+/// can't be reached" for an eager scan).
+///
+/// `reqwest` (rustls, already a dep) is the client — no new crate.
+async fn probe_tunnel_ready(url: &str) -> Result<(), String> {
+    probe_tunnel_ready_with(
+        url,
+        std::time::Duration::from_secs(TUNNEL_READY_PROBE_TIMEOUT_SECS),
+        std::time::Duration::from_millis(TUNNEL_READY_PROBE_INTERVAL_MS),
+    )
+    .await
+}
+
+/// Parameterized probe core so tests can run a short deadline against a
+/// definitely-unreachable URL without waiting the full 10s.
+async fn probe_tunnel_ready_with(
+    url: &str,
+    timeout: std::time::Duration,
+    interval: std::time::Duration,
+) -> Result<(), String> {
+    // A per-request timeout bounds each GET so a hung edge (no response) can't
+    // stall the loop past the deadline — without it reqwest has no default
+    // timeout and a hung send() would never yield the retry.
+    let client = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(3))
+        .build()
+        .map_err(|e| format!("tunnel probe client build failed: {e}"))?;
+    let deadline = std::time::Instant::now() + timeout;
+    while std::time::Instant::now() < deadline {
+        // Any 2xx means the edge is routing to the origin. Non-2xx / network
+        // errors (edge not yet routing, NXDOMAIN, origin refused) → retry.
+        let reachable = client
+            .get(url)
+            .send()
+            .await
+            .map(|resp| resp.status().is_success())
+            .unwrap_or(false);
+        if reachable {
+            return Ok(());
+        }
+        tokio::time::sleep(interval).await;
+    }
+    Err(format!(
+        "tunnel URL not reachable within {}s",
+        timeout.as_secs()
+    ))
+}
+
 /// Spawn `cloudflared tunnel --url http://localhost:{port}` and wait (up to
 /// [`TUNNEL_URL_TIMEOUT_SECS`]) for the ephemeral trycloudflare URL.
 ///
@@ -181,7 +243,14 @@ pub async fn start_quick_tunnel(port: u16) -> Result<QuickTunnel, String> {
 
     let mut child = command
         .spawn()
-        .map_err(|e| format!("cloudflared binary not found at {path}: {e}"))?;
+        .map_err(|e| {
+            log::error!("cloudflared failed to spawn at {path}: {e}");
+            format!("cloudflared binary not found at {path}: {e}")
+        })?;
+    log::info!(
+        "cloudflared spawned (pid={:?}) from {path}; waiting for tunnel URL…",
+        child.id()
+    );
 
     let stdout = child
         .stdout
@@ -204,14 +273,31 @@ pub async fn start_quick_tunnel(port: u16) -> Result<QuickTunnel, String> {
     )
     .await
     {
-        Ok(Ok(url)) => Ok(QuickTunnel { url, child }),
+        Ok(Ok(url)) => {
+            log::info!(
+                "cloudflared tunnel URL obtained ({url}); probing edge reachability…"
+            );
+            // cloudflared prints the URL before the edge route is live; an
+            // eager QR yields "This site can't be reached" in the first few
+            // seconds. Probe the public URL end-to-end until it returns 2xx —
+            // the only signal proving the phone will succeed.
+            if let Err(e) = probe_tunnel_ready(&url).await {
+                let _ = child.kill().await;
+                log::warn!("cloudflared tunnel probe failed: {e}");
+                return Err(e);
+            }
+            log::info!("cloudflared tunnel reachable — edge routes to origin");
+            Ok(QuickTunnel { url, child })
+        }
         // Sender dropped without sending → cloudflared exited before printing.
         Ok(Err(_)) => {
             let _ = child.kill().await;
+            log::warn!("cloudflared exited before producing a tunnel URL");
             Err("cloudflared exited before producing a tunnel URL".to_string())
         }
         Err(_) => {
             let _ = child.kill().await;
+            log::warn!("tunnel URL not received within {TUNNEL_URL_TIMEOUT_SECS}s");
             Err(format!(
                 "tunnel URL not received within {TUNNEL_URL_TIMEOUT_SECS}s"
             ))
@@ -306,5 +392,25 @@ mod tests {
         assert!(TRY_TUNNEL_URL_RE
             .find("redirect to https://example.com/path")
             .is_none());
+    }
+
+    #[tokio::test]
+    async fn probe_returns_err_for_unreachable_url_near_deadline() {
+        // Port 1 on loopback → connection refused (fast), so each GET returns
+        // immediately; the 2s deadline bounds total elapsed time. Asserts the
+        // probe gives up near the deadline (never hangs) + surfaces the error.
+        let start = std::time::Instant::now();
+        let result = probe_tunnel_ready_with(
+            "http://127.0.0.1:1/",
+            std::time::Duration::from_secs(2),
+            std::time::Duration::from_millis(250),
+        )
+        .await;
+        assert!(result.is_err(), "unreachable URL must not be reported ready");
+        assert!(
+            start.elapsed() < std::time::Duration::from_secs(5),
+            "probe must give up near the deadline, not hang"
+        );
+        assert!(result.unwrap_err().contains("not reachable within 2s"));
     }
 }

--- a/src-tauri/src/remote/host.rs
+++ b/src-tauri/src/remote/host.rs
@@ -157,9 +157,16 @@ struct RemoteServer {
     bind_mode: RemoteBindMode,
     /// Ephemeral trycloudflare URL (set when the quick-tunnel came up).
     tunnel_url: Option<String>,
-    /// Live `cloudflared` child. Killed in `stop()`; `kill_on_drop(true)` is
-    /// the safety net for the panic/abort path where `stop()` never runs.
-    tunnel_child: Option<Child>,
+    /// `true` once the cloudflared watchdog observed the child exit. Read by
+    /// `status()` (sync) to drop the stale `tunnel_url` so the renderer poller
+    /// clears the QR (it would otherwise offer a link that yields "This site
+    /// can't be reached"). `None` when no tunnel is attached.
+    tunnel_dead: Option<std::sync::Arc<std::sync::atomic::AtomicBool>>,
+    /// The watchdog task owning the cloudflared child: it `wait()`s for exit
+    /// then flips `tunnel_dead`. Aborted on `stop()`/`Drop` so the owned child
+    /// is reaped via `kill_on_drop` — the child is NOT held here directly,
+    /// which keeps `status()` sync (no try_wait-across-`.await` dance).
+    tunnel_watchdog: Option<tokio::task::JoinHandle<()>>,
 }
 
 impl RemoteServer {
@@ -176,11 +183,17 @@ impl Drop for RemoteServer {
     fn drop(&mut self) {
         // Best-effort graceful shutdown on drop (e.g. app exit). Signal the
         // serve task to drain; the JoinHandle is left to the runtime to reap
-        // (awaiting it in `Drop` isn't possible — `Drop` is sync). The
-        // cloudflared `tunnel_child` is dropped here too — its `kill_on_drop`
-        // guarantees the process is reaped even when `stop()` never ran.
+        // (awaiting it in `Drop` isn't possible — `Drop` is sync).
         if let Some(tx) = self.shutdown_tx.take() {
             let _ = tx.send(());
+        }
+        // Abort the cloudflared watchdog so the child it owns is reaped via
+        // `kill_on_drop` (the child lives inside the watchdog task; aborting
+        // drops its future → drops the child). Without this, dropping the
+        // JoinHandle would detach the task and the cloudflared process could
+        // outlive the server on a hard exit where `stop()` never ran.
+        if let Some(handle) = self.tunnel_watchdog.take() {
+            handle.abort();
         }
     }
 }
@@ -313,11 +326,13 @@ impl RemoteServerState {
             serve_handle: Some(serve_handle),
             addr,
             bind_mode,
-            // Tunnel URL + child are attached after `cloudflared::start_quick_tunnel`
-            // resolves in `remote_server_start` — keeps this method testable without
-            // a real cloudflared binary (the lifecycle tests bind/stop/status here).
+            // Tunnel URL + watchdog are attached after
+            // `cloudflared::start_quick_tunnel` resolves in
+            // `remote_server_start` — keeps this method testable without a real
+            // cloudflared binary (the lifecycle tests bind/stop/status here).
             tunnel_url: None,
-            tunnel_child: None,
+            tunnel_dead: None,
+            tunnel_watchdog: None,
         });
         Ok(status)
     }
@@ -332,15 +347,17 @@ impl RemoteServerState {
         let server = { self.inner.lock().unwrap().take() };
         match server {
             Some(mut server) => {
-                // Kill the cloudflared child first so the public tunnel stops
-                // forwarding new traffic before Axum drains existing conns.
-                // (kill_on_drop would also reap it on Drop, but an explicit
-                // kill here lets us await + log failures, and the child stays
-                // owned until this call so Drop can't race us.)
-                if let Some(mut child) = server.tunnel_child.take() {
-                    if let Err(e) = child.kill().await {
-                        warn!("cloudflared child kill failed during stop: {e}");
-                    }
+                // Abort the cloudflared watchdog so the owned child is reaped
+                // via `kill_on_drop` (the child lives inside the watchdog task;
+                // aborting drops its future → drops the child). Done before
+                // Axum drains so the public tunnel stops forwarding new traffic
+                // before existing conns flush. An already-exited child (the
+                // watchdog already completed) is a no-op.
+                if let Some(handle) = server.tunnel_watchdog.take() {
+                    handle.abort();
+                    // Await completion of the abort so the child is reaped
+                    // before we proceed (returns Err(Cancelled) — ignored).
+                    let _ = handle.await;
                 }
                 // Signal drain, then await the serve task so Axum finishes
                 // flushing before the caller proceeds (e.g. app exit →
@@ -365,20 +382,37 @@ impl RemoteServerState {
     }
 
     /// Current status of the in-process web server.
+    ///
+    /// Also detects a dead cloudflared child: if the watchdog flag reports the
+    /// child has exited, the public trycloudflare URL no longer routes, so the
+    /// stale `tunnel_url` is cleared — the renderer poller then drops the QR
+    /// (it would otherwise offer a link that yields "This site can't be
+    /// reached"). Stays sync (reads an `AtomicBool`) so callers need no
+    /// `.await`.
     pub fn status(&self) -> RemoteStatus {
-        let slot = self.inner.lock().unwrap();
-        match slot.as_ref() {
-            // If the spawned serve task has exited (error/panic), don't keep
-            // reporting `running` with a dead listener — surface stopped so the
-            // UI doesn't lie about a server the phone can't reach.
-            Some(server) if !server.task_finished() => RemoteStatus::running(
-                server.addr,
-                server.bind_mode,
-                server.tunnel_url.clone(),
-            ),
-            Some(_) => RemoteStatus::stopped(),
-            None => RemoteStatus::stopped(),
+        let mut slot = self.inner.lock().unwrap();
+        let Some(server) = slot.as_mut() else {
+            return RemoteStatus::stopped();
+        };
+        // If the spawned serve task has exited (error/panic), don't keep
+        // reporting `running` with a dead listener — surface stopped so the
+        // UI doesn't lie about a server the phone can't reach.
+        if server.task_finished() {
+            return RemoteStatus::stopped();
         }
+        // Clear the tunnel URL once the cloudflared watchdog reports the child
+        // dead (the public URL no longer routes). Logged once: the flag stays
+        // set but `tunnel_url` is cleared here so subsequent polls skip the arm.
+        if server
+            .tunnel_dead
+            .as_ref()
+            .is_some_and(|flag| flag.load(std::sync::atomic::Ordering::Relaxed))
+            && server.tunnel_url.is_some()
+        {
+            warn!("cloudflared tunnel child exited; clearing stale tunnel URL");
+            server.tunnel_url = None;
+        }
+        RemoteStatus::running(server.addr, server.bind_mode, server.tunnel_url.clone())
     }
 
     /// Attach a started cloudflared quick-tunnel (URL + live child) to the
@@ -395,8 +429,24 @@ impl RemoteServerState {
         let mut slot = self.inner.lock().unwrap();
         match slot.as_mut() {
             Some(server) if !server.task_finished() => {
+                let child = child.take().expect("child present after take");
+                let dead_flag =
+                    std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+                let flag = dead_flag.clone();
+                // The watchdog owns the child: `wait()` for natural exit, then
+                // flag death so the next `status()` poll clears the stale URL.
+                // Aborted on `stop()`/`Drop`; at that point the owned child is
+                // reaped via its `kill_on_drop`. Owning the child in a task
+                // (not in `RemoteServer`) keeps `status()` sync — no
+                // `try_wait`-across-`.await` + no `!Send` MutexGuard hazard.
+                let watchdog = tokio::spawn(async move {
+                    let mut child = child;
+                    let _ = child.wait().await;
+                    flag.store(true, std::sync::atomic::Ordering::Relaxed);
+                });
                 server.tunnel_url = Some(url);
-                server.tunnel_child = child.take();
+                server.tunnel_dead = Some(dead_flag);
+                server.tunnel_watchdog = Some(watchdog);
                 Ok(())
             }
             _ => {
@@ -640,6 +690,69 @@ mod tests {
         // direct kill_all assertion possible without a spy; the invariant is
         // structural: serve_router does not call kill_all, host::stop does not
         // call kill_all. This test guards the path end-to-end.)
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn status_clears_tunnel_url_when_cloudflared_child_exits() {
+        // The watchdog flips `tunnel_dead` once the child exits; `status()`
+        // then clears `tunnel_url` so the renderer poller drops the stale QR
+        // (it would otherwise offer a link that yields "This site can't be
+        // reached").
+        let (acp, relay, registry, chat_history_cache) = lifecycle_fixtures();
+        let state = RemoteServerState::new();
+        let _ = state
+            .start(
+                acp.clone(),
+                relay.clone(),
+                registry.clone(),
+                chat_history_cache.clone(),
+                RemoteBindMode::Localhost,
+            )
+            .await
+            .expect("start");
+
+        // Attach a tunnel child that exits almost immediately (cross-platform
+        // exit-0). kill_on_drop mirrors the real start_quick_tunnel child.
+        let mut cmd = quick_exit_command();
+        cmd.kill_on_drop(true);
+        let child = cmd.spawn().expect("spawn quick-exit child");
+        state
+            .attach_tunnel("https://stale.trycloudflare.com".to_string(), child)
+            .expect("attach");
+
+        // Poll status until the dead-child path clears the tunnel URL. The
+        // child exits within a few ms; allow up to 1s for the OS + watchdog.
+        let mut cleared = false;
+        for _ in 0..20 {
+            let s = state.status();
+            if s.running && s.tunnel_url.is_none() {
+                cleared = true;
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        }
+        assert!(
+            cleared,
+            "status() must clear tunnel_url once cloudflared exits"
+        );
+
+        let _ = state.stop().await;
+    }
+
+    /// A cross-platform command that exits 0 almost immediately, for the
+    /// dead-child staleness test.
+    fn quick_exit_command() -> tokio::process::Command {
+        #[cfg(target_os = "windows")]
+        let mut c = tokio::process::Command::new("cmd");
+        #[cfg(target_os = "windows")]
+        c.args(["/c", "exit", "0"]);
+        #[cfg(not(target_os = "windows"))]
+        let mut c = tokio::process::Command::new("true");
+
+        c.stdin(std::process::Stdio::null())
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null());
+        c
     }
 
     #[test]

--- a/src/renderer/components/RemoteAccessPopover.tsx
+++ b/src/renderer/components/RemoteAccessPopover.tsx
@@ -1,6 +1,6 @@
 import { AlertCircle, Check, Copy, Monitor, ShieldAlert } from 'lucide-react'
 import { QRCodeSVG } from 'qrcode.react'
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { toast } from 'sonner'
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
 import { Switch } from '@/components/ui/switch'
@@ -36,6 +36,14 @@ export function RemoteAccessPopover(): React.JSX.Element {
   const isRunning = remoteStatus?.running ?? false
   // The QR encodes the public tunnel URL only — never the localhost `url`.
   const tunnelUrl = remoteStatus?.tunnelUrl ?? null
+  // Track whether a tunnel URL was ever seen this session so the popover can
+  // distinguish "Starting tunnel…" (never connected) from "Tunnel
+  // disconnected" (was connected, now gone — the 3s status poll cleared it).
+  const [sawUrl, setSawUrl] = useState(false)
+  useEffect(() => {
+    if (tunnelUrl) setSawUrl(true)
+    if (!isRunning) setSawUrl(false)
+  }, [tunnelUrl, isRunning])
 
   const handleRemoteToggle = async (enable: boolean): Promise<void> => {
     setRemoteBusy(true)
@@ -178,7 +186,7 @@ export function RemoteAccessPopover(): React.JSX.Element {
 
           {isRunning && !tunnelUrl && (
             <div className="flex items-center justify-center text-xs text-muted-foreground py-2">
-              Starting tunnel…
+              {sawUrl ? 'Tunnel disconnected — toggle off and on to retry' : 'Starting tunnel…'}
             </div>
           )}
         </div>


### PR DESCRIPTION
## Summary

Scanning the remote-access QR right after toggling remote access on opened to **"This site can't be reached"** on the phone. Root cause (two failure modes, both in the recently-merged scan-to-connect feature #469):

1. **Edge-race:** `start_quick_tunnel` attached the trycloudflare URL to the QR the instant cloudflared *printed* it — before the edge route + phone-DNS had converged. Scanning in the first few seconds hit an unreachable hostname.
2. **Staleness:** `RemoteServerState::status()` never checked the cloudflared child. If cloudflared exited after the QR appeared, the 3s renderer poller kept serving a dead URL → "can't be reached". The tunnel path also logged nothing (errors were returned to the renderer via `IpcResult` but never hit `termul.log`), making it invisible.

This PR gates the QR on **real edge reachability**, clears the stale URL when cloudflared dies, and adds full lifecycle logging.

## Related Issue

There is no related issue — this bug was reported directly by the maintainer while testing the scan-to-connect feature shipped in #469. The symptom is reproducible from the prod `termul.log` (the shared-live server bouncing across ports `63905→63921→64931` with **zero** cloudflared lines) plus the live process state at diagnosis time (cloudflared PID 19544 healthy, edge `/ready` `readyConnections:1`, origin `:64931` serving 200) — i.e. the server/origin were fine; the scanned URL was stale or pre-edge-live.

## Type of Change

- [x] fix: bug fix

## What Changed

- **`src-tauri/src/remote/cloudflared.rs`** — new `probe_tunnel_ready(url)`: after cloudflared prints the URL, HTTP-GETs the public trycloudflare URL (reqwest + rustls, both already deps) until it returns 2xx — proving the edge→cloudflared→origin path the phone will use is actually live (cloudflared's local `/ready` only proves the edge *connection*, not that the hostname routes). Both the per-request timeout **and** the retry sleep are capped to the remaining deadline so the probe can't overshoot the documented bound. On timeout the child is killed and `REMOTE_TUNNEL_FAILED "tunnel URL not reachable within 10s"` is surfaced (server drained). Added `log::info/warn/error` for spawn / url-obtained / ready / kill / probe-failure / timeout so the lifecycle is visible in `termul.log` (silent before).
- **`src-tauri/src/remote/host.rs`** — `attach_tunnel` now spawns a **watchdog task** that owns the cloudflared `Child`, `wait()`s for natural exit, and flips an `AtomicBool`. `status()` (stays **sync** — zero caller changes) reads the flag and, on death, clears `tunnel_url` so the existing 3s renderer poller drops the stale QR. `stop()` + `Drop` abort the watchdog so the child is reaped via `kill_on_drop`. (Chose a watchdog over making `status()` async to avoid holding a `!Send` `std::MutexGuard` across `.await` — Tauri command futures must be `Send` — and to keep `remote_server_start`/`_status` + all existing tests unchanged.)
- **`src/renderer/components/RemoteAccessPopover.tsx`** — tracks `sawUrl`; when running with no `tunnelUrl` it now shows **"Tunnel disconnected — toggle off and on to retry"** if a URL was previously seen, vs **"Starting tunnel…"** on the first connect. Honest UI after a mid-session cloudflared death.

## How It Was Tested

- [x] `bun run ci` (Biome lint + format + imports, strict mode)
- [x] `bun run typecheck`
- [x] `bun run test` — 2514 passed / 1 skipped
- [x] `cargo clippy --all-targets -- -D warnings` (in src-tauri) — clean
- [x] `cargo test` (in src-tauri) — 499 passed / 2 ignored
- [ ] Manual verification — live process state (cloudflared PID, edge `/ready`, origin `/health`) confirmed during diagnosis; probe + staleness paths are unit-tested. End-to-end phone-scan is left for the maintainer to confirm.

New unit tests:
- `probe_returns_err_for_unreachable_url_near_deadline` (cloudflared.rs) — proves the probe gives up near its deadline against an unreachable URL (never hangs) and surfaces the "not reachable within Ns" error.
- `probe_bounded_by_deadline_against_hanging_listener` (cloudflared.rs) — a local listener that accepts but never responds exercises the per-request-timeout + capped-retry-sleep path; asserts total wait hugs the 2s deadline (< 3s).
- `status_clears_tunnel_url_when_cloudflared_child_exits` (host.rs) — attaches a real short-lived exit-0 child, asserts `status()` clears `tunnel_url` once the child exits (multi-thread runtime so the watchdog runs).

## Screenshots or Recordings

N/A — behavior/edge-case fix; the QR component is unchanged (same `QRCodeSVG`). The only UI delta is the disconnected-state copy.

## CI & Review Gate

- [x] All CI checks pass — PR Validation (Validate PR Description/Title, Lint/Typecheck/Test, Rust Checks, ACP Registry, Web Client Build, Standalone Server Build, Rust Windows Smoke, Verify Tauri Frontend Build), CodeQL, Secret Scan, Dependency Review all green on run 30530424556.
- [x] Code review comments from CodeRabbit addressed/resolved — the one actionable inline comment (probe per-request timeout overshoot) is fixed in 1357cd5f; its two 🟡 follow-ups (cap the retry sleep; cover the hanging-request path in tests) are fixed in 7e2e8b6d. Reply posted to the inline thread. CodeRabbit was rate-limited for its final pass; the comments are addressed in code regardless.
- [x] No unresolved review findings remain

## Checklist

- [x] PR title follows the conventional commit format used by this repo
- [x] I linked the related issue or explained why none exists
- [x] I updated docs when needed (inline code comments; no external doc change needed)
- [x] I added or updated tests when needed
- [x] I verified the change does not introduce unrelated modifications (3 files, all in the remote/tunnel path)
- [x] I read AGENTS.md / CLAUDE.md and followed the contributor guidelines
