### PR TITLE
fix(remote): make tunnel probe best-effort (non-blocking) — fixes #471 no-QR regression

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -3043,11 +3043,19 @@ pub async fn remote_server_start(
             };
             match remote::cloudflared::start_quick_tunnel(port).await {
                 Ok(tunnel) => {
+                    // Clone the URL before attach consumes it, so the background
+                    // probe can log reachability without blocking the QR.
+                    let probe_url = tunnel.url.clone();
                     if let Err(e) = remote_state.attach_tunnel(tunnel.url, tunnel.child) {
                         // Server stopped between start and attach; attach already
                         // killed the orphan child. Surface the error.
                         return Ok(IpcResult::error(e, "REMOTE_TUNNEL_FAILED"));
                     }
+                    // Best-effort reachability probe in the background — logs
+                    // whether the edge routes to the origin. Non-blocking so the
+                    // QR appears immediately; never hides the QR on probe timeout
+                    // (a slow edge / cold start must not block the connect UI).
+                    tokio::spawn(remote::cloudflared::log_tunnel_reachability(probe_url));
                     Ok(IpcResult::success(remote_state.status()))
                 }
                 Err(e) => {

--- a/src-tauri/src/remote/cloudflared.rs
+++ b/src-tauri/src/remote/cloudflared.rs
@@ -229,6 +229,23 @@ async fn probe_tunnel_ready_with(
     ))
 }
 
+/// Best-effort, non-blocking reachability probe: GET the public tunnel URL
+/// until 2xx or the deadline, then log the outcome. Spawned in the background
+/// by `remote_server_start` after the tunnel is attached, so the QR appears
+/// immediately and the probe only informs the log — it never hides the QR on a
+/// timeout (a slow edge / cold start must not block the connect UI).
+pub async fn log_tunnel_reachability(url: String) {
+    match probe_tunnel_ready(&url).await {
+        Ok(()) => log::info!(
+            "cloudflared tunnel reachable — edge routes to origin ({url})"
+        ),
+        Err(e) => log::warn!(
+            "cloudflared tunnel not confirmed reachable within deadline ({url}): {e} \
+             — QR shown anyway; rescan if the page doesn't load"
+        ),
+    }
+}
+
 /// Spawn `cloudflared tunnel --url http://localhost:{port}` and wait (up to
 /// [`TUNNEL_URL_TIMEOUT_SECS`]) for the ephemeral trycloudflare URL.
 ///
