### PR TITLE
fix(acp): persist web/remote session across mobile idle/background

### DIFF
--- a/src/renderer/lib/acp-transport.test.ts
+++ b/src/renderer/lib/acp-transport.test.ts
@@ -937,6 +937,241 @@ describe('WsAcpTransport reconnect listener (Story 5.3)', () => {
   })
 })
 
+// Web/remote ACP session persistence across mobile idle/background: a
+// visibility/focus-triggered proactive reconnect so the existing cursor-replay
+// machinery actually engages when a backgrounded mobile tab returns to the
+// foreground (the browser delivers `onclose` late or never after suspension,
+// leaving a half-open socket the client trusts and never re-establishes).
+type TransportInternals = {
+  socket: FakeWebSocket
+  lastHiddenAt: number | null
+  visibilityHandler: (() => void) | null
+  focusHandler: (() => void) | null
+  reconnectTimer: ReturnType<typeof setTimeout> | null
+  reconnectAttempt: number
+  lastSeq: Map<string, number>
+  subscribed: Set<string>
+}
+
+/** Override `document.visibilityState` + dispatch `visibilitychange` (jsdom's
+ * default is not reliable for the hidden/visible transitions under test). */
+function dispatchVisibility(state: 'visible' | 'hidden'): void {
+  Object.defineProperty(document, 'visibilityState', {
+    configurable: true,
+    value: state
+  })
+  document.dispatchEvent(new Event('visibilitychange'))
+}
+
+/** Restore an own `visibilityState = 'visible'` so later suites read visible. */
+function restoreVisibility(): void {
+  Object.defineProperty(document, 'visibilityState', {
+    configurable: true,
+    value: 'visible'
+  })
+}
+
+/** Find the LAST sent request frame of a given type on a FakeWebSocket. */
+function findSentRequest(
+  sock: FakeWebSocket,
+  type: string
+): { id: string; type: string; payload: Record<string, unknown> } | undefined {
+  for (const raw of [...sock.sent].reverse()) {
+    const parsed = JSON.parse(raw) as {
+      id: string
+      type: string
+      payload: Record<string, unknown>
+    }
+    if (parsed.type === type) return parsed
+  }
+  return undefined
+}
+
+describe('WsAcpTransport visibility-triggered reconnect (web idle persist)', () => {
+  afterEach(() => {
+    restoreVisibility()
+    _resetAcpTransportForTests(null)
+    vi.useRealTimers()
+  })
+
+  it('reconnects + re-subscribes with cursor after a long hide (> threshold)', async () => {
+    vi.useFakeTimers()
+    const transport = new WsAcpTransport({
+      url: 'ws://test/ws',
+      WebSocketImpl: FakeWebSocket as unknown as typeof WebSocket
+    })
+    await transport.connect()
+    const states: boolean[] = []
+    transport.setReconnectListener((r) => states.push(r))
+    // Subscribe + deliver one sequenced event so the cursor (`lastSeq`) is set.
+    await transport.subscribeSession('sess-A')
+    const internals = transport as unknown as TransportInternals
+    const oldSocket = internals.socket
+    oldSocket.emit({
+      sid: 'sess-A',
+      seq: 1,
+      type: 'message_chunk',
+      payload: { role: 'agent', content: { text: 'hi' } }
+    })
+    await Promise.resolve() // flush onMessage
+    expect(internals.lastSeq.get('sess-A')).toBe(1)
+
+    // Long hide (> 30s threshold) → return → proactive reconnect.
+    dispatchVisibility('hidden')
+    await vi.advanceTimersByTimeAsync(31_000)
+    dispatchVisibility('visible')
+    // forceReconnect → scheduleReconnect fires `true` immediately.
+    expect(states[0]).toBe(true)
+
+    // Advance past the 500ms backoff → reconnect re-opens + re-subscribes.
+    await vi.advanceTimersByTimeAsync(600)
+    await Promise.resolve()
+
+    expect(internals.socket).not.toBe(oldSocket) // new socket opened
+    expect(states[states.length - 1]).toBe(false) // overlay cleared
+    const sub = findSentRequest(internals.socket, 'subscribe')
+    expect(sub).toBeDefined()
+    expect(sub?.payload.sessionId).toBe('sess-A')
+    expect(sub?.payload.lastSeq).toBe(1) // cursor carried → gap replay path
+
+    const timerField = transport as unknown as {
+      reconnectTimer: ReturnType<typeof setTimeout> | null
+    }
+    if (timerField.reconnectTimer) {
+      clearTimeout(timerField.reconnectTimer)
+      timerField.reconnectTimer = null
+    }
+    transport.dispose()
+  })
+
+  it('does NOT reconnect after a brief hide (< threshold) with a healthy OPEN socket', async () => {
+    vi.useFakeTimers()
+    const transport = new WsAcpTransport({
+      url: 'ws://test/ws',
+      WebSocketImpl: FakeWebSocket as unknown as typeof WebSocket
+    })
+    await transport.connect()
+    const states: boolean[] = []
+    transport.setReconnectListener((r) => states.push(r))
+    await transport.subscribeSession('sess-A')
+    const internals = transport as unknown as TransportInternals
+    const socketBefore = internals.socket
+
+    dispatchVisibility('hidden')
+    await vi.advanceTimersByTimeAsync(5_000) // well under the 30s threshold
+    dispatchVisibility('visible')
+    await Promise.resolve()
+
+    expect(states).toEqual([]) // no reconnect transition
+    expect(internals.socket).toBe(socketBefore) // same socket, not torn down
+    expect(internals.lastHiddenAt).toBeNull() // consumed
+
+    const timerField = transport as unknown as {
+      reconnectTimer: ReturnType<typeof setTimeout> | null
+    }
+    if (timerField.reconnectTimer) {
+      clearTimeout(timerField.reconnectTimer)
+      timerField.reconnectTimer = null
+    }
+    transport.dispose()
+  })
+
+  it('force-reconnects a half-open (still-OPEN) socket on return, detaching old handlers', async () => {
+    vi.useFakeTimers()
+    const transport = new WsAcpTransport({
+      url: 'ws://test/ws',
+      WebSocketImpl: FakeWebSocket as unknown as typeof WebSocket
+    })
+    await transport.connect()
+    const states: boolean[] = []
+    transport.setReconnectListener((r) => states.push(r))
+    await transport.subscribeSession('sess-A')
+    const internals = transport as unknown as TransportInternals
+    const oldSocket = internals.socket
+    // The socket is OPEN (half-open: server gave up, client doesn't know yet).
+    expect(oldSocket.readyState).toBe(FakeWebSocket.OPEN)
+
+    dispatchVisibility('hidden')
+    await vi.advanceTimersByTimeAsync(31_000)
+    dispatchVisibility('visible')
+    expect(states[0]).toBe(true)
+
+    await vi.advanceTimersByTimeAsync(600)
+    await Promise.resolve()
+
+    // The still-OPEN socket was forcibly torn down despite `readyState === OPEN`
+    // (the connect() short-circuit must NOT have engaged) and replaced.
+    expect(internals.socket).not.toBe(oldSocket)
+    expect(oldSocket.readyState).toBe(FakeWebSocket.CLOSED) // forceReconnect closed it
+    expect(oldSocket.onclose).toBeNull() // handlers detached → no double fire
+    expect(states.filter((s) => s)).toHaveLength(1) // exactly one `true`
+    expect(states.filter((s) => !s)).toHaveLength(1) // exactly one `false`
+
+    const timerField = transport as unknown as {
+      reconnectTimer: ReturnType<typeof setTimeout> | null
+    }
+    if (timerField.reconnectTimer) {
+      clearTimeout(timerField.reconnectTimer)
+      timerField.reconnectTimer = null
+    }
+    transport.dispose()
+  })
+
+  it('coalesces: a `focus` following `visibilitychange` does not double-reconnect', async () => {
+    vi.useFakeTimers()
+    const transport = new WsAcpTransport({
+      url: 'ws://test/ws',
+      WebSocketImpl: FakeWebSocket as unknown as typeof WebSocket
+    })
+    await transport.connect()
+    const states: boolean[] = []
+    transport.setReconnectListener((r) => states.push(r))
+    await transport.subscribeSession('sess-A')
+
+    // Long hide → visible triggers forceReconnect (consumes lastHiddenAt).
+    dispatchVisibility('hidden')
+    await vi.advanceTimersByTimeAsync(31_000)
+    dispatchVisibility('visible')
+    expect(states[0]).toBe(true)
+
+    // A `focus` right after (the fallback path) must NOT trigger a 2nd reconnect
+    // — lastHiddenAt was consumed. Dispatched on `window` (focus is a
+    // window-level event that does not bubble to `document`).
+    window.dispatchEvent(new Event('focus'))
+    await Promise.resolve()
+    expect(states.filter((s) => s)).toHaveLength(1)
+
+    await vi.advanceTimersByTimeAsync(600)
+    await Promise.resolve()
+    expect(states.filter((s) => !s)).toHaveLength(1) // one reconnect, one `false`
+
+    const timerField = transport as unknown as {
+      reconnectTimer: ReturnType<typeof setTimeout> | null
+    }
+    if (timerField.reconnectTimer) {
+      clearTimeout(timerField.reconnectTimer)
+      timerField.reconnectTimer = null
+    }
+    transport.dispose()
+  })
+
+  it('dispose() detaches the visibility/focus listeners', async () => {
+    vi.useFakeTimers()
+    const transport = new WsAcpTransport({
+      url: 'ws://test/ws',
+      WebSocketImpl: FakeWebSocket as unknown as typeof WebSocket
+    })
+    await transport.connect()
+    const internals = transport as unknown as TransportInternals
+    expect(internals.visibilityHandler).not.toBeNull()
+    expect(internals.focusHandler).not.toBeNull()
+
+    transport.dispose()
+    expect(internals.visibilityHandler).toBeNull()
+    expect(internals.focusHandler).toBeNull()
+  })
+})
+
 describe('createAcpTransport selection', () => {
   beforeEach(() => {
     _resetAcpTransportForTests(null)

--- a/src/renderer/lib/acp-transport.ts
+++ b/src/renderer/lib/acp-transport.ts
@@ -248,6 +248,18 @@ const SEND_PROMPT_GRACE_MS = 10_000
 const SEND_PROMPT_TIMEOUT_MS = 600_000 + SEND_PROMPT_GRACE_MS
 const RECONNECT_BASE_MS = 500
 const RECONNECT_MAX_MS = 8_000
+/**
+ * How long the page must stay hidden before a return triggers a proactive
+ * reconnect. Mobile browsers suspend JS in backgrounded tabs, so the server's
+ * keepalive Ping goes un-ponged and the server tears the socket down at its
+ * ~75s Pong-timeout (`web/ws.rs::PONG_TIMEOUT`) — but the client only learns
+ * this when `onclose` is finally delivered on resume (late, or never on a
+ * half-open link). 30s sits between the server's 20s Ping interval and its 75s
+ * Pong-timeout: long enough to ride out a brief tab switch without a needless
+ * reconnect, short enough that a real background/idle triggers recovery before
+ * the user sees a dead chat. Tunable.
+ */
+const VISIBILITY_STALE_THRESHOLD_MS = 30_000
 
 function requestTimeoutMs(type: WsRequestType): number {
   return type === 'send_prompt' ? SEND_PROMPT_TIMEOUT_MS : REQUEST_TIMEOUT_MS
@@ -275,6 +287,12 @@ export class WsAcpTransport implements AcpTransport {
   private disposed = false
   private reconnectAttempt = 0
   private reconnectTimer: ReturnType<typeof setTimeout> | null = null
+  /** When the page became hidden (epoch-ms), or null while visible. Drives the
+   * visibility-triggered proactive reconnect on mobile idle/background resume. */
+  private lastHiddenAt: number | null = null
+  /** Bound DOM-listener refs so `dispose()` can detach them. */
+  private visibilityHandler: (() => void) | null = null
+  private focusHandler: (() => void) | null = null
   private readonly pending = new Map<string, Pending>()
   private readonly listeners = new Map<string, Set<EventListener>>()
   /** Per-session last contiguous delivered seq. */
@@ -313,6 +331,7 @@ export class WsAcpTransport implements AcpTransport {
 
   async connect(): Promise<void> {
     if (this.disposed) return
+    this.attachVisibilityListeners()
     if (this.socket?.readyState === WebSocket.OPEN && this.authed) return
     if (this.connecting) return this.connecting
     this.connecting = this.openSocket()
@@ -325,6 +344,7 @@ export class WsAcpTransport implements AcpTransport {
 
   dispose(): void {
     this.disposed = true
+    this.detachVisibilityListeners()
     if (this.reconnectTimer) {
       clearTimeout(this.reconnectTimer)
       this.reconnectTimer = null
@@ -644,6 +664,110 @@ export class WsAcpTransport implements AcpTransport {
       p.reject(new AcpTransportError(code, message))
     }
     this.pending.clear()
+  }
+
+  /**
+   * Attach `visibilitychange` + `focus` listeners (web only) so a return from a
+   * backgrounded mobile tab proactively reconnects instead of waiting for an
+   * `onclose` the suspended browser delivers late or never. Idempotent; detached
+   * in {@link dispose}. `visibilitychange` is the primary signal (it carries
+   * hidden/visible timing); `focus` is a fallback for platforms where
+   * `visibilitychange` is unreliable.
+   */
+  private attachVisibilityListeners(): void {
+    if (this.visibilityHandler || typeof document === 'undefined') return
+    const onVisibility = (): void => {
+      if (document.visibilityState === 'hidden') {
+        this.lastHiddenAt = Date.now()
+        return
+      }
+      // visible — a backgrounded tab returning to the foreground.
+      this.maybeReconnectOnReturn()
+    }
+    const onFocus = (): void => {
+      // Fallback: focus implies the window is active again. Only acts when we
+      // previously recorded a hide, so normal interaction is a no-op.
+      this.maybeReconnectOnReturn()
+    }
+    this.visibilityHandler = onVisibility
+    this.focusHandler = onFocus
+    document.addEventListener('visibilitychange', onVisibility)
+    // `focus`/`blur` for tab/window backgrounding are window-level events and do
+    // NOT bubble — attach to `window`, not `document` (a document-level listener
+    // would never fire for window focus changes, making the fallback dead code).
+    window.addEventListener('focus', onFocus)
+  }
+
+  /** Detach the visibility/focus listeners (called from {@link dispose}). */
+  private detachVisibilityListeners(): void {
+    if (this.visibilityHandler && typeof document !== 'undefined') {
+      document.removeEventListener('visibilitychange', this.visibilityHandler)
+      this.visibilityHandler = null
+    }
+    if (this.focusHandler && typeof window !== 'undefined') {
+      window.removeEventListener('focus', this.focusHandler)
+      this.focusHandler = null
+    }
+  }
+
+  /**
+   * On a return-to-foreground, if the page was hidden past the staleness
+   * threshold OR the socket is not OPEN, force a reconnect. The existing
+   * `reconnect()` + `subscribeSession(lastSeq)` cursor path then replays missed
+   * events from the server's per-session event log and resumes streaming — no
+   * manual page reload. Consumes `lastHiddenAt` so a `focus` following a
+   * `visibilitychange` (or vice-versa) does not double-trigger.
+   */
+  private maybeReconnectOnReturn(): void {
+    if (this.disposed) return
+    const hiddenAt = this.lastHiddenAt
+    this.lastHiddenAt = null
+    if (hiddenAt == null) return // never recorded a hide — nothing to recover
+    const hiddenFor = Date.now() - hiddenAt
+    const socketDown = this.socket?.readyState !== WebSocket.OPEN
+    if (hiddenFor > VISIBILITY_STALE_THRESHOLD_MS || socketDown) {
+      this.forceReconnect(
+        socketDown ? 'socket closed while page was hidden' : 'visibility return after idle'
+      )
+    }
+  }
+
+  /**
+   * Force a clean reconnect, bypassing the `connect()` fast path that trusts
+   * `readyState === OPEN`. Used by the visibility-triggered path: a mobile
+   * browser backgrounded the tab, the server tore the socket down at its
+   * Pong-timeout, and the client's `onclose` may not have fired yet (or the
+   * link is half-open and still reports OPEN). Tears down the suspect socket
+   * (detaching its handlers so its eventual close does not double-trigger
+   * `scheduleReconnect`/`rejectAllPending`), then reuses `scheduleReconnect()`
+   * so the existing backoff + `reconnect()` + cursor-resubscribe +
+   * `onReconnectStateChange` machinery runs unchanged.
+   */
+  private forceReconnect(reason: string): void {
+    if (this.disposed) return
+    const old = this.socket
+    this.socket = null
+    this.authed = false
+    this.connecting = null
+    this.rejectAllPending('closed', reason)
+    if (this.reconnectTimer) {
+      clearTimeout(this.reconnectTimer)
+      this.reconnectTimer = null
+    }
+    this.reconnectAttempt = 0
+    if (old) {
+      // Detach so the old socket's close does not double-fire scheduleReconnect
+      // / rejectAllPending on an already-tearing-down transport.
+      old.onclose = null
+      old.onerror = null
+      old.onmessage = null
+      try {
+        old.close()
+      } catch {
+        /* ignore — already closed */
+      }
+    }
+    this.scheduleReconnect()
   }
 
   private scheduleReconnect(): void {


### PR DESCRIPTION
## Summary

The web/remote ACP client (phone browser over the WS relay) lost its chat whenever the tab was backgrounded/idle and never recovered without a manual page reload — making termul remote "almost not usable" on mobile. The architecture's persistence machinery (D5 per-session event log + `lastSeq` cursor replay in `web/sink.rs`, server keepalive Ping/Pong-timeout in `web/ws.rs`, client `reconnect()` + `transportReconnecting` overlay in `acp-transport.ts`) was **already built**; the missing piece was a **proactive reconnect trigger** on mobile resume.

Mobile browsers suspend JS in backgrounded tabs, so the server's keepalive Ping goes un-ponged and the server tears the socket down at its ~75s Pong-timeout — but the client only learns this when `ws.onclose` is finally delivered on resume (late, or never on a half-open link), leaving a half-open socket that `connect()` trusts (`readyState === OPEN` short-circuit) and never re-establishes.

This adds a `visibilitychange`/`focus`-triggered proactive reconnect to `WsAcpTransport`: on return from a hide longer than 30s (or a non-OPEN socket), `forceReconnect()` tears down the suspect socket (detaching its handlers so the close doesn't double-fire `scheduleReconnect`) and reuses the existing backoff → `reconnect()` → `subscribeSession(lastSeq)` cursor path — missed events replay from the server's per-session event log and streaming resumes. Desktop Tauri (IPC) is untouched (`WsAcpTransport` is web-only by construction).

## Related Issue

No related issue. The **desktop** ACP idle-disconnect was addressed in spec `spec-fix-acp-idle-disconnect-resume` (status: done), which explicitly excluded the web/WS path: _"No WS / web-client changes (this is desktop `dev` only; the WS relay lives on `feat/acp-web-agent-mvp`)."_ This PR addresses that excluded web/remote path — the same family of problem (idle/background → disconnect) on the WS transport.

## Type of Change

- [x] fix: bug fix

## What Changed

- `src/renderer/lib/acp-transport.ts` — `WsAcpTransport`:
  - `VISIBILITY_STALE_THRESHOLD_MS = 30_000` — sits between the server's 20s Ping interval and 75s Pong-timeout (`web/ws.rs`).
  - `attachVisibilityListeners()` / `detachVisibilityListeners()` — `visibilitychange` + `focus` wiring (idempotent; attached in `connect()`, detached in `dispose()`). `focus` is a fallback for platforms where `visibilitychange` is unreliable.
  - `maybeReconnectOnReturn()` — on a hidden→visible transition (or `focus`), if `hiddenDuration > threshold` OR `socket.readyState !== OPEN`, call `forceReconnect()`. Triggered on `hiddenDuration` (not inbound-idle) so a long agent "thinking" phase (no `onmessage` for 60s+ while the page stays visible + healthy — server Pings are control frames JS never sees) does NOT false-positive.
  - `forceReconnect(reason)` — tears down the suspect socket (`socket`/`authed`/`connecting` nulled, pending requests rejected, old socket handlers detached, old socket closed), clears the backoff timer, resets `reconnectAttempt`, then reuses `scheduleReconnect()` so the existing backoff + `reconnect()` + cursor-resubscribe + `onReconnectStateChange` overlay machinery runs unchanged.
- `src/renderer/lib/acp-transport.test.ts` — 5 regression tests: long-hide → cursor replay; brief-hide → no-op; half-open OPEN socket → force-reconnect bypasses the short-circuit + detaches old handlers (no double-fire); `focus` following `visibilitychange` coalesces (no double-reconnect); `dispose()` detaches listeners.

## How It Was Tested

- [x] `bun run ci` (Biome lint + format + imports, strict mode) — clean (712 files)
- [x] `bun run typecheck` (node + web + test) — clean
- [x] `bun run test` — 225 files / 2519 tests passed, 0 failures (incl. the 5 new visibility-reconnect cases)
- [ ] `cargo clippy --all-targets -- -D warnings` (in src-tauri) — N/A (no Rust changes)
- [ ] `cargo test` (in src-tauri) — N/A (no Rust changes)
- [ ] Manual verification completed — **pending**: needs a real phone (idle > 30s → return → "Reconnecting…" → streaming resumes, no reload; brief switch < 30s → no disruption; turn mid-flight → cursor replays the outcome → can resend)

## CI & Review Gate

- [ ] All CI checks pass (PR Validation, Rust Checks, Build Verification, Security Scans) — _waiting for CI_
- [ ] Code review comments from CodeRabbit / Claude have been addressed or resolved — _waiting for review_
- [ ] No unresolved review findings remain

_I will not mark this ready for merge until CI is green and CodeRabbit findings are resolved (per AGENTS.md)._

## Checklist

- [x] My PR title follows the conventional commit format used by this repo
- [x] I linked the related issue or explained why none exists
- [x] I updated docs when needed — N/A (transparent behavior change; `architecture-web-acp-agent.md` already specified this D5 reconnect-with-cursor path)
- [x] I added or updated tests when needed — 5 regression tests covering the I/O matrix
- [x] I verified the change does not introduce unrelated modifications — 2 files, +355/-0
- [x] I read AGENTS.md and followed the contributor guidelines
- [ ] A human reviewed the complete diff before submission — _CodeRabbit + remote CI pending_


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved connection recovery when returning to the app after extended background inactivity.
  * Restores active sessions and replays missed updates after reconnecting.
  * Prevents duplicate reconnect attempts when visibility and focus events occur together.
  * Handles unhealthy connections more reliably, including cleanup of pending requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->