### PR TITLE
fix(acp): keep web/remote ACP alive through proxies and dedup user_prompt echo

### DIFF
--- a/src-tauri/src/web/ws.rs
+++ b/src-tauri/src/web/ws.rs
@@ -365,6 +365,15 @@ const PONG_TIMEOUT: Duration = Duration::from_secs(75);
 /// Must stay under 125 bytes per RFC 6455 control-frame limits.
 const PING_PAYLOAD: &[u8] = b"keepalive";
 
+/// Pure keepalive-watchdog decision: returns true when no inbound frame
+/// (text request, Pong, or client Ping) has arrived for longer than
+/// `PONG_TIMEOUT`. Extracted from the write task so the threshold semantics
+/// (strict `>`) are unit-testable without spinning up a real socket. The write
+/// task calls this with `last_activity.load()` + `now_ms()` on each ping tick.
+fn watchdog_is_stale(last_activity_ms: u64, now_ms_value: u64) -> bool {
+    now_ms_value.saturating_sub(last_activity_ms) > PONG_TIMEOUT.as_millis() as u64
+}
+
 /// Epoch-millis timestamp for the keepalive watchdog. Uses `SystemTime` (not
 /// `Instant`) so it fits an `AtomicU64`; clock skew inside one process over a
 /// ~minute window is negligible, and `saturating_sub` keeps the compare safe
@@ -468,9 +477,10 @@ async fn run_relay(socket: WebSocket, state: AppState) {
                     // instead of the server silently holding a dead socket
                     // (which would otherwise leak subscriptions + pending
                     // permissions and stall the chat UI mid-response).
-                    let stale = now_ms()
-                        .saturating_sub(write_last_activity.load(Ordering::Relaxed));
-                    if stale > PONG_TIMEOUT.as_millis() as u64 {
+                    let last = write_last_activity.load(Ordering::Relaxed);
+                    let now = now_ms();
+                    let stale = now.saturating_sub(last);
+                    if watchdog_is_stale(last, now) {
                         warn!(
                             "[ws] keepalive: no client activity for {stale} ms \
                              (>{PONG_TIMEOUT:?}); closing connection"
@@ -648,6 +658,13 @@ async fn handle_request(
             // Idempotent re-auth — accept and succeed.
             WsReply::ok(id, Some(json!({})))
         }
+        // Application-level heartbeat: a client-emitted `ping` request keeps
+        // the keepalive watchdog (`last_activity`) fresh through proxies that
+        // strip WS-level Ping/Pong control frames (Cloudflare tunnels, etc.).
+        // The read loop stamps `last_activity` on every inbound text frame
+        // before routing, so this handler only needs to round-trip a reply so
+        // the client's request promise resolves (no timeout).
+        "ping" => WsReply::ok(id, Some(json!({}))),
         "subscribe" => handle_subscribe(id, &req.payload, relay, out_tx, subscribed_clients).await,
         "list_persisted_sessions" => {
             handle_list_persisted_sessions(id, relay, chat_history_cache, history_mode)
@@ -2579,6 +2596,46 @@ mod tests {
         );
         assert!(!reply.ok);
         assert_eq!(reply.err.unwrap().code, "unsupported");
+    }
+
+    #[test]
+    fn ping_request_replies_ok_post_auth() {
+        // Heartbeat handler: a post-auth `ping` round-trips an ok reply so the
+        // client's request promise resolves (no timeout). The keepalive value
+        // is that the read loop stamps `last_activity` on the inbound text
+        // frame before routing — that refresh happens regardless of the reply.
+        let mut authed = true;
+        let reply = handle_sync(r#"{"id":"r1","type":"ping","payload":{}}"#, &mut authed);
+        assert!(reply.ok, "ping must round-trip an ok reply");
+        assert_eq!(reply.id, "r1");
+    }
+
+    #[test]
+    fn ping_request_pre_auth_rejected_unauthorized() {
+        // A pre-auth `ping` is gated like every other non-`authenticate` type —
+        // the heartbeat only refreshes the watchdog on an already-authed socket.
+        let mut authed = false;
+        let reply = handle_sync(r#"{"id":"r1","type":"ping","payload":{}}"#, &mut authed);
+        assert!(!reply.ok);
+        assert_eq!(reply.err.unwrap().code, "unauthorized");
+    }
+
+    #[test]
+    fn watchdog_is_stale_only_past_pong_timeout() {
+        // Pure threshold semantics for the keepalive watchdog: a connection is
+        // torn down only after strictly more than PONG_TIMEOUT with no inbound
+        // frame. Tests the decision the write task consults on each ping tick
+        // (the false-positive symptom behind issue: a focused tab through a
+        // proxy dropped every ~75s because Pongs didn't round-trip; a client
+        // `ping` text frame refreshes this and stays open).
+        let base = 1_000_000_u64;
+        let timeout = PONG_TIMEOUT.as_millis() as u64;
+        assert!(!watchdog_is_stale(base, base), "fresh connection is not stale");
+        assert!(!watchdog_is_stale(base, base + timeout), "exactly at timeout is not stale (strict >)");
+        assert!(!watchdog_is_stale(base, base + timeout - 1), "just under timeout is not stale");
+        assert!(watchdog_is_stale(base, base + timeout + 1), "just past timeout is stale");
+        // Clock-skew safe: a future `last_activity` saturates to 0 (not stale).
+        assert!(!watchdog_is_stale(base + 10_000, base));
     }
 
     #[test]

--- a/src/renderer/lib/acp-api.test.ts
+++ b/src/renderer/lib/acp-api.test.ts
@@ -159,7 +159,7 @@ describe('acp-api web path (injected WS transport)', () => {
 
     const reason = await acpSendPrompt('a1', 's1', 'hi')
     expect(reason).toBe('end_turn')
-    expect(sendPrompt).toHaveBeenCalledWith('a1', 's1', 'hi')
+    expect(sendPrompt).toHaveBeenCalledWith('a1', 's1', 'hi', undefined)
     expect(invoke).not.toHaveBeenCalled()
     _resetAcpTransportForTests(null)
   })

--- a/src/renderer/lib/acp-api.ts
+++ b/src/renderer/lib/acp-api.ts
@@ -485,17 +485,19 @@ export async function acpListSessions(
 export async function acpSendPrompt(
   agentId: AgentId,
   sessionId: SessionId,
-  text: string
+  text: string,
+  turnId?: string
 ): Promise<StopReason> {
-  return getAcpTransport().sendPrompt(agentId, sessionId, text)
+  return getAcpTransport().sendPrompt(agentId, sessionId, text, turnId)
 }
 
 export async function acpSendPromptBlocks(
   agentId: AgentId,
   sessionId: SessionId,
-  content: ContentBlock[]
+  content: ContentBlock[],
+  turnId?: string
 ): Promise<StopReason> {
-  return getAcpTransport().sendPromptBlocks(agentId, sessionId, content)
+  return getAcpTransport().sendPromptBlocks(agentId, sessionId, content, turnId)
 }
 
 export async function acpCancelPrompt(agentId: AgentId, sessionId: SessionId): Promise<void> {

--- a/src/renderer/lib/acp-transport.test.ts
+++ b/src/renderer/lib/acp-transport.test.ts
@@ -71,6 +71,12 @@ class FakeWebSocket {
       this.emitReply({ id: req.id, ok: true, payload: {} })
       return
     }
+    if (req.type === 'ping') {
+      // Heartbeat handler: round-trip an ok reply so the client's request
+      // promise resolves (a healthy ping resets the failure counter).
+      this.emitReply({ id: req.id, ok: true, payload: {} })
+      return
+    }
     if (req.type === 'subscribe') {
       const payload = req.payload as { sessionId: string; lastSeq?: number }
       if (payload.lastSeq === 99) {
@@ -409,6 +415,47 @@ describe('WsAcpTransport', () => {
     const after = sock.sent.filter((s) => JSON.parse(s).type === 'subscribe').length
     expect(after).toBe(before)
     transport.dispose()
+  })
+
+  it('forwards a caller-supplied turnId on send_prompt (no fresh mint)', async () => {
+    // The store mints the turn-id and passes it through so the optimistic
+    // user message can share the same `turn:<turnId>` id as the server echo.
+    const transport = new WsAcpTransport({
+      url: 'ws://test/ws',
+      WebSocketImpl: FakeWebSocket as unknown as typeof WebSocket
+    })
+    await transport.connect()
+    const sock = (transport as unknown as { socket: FakeWebSocket }).socket
+    await transport.sendPrompt('a1', 's1', 'hello', 'my-turn-id')
+    const sendPromptFrame = sock.sent
+      .map((s) => JSON.parse(s) as { type: string; payload?: { turnId?: string } })
+      .find((f) => f.type === 'send_prompt')
+    expect(sendPromptFrame?.payload?.turnId).toBe('my-turn-id')
+    transport.dispose()
+  })
+
+  it('sends a ping heartbeat on the interval to refresh the server watchdog', async () => {
+    // Proxies that strip WS-level Ping/Pong (Cloudflare tunnels) let the
+    // server's ~75s watchdog false-positive drop a focused tab; a periodic
+    // `ping` text request refreshes `last_activity` through any proxy.
+    vi.useFakeTimers()
+    try {
+      const transport = new WsAcpTransport({
+        url: 'ws://test/ws',
+        WebSocketImpl: FakeWebSocket as unknown as typeof WebSocket
+      })
+      await transport.connect()
+      const sock = (transport as unknown as { socket: FakeWebSocket }).socket
+      const pingsBefore = sock.sent.filter((s) => JSON.parse(s).type === 'ping').length
+      // HEARTBEAT_INTERVAL_MS = 30s; advance past one tick.
+      await vi.advanceTimersByTimeAsync(31_000)
+      const pingsAfter = sock.sent.filter((s) => JSON.parse(s).type === 'ping').length
+      expect(pingsAfter).toBeGreaterThan(pingsBefore)
+      expect(pingsAfter).toBeGreaterThanOrEqual(1)
+      transport.dispose()
+    } finally {
+      vi.useRealTimers()
+    }
   })
 
   it('delivers reliable events on arrival across a seq gap (no reorder-recovery)', async () => {

--- a/src/renderer/lib/acp-transport.ts
+++ b/src/renderer/lib/acp-transport.ts
@@ -72,11 +72,17 @@ export interface AcpTransport {
   resumeSession(agentId: AgentId, sessionId: SessionId, cwd: string): Promise<SessionReopenOutcome>
   closeSession(agentId: AgentId, sessionId: SessionId): Promise<void>
   listSessions(agentId: AgentId, cwd?: string, cursor?: string): Promise<ListSessionsResponse>
-  sendPrompt(agentId: AgentId, sessionId: SessionId, text: string): Promise<StopReason>
+  sendPrompt(
+    agentId: AgentId,
+    sessionId: SessionId,
+    text: string,
+    turnId?: string
+  ): Promise<StopReason>
   sendPromptBlocks(
     agentId: AgentId,
     sessionId: SessionId,
-    content: ContentBlock[]
+    content: ContentBlock[],
+    turnId?: string
   ): Promise<StopReason>
   cancelPrompt(agentId: AgentId, sessionId: SessionId): Promise<void>
   setConfigOption(
@@ -152,9 +158,9 @@ function createTauriAcpTransport(): AcpTransport {
     },
     listSessions: (agentId, cwd, cursor) =>
       invoke<ListSessionsResponse>('acp_list_sessions', { agentId, cwd, cursor }),
-    sendPrompt: (agentId, sessionId, text) =>
+    sendPrompt: (agentId, sessionId, text, _turnId) =>
       invoke<StopReason>('acp_send_prompt', { agentId, sessionId, text }),
-    sendPromptBlocks: (agentId, sessionId, content) =>
+    sendPromptBlocks: (agentId, sessionId, content, _turnId) =>
       invoke<StopReason>('acp_send_prompt', { agentId, sessionId, content }),
     cancelPrompt: async (agentId, sessionId) => {
       await invoke('acp_cancel_prompt', { agentId, sessionId })
@@ -261,6 +267,25 @@ const RECONNECT_MAX_MS = 8_000
  */
 const VISIBILITY_STALE_THRESHOLD_MS = 30_000
 
+/**
+ * Application-level heartbeat interval. A client-emitted `ping` text request
+ * refreshes the server keepalive watchdog (`last_activity`) through proxies
+ * that strip WS-level Ping/Pong control frames (Cloudflare tunnels, etc.), so
+ * a focused tab no longer false-positive drops at the server's ~75s
+ * `PONG_TIMEOUT`. ~30s sits under both the 75s timeout and the 20s Ping
+ * interval, so even a single tick keeps a healthy peer alive. Tunable.
+ */
+const HEARTBEAT_INTERVAL_MS = 30_000
+
+/**
+ * Consecutive ping failures that trigger a forced reconnect. A single missed
+ * reply can be transient (slow link); two in a row (~60s+ of no round-trip) is
+ * a strong half-open signal — the inbound ping keeps the *server's* watchdog
+ * fresh, so without this the client could sit on a dead socket whose `onclose`
+ * never fires (the server→client reply path is broken but client→server works).
+ */
+const HEARTBEAT_FAILURE_THRESHOLD = 2
+
 function requestTimeoutMs(type: WsRequestType): number {
   return type === 'send_prompt' ? SEND_PROMPT_TIMEOUT_MS : REQUEST_TIMEOUT_MS
 }
@@ -287,6 +312,11 @@ export class WsAcpTransport implements AcpTransport {
   private disposed = false
   private reconnectAttempt = 0
   private reconnectTimer: ReturnType<typeof setTimeout> | null = null
+  /** Application-level heartbeat timer (`setInterval`) — cleared on close /
+   * dispose / force-reconnect. `null` while no socket is live. */
+  private heartbeatTimer: ReturnType<typeof setInterval> | null = null
+  /** Consecutive heartbeat ping failures — forces a reconnect at the threshold. */
+  private consecutivePingFailures = 0
   /** When the page became hidden (epoch-ms), or null while visible. Drives the
    * visibility-triggered proactive reconnect on mobile idle/background resume. */
   private lastHiddenAt: number | null = null
@@ -345,6 +375,7 @@ export class WsAcpTransport implements AcpTransport {
   dispose(): void {
     this.disposed = true
     this.detachVisibilityListeners()
+    this.clearHeartbeat()
     if (this.reconnectTimer) {
       clearTimeout(this.reconnectTimer)
       this.reconnectTimer = null
@@ -536,24 +567,32 @@ export class WsAcpTransport implements AcpTransport {
     return this.request<ListSessionsResponse>('list_sessions', { agentId, cwd, cursor })
   }
 
-  async sendPrompt(agentId: AgentId, sessionId: SessionId, text: string): Promise<StopReason> {
+  async sendPrompt(
+    agentId: AgentId,
+    sessionId: SessionId,
+    text: string,
+    turnId?: string
+  ): Promise<StopReason> {
     await this.subscribeSession(sessionId) // no-op if already subscribed
-    // Story 1.8 T3.1 (FR11): generate a client turn-id so the server echoes it
-    // back on `prompt_complete` → our `seenTurnIds` dedup fires (no duplicate
-    // completion on reconnect replay). `crypto.randomUUID()` (available in
-    // browsers + Node 19+; the web build targets modern evergreen browsers).
-    const turnId = crypto.randomUUID()
-    return this.request<StopReason>('send_prompt', { agentId, sessionId, text, turnId })
+    // The turn-id is minted by the store (`runPromptTurn`) so the optimistic
+    // user message can share the same `turn:<turnId>` id as the server's
+    // `user_prompt` echo → reliable dedup in `_onUserPrompt` regardless of
+    // block differences (issue: the echo rendered a second user bubble because
+    // the optimistic id (`newId('msg')`) never matched the echo's `turn:<uuid>`).
+    // Fall back to a fresh UUID for callers that omit it (backward-compat / tests).
+    const id = turnId ?? crypto.randomUUID()
+    return this.request<StopReason>('send_prompt', { agentId, sessionId, text, turnId: id })
   }
 
   async sendPromptBlocks(
     agentId: AgentId,
     sessionId: SessionId,
-    content: ContentBlock[]
+    content: ContentBlock[],
+    turnId?: string
   ): Promise<StopReason> {
     await this.subscribeSession(sessionId)
-    const turnId = crypto.randomUUID()
-    return this.request<StopReason>('send_prompt', { agentId, sessionId, content, turnId })
+    const id = turnId ?? crypto.randomUUID()
+    return this.request<StopReason>('send_prompt', { agentId, sessionId, content, turnId: id })
   }
 
   async cancelPrompt(agentId: AgentId, sessionId: SessionId): Promise<void> {
@@ -640,6 +679,7 @@ export class WsAcpTransport implements AcpTransport {
       ws.onclose = () => {
         this.socket = null
         this.authed = false
+        this.clearHeartbeat()
         this.rejectAllPending('closed', 'WebSocket closed')
         if (!this.disposed) this.scheduleReconnect()
         settleErr(new AcpTransportError('closed', 'WebSocket closed before auth'))
@@ -750,6 +790,7 @@ export class WsAcpTransport implements AcpTransport {
     this.authed = false
     this.connecting = null
     this.rejectAllPending('closed', reason)
+    this.clearHeartbeat()
     if (this.reconnectTimer) {
       clearTimeout(this.reconnectTimer)
       this.reconnectTimer = null
@@ -768,6 +809,48 @@ export class WsAcpTransport implements AcpTransport {
       }
     }
     this.scheduleReconnect()
+  }
+
+  /**
+   * Start the application-level heartbeat that keeps the server's keepalive
+   * watchdog fresh through proxies that strip WS-level Ping/Pong control
+   * frames. A periodic `ping` text request lands in the server read loop,
+   * which stamps `last_activity` on every inbound frame — so a focused tab no
+   * longer false-positive drops at the ~75s `PONG_TIMEOUT`. Idempotent: clears
+   * any prior timer first. Stopped on close / dispose / force-reconnect.
+   */
+  private startHeartbeat(): void {
+    this.clearHeartbeat()
+    this.heartbeatTimer = setInterval(() => {
+      if (this.disposed) return
+      // Only tick while OPEN; the reconnect path owns recovery otherwise. A
+      // failed ping (half-open link) is swallowed per-tick but counted — at the
+      // threshold, force a reconnect so a dead reply path doesn't strand the
+      // client on a socket whose onclose may never fire.
+      if (this.socket?.readyState === WebSocket.OPEN) {
+        void this.request<void>('ping', {})
+          .then(() => {
+            this.consecutivePingFailures = 0
+          })
+          .catch(() => {
+            this.consecutivePingFailures += 1
+            if (!this.disposed && this.consecutivePingFailures >= HEARTBEAT_FAILURE_THRESHOLD) {
+              this.forceReconnect(
+                `ping heartbeat: ${this.consecutivePingFailures} consecutive failures (half-open link)`
+              )
+            }
+          })
+      }
+    }, HEARTBEAT_INTERVAL_MS)
+  }
+
+  /** Stop the heartbeat timer (on close / dispose / force-reconnect). */
+  private clearHeartbeat(): void {
+    if (this.heartbeatTimer) {
+      clearInterval(this.heartbeatTimer)
+      this.heartbeatTimer = null
+    }
+    this.consecutivePingFailures = 0
   }
 
   private scheduleReconnect(): void {
@@ -849,6 +932,10 @@ export class WsAcpTransport implements AcpTransport {
         })
         this.negotiatedHistoryMode = auth?.historyMode ?? 'live_only'
         this.authed = true
+        // Start the application-level heartbeat now that the socket is OPEN
+        // + authed — it refreshes the server keepalive watchdog through proxies
+        // that strip WS-level Ping/Pong so a focused tab stops dropping at ~75s.
+        this.startHeartbeat()
       } catch (err) {
         try {
           this.socket?.close()

--- a/src/renderer/stores/acp-store.test.ts
+++ b/src/renderer/stores/acp-store.test.ts
@@ -484,6 +484,36 @@ describe('acp-store', () => {
     expect(useAcpStore.getState().sessions['s1'].activeTurn).toBe(true)
   })
 
+  it('stages the optimistic user message with a turn:<id> and dedups a same-turnId echo even when blocks differ', async () => {
+    // Regression for the duplicate-bubble bug: the optimistic message and the
+    // server `user_prompt` echo must share the same `turn:<turnId>` id so
+    // `_onUserPrompt` dedups by id (not a fragile block-exact compare) — a
+    // differing echo is collapsed into the optimistic message, not appended.
+    seedSession('s1', 'agent-1', false)
+    // never resolve, so the turn stays active for the assertion
+    ;(invoke as ReturnType<typeof vi.fn>).mockReturnValue(new Promise(() => {}))
+    void useAcpStore.getState().sendPrompt('s1', 'hi there')
+    await Promise.resolve()
+    const msgs = useAcpStore.getState().messages['s1']
+    expect(msgs).toHaveLength(1)
+    expect(msgs[0].role).toBe('user')
+    expect(msgs[0].id.startsWith('turn:')).toBe(true)
+    const turnId = msgs[0].id.slice('turn:'.length)
+    expect(turnId.length).toBeGreaterThan(0)
+    // Server echoes the SAME turn id but with DIFFERENT block content — must
+    // collapse into the optimistic message (dedup by id), not append a copy.
+    useAcpStore.getState()._onUserPrompt({
+      agentId: 'agent-1',
+      sessionId: 's1',
+      turnId,
+      content: [{ type: 'text', text: 'echoed-different-blocks' }]
+    })
+    const after = useAcpStore.getState().messages['s1']
+    expect(after).toHaveLength(1)
+    expect(after[0].id).toBe(`turn:${turnId}`)
+    expect(after[0].blocks[0]).toEqual({ type: 'text', text: 'hi there' })
+  })
+
   it('sendPrompt updates the persisted history title from the first user message', async () => {
     seedSession('s1', 'agent-09d39730', false)
     useAcpStore.setState({

--- a/src/renderer/stores/acp-store.ts
+++ b/src/renderer/stores/acp-store.ts
@@ -858,7 +858,7 @@ function flushNextQueuedPrompt(set: TurnEndSetter, sessionId: SessionId): void {
     () => useAcpStore.getState(),
     sessionId,
     next.blocks,
-    (s) => acpApi.sendPromptBlocks(s.agentId, sessionId, next.blocks),
+    (s, turnId) => acpApi.sendPromptBlocks(s.agentId, sessionId, next.blocks, turnId),
     next
   ).catch((err) => {
     // Busy recovery is handled inside runPromptTurn (FIFO restore via queuedOrigin).
@@ -1796,7 +1796,7 @@ async function runPromptTurn(
   get: () => AcpState,
   sessionId: SessionId,
   userBlocks: ContentBlock[],
-  dispatch: (session: AcpSession) => Promise<StopReason>,
+  dispatch: (session: AcpSession, turnId: string) => Promise<StopReason>,
   queuedOrigin?: QueuedPrompt,
   options?: { skipUserAppend?: boolean }
 ): Promise<void> {
@@ -1810,6 +1810,12 @@ async function runPromptTurn(
   let openTurnId = ''
   const previousOpenTurnId = session.openTurnId
   const skipUserAppend = Boolean(options?.skipUserAppend)
+  // Mint the client turn-id HERE (not inside the transport) so the optimistic
+  // user message below can share the same `turn:<turnId>` id as the server's
+  // `user_prompt` echo → reliable dedup in `_onUserPrompt` regardless of block
+  // differences (the bug: the echo rendered a second user bubble because the
+  // optimistic id (`msg-<uuid>`) never matched the echo's `turn:<uuid>`).
+  const turnId = crypto.randomUUID()
 
   // Atomically decide enqueue vs start so rapid sends cannot both reach the backend.
   set((s) => {
@@ -1838,7 +1844,7 @@ async function runPromptTurn(
         [...(s.messages[sessionId] ?? [])].reverse().find((m) => m.role === 'user') ?? null
       if (!userMessage) {
         userMessage = {
-          id: newId('msg'),
+          id: `turn:${turnId}`,
           role: 'user',
           blocks: userBlocks,
           streaming: false,
@@ -1866,7 +1872,7 @@ async function runPromptTurn(
     }
 
     userMessage = {
-      id: newId('msg'),
+      id: `turn:${turnId}`,
       role: 'user',
       blocks: userBlocks,
       streaming: false,
@@ -1896,7 +1902,7 @@ async function runPromptTurn(
     // `_onPromptComplete` (which also calls `scheduleTurnEnd`).
     const liveSession = get().sessions[sessionId]
     if (!liveSession) throw new Error(`unknown session ${sessionId}`)
-    const stopReason = await dispatch(liveSession)
+    const stopReason = await dispatch(liveSession, turnId)
     scheduleTurnEnd(set, sessionId, stopReason, openTurnId)
   } catch (err) {
     if (isPromptTurnInProgressError(err)) {
@@ -2860,12 +2866,12 @@ export const useAcpStore = create<AcpState>((set, get) => ({
           get,
           sessionId,
           blocks,
-          (session) => {
+          (session, turnId) => {
             const only = blocks.length === 1 ? blocks[0] : null
             if (only?.type === 'text' && typeof only.text === 'string') {
-              return acpApi.sendPrompt(session.agentId, sessionId, only.text)
+              return acpApi.sendPrompt(session.agentId, sessionId, only.text, turnId)
             }
-            return acpApi.sendPromptBlocks(session.agentId, sessionId, blocks)
+            return acpApi.sendPromptBlocks(session.agentId, sessionId, blocks, turnId)
           },
           undefined,
           { skipUserAppend: hadOptimisticUser }
@@ -3023,10 +3029,10 @@ export const useAcpStore = create<AcpState>((set, get) => ({
         get,
         sessionId,
         lastUserBlocks,
-        (s) =>
+        (s, turnId) =>
           only?.type === 'text' && typeof only.text === 'string'
-            ? acpApi.sendPrompt(s.agentId, sessionId, only.text)
-            : acpApi.sendPromptBlocks(s.agentId, sessionId, lastUserBlocks!),
+            ? acpApi.sendPrompt(s.agentId, sessionId, only.text, turnId)
+            : acpApi.sendPromptBlocks(s.agentId, sessionId, lastUserBlocks!, turnId),
         undefined,
         { skipUserAppend: true }
       )
@@ -3388,8 +3394,8 @@ export const useAcpStore = create<AcpState>((set, get) => ({
   },
 
   sendPrompt: (sessionId, text) =>
-    runPromptTurn(set, get, sessionId, [{ type: 'text', text }], (session) =>
-      acpApi.sendPrompt(session.agentId, sessionId, text)
+    runPromptTurn(set, get, sessionId, [{ type: 'text', text }], (session, turnId) =>
+      acpApi.sendPrompt(session.agentId, sessionId, text, turnId)
     ),
 
   sendPromptBlocks: (sessionId, blocks, options) =>
@@ -3398,7 +3404,7 @@ export const useAcpStore = create<AcpState>((set, get) => ({
       get,
       sessionId,
       blocks,
-      (session) => acpApi.sendPromptBlocks(session.agentId, sessionId, blocks),
+      (session, turnId) => acpApi.sendPromptBlocks(session.agentId, sessionId, blocks, turnId),
       undefined,
       options
     ),
@@ -3446,7 +3452,7 @@ export const useAcpStore = create<AcpState>((set, get) => ({
         get,
         sessionId,
         item.blocks,
-        (s) => acpApi.sendPromptBlocks(s.agentId, sessionId, item.blocks),
+        (s, turnId) => acpApi.sendPromptBlocks(s.agentId, sessionId, item.blocks, turnId),
         item
       )
     } catch (err) {

--- a/src/shared/types/web-protocol.types.test.ts
+++ b/src/shared/types/web-protocol.types.test.ts
@@ -58,8 +58,8 @@ describe('web-protocol.types — event/request type registries (AC2)', () => {
     expect(WS_REQUEST_TYPES).toContain('get_session_payload')
   })
 
-  it('exports exactly 20 request types including persisted history list/open', () => {
-    expect(WS_REQUEST_TYPES).toHaveLength(20)
+  it('exports exactly 21 request types including the ping heartbeat', () => {
+    expect(WS_REQUEST_TYPES).toHaveLength(21)
     const expected = [
       'send_prompt',
       'cancel_prompt',
@@ -78,6 +78,7 @@ describe('web-protocol.types — event/request type registries (AC2)', () => {
       'switch_project',
       'authenticate',
       'subscribe',
+      'ping',
       'list_persisted_sessions',
       'open_persisted_session',
       'get_session_payload'

--- a/src/shared/types/web-protocol.types.ts
+++ b/src/shared/types/web-protocol.types.ts
@@ -99,6 +99,9 @@ export type WsEventType = (typeof WS_EVENT_TYPES)[number]
  *
  * `subscribe` (Story 1.6) is relay-level (not an `acp_*` command): binds a
  * connection to a session event log with an optional `lastSeq` cursor.
+ * `ping` is a relay-level heartbeat: a client-emitted request that round-trips
+ * an ok reply so the server's keepalive watchdog (`last_activity`) stays fresh
+ * through proxies that strip WS-level Ping/Pong control frames.
  */
 export const WS_REQUEST_TYPES = [
   'send_prompt',
@@ -118,6 +121,7 @@ export const WS_REQUEST_TYPES = [
   'switch_project',
   'authenticate',
   'subscribe',
+  'ping',
   'list_persisted_sessions',
   'open_persisted_session',
   'get_session_payload'


### PR DESCRIPTION
## Summary

The web/remote ACP chat dropped its WebSocket every ~75s while the tab was focused, and a single sent prompt rendered the user's message twice. Both stem from the web/remote transport path: the server's keepalive watchdog killed live connections because the browser's auto-Pong doesn't survive Cloudflare-tunneled / WS-terminating proxies, and the optimistic user message + the server's `user_prompt` echo couldn't dedup because their ids never matched (falling back to a fragile block-exact compare). This PR makes the connection robust through any proxy and makes prompt dedup reliable by id.

## Related Issue

No related issue — bug found from local runtime logs (`termul.log` showed recurring `[ws] keepalive: no client activity for >75s; closing connection` drops plus a duplicate user-message bubble on send); no tracking issue filed.

## Type of Change

- [x] fix: bug fix

## What Changed

- `src-tauri/src/web/ws.rs`: added a relay-level `ping` request handler (round-trips an ok reply; the read loop already stamps `last_activity` on every inbound text frame, so a client heartbeat refreshes the watchdog through any proxy). Extracted the keepalive decision into a pure, unit-tested `watchdog_is_stale` — the first coverage for the previously-untested 75s no-inbound teardown.
- `src/shared/types/web-protocol.types.ts`: registered `'ping'` as a WS request type (21 total).
- `src/renderer/lib/acp-transport.ts`: added a ~30s application-level heartbeat that sends a `ping` text request while the socket is OPEN (refreshes the server watchdog through proxies that strip WS-level Ping/Pong — fixes the periodic ~75s false-positive drops on a focused tab via a tunnel). Two consecutive ping failures force a reconnect, restoring the half-open detection the no-Pong watchdog used to provide. Accept an optional `turnId` param on `sendPrompt`/`sendPromptBlocks` (uses it instead of minting).
- `src/renderer/lib/acp-api.ts`: thread `turnId` through `acpSendPrompt`/`acpSendPromptBlocks`.
- `src/renderer/stores/acp-store.ts`: mint the `turnId` in `runPromptTurn` and stage the optimistic user message with id `turn:<turnId>`, so the server's `user_prompt` echo collapses into it by id (not a fragile `JSON.stringify` block compare) — fixes the duplicate user-message bubble. Forwarded the turnId through all dispatch closures. Desktop (Tauri) path is unchanged (no `user_prompt` echo there; `acp_send_prompt` still passes `None`).

## How It Was Tested

- [x] `bun run ci` (Biome lint + format + imports, strict mode)
- [x] `bun run typecheck`
- [x] `bun run test`
- [x] `cargo clippy --all-targets -- -D warnings` (in src-tauri)
- [x] `cargo test` (in src-tauri)
- [x] Manual verification completed

## Screenshots or Recordings

Not applicable — backend transport + store logic; no UI surface changed.

## CI & Review Gate

- [ ] All CI checks pass (PR Validation, Rust Checks, Build Verification, Security Scans)
- [ ] Code review comments from CodeRabbit / Claude have been addressed or resolved
- [ ] No unresolved review findings remain

## Checklist

- [x] My PR title follows the conventional commit format used by this repo
- [x] I linked the related issue or explained why none exists
- [x] I updated docs when needed
- [x] I added or updated tests when needed
- [x] I verified the change does not introduce unrelated modifications
- [x] I read AGENTS.md and followed the contributor guidelines
- [x] A human reviewed the complete diff before submission


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added reliable WebSocket heartbeats to detect connection failures and reconnect automatically.
  - Added authenticated ping support for maintaining relay connections.
  - Added optional turn IDs for tracking prompt requests across transports.
  - Improved message handling to prevent duplicate user messages.

- **Bug Fixes**
  - Improved retry and queued-prompt behavior while preserving message identity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->