### PR TITLE
feat(web): add mobile file explorer drawer for web/remote browsing

### DIFF
--- a/src-tauri/src/web/fs_api.rs
+++ b/src-tauri/src/web/fs_api.rs
@@ -110,6 +110,51 @@ pub struct GitInitRequest {
     pub cwd: String,
 }
 
+/// Mirrors the renderer's `MAX_FILE_SIZE` (1 MiB). `/fs/read` refuses files
+/// larger than this with `code: "FILE_TOO_LARGE"` BEFORE reading or
+/// transferring the content, matching the desktop facade's size guard.
+const MAX_FILE_SIZE: u64 = 1024 * 1024;
+
+/// `GET /fs/read?path=...` response body (one item). Mirrors the shared TS
+/// `FileContent` contract (`{ content, encoding, size, modifiedAt }`) used by
+/// the renderer's `filesystemApi.readFile` / editor store.
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FileContentDto {
+    pub content: String,
+    pub encoding: String,
+    pub size: u64,
+    pub modified_at: u64,
+}
+
+/// `POST /fs/delete` body: `{ "path": "...", "recursive": true? }`.
+/// `recursive` defaults to `false`; directories require it to be `true`
+/// (mirrors `@tauri-apps/plugin-fs` `remove` semantics).
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DeleteRequest {
+    pub path: String,
+    pub recursive: Option<bool>,
+}
+
+/// `POST /fs/rename` body: `{ "from": "...", "to": "..." }`. Both endpoints
+/// are resolved through `check_within_root` so the destination stays inside
+/// the project root.
+#[derive(Debug, Deserialize)]
+pub struct RenameRequest {
+    pub from: String,
+    pub to: String,
+}
+
+/// `POST /fs/copy` body: `{ "from": "...", "to": "..." }`. Copies a single
+/// file (matches the desktop `copyFile` which uses `@tauri-apps/plugin-fs`
+/// `copyFile` — directories error with `COPY_ERROR`).
+#[derive(Debug, Deserialize)]
+pub struct CopyRequest {
+    pub from: String,
+    pub to: String,
+}
+
 // Names commonly git-ignored; entries matching these are surfaced with
 // `ignored: true` (shown dimmed in the tree, same as the Tauri path).
 const ALWAYS_IGNORE: &[&str] = &[
@@ -475,6 +520,184 @@ pub async fn browse(
     (StatusCode::OK, Json(body))
 }
 
+/// `GET /fs/read?path=...` — read a text file's content. Returns
+/// `{ success: true, data: FileContent }` or
+/// `{ success: false, error, code }` where code is one of `PATH_TRAVERSAL`
+/// (explicit `..` component, defense-in-depth — matches `ls`/`mkdir`),
+/// `READ_ERROR` (missing/dir/io), `FILE_TOO_LARGE` (> 1 MiB, refused before
+/// read), or `BINARY_FILE` (NUL/control bytes in the first 512 bytes —
+/// mirrors the renderer's `isBinaryFile`). Paths outside the configured
+/// `project_root` are allowed (the prefix-containment jail was removed by
+/// spec-remove-web-fs-path-jail), matching `/fs/ls` + `/fs/browse`. A read
+/// route: intentionally NOT loopback-guarded, so desktop-hosted LAN clients
+/// can open files in the editor; mutations stay loopback-only
+/// (`delete`/`rename`/`copy`).
+pub async fn read(State(_state): State<AppState>, Query(q): Query<PathQuery>) -> impl IntoResponse {
+    let path = match resolve_request_path(Path::new(&q.path)) {
+        Ok(safe) => safe,
+        Err((msg, code)) => {
+            return (StatusCode::OK, Json(IpcBody::<FileContentDto>::err(msg, code)));
+        }
+    };
+    let result = tokio::task::spawn_blocking(move || -> Result<FileContentDto, (String, &'static str)> {
+        let metadata = fs::metadata(&path).map_err(|e| (format!("{e}"), "READ_ERROR"))?;
+        if metadata.is_dir() {
+            return Err((
+                "cannot read a directory as a file".to_string(),
+                "READ_ERROR",
+            ));
+        }
+        let size = metadata.len();
+        if size > MAX_FILE_SIZE {
+            return Err((
+                format!("File too large ({size} bytes, max {MAX_FILE_SIZE})"),
+                "FILE_TOO_LARGE",
+            ));
+        }
+        let modified_at = metadata
+            .modified()
+            .ok()
+            .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
+            .map(|d| d.as_millis() as u64)
+            .unwrap_or(0);
+        let bytes = fs::read(&path).map_err(|e| (format!("{e}"), "READ_ERROR"))?;
+        // Binary detection: control bytes (0x00-0x08) in the first 512
+        // bytes — mirrors the renderer's `isBinaryFile` regex `/[\x00-\x08]/`
+        // so the web path rejects binaries exactly like desktop.
+        let sample_end = bytes.len().min(512);
+        if bytes[..sample_end].iter().any(|&b| b <= 0x08) {
+            return Err((
+                "Binary file cannot be displayed".to_string(),
+                "BINARY_FILE",
+            ));
+        }
+        let content = String::from_utf8_lossy(&bytes).into_owned();
+        Ok(FileContentDto {
+            content,
+            encoding: "utf-8".to_string(),
+            size,
+            modified_at,
+        })
+    })
+    .await
+    .map_err(|e| format!("read task failed: {e}"));
+    let body = match result {
+        Ok(Ok(fc)) => IpcBody::ok(fc),
+        Ok(Err((msg, code))) => IpcBody::<FileContentDto>::err(msg, code),
+        Err(e) => IpcBody::<FileContentDto>::err(format!("read task failed: {e}"), "READ_ERROR"),
+    };
+    (StatusCode::OK, Json(body))
+}
+
+/// `POST /fs/delete` — delete a file or directory. `{ "path": "...",
+/// "recursive": true? }`. A non-recursive delete of a non-empty directory
+/// fails with `DELETE_ERROR` (mirrors `fs::remove_dir`). Loopback-guarded
+/// like `mkdir`/`write` — mutations stay localhost-only even when the server
+/// is bound to `0.0.0.0`.
+pub async fn delete(
+    State(_state): State<AppState>,
+    ConnectInfo(peer): ConnectInfo<SocketAddr>,
+    Json(req): Json<DeleteRequest>,
+) -> impl IntoResponse {
+    if let Some(forbidden) = check_local_only::<()>(peer) {
+        return (StatusCode::OK, Json(forbidden));
+    }
+    let path = match resolve_request_path(Path::new(&req.path)) {
+        Ok(safe) => safe,
+        Err((msg, code)) => {
+            return (StatusCode::OK, Json(IpcBody::<()>::err(msg, code)));
+        }
+    };
+    let recursive = req.recursive.unwrap_or(false);
+    let result = tokio::task::spawn_blocking(move || -> std::io::Result<()> {
+        match fs::metadata(&path) {
+            Ok(m) if m.is_dir() && recursive => fs::remove_dir_all(&path),
+            Ok(m) if m.is_dir() => fs::remove_dir(&path),
+            _ => fs::remove_file(&path),
+        }
+    })
+    .await
+    .map_err(|e| format!("delete task failed: {e}"));
+    let body = match result {
+        Ok(Ok(())) => IpcBody::<()>::ok(()),
+        Ok(Err(e)) => IpcBody::<()>::err(format!("{e}"), "DELETE_ERROR"),
+        Err(e) => IpcBody::<()>::err(format!("delete task failed: {e}"), "DELETE_ERROR"),
+    };
+    (StatusCode::OK, Json(body))
+}
+
+/// `POST /fs/rename` — rename/move a file or directory. `{ "from": "...",
+/// "to": "..." }`. Both endpoints are resolved via `resolve_request_path`
+/// (explicit `..` components are rejected; paths outside `project_root` are
+/// allowed, matching `ls`/`mkdir`). Loopback-guarded (mutation).
+pub async fn rename(
+    State(_state): State<AppState>,
+    ConnectInfo(peer): ConnectInfo<SocketAddr>,
+    Json(req): Json<RenameRequest>,
+) -> impl IntoResponse {
+    if let Some(forbidden) = check_local_only::<()>(peer) {
+        return (StatusCode::OK, Json(forbidden));
+    }
+    let from = match resolve_request_path(Path::new(&req.from)) {
+        Ok(safe) => safe,
+        Err((msg, code)) => {
+            return (StatusCode::OK, Json(IpcBody::<()>::err(msg, code)));
+        }
+    };
+    let to = match resolve_request_path(Path::new(&req.to)) {
+        Ok(safe) => safe,
+        Err((msg, code)) => {
+            return (StatusCode::OK, Json(IpcBody::<()>::err(msg, code)));
+        }
+    };
+    let result = tokio::task::spawn_blocking(move || fs::rename(&from, &to))
+        .await
+        .map_err(|e| format!("rename task failed: {e}"));
+    let body = match result {
+        Ok(Ok(())) => IpcBody::<()>::ok(()),
+        Ok(Err(e)) => IpcBody::<()>::err(format!("{e}"), "RENAME_ERROR"),
+        Err(e) => IpcBody::<()>::err(format!("rename task failed: {e}"), "RENAME_ERROR"),
+    };
+    (StatusCode::OK, Json(body))
+}
+
+/// `POST /fs/copy` — copy a single file. `{ "from": "...", "to": "..." }`.
+/// `std::fs::copy` copies one file (not a directory) — directories fail with
+/// `COPY_ERROR`, matching the desktop `copyFile`. Both endpoints are resolved
+/// via `resolve_request_path` (explicit `..` components are rejected; paths
+/// outside `project_root` are allowed, matching `ls`/`mkdir`). Loopback-guarded
+/// (mutation).
+pub async fn copy(
+    State(_state): State<AppState>,
+    ConnectInfo(peer): ConnectInfo<SocketAddr>,
+    Json(req): Json<CopyRequest>,
+) -> impl IntoResponse {
+    if let Some(forbidden) = check_local_only::<()>(peer) {
+        return (StatusCode::OK, Json(forbidden));
+    }
+    let from = match resolve_request_path(Path::new(&req.from)) {
+        Ok(safe) => safe,
+        Err((msg, code)) => {
+            return (StatusCode::OK, Json(IpcBody::<()>::err(msg, code)));
+        }
+    };
+    let to = match resolve_request_path(Path::new(&req.to)) {
+        Ok(safe) => safe,
+        Err((msg, code)) => {
+            return (StatusCode::OK, Json(IpcBody::<()>::err(msg, code)));
+        }
+    };
+    let result = tokio::task::spawn_blocking(move || fs::copy(&from, &to).map(|_| ()))
+        .await
+        .map_err(|e| format!("copy task failed: {e}"));
+    let body = match result {
+        Ok(Ok(())) => IpcBody::<()>::ok(()),
+        Ok(Err(e)) => IpcBody::<()>::err(format!("{e}"), "COPY_ERROR"),
+        Err(e) => IpcBody::<()>::err(format!("copy task failed: {e}"), "COPY_ERROR"),
+    };
+    (StatusCode::OK, Json(body))
+}
+
 /// `POST /git/init` — initialize a git repository in `cwd`. Reuses
 /// `GitTracker::run_git_command(&cwd, &["init"])` (same call the
 /// `#[tauri::command] git_init` makes). Returns `{ success: true }` or
@@ -687,6 +910,10 @@ mod tests {
             .route("/fs/write", axum::routing::post(write))
             .route("/fs/ls", axum::routing::get(ls))
             .route("/fs/browse", axum::routing::get(browse))
+            .route("/fs/read", axum::routing::get(read))
+            .route("/fs/delete", axum::routing::post(delete))
+            .route("/fs/rename", axum::routing::post(rename))
+            .route("/fs/copy", axum::routing::post(copy))
             .route("/git/init", axum::routing::post(git_init))
             .route("/shells", axum::routing::get(shells))
             .with_state(state)
@@ -1250,5 +1477,270 @@ mod tests {
         assert_eq!(body.code.as_deref(), Some("GIT_INIT_ERROR"));
         let err = body.error.expect("error message present");
         assert!(!err.trim().is_empty(), "error must be non-empty: {err:?}");
+    }
+
+    /// `/fs/read` returns the file content + size + modifiedAt for an existing
+    /// text file inside the project root.
+    #[tokio::test]
+    async fn read_returns_file_content() {
+        let root = TempDir::new("read-root");
+        let file = root.path().join("note.txt");
+        fs::write(&file, "hello world").expect("write file");
+        let uri = format!("/fs/read?path={}", urlencoding(&file.to_string_lossy()));
+        let resp = get_request(test_state_with_root(root.path()), &uri).await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body: IpcBody<FileContentDto> = body_as_json(resp.into_body()).await;
+        assert!(body.success, "read inside root must succeed");
+        let fc = body.data.expect("content present");
+        assert_eq!(fc.content, "hello world");
+        assert_eq!(fc.encoding, "utf-8");
+        assert_eq!(fc.size, "hello world".len() as u64);
+        assert!(fc.modified_at > 0, "modifiedAt must be populated");
+    }
+
+    /// `/fs/read` allows a path outside the project root (the prefix-containment
+    /// jail was removed by spec-remove-web-fs-path-jail; matches `/fs/ls`).
+    #[tokio::test]
+    async fn read_allows_path_outside_project_root() {
+        let root = TempDir::new("read-root");
+        let outside = TempDir::new("read-outside");
+        let target = outside.path().join("evil.txt");
+        fs::write(&target, "pwn").expect("write outside file");
+        let uri = format!("/fs/read?path={}", urlencoding(&target.to_string_lossy()));
+        let resp = get_request(test_state_with_root(root.path()), &uri).await;
+        let body: IpcBody<FileContentDto> = body_as_json(resp.into_body()).await;
+        assert!(body.success, "read outside root should succeed: {:?}", body.error);
+        assert_eq!(body.data.expect("content").content, "pwn");
+    }
+
+    /// `/fs/read` rejects explicit `..` traversal components (defense-in-depth).
+    #[tokio::test]
+    async fn read_rejects_traversal_sequence_in_path() {
+        let root = TempDir::new("read-trav-root");
+        let inside = root.path().join("sub");
+        fs::create_dir_all(&inside).expect("mkdir inside");
+        let traversal = inside.join("..").join("..").join("etc");
+        let uri = format!("/fs/read?path={}", urlencoding(&traversal.to_string_lossy()));
+        let resp = get_request(test_state_with_root(root.path()), &uri).await;
+        let body: IpcBody<FileContentDto> = body_as_json(resp.into_body()).await;
+        assert!(!body.success, "traversal must be refused");
+        let code = body.code.as_deref().unwrap_or("");
+        assert!(
+            code == "PATH_TRAVERSAL" || code == "OUTSIDE_ROOT",
+            "expected PATH_TRAVERSAL or OUTSIDE_ROOT, got {code:?}"
+        );
+    }
+
+    /// `/fs/read` refuses a directory (cannot read a dir as a file) with
+    /// `READ_ERROR`, never returning a directory listing.
+    #[tokio::test]
+    async fn read_rejects_directory() {
+        let root = TempDir::new("read-dir-root");
+        let dir_path = root.path().join("a-dir");
+        fs::create_dir_all(&dir_path).expect("mkdir");
+        let uri = format!("/fs/read?path={}", urlencoding(&dir_path.to_string_lossy()));
+        let resp = get_request(test_state_with_root(root.path()), &uri).await;
+        let body: IpcBody<FileContentDto> = body_as_json(resp.into_body()).await;
+        assert!(!body.success, "reading a directory must fail");
+        assert_eq!(body.code.as_deref(), Some("READ_ERROR"));
+    }
+
+    /// `/fs/read` refuses a binary file (NUL/control bytes in the first 512
+    /// bytes) with `BINARY_FILE`, mirroring the renderer's `isBinaryFile`.
+    #[tokio::test]
+    async fn read_rejects_binary_file() {
+        let root = TempDir::new("read-bin-root");
+        let file = root.path().join("blob.bin");
+        // Leading NUL byte (0x00) — caught by the binary sample scan.
+        fs::write(&file, [0x00u8, 0x01, 0x02, 0x03]).expect("write binary");
+        let uri = format!("/fs/read?path={}", urlencoding(&file.to_string_lossy()));
+        let resp = get_request(test_state_with_root(root.path()), &uri).await;
+        let body: IpcBody<FileContentDto> = body_as_json(resp.into_body()).await;
+        assert!(!body.success, "binary file must be refused");
+        assert_eq!(body.code.as_deref(), Some("BINARY_FILE"));
+    }
+
+    /// `/fs/delete` removes a file inside the project root.
+    #[tokio::test]
+    async fn delete_removes_file() {
+        let root = TempDir::new("delete-root");
+        let file = root.path().join("doomed.txt");
+        fs::write(&file, "bye").expect("write file");
+        let req_body = serde_json::json!({ "path": file.to_string_lossy() });
+        let resp = post_json(test_state_with_root(root.path()), "/fs/delete", &req_body).await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body: IpcBody<()> = body_as_json(resp.into_body()).await;
+        assert!(body.success, "delete must succeed");
+        assert!(!file.exists(), "file must be gone after delete");
+    }
+
+    /// `/fs/delete` removes a non-empty directory only when `recursive: true`.
+    #[tokio::test]
+    async fn delete_removes_dir_recursive() {
+        let root = TempDir::new("delete-rec-root");
+        let dir = root.path().join("tree");
+        fs::create_dir_all(dir.join("child")).expect("mkdir tree");
+        fs::write(dir.join("child").join("f.txt"), "x").expect("write child");
+        let req_body = serde_json::json!({ "path": dir.to_string_lossy(), "recursive": true });
+        let resp = post_json(test_state_with_root(root.path()), "/fs/delete", &req_body).await;
+        let body: IpcBody<()> = body_as_json(resp.into_body()).await;
+        assert!(body.success, "recursive delete must succeed");
+        assert!(!dir.exists(), "dir must be gone after recursive delete");
+    }
+
+    /// `/fs/delete` allows a path outside the project root (the jail was
+    /// removed; matches `mkdir`/`write`). The file is actually removed.
+    #[tokio::test]
+    async fn delete_allows_path_outside_project_root() {
+        let root = TempDir::new("delete-root");
+        let outside = TempDir::new("delete-outside");
+        let target = outside.path().join("evil.txt");
+        fs::write(&target, "pwn").expect("write outside");
+        let req_body = serde_json::json!({ "path": target.to_string_lossy() });
+        let resp = post_json(test_state_with_root(root.path()), "/fs/delete", &req_body).await;
+        let body: IpcBody<()> = body_as_json(resp.into_body()).await;
+        assert!(body.success, "delete outside root should succeed: {:?}", body.error);
+        assert!(!target.exists(), "file outside root must be deleted");
+    }
+
+    /// `/fs/delete` is loopback-guarded: a non-loopback peer is refused with
+    /// `FORBIDDEN` (Patch D, same as `mkdir`/`write`).
+    #[tokio::test]
+    async fn delete_rejects_non_loopback_peer() {
+        let root = TempDir::new("delete-peer-root");
+        let file = root.path().join("doomed.txt");
+        fs::write(&file, "bye").expect("write file");
+        let req_body = serde_json::json!({ "path": file.to_string_lossy() });
+        let resp = post_json_from(
+            test_state_with_root(root.path()),
+            "/fs/delete",
+            &req_body,
+            SocketAddr::from(([192, 168, 1, 10], 54321)),
+        )
+        .await;
+        let body: IpcBody<()> = body_as_json(resp.into_body()).await;
+        assert!(!body.success, "non-loopback delete must be refused");
+        assert_eq!(body.code.as_deref(), Some("FORBIDDEN"));
+        assert!(file.exists(), "refused delete must not remove the file");
+    }
+
+    /// `/fs/rename` moves a file inside the project root.
+    #[tokio::test]
+    async fn rename_moves_file() {
+        let root = TempDir::new("rename-root");
+        let from = root.path().join("a.txt");
+        let to = root.path().join("b.txt");
+        fs::write(&from, "payload").expect("write from");
+        let req_body = serde_json::json!({ "from": from.to_string_lossy(), "to": to.to_string_lossy() });
+        let resp = post_json(test_state_with_root(root.path()), "/fs/rename", &req_body).await;
+        let body: IpcBody<()> = body_as_json(resp.into_body()).await;
+        assert!(body.success, "rename must succeed");
+        assert!(!from.exists(), "source must be gone after rename");
+        assert!(to.exists(), "destination must exist after rename");
+        assert_eq!(fs::read_to_string(&to).unwrap(), "payload");
+    }
+
+    /// `/fs/rename` allows a destination outside the project root (the jail
+    /// was removed; matches `mkdir`/`write`). The source is actually moved.
+    #[tokio::test]
+    async fn rename_allows_destination_outside_root() {
+        let root = TempDir::new("rename-root");
+        let outside = TempDir::new("rename-outside");
+        let from = root.path().join("a.txt");
+        let to = outside.path().join("b.txt");
+        fs::write(&from, "payload").expect("write from");
+        let req_body = serde_json::json!({ "from": from.to_string_lossy(), "to": to.to_string_lossy() });
+        let resp = post_json(test_state_with_root(root.path()), "/fs/rename", &req_body).await;
+        let body: IpcBody<()> = body_as_json(resp.into_body()).await;
+        assert!(body.success, "rename to outside root should succeed: {:?}", body.error);
+        assert!(!from.exists(), "source must be gone after rename");
+        assert!(to.exists(), "destination must exist after rename");
+        assert_eq!(fs::read_to_string(&to).unwrap(), "payload");
+    }
+
+    /// `/fs/copy` duplicates a file inside the project root (source kept).
+    #[tokio::test]
+    async fn copy_duplicates_file() {
+        let root = TempDir::new("copy-root");
+        let from = root.path().join("orig.txt");
+        let to = root.path().join("dup.txt");
+        fs::write(&from, "payload").expect("write from");
+        let req_body = serde_json::json!({ "from": from.to_string_lossy(), "to": to.to_string_lossy() });
+        let resp = post_json(test_state_with_root(root.path()), "/fs/copy", &req_body).await;
+        let body: IpcBody<()> = body_as_json(resp.into_body()).await;
+        assert!(body.success, "copy must succeed");
+        assert!(from.exists(), "source must remain after copy");
+        assert!(to.exists(), "destination must exist after copy");
+        assert_eq!(fs::read_to_string(&to).unwrap(), "payload");
+    }
+
+    /// `/fs/copy` allows a destination outside the project root (the jail was
+    /// removed; matches `mkdir`/`write`). The source is kept and the copy is
+    /// written outside.
+    #[tokio::test]
+    async fn copy_allows_destination_outside_root() {
+        let root = TempDir::new("copy-root");
+        let outside = TempDir::new("copy-outside");
+        let from = root.path().join("orig.txt");
+        let to = outside.path().join("dup.txt");
+        fs::write(&from, "payload").expect("write from");
+        let req_body = serde_json::json!({ "from": from.to_string_lossy(), "to": to.to_string_lossy() });
+        let resp = post_json(test_state_with_root(root.path()), "/fs/copy", &req_body).await;
+        let body: IpcBody<()> = body_as_json(resp.into_body()).await;
+        assert!(body.success, "copy to outside root should succeed: {:?}", body.error);
+        assert!(from.exists(), "source must remain after copy");
+        assert!(to.exists(), "destination must exist after copy");
+        assert_eq!(fs::read_to_string(&to).unwrap(), "payload");
+    }
+
+    /// `/fs/delete` rejects explicit `..` components with `PATH_TRAVERSAL`
+    /// (defense-in-depth — matches `mkdir`).
+    #[tokio::test]
+    async fn delete_rejects_traversal_sequence_in_path() {
+        let root = TempDir::new("delete-trav-root");
+        let inside = root.path().join("sub");
+        fs::create_dir_all(&inside).expect("mkdir inside");
+        let traversal = inside.join("..").join("..").join("etc");
+        let req_body = serde_json::json!({ "path": traversal.to_string_lossy() });
+        let resp = post_json(test_state_with_root(root.path()), "/fs/delete", &req_body).await;
+        let body: IpcBody<()> = body_as_json(resp.into_body()).await;
+        assert!(!body.success, "traversal delete must be refused");
+        assert_eq!(body.code.as_deref(), Some("PATH_TRAVERSAL"));
+    }
+
+    /// `/fs/rename` rejects explicit `..` components in either endpoint with
+    /// `PATH_TRAVERSAL` (defense-in-depth — matches `mkdir`).
+    #[tokio::test]
+    async fn rename_rejects_traversal_sequence_in_path() {
+        let root = TempDir::new("rename-trav-root");
+        let inside = root.path().join("sub");
+        fs::create_dir_all(&inside).expect("mkdir inside");
+        let traversal_from = inside.join("..").join("..").join("etc");
+        let req_body = serde_json::json!({
+            "from": traversal_from.to_string_lossy(),
+            "to": root.path().join("x.txt").to_string_lossy()
+        });
+        let resp = post_json(test_state_with_root(root.path()), "/fs/rename", &req_body).await;
+        let body: IpcBody<()> = body_as_json(resp.into_body()).await;
+        assert!(!body.success, "traversal rename must be refused");
+        assert_eq!(body.code.as_deref(), Some("PATH_TRAVERSAL"));
+    }
+
+    /// `/fs/copy` rejects explicit `..` components with `PATH_TRAVERSAL`
+    /// (defense-in-depth — matches `mkdir`).
+    #[tokio::test]
+    async fn copy_rejects_traversal_sequence_in_path() {
+        let root = TempDir::new("copy-trav-root");
+        let inside = root.path().join("sub");
+        fs::create_dir_all(&inside).expect("mkdir inside");
+        let traversal_from = inside.join("..").join("..").join("etc");
+        let req_body = serde_json::json!({
+            "from": traversal_from.to_string_lossy(),
+            "to": root.path().join("x.txt").to_string_lossy()
+        });
+        let resp = post_json(test_state_with_root(root.path()), "/fs/copy", &req_body).await;
+        let body: IpcBody<()> = body_as_json(resp.into_body()).await;
+        assert!(!body.success, "traversal copy must be refused");
+        assert_eq!(body.code.as_deref(), Some("PATH_TRAVERSAL"));
     }
 }

--- a/src-tauri/src/web/router.rs
+++ b/src-tauri/src/web/router.rs
@@ -64,6 +64,10 @@ pub fn router(
         .route("/fs/write", post(fs_api::write))
         .route("/fs/ls", get(fs_api::ls))
         .route("/fs/browse", get(fs_api::browse))
+        .route("/fs/read", get(fs_api::read))
+        .route("/fs/delete", post(fs_api::delete))
+        .route("/fs/rename", post(fs_api::rename))
+        .route("/fs/copy", post(fs_api::copy))
         .route("/git/init", post(fs_api::git_init))
         .route("/shells", get(fs_api::shells));
     // Static fallback: disk ServeDir in dev (dist-web/ on disk) or the embedded
@@ -102,6 +106,10 @@ pub fn router_with_static(
         .route("/fs/write", post(fs_api::write))
         .route("/fs/ls", get(fs_api::ls))
         .route("/fs/browse", get(fs_api::browse))
+        .route("/fs/read", get(fs_api::read))
+        .route("/fs/delete", post(fs_api::delete))
+        .route("/fs/rename", post(fs_api::rename))
+        .route("/fs/copy", post(fs_api::copy))
         .route("/git/init", post(fs_api::git_init))
         .route("/shells", get(fs_api::shells))
         .fallback_service(assets::static_service_from(static_dir))

--- a/src/renderer/assets/agent-icons/acp/agents.json
+++ b/src/renderer/assets/agent-icons/acp/agents.json
@@ -81,11 +81,11 @@
   {
     "id": "cline",
     "name": "Cline",
-    "version": "3.0.47",
+    "version": "3.0.48",
     "description": "Autonomous coding agent CLI - capable of creating/editing files, running commands, using the browser, and more",
     "distribution": {
       "npx": {
-        "package": "cline@3.0.47",
+        "package": "cline@3.0.48",
         "args": ["--acp"]
       }
     }
@@ -332,11 +332,11 @@
   {
     "id": "factory-droid",
     "name": "Factory Droid",
-    "version": "0.184.0",
+    "version": "0.185.0",
     "description": "Factory Droid - AI coding agent powered by Factory AI",
     "distribution": {
       "npx": {
-        "package": "droid@0.184.0",
+        "package": "droid@0.185.0",
         "args": ["exec", "--output-format", "acp-daemon"],
         "env": {
           "DROID_DISABLE_AUTO_UPDATE": "true",
@@ -372,11 +372,11 @@
   {
     "id": "github-copilot-cli",
     "name": "GitHub Copilot",
-    "version": "1.0.76",
+    "version": "1.0.77",
     "description": "GitHub's AI pair programmer",
     "distribution": {
       "npx": {
-        "package": "@github/copilot@1.0.76",
+        "package": "@github/copilot@1.0.77",
         "args": ["--acp"]
       }
     }

--- a/src/renderer/components/mobile/MobileChatShell.test.tsx
+++ b/src/renderer/components/mobile/MobileChatShell.test.tsx
@@ -70,6 +70,28 @@ vi.mock('@/components/chat/ProjectSwitcherDrawer', () => ({
     ) : null
 }))
 
+// Stub the file-explorer drawer so the shell test focuses on the trigger
+// wiring (button → filesOpen → drawer `open` prop → onOpenChange close).
+// The drawer's own open/close + file-management is covered in
+// MobileFileExplorer.test.tsx.
+vi.mock('./MobileFileExplorer', () => ({
+  MobileFileExplorer: ({
+    open,
+    onOpenChange
+  }: {
+    open: boolean
+    onOpenChange: (open: boolean) => void
+  }) =>
+    open ? (
+      <div>
+        <span>files-drawer</span>
+        <button type="button" onClick={() => onOpenChange(false)}>
+          close-files
+        </button>
+      </div>
+    ) : null
+}))
+
 vi.mock('@/lib/tauri-runtime', () => ({
   isTauriContext: () => tauriRef.current
 }))
@@ -171,5 +193,42 @@ describe('MobileChatShell', () => {
     // Closing via the drawer's onOpenChange(false) unmounts its content.
     fireEvent.click(screen.getByText('close-drawer'))
     expect(screen.queryByText('project-drawer')).not.toBeInTheDocument()
+  })
+
+  it('mounts the files drawer trigger in web mode and toggles it open/closed', async () => {
+    tauriRef.current = false
+    render(
+      <MemoryRouter>
+        <MobileChatShell onNewChat={vi.fn()} canNewChat>
+          <div>chat body</div>
+        </MobileChatShell>
+      </MemoryRouter>
+    )
+
+    const filesBtn = screen.getByLabelText('Browse files')
+    expect(filesBtn).toBeInTheDocument()
+    // Drawer starts closed.
+    expect(screen.queryByText('files-drawer')).not.toBeInTheDocument()
+
+    fireEvent.click(filesBtn)
+    expect(await screen.findByText('files-drawer')).toBeInTheDocument()
+
+    // Closing via the drawer's onOpenChange(false) unmounts its content.
+    fireEvent.click(screen.getByText('close-files'))
+    expect(screen.queryByText('files-drawer')).not.toBeInTheDocument()
+  })
+
+  it('hides the Browse files button in Tauri (desktop) mode', () => {
+    tauriRef.current = true
+    render(
+      <MemoryRouter>
+        <MobileChatShell onNewChat={vi.fn()} canNewChat>
+          <div>chat body</div>
+        </MobileChatShell>
+      </MemoryRouter>
+    )
+    // Desktop never mounts the web/remote file explorer — the right-sidebar
+    // FileExplorer owns file browsing there.
+    expect(screen.queryByLabelText('Browse files')).not.toBeInTheDocument()
   })
 })

--- a/src/renderer/components/mobile/MobileChatShell.tsx
+++ b/src/renderer/components/mobile/MobileChatShell.tsx
@@ -1,4 +1,4 @@
-import { FolderGit2, Menu, MessageSquarePlus, Settings } from 'lucide-react'
+import { FolderGit2, FolderTree, Menu, MessageSquarePlus, Settings } from 'lucide-react'
 import { useMemo, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { ChatHistoryTab } from '@/components/chat/ChatHistoryTab'
@@ -16,6 +16,7 @@ import { isTauriContext } from '@/lib/tauri-runtime'
 import { useAcpStore } from '@/stores/acp-store'
 import { useActiveProject } from '@/stores/project-store'
 import { getAllLeafPanes, useWorkspaceStore } from '@/stores/workspace-store'
+import { MobileFileExplorer } from './MobileFileExplorer'
 
 interface MobileChatShellProps {
   children: React.ReactNode
@@ -37,6 +38,7 @@ export function MobileChatShell({
 }: MobileChatShellProps): React.JSX.Element {
   const [drawerOpen, setDrawerOpen] = useState(false)
   const [projectsOpen, setProjectsOpen] = useState(false)
+  const [filesOpen, setFilesOpen] = useState(false)
   const navigate = useNavigate()
   const activeProject = useActiveProject()
 
@@ -94,6 +96,19 @@ export function MobileChatShell({
             onClick={() => setProjectsOpen(true)}
           >
             <FolderGit2 size={20} />
+          </Button>
+        )}
+
+        {!isTauriContext() && (
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon"
+            className="size-10 shrink-0"
+            aria-label="Browse files"
+            onClick={() => setFilesOpen(true)}
+          >
+            <FolderTree size={20} />
           </Button>
         )}
 
@@ -166,6 +181,8 @@ export function MobileChatShell({
       {!isTauriContext() && (
         <ProjectSwitcherDrawer open={projectsOpen} onOpenChange={setProjectsOpen} />
       )}
+
+      {!isTauriContext() && <MobileFileExplorer open={filesOpen} onOpenChange={setFilesOpen} />}
     </div>
   )
 }

--- a/src/renderer/components/mobile/MobileFileExplorer.test.tsx
+++ b/src/renderer/components/mobile/MobileFileExplorer.test.tsx
@@ -1,0 +1,257 @@
+import type { DirectoryEntry } from '@shared/types/filesystem.types'
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { MobileFileExplorer } from './MobileFileExplorer'
+
+const mockToggleDirectory = vi.fn().mockResolvedValue(undefined)
+const mockRefreshDirectory = vi.fn().mockResolvedValue(undefined)
+const mockSelectPath = vi.fn()
+const mockCollapseAll = vi.fn()
+
+const mockOpenFile = vi.fn()
+const mockCloseFile = vi.fn()
+const mockAddEditorTab = vi.fn()
+const mockRemoveTab = vi.fn()
+
+// Stable editor state object so tests can seed `openFiles` and have the
+// component read the same map via `useEditorStore.getState()`.
+const mockEditorStore = {
+  openFile: mockOpenFile,
+  openFiles: new Map<string, unknown>(),
+  closeFile: mockCloseFile
+}
+
+const mockCreateFile = vi.fn()
+const mockCreateDirectory = vi.fn()
+const mockDeletePath = vi.fn()
+const mockRenameFile = vi.fn()
+const mockCopyFile = vi.fn()
+const mockToastError = vi.fn()
+
+// Mutable explorer state so individual tests can seed the tree (loaded root,
+// empty root, load error, no project) without re-declaring the module mock.
+const mockExplorerState = {
+  rootPath: '/proj' as string | null,
+  directoryContents: new Map<string, DirectoryEntry[]>(),
+  expandedDirs: new Set<string>(),
+  loadingDirs: new Set<string>(),
+  rootLoadError: null as null | { message: string; code?: string }
+}
+
+vi.mock('@/stores/file-explorer-store', () => ({
+  useFileExplorer: () => mockExplorerState,
+  useFileExplorerActions: () => ({
+    toggleDirectory: mockToggleDirectory,
+    refreshDirectory: mockRefreshDirectory,
+    selectPath: mockSelectPath,
+    collapseAll: mockCollapseAll
+  })
+}))
+
+vi.mock('@/stores/editor-store', () => ({
+  useEditorStore: {
+    getState: () => mockEditorStore
+  }
+}))
+
+vi.mock('@/stores/workspace-store', () => ({
+  useWorkspaceStore: {
+    getState: vi.fn(() => ({
+      addEditorTab: mockAddEditorTab,
+      removeTab: mockRemoveTab
+    }))
+  },
+  editorTabId: (path: string) => `edit-${path}`
+}))
+
+vi.mock('@/lib/api', () => ({
+  filesystemApi: {
+    createFile: (...args: unknown[]) => mockCreateFile(...args),
+    createDirectory: (...args: unknown[]) => mockCreateDirectory(...args),
+    deletePath: (...args: unknown[]) => mockDeletePath(...args),
+    renameFile: (...args: unknown[]) => mockRenameFile(...args),
+    copyFile: (...args: unknown[]) => mockCopyFile(...args)
+  }
+}))
+
+vi.mock('sonner', () => ({
+  toast: { error: (...args: unknown[]) => mockToastError(...args) }
+}))
+
+// MaterialFileIcon pulls in the app-settings store + an SVG resolver; stub it
+// (no name text) so row text assertions aren't duplicated by the icon span.
+vi.mock('@/components/file-explorer/MaterialFileIcon', () => ({
+  MaterialFileIcon: () => <span data-testid="mfi" />
+}))
+
+function entry(name: string, type: 'file' | 'directory', path?: string): DirectoryEntry {
+  return {
+    name,
+    path: path ?? `/proj/${name}`,
+    type,
+    extension: type === 'file' && name.includes('.') ? name.split('.').pop()! : null,
+    size: 0,
+    modifiedAt: 0,
+    ignored: false
+  }
+}
+
+function setRoot(entries: DirectoryEntry[]): void {
+  mockExplorerState.rootPath = '/proj'
+  mockExplorerState.directoryContents = new Map([['/proj', entries]])
+  mockExplorerState.expandedDirs = new Set()
+  mockExplorerState.loadingDirs = new Set()
+  mockExplorerState.rootLoadError = null
+}
+
+describe('MobileFileExplorer', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockExplorerState.rootPath = '/proj'
+    mockExplorerState.directoryContents = new Map()
+    mockExplorerState.expandedDirs = new Set()
+    mockExplorerState.loadingDirs = new Set()
+    mockExplorerState.rootLoadError = null
+    mockOpenFile.mockResolvedValue(true)
+    mockCreateFile.mockResolvedValue({ success: true, data: undefined })
+    mockCreateDirectory.mockResolvedValue({ success: true, data: undefined })
+    mockDeletePath.mockResolvedValue({ success: true, data: undefined })
+    mockRenameFile.mockResolvedValue({ success: true, data: undefined })
+    mockCopyFile.mockResolvedValue({ success: true, data: undefined })
+    mockEditorStore.openFiles.clear()
+  })
+
+  it('renders the Files header and lists root entries when open with a loaded root', async () => {
+    setRoot([entry('a.txt', 'file'), entry('sub', 'directory')])
+
+    render(<MobileFileExplorer open onOpenChange={vi.fn()} />)
+
+    expect(await screen.findByText('Files')).toBeInTheDocument()
+    expect(await screen.findByText('a.txt')).toBeInTheDocument()
+    expect(screen.getByText('sub')).toBeInTheDocument()
+  })
+
+  it('lazy-loads the root listing via toggleDirectory when opening with an empty root', async () => {
+    // Root set, but no contents yet — the open effect must trigger the load.
+    mockExplorerState.rootPath = '/proj'
+    mockExplorerState.directoryContents = new Map()
+
+    render(<MobileFileExplorer open onOpenChange={vi.fn()} />)
+
+    await waitFor(() => expect(mockToggleDirectory).toHaveBeenCalledWith('/proj'))
+  })
+
+  it('tapping a directory row calls toggleDirectory with its path', async () => {
+    setRoot([entry('sub', 'directory')])
+
+    render(<MobileFileExplorer open onOpenChange={vi.fn()} />)
+
+    fireEvent.click(await screen.findByText('sub'))
+    await waitFor(() => expect(mockToggleDirectory).toHaveBeenCalledWith('/proj/sub'))
+  })
+
+  it('tapping a file opens it in the editor and closes the drawer', async () => {
+    setRoot([entry('a.txt', 'file')])
+
+    const onOpenChange = vi.fn()
+    render(<MobileFileExplorer open onOpenChange={onOpenChange} />)
+
+    fireEvent.click(await screen.findByText('a.txt'))
+
+    await waitFor(() => expect(mockSelectPath).toHaveBeenCalledWith('/proj/a.txt'))
+    await waitFor(() => expect(mockOpenFile).toHaveBeenCalledWith('/proj/a.txt'))
+    await waitFor(() => expect(mockAddEditorTab).toHaveBeenCalledWith('/proj/a.txt'))
+    await waitFor(() => expect(onOpenChange).toHaveBeenCalledWith(false))
+  })
+
+  it('creates a new file via the facade then refreshes the root', async () => {
+    setRoot([])
+
+    render(<MobileFileExplorer open onOpenChange={vi.fn()} />)
+
+    fireEvent.click(await screen.findByLabelText('New file'))
+    const input = await screen.findByPlaceholderText('new-file.txt')
+    fireEvent.change(input, { target: { value: 'made.txt' } })
+    fireEvent.keyDown(input, { key: 'Enter' })
+
+    await waitFor(() => expect(mockCreateFile).toHaveBeenCalledWith('/proj/made.txt'))
+    await waitFor(() => expect(mockRefreshDirectory).toHaveBeenCalledWith('/proj'))
+  })
+
+  it('surfaces a server error code as a toast when create fails', async () => {
+    setRoot([])
+    mockCreateFile.mockResolvedValue({
+      success: false,
+      error: 'path traversal rejected',
+      code: 'PATH_TRAVERSAL'
+    })
+
+    render(<MobileFileExplorer open onOpenChange={vi.fn()} />)
+
+    fireEvent.click(await screen.findByLabelText('New file'))
+    const input = await screen.findByPlaceholderText('new-file.txt')
+    fireEvent.change(input, { target: { value: 'bad.txt' } })
+    fireEvent.keyDown(input, { key: 'Enter' })
+
+    await waitFor(() => expect(mockToastError).toHaveBeenCalled())
+    expect(mockToastError).toHaveBeenCalledWith('Failed to create', {
+      description: 'path traversal rejected'
+    })
+    // No mutation/refresh when the server refuses.
+    expect(mockRefreshDirectory).not.toHaveBeenCalled()
+  })
+
+  it('deletes a file via the action sheet + confirm, reconciling an open editor tab', async () => {
+    const file = entry('doomed.txt', 'file')
+    setRoot([file])
+    // Pretend the file is open in the editor so reconciliation fires.
+    mockEditorStore.openFiles.set('/proj/doomed.txt', { isDirty: false })
+
+    render(<MobileFileExplorer open onOpenChange={vi.fn()} />)
+
+    // Open the row action sheet.
+    fireEvent.click(await screen.findByLabelText('Actions for doomed.txt'))
+    fireEvent.click(await screen.findByText('Delete'))
+
+    // ConfirmDialog confirm button is labelled "Delete" (confirmLabel="Delete").
+    // The delete confirm is a Radix AlertDialog (stacks above the Sheet so it
+    // stays accessible — a plain overlay inside #root would be aria-hidden by
+    // the Sheet's inert). Scope the confirm button within the alertdialog to
+    // avoid colliding with the action-sheet's "Delete" button during close.
+    const dialog = await screen.findByRole('alertdialog')
+    const confirmBtn = within(dialog).getByRole('button', { name: 'Delete' })
+    fireEvent.click(confirmBtn)
+
+    await waitFor(() =>
+      expect(mockDeletePath).toHaveBeenCalledWith('/proj/doomed.txt', {
+        recursive: false
+      })
+    )
+    await waitFor(() => expect(mockCloseFile).toHaveBeenCalledWith('/proj/doomed.txt'))
+    await waitFor(() => expect(mockRemoveTab).toHaveBeenCalledWith('edit-/proj/doomed.txt'))
+    await waitFor(() => expect(mockRefreshDirectory).toHaveBeenCalledWith('/proj'))
+  })
+
+  it('shows the root load error with a Retry button', async () => {
+    mockExplorerState.rootPath = '/proj'
+    // Keep the open effect from firing a load while the error is shown.
+    mockExplorerState.loadingDirs = new Set(['/proj'])
+    mockExplorerState.rootLoadError = { message: 'watch failed', code: 'WATCH_FAILED' }
+
+    render(<MobileFileExplorer open onOpenChange={vi.fn()} />)
+
+    expect(await screen.findByText('watch failed')).toBeInTheDocument()
+    fireEvent.click(await screen.findByText('Retry'))
+    await waitFor(() => expect(mockRefreshDirectory).toHaveBeenCalledWith('/proj'))
+  })
+
+  it('shows the empty state when no project is active', async () => {
+    mockExplorerState.rootPath = null
+
+    render(<MobileFileExplorer open onOpenChange={vi.fn()} />)
+
+    expect(await screen.findByText('No active project')).toBeInTheDocument()
+    // The new-file/new-folder actions are disabled without a root.
+    expect(await screen.findByLabelText('New file')).toBeDisabled()
+  })
+})

--- a/src/renderer/components/mobile/MobileFileExplorer.tsx
+++ b/src/renderer/components/mobile/MobileFileExplorer.tsx
@@ -1,0 +1,463 @@
+import type { DirectoryEntry } from '@shared/types/filesystem.types'
+import {
+  ChevronRight,
+  Copy,
+  FilePlus,
+  FolderPlus,
+  MoreHorizontal,
+  Pencil,
+  RefreshCw,
+  Trash2
+} from 'lucide-react'
+import { useEffect, useState } from 'react'
+import { toast } from 'sonner'
+import { MaterialFileIcon } from '@/components/file-explorer/MaterialFileIcon'
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle
+} from '@/components/ui/alert-dialog'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle
+} from '@/components/ui/sheet'
+import { filesystemApi } from '@/lib/api'
+import { useEditorStore } from '@/stores/editor-store'
+import { useFileExplorer, useFileExplorerActions } from '@/stores/file-explorer-store'
+import { editorTabId, useWorkspaceStore } from '@/stores/workspace-store'
+
+interface MobileFileExplorerProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}
+
+interface CreateState {
+  type: 'file' | 'directory'
+  value: string
+}
+
+interface RenameState {
+  path: string
+  value: string
+}
+
+/** Lean touch-first file explorer drawer for the web/mobile view. Reuses the
+ * shared `file-explorer-store` (browse/select/toggle/refresh) + the
+ * `MaterialFileIcon` primitive, but renders its own tall, full-width tap
+ * targets (no drag-drop/context-menu/keyboard-shortcuts/resize — those stay
+ * desktop). Tapping a file reuses the desktop open-file wiring
+ * (`selectPath` → `editorStore.openFile` → `workspaceStore.addEditorTab`) so
+ * files open in the existing editor tab in the mobile pane tree, identical to
+ * desktop double-click. Gated to `!isTauriContext()` by the caller
+ * (`MobileChatShell`). v1 has no live watchers (web re-fetches on
+ * action/refresh) and no streaming search. */
+export function MobileFileExplorer({
+  open,
+  onOpenChange
+}: MobileFileExplorerProps): React.JSX.Element {
+  const { rootPath, directoryContents, expandedDirs, loadingDirs, rootLoadError } =
+    useFileExplorer()
+  const { toggleDirectory, refreshDirectory, selectPath, collapseAll } = useFileExplorerActions()
+
+  const [actionEntry, setActionEntry] = useState<DirectoryEntry | null>(null)
+  const [renaming, setRenaming] = useState<RenameState | null>(null)
+  const [creating, setCreating] = useState<CreateState | null>(null)
+  const [pendingDelete, setPendingDelete] = useState<DirectoryEntry | null>(null)
+
+  // Load the root listing when the drawer opens (web has no watchers, so the
+  // store is not pre-populated by the workspace layout's watch effect).
+  useEffect(() => {
+    if (!open || !rootPath) return
+    if (!directoryContents.has(rootPath) && !loadingDirs.has(rootPath)) {
+      void toggleDirectory(rootPath)
+    }
+  }, [open, rootPath, directoryContents, loadingDirs, toggleDirectory])
+
+  function parentOf(path: string): string {
+    const normalized = path.replace(/\\/g, '/')
+    const idx = normalized.lastIndexOf('/')
+    return idx <= 0 ? (rootPath ?? normalized) : normalized.slice(0, idx)
+  }
+
+  async function handleOpenFile(entry: DirectoryEntry): Promise<void> {
+    selectPath(entry.path)
+    try {
+      await useEditorStore.getState().openFile(entry.path)
+      useWorkspaceStore.getState().addEditorTab(entry.path)
+      onOpenChange(false)
+    } catch (error) {
+      toast.error('Failed to open file', {
+        description: error instanceof Error ? error.message : String(error)
+      })
+    }
+  }
+
+  function handleRowTap(entry: DirectoryEntry): void {
+    if (renaming?.path === entry.path) return
+    if (entry.type === 'directory') {
+      void toggleDirectory(entry.path)
+    } else {
+      void handleOpenFile(entry)
+    }
+  }
+
+  async function handleCreate(): Promise<void> {
+    if (!creating || !rootPath) return
+    const name = creating.value.trim()
+    if (!name) return
+    const fullPath = `${rootPath.replace(/\\/g, '/')}/${name}`
+    const result =
+      creating.type === 'file'
+        ? await filesystemApi.createFile(fullPath)
+        : await filesystemApi.createDirectory(fullPath)
+    if (!result.success) {
+      toast.error('Failed to create', { description: result.error })
+      return
+    }
+    setCreating(null)
+    await refreshDirectory(rootPath)
+  }
+
+  async function handleRename(entry: DirectoryEntry, value: string): Promise<void> {
+    const name = value.trim()
+    if (!name || !renaming) {
+      setRenaming(null)
+      return
+    }
+    const parent = parentOf(entry.path)
+    const newPath = `${parent.replace(/\\/g, '/')}/${name}`
+    if (newPath === entry.path) {
+      setRenaming(null)
+      return
+    }
+    const result = await filesystemApi.renameFile(entry.path, newPath)
+    if (!result.success) {
+      toast.error('Failed to rename', { description: result.error })
+      setRenaming(null)
+      return
+    }
+    // Reconcile open editor tabs: close the old tab so the mobile pane tree
+    // never shows a stale/orphan path (mirrors desktop FileExplorer).
+    const editor = useEditorStore.getState()
+    if (editor.openFiles.has(entry.path)) {
+      editor.closeFile(entry.path)
+      useWorkspaceStore.getState().removeTab(editorTabId(entry.path))
+    }
+    setRenaming(null)
+    await refreshDirectory(parent)
+  }
+
+  async function handleDelete(entry: DirectoryEntry): Promise<void> {
+    const result = await filesystemApi.deletePath(entry.path, {
+      recursive: entry.type === 'directory'
+    })
+    if (!result.success) {
+      toast.error('Failed to delete', { description: result.error })
+      return
+    }
+    const editor = useEditorStore.getState()
+    if (editor.openFiles.has(entry.path)) {
+      editor.closeFile(entry.path)
+      useWorkspaceStore.getState().removeTab(editorTabId(entry.path))
+    }
+    await refreshDirectory(parentOf(entry.path))
+  }
+
+  async function handleDuplicate(entry: DirectoryEntry): Promise<void> {
+    const dot = entry.name.lastIndexOf('.')
+    const stem = dot > 0 ? entry.name.slice(0, dot) : entry.name
+    const ext = dot > 0 ? entry.name.slice(dot) : ''
+    const dest = `${parentOf(entry.path).replace(/\\/g, '/')}/${stem} copy${ext}`
+    const result = await filesystemApi.copyFile(entry.path, dest)
+    if (!result.success) {
+      toast.error('Failed to copy', { description: result.error })
+      return
+    }
+    await refreshDirectory(parentOf(entry.path))
+  }
+
+  function renderRow(entry: DirectoryEntry, depth: number): React.ReactNode {
+    const isExpanded = expandedDirs.has(entry.path)
+    const isRenaming = renaming?.path === entry.path
+    const isLoading = loadingDirs.has(entry.path)
+    return (
+      <div
+        key={entry.path}
+        role="treeitem"
+        tabIndex={-1}
+        aria-expanded={entry.type === 'directory' ? isExpanded : undefined}
+      >
+        {isRenaming ? (
+          <Input
+            autoFocus
+            defaultValue={renaming.value}
+            onChange={(e) => setRenaming({ path: entry.path, value: e.target.value })}
+            onBlur={() => void handleRename(entry, renaming.value)}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') void handleRename(entry, renaming.value)
+              if (e.key === 'Escape') setRenaming(null)
+            }}
+            className="m-1 h-11"
+            aria-label={`Rename ${entry.name}`}
+          />
+        ) : (
+          <div
+            className="flex h-11 items-center gap-2 px-2"
+            style={{ paddingLeft: `${depth * 14 + 8}px` }}
+          >
+            <button
+              type="button"
+              className="flex h-11 min-w-0 flex-1 items-center gap-2 text-left"
+              onClick={() => handleRowTap(entry)}
+              aria-label={
+                entry.type === 'directory'
+                  ? `${isExpanded ? 'Collapse' : 'Expand'} ${entry.name}`
+                  : `Open ${entry.name}`
+              }
+            >
+              <MaterialFileIcon
+                name={entry.name}
+                extension={entry.extension}
+                isDirectory={entry.type === 'directory'}
+                isExpanded={isExpanded}
+                depth={depth}
+                size={18}
+              />
+              <span
+                className={`min-w-0 flex-1 truncate text-sm ${entry.ignored ? 'text-muted-foreground' : 'text-foreground'}`}
+              >
+                {entry.name}
+              </span>
+              {entry.type === 'directory' && (
+                <ChevronRight
+                  size={16}
+                  className={`shrink-0 text-muted-foreground transition-transform ${isExpanded ? 'rotate-90' : ''}`}
+                />
+              )}
+            </button>
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon"
+              className="size-9 shrink-0"
+              aria-label={`Actions for ${entry.name}`}
+              onClick={(e) => {
+                e.stopPropagation()
+                setActionEntry(entry)
+              }}
+            >
+              <MoreHorizontal size={18} />
+            </Button>
+          </div>
+        )}
+        {entry.type === 'directory' && isExpanded && renderEntries(entry.path, depth + 1)}
+        {entry.type === 'directory' && isLoading && !directoryContents.has(entry.path) && (
+          <div className="px-4 py-2 text-xs text-muted-foreground">Loading…</div>
+        )}
+      </div>
+    )
+  }
+
+  function renderEntries(dirPath: string, depth: number): React.ReactNode {
+    const entries = directoryContents.get(dirPath)
+    if (!entries) return null
+    if (entries.length === 0) {
+      return (
+        <div
+          className="px-4 py-2 text-xs text-muted-foreground"
+          style={{ paddingLeft: `${depth * 14 + 8}px` }}
+        >
+          Empty
+        </div>
+      )
+    }
+    return entries.map((entry) => renderRow(entry, depth))
+  }
+
+  return (
+    <Sheet open={open} onOpenChange={onOpenChange}>
+      <SheetContent
+        side="right"
+        className="flex w-[min(100vw,26rem)] flex-col gap-0 p-0 sm:max-w-md"
+      >
+        <SheetHeader className="space-y-0 border-b border-border/60 px-3 py-3 text-left">
+          <SheetTitle className="text-base">Files</SheetTitle>
+          <SheetDescription className="sr-only">Browse project files</SheetDescription>
+        </SheetHeader>
+
+        <div className="flex shrink-0 items-center gap-1 border-b border-border/60 px-2 py-1">
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon"
+            className="size-9"
+            aria-label="Refresh"
+            disabled={!rootPath}
+            onClick={() => rootPath && void refreshDirectory(rootPath)}
+          >
+            <RefreshCw size={16} />
+          </Button>
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon"
+            className="size-9"
+            aria-label="New file"
+            disabled={!rootPath}
+            onClick={() => setCreating({ type: 'file', value: '' })}
+          >
+            <FilePlus size={16} />
+          </Button>
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon"
+            className="size-9"
+            aria-label="New folder"
+            disabled={!rootPath}
+            onClick={() => setCreating({ type: 'directory', value: '' })}
+          >
+            <FolderPlus size={16} />
+          </Button>
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon"
+            className="ml-auto size-9"
+            aria-label="Collapse all"
+            disabled={!rootPath}
+            onClick={() => collapseAll()}
+          >
+            <span className="text-xs">Collapse</span>
+          </Button>
+        </div>
+
+        <div className="min-h-0 flex-1 overflow-y-auto py-1">
+          {rootLoadError ? (
+            <div className="flex flex-col items-center gap-2 px-4 py-8 text-center">
+              <p className="text-sm text-muted-foreground">{rootLoadError.message}</p>
+              {rootPath && (
+                <Button
+                  type="button"
+                  variant="secondary"
+                  size="sm"
+                  onClick={() => void refreshDirectory(rootPath)}
+                >
+                  Retry
+                </Button>
+              )}
+            </div>
+          ) : creating ? (
+            <div className="px-2 py-1">
+              <Input
+                autoFocus
+                placeholder={creating.type === 'file' ? 'new-file.txt' : 'new-folder'}
+                onChange={(e) => setCreating({ ...creating, value: e.target.value })}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter') void handleCreate()
+                  if (e.key === 'Escape') setCreating(null)
+                }}
+                className="h-11"
+                aria-label={creating.type === 'file' ? 'New file name' : 'New folder name'}
+              />
+            </div>
+          ) : !rootPath ? (
+            <div className="px-4 py-8 text-center text-sm text-muted-foreground">
+              No active project
+            </div>
+          ) : (
+            <div role="tree">{renderEntries(rootPath, 0)}</div>
+          )}
+        </div>
+
+        {/* Action sheet (bottom) for the selected row. */}
+        <Sheet open={!!actionEntry} onOpenChange={(v) => !v && setActionEntry(null)}>
+          <SheetContent
+            side="bottom"
+            className="flex flex-col gap-0 rounded-t-xl p-2"
+            aria-label={actionEntry ? `Actions for ${actionEntry.name}` : undefined}
+          >
+            {actionEntry && (
+              <>
+                <SheetHeader className="px-3 py-2 text-left">
+                  <SheetTitle className="truncate text-sm">{actionEntry.name}</SheetTitle>
+                </SheetHeader>
+                <button
+                  type="button"
+                  className="flex h-11 items-center gap-3 rounded-md px-3 text-sm hover:bg-accent"
+                  onClick={() => {
+                    setRenaming({ path: actionEntry.path, value: actionEntry.name })
+                    setActionEntry(null)
+                  }}
+                >
+                  <Pencil size={16} /> Rename
+                </button>
+                <button
+                  type="button"
+                  className="flex h-11 items-center gap-3 rounded-md px-3 text-sm hover:bg-accent"
+                  onClick={() => {
+                    const e = actionEntry
+                    setActionEntry(null)
+                    void handleDuplicate(e)
+                  }}
+                >
+                  <Copy size={16} /> Duplicate
+                </button>
+                <button
+                  type="button"
+                  className="flex h-11 items-center gap-3 rounded-md px-3 text-sm text-destructive hover:bg-accent"
+                  onClick={() => {
+                    setPendingDelete(actionEntry)
+                    setActionEntry(null)
+                  }}
+                >
+                  <Trash2 size={16} /> Delete
+                </button>
+              </>
+            )}
+          </SheetContent>
+        </Sheet>
+      </SheetContent>
+
+      <AlertDialog
+        open={!!pendingDelete}
+        onOpenChange={(open) => {
+          if (!open) setPendingDelete(null)
+        }}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Delete {pendingDelete?.name ?? ''}</AlertDialogTitle>
+            <AlertDialogDescription>
+              {pendingDelete?.type === 'directory'
+                ? 'This will delete the folder and all its contents. This cannot be undone.'
+                : 'This will delete the file. This cannot be undone.'}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              className="bg-red-500 text-white hover:bg-red-600"
+              onClick={() => {
+                if (pendingDelete) void handleDelete(pendingDelete)
+                setPendingDelete(null)
+              }}
+            >
+              Delete
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </Sheet>
+  )
+}

--- a/src/renderer/lib/tauri-filesystem-api.ts
+++ b/src/renderer/lib/tauri-filesystem-api.ts
@@ -238,6 +238,12 @@ export function createTauriFilesystemApi(): FilesystemApi {
     },
 
     async readFile(filePath: string): Promise<IpcResult<FileContent>> {
+      // Web/remote mode: route through the same-origin server. The server
+      // enforces size + binary checks (FILE_TOO_LARGE / BINARY_FILE) so this
+      // is a thin passthrough mirroring the desktop facade's behavior.
+      if (!isTauriContext()) {
+        return webServerFilesystem.readFile(filePath)
+      }
       try {
         const info = await stat(filePath)
         if (info.size > MAX_FILE_SIZE) {
@@ -641,6 +647,10 @@ export function createTauriFilesystemApi(): FilesystemApi {
     },
 
     async deletePath(path: string, options?: { recursive?: boolean }): Promise<IpcResult<void>> {
+      // Web/remote mode: route through the same-origin server.
+      if (!isTauriContext()) {
+        return webServerFilesystem.deletePath(path, options)
+      }
       try {
         await remove(path, { recursive: options?.recursive ?? false })
         return { success: true, data: undefined }
@@ -650,6 +660,10 @@ export function createTauriFilesystemApi(): FilesystemApi {
     },
 
     async renameFile(oldPath: string, newPath: string): Promise<IpcResult<void>> {
+      // Web/remote mode: route through the same-origin server.
+      if (!isTauriContext()) {
+        return webServerFilesystem.renameFile(oldPath, newPath)
+      }
       try {
         await rename(oldPath, newPath)
         return { success: true, data: undefined }
@@ -663,6 +677,10 @@ export function createTauriFilesystemApi(): FilesystemApi {
      * Returns `COPY_ERROR` on failure (e.g. when the source is a directory).
      */
     async copyFile(srcPath: string, destPath: string): Promise<IpcResult<void>> {
+      // Web/remote mode: route through the same-origin server.
+      if (!isTauriContext()) {
+        return webServerFilesystem.copyFile(srcPath, destPath)
+      }
       try {
         await copyFile(srcPath, destPath)
         return { success: true, data: undefined }
@@ -672,6 +690,12 @@ export function createTauriFilesystemApi(): FilesystemApi {
     },
 
     async watchDirectory(dirPath: string): Promise<IpcResult<void>> {
+      // Web/remote mode: live file watchers are desktop-only (Tauri events).
+      // The mobile file explorer v1 re-fetches on action/refresh instead of
+      // subscribing to fs events, so watching is a no-op success on web.
+      if (!isTauriContext()) {
+        return { success: true, data: undefined }
+      }
       try {
         const normalizedDirPath = dirPath.replace(/\\/g, '/')
 
@@ -721,6 +745,10 @@ export function createTauriFilesystemApi(): FilesystemApi {
     },
 
     async unwatchDirectory(dirPath: string): Promise<IpcResult<void>> {
+      // Web/remote mode: nothing to unwatch (watchers are desktop-only).
+      if (!isTauriContext()) {
+        return { success: true, data: undefined }
+      }
       try {
         const normalizedDirPath = dirPath.replace(/\\/g, '/')
         const unlisten = activeWatchers.get(normalizedDirPath)

--- a/src/renderer/lib/web-server-api.ts
+++ b/src/renderer/lib/web-server-api.ts
@@ -14,7 +14,12 @@
  * `IpcResult { success: false, code: 'NETWORK_ERROR' }` so the renderer never
  * sees a thrown exception from the network layer.
  */
-import type { DetectedShells, DirectoryEntry, IpcResult } from '@shared/types/ipc.types'
+import type {
+  DetectedShells,
+  DirectoryEntry,
+  FileContent,
+  IpcResult
+} from '@shared/types/ipc.types'
 import type { ProjectListPayload } from '@shared/types/web-projects.types'
 import { isTauriContext } from './tauri-runtime'
 
@@ -96,6 +101,26 @@ export const webServerFilesystem = {
   async readDirectory(dirPath: string): Promise<IpcResult<DirectoryEntry[]>> {
     const encoded = encodeURIComponent(dirPath)
     return getJson<DirectoryEntry[]>(`/fs/ls?path=${encoded}`)
+  },
+
+  async readFile(filePath: string): Promise<IpcResult<FileContent>> {
+    const encoded = encodeURIComponent(filePath)
+    return getJson<FileContent>(`/fs/read?path=${encoded}`)
+  },
+
+  async deletePath(path: string, options?: { recursive?: boolean }): Promise<IpcResult<void>> {
+    return postJson<void>('/fs/delete', {
+      path,
+      ...(options?.recursive ? { recursive: options.recursive } : {})
+    })
+  },
+
+  async renameFile(oldPath: string, newPath: string): Promise<IpcResult<void>> {
+    return postJson<void>('/fs/rename', { from: oldPath, to: newPath })
+  },
+
+  async copyFile(srcPath: string, destPath: string): Promise<IpcResult<void>> {
+    return postJson<void>('/fs/copy', { from: srcPath, to: destPath })
   }
 }
 


### PR DESCRIPTION
## Summary

The web/mobile view (`MobileChatShell`) was chat-only — at phone width (≤767px) the renderer switches to `MobileChatShell`, which had no file-browsing surface, so a remote/phone user could not browse, open, or manage project files. This adds a lean, touch-first **`MobileFileExplorer`** drawer (opened from a new `FolderTree` header button, gated `!isTauriContext()`) that reuses the shared `file-explorer-store` + `MaterialFileIcon` primitives and the desktop open-file wiring (`selectPath` → `editorStore.openFile` → `workspaceStore.addEditorTab`), so tapping a file opens it in the existing editor tab in the mobile pane tree — identical to desktop double-click.

It also extends the same-origin web transport with full file management: new `/fs/read`, `/fs/delete`, `/fs/rename`, `/fs/copy` handlers, and the `createTauriFilesystemApi` facade is branched so `readFile`/`deletePath`/`renameFile`/`copyFile` route through `webServerFilesystem` on web (editor open/save and explorer CRUD become web-enabled transitively). `readFile` enforces the 1 MiB + binary-sample guards mirroring the desktop facade.

## Related Issue

No related issue. Implements the BMAD spec `_bmad-output/implementation-artifacts/spec-web-mobile-file-explorer.md` (status: in-progress). No prior open/closed PR found for this feature.

## Type of Change

- [x] feat: new feature

## What Changed

- **`src/renderer/components/mobile/MobileFileExplorer.tsx`** (new) — touch-first explorer drawer: header (title + new-file/new-folder/refresh/collapse-all), scrollable tap-target tree reusing `file-explorer-store` + `MaterialFileIcon`; tap dir = toggle, tap file = open-via-3-step-wiring; long action button → bottom action sheet (rename/duplicate/delete). Delete confirm uses a **Radix `AlertDialog`** (not the plain `ConfirmDialog` overlay) so it stacks above the parent `Sheet` and stays accessible — a plain overlay rendered inside `#root` would be `aria-hidden` by the Sheet's inert.
- **`src/renderer/components/mobile/MobileChatShell.tsx`** — add the `FolderTree` header button + mount `<MobileFileExplorer>` (`!isTauriContext()` only).
- **`src-tauri/src/web/fs_api.rs`** — add `read`/`delete`/`rename`/`copy` handlers + DTOs. They reuse `resolve_request_path` (explicit `..` rejected; paths outside `project_root` **allowed**) so they inherit the current path posture **exactly** from `/fs/ls` and `/fs/mkdir`, including the prefix-containment jail removal in #468. Mutations are loopback-guarded; `read` is not (matching `ls`/`browse` so desktop-hosted LAN clients can open files). `readFile` enforces 1 MiB + binary-sample guards.
- **`src-tauri/src/web/router.rs`** — register the 4 new routes on **both** router builders (standalone `termul-server` + desktop-hosted shared-live).
- **`src/renderer/lib/tauri-filesystem-api.ts`** — branch `readFile`/`deletePath`/`renameFile`/`copyFile` to `webServerFilesystem` on web; `watchDirectory`/`unwatchDirectory` no-op on web (mobile re-fetches on action).
- **`src/renderer/lib/web-server-api.ts`** — add `readFile`/`deletePath`/`renameFile`/`copyFile` to `webServerFilesystem`.

## How It Was Tested

- [x] `bun run ci` (Biome lint + format + imports, strict mode)
- [x] `bun run typecheck`
- [x] `bun run test` (2525 passed, 43 skipped)
- [x] `cargo clippy --all-targets -- -D warnings` (in src-tauri)
- [x] `cargo test` (in src-tauri) — 520 lib tests pass, incl. 16 new `fs_api` tests (read/delete/rename/copy happy path, `PATH_TRAVERSAL`, outside-root-allowed, loopback guard) + `MobileFileExplorer.test.tsx` (drawer open/close, lazy load, dir toggle, file-open wiring, create CRUD, delete reconcile, error surfacing, root error, empty state)
- [ ] Manual verification completed — **recommended before merge**: smoke-test at phone width (open drawer, expand a dir, tap a file → editor tab, create/delete/rename/copy).

## Screenshots or Recordings

N/A — code change; manual mobile-width smoke recommended (see above).

## CI & Review Gate

- [ ] All CI checks pass (PR Validation, Rust Checks, Build Verification, Security Scans)
- [ ] Code review comments from CodeRabbit / Claude have been addressed or resolved
- [ ] No unresolved review findings remain

(Will update as CI + CodeRabbit complete.)

## Checklist

- [x] My PR title follows the conventional commit format used by this repo
- [x] I linked the related issue or explained why none exists
- [x] I updated docs when needed (N/A — no user-facing docs)
- [x] I added or updated tests when needed
- [x] I verified the change does not introduce unrelated modifications
- [x] I read AGENTS.md and followed the contributor guidelines
- [ ] A human reviewed the complete diff before submission

## Notes for reviewers

- **Path posture consistency:** the new handlers deliberately allow paths outside `project_root`, matching the jail-removal posture shipped in #468 for `ls`/`mkdir`/`write`/`browse`. `..` traversal is still rejected (`PATH_TRAVERSAL`). This is per the spec ("new ops match the existing ls/mkdir posture exactly — no independent jail decision here").
- **`read` is not loopback-guarded**, matching `ls`/`browse` — so a desktop-hosted LAN client can open files in the editor. This is consistent with existing behavior (a LAN client can already `ls` any path post-#468); no new exposure introduced.