@@ -285,19 +302,13 @@ pub async fn start_quick_tunnel(port: u16) -> Result<QuickTunnel, String> {
     .await
     {
         Ok(Ok(url)) => {
-            log::info!(
-                "cloudflared tunnel URL obtained ({url}); probing edge reachability…"
-            );
-            // cloudflared prints the URL before the edge route is live; an
-            // eager QR yields "This site can't be reached" in the first few
-            // seconds. Probe the public URL end-to-end until it returns 2xx —
-            // the only signal proving the phone will succeed.
-            if let Err(e) = probe_tunnel_ready(&url).await {
-                let _ = child.kill().await;
-                log::warn!("cloudflared tunnel probe failed: {e}");
-                return Err(e);
-            }
-            log::info!("cloudflared tunnel reachable — edge routes to origin");
+            // Return the URL + child immediately. The edge-reachability probe is
+            // best-effort and runs in the background from `remote_server_start`
+            // (after attach) — fail-closed probing hid the QR entirely on slow
+            // edges / cold starts, which was worse than a scan that might need a
+            // rescan. The staleness watchdog in `host::status` clears the QR
+            // if cloudflared dies.
+            log::info!("cloudflared tunnel URL obtained ({url})");
             Ok(QuickTunnel { url, child })
         }
         // Sender dropped without sending → cloudflared exited before printing.


### PR DESCRIPTION
## Summary

**Follow-up to #471.** The fail-closed reachability probe merged in #471 **false-fails in the field**, hiding the QR entirely ("tunnel unreachable … no QR appear"). cloudflared produces a valid trycloudflare URL, but the probe's reqwest GET to it never returns 2xx within 10s, so the server is drained + no QR is shown — worse than the original "can't be reached" symptom.

This PR makes the probe **best-effort / non-blocking**: `start_quick_tunnel` returns the URL immediately, `remote_server_start` attaches it (QR shows) + spawns a background probe that only **logs** reachability — it never hides the QR.

## Root-cause note (why the probe was wrong to fail-close)

A curl reproduction from the affected machine got **HTTP 200 immediately** against a live trycloudflare URL (python origin). The desktop, Cloudflare edge, and TLS (reqwest `rustls`→`rustls-platform-verifier`, i.e. the OS trust store — same roots curl uses) are all fine. The probe's reqwest GET specifically false-fails against the termul origin via the tunnel (a reqwest/rustls-vs-schannel discrepancy I couldn't fully pin down locally — disk-full blocked a reqwest repro build). Regardless of the exact cause, **gating the QR on the probe was wrong**: it converts a rare false-failure into a total "no QR" regression.

## What Changed

- **`src-tauri/src/remote/cloudflared.rs`** — `start_quick_tunnel` no longer probes inline; it returns `QuickTunnel { url, child }` immediately on URL obtain. New `pub async fn log_tunnel_reachability(url)` runs the existing `probe_tunnel_ready` + logs Ok/Warn (best-effort, never fatal).
- **`src-tauri/src/commands.rs`** — `remote_server_start` clones the URL before `attach_tunnel` consumes it, attaches (QR shows), then `tokio::spawn(log_tunnel_reachability(probe_url))` — non-blocking.

Unchanged from #471: the **staleness watchdog** (clears the QR if cloudflared dies → fixes the real stale-QR "can't be reached" cause) and the **lifecycle logging** (visibility in `termul.log`). `probe_tunnel_ready`/`_with` + their tests are unchanged.

## Related Issue

There is no related issue — regression found by the maintainer testing the #471 merge. The prod `termul.log` shows it directly: `cloudflared tunnel URL obtained (https://…); probing edge reachability…` → `[10s later] cloudflared tunnel probe failed: tunnel URL not reachable within 10s` → `Shared-live web server shutting down…` (drained, no QR).

## Type of Change

- [x] fix: bug fix

## What Changed

- `src-tauri/src/remote/cloudflared.rs` — `start_quick_tunnel` returns the URL immediately (no inline probe); added `log_tunnel_reachability(url)` best-effort logger.
- `src-tauri/src/commands.rs` — `remote_server_start` spawns the background probe after attach (non-blocking).

## How It Was Tested

- [x] `cargo check --lib` (in src-tauri) — clean
- [x] `cargo test --lib remote::` (in src-tauri) — 23 passed (incl. `probe_returns_err_for_unreachable_url_near_deadline`, `probe_bounded_by_deadline_against_hanging_listener`, `status_clears_tunnel_url_when_cloudflared_child_exits`)
- [ ] `bun run ci` / `bun run typecheck` / `bun run test` — running on CI (no renderer change in this PR; cherry-pick of the already-verified #471 code)
- [ ] Manual verification — maintainer to confirm: toggle on → QR appears immediately (no "tunnel unreachable"), scan → web client loads; `taskkill cloudflared` → QR clears within ~3s (watchdog).

## Screenshots or Recordings

N/A — behavior fix; the QR UI is unchanged.

## CI & Review Gate

- [ ] All CI checks pass — _checking once CI runs_
- [ ] Code review comments from CodeRabbit addressed/resolved — _will address_
- [ ] No unresolved review findings remain

## Checklist

- [x] PR title follows the conventional commit format used by this repo
- [x] I linked the related issue or explained why none exists (follow-up to #471)
- [x] I updated docs when needed (inline code comments; no external doc change)
- [x] I added or updated tests when needed (tests carried over from #471 unchanged)
- [x] I verified the change does not introduce unrelated modifications (2 files, remote/tunnel path only)
- [x] I read AGENTS.md / CLAUDE.md and followed the contributor guidelines


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Remote tunnel startup now returns success sooner instead of waiting for reachability confirmation.
  * Tunnel availability is checked in the background, improving responsiveness while still recording connectivity results.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->