### PR TITLE
fix(web): desktop subdir expansion + mobile last-folder persistence

### DIFF
--- a/src/renderer/components/mobile/MobileFileExplorer.test.tsx
+++ b/src/renderer/components/mobile/MobileFileExplorer.test.tsx
@@ -311,6 +311,8 @@ describe('MobileFileExplorer', () => {
 
     fireEvent.click(await screen.findByText('child'))
     expect(await screen.findByText('inside.txt')).toBeInTheDocument()
+    // Drive-root (`C:/`) subtitle must show the full child name, not drop a char.
+    expect(screen.getByText('child', { selector: 'p' })).toBeInTheDocument()
     fireEvent.click(screen.getByLabelText('Back to parent folder'))
 
     expect(await screen.findByText('child')).toBeInTheDocument()

--- a/src/renderer/components/mobile/MobileFileExplorer.test.tsx
+++ b/src/renderer/components/mobile/MobileFileExplorer.test.tsx
@@ -3,6 +3,25 @@ import { fireEvent, render, screen, waitFor, within } from '@testing-library/rea
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { MobileFileExplorer } from './MobileFileExplorer'
 
+let mockReducedMotion = false
+
+vi.mock('framer-motion', async () => {
+  const React = await import('react')
+  return {
+    AnimatePresence: ({ children }: { children: React.ReactNode }) => children,
+    motion: {
+      div: React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+        ({ children, ...props }, ref) => (
+          <div ref={ref} {...props}>
+            {children}
+          </div>
+        )
+      )
+    },
+    useReducedMotion: () => mockReducedMotion
+  }
+})
+
 const mockToggleDirectory = vi.fn().mockResolvedValue(undefined)
 const mockRefreshDirectory = vi.fn().mockResolvedValue(undefined)
 const mockSelectPath = vi.fn()
@@ -84,7 +103,12 @@ vi.mock('@/components/file-explorer/MaterialFileIcon', () => ({
   MaterialFileIcon: () => <span data-testid="mfi" />
 }))
 
-function entry(name: string, type: 'file' | 'directory', path?: string): DirectoryEntry {
+function entry(
+  name: string,
+  type: 'file' | 'directory',
+  path?: string,
+  ignored = false
+): DirectoryEntry {
   return {
     name,
     path: path ?? `/proj/${name}`,
@@ -92,7 +116,7 @@ function entry(name: string, type: 'file' | 'directory', path?: string): Directo
     extension: type === 'file' && name.includes('.') ? name.split('.').pop()! : null,
     size: 0,
     modifiedAt: 0,
-    ignored: false
+    ignored
   }
 }
 
@@ -107,6 +131,7 @@ function setRoot(entries: DirectoryEntry[]): void {
 describe('MobileFileExplorer', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    mockReducedMotion = false
     mockExplorerState.rootPath = '/proj'
     mockExplorerState.directoryContents = new Map()
     mockExplorerState.expandedDirs = new Set()
@@ -121,14 +146,16 @@ describe('MobileFileExplorer', () => {
     mockEditorStore.openFiles.clear()
   })
 
-  it('renders the Files header and lists root entries when open with a loaded root', async () => {
+  it('renders the project folder context and lists root entries when open', async () => {
     setRoot([entry('a.txt', 'file'), entry('sub', 'directory')])
 
     render(<MobileFileExplorer open onOpenChange={vi.fn()} />)
 
-    expect(await screen.findByText('Files')).toBeInTheDocument()
+    expect(await screen.findByRole('heading', { name: 'proj' })).toBeInTheDocument()
+    expect(screen.getByText('Project files')).toBeInTheDocument()
     expect(await screen.findByText('a.txt')).toBeInTheDocument()
     expect(screen.getByText('sub')).toBeInTheDocument()
+    expect(screen.getByLabelText('Back to parent folder')).toBeDisabled()
   })
 
   it('lazy-loads the root listing via toggleDirectory when opening with an empty root', async () => {
@@ -141,13 +168,107 @@ describe('MobileFileExplorer', () => {
     await waitFor(() => expect(mockToggleDirectory).toHaveBeenCalledWith('/proj'))
   })
 
-  it('tapping a directory row calls toggleDirectory with its path', async () => {
+  it('drills into a directory, loads it, and slides forward', async () => {
     setRoot([entry('sub', 'directory')])
 
     render(<MobileFileExplorer open onOpenChange={vi.fn()} />)
 
     fireEvent.click(await screen.findByText('sub'))
+
+    expect(await screen.findByRole('heading', { name: 'sub' })).toBeInTheDocument()
+    expect(screen.getByText('sub', { selector: 'p' })).toBeInTheDocument()
+    expect(screen.getByLabelText('Back to parent folder')).toBeEnabled()
+    expect(screen.getByTestId('mobile-folder-view')).toHaveAttribute(
+      'data-navigation-direction',
+      'forward'
+    )
     await waitFor(() => expect(mockToggleDirectory).toHaveBeenCalledWith('/proj/sub'))
+  })
+
+  it('resets to the project root when the drawer is reopened', async () => {
+    setRoot([entry('sub', 'directory')])
+    mockExplorerState.directoryContents.set('/proj/sub', [])
+
+    const { rerender } = render(<MobileFileExplorer open onOpenChange={vi.fn()} />)
+    fireEvent.click(await screen.findByText('sub'))
+    expect(await screen.findByRole('heading', { name: 'sub' })).toBeInTheDocument()
+
+    rerender(<MobileFileExplorer open={false} onOpenChange={vi.fn()} />)
+    rerender(<MobileFileExplorer open onOpenChange={vi.fn()} />)
+
+    expect(await screen.findByRole('heading', { name: 'proj' })).toBeInTheDocument()
+    expect(screen.getByLabelText('Back to parent folder')).toBeDisabled()
+  })
+
+  it('returns to the parent folder and slides back without going above root', async () => {
+    setRoot([entry('sub', 'directory')])
+    mockExplorerState.directoryContents.set('/proj/sub', [
+      entry('inside.txt', 'file', '/proj/sub/inside.txt')
+    ])
+
+    render(<MobileFileExplorer open onOpenChange={vi.fn()} />)
+
+    fireEvent.click(await screen.findByText('sub'))
+    expect(await screen.findByText('inside.txt')).toBeInTheDocument()
+    fireEvent.click(screen.getByLabelText('Back to parent folder'))
+
+    expect(await screen.findByRole('heading', { name: 'proj' })).toBeInTheDocument()
+    expect(screen.getByTestId('mobile-folder-view')).toHaveAttribute(
+      'data-navigation-direction',
+      'back'
+    )
+    expect(screen.getByLabelText('Back to parent folder')).toBeDisabled()
+  })
+
+  it('preserves a Windows drive-root path when navigating back', async () => {
+    mockExplorerState.rootPath = 'C:/'
+    mockExplorerState.directoryContents = new Map([
+      ['C:/', [entry('child', 'directory', 'C:/child')]],
+      ['C:/child', [entry('inside.txt', 'file', 'C:/child/inside.txt')]]
+    ])
+
+    render(<MobileFileExplorer open onOpenChange={vi.fn()} />)
+
+    fireEvent.click(await screen.findByText('child'))
+    expect(await screen.findByText('inside.txt')).toBeInTheDocument()
+    fireEvent.click(screen.getByLabelText('Back to parent folder'))
+
+    expect(await screen.findByText('child')).toBeInTheDocument()
+    expect(mockToggleDirectory).not.toHaveBeenCalledWith('C:')
+    expect(screen.getByLabelText('Back to parent folder')).toBeDisabled()
+  })
+
+  it('sorts visible entries exactly like desktop: directories, ignored state, then A-Z', async () => {
+    setRoot([
+      entry('z-file.txt', 'file'),
+      entry('beta', 'directory', undefined, true),
+      entry('Alpha.txt', 'file'),
+      entry('Zoo', 'directory'),
+      entry('alpha', 'directory'),
+      entry('aardvark.txt', 'file', undefined, true)
+    ])
+
+    render(<MobileFileExplorer open onOpenChange={vi.fn()} />)
+
+    const list = await screen.findByRole('list', { name: 'Files in proj' })
+    expect(
+      within(list)
+        .getAllByRole('listitem')
+        .map((item) => item.textContent)
+    ).toEqual(['alpha', 'Zoo', 'beta', 'Alpha.txt', 'z-file.txt', 'aardvark.txt'])
+  })
+
+  it('disables slide movement when reduced motion is preferred', async () => {
+    mockReducedMotion = true
+    setRoot([entry('sub', 'directory')])
+
+    render(<MobileFileExplorer open onOpenChange={vi.fn()} />)
+    fireEvent.click(await screen.findByText('sub'))
+
+    expect(await screen.findByTestId('mobile-folder-view')).toHaveAttribute(
+      'data-reduced-motion',
+      'true'
+    )
   })
 
   it('tapping a file opens it in the editor and closes the drawer', async () => {
@@ -164,18 +285,52 @@ describe('MobileFileExplorer', () => {
     await waitFor(() => expect(onOpenChange).toHaveBeenCalledWith(false))
   })
 
-  it('creates a new file via the facade then refreshes the root', async () => {
-    setRoot([])
+  it('creates and refreshes inside the currently viewed directory', async () => {
+    setRoot([entry('sub', 'directory')])
+    mockExplorerState.directoryContents.set('/proj/sub', [])
 
     render(<MobileFileExplorer open onOpenChange={vi.fn()} />)
 
-    fireEvent.click(await screen.findByLabelText('New file'))
+    fireEvent.click(await screen.findByText('sub'))
+    expect(await screen.findByRole('heading', { name: 'sub' })).toBeInTheDocument()
+    fireEvent.click(screen.getByLabelText('New file'))
     const input = await screen.findByPlaceholderText('new-file.txt')
     fireEvent.change(input, { target: { value: 'made.txt' } })
     fireEvent.keyDown(input, { key: 'Enter' })
 
-    await waitFor(() => expect(mockCreateFile).toHaveBeenCalledWith('/proj/made.txt'))
-    await waitFor(() => expect(mockRefreshDirectory).toHaveBeenCalledWith('/proj'))
+    await waitFor(() => expect(mockCreateFile).toHaveBeenCalledWith('/proj/sub/made.txt'))
+    await waitFor(() => expect(mockRefreshDirectory).toHaveBeenCalledWith('/proj/sub'))
+
+    mockRefreshDirectory.mockClear()
+    fireEvent.click(screen.getByLabelText('Refresh current folder'))
+    expect(mockRefreshDirectory).toHaveBeenCalledWith('/proj/sub')
+  })
+
+  it('prevents navigation and a second create form while a create request is pending', async () => {
+    setRoot([entry('sub', 'directory')])
+    mockExplorerState.directoryContents.set('/proj/sub', [])
+    let resolveCreate: ((result: { success: true; data: undefined }) => void) | undefined
+    mockCreateFile.mockReturnValue(
+      new Promise((resolve) => {
+        resolveCreate = resolve
+      })
+    )
+
+    render(<MobileFileExplorer open onOpenChange={vi.fn()} />)
+
+    fireEvent.click(await screen.findByText('sub'))
+    fireEvent.click(screen.getByLabelText('New file'))
+    const input = await screen.findByPlaceholderText('new-file.txt')
+    fireEvent.change(input, { target: { value: 'made.txt' } })
+    fireEvent.keyDown(input, { key: 'Enter' })
+
+    await waitFor(() => expect(mockCreateFile).toHaveBeenCalledWith('/proj/sub/made.txt'))
+    expect(screen.getByLabelText('Back to parent folder')).toBeDisabled()
+    expect(screen.getByLabelText('New file')).toBeDisabled()
+    expect(input).toBeDisabled()
+
+    resolveCreate?.({ success: true, data: undefined })
+    await waitFor(() => expect(mockRefreshDirectory).toHaveBeenCalledWith('/proj/sub'))
   })
 
   it('surfaces a server error code as a toast when create fails', async () => {
@@ -253,6 +408,34 @@ describe('MobileFileExplorer', () => {
     await waitFor(() => expect(mockCloseFile).toHaveBeenCalledWith('/proj/old.txt'))
     await waitFor(() => expect(mockRemoveTab).toHaveBeenCalledWith('edit-/proj/old.txt'))
     await waitFor(() => expect(mockRefreshDirectory).toHaveBeenCalledWith('/proj'))
+  })
+
+  it('renames a child directory and refreshes the current parent folder', async () => {
+    const sub = entry('sub', 'directory')
+    setRoot([sub])
+    mockExplorerState.directoryContents.set('/proj/sub', [
+      entry('child', 'directory', '/proj/sub/child')
+    ])
+    mockExplorerState.directoryContents.set('/proj/sub/child', [])
+
+    render(<MobileFileExplorer open onOpenChange={vi.fn()} />)
+    fireEvent.click(await screen.findByText('sub'))
+    fireEvent.click(await screen.findByText('child'))
+    expect(await screen.findByRole('heading', { name: 'child' })).toBeInTheDocument()
+
+    // Navigate back to the parent listing and rename its child directory.
+    fireEvent.click(screen.getByLabelText('Back to parent folder'))
+    fireEvent.click(await screen.findByLabelText('Actions for child'))
+    fireEvent.click(await screen.findByText('Rename'))
+    const input = await screen.findByLabelText('Rename child')
+    fireEvent.change(input, { target: { value: 'renamed' } })
+    fireEvent.keyDown(input, { key: 'Enter' })
+
+    await waitFor(() =>
+      expect(mockRenameFile).toHaveBeenCalledWith('/proj/sub/child', '/proj/sub/renamed')
+    )
+    expect(screen.getByRole('heading', { name: 'sub' })).toBeInTheDocument()
+    await waitFor(() => expect(mockRefreshDirectory).toHaveBeenCalledWith('/proj/sub'))
   })
 
   it('renames a file via blur using the parentOf-derived target path', async () => {

--- a/src/renderer/components/mobile/MobileFileExplorer.test.tsx
+++ b/src/renderer/components/mobile/MobileFileExplorer.test.tsx
@@ -46,6 +46,9 @@ const mockDeletePath = vi.fn()
 const mockRenameFile = vi.fn()
 const mockCopyFile = vi.fn()
 const mockToastError = vi.fn()
+const mockPersistenceRead = vi.fn()
+const mockPersistenceWrite = vi.fn()
+let mockProjectId: string | undefined
 
 // Mutable explorer state so individual tests can seed the tree (loaded root,
 // empty root, load error, no project) without re-declaring the module mock.
@@ -83,6 +86,10 @@ vi.mock('@/stores/workspace-store', () => ({
   editorTabId: (path: string) => `edit-${path}`
 }))
 
+vi.mock('@/stores/project-store', () => ({
+  useActiveProjectId: () => mockProjectId
+}))
+
 vi.mock('@/lib/api', () => ({
   filesystemApi: {
     createFile: (...args: unknown[]) => mockCreateFile(...args),
@@ -90,6 +97,10 @@ vi.mock('@/lib/api', () => ({
     deletePath: (...args: unknown[]) => mockDeletePath(...args),
     renameFile: (...args: unknown[]) => mockRenameFile(...args),
     copyFile: (...args: unknown[]) => mockCopyFile(...args)
+  },
+  persistenceApi: {
+    read: (...args: unknown[]) => mockPersistenceRead(...args),
+    write: (...args: unknown[]) => mockPersistenceWrite(...args)
   }
 }))
 
@@ -131,6 +142,9 @@ function setRoot(entries: DirectoryEntry[]): void {
 describe('MobileFileExplorer', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    mockProjectId = undefined
+    mockPersistenceRead.mockReset()
+    mockPersistenceWrite.mockReset()
     mockReducedMotion = false
     mockExplorerState.rootPath = '/proj'
     mockExplorerState.directoryContents = new Map()
@@ -185,19 +199,85 @@ describe('MobileFileExplorer', () => {
     await waitFor(() => expect(mockToggleDirectory).toHaveBeenCalledWith('/proj/sub'))
   })
 
-  it('resets to the project root when the drawer is reopened', async () => {
+  it('restores the persisted folder on open and keeps it on reopen', async () => {
+    mockProjectId = 'proj-1'
+    mockPersistenceRead.mockResolvedValue({ success: true, data: '/proj/sub' })
     setRoot([entry('sub', 'directory')])
     mockExplorerState.directoryContents.set('/proj/sub', [])
 
     const { rerender } = render(<MobileFileExplorer open onOpenChange={vi.fn()} />)
-    fireEvent.click(await screen.findByText('sub'))
-    expect(await screen.findByRole('heading', { name: 'sub' })).toBeInTheDocument()
 
+    // First open restores the persisted subfolder, not the project root.
+    expect(await screen.findByRole('heading', { name: 'sub' })).toBeInTheDocument()
+    expect(screen.getByLabelText('Back to parent folder')).toBeEnabled()
+    expect(mockPersistenceRead).toHaveBeenCalledWith('mobile-file-explorer/proj-1')
+
+    // Reopening keeps the user's folder — no reset to root, no re-read.
+    mockPersistenceRead.mockClear()
     rerender(<MobileFileExplorer open={false} onOpenChange={vi.fn()} />)
     rerender(<MobileFileExplorer open onOpenChange={vi.fn()} />)
+    expect(await screen.findByRole('heading', { name: 'sub' })).toBeInTheDocument()
+    expect(screen.getByLabelText('Back to parent folder')).toBeEnabled()
+    expect(mockPersistenceRead).not.toHaveBeenCalled()
+  })
+
+  it('persists the folder on navigation and restores it on a fresh mount', async () => {
+    mockProjectId = 'proj-1'
+    mockPersistenceRead.mockResolvedValue({ success: true, data: '/proj' })
+    setRoot([entry('sub', 'directory')])
+    mockExplorerState.directoryContents.set('/proj/sub', [])
+
+    const { unmount } = render(<MobileFileExplorer open onOpenChange={vi.fn()} />)
+    expect(await screen.findByRole('heading', { name: 'proj' })).toBeInTheDocument()
+
+    // Navigating into a subfolder writes the new folder to persistence.
+    fireEvent.click(await screen.findByText('sub'))
+    expect(await screen.findByRole('heading', { name: 'sub' })).toBeInTheDocument()
+    expect(mockPersistenceWrite).toHaveBeenCalledWith('mobile-file-explorer/proj-1', '/proj/sub')
+
+    // A fresh mount (page reload) restores the persisted folder.
+    mockPersistenceRead.mockResolvedValue({ success: true, data: '/proj/sub' })
+    unmount()
+    render(<MobileFileExplorer open onOpenChange={vi.fn()} />)
+    expect(await screen.findByRole('heading', { name: 'sub' })).toBeInTheDocument()
+  })
+
+  it('falls back to the project root when the persisted folder is outside the root', async () => {
+    mockProjectId = 'proj-1'
+    mockPersistenceRead.mockResolvedValue({ success: true, data: '/other-project/sub' })
+    setRoot([entry('a.txt', 'file')])
+
+    render(<MobileFileExplorer open onOpenChange={vi.fn()} />)
 
     expect(await screen.findByRole('heading', { name: 'proj' })).toBeInTheDocument()
     expect(screen.getByLabelText('Back to parent folder')).toBeDisabled()
+    expect(mockPersistenceRead).toHaveBeenCalledWith('mobile-file-explorer/proj-1')
+  })
+
+  it('restores the new project folder after a project switch', async () => {
+    mockProjectId = 'proj-1'
+    mockPersistenceRead.mockResolvedValue({ success: true, data: '/proj/sub' })
+    setRoot([entry('sub', 'directory')])
+    mockExplorerState.directoryContents.set('/proj/sub', [])
+
+    const { rerender } = render(<MobileFileExplorer open onOpenChange={vi.fn()} />)
+    expect(await screen.findByRole('heading', { name: 'sub' })).toBeInTheDocument()
+
+    // Switch the active project: the drawer should restore that project's own
+    // persisted folder, not keep the previous project's.
+    mockExplorerState.rootPath = '/proj2'
+    mockExplorerState.directoryContents = new Map([
+      ['/proj2', [entry('deep', 'directory', '/proj2/deep')]],
+      ['/proj2/deep', []]
+    ])
+    mockProjectId = 'proj-2'
+    mockPersistenceRead.mockResolvedValue({ success: true, data: '/proj2/deep' })
+
+    rerender(<MobileFileExplorer open onOpenChange={vi.fn()} />)
+
+    expect(await screen.findByRole('heading', { name: 'deep' })).toBeInTheDocument()
+    expect(screen.getByLabelText('Back to parent folder')).toBeEnabled()
+    expect(mockPersistenceRead).toHaveBeenCalledWith('mobile-file-explorer/proj-2')
   })
 
   it('returns to the parent folder and slides back without going above root', async () => {

--- a/src/renderer/components/mobile/MobileFileExplorer.tsx
+++ b/src/renderer/components/mobile/MobileFileExplorer.tsx
@@ -1,5 +1,7 @@
 import type { DirectoryEntry } from '@shared/types/filesystem.types'
+import { AnimatePresence, motion, useReducedMotion } from 'framer-motion'
 import {
+  ChevronLeft,
   ChevronRight,
   Copy,
   FilePlus,
@@ -32,6 +34,7 @@ import {
   SheetTitle
 } from '@/components/ui/sheet'
 import { filesystemApi } from '@/lib/api'
+import { sortDirectoryEntries } from '@/lib/filesystem-sort'
 import { useEditorStore } from '@/stores/editor-store'
 import { useFileExplorer, useFileExplorerActions } from '@/stores/file-explorer-store'
 import { editorTabId, useWorkspaceStore } from '@/stores/workspace-store'
@@ -51,56 +54,80 @@ interface RenameState {
   value: string
 }
 
-/** Lean touch-first file explorer drawer for the web/mobile view. Reuses the
- * shared `file-explorer-store` (browse/select/toggle/refresh) + the
- * `MaterialFileIcon` primitive, but renders its own tall, full-width tap
- * targets (no drag-drop/context-menu/keyboard-shortcuts/resize — those stay
- * desktop). Tapping a file reuses the desktop open-file wiring
- * (`selectPath` → `editorStore.openFile` → `workspaceStore.addEditorTab`) so
- * files open in the existing editor tab in the mobile pane tree, identical to
- * desktop double-click. Gated to `!isTauriContext()` by the caller
- * (`MobileChatShell`). v1 has no live watchers (web re-fetches on
- * action/refresh) and no streaming search. */
+type NavigationDirection = -1 | 0 | 1
+
+function normalizePath(path: string): string {
+  const normalized = path.replace(/\\/g, '/')
+  if (normalized === '/' || /^[A-Za-z]:\/$/.test(normalized)) return normalized
+  return normalized.replace(/\/+$/, '') || '/'
+}
+
+function pathIdentity(path: string): string {
+  const normalized = normalizePath(path)
+  return normalized === '/' ? normalized : normalized.replace(/\/+$/, '')
+}
+
+function joinPath(parent: string, name: string): string {
+  return `${normalizePath(parent).replace(/\/$/, '')}/${name}`
+}
+
+/** Lean touch-first file explorer drawer for the web/mobile view. Directory
+ * rows drill into a single folder at a time, while files reuse the desktop
+ * open-file wiring. Native desktop keeps its existing tree explorer. */
 export function MobileFileExplorer({
   open,
   onOpenChange
 }: MobileFileExplorerProps): React.JSX.Element {
-  const { rootPath, directoryContents, expandedDirs, loadingDirs, rootLoadError } =
-    useFileExplorer()
-  const { toggleDirectory, refreshDirectory, selectPath, collapseAll } = useFileExplorerActions()
+  const { rootPath, directoryContents, loadingDirs, rootLoadError } = useFileExplorer()
+  const { toggleDirectory, refreshDirectory, selectPath } = useFileExplorerActions()
+  const reducedMotion = useReducedMotion() ?? false
 
+  const [currentPath, setCurrentPath] = useState<string | null>(rootPath)
+  const [navigationDirection, setNavigationDirection] = useState<NavigationDirection>(0)
   const [actionEntry, setActionEntry] = useState<DirectoryEntry | null>(null)
   const [renaming, setRenaming] = useState<RenameState | null>(null)
   const [creating, setCreating] = useState<CreateState | null>(null)
+  const [createSubmitting, setCreateSubmitting] = useState(false)
   const [pendingDelete, setPendingDelete] = useState<DirectoryEntry | null>(null)
 
-  // Load the root listing when the drawer opens (web has no watchers, so the
-  // store is not pre-populated by the workspace layout's watch effect).
+  // Every project/drawer opening starts at the project root, avoiding a stale
+  // subfolder when the active project changes while the drawer is closed.
   useEffect(() => {
-    if (!open || !rootPath) return
-    if (!directoryContents.has(rootPath) && !loadingDirs.has(rootPath)) {
-      void toggleDirectory(rootPath)
+    if (!open) return
+    setCurrentPath(rootPath)
+    setNavigationDirection(0)
+    setActionEntry(null)
+    setRenaming(null)
+    setCreating(null)
+  }, [open, rootPath])
+
+  // Web has no directory watcher, so load whichever folder is currently shown.
+  useEffect(() => {
+    if (!open || !currentPath) return
+    if (!directoryContents.has(currentPath) && !loadingDirs.has(currentPath)) {
+      void toggleDirectory(currentPath)
     }
-  }, [open, rootPath, directoryContents, loadingDirs, toggleDirectory])
+  }, [open, currentPath, directoryContents, loadingDirs, toggleDirectory])
 
   function parentOf(path: string): string {
-    const normalized = path.replace(/\\/g, '/')
-    const idx = normalized.lastIndexOf('/')
-    return idx <= 0 ? (rootPath ?? normalized) : normalized.slice(0, idx)
+    const normalized = normalizePath(path)
+    const canonicalRoot = rootPath ?? normalized
+    const rootIdentity = pathIdentity(canonicalRoot)
+    const currentIdentity = pathIdentity(normalized)
+    const rootPrefix = rootIdentity === '/' ? '/' : `${rootIdentity}/`
+    if (currentIdentity === rootIdentity || !currentIdentity.startsWith(rootPrefix)) {
+      return canonicalRoot
+    }
+    const parent = normalized.slice(0, normalized.lastIndexOf('/'))
+    return pathIdentity(parent) === rootIdentity ? canonicalRoot : parent
   }
 
-  /** Close every open editor tab pointing at `target` — the exact path for a
-   * file, or the path plus any descendant for a directory (a recursive
-   * delete or a directory rename moves/removes them all). Keeps the mobile
-   * pane tree free of stale/orphan tabs, mirroring desktop FileExplorer's
-   * reconciliation but covering the recursive directory case the exact-match
-   * check missed. */
   function closeAffectedTabs(target: DirectoryEntry): void {
     const editor = useEditorStore.getState()
-    const targetNorm = target.path.replace(/\\/g, '/')
+    const targetNorm = normalizePath(target.path)
     const prefix = `${targetNorm}/`
     for (const openPath of Array.from(editor.openFiles.keys())) {
-      const openNorm = openPath.replace(/\\/g, '/')
+      const openNorm = normalizePath(openPath)
       if (openNorm === targetNorm || (target.type === 'directory' && openNorm.startsWith(prefix))) {
         editor.closeFile(openPath)
         useWorkspaceStore.getState().removeTab(editorTabId(openPath))
@@ -121,30 +148,48 @@ export function MobileFileExplorer({
     }
   }
 
+  function navigateForward(path: string): void {
+    setCreating(null)
+    setRenaming(null)
+    setNavigationDirection(1)
+    setCurrentPath(normalizePath(path))
+  }
+
+  function navigateBack(): void {
+    if (!currentPath || !rootPath || pathIdentity(currentPath) === pathIdentity(rootPath)) return
+    setCreating(null)
+    setRenaming(null)
+    setNavigationDirection(-1)
+    setCurrentPath(parentOf(currentPath))
+  }
+
   function handleRowTap(entry: DirectoryEntry): void {
     if (renaming?.path === entry.path) return
-    if (entry.type === 'directory') {
-      void toggleDirectory(entry.path)
-    } else {
-      void handleOpenFile(entry)
-    }
+    if (entry.type === 'directory') navigateForward(entry.path)
+    else void handleOpenFile(entry)
   }
 
   async function handleCreate(): Promise<void> {
-    if (!creating || !rootPath) return
+    if (!creating || !currentPath || createSubmitting) return
     const name = creating.value.trim()
     if (!name) return
-    const fullPath = `${rootPath.replace(/\\/g, '/')}/${name}`
-    const result =
-      creating.type === 'file'
-        ? await filesystemApi.createFile(fullPath)
-        : await filesystemApi.createDirectory(fullPath)
-    if (!result.success) {
-      toast.error('Failed to create', { description: result.error })
-      return
+    const submittedPath = currentPath
+    const fullPath = joinPath(submittedPath, name)
+    setCreateSubmitting(true)
+    try {
+      const result =
+        creating.type === 'file'
+          ? await filesystemApi.createFile(fullPath)
+          : await filesystemApi.createDirectory(fullPath)
+      if (!result.success) {
+        toast.error('Failed to create', { description: result.error })
+        return
+      }
+      setCreating(null)
+      await refreshDirectory(submittedPath)
+    } finally {
+      setCreateSubmitting(false)
     }
-    setCreating(null)
-    await refreshDirectory(rootPath)
   }
 
   async function handleRename(entry: DirectoryEntry, value: string): Promise<void> {
@@ -154,27 +199,22 @@ export function MobileFileExplorer({
       return
     }
     const parent = parentOf(entry.path)
-    const newPath = `${parent.replace(/\\/g, '/')}/${name}`
-    if (newPath === entry.path) {
+    const newPath = joinPath(parent, name)
+    if (normalizePath(newPath) === normalizePath(entry.path)) {
       setRenaming(null)
       return
     }
-    // Clear the rename state BEFORE the async request so an Enter→blur
-    // sequence can't fire `handleRename` twice — the second call would hit a
-    // missing source (already renamed) and surface a spurious "Failed to
-    // rename" toast after a successful rename. With state cleared up front,
-    // a late blur re-enters `handleRename`, sees `renaming === null`, and
-    // returns early via the guard above.
     setRenaming(null)
     const result = await filesystemApi.renameFile(entry.path, newPath)
     if (!result.success) {
       toast.error('Failed to rename', { description: result.error })
       return
     }
-    // Reconcile open editor tabs: close tabs pointing at the old path (and,
-    // for a renamed directory, its descendants) so the mobile pane tree never
-    // shows a stale/orphan path.
     closeAffectedTabs(entry)
+    if (currentPath && normalizePath(currentPath).startsWith(`${normalizePath(entry.path)}/`)) {
+      setCurrentPath(parent)
+      setNavigationDirection(-1)
+    }
     await refreshDirectory(parent)
   }
 
@@ -186,70 +226,65 @@ export function MobileFileExplorer({
       toast.error('Failed to delete', { description: result.error })
       return
     }
-    // Close tabs pointing at the deleted path — the exact path for a file,
-    // or the path plus any descendant for a recursive directory delete.
     closeAffectedTabs(entry)
-    await refreshDirectory(parentOf(entry.path))
+    const parent = parentOf(entry.path)
+    if (
+      currentPath &&
+      (normalizePath(currentPath) === normalizePath(entry.path) ||
+        normalizePath(currentPath).startsWith(`${normalizePath(entry.path)}/`))
+    ) {
+      setCurrentPath(parent)
+      setNavigationDirection(-1)
+    }
+    await refreshDirectory(parent)
   }
 
   async function handleDuplicate(entry: DirectoryEntry): Promise<void> {
     const dot = entry.name.lastIndexOf('.')
     const stem = dot > 0 ? entry.name.slice(0, dot) : entry.name
     const ext = dot > 0 ? entry.name.slice(dot) : ''
-    const dest = `${parentOf(entry.path).replace(/\\/g, '/')}/${stem} copy${ext}`
-    const result = await filesystemApi.copyFile(entry.path, dest)
+    const parent = parentOf(entry.path)
+    const result = await filesystemApi.copyFile(entry.path, joinPath(parent, `${stem} copy${ext}`))
     if (!result.success) {
       toast.error('Failed to copy', { description: result.error })
       return
     }
-    await refreshDirectory(parentOf(entry.path))
+    await refreshDirectory(parent)
   }
 
-  function renderRow(entry: DirectoryEntry, depth: number): React.ReactNode {
-    const isExpanded = expandedDirs.has(entry.path)
+  function renderRow(entry: DirectoryEntry): React.ReactNode {
     const isRenaming = renaming?.path === entry.path
-    const isLoading = loadingDirs.has(entry.path)
     return (
-      <div
-        key={entry.path}
-        role="treeitem"
-        tabIndex={-1}
-        aria-expanded={entry.type === 'directory' ? isExpanded : undefined}
-      >
+      <li key={entry.path}>
         {isRenaming ? (
           <Input
             autoFocus
             defaultValue={renaming.value}
-            onChange={(e) => setRenaming({ path: entry.path, value: e.target.value })}
+            onChange={(event) => setRenaming({ path: entry.path, value: event.target.value })}
             onBlur={() => void handleRename(entry, renaming.value)}
-            onKeyDown={(e) => {
-              if (e.key === 'Enter') void handleRename(entry, renaming.value)
-              if (e.key === 'Escape') setRenaming(null)
+            onKeyDown={(event) => {
+              if (event.key === 'Enter') void handleRename(entry, renaming.value)
+              if (event.key === 'Escape') setRenaming(null)
             }}
             className="m-1 h-11"
             aria-label={`Rename ${entry.name}`}
           />
         ) : (
-          <div
-            className="flex h-11 items-center gap-2 px-2"
-            style={{ paddingLeft: `${depth * 14 + 8}px` }}
-          >
+          <div className="flex h-11 items-center gap-2 px-2">
             <button
               type="button"
               className="flex h-11 min-w-0 flex-1 items-center gap-2 text-left"
               onClick={() => handleRowTap(entry)}
               aria-label={
-                entry.type === 'directory'
-                  ? `${isExpanded ? 'Collapse' : 'Expand'} ${entry.name}`
-                  : `Open ${entry.name}`
+                entry.type === 'directory' ? `Open folder ${entry.name}` : `Open ${entry.name}`
               }
             >
               <MaterialFileIcon
                 name={entry.name}
                 extension={entry.extension}
                 isDirectory={entry.type === 'directory'}
-                isExpanded={isExpanded}
-                depth={depth}
+                isExpanded={false}
+                depth={0}
                 size={18}
               />
               <span
@@ -258,10 +293,7 @@ export function MobileFileExplorer({
                 {entry.name}
               </span>
               {entry.type === 'directory' && (
-                <ChevronRight
-                  size={16}
-                  className={`shrink-0 text-muted-foreground transition-transform ${isExpanded ? 'rotate-90' : ''}`}
-                />
+                <ChevronRight size={16} className="shrink-0 text-muted-foreground" />
               )}
             </button>
             <Button
@@ -270,8 +302,8 @@ export function MobileFileExplorer({
               size="icon"
               className="size-9 shrink-0"
               aria-label={`Actions for ${entry.name}`}
-              onClick={(e) => {
-                e.stopPropagation()
+              onClick={(event) => {
+                event.stopPropagation()
                 setActionEntry(entry)
               }}
             >
@@ -279,34 +311,25 @@ export function MobileFileExplorer({
             </Button>
           </div>
         )}
-        {entry.type === 'directory' && isExpanded && (
-          // biome-ignore lint/a11y/useSemanticElements: ARIA tree pattern groups a treeitem's expanded children under role="group"; <fieldset> is a form-grouping element, not appropriate for tree structure
-          <div role="group">
-            {renderEntries(entry.path, depth + 1)}
-            {isLoading && !directoryContents.has(entry.path) && (
-              <div className="px-4 py-2 text-xs text-muted-foreground">Loading…</div>
-            )}
-          </div>
-        )}
-      </div>
+      </li>
     )
   }
 
-  function renderEntries(dirPath: string, depth: number): React.ReactNode {
-    const entries = directoryContents.get(dirPath)
-    if (!entries) return null
-    if (entries.length === 0) {
-      return (
-        <div
-          className="px-4 py-2 text-xs text-muted-foreground"
-          style={{ paddingLeft: `${depth * 14 + 8}px` }}
-        >
-          Empty
-        </div>
-      )
-    }
-    return entries.map((entry) => renderRow(entry, depth))
-  }
+  const normalizedRoot = rootPath ? normalizePath(rootPath) : null
+  const normalizedCurrent = currentPath ? normalizePath(currentPath) : null
+  const isAtRoot =
+    !normalizedRoot || pathIdentity(normalizedCurrent ?? '/') === pathIdentity(normalizedRoot)
+  const currentName =
+    normalizedCurrent && normalizedRoot
+      ? isAtRoot
+        ? normalizedRoot.split('/').filter(Boolean).at(-1) || normalizedRoot
+        : normalizedCurrent.split('/').filter(Boolean).at(-1) || normalizedCurrent
+      : 'Files'
+  const currentEntries = currentPath
+    ? sortDirectoryEntries(directoryContents.get(currentPath) ?? [])
+    : []
+  const isCurrentLoading = !!currentPath && loadingDirs.has(currentPath)
+  const slideDistance = reducedMotion ? 0 : 28
 
   return (
     <Sheet open={open} onOpenChange={onOpenChange}>
@@ -315,7 +338,30 @@ export function MobileFileExplorer({
         className="flex w-[min(100vw,26rem)] flex-col gap-0 p-0 sm:max-w-md"
       >
         <SheetHeader className="space-y-0 border-b border-border/60 px-3 py-3 text-left">
-          <SheetTitle className="text-base">Files</SheetTitle>
+          <div className="flex min-w-0 items-center gap-1">
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon"
+              className="-ml-2 size-9 shrink-0"
+              aria-label="Back to parent folder"
+              disabled={isAtRoot || createSubmitting}
+              onClick={navigateBack}
+            >
+              <ChevronLeft size={19} />
+            </Button>
+            <div className="min-w-0">
+              <SheetTitle className="truncate text-base">{currentName}</SheetTitle>
+              <p
+                className="truncate text-xs text-muted-foreground"
+                title={normalizedCurrent ?? undefined}
+              >
+                {isAtRoot
+                  ? 'Project files'
+                  : normalizedCurrent?.slice((normalizedRoot?.length ?? 0) + 1)}
+              </p>
+            </div>
+          </div>
           <SheetDescription className="sr-only">Browse project files</SheetDescription>
         </SheetHeader>
 
@@ -325,9 +371,9 @@ export function MobileFileExplorer({
             variant="ghost"
             size="icon"
             className="size-9"
-            aria-label="Refresh"
-            disabled={!rootPath}
-            onClick={() => rootPath && void refreshDirectory(rootPath)}
+            aria-label="Refresh current folder"
+            disabled={!currentPath || createSubmitting}
+            onClick={() => currentPath && void refreshDirectory(currentPath)}
           >
             <RefreshCw size={16} />
           </Button>
@@ -337,7 +383,7 @@ export function MobileFileExplorer({
             size="icon"
             className="size-9"
             aria-label="New file"
-            disabled={!rootPath}
+            disabled={!currentPath || createSubmitting}
             onClick={() => setCreating({ type: 'file', value: '' })}
           >
             <FilePlus size={16} />
@@ -348,64 +394,85 @@ export function MobileFileExplorer({
             size="icon"
             className="size-9"
             aria-label="New folder"
-            disabled={!rootPath}
+            disabled={!currentPath || createSubmitting}
             onClick={() => setCreating({ type: 'directory', value: '' })}
           >
             <FolderPlus size={16} />
           </Button>
-          <Button
-            type="button"
-            variant="ghost"
-            size="icon"
-            className="ml-auto size-9"
-            aria-label="Collapse all"
-            disabled={!rootPath}
-            onClick={() => collapseAll()}
-          >
-            <span className="text-xs">Collapse</span>
-          </Button>
         </div>
 
-        <div className="min-h-0 flex-1 overflow-y-auto py-1">
-          {rootLoadError ? (
+        <div className="relative min-h-0 flex-1 overflow-hidden">
+          {rootLoadError && isAtRoot ? (
             <div className="flex flex-col items-center gap-2 px-4 py-8 text-center">
               <p className="text-sm text-muted-foreground">{rootLoadError.message}</p>
-              {rootPath && (
+              {currentPath && (
                 <Button
                   type="button"
                   variant="secondary"
                   size="sm"
-                  onClick={() => void refreshDirectory(rootPath)}
+                  onClick={() => void refreshDirectory(currentPath)}
                 >
                   Retry
                 </Button>
               )}
             </div>
-          ) : creating ? (
-            <div className="px-2 py-1">
-              <Input
-                autoFocus
-                placeholder={creating.type === 'file' ? 'new-file.txt' : 'new-folder'}
-                onChange={(e) => setCreating({ ...creating, value: e.target.value })}
-                onKeyDown={(e) => {
-                  if (e.key === 'Enter') void handleCreate()
-                  if (e.key === 'Escape') setCreating(null)
-                }}
-                className="h-11"
-                aria-label={creating.type === 'file' ? 'New file name' : 'New folder name'}
-              />
-            </div>
-          ) : !rootPath ? (
+          ) : !currentPath ? (
             <div className="px-4 py-8 text-center text-sm text-muted-foreground">
               No active project
             </div>
           ) : (
-            <div role="tree">{renderEntries(rootPath, 0)}</div>
+            <AnimatePresence initial={false} mode="wait" custom={navigationDirection}>
+              <motion.div
+                key={currentPath}
+                custom={navigationDirection}
+                data-testid="mobile-folder-view"
+                data-navigation-direction={
+                  navigationDirection === 1
+                    ? 'forward'
+                    : navigationDirection === -1
+                      ? 'back'
+                      : 'none'
+                }
+                data-reduced-motion={reducedMotion ? 'true' : 'false'}
+                className="absolute inset-0 overflow-y-auto py-1"
+                initial={{ opacity: reducedMotion ? 1 : 0, x: navigationDirection * slideDistance }}
+                animate={{ opacity: 1, x: 0 }}
+                exit={{
+                  opacity: reducedMotion ? 1 : 0,
+                  x: navigationDirection * -slideDistance
+                }}
+                transition={{ duration: reducedMotion ? 0 : 0.18, ease: 'easeOut' }}
+              >
+                {creating ? (
+                  <div className="px-2 py-1">
+                    <Input
+                      autoFocus
+                      disabled={createSubmitting}
+                      placeholder={creating.type === 'file' ? 'new-file.txt' : 'new-folder'}
+                      onChange={(event) => setCreating({ ...creating, value: event.target.value })}
+                      onKeyDown={(event) => {
+                        if (event.key === 'Enter') void handleCreate()
+                        if (event.key === 'Escape') setCreating(null)
+                      }}
+                      className="h-11"
+                      aria-label={creating.type === 'file' ? 'New file name' : 'New folder name'}
+                    />
+                  </div>
+                ) : isCurrentLoading && !directoryContents.has(currentPath) ? (
+                  <div className="px-4 py-8 text-center text-sm text-muted-foreground">
+                    Loading…
+                  </div>
+                ) : currentEntries.length === 0 ? (
+                  <div className="px-4 py-8 text-center text-sm text-muted-foreground">Empty</div>
+                ) : (
+                  <ul aria-label={`Files in ${currentName}`}>{currentEntries.map(renderRow)}</ul>
+                )}
+              </motion.div>
+            </AnimatePresence>
           )}
         </div>
 
-        {/* Action sheet (bottom) for the selected row. */}
-        <Sheet open={!!actionEntry} onOpenChange={(v) => !v && setActionEntry(null)}>
+        <Sheet open={!!actionEntry} onOpenChange={(value) => !value && setActionEntry(null)}>
           <SheetContent
             side="bottom"
             className="flex flex-col gap-0 rounded-t-xl p-2"
@@ -430,9 +497,9 @@ export function MobileFileExplorer({
                   type="button"
                   className="flex h-11 items-center gap-3 rounded-md px-3 text-sm hover:bg-accent"
                   onClick={() => {
-                    const e = actionEntry
+                    const entry = actionEntry
                     setActionEntry(null)
-                    void handleDuplicate(e)
+                    void handleDuplicate(entry)
                   }}
                 >
                   <Copy size={16} /> Duplicate
@@ -455,8 +522,8 @@ export function MobileFileExplorer({
 
       <AlertDialog
         open={!!pendingDelete}
-        onOpenChange={(open) => {
-          if (!open) setPendingDelete(null)
+        onOpenChange={(dialogOpen) => {
+          if (!dialogOpen) setPendingDelete(null)
         }}
       >
         <AlertDialogContent>

--- a/src/renderer/components/mobile/MobileFileExplorer.tsx
+++ b/src/renderer/components/mobile/MobileFileExplorer.tsx
@@ -127,21 +127,34 @@ export function MobileFileExplorer({
       setCurrentPath(null)
       return
     }
-    if (restoredForRootRef.current === rootPath) return
-    restoredForRootRef.current = rootPath
+    const restoreKey = `${projectId ?? ''}:${rootPath}`
+    if (restoredForRootRef.current === restoreKey) return
+    restoredForRootRef.current = restoreKey
+    const normalizedRoot = normalizePath(rootPath)
     if (!projectId) {
-      setCurrentPath(rootPath)
+      setCurrentPath(normalizedRoot)
       return
     }
     // Clear a stale folder from a different project while reading the
     // persisted one, so the drawer shows loading instead of old contents.
     setCurrentPath(null)
+    // Cancel the pending read if rootPath/projectId change mid-flight, so a
+    // late resolution can't apply the previous project's folder; fall back to
+    // root on rejection (persistenceApi.read shouldn't reject, but defend it).
+    let cancelled = false
     void persistenceApi
       .read<string>(PersistenceKeys.mobileFileExplorerFolder(projectId))
       .then((res) => {
+        if (cancelled) return
         const persisted = res.success ? res.data : null
-        setCurrentPath(persisted && isWithinRoot(persisted, rootPath) ? persisted : rootPath)
+        setCurrentPath(persisted && isWithinRoot(persisted, rootPath) ? persisted : normalizedRoot)
       })
+      .catch(() => {
+        if (!cancelled) setCurrentPath(normalizedRoot)
+      })
+    return () => {
+      cancelled = true
+    }
   }, [open, rootPath, projectId])
 
   // Web has no directory watcher, so load whichever folder is currently shown.
@@ -154,7 +167,7 @@ export function MobileFileExplorer({
 
   function parentOf(path: string): string {
     const normalized = normalizePath(path)
-    const canonicalRoot = rootPath ?? normalized
+    const canonicalRoot = rootPath ? normalizePath(rootPath) : normalized
     const rootIdentity = pathIdentity(canonicalRoot)
     const currentIdentity = pathIdentity(normalized)
     const rootPrefix = rootIdentity === '/' ? '/' : `${rootIdentity}/`
@@ -366,6 +379,15 @@ export function MobileFileExplorer({
 
   const normalizedRoot = rootPath ? normalizePath(rootPath) : null
   const normalizedCurrent = currentPath ? normalizePath(currentPath) : null
+  // Roots ending in a separator (`/`, `C:/`) already include it, so the
+  // relative-path label slices from the root length itself; otherwise skip the
+  // separator after the root (the old `+ 1` dropped the first child char for
+  // `C:/`/`/`).
+  const rootPrefixLength = normalizedRoot
+    ? normalizedRoot.endsWith('/')
+      ? normalizedRoot.length
+      : normalizedRoot.length + 1
+    : 0
   const isAtRoot =
     !normalizedRoot || pathIdentity(normalizedCurrent ?? '/') === pathIdentity(normalizedRoot)
   const currentName =
@@ -405,9 +427,7 @@ export function MobileFileExplorer({
                 className="truncate text-xs text-muted-foreground"
                 title={normalizedCurrent ?? undefined}
               >
-                {isAtRoot
-                  ? 'Project files'
-                  : normalizedCurrent?.slice((normalizedRoot?.length ?? 0) + 1)}
+                {isAtRoot ? 'Project files' : normalizedCurrent?.slice(rootPrefixLength)}
               </p>
             </div>
           </div>

--- a/src/renderer/components/mobile/MobileFileExplorer.tsx
+++ b/src/renderer/components/mobile/MobileFileExplorer.tsx
@@ -1,4 +1,5 @@
 import type { DirectoryEntry } from '@shared/types/filesystem.types'
+import { PersistenceKeys } from '@shared/types/persistence.types'
 import { AnimatePresence, motion, useReducedMotion } from 'framer-motion'
 import {
   ChevronLeft,
@@ -11,7 +12,7 @@ import {
   RefreshCw,
   Trash2
 } from 'lucide-react'
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { toast } from 'sonner'
 import { MaterialFileIcon } from '@/components/file-explorer/MaterialFileIcon'
 import {
@@ -33,10 +34,11 @@ import {
   SheetHeader,
   SheetTitle
 } from '@/components/ui/sheet'
-import { filesystemApi } from '@/lib/api'
+import { filesystemApi, persistenceApi } from '@/lib/api'
 import { sortDirectoryEntries } from '@/lib/filesystem-sort'
 import { useEditorStore } from '@/stores/editor-store'
 import { useFileExplorer, useFileExplorerActions } from '@/stores/file-explorer-store'
+import { useActiveProjectId } from '@/stores/project-store'
 import { editorTabId, useWorkspaceStore } from '@/stores/workspace-store'
 
 interface MobileFileExplorerProps {
@@ -71,6 +73,16 @@ function joinPath(parent: string, name: string): string {
   return `${normalizePath(parent).replace(/\/$/, '')}/${name}`
 }
 
+function isWithinRoot(path: string, root: string): boolean {
+  const p = pathIdentity(path)
+  const r = pathIdentity(root)
+  if (p === r) return true
+  // Drive roots (`C:/`) and posix `/` prefix any child without a trailing
+  // separator, so check `startsWith(r)` directly for those.
+  if (r === '/' || /^[A-Za-z]:\/$/.test(r)) return p.startsWith(r)
+  return p.startsWith(`${r}/`)
+}
+
 /** Lean touch-first file explorer drawer for the web/mobile view. Directory
  * rows drill into a single folder at a time, while files reuse the desktop
  * open-file wiring. Native desktop keeps its existing tree explorer. */
@@ -81,25 +93,56 @@ export function MobileFileExplorer({
   const { rootPath, directoryContents, loadingDirs, rootLoadError } = useFileExplorer()
   const { toggleDirectory, refreshDirectory, selectPath } = useFileExplorerActions()
   const reducedMotion = useReducedMotion() ?? false
+  const projectId = useActiveProjectId()
 
-  const [currentPath, setCurrentPath] = useState<string | null>(rootPath)
+  const [currentPath, setCurrentPath] = useState<string | null>(null)
   const [navigationDirection, setNavigationDirection] = useState<NavigationDirection>(0)
   const [actionEntry, setActionEntry] = useState<DirectoryEntry | null>(null)
   const [renaming, setRenaming] = useState<RenameState | null>(null)
   const [creating, setCreating] = useState<CreateState | null>(null)
   const [createSubmitting, setCreateSubmitting] = useState(false)
   const [pendingDelete, setPendingDelete] = useState<DirectoryEntry | null>(null)
+  // Tracks the project root we've already restored the persisted folder for.
+  // Prevents re-reading persistence (and clobbering the in-session folder) on
+  // every drawer reopen — the component stays mounted across close, so
+  // currentPath already holds the user's last folder.
+  const restoredForRootRef = useRef<string | null>(null)
 
-  // Every project/drawer opening starts at the project root, avoiding a stale
-  // subfolder when the active project changes while the drawer is closed.
+  function persistFolder(path: string): void {
+    if (!projectId) return
+    void persistenceApi.write(PersistenceKeys.mobileFileExplorerFolder(projectId), path)
+  }
+
+  // Restore the last folder the user navigated into (persisted per project)
+  // when opening for a new/different project root — first open, reload, or
+  // project switch. Within-session reopens keep the current folder: the
+  // component stays mounted across drawer close, so currentPath survives.
   useEffect(() => {
     if (!open) return
-    setCurrentPath(rootPath)
     setNavigationDirection(0)
     setActionEntry(null)
     setRenaming(null)
     setCreating(null)
-  }, [open, rootPath])
+    if (!rootPath) {
+      setCurrentPath(null)
+      return
+    }
+    if (restoredForRootRef.current === rootPath) return
+    restoredForRootRef.current = rootPath
+    if (!projectId) {
+      setCurrentPath(rootPath)
+      return
+    }
+    // Clear a stale folder from a different project while reading the
+    // persisted one, so the drawer shows loading instead of old contents.
+    setCurrentPath(null)
+    void persistenceApi
+      .read<string>(PersistenceKeys.mobileFileExplorerFolder(projectId))
+      .then((res) => {
+        const persisted = res.success ? res.data : null
+        setCurrentPath(persisted && isWithinRoot(persisted, rootPath) ? persisted : rootPath)
+      })
+  }, [open, rootPath, projectId])
 
   // Web has no directory watcher, so load whichever folder is currently shown.
   useEffect(() => {
@@ -152,7 +195,9 @@ export function MobileFileExplorer({
     setCreating(null)
     setRenaming(null)
     setNavigationDirection(1)
-    setCurrentPath(normalizePath(path))
+    const next = normalizePath(path)
+    setCurrentPath(next)
+    persistFolder(next)
   }
 
   function navigateBack(): void {
@@ -160,7 +205,9 @@ export function MobileFileExplorer({
     setCreating(null)
     setRenaming(null)
     setNavigationDirection(-1)
-    setCurrentPath(parentOf(currentPath))
+    const next = parentOf(currentPath)
+    setCurrentPath(next)
+    persistFolder(next)
   }
 
   function handleRowTap(entry: DirectoryEntry): void {
@@ -214,6 +261,7 @@ export function MobileFileExplorer({
     if (currentPath && normalizePath(currentPath).startsWith(`${normalizePath(entry.path)}/`)) {
       setCurrentPath(parent)
       setNavigationDirection(-1)
+      persistFolder(parent)
     }
     await refreshDirectory(parent)
   }
@@ -235,6 +283,7 @@ export function MobileFileExplorer({
     ) {
       setCurrentPath(parent)
       setNavigationDirection(-1)
+      persistFolder(parent)
     }
     await refreshDirectory(parent)
   }
@@ -417,9 +466,13 @@ export function MobileFileExplorer({
               )}
             </div>
           ) : !currentPath ? (
-            <div className="px-4 py-8 text-center text-sm text-muted-foreground">
-              No active project
-            </div>
+            rootPath ? (
+              <div className="px-4 py-8 text-center text-sm text-muted-foreground">Loading…</div>
+            ) : (
+              <div className="px-4 py-8 text-center text-sm text-muted-foreground">
+                No active project
+              </div>
+            )
           ) : (
             <AnimatePresence initial={false} mode="wait" custom={navigationDirection}>
               <motion.div

--- a/src/renderer/lib/__tests__/tauri-filesystem-api.web.test.ts
+++ b/src/renderer/lib/__tests__/tauri-filesystem-api.web.test.ts
@@ -109,6 +109,44 @@ describe('tauriFilesystemApi (web branch)', () => {
     )
   })
 
+  it('readDirectory normalizes Windows backslash entry paths to forward slashes (web)', async () => {
+    // fs_api.rs `ls` joins paths with PathBuf and returns to_string_lossy() —
+    // backslash separators on a Windows server. The file-explorer store keys
+    // expandedDirs/directoryContents by normalizePath (`\`→`/`) but
+    // FileTreeNode reads by raw entry.path; without this normalization the
+    // desktop tree can't expand subdirs at level 2+ on web.
+    const entries = [
+      {
+        name: 'src',
+        path: 'C:\\web\\src',
+        type: 'directory',
+        extension: null,
+        size: 0,
+        modifiedAt: 1
+      },
+      {
+        name: 'a.txt',
+        path: 'C:\\web\\a.txt',
+        type: 'file',
+        extension: 'txt',
+        size: 4,
+        modifiedAt: 2
+      }
+    ]
+    mockFetch.mockResolvedValueOnce(jsonResponse({ success: true, data: entries }))
+
+    const result = await tauriFilesystemApi.readDirectory('C:\\web')
+
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data.map((e) => e.path)).toEqual(['C:/web/src', 'C:/web/a.txt'])
+    }
+    expect(mockFetch).toHaveBeenCalledWith(
+      `${window.location.origin}/fs/ls?path=${encodeURIComponent('C:\\web')}`,
+      expect.objectContaining({ method: 'GET' })
+    )
+  })
+
   it('propagates a server-side failure body (e.g. MKDIR_ERROR) from the web client', async () => {
     mockFetch.mockResolvedValueOnce(
       jsonResponse({ success: false, error: 'permission denied', code: 'MKDIR_ERROR' })

--- a/src/renderer/lib/filesystem-sort.ts
+++ b/src/renderer/lib/filesystem-sort.ts
@@ -1,0 +1,14 @@
+import type { DirectoryEntry } from '@shared/types/filesystem.types'
+
+/** Match the desktop explorer's default ordering for every filesystem surface. */
+export function sortDirectoryEntries(entries: DirectoryEntry[]): DirectoryEntry[] {
+  return [...entries].sort((a, b) => {
+    if (a.type === 'directory' && b.type === 'file') return -1
+    if (a.type === 'file' && b.type === 'directory') return 1
+
+    if (!a.ignored && b.ignored) return -1
+    if (a.ignored && !b.ignored) return 1
+
+    return a.name.toLowerCase().localeCompare(b.name.toLowerCase())
+  })
+}

--- a/src/renderer/lib/tauri-filesystem-api.ts
+++ b/src/renderer/lib/tauri-filesystem-api.ts
@@ -23,6 +23,7 @@ import {
   watchImmediate,
   writeTextFile
 } from '@tauri-apps/plugin-fs'
+import { sortDirectoryEntries } from './filesystem-sort'
 import { cleanupTauriListener, isTauriContext } from './tauri-runtime'
 import { webServerFilesystem } from './web-server-api'
 
@@ -97,26 +98,6 @@ const globalCallbacks = new Set<FileChangeCallback>()
 
 function shouldIgnore(name: string): boolean {
   return ALWAYS_IGNORE.includes(name)
-}
-
-/**
- * Sort directory entries: directories first (A-Z), then files (A-Z)
- */
-function sortDirectoryEntries(entries: DirectoryEntry[]): DirectoryEntry[] {
-  return [...entries].sort((a, b) => {
-    // Directories come before files
-    if (a.type === 'directory' && b.type === 'file') return -1
-    if (a.type === 'file' && b.type === 'directory') return 1
-
-    // Within same type, non-ignored entries come before ignored ones
-    if (!a.ignored && b.ignored) return -1
-    if (a.ignored && !b.ignored) return 1
-
-    // Within same type/ignored group, sort alphabetically by name (case-insensitive)
-    const nameA = a.name.toLowerCase()
-    const nameB = b.name.toLowerCase()
-    return nameA.localeCompare(nameB)
-  })
 }
 
 function isBinaryFile(content: string): boolean {

--- a/src/renderer/lib/tauri-filesystem-api.ts
+++ b/src/renderer/lib/tauri-filesystem-api.ts
@@ -174,7 +174,23 @@ export function createTauriFilesystemApi(): FilesystemApi {
       // Web/remote mode: route through the same-origin server (Story: Web/
       // remote project creation). Desktop stays on @tauri-apps/plugin-fs.
       if (!isTauriContext()) {
-        return webServerFilesystem.readDirectory(dirPath)
+        // The web server (fs_api.rs `ls`) returns OS-native entry paths — on
+        // Windows that is backslash separators. The file-explorer store keys
+        // `expandedDirs`/`directoryContents` by normalizePath (`\`→`/`) but
+        // FileTreeNode reads them by raw `entry.path`, so backslash paths
+        // break subdir expansion at level 2+. Normalize to forward slashes to
+        // match the Tauri branch below.
+        const result = await webServerFilesystem.readDirectory(dirPath)
+        if (result.success) {
+          return {
+            success: true,
+            data: result.data.map((entry) => ({
+              ...entry,
+              path: entry.path.replace(/\\/g, '/')
+            }))
+          }
+        }
+        return result
       }
       try {
         const normalizedDirPath = dirPath.replace(/\\/g, '/')

--- a/src/shared/types/persistence.types.ts
+++ b/src/shared/types/persistence.types.ts
@@ -66,7 +66,10 @@ export const PersistenceKeys = {
   // Last-selected agent in the launcher (persisted across sessions).
   // GH-289: value shape is `LastSelectedAgent` ({ agentId, mode }); legacy
   // records carrying only `{ agentId }` are read as `mode: 'cli'`.
-  lastSelectedAgent: 'agents/last-selected'
+  lastSelectedAgent: 'agents/last-selected',
+  // Mobile file explorer: last folder the user navigated into, per project.
+  // Restored on drawer reopen across close/reopen and page reloads (web only).
+  mobileFileExplorerFolder: (projectId: string): string => `mobile-file-explorer/${projectId}`
 } as const
 
 // GH-289: persisted launcher selection — the chosen agent plus its call mode.


### PR DESCRIPTION
## Summary

Two problems on top of the just-shipped mobile file-explorer drawer (#479/#480):

1. **Desktop web couldn't expand subdirectories.** On the desktop web view (>767px, non-Tauri) the desktop `FileExplorer` opened files on click but tapping a folder did nothing — subdirs wouldn't expand (worked on native Tauri). **Root cause:** `fs_api.rs` `ls` joins paths with `PathBuf` + `to_string_lossy()`, so on a **Windows server** entry paths come back with backslash separators. The file-explorer store keys `expandedDirs`/`directoryContents` by `normalizePath` (`\`→`/`) but `FileTreeNode` reads them by **raw** `entry.path` — at level 2+ the keys mismatch, `isExpanded` stays false, children never render. Root works only because `setRootPath` pre-normalizes the root.

2. **The mobile explorer reset to the project root on every drawer reopen**, losing the user's last folder across close/reopen and reloads.

This PR also includes the **mobile drill-nav refactor** (tree expand/collapse → single-folder drill navigation with slide transitions) — the foundation the persistence builds on. The unrelated web agent-builder WIP was split off to `wip/web-agent-builder` for a separate PR.

## Approach
- **Goal 1 (fix):** Normalize web entry paths to forward slashes in the `filesystemApi.readDirectory` facade's web branch — mirroring the Tauri branch — so the store's normalized keys match the tree's raw reads. Renderer-only (no Rust change); consistent with the existing Tauri-side normalization.
- **Goal 2 (feat):** Persist the last-navigated folder per project (`PersistenceKeys.mobileFileExplorerFolder` + `persistenceApi`), restored on drawer open with an `isWithinRoot` guard → fallback to root. Writes fire only on navigation/rename/delete events, never per-render.

## Related Issue

No related issue — reported interactively during a quick-dev session; builds on #479/#480. Searched open + closed PRs; no duplicate.

## Type of Change

- [x] feat: new feature (mobile drill-nav refactor + last-folder persistence)
- [x] fix: bug fix (desktop web subdir expansion)

## What Changed

- `src/renderer/lib/tauri-filesystem-api.ts` — `readDirectory` web branch normalizes Windows backslash entry paths → forward slashes. **Root-cause fix.**
- `src/renderer/components/mobile/MobileFileExplorer.tsx` — drill-nav refactor (single-folder navigation, framer-motion slides, reduced-motion, sort parity) + per-project last-folder persistence (restore-on-open via `persistenceApi.read` with `restoredForRootRef` guard, persist on navigate/rename/delete, `isWithinRoot` fallback, null-initial + loading render).
- `src/shared/types/persistence.types.ts` — `PersistenceKeys.mobileFileExplorerFolder(projectId)`.
- `src/renderer/components/mobile/MobileFileExplorer.test.tsx` — replaced "resets to root on reopen" with restore/reload/project-switch/outside-root-fallback tests.
- `src/renderer/lib/__tests__/tauri-filesystem-api.web.test.ts` — regression: server returns backslash paths → facade normalizes.

## How It Was Tested

- [x] `bun run ci` (Biome strict) — clean (717 files)
- [x] `bun run typecheck` — clean
- [x] `bun run test` — 228/229 files, 2591 tests passed (1 pre-existing skip)
- [ ] `cargo clippy` / `cargo test` — N/A (renderer-only; no Rust change)
- [x] Manual verification — automated suite green; **desktop-expand-on-Windows-server AC still needs a manual check on a real Windows termul-server** (facade unit test + regression test cover the root cause; the desktop tree's end-to-end expand isn't unit-tested because `FileExplorer.test.tsx` stubs `FileTreeNodeWrapper`).

## Screenshots or Recordings

TODO: mobile drill-nav + desktop-expand screenshots (attach on request).

## CI & Review Gate

- [ ] All CI checks pass — triggered on PR creation; will monitor.
- [ ] Code review (CodeRabbit/Claude) addressed.
- [ ] No unresolved findings remain.

(Independently: an orchestrator self-review at the session model found 0 critical / 0 patch findings — the two candidates were theoretical. CodeRabbit provides the independent fresh-context review.)

## Checklist

- [x] PR title follows conventional commit format
- [x] Linked issue / explained why none (interactive; builds on #479/#480)
- [ ] Updated docs — N/A (refinement of existing mobile explorer; no new user-facing surface)
- [x] Added/updated tests
- [x] No unrelated modifications (web agent-builder WIP split to `wip/web-agent-builder`)
- [x] Read AGENTS.md / followed contributor guidelines
- [ ] Human reviewed complete diff — pending review on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Redesigned the mobile file explorer for focused, one-folder-at-a-time navigation with parent controls.
  * Restores the last open folder for each project.
  * Supports creating, renaming, deleting, and duplicating items within the active folder.
  * Adds consistent sorting with folders first and ignored items last.
  * Supports smooth transitions and reduced-motion preferences.

* **Bug Fixes**
  * Improved Windows path handling and navigation reliability.
  * Refreshes folder contents and editor tabs more accurately after file operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->