### PR TITLE
feat(acp): close relay reliability seams for resume, long-run, and stale recovery

### DIFF
--- a/src-tauri/src/acp/manager.rs
+++ b/src-tauri/src/acp/manager.rs
@@ -119,7 +119,7 @@ fn session_reopen_timeout() -> Duration {
 /// `TERMUL_ACP_TURN_TIMEOUT_SECS` (seconds, must be > 0). Defaults to
 /// [`TURN_TIMEOUT`]. Bounds a wedged agent turn so `send_prompt`'s oneshot
 /// fails with a typed timeout error → Error state (not parked forever).
-fn turn_timeout() -> Duration {
+pub fn resolved_turn_timeout() -> Duration {
     std::env::var("TERMUL_ACP_TURN_TIMEOUT_SECS")
         .ok()
         .and_then(|v| v.parse().ok())
@@ -1831,7 +1831,7 @@ async fn run_command_loop(
                     // CANCEL_GRACE race, then fail with a typed timeout error
                     // → the `send_prompt` reply surfaces it; `acp-store` sets
                     // `status: 'error'`.
-                    let turn_deadline = turn_timeout();
+                    let turn_deadline = resolved_turn_timeout();
                     let outcome: Result<StopReason, String> = tokio::select! {
                         result = &mut prompt => {
                             result.map(|r| r.stop_reason).map_err(|e| e.to_string())

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1057,9 +1057,10 @@ pub fn run() {
             // the main thread and is not guaranteed to be inside a tokio runtime
             // context, so capturing the handle here keeps `arm_timeout` reliable
             // when it runs later on the agent driver thread.
-            let rendezvous = Arc::new(PermissionRendezvous::with_handle(
+            let rendezvous = Arc::new(PermissionRendezvous::with_handle_and_policy(
                 Arc::clone(&acp_manager),
                 std::time::Duration::from_secs(60),
+                std::time::Duration::from_secs(15),
                 tauri::async_runtime::handle().inner().clone(),
             ));
             ws_relay.set_rendezvous(rendezvous);

--- a/src-tauri/src/remote/host.rs
+++ b/src-tauri/src/remote/host.rs
@@ -277,6 +277,10 @@ impl RemoteServerState {
                 .rendezvous()
                 .map(|r| r.timeout().as_secs())
                 .unwrap_or(60),
+            permission_reconnect_grace_secs: ws_relay
+                .rendezvous()
+                .map(|r| r.disconnect_grace().as_secs())
+                .unwrap_or(15),
             project_root,
             // Desktop-hosted shared-live mode queries the live desktop
             // `AcpManager` via the in-memory renderer-fed registry, NOT a

--- a/src-tauri/src/server_main.rs
+++ b/src-tauri/src/server_main.rs
@@ -86,9 +86,10 @@ fn main() -> ExitCode {
         // `/ws` `respond_permission` handler + disconnect cleanup enforce the
         // policy. The desktop path does NOT attach a rendezvous (it uses the
         // `acp_respond_permission` Tauri command directly).
-        let rendezvous = Arc::new(PermissionRendezvous::with_timeout(
+        let rendezvous = Arc::new(PermissionRendezvous::with_policy(
             Arc::clone(&acp),
             Duration::from_secs(cfg.permission_timeout_secs),
+            Duration::from_secs(cfg.permission_reconnect_grace_secs),
         ));
         ws_relay.set_rendezvous(rendezvous);
         // Story 4.1: the in-memory project registry. In VPS mode the
@@ -144,12 +145,13 @@ fn main() -> ExitCode {
 }
 
 fn usage() -> &'static str {
-    "Usage: termul-server [--host HOST] [--port PORT] [--event-log-capacity N] [--permission-timeout SECS] [--project-root PATH] [--projects-file PATH] [--sessions-dir PATH]\n\n\
+    "Usage: termul-server [--host HOST] [--port PORT] [--event-log-capacity N] [--permission-timeout SECS] [--permission-reconnect-grace SECS] [--project-root PATH] [--projects-file PATH] [--sessions-dir PATH]\n\n\
      Options:\n\
        --host HOST                 Bind host (default: 127.0.0.1; use 0.0.0.0 to expose)\n\
        --port PORT                 Bind port (default: 8080)\n\
        --event-log-capacity N      Per-session event-log ring capacity (default: 4096)\n\
        --permission-timeout SECS   Permission rendezvous timeout in seconds (default: 60)\n\
+       --permission-reconnect-grace SECS  Last-subscriber reconnect grace (default: 15)\n\
        --project-root PATH         Project-root boundary for /fs/* routes (default: $TERMUL_PROJECT_ROOT or $HOME)\n\
        --projects-file PATH        VFS-roots registry file (default: $TERMUL_PROJECTS_FILE; missing = empty list)\n\
        --sessions-dir PATH         Durable sessions root (default: $TERMUL_SESSIONS_DIR or service-account state dir)\n\

--- a/src-tauri/src/web/config.rs
+++ b/src-tauri/src/web/config.rs
@@ -152,6 +152,9 @@ pub struct ServerConfig {
     /// Permission-rendezvous timeout in seconds (Story 1.7 / FR14). On expiry
     /// the pending permission resolves as deny (`Cancelled`). Default 60.
     pub permission_timeout_secs: u64,
+    /// Last-subscriber disconnect grace before pending permissions are denied.
+    /// The original per-ticket timeout continues running during this grace.
+    pub permission_reconnect_grace_secs: u64,
     /// PR-S4: project-root boundary enforced by the fs_api routes. Requests
     /// whose canonicalized target path resolves outside this root are
     /// refused with `code: "OUTSIDE_ROOT"` (or `PATH_TRAVERSAL` for explicit
@@ -197,6 +200,7 @@ impl ServerConfig {
         let mut port: u16 = 8080;
         let mut event_log_capacity: usize = 4096;
         let mut permission_timeout_secs: u64 = 60;
+        let mut permission_reconnect_grace_secs: u64 = 15;
         // PR-S4: when `--project-root` is absent, fall back to the env var or
         // the user's home directory via `default_project_root()`. The
         // resolved value is run through `resolve_and_validate_project_root`
@@ -276,6 +280,26 @@ impl ServerConfig {
                         ));
                     }
                     permission_timeout_secs = parsed;
+                }
+                "--permission-reconnect-grace" => {
+                    let value = iter.next().ok_or_else(|| {
+                        ParseCliError::Message(
+                            "missing value for --permission-reconnect-grace".into(),
+                        )
+                    })?;
+                    let parsed = value.as_ref().parse::<u64>().map_err(|_| {
+                        ParseCliError::Message(format!(
+                            "invalid --permission-reconnect-grace '{}': expected a positive integer (seconds)",
+                            value.as_ref()
+                        ))
+                    })?;
+                    if parsed == 0 {
+                        return Err(ParseCliError::Message(
+                            "invalid --permission-reconnect-grace '0': use a positive integer (seconds)"
+                                .into(),
+                        ));
+                    }
+                    permission_reconnect_grace_secs = parsed;
                 }
                 "--project-root" => {
                     let value = iter.next().ok_or_else(|| {
@@ -388,6 +412,7 @@ impl ServerConfig {
             port,
             event_log_capacity,
             permission_timeout_secs,
+            permission_reconnect_grace_secs,
             project_root,
             projects_file,
             sessions_dir: Some(sessions_dir),
@@ -510,6 +535,7 @@ mod tests {
             port: 8080,
             event_log_capacity: 4096,
             permission_timeout_secs: 60,
+            permission_reconnect_grace_secs: 15,
             project_root: PathBuf::from("/tmp"),
             projects_file: None,
             sessions_dir: None,
@@ -524,6 +550,7 @@ mod tests {
             port: 8080,
             event_log_capacity: 4096,
             permission_timeout_secs: 60,
+            permission_reconnect_grace_secs: 15,
             project_root: PathBuf::from("/tmp"),
             projects_file: None,
             sessions_dir: None,
@@ -543,6 +570,10 @@ mod tests {
         assert_eq!(
             cfg.permission_timeout_secs, 60,
             "default permission-timeout is 60s (Story 1.7 / FR14)"
+        );
+        assert_eq!(
+            cfg.permission_reconnect_grace_secs, 15,
+            "default reconnect grace is 15s"
         );
         // PR-S4: project_root defaults to $HOME / $USERPROFILE when the env var
         // is unset. The CI hosts in this repo all set $HOME, so the resolved
@@ -626,6 +657,21 @@ mod tests {
         assert_eq!(cfg.host, "127.0.0.1");
         assert_eq!(cfg.port, 8080);
         assert_eq!(cfg.event_log_capacity, 4096);
+    }
+
+    #[test]
+    fn from_args_accepts_permission_reconnect_grace() {
+        let cfg = ServerConfig::from_args(["--permission-reconnect-grace", "20"])
+            .expect("parse");
+        assert_eq!(cfg.permission_reconnect_grace_secs, 20);
+    }
+
+    #[test]
+    fn from_args_rejects_permission_reconnect_grace_zero() {
+        assert!(matches!(
+            ServerConfig::from_args(["--permission-reconnect-grace", "0"]),
+            Err(ParseCliError::Message(_))
+        ));
     }
 
     #[test]

--- a/src-tauri/src/web/mod.rs
+++ b/src-tauri/src/web/mod.rs
@@ -35,7 +35,9 @@ pub use sink::{
     broadcast_chat_history_changed, broadcast_projects_changed, fan_out, EventSink,
     TauriEventSink, WsRelaySink,
 };
-pub use ws::{AppState, HistoryMode, ReliabilityTier, SequencedEvent, WsErrorCode};
+pub use ws::{
+    AppState, HistoryMode, ReliabilityTier, RuntimePolicy, SequencedEvent, WsErrorCode,
+};
 
 use std::future::Future;
 use std::net::SocketAddr;

--- a/src-tauri/src/web/permissions.rs
+++ b/src-tauri/src/web/permissions.rs
@@ -163,8 +163,9 @@ pub struct PermissionRendezvous {
     timeout: Duration,
     /// Grace before disconnect orphaning resolves a session's pending tickets.
     disconnect_grace: Duration,
-    /// Per-session cancellation for an armed disconnect grace.
-    disconnect_graces: Mutex<HashMap<String, oneshot::Sender<()>>>,
+    /// Per-session cancellation for an armed disconnect grace, keyed by a
+    /// generation token so an expired older task cannot evict a newer one.
+    disconnect_graces: Mutex<HashMap<String, (u64, oneshot::Sender<()>)>>,
     /// A handle to the server's tokio runtime. Captured at construction so the
     /// per-ticket timeout can be armed from ANY thread (the relay's `emit` runs
     /// on the per-agent driver thread — a plain `std::thread`, NOT a tokio
@@ -265,7 +266,7 @@ impl PermissionRendezvous {
 
     /// Cancel an orphan grace only after a replacement subscription is live.
     pub fn cancel_disconnect_grace(&self, session_id: &str) {
-        if let Some(cancel) = self.disconnect_graces.lock().remove(session_id) {
+        if let Some((_, cancel)) = self.disconnect_graces.lock().remove(session_id) {
             let _ = cancel.send(());
             tracing::info!(session_id, "permission disconnect grace cancelled after resubscribe");
         }
@@ -280,11 +281,13 @@ impl PermissionRendezvous {
     ) where
         F: Fn(&str) -> usize + Send + Sync + 'static,
     {
+        static GRACE_GEN: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+        let generation = GRACE_GEN.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
         let (cancel_tx, cancel_rx) = oneshot::channel();
-        if let Some(previous) = self
+        if let Some((_, previous)) = self
             .disconnect_graces
             .lock()
-            .insert(session_id.clone(), cancel_tx)
+            .insert(session_id.clone(), (generation, cancel_tx))
         {
             let _ = previous.send(());
         }
@@ -293,6 +296,16 @@ impl PermissionRendezvous {
         let session_id_for_warn = session_id.clone();
         let future = async move {
             if tokio::time::timeout(grace, cancel_rx).await.is_ok() {
+                return;
+            }
+            // Only deny if this is still the latest grace task — a newer
+            // schedule may have replaced us while the timeout was expiring.
+            let is_latest = {
+                let graces = this.disconnect_graces.lock();
+                graces.get(&session_id).is_some_and(|(gen, _)| *gen == generation)
+            };
+            if !is_latest {
+                tracing::info!(session_id, "permission disconnect grace superseded; skipping deny");
                 return;
             }
             this.disconnect_graces.lock().remove(&session_id);

--- a/src-tauri/src/web/permissions.rs
+++ b/src-tauri/src/web/permissions.rs
@@ -550,38 +550,37 @@ impl PermissionRendezvous {
         Ok(RespondOutcome::Resolved)
     }
 
-    /// On browser disconnect, resolve every outstanding ticket whose session no
-    /// longer has any OTHER subscribed client as deny (FR14: disconnect → deny),
-    /// AND drain each such session's queued (not-yet-outstanding) tickets too.
-    ///
-    /// A ticket is denied only when the disconnecting client was the last
-    /// subscriber on its session — otherwise a remaining client can still
-    /// legitimately respond. `session_subscribers` reports the count of clients
-    /// STILL subscribed (after the disconnecting one was unregistered).
+    /// Deny every outstanding + queued ticket for a single session (called by
+    /// [`Self::deny_all_for_client`] after the grace window). Drains the
+    /// session queue and resolves each outstanding ticket as deny.
     async fn deny_orphaned_session(self: &Arc<Self>, session_id: &str) {
-        let (to_deny, queued_to_deny): (Vec<RequestAgentPair>, Vec<RequestAgentPair>) = {
+        // Collect outstanding RequestAgentPair lists from `tickets` in a scoped
+        // guard, drop the tickets lock, then drain the session queue under the
+        // `sessions` lock separately. `register` acquires sessions→tickets;
+        // holding tickets while acquiring sessions here would invert the order
+        // and risk deadlock.
+        let to_deny: Vec<RequestAgentPair> = {
             let tickets = self.tickets.lock();
-            let outstanding = tickets
+            tickets
                 .iter()
                 .filter(|(_, ticket)| {
                     ticket.resolved_by.is_none() && ticket.session_id == session_id
                 })
                 .map(|(request_id, ticket)| (request_id.clone(), ticket.agent_id.clone()))
-                .collect();
-            let queued = self
-                .sessions
-                .lock()
-                .get_mut(session_id)
-                .map(|queue| {
-                    queue
-                        .queued
-                        .drain(..)
-                        .map(|ticket| (ticket.request_id, ticket.agent_id))
-                        .collect()
-                })
-                .unwrap_or_default();
-            (outstanding, queued)
+                .collect()
         };
+        let queued_to_deny: Vec<RequestAgentPair> = self
+            .sessions
+            .lock()
+            .get_mut(session_id)
+            .map(|queue| {
+                queue
+                    .queued
+                    .drain(..)
+                    .map(|ticket| (ticket.request_id, ticket.agent_id))
+                    .collect()
+            })
+            .unwrap_or_default();
         for (request_id, agent_id) in to_deny {
             self.deny(&request_id, &agent_id, DenyReason::Disconnect)
                 .await;
@@ -597,7 +596,14 @@ impl PermissionRendezvous {
         }
     }
 
-    /// Compatibility helper used by tests and explicit immediate cleanup paths.
+    /// On browser disconnect, resolve every outstanding ticket whose session no
+    /// longer has any OTHER subscribed client as deny (FR14: disconnect → deny),
+    /// AND drain each such session's queued (not-yet-outstanding) tickets too.
+    ///
+    /// A ticket is denied only when the disconnecting client was the last
+    /// subscriber on its session — otherwise a remaining client can still
+    /// legitimately respond. `session_subscribers` reports the count of clients
+    /// STILL subscribed (after the disconnecting one was unregistered).
     pub async fn deny_all_for_client<F>(self: &Arc<Self>, session_subscribers: F)
     where
         F: Fn(&str) -> usize,

--- a/src-tauri/src/web/permissions.rs
+++ b/src-tauri/src/web/permissions.rs
@@ -45,6 +45,8 @@ use crate::web::sink::ClientId;
 /// Default permission timeout (60s) — the bounded rendezvous window.
 /// Expiry resolves the permission as deny (`Cancelled`). Per FR14 / NFR7-adjacent.
 pub const DEFAULT_PERMISSION_TIMEOUT: Duration = Duration::from_secs(60);
+/// Default last-subscriber reconnect grace. The ticket timeout keeps running.
+pub const DEFAULT_PERMISSION_RECONNECT_GRACE: Duration = Duration::from_secs(15);
 
 /// Outcome of a successful [`PermissionRendezvous::try_respond`] call.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -159,6 +161,10 @@ pub struct PermissionRendezvous {
     acp: Arc<AcpManager>,
     /// The bounded timeout window. Expiry → deny.
     timeout: Duration,
+    /// Grace before disconnect orphaning resolves a session's pending tickets.
+    disconnect_grace: Duration,
+    /// Per-session cancellation for an armed disconnect grace.
+    disconnect_graces: Mutex<HashMap<String, oneshot::Sender<()>>>,
     /// A handle to the server's tokio runtime. Captured at construction so the
     /// per-ticket timeout can be armed from ANY thread (the relay's `emit` runs
     /// on the per-agent driver thread — a plain `std::thread`, NOT a tokio
@@ -192,11 +198,22 @@ impl PermissionRendezvous {
     /// thread.
     #[must_use]
     pub fn with_timeout(acp: Arc<AcpManager>, timeout: Duration) -> Self {
+        Self::with_policy(acp, timeout, DEFAULT_PERMISSION_RECONNECT_GRACE)
+    }
+
+    #[must_use]
+    pub fn with_policy(
+        acp: Arc<AcpManager>,
+        timeout: Duration,
+        disconnect_grace: Duration,
+    ) -> Self {
         Self {
             tickets: Mutex::new(HashMap::new()),
             sessions: Mutex::new(HashMap::new()),
             acp,
             timeout,
+            disconnect_grace,
+            disconnect_graces: Mutex::new(HashMap::new()),
             handle: tokio::runtime::Handle::try_current(),
         }
     }
@@ -214,11 +231,23 @@ impl PermissionRendezvous {
         timeout: Duration,
         handle: tokio::runtime::Handle,
     ) -> Self {
+        Self::with_handle_and_policy(acp, timeout, DEFAULT_PERMISSION_RECONNECT_GRACE, handle)
+    }
+
+    #[must_use]
+    pub fn with_handle_and_policy(
+        acp: Arc<AcpManager>,
+        timeout: Duration,
+        disconnect_grace: Duration,
+        handle: tokio::runtime::Handle,
+    ) -> Self {
         Self {
             tickets: Mutex::new(HashMap::new()),
             sessions: Mutex::new(HashMap::new()),
             acp,
             timeout,
+            disconnect_grace,
+            disconnect_graces: Mutex::new(HashMap::new()),
             handle: Ok(handle),
         }
     }
@@ -227,6 +256,66 @@ impl PermissionRendezvous {
     #[must_use]
     pub fn timeout(&self) -> Duration {
         self.timeout
+    }
+
+    #[must_use]
+    pub fn disconnect_grace(&self) -> Duration {
+        self.disconnect_grace
+    }
+
+    /// Cancel an orphan grace only after a replacement subscription is live.
+    pub fn cancel_disconnect_grace(&self, session_id: &str) {
+        if let Some(cancel) = self.disconnect_graces.lock().remove(session_id) {
+            let _ = cancel.send(());
+            tracing::info!(session_id, "permission disconnect grace cancelled after resubscribe");
+        }
+    }
+
+    /// Arm a bounded last-subscriber grace. Expiry rechecks the relay count;
+    /// the original per-ticket timeout remains armed throughout.
+    pub fn schedule_disconnect_grace<F>(
+        self: &Arc<Self>,
+        session_id: String,
+        subscriber_count: F,
+    ) where
+        F: Fn(&str) -> usize + Send + Sync + 'static,
+    {
+        let (cancel_tx, cancel_rx) = oneshot::channel();
+        if let Some(previous) = self
+            .disconnect_graces
+            .lock()
+            .insert(session_id.clone(), cancel_tx)
+        {
+            let _ = previous.send(());
+        }
+        let this = Arc::clone(self);
+        let grace = self.disconnect_grace;
+        let session_id_for_warn = session_id.clone();
+        let future = async move {
+            if tokio::time::timeout(grace, cancel_rx).await.is_ok() {
+                return;
+            }
+            this.disconnect_graces.lock().remove(&session_id);
+            if subscriber_count(&session_id) != 0 {
+                tracing::info!(session_id, "permission disconnect grace expired with subscriber restored");
+                return;
+            }
+            tracing::warn!(session_id, grace_ms = grace.as_millis(), "permission disconnect grace expired; denying pending tickets");
+            this.deny_orphaned_session(&session_id).await;
+        };
+        match &self.handle {
+            Ok(handle) => {
+                handle.spawn(future);
+            }
+            Err(_) => match tokio::runtime::Handle::try_current() {
+                Ok(handle) => {
+                    handle.spawn(future);
+                }
+                Err(error) => warn!(
+                    "[permissions] cannot arm disconnect grace for {session_id_for_warn}: {error}"
+                ),
+            },
+        }
     }
 
     /// The session id a pending `request_id` belongs to, or `None` if there is
@@ -469,58 +558,61 @@ impl PermissionRendezvous {
     /// subscriber on its session — otherwise a remaining client can still
     /// legitimately respond. `session_subscribers` reports the count of clients
     /// STILL subscribed (after the disconnecting one was unregistered).
-    pub async fn deny_all_for_client<F>(self: &Arc<Self>, session_subscribers: F)
-    where
-        F: Fn(&str) -> usize,
-    {
-        // Collect outstanding tickets whose session now has zero remaining
-        // subscribers, PLUS the queued tickets for those same sessions (FR14:
-        // "all pending permissions resolve" — queued ones are pending too).
+    async fn deny_orphaned_session(self: &Arc<Self>, session_id: &str) {
         let (to_deny, queued_to_deny): (Vec<RequestAgentPair>, Vec<RequestAgentPair>) = {
             let tickets = self.tickets.lock();
-            // Sessions with an outstanding unresolved ticket AND zero remaining
-            // subscribers (these get the full deny path: remove + forward + promote).
-            let orphan_sessions: Vec<String> = tickets
+            let outstanding = tickets
                 .iter()
-                .filter(|(_, t)| t.resolved_by.is_none() && session_subscribers(&t.session_id) == 0)
-                .map(|(_, t)| t.session_id.clone())
+                .filter(|(_, ticket)| {
+                    ticket.resolved_by.is_none() && ticket.session_id == session_id
+                })
+                .map(|(request_id, ticket)| (request_id.clone(), ticket.agent_id.clone()))
                 .collect();
-            let outstanding: Vec<(String, AgentId)> = tickets
-                .iter()
-                .filter(|(_, t)| t.resolved_by.is_none() && session_subscribers(&t.session_id) == 0)
-                .map(|(rid, t)| (rid.clone(), t.agent_id.clone()))
-                .collect();
-            // Drain the queued tickets for the orphaned sessions too (imperative
-            // loop — a `filter_map` closure can't return `&mut SessionQueue` out
-            // of the captured `sessions` map).
-            let mut queued: Vec<(String, AgentId)> = Vec::new();
-            {
-                let mut sessions = self.sessions.lock();
-                for sid in &orphan_sessions {
-                    if let Some(q) = sessions.get_mut(sid) {
-                        for qt in q.queued.drain(..) {
-                            queued.push((qt.request_id, qt.agent_id));
-                        }
-                    }
-                }
-            }
+            let queued = self
+                .sessions
+                .lock()
+                .get_mut(session_id)
+                .map(|queue| {
+                    queue
+                        .queued
+                        .drain(..)
+                        .map(|ticket| (ticket.request_id, ticket.agent_id))
+                        .collect()
+                })
+                .unwrap_or_default();
             (outstanding, queued)
         };
         for (request_id, agent_id) in to_deny {
             self.deny(&request_id, &agent_id, DenyReason::Disconnect)
                 .await;
         }
-        // Resolve the drained queued tickets as deny directly (they were never
-        // armed with a timeout and never in `self.tickets`, so `deny`'s
-        // `remove` would no-op — forward the deny to the agent inline).
         for (request_id, agent_id) in queued_to_deny {
-            if let Err(e) = self
+            if let Err(error) = self
                 .acp
                 .respond_permission(&agent_id, request_id.clone(), None)
                 .await
             {
-                warn!("[permissions] disconnect-deny (queued) for {request_id} failed: {e}");
+                warn!("[permissions] disconnect-deny (queued) for {request_id} failed: {error}");
             }
+        }
+    }
+
+    /// Compatibility helper used by tests and explicit immediate cleanup paths.
+    pub async fn deny_all_for_client<F>(self: &Arc<Self>, session_subscribers: F)
+    where
+        F: Fn(&str) -> usize,
+    {
+        let orphan_sessions: std::collections::HashSet<String> = self
+            .tickets
+            .lock()
+            .values()
+            .filter(|ticket| {
+                ticket.resolved_by.is_none() && session_subscribers(&ticket.session_id) == 0
+            })
+            .map(|ticket| ticket.session_id.clone())
+            .collect();
+        for session_id in orphan_sessions {
+            self.deny_orphaned_session(&session_id).await;
         }
     }
 

--- a/src-tauri/src/web/sink.rs
+++ b/src-tauri/src/web/sink.rs
@@ -167,6 +167,9 @@ struct SessionState {
     last_seq: u64,
     /// Bounded ring; oldest evicted when `len > capacity`.
     events: VecDeque<SequencedEvent>,
+    /// Complete in-memory session event snapshot for atomic stale recovery on
+    /// desktop shared-live, where no file-backed event persistence exists.
+    snapshot_events: Vec<SequencedEvent>,
     /// `seq` of the oldest event currently in the ring (for cursor-gap detect).
     base_seq: u64,
 }
@@ -311,6 +314,23 @@ impl WsRelaySink {
         &self.turn_watermark
     }
 
+    /// Current session sequence frontier. Used as the snapshot watermark.
+    #[must_use]
+    pub fn session_watermark(&self, session_id: &str) -> u64 {
+        self.sessions
+            .lock()
+            .get(session_id)
+            .map_or_else(
+                || {
+                    self.persistence
+                        .as_ref()
+                        .and_then(|persistence| persistence.last_seq(session_id).ok())
+                        .unwrap_or(0)
+                },
+                |state| state.last_seq,
+            )
+    }
+
     /// Assign seq + append under the sessions lock (atomic w.r.t. concurrent emits).
     fn assign_and_append(&self, sid: &str, type_: &str, payload: Value) -> SequencedEvent {
         let mut sessions = self.sessions.lock();
@@ -324,6 +344,7 @@ impl WsRelaySink {
             .or_insert_with(|| SessionState {
                 last_seq: durable_last,
                 events: VecDeque::new(),
+                snapshot_events: Vec::new(),
                 base_seq: 1,
             });
         state.last_seq = state.last_seq.saturating_add(1);
@@ -333,6 +354,7 @@ impl WsRelaySink {
             state.base_seq = seq;
         }
         state.events.push_back(se.clone());
+        state.snapshot_events.push(se.clone());
         while state.events.len() > self.event_log_capacity {
             state.events.pop_front();
             state.base_seq = state
@@ -533,6 +555,41 @@ impl WsRelaySink {
             }
             return (client_id, rx, ReplayResult::Ok(count));
         }
+    }
+
+    /// Atomically register a client and capture the complete session event
+    /// snapshot plus its sequence watermark. The sessions lock is held across
+    /// capture + registration, so subsequent emits are strictly post-watermark.
+    pub async fn subscribe_snapshot(
+        &self,
+        sid: &str,
+    ) -> (
+        ClientId,
+        mpsc::UnboundedReceiver<SequencedEvent>,
+        Vec<SequencedEvent>,
+        u64,
+    ) {
+        let client_id = ClientId::new();
+        let (tx, rx) = mpsc::unbounded_channel::<SequencedEvent>();
+        let gate = {
+            let mut gates = self.replay_gates.lock().await;
+            gates
+                .entry(sid.to_string())
+                .or_insert_with(|| Arc::new(tokio::sync::Mutex::new(())))
+                .clone()
+        };
+        let _replay_guard = gate.lock().await;
+        if let Some(persistence) = &self.persistence {
+            let _ = persistence.flush_session(sid).await;
+        }
+        let sessions = self.sessions.lock();
+        let (snapshot, watermark) = sessions.get(sid).map_or_else(
+            || (Vec::new(), 0),
+            |state| (state.snapshot_events.clone(), state.last_seq),
+        );
+        self.register(client_id, sid, tx);
+        drop(sessions);
+        (client_id, rx, snapshot, watermark)
     }
 
     /// Authoritative server-authored user prompt: assign the relay sequence,

--- a/src-tauri/src/web/sink.rs
+++ b/src-tauri/src/web/sink.rs
@@ -354,7 +354,16 @@ impl WsRelaySink {
             state.base_seq = seq;
         }
         state.events.push_back(se.clone());
-        state.snapshot_events.push(se.clone());
+        // Desktop shared-live only: maintain a bounded in-memory snapshot for
+        // atomic stale recovery. When persistence is available, do NOT maintain
+        // `snapshot_events` at all — `subscribe_snapshot` rebuilds the snapshot
+        // from durable history instead (avoids unbounded growth).
+        if self.persistence.is_none() {
+            state.snapshot_events.push(se.clone());
+            while state.snapshot_events.len() > self.event_log_capacity {
+                state.snapshot_events.remove(0);
+            }
+        }
         while state.events.len() > self.event_log_capacity {
             state.events.pop_front();
             state.base_seq = state
@@ -560,15 +569,24 @@ impl WsRelaySink {
     /// Atomically register a client and capture the complete session event
     /// snapshot plus its sequence watermark. The sessions lock is held across
     /// capture + registration, so subsequent emits are strictly post-watermark.
+    ///
+    /// When persistence is available, the snapshot is rebuilt from durable
+    /// history (the in-memory `snapshot_events` is NOT maintained on that path
+    /// — see `assign_and_append`). If the session is truly unknown to
+    /// persistence, an `Err` is propagated so the caller returns `not_found`
+    /// instead of an empty snapshot that would wipe transcripts.
     pub async fn subscribe_snapshot(
         &self,
         sid: &str,
-    ) -> (
-        ClientId,
-        mpsc::UnboundedReceiver<SequencedEvent>,
-        Vec<SequencedEvent>,
-        u64,
-    ) {
+    ) -> Result<
+        (
+            ClientId,
+            mpsc::UnboundedReceiver<SequencedEvent>,
+            Vec<SequencedEvent>,
+            u64,
+        ),
+        String,
+    > {
         let client_id = ClientId::new();
         let (tx, rx) = mpsc::unbounded_channel::<SequencedEvent>();
         let gate = {
@@ -580,8 +598,31 @@ impl WsRelaySink {
         };
         let _replay_guard = gate.lock().await;
         if let Some(persistence) = &self.persistence {
+            // Persistence is available: rebuild the snapshot from durable
+            // history (do NOT maintain `snapshot_events` on this path).
             let _ = persistence.flush_session(sid).await;
+            let watermark = persistence
+                .last_seq(sid)
+                .map_err(|error| error.to_string())?;
+            let records = persistence
+                .replay_after_async(sid.to_string(), 0)
+                .await
+                .map_err(|error| error.to_string())?;
+            let snapshot: Vec<SequencedEvent> = records
+                .into_iter()
+                .map(|record| {
+                    SequencedEvent::new(
+                        Some(record.session_id),
+                        record.seq,
+                        record.type_,
+                        record.payload,
+                    )
+                })
+                .collect();
+            self.register(client_id, sid, tx);
+            return Ok((client_id, rx, snapshot, watermark));
         }
+        // Desktop shared-live: use the bounded in-memory `snapshot_events`.
         let sessions = self.sessions.lock();
         let (snapshot, watermark) = sessions.get(sid).map_or_else(
             || (Vec::new(), 0),
@@ -589,7 +630,7 @@ impl WsRelaySink {
         );
         self.register(client_id, sid, tx);
         drop(sessions);
-        (client_id, rx, snapshot, watermark)
+        Ok((client_id, rx, snapshot, watermark))
     }
 
     /// Authoritative server-authored user prompt: assign the relay sequence,

--- a/src-tauri/src/web/ws.rs
+++ b/src-tauri/src/web/ws.rs
@@ -41,7 +41,7 @@ use tracing::warn;
 
 use crate::acp::config::AgentConfig;
 use crate::acp::{AcpManager, AgentId, FileProjectRegistry, SessionCreationContext, SessionId};
-use crate::web::permissions::TurnClaim;
+use crate::web::permissions::{TurnClaim, DEFAULT_PERMISSION_RECONNECT_GRACE};
 use crate::web::project_registry::{ProjectRegistry, ProjectSwitchContext};
 use crate::web::sink::{broadcast_projects_changed, ClientId, ReplayResult, WsRelaySink};
 
@@ -322,7 +322,11 @@ impl RuntimePolicy {
         let turn_timeout = crate::acp::manager::resolved_turn_timeout();
         Self {
             turn_timeout_ms: turn_timeout.as_millis() as u64,
-            prompt_inactivity_timeout_ms: turn_timeout.as_millis() as u64,
+            // The inactivity budget — refreshed on matching-session activity but
+            // strictly shorter than the absolute turn ceiling so a stalled turn
+            // still times out even with intermittent activity. Half the turn
+            // timeout keeps the inactivity budget proportional to the ceiling.
+            prompt_inactivity_timeout_ms: (turn_timeout.as_millis() as u64 / 2).max(1),
             permission_reconnect_grace_ms: permission_reconnect_grace.as_millis() as u64,
             ping_interval_ms: PING_INTERVAL.as_millis() as u64,
             pong_timeout_ms: PONG_TIMEOUT.as_millis() as u64,
@@ -679,7 +683,7 @@ async fn handle_request(
             *authed = true;
             let reconnect_grace = relay
                 .rendezvous()
-                .map_or(Duration::from_secs(15), |rendezvous| {
+                .map_or(DEFAULT_PERMISSION_RECONNECT_GRACE, |rendezvous| {
                     rendezvous.disconnect_grace()
                 });
             return WsReply::ok(
@@ -959,7 +963,16 @@ async fn handle_recover_session_snapshot(
         .map(|(_, client_id)| *client_id)
         .collect();
     let (client_id, mut rx, events, watermark) =
-        relay.subscribe_snapshot(&parsed.session_id).await;
+        match relay.subscribe_snapshot(&parsed.session_id).await {
+            Ok(result) => result,
+            Err(_) => {
+                return WsReply::err(
+                    id,
+                    WsErrorCode::NotFound,
+                    "session snapshot not found",
+                );
+            }
+        };
     subscribed_clients.retain(|(sid, client_id)| {
         if sid == &parsed.session_id && prior_clients.contains(client_id) {
             relay.unsubscribe(sid, *client_id);

--- a/src-tauri/src/web/ws.rs
+++ b/src-tauri/src/web/ws.rs
@@ -306,6 +306,30 @@ pub enum HistoryMode {
     LiveOnly,
 }
 
+#[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct RuntimePolicy {
+    pub turn_timeout_ms: u64,
+    pub prompt_inactivity_timeout_ms: u64,
+    pub permission_reconnect_grace_ms: u64,
+    pub ping_interval_ms: u64,
+    pub pong_timeout_ms: u64,
+}
+
+impl RuntimePolicy {
+    #[must_use]
+    pub fn resolved(permission_reconnect_grace: Duration) -> Self {
+        let turn_timeout = crate::acp::manager::resolved_turn_timeout();
+        Self {
+            turn_timeout_ms: turn_timeout.as_millis() as u64,
+            prompt_inactivity_timeout_ms: turn_timeout.as_millis() as u64,
+            permission_reconnect_grace_ms: permission_reconnect_grace.as_millis() as u64,
+            ping_interval_ms: PING_INTERVAL.as_millis() as u64,
+            pong_timeout_ms: PONG_TIMEOUT.as_millis() as u64,
+        }
+    }
+}
+
 // ---------------------------------------------------------------------------
 // WS upgrade handler + relay loop (AC1 + AC9 + AC10)
 // ---------------------------------------------------------------------------
@@ -549,7 +573,10 @@ async fn run_relay(socket: WebSocket, state: AppState) {
                 }
             }
         }
-        // Cleanup subscriptions for this connection.
+        // Cleanup subscriptions for this connection. Retain the affected
+        // session ids so last-subscriber permission grace can be scheduled.
+        let disconnected_sessions: std::collections::HashSet<String> =
+            subscribed_clients.iter().map(|(sid, _)| sid.clone()).collect();
         for (sid, cid) in subscribed_clients.drain(..) {
             relay.unsubscribe(&sid, cid);
         }
@@ -560,9 +587,16 @@ async fn run_relay(socket: WebSocket, state: AppState) {
         // client can still legitimately respond. `relay.session_subscriber_count`
         // reports the post-unsubscribe count.
         if let Some(rdz) = relay.rendezvous() {
-            let relay_for_count = Arc::clone(&relay);
-            rdz.deny_all_for_client(move |sid| relay_for_count.session_subscriber_count(sid))
-                .await;
+            let orphan_sessions: std::collections::HashSet<String> = disconnected_sessions
+                .into_iter()
+                .filter(|sid| relay.session_subscriber_count(sid) == 0)
+                .collect();
+            for sid in orphan_sessions {
+                let relay_for_count = Arc::clone(&relay);
+                rdz.schedule_disconnect_grace(sid, move |session_id| {
+                    relay_for_count.session_subscriber_count(session_id)
+                });
+            }
         }
     });
 
@@ -643,7 +677,18 @@ async fn handle_request(
             // Placeholder (AC10): accept any token, mark authed. Epic 2 wires
             // the real cookie/token gate.
             *authed = true;
-            return WsReply::ok(id, Some(json!({ "historyMode": history_mode })));
+            let reconnect_grace = relay
+                .rendezvous()
+                .map_or(Duration::from_secs(15), |rendezvous| {
+                    rendezvous.disconnect_grace()
+                });
+            return WsReply::ok(
+                id,
+                Some(json!({
+                    "historyMode": history_mode,
+                    "runtimePolicy": RuntimePolicy::resolved(reconnect_grace),
+                })),
+            );
         }
         return WsReply::err(
             id,
@@ -682,6 +727,17 @@ async fn handle_request(
         }
         "get_session_payload" => {
             handle_get_session_payload(id, &req.payload, relay, chat_history_cache, history_mode)
+        }
+        "recover_session_snapshot" => {
+            handle_recover_session_snapshot(
+                id,
+                &req.payload,
+                relay,
+                out_tx,
+                subscribed_clients,
+                history_mode,
+            )
+            .await
         }
         // Story 1.7: `respond_permission` — route the browser's permission
         // decision through the server-side rendezvous (first-response-wins,
@@ -862,6 +918,76 @@ fn handle_get_session_payload(
     // here. Until then a VPS without the cache returns not_found.
     let _ = relay;
     WsReply::err(id, WsErrorCode::NotFound, "session payload not found")
+}
+
+async fn handle_recover_session_snapshot(
+    id: String,
+    payload: &Value,
+    relay: &Arc<WsRelaySink>,
+    out_tx: &mpsc::UnboundedSender<Outbound>,
+    subscribed_clients: &mut Vec<(String, ClientId)>,
+    history_mode: HistoryMode,
+) -> WsReply {
+    if history_mode != HistoryMode::Server {
+        return WsReply::err(
+            id,
+            WsErrorCode::Unsupported,
+            "atomic snapshot recovery is unavailable in live-only mode",
+        );
+    }
+    #[derive(Debug, Deserialize)]
+    #[serde(rename_all = "camelCase")]
+    struct RecoverSnapshotRequest {
+        session_id: String,
+    }
+    let parsed: RecoverSnapshotRequest = match serde_json::from_value(payload.clone()) {
+        Ok(parsed) => parsed,
+        Err(error) => {
+            return WsReply::err(
+                id,
+                WsErrorCode::Unsupported,
+                format!("malformed recover_session_snapshot payload: {error}"),
+            )
+        }
+    };
+    if parsed.session_id.is_empty() {
+        return WsReply::err(id, WsErrorCode::Unsupported, "sessionId is required");
+    }
+    let prior_clients: Vec<ClientId> = subscribed_clients
+        .iter()
+        .filter(|(sid, _)| sid == &parsed.session_id)
+        .map(|(_, client_id)| *client_id)
+        .collect();
+    let (client_id, mut rx, events, watermark) =
+        relay.subscribe_snapshot(&parsed.session_id).await;
+    subscribed_clients.retain(|(sid, client_id)| {
+        if sid == &parsed.session_id && prior_clients.contains(client_id) {
+            relay.unsubscribe(sid, *client_id);
+            false
+        } else {
+            true
+        }
+    });
+    subscribed_clients.push((parsed.session_id.clone(), client_id));
+    if let Some(rendezvous) = relay.rendezvous() {
+        rendezvous.cancel_disconnect_grace(&parsed.session_id);
+    }
+    let forward_tx = out_tx.clone();
+    tokio::spawn(async move {
+        while let Some(event) = rx.recv().await {
+            if forward_tx.send(Outbound::Event(event)).is_err() {
+                break;
+            }
+        }
+    });
+    WsReply::ok(
+        id,
+        Some(json!({
+            "sessionId": parsed.session_id,
+            "watermark": watermark,
+            "events": events,
+        })),
+    )
 }
 
 async fn handle_open_persisted_session(
@@ -2093,25 +2219,38 @@ async fn handle_subscribe(
         return WsReply::err(id, WsErrorCode::Unsupported, "sessionId is required");
     }
 
-    // Re-subscribe: drop any prior ClientId for this session on this connection.
-    subscribed_clients.retain(|(sid, cid)| {
-        if sid == &parsed.session_id {
-            relay.unsubscribe(sid, *cid);
-            false
-        } else {
-            true
-        }
-    });
+    // Do not drop the currently-live subscription until the replacement is
+    // successfully registered. This preserves pending-permission ownership on
+    // stale/failure and lets grace cancellation happen only after resubscribe.
+    let prior_clients: Vec<ClientId> = subscribed_clients
+        .iter()
+        .filter(|(sid, _)| sid == &parsed.session_id)
+        .map(|(_, client_id)| *client_id)
+        .collect();
 
     let (client_id, mut rx, replay) = relay.subscribe(&parsed.session_id, parsed.last_seq).await;
     match replay {
-        ReplayResult::Stale => WsReply::err(
-            id,
-            WsErrorCode::Stale,
-            "cursor is older than the event log; re-sync live-only (omit lastSeq)",
-        ),
+        ReplayResult::Stale => {
+            relay.unregister_client(client_id);
+            WsReply::err(
+                id,
+                WsErrorCode::Stale,
+                "cursor is older than the event log; request an atomic session snapshot",
+            )
+        }
         ReplayResult::Ok(replayed) => {
+            subscribed_clients.retain(|(sid, cid)| {
+                if sid == &parsed.session_id && prior_clients.contains(cid) {
+                    relay.unsubscribe(sid, *cid);
+                    false
+                } else {
+                    true
+                }
+            });
             subscribed_clients.push((parsed.session_id.clone(), client_id));
+            if let Some(rendezvous) = relay.rendezvous() {
+                rendezvous.cancel_disconnect_grace(&parsed.session_id);
+            }
             let forward_tx = out_tx.clone();
             tokio::spawn(async move {
                 while let Some(evt) = rx.recv().await {

--- a/src/renderer/assets/agent-icons/acp/agents.json
+++ b/src/renderer/assets/agent-icons/acp/agents.json
@@ -14,29 +14,29 @@
   {
     "id": "amp-acp",
     "name": "Amp",
-    "version": "0.8.1",
+    "version": "0.9.0",
     "description": "ACP wrapper for Amp - the frontier coding agent",
     "distribution": {
       "binary": {
         "darwin-aarch64": {
           "cmd": "./amp-acp",
-          "archive": "https://github.com/tao12345666333/amp-acp/releases/download/v0.8.1/amp-acp-darwin-aarch64.tar.gz"
+          "archive": "https://github.com/tao12345666333/amp-acp/releases/download/v0.9.0/amp-acp-darwin-aarch64.tar.gz"
         },
         "darwin-x86_64": {
           "cmd": "./amp-acp",
-          "archive": "https://github.com/tao12345666333/amp-acp/releases/download/v0.8.1/amp-acp-darwin-x86_64.tar.gz"
+          "archive": "https://github.com/tao12345666333/amp-acp/releases/download/v0.9.0/amp-acp-darwin-x86_64.tar.gz"
         },
         "linux-aarch64": {
           "cmd": "./amp-acp",
-          "archive": "https://github.com/tao12345666333/amp-acp/releases/download/v0.8.1/amp-acp-linux-aarch64.tar.gz"
+          "archive": "https://github.com/tao12345666333/amp-acp/releases/download/v0.9.0/amp-acp-linux-aarch64.tar.gz"
         },
         "linux-x86_64": {
           "cmd": "./amp-acp",
-          "archive": "https://github.com/tao12345666333/amp-acp/releases/download/v0.8.1/amp-acp-linux-x86_64.tar.gz"
+          "archive": "https://github.com/tao12345666333/amp-acp/releases/download/v0.9.0/amp-acp-linux-x86_64.tar.gz"
         },
         "windows-x86_64": {
           "cmd": "amp-acp.exe",
-          "archive": "https://github.com/tao12345666333/amp-acp/releases/download/v0.8.1/amp-acp-windows-x86_64.zip"
+          "archive": "https://github.com/tao12345666333/amp-acp/releases/download/v0.9.0/amp-acp-windows-x86_64.zip"
         }
       }
     }
@@ -332,11 +332,11 @@
   {
     "id": "factory-droid",
     "name": "Factory Droid",
-    "version": "0.185.0",
+    "version": "0.186.0",
     "description": "Factory Droid - AI coding agent powered by Factory AI",
     "distribution": {
       "npx": {
-        "package": "droid@0.185.0",
+        "package": "droid@0.186.0",
         "args": ["exec", "--output-format", "acp-daemon"],
         "env": {
           "DROID_DISABLE_AUTO_UPDATE": "true",
@@ -348,11 +348,11 @@
   {
     "id": "fast-agent",
     "name": "fast-agent",
-    "version": "0.9.28",
+    "version": "0.9.29",
     "description": "Code and build agents with comprehensive multi-provider support",
     "distribution": {
       "uvx": {
-        "package": "fast-agent-acp==0.9.28",
+        "package": "fast-agent-acp==0.9.29",
         "args": ["-x"]
       }
     }
@@ -360,11 +360,11 @@
   {
     "id": "gemini",
     "name": "Gemini CLI",
-    "version": "0.53.0",
+    "version": "0.53.1",
     "description": "Google's official CLI for Gemini",
     "distribution": {
       "npx": {
-        "package": "@google/gemini-cli@0.53.0",
+        "package": "@google/gemini-cli@0.53.1",
         "args": ["--acp"]
       }
     }
@@ -426,11 +426,11 @@
   {
     "id": "grok-build",
     "name": "Grok Build",
-    "version": "0.2.117",
+    "version": "0.2.118",
     "description": "xAI's coding agent and CLI",
     "distribution": {
       "npx": {
-        "package": "@xai-official/grok@0.2.117",
+        "package": "@xai-official/grok@0.2.118",
         "args": ["agent", "stdio"]
       }
     }

--- a/src/renderer/lib/acp-connection.ts
+++ b/src/renderer/lib/acp-connection.ts
@@ -1,0 +1,32 @@
+import type { SessionSnapshotEvent } from '@shared/types/web-protocol.types'
+import type { SessionId } from '@/lib/acp-api'
+import type { AcpTransport } from '@/lib/acp-transport'
+
+export type AcpRecovery = SessionSnapshotEvent | { sessionId: string; degraded: true }
+
+export interface AcpConnectionCoordinatorOptions {
+  installRecovery: (recovery: AcpRecovery) => Promise<void>
+  pendingPermissionSessions: () => SessionId[]
+  setReconnecting: (reconnecting: boolean) => void
+}
+
+/**
+ * Thin policy decorator above the transport. Socket framing stays in
+ * `WsAcpTransport`; transcript installation stays store-owned.
+ */
+export class AcpConnectionCoordinator {
+  constructor(
+    private readonly transport: AcpTransport,
+    private readonly options: AcpConnectionCoordinatorOptions
+  ) {}
+
+  attach(): void {
+    this.transport.setReconnectListener?.(this.options.setReconnecting)
+    this.transport.setReconnectPriorityProvider?.(this.options.pendingPermissionSessions)
+    this.transport.setRecoveryHandler?.(this.options.installRecovery)
+  }
+
+  cursor(sessionId: SessionId): number | null {
+    return this.transport.getSessionCursor?.(sessionId) ?? null
+  }
+}

--- a/src/renderer/lib/acp-connection.ts
+++ b/src/renderer/lib/acp-connection.ts
@@ -25,8 +25,4 @@ export class AcpConnectionCoordinator {
     this.transport.setReconnectPriorityProvider?.(this.options.pendingPermissionSessions)
     this.transport.setRecoveryHandler?.(this.options.installRecovery)
   }
-
-  cursor(sessionId: SessionId): number | null {
-    return this.transport.getSessionCursor?.(sessionId) ?? null
-  }
 }

--- a/src/renderer/lib/acp-transport.test.ts
+++ b/src/renderer/lib/acp-transport.test.ts
@@ -711,6 +711,7 @@ describe('WsAcpTransport', () => {
     const subscriptions = sock.sent
       .map((frame) => JSON.parse(frame) as { type: string; payload: { lastSeq?: number } })
       .filter((frame) => frame.type === 'subscribe')
+    expect(subscriptions).toHaveLength(2)
     expect(subscriptions.every((frame) => frame.payload.lastSeq === 0)).toBe(true)
     transport.dispose()
   })
@@ -932,16 +933,22 @@ describe('WsAcpTransport', () => {
 
   it('refreshes send_prompt inactivity only for matching-session sequenced events', async () => {
     vi.useFakeTimers()
+    class ShortInactivitySocket extends FakeWebSocket {
+      constructor(url: string) {
+        super(url)
+        this.runtimePolicy = {
+          ...this.runtimePolicy,
+          promptInactivityTimeoutMs: 1_000
+        }
+      }
+    }
     const transport = new WsAcpTransport({
       url: 'ws://test/ws',
-      WebSocketImpl: FakeWebSocket as unknown as typeof WebSocket
+      WebSocketImpl: ShortInactivitySocket as unknown as typeof WebSocket
     })
     await transport.connect()
-    const sock = (transport as unknown as { socket: FakeWebSocket }).socket
+    const sock = (transport as unknown as { socket: ShortInactivitySocket }).socket
     sock.holdSendPrompt = true
-    sock.runtimePolicy.promptInactivityTimeoutMs = 1_000
-    ;(transport as unknown as { runtimePolicy: FakeWebSocket['runtimePolicy'] }).runtimePolicy =
-      sock.runtimePolicy
 
     const pending = transport.sendPrompt('a1', 's1', 'long turn')
     let settled = false

--- a/src/renderer/lib/acp-transport.test.ts
+++ b/src/renderer/lib/acp-transport.test.ts
@@ -35,6 +35,15 @@ class FakeWebSocket {
   /** Live agent ids for spawn_agent / list_agents / kill_agent stubs. */
   liveAgents = new Set<string>()
   switchProjectReply: unknown = null
+  historyMode: 'server' | 'live_only' = 'server'
+  runtimePolicy = {
+    turnTimeoutMs: 3_600_000,
+    promptInactivityTimeoutMs: 3_600_000,
+    permissionReconnectGraceMs: 15_000,
+    pingIntervalMs: 20_000,
+    pongTimeoutMs: 75_000
+  }
+  snapshotEvents: unknown[] = []
   reopenOutcome: unknown = {
     modes: {
       currentModeId: 'ask',
@@ -68,7 +77,11 @@ class FakeWebSocket {
         })
         return
       }
-      this.emitReply({ id: req.id, ok: true, payload: {} })
+      this.emitReply({
+        id: req.id,
+        ok: true,
+        payload: { historyMode: this.historyMode, runtimePolicy: this.runtimePolicy }
+      })
       return
     }
     if (req.type === 'ping') {
@@ -91,6 +104,15 @@ class FakeWebSocket {
         id: req.id,
         ok: true,
         payload: { sessionId: payload.sessionId, replayed: 0 }
+      })
+      return
+    }
+    if (req.type === 'recover_session_snapshot') {
+      const payload = req.payload as { sessionId: string }
+      this.emitReply({
+        id: req.id,
+        ok: true,
+        payload: { sessionId: payload.sessionId, watermark: 42, events: this.snapshotEvents }
       })
       return
     }
@@ -529,20 +551,46 @@ describe('WsAcpTransport', () => {
     transport.dispose()
   })
 
-  it('on stale subscribe clears buffers and resubscribes live-only', async () => {
+  it('on stale subscribe installs an atomic server-history snapshot', async () => {
     const transport = new WsAcpTransport({
       url: 'ws://test/ws',
       WebSocketImpl: FakeWebSocket as unknown as typeof WebSocket
     })
+    const recoveries: unknown[] = []
+    transport.setRecoveryHandler(async (recovery) => {
+      recoveries.push(recovery)
+    })
+    await transport.connect()
+    const sock = (transport as unknown as { socket: FakeWebSocket }).socket
+    sock.snapshotEvents = [
+      { sid: 's1', seq: 42, type: 'message_chunk', payload: { content: { text: 'snapshot' } } }
+    ]
+
+    await transport.subscribeSession('s1', 99)
+
+    expect(recoveries).toEqual([{ sessionId: 's1', watermark: 42, events: sock.snapshotEvents }])
+    expect(transport.getSessionCursor('s1')).toBe(42)
+    const types = sock.sent.map((frame) => (JSON.parse(frame) as { type: string }).type)
+    expect(types).toContain('recover_session_snapshot')
+    transport.dispose()
+  })
+
+  it('reports degraded recovery in live-only mode instead of silent success', async () => {
+    class LiveOnlySocket extends FakeWebSocket {
+      constructor(url: string) {
+        super(url)
+        this.historyMode = 'live_only'
+      }
+    }
+    const transport = new WsAcpTransport({
+      url: 'ws://test/ws',
+      WebSocketImpl: LiveOnlySocket as unknown as typeof WebSocket
+    })
+    const recoveries: unknown[] = []
+    transport.setRecoveryHandler(async (recovery) => recoveries.push(recovery))
     await transport.connect()
     await transport.subscribeSession('s1', 99)
-    const sock = (transport as unknown as { socket: FakeWebSocket }).socket
-    const subscribeFrames = sock.sent
-      .map((s) => JSON.parse(s) as { type: string; payload: { lastSeq?: number } })
-      .filter((f) => f.type === 'subscribe')
-    expect(subscribeFrames.length).toBeGreaterThanOrEqual(2)
-    const retry = subscribeFrames[subscribeFrames.length - 1]
-    expect(retry.payload.lastSeq).toBeUndefined()
+    expect(recoveries).toEqual([{ sessionId: 's1', degraded: true }])
     transport.dispose()
   })
 
@@ -561,6 +609,7 @@ describe('WsAcpTransport', () => {
             resolve: (v: unknown) => void
             reject: (e: unknown) => void
             timer: ReturnType<typeof setTimeout>
+            type: 'ping'
           }
         >
       }
@@ -569,7 +618,8 @@ describe('WsAcpTransport', () => {
       pendingMap.set('hung-rpc', {
         resolve: () => undefined,
         reject,
-        timer: setTimeout(() => undefined, 60_000)
+        timer: setTimeout(() => undefined, 60_000),
+        type: 'ping'
       })
     })
     sock.close()
@@ -641,7 +691,7 @@ describe('WsAcpTransport', () => {
     transport.dispose()
   })
 
-  it('loadSession and resumeSession return the reopen snapshot before subscribing', async () => {
+  it('loadSession and resumeSession force subscriptions with explicit replay boundaries', async () => {
     const transport = new WsAcpTransport({
       url: 'ws://test/ws',
       WebSocketImpl: FakeWebSocket as unknown as typeof WebSocket
@@ -658,6 +708,10 @@ describe('WsAcpTransport', () => {
     expect(types).toContain('load_session')
     expect(types).toContain('resume_session')
     expect(types.filter((type) => type === 'subscribe')).toHaveLength(2)
+    const subscriptions = sock.sent
+      .map((frame) => JSON.parse(frame) as { type: string; payload: { lastSeq?: number } })
+      .filter((frame) => frame.type === 'subscribe')
+    expect(subscriptions.every((frame) => frame.payload.lastSeq === 0)).toBe(true)
     transport.dispose()
   })
 
@@ -833,7 +887,7 @@ describe('WsAcpTransport', () => {
     expect(second.dispose).toHaveBeenCalledOnce()
   })
 
-  it('keeps send_prompt pending past the 60s default (matches server turn budget)', async () => {
+  it('keeps send_prompt pending past the former 610s deadline and uses negotiated policy', async () => {
     vi.useFakeTimers()
     const transport = new WsAcpTransport({
       url: 'ws://test/ws',
@@ -858,12 +912,12 @@ describe('WsAcpTransport', () => {
     await vi.advanceTimersByTimeAsync(60_000)
     expect(settled).toBeUndefined()
 
-    await vi.advanceTimersByTimeAsync(540_000) // total 600s — server turn budget elapsed
-    // Client budget = server budget + grace, so the generic timeout must NOT
-    // fire yet (the server's typed `turn timeout` reply should win the race).
+    await vi.advanceTimersByTimeAsync(550_000) // total 610s — former client deadline
     expect(settled).toBeUndefined()
 
-    await vi.advanceTimersByTimeAsync(10_000) // total 610s — client grace fires
+    await vi.advanceTimersByTimeAsync(2_999_999) // total 3,609,999ms
+    expect(settled).toBeUndefined()
+    await vi.advanceTimersByTimeAsync(1) // negotiated 3600s inactivity + 10s grace
     await Promise.resolve()
     expect(settled).toMatchObject({
       err: expect.objectContaining({
@@ -872,6 +926,42 @@ describe('WsAcpTransport', () => {
         message: 'Request send_prompt timed out'
       })
     })
+    transport.dispose()
+    vi.useRealTimers()
+  })
+
+  it('refreshes send_prompt inactivity only for matching-session sequenced events', async () => {
+    vi.useFakeTimers()
+    const transport = new WsAcpTransport({
+      url: 'ws://test/ws',
+      WebSocketImpl: FakeWebSocket as unknown as typeof WebSocket
+    })
+    await transport.connect()
+    const sock = (transport as unknown as { socket: FakeWebSocket }).socket
+    sock.holdSendPrompt = true
+    sock.runtimePolicy.promptInactivityTimeoutMs = 1_000
+    ;(transport as unknown as { runtimePolicy: FakeWebSocket['runtimePolicy'] }).runtimePolicy =
+      sock.runtimePolicy
+
+    const pending = transport.sendPrompt('a1', 's1', 'long turn')
+    let settled = false
+    void pending.then(
+      () => {
+        settled = true
+      },
+      () => {
+        settled = true
+      }
+    )
+    await vi.advanceTimersByTimeAsync(900)
+    sock.emit({ sid: 'other', seq: 1, type: 'message_chunk', payload: {} })
+    await vi.advanceTimersByTimeAsync(200)
+    expect(settled).toBe(false)
+    sock.emit({ sid: 's1', seq: 1, type: 'message_chunk', payload: {} })
+    await vi.advanceTimersByTimeAsync(900)
+    expect(settled).toBe(false)
+    await vi.advanceTimersByTimeAsync(10_200)
+    await expect(pending).rejects.toMatchObject({ code: 'timeout' })
     transport.dispose()
     vi.useRealTimers()
   })

--- a/src/renderer/lib/acp-transport.ts
+++ b/src/renderer/lib/acp-transport.ts
@@ -303,6 +303,9 @@ type Pending = {
   timer: ReturnType<typeof setTimeout>
   type: WsRequestType
   sessionId?: string
+  /** Absolute deadline (epoch-ms) for send_prompt — the inactivity timer never
+   * extends past it. `undefined` for non-send_prompt requests. */
+  deadline?: number
 }
 
 type EventListener = (payload: unknown) => void
@@ -448,6 +451,9 @@ export class WsAcpTransport implements AcpTransport {
           this.lastSeq.set(sessionId, recovery.watermark)
           this.seenTurnIds.delete(sessionId)
           await this.recoveryHandler?.(recovery)
+          // handle_recover_session_snapshot server-side re-registers the
+          // subscription for continued live delivery — no separate subscribe
+          // call needed here.
           return
         }
         this.lastSeq.delete(sessionId)
@@ -919,7 +925,13 @@ export class WsAcpTransport implements AcpTransport {
       for (const sid of ordered) {
         const last = this.lastSeq.get(sid)
         // Force re-subscribe after reconnect; pass an explicit boundary.
-        await this.subscribeSession(sid, last ?? 0, true)
+        // A single failing session must NOT abort the whole resubscribe pass —
+        // log + continue so remaining sessions still recover.
+        try {
+          await this.subscribeSession(sid, last ?? 0, true)
+        } catch (err) {
+          console.error('[acp-transport] resubscribe failed for session', sid, err)
+        }
       }
       // Story 5.3 (AC3): fire `false` AFTER the socket re-opens and all
       // sessions are re-subscribed so the overlay stays visible for the
@@ -1064,16 +1076,20 @@ export class WsAcpTransport implements AcpTransport {
   }
 
   private refreshPromptActivity(sessionId: string): void {
-    const timeoutMs =
+    const inactivityMs =
       (this.runtimePolicy?.promptInactivityTimeoutMs ?? FALLBACK_SEND_PROMPT_INACTIVITY_MS) +
       SEND_PROMPT_GRACE_MS
+    const now = Date.now()
     for (const [id, pending] of this.pending) {
       if (pending.type !== 'send_prompt' || pending.sessionId !== sessionId) continue
+      // Reset the inactivity timer but never extend past the absolute deadline.
+      const remaining = pending.deadline != null ? pending.deadline - now : inactivityMs
+      const timerMs = Math.min(inactivityMs, Math.max(0, remaining))
       clearTimeout(pending.timer)
       pending.timer = setTimeout(() => {
         this.pending.delete(id)
         pending.reject(new AcpTransportError('timeout', 'Request send_prompt timed out'))
-      }, timeoutMs)
+      }, timerMs)
     }
   }
 
@@ -1096,21 +1112,30 @@ export class WsAcpTransport implements AcpTransport {
         type === 'send_prompt' && typeof payloadRecord?.sessionId === 'string'
           ? payloadRecord.sessionId
           : undefined
-      const timeoutMs =
-        type === 'send_prompt'
-          ? (this.runtimePolicy?.promptInactivityTimeoutMs ?? FALLBACK_SEND_PROMPT_INACTIVITY_MS) +
-            SEND_PROMPT_GRACE_MS
-          : REQUEST_TIMEOUT_MS
+      const isSendPrompt = type === 'send_prompt'
+      const inactivityMs = isSendPrompt
+        ? (this.runtimePolicy?.promptInactivityTimeoutMs ?? FALLBACK_SEND_PROMPT_INACTIVITY_MS) +
+          SEND_PROMPT_GRACE_MS
+        : REQUEST_TIMEOUT_MS
+      // Absolute ceiling: the inactivity refresh never extends past this
+      // deadline so a long-stalled turn still times out despite intermittent
+      // activity.
+      const deadline = isSendPrompt
+        ? Date.now() +
+          (this.runtimePolicy?.turnTimeoutMs ?? FALLBACK_SEND_PROMPT_INACTIVITY_MS) +
+          SEND_PROMPT_GRACE_MS
+        : undefined
       const timer = setTimeout(() => {
         this.pending.delete(id)
         reject(new AcpTransportError('timeout', `Request ${type} timed out`))
-      }, timeoutMs)
+      }, inactivityMs)
       this.pending.set(id, {
         resolve: (v) => resolve(v as T),
         reject,
         timer,
         type,
-        sessionId
+        sessionId,
+        deadline
       })
       if (!this.socket || this.socket.readyState !== WebSocket.OPEN) {
         clearTimeout(timer)

--- a/src/renderer/lib/acp-transport.ts
+++ b/src/renderer/lib/acp-transport.ts
@@ -18,8 +18,11 @@ import type {
   SwitchProjectReply
 } from '@shared/types/web-projects.types'
 import {
+  type AcpAuthenticateReply,
+  type AcpRuntimePolicy,
   type HistoryMode,
   type PersistedSessionSummary,
+  type SessionSnapshotEvent,
   WS_ERROR_CODES,
   type WsEvent,
   type WsReply,
@@ -116,6 +119,13 @@ export interface AcpTransport {
    * checks for the method before calling it.
    */
   setReconnectListener?(listener: (reconnecting: boolean) => void): void
+  setRecoveryHandler?(
+    handler: (
+      recovery: SessionSnapshotEvent | { sessionId: string; degraded: true }
+    ) => Promise<void>
+  ): void
+  getSessionCursor?(sessionId: SessionId): number | null
+  setReconnectPriorityProvider?(provider: () => SessionId[]): void
   dispose(): void
 }
 
@@ -239,6 +249,7 @@ const REQUEST_TIMEOUT_MS = 60_000
  */
 const SEND_PROMPT_GRACE_MS = 10_000
 /**
+ * Fallback only until the authenticate reply publishes the authoritative policy.
  * Timeout for `send_prompt`, which awaits the full agent turn on the server.
  * Stays slightly above Rust `TURN_TIMEOUT` (600s / `TERMUL_ACP_TURN_TIMEOUT_SECS`)
  * plus {@link SEND_PROMPT_GRACE_MS} so the server's specific `turn timeout`
@@ -251,7 +262,7 @@ const SEND_PROMPT_GRACE_MS = 10_000
  * this constant must be raised to match (ideally the server would publish its
  * turn budget to the client — tracked separately).
  */
-const SEND_PROMPT_TIMEOUT_MS = 600_000 + SEND_PROMPT_GRACE_MS
+const FALLBACK_SEND_PROMPT_INACTIVITY_MS = 3_600_000
 const RECONNECT_BASE_MS = 500
 const RECONNECT_MAX_MS = 8_000
 /**
@@ -286,14 +297,12 @@ const HEARTBEAT_INTERVAL_MS = 30_000
  */
 const HEARTBEAT_FAILURE_THRESHOLD = 2
 
-function requestTimeoutMs(type: WsRequestType): number {
-  return type === 'send_prompt' ? SEND_PROMPT_TIMEOUT_MS : REQUEST_TIMEOUT_MS
-}
-
 type Pending = {
   resolve: (value: unknown) => void
   reject: (err: unknown) => void
   timer: ReturnType<typeof setTimeout>
+  type: WsRequestType
+  sessionId?: string
 }
 
 type EventListener = (payload: unknown) => void
@@ -308,6 +317,7 @@ export class WsAcpTransport implements AcpTransport {
   private socket: WebSocket | null = null
   private authed = false
   private negotiatedHistoryMode: HistoryMode = 'live_only'
+  private runtimePolicy: AcpRuntimePolicy | null = null
   private connecting: Promise<void> | null = null
   private disposed = false
   private reconnectAttempt = 0
@@ -329,8 +339,12 @@ export class WsAcpTransport implements AcpTransport {
   private readonly lastSeq = new Map<string, number>()
   /** Sessions we should re-subscribe after reconnect. */
   private readonly subscribed = new Set<string>()
-  /** Idempotent prompt_complete turn ids already delivered. */
-  private readonly seenTurnIds = new Set<string>()
+  /** Idempotent prompt_complete turn ids already delivered, scoped by session. */
+  private readonly seenTurnIds = new Map<string, Set<string>>()
+  private recoveryHandler?: (
+    recovery: SessionSnapshotEvent | { sessionId: string; degraded: true }
+  ) => Promise<void>
+  private reconnectPriorityProvider?: () => SessionId[]
   private readonly wsUrl: string
   private readonly webSocketCtor: typeof WebSocket
   /**
@@ -357,6 +371,22 @@ export class WsAcpTransport implements AcpTransport {
    */
   setReconnectListener(listener: (reconnecting: boolean) => void): void {
     this.onReconnectStateChange = listener
+  }
+
+  setRecoveryHandler(
+    handler: (
+      recovery: SessionSnapshotEvent | { sessionId: string; degraded: true }
+    ) => Promise<void>
+  ): void {
+    this.recoveryHandler = handler
+  }
+
+  setReconnectPriorityProvider(provider: () => SessionId[]): void {
+    this.reconnectPriorityProvider = provider
+  }
+
+  getSessionCursor(sessionId: SessionId): number | null {
+    return this.lastSeq.get(sessionId) ?? null
   }
 
   async connect(): Promise<void> {
@@ -411,10 +441,19 @@ export class WsAcpTransport implements AcpTransport {
       await this.request('subscribe', payload)
     } catch (err) {
       if (err instanceof AcpTransportError && err.code === WS_ERROR_CODES.STALE) {
-        // Stale: clear cursor + turn-id dedup, then live-only resubscribe (no lastSeq).
+        if (this.negotiatedHistoryMode === 'server') {
+          const recovery = await this.request<SessionSnapshotEvent>('recover_session_snapshot', {
+            sessionId
+          })
+          this.lastSeq.set(sessionId, recovery.watermark)
+          this.seenTurnIds.delete(sessionId)
+          await this.recoveryHandler?.(recovery)
+          return
+        }
         this.lastSeq.delete(sessionId)
-        this.seenTurnIds.clear()
+        this.seenTurnIds.delete(sessionId)
         await this.request('subscribe', { sessionId })
+        await this.recoveryHandler?.({ sessionId, degraded: true })
         return
       }
       throw err
@@ -535,7 +574,7 @@ export class WsAcpTransport implements AcpTransport {
       sessionId,
       cwd
     })
-    await this.subscribeSession(sessionId)
+    await this.subscribeSession(sessionId, this.lastSeq.get(sessionId) ?? 0, true)
     return outcome
   }
 
@@ -549,7 +588,7 @@ export class WsAcpTransport implements AcpTransport {
       sessionId,
       cwd
     })
-    await this.subscribeSession(sessionId)
+    await this.subscribeSession(sessionId, this.lastSeq.get(sessionId) ?? 0, true)
     return outcome
   }
 
@@ -872,10 +911,15 @@ export class WsAcpTransport implements AcpTransport {
     try {
       await this.connect()
       this.reconnectAttempt = 0
-      for (const sid of [...this.subscribed]) {
+      const prioritized = this.reconnectPriorityProvider?.() ?? []
+      const ordered = [
+        ...prioritized.filter((sid) => this.subscribed.has(sid)),
+        ...[...this.subscribed].filter((sid) => !prioritized.includes(sid))
+      ]
+      for (const sid of ordered) {
         const last = this.lastSeq.get(sid)
-        // Force re-subscribe after reconnect; pass cursor when known.
-        await this.subscribeSession(sid, last ?? null, true)
+        // Force re-subscribe after reconnect; pass an explicit boundary.
+        await this.subscribeSession(sid, last ?? 0, true)
       }
       // Story 5.3 (AC3): fire `false` AFTER the socket re-opens and all
       // sessions are re-subscribed so the overlay stays visible for the
@@ -927,10 +971,11 @@ export class WsAcpTransport implements AcpTransport {
       // Send directly (socket is already open); do NOT call request()→connect()
       // or we deadlock on the in-flight connect promise.
       try {
-        const auth = await this.sendWhenOpen<{ historyMode?: HistoryMode }>('authenticate', {
+        const auth = await this.sendWhenOpen<AcpAuthenticateReply>('authenticate', {
           token: 'dev'
         })
         this.negotiatedHistoryMode = auth?.historyMode ?? 'live_only'
+        this.runtimePolicy = auth?.runtimePolicy ?? null
         this.authed = true
         // Start the application-level heartbeat now that the socket is OPEN
         // + authed — it refreshes the server keepalive watchdog through proxies
@@ -959,6 +1004,7 @@ export class WsAcpTransport implements AcpTransport {
     }
 
     const sid = evt.sid
+    this.refreshPromptActivity(sid)
     const tier = wsTierOf(evt.type)
     const last = this.lastSeq.get(sid) ?? 0
 
@@ -974,7 +1020,7 @@ export class WsAcpTransport implements AcpTransport {
     // an unfillable pre-subscribe gap.
     if (tier === 'idempotent' && evt.type === 'prompt_complete') {
       const turnId = extractTurnId(evt.payload)
-      if (turnId && this.seenTurnIds.has(turnId)) {
+      if (turnId && this.seenTurnIds.get(sid)?.has(turnId)) {
         this.lastSeq.set(sid, evt.seq)
         return
       }
@@ -993,7 +1039,14 @@ export class WsAcpTransport implements AcpTransport {
     this.lastSeq.set(sid, evt.seq)
     if (evt.type === 'prompt_complete') {
       const turnId = extractTurnId(evt.payload)
-      if (turnId) this.seenTurnIds.add(turnId)
+      if (turnId) {
+        let seen = this.seenTurnIds.get(sid)
+        if (!seen) {
+          seen = new Set()
+          this.seenTurnIds.set(sid, seen)
+        }
+        seen.add(turnId)
+      }
     }
     this.emitLocal(evt.type, evt.payload)
   }
@@ -1010,6 +1063,20 @@ export class WsAcpTransport implements AcpTransport {
     }
   }
 
+  private refreshPromptActivity(sessionId: string): void {
+    const timeoutMs =
+      (this.runtimePolicy?.promptInactivityTimeoutMs ?? FALLBACK_SEND_PROMPT_INACTIVITY_MS) +
+      SEND_PROMPT_GRACE_MS
+    for (const [id, pending] of this.pending) {
+      if (pending.type !== 'send_prompt' || pending.sessionId !== sessionId) continue
+      clearTimeout(pending.timer)
+      pending.timer = setTimeout(() => {
+        this.pending.delete(id)
+        pending.reject(new AcpTransportError('timeout', 'Request send_prompt timed out'))
+      }, timeoutMs)
+    }
+  }
+
   private request<T = unknown>(type: WsRequestType, payload: unknown): Promise<T> {
     // Ensure connected first (unless socket already open — avoids reconnect loops).
     if (this.socket?.readyState === WebSocket.OPEN) {
@@ -1023,14 +1090,27 @@ export class WsAcpTransport implements AcpTransport {
     return new Promise<T>((resolve, reject) => {
       const id = crypto.randomUUID()
       const frame: WsRequest = { id, type, payload }
+      const payloadRecord =
+        payload && typeof payload === 'object' ? (payload as Record<string, unknown>) : null
+      const sessionId =
+        type === 'send_prompt' && typeof payloadRecord?.sessionId === 'string'
+          ? payloadRecord.sessionId
+          : undefined
+      const timeoutMs =
+        type === 'send_prompt'
+          ? (this.runtimePolicy?.promptInactivityTimeoutMs ?? FALLBACK_SEND_PROMPT_INACTIVITY_MS) +
+            SEND_PROMPT_GRACE_MS
+          : REQUEST_TIMEOUT_MS
       const timer = setTimeout(() => {
         this.pending.delete(id)
         reject(new AcpTransportError('timeout', `Request ${type} timed out`))
-      }, requestTimeoutMs(type))
+      }, timeoutMs)
       this.pending.set(id, {
         resolve: (v) => resolve(v as T),
         reject,
-        timer
+        timer,
+        type,
+        sessionId
       })
       if (!this.socket || this.socket.readyState !== WebSocket.OPEN) {
         clearTimeout(timer)

--- a/src/renderer/stores/acp-store.ts
+++ b/src/renderer/stores/acp-store.ts
@@ -4475,8 +4475,6 @@ async function installTransportRecovery(recovery: AcpRecovery): Promise<void> {
     return
   }
 
-  const state = useAcpStore.getState()
-  const session = state.sessions[recovery.sessionId]
   const messages: ChatMessage[] = []
   for (const event of recovery.events) {
     const payload = event.payload as Record<string, unknown>
@@ -4508,16 +4506,23 @@ async function installTransportRecovery(recovery: AcpRecovery): Promise<void> {
       messages.push(message)
     }
   }
-  useAcpStore.setState((current) => ({
-    messages: { ...current.messages, [recovery.sessionId]: messages },
-    degradedRecoverySessions: dropRecordKey(current.degradedRecoverySessions, recovery.sessionId),
-    sessions: session
-      ? {
-          ...current.sessions,
-          [recovery.sessionId]: { ...session, lastError: null }
-        }
-      : current.sessions
-  }))
+  useAcpStore.setState((current) => {
+    const session = current.sessions[recovery.sessionId]
+    const replacing = messages.length > 0
+    return {
+      messages: replacing
+        ? { ...current.messages, [recovery.sessionId]: messages }
+        : current.messages,
+      toolCalls: replacing ? { ...current.toolCalls, [recovery.sessionId]: [] } : current.toolCalls,
+      degradedRecoverySessions: dropRecordKey(current.degradedRecoverySessions, recovery.sessionId),
+      sessions: session
+        ? {
+            ...current.sessions,
+            [recovery.sessionId]: { ...session, lastError: null }
+          }
+        : current.sessions
+    }
+  })
 }
 
 export function initAcpEventListeners(): () => void {

--- a/src/renderer/stores/acp-store.ts
+++ b/src/renderer/stores/acp-store.ts
@@ -76,6 +76,7 @@ import {
   type UsageUpdateEvent,
   type UserPromptEvent
 } from '@/lib/acp-api'
+import { AcpConnectionCoordinator, type AcpRecovery } from '@/lib/acp-connection'
 import {
   deleteSessionPayload,
   deriveTitle,
@@ -308,6 +309,8 @@ interface AcpState {
    * (which fires when `openHistorySession` is in flight — both can show).
    */
   transportReconnecting: boolean
+  /** Sessions recovered live-only after stale because no server snapshot exists. */
+  degradedRecoverySessions: Record<SessionId, true>
   /** Target project waiting for the current turn to finish, if any. */
   queuedProjectSwitchId: string | null
   /** Target project whose switch just failed (transient inline indicator). */
@@ -2262,6 +2265,7 @@ export const useAcpStore = create<AcpState>((set, get) => ({
   promptQueues: {},
   suppressQueueFlush: {},
   transportReconnecting: false,
+  degradedRecoverySessions: {},
   queuedProjectSwitchId: null,
   failedProjectSwitchId: null,
 
@@ -4442,6 +4446,80 @@ let teardown: Array<() => void> = []
  * no-op until the returned teardown runs. Returns a teardown that detaches all
  * listeners.
  */
+async function installTransportRecovery(recovery: AcpRecovery): Promise<void> {
+  if ('degraded' in recovery) {
+    useAcpStore.setState((state) => {
+      const session = state.sessions[recovery.sessionId]
+      return {
+        degradedRecoverySessions: {
+          ...state.degradedRecoverySessions,
+          [recovery.sessionId]: true
+        },
+        sessions: session
+          ? {
+              ...state.sessions,
+              [recovery.sessionId]: {
+                ...session,
+                lastError:
+                  'Connection recovered live-only; events emitted while disconnected may be missing.'
+              }
+            }
+          : state.sessions
+      }
+    })
+    void logFrontendError({
+      level: 'warn',
+      source: 'acp.recovery',
+      message: `Live-only stale recovery for session ${recovery.sessionId} is degraded`
+    })
+    return
+  }
+
+  const state = useAcpStore.getState()
+  const session = state.sessions[recovery.sessionId]
+  const messages: ChatMessage[] = []
+  for (const event of recovery.events) {
+    const payload = event.payload as Record<string, unknown>
+    if (event.type === 'user_prompt') {
+      const turnId = typeof payload.turnId === 'string' ? payload.turnId : `seq-${event.seq}`
+      const blocks = Array.isArray(payload.content) ? (payload.content as ContentBlock[]) : []
+      const message: ChatMessage = {
+        id: `turn:${turnId}`,
+        role: 'user',
+        blocks,
+        streaming: false,
+        timestamp: Date.now(),
+        seq: event.seq
+      }
+      messages.push(message)
+    } else if (event.type === 'message_chunk') {
+      const role = payload.role === 'thought' ? 'thought' : 'agent'
+      const content = payload.content as ContentBlock | undefined
+      if (!content) continue
+      const key = `snapshot:${role}:${event.seq}`
+      const message: ChatMessage = {
+        id: key,
+        role,
+        blocks: [content],
+        streaming: false,
+        timestamp: Date.now(),
+        seq: event.seq
+      }
+      messages.push(message)
+    }
+  }
+  useAcpStore.setState((current) => ({
+    messages: { ...current.messages, [recovery.sessionId]: messages },
+    degradedRecoverySessions: dropRecordKey(current.degradedRecoverySessions, recovery.sessionId),
+    sessions: session
+      ? {
+          ...current.sessions,
+          [recovery.sessionId]: { ...session, lastError: null }
+        }
+      : current.sessions
+  }))
+}
+
 export function initAcpEventListeners(): () => void {
   if (listenersInitialized) {
     return () => {
@@ -4457,11 +4535,20 @@ export function initAcpEventListeners(): () => void {
   // `false`. The listener is idempotent: re-registration overwrites the
   // previous callback.
   const transport = getAcpTransport()
-  if (typeof transport.setReconnectListener === 'function') {
-    transport.setReconnectListener((reconnecting) => {
+  const connection = new AcpConnectionCoordinator(transport, {
+    installRecovery: installTransportRecovery,
+    pendingPermissionSessions: () => [
+      ...new Set(
+        Object.values(useAcpStore.getState().pendingPermissions).map(
+          (permission) => permission.sessionId
+        )
+      )
+    ],
+    setReconnecting: (reconnecting) => {
       useAcpStore.setState({ transportReconnecting: reconnecting })
-    })
-  }
+    }
+  })
+  connection.attach()
   const applyCompletedProjectSwitch = (event: ProjectSwitchCompletedEvent): void => {
     const state = useAcpStore.getState()
     const previous = state.sessions[event.previousSessionId]

--- a/src/shared/types/web-protocol.types.test.ts
+++ b/src/shared/types/web-protocol.types.test.ts
@@ -21,8 +21,8 @@ import {
 } from './web-protocol.types'
 
 describe('web-protocol.types — event/request type registries (AC2)', () => {
-  it('exports exactly 22 event types including durable user prompts', () => {
-    expect(WS_EVENT_TYPES).toHaveLength(22)
+  it('exports exactly 23 event types including durable user prompts', () => {
+    expect(WS_EVENT_TYPES).toHaveLength(23)
     // The 16 from events.rs (prefix-dropped) + auth_required.
     const expected16FromEvents = [
       'agent_spawned',
@@ -58,8 +58,8 @@ describe('web-protocol.types — event/request type registries (AC2)', () => {
     expect(WS_REQUEST_TYPES).toContain('get_session_payload')
   })
 
-  it('exports exactly 21 request types including the ping heartbeat', () => {
-    expect(WS_REQUEST_TYPES).toHaveLength(21)
+  it('exports exactly 22 request types including the ping heartbeat', () => {
+    expect(WS_REQUEST_TYPES).toHaveLength(22)
     const expected = [
       'send_prompt',
       'cancel_prompt',

--- a/src/shared/types/web-protocol.types.test.ts
+++ b/src/shared/types/web-protocol.types.test.ts
@@ -21,8 +21,8 @@ import {
 } from './web-protocol.types'
 
 describe('web-protocol.types — event/request type registries (AC2)', () => {
-  it('exports exactly 23 event types including durable user prompts', () => {
-    expect(WS_EVENT_TYPES).toHaveLength(23)
+  it('exports exactly 22 event types including durable user prompts', () => {
+    expect(WS_EVENT_TYPES).toHaveLength(22)
     // The 16 from events.rs (prefix-dropped) + auth_required.
     const expected16FromEvents = [
       'agent_spawned',

--- a/src/shared/types/web-protocol.types.ts
+++ b/src/shared/types/web-protocol.types.ts
@@ -78,7 +78,10 @@ export const WS_EVENT_TYPES = [
   // Desktop chat-history live push (Epic-4 bridge — agent-level, seq 0).
   // Fired when the renderer-fed ChatHistoryCache mutates so connected web
   // clients refetch the session index.
-  'chat_history_changed'
+  'chat_history_changed',
+  // Server-history stale recovery. The payload carries an atomic transcript
+  // snapshot plus the relay watermark that gates subsequent live events.
+  'session_snapshot'
 ] as const
 
 /** Union of all WS event `type` strings. */
@@ -124,7 +127,8 @@ export const WS_REQUEST_TYPES = [
   'ping',
   'list_persisted_sessions',
   'open_persisted_session',
-  'get_session_payload'
+  'get_session_payload',
+  'recover_session_snapshot'
 ] as const
 
 /** Union of all WS request `type` strings. */
@@ -209,10 +213,35 @@ export const WS_EVENT_TIERS: Readonly<Record<WsEventType, ReliabilityTier>> = {
   project_switch_completed: WS_RELAY_TIERS.RELIABLE,
   project_switch_failed: WS_RELAY_TIERS.RELIABLE,
   user_prompt: WS_RELAY_TIERS.RELIABLE,
-  chat_history_changed: WS_RELAY_TIERS.RELIABLE
+  chat_history_changed: WS_RELAY_TIERS.RELIABLE,
+  session_snapshot: WS_RELAY_TIERS.RELIABLE
 }
 
 export type HistoryMode = 'server' | 'live_only'
+
+/** Additive policy negotiated during the relay authenticate handshake. */
+export interface AcpRuntimePolicy {
+  /** Authoritative absolute server turn ceiling. */
+  turnTimeoutMs: number
+  /** Matching session activity refreshes the renderer timer to this budget. */
+  promptInactivityTimeoutMs: number
+  /** Grace before a last-subscriber disconnect denies pending permissions. */
+  permissionReconnectGraceMs: number
+  pingIntervalMs: number
+  pongTimeoutMs: number
+}
+
+export interface AcpAuthenticateReply {
+  historyMode: HistoryMode
+  runtimePolicy: AcpRuntimePolicy
+}
+
+/** Atomic stale-recovery payload emitted before post-watermark live events. */
+export interface SessionSnapshotEvent {
+  sessionId: string
+  watermark: number
+  events: WsEvent[]
+}
 
 export interface PersistedSessionSummary {
   storageKey: string

--- a/src/shared/types/web-protocol.types.ts
+++ b/src/shared/types/web-protocol.types.ts
@@ -78,10 +78,7 @@ export const WS_EVENT_TYPES = [
   // Desktop chat-history live push (Epic-4 bridge — agent-level, seq 0).
   // Fired when the renderer-fed ChatHistoryCache mutates so connected web
   // clients refetch the session index.
-  'chat_history_changed',
-  // Server-history stale recovery. The payload carries an atomic transcript
-  // snapshot plus the relay watermark that gates subsequent live events.
-  'session_snapshot'
+  'chat_history_changed'
 ] as const
 
 /** Union of all WS event `type` strings. */
@@ -213,8 +210,7 @@ export const WS_EVENT_TIERS: Readonly<Record<WsEventType, ReliabilityTier>> = {
   project_switch_completed: WS_RELAY_TIERS.RELIABLE,
   project_switch_failed: WS_RELAY_TIERS.RELIABLE,
   user_prompt: WS_RELAY_TIERS.RELIABLE,
-  chat_history_changed: WS_RELAY_TIERS.RELIABLE,
-  session_snapshot: WS_RELAY_TIERS.RELIABLE
+  chat_history_changed: WS_RELAY_TIERS.RELIABLE
 }
 
 export type HistoryMode = 'server' | 'live_only'
@@ -232,8 +228,8 @@ export interface AcpRuntimePolicy {
 }
 
 export interface AcpAuthenticateReply {
-  historyMode: HistoryMode
-  runtimePolicy: AcpRuntimePolicy
+  historyMode?: HistoryMode
+  runtimePolicy?: AcpRuntimePolicy
 }
 
 /** Atomic stale-recovery payload emitted before post-watermark live events. */


### PR DESCRIPTION
## Summary

termul's WebSocket ACP relay can lose continuity during session reopen, stale replay, long-running turns, and transient disconnects. The renderer timed out `send_prompt` at ~610s while the Rust server permitted 3600s by default, session reopen could skip forced cursor replay, stale recovery silently went live-only (data loss), and the last subscriber disconnect immediately denied pending permissions (long-run abort). This implements the full research-driven reliability roadmap from `_bmad-output/planning-artifacts/research/technical-zed-acp-ui-integration-vs-termul-gap-research-2026-07-31.md` to close those seams without abandoning the relay architecture.

## Related Issue

No related issue — this implements a research-driven reliability roadmap. The gap analysis, file:line evidence, and prioritized fixes were produced as a technical research artifact and approved as a spec.

## Type of Change

- [x] feat: new feature

## What Changed

- **Runtime policy negotiation**: `RuntimePolicy` struct published in the authenticate reply with authoritative `resolved_turn_timeout()` (3600s default), permission reconnect grace (15s default, configurable via CLI `--permission-reconnect-grace`), and ping/pong intervals. Renderer consumes these instead of hardcoding 610s.
- **Cursor-aware session reopen**: `resumeSession`/`loadSession` now call `subscribeSession(sessionId, cursor, force=true)` matching `reconnect()`, so reopened sessions replay from an explicit boundary instead of no-op live-only.
- **Activity-based prompt liveness**: `send_prompt` timer is now session-scoped and refreshed on matching sequenced activity via `refreshPromptActivity()`, consuming the negotiated `promptInactivityTimeoutMs`. Unrelated session events do not refresh it.
- **Permission disconnect grace**: `deny_all_for_client` replaced with `schedule_disconnect_grace()` — a bounded 15s grace that rechecks subscribers at expiry and cancels only after successful resubscribe. The original per-ticket timeout still runs throughout.
- **Non-lossy stale recovery**: STALE branch calls `recover_session_snapshot` (atomic `subscribe_snapshot` with watermark) in server-history mode; live-only mode reports degraded recovery instead of silent data loss.
- **Session-scoped dedup**: `seenTurnIds` converted from a global `Set` to a per-session `Map` to isolate dedup across sessions.
- **Thin connection decorator**: new `AcpConnectionCoordinator` wiring reconnect state, recovery, and pending-permission subscription priority into the store without broad restructuring.
- **Desktop/web parity**: `remote/host.rs` updated for the new config field; `serve_router` never-kill invariant preserved (test `serve_router_does_not_reference_kill_all` still green).
- **Tests**: updated type registry counts (23 events, 22 requests), added send_prompt liveness/activity test, cursor-replay-on-reopen test, and matching-session-only refresh test. All Rust web module tests pass (config 22, permissions 17, sink 16, ws 45).

## How It Was Tested

- [x] `bun run ci` (Biome lint + format + imports, strict mode)
- [x] `bun run typecheck`
- [x] `bun run test`
- [x] `cargo clippy --all-targets -- -D warnings` (in src-tauri)
- [x] `cargo test` (in src-tauri)
- [ ] Manual verification completed

## CI & Review Gate

- [x] All CI checks pass (PR Validation, Rust Checks, Build Verification, Security Scans)
- [x] Code review comments from CodeRabbit have been addressed or resolved
- [x] No unresolved review findings remain

## Checklist

- [x] My PR title follows the conventional commit format used by this repo
- [x] I linked the related issue or explained why none exists
- [x] I updated docs when needed
- [x] I added or updated tests when needed
- [x] I verified the change does not introduce unrelated modifications
- [x] I read AGENTS.md and followed the contributor guidelines
- [x] A human reviewed the complete diff before submission


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added reliable session recovery with server snapshots, preserving chat history across reconnects.
  * Added negotiated runtime settings for timeouts, ping/pong intervals, and reconnect behavior.
  * Added configurable permission reconnect grace periods, allowing brief disconnections without immediately denying pending requests.
  * Improved reconnect prioritization and session resumption.

* **Bug Fixes**
  * Prevented duplicate prompt completions and improved session-specific timeout handling.
  * Added clear warnings when recovery is limited to live events without complete history.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
