### PR TITLE
feat: add web terminal parity for desktop and mobile

### DIFF
--- a/docs/api-contracts.md
+++ b/docs/api-contracts.md
@@ -170,6 +170,20 @@ Returns registered migrations.
 ### `data_migration_rollback`
 Runs rollback logic for a migration.
 
+## Web Terminal WebSocket
+
+`GET /terminal/ws` upgrades to the browser terminal transport and is isolated from ACP `/ws`.
+
+Client request envelope:
+
+```json
+{ "id": "terminal-1", "type": "resize", "payload": { "terminalId": "...", "cols": 100, "rows": 30 } }
+```
+
+Supported request types are `spawn`, `write`, `resize`, `kill`, `attach`, `get_cwd`, `get_git_branch`, `get_git_status`, `get_exit_code`, `add_renderer_ref`, `remove_renderer_ref`, `set_protected`, and `update_orphan_detection`. Replies use the existing `IpcResult` shape with the request `id`. Output frames are `{ "type": "data", "terminalId": "...", "data": [byte...] }`; event frames contain the transport-neutral exit/cwd/git/exit-code payload. `attach` sends bounded retained scrollback before subscribed live output.
+
+The service deliberately does not log request data, terminal bytes, environment values, or secrets. Authentication, authorization, TLS, and sandboxing are not provided; this endpoint is unsafe for public or untrusted network exposure.
+
 ## Event Contracts
 
 ### Terminal Event Flow

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -332,6 +332,14 @@ CI runs:
 - good CI discipline across JS and Rust stacks
 - significant test surface in renderer code
 
+## Web Terminal Transport
+
+The renderer terminal seam is `terminal-api.ts`: Tauri uses typed commands and browser builds use a dedicated `/terminal/ws` socket. The terminal socket is intentionally separate from ACP `/ws`; it carries PTY requests, bounded scrollback replay/live output, and transport-neutral lifecycle/cwd/git/exit events. `ConnectedTerminal` remains the single xterm surface in both runtimes.
+
+Standalone `termul-server` owns its `PtyManager` and terminates those PTYs after graceful shutdown. Desktop shared-live mode passes the already-managed desktop `Arc<PtyManager>` into Axum, so stopping sharing detaches browser clients without killing desktop terminals. Output broadcast queues and replay scrollback remain bounded.
+
+**Security boundary:** terminal authentication, authorization, TLS, and sandbox hardening are deferred. `/terminal/ws` must not be exposed to public or untrusted networks; existing server exposure controls are the only boundary in this version. Logs record lifecycle/request outcomes only and must never record terminal input, output, environment values, or secrets.
+
 ## Architectural Risks / Constraints
 
 - terminal and pane rendering paths are performance-sensitive and complex

--- a/docs/component-inventory.md
+++ b/docs/component-inventory.md
@@ -37,6 +37,8 @@ Supporting these are shared layout, navigation, modal, and design-system compone
 - `terminal/TauriTerminal.tsx` — alternate direct Tauri PTY terminal implementation
 - `terminal/TerminalSearchBar.tsx` — terminal text search UI
 - `terminal/ActivityIndicator.tsx` — recent terminal activity indicator
+- `mobile/MobileChatShell.tsx` — narrow web shell with terminal creation, selection, and close navigation alongside chat history
+- `mobile/MobileTerminalControls.tsx` — touch-sized Esc/Tab/Ctrl+C/arrows/PgUp/PgDn and clipboard-paste accessory that writes standard terminal sequences
 - `TerminalTabBar.tsx` / `TerminalView.tsx` — legacy or transitional terminal view helpers retained in repository
 
 ### Editor Components
@@ -115,6 +117,8 @@ These components are coordinated by dedicated Zustand stores:
 The app shell (`WorkspaceLayout`) owns cross-cutting concerns, while feature surfaces (`ConnectedTerminal`, `EditorPanel`, `BrowserPanel`) encapsulate mode-specific behavior.
 
 ### 2. Adapter Isolation Pattern
+
+`terminal-api.ts` selects `tauri-terminal-api.ts` or `web-terminal-api.ts` at runtime. Renderer components, including `ConnectedTerminal` and mobile controls, never import Tauri APIs directly. The browser adapter owns `/terminal/ws` request correlation, listener fan-out, reconnect, and reattach behavior.
 UI components prefer `@/lib/api` adapters rather than direct Tauri APIs, keeping runtime coupling isolated in a service layer.
 
 ### 3. Store-Driven Rendering

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -2998,6 +2998,7 @@ pub async fn sftp_create_file(
 #[tauri::command]
 pub async fn remote_server_start(
     acp_manager: State<'_, Arc<crate::acp::AcpManager>>,
+    pty_manager: State<'_, Arc<PtyManager>>,
     ws_relay: State<'_, Arc<crate::web::WsRelaySink>>,
     remote_state: State<'_, Arc<remote::RemoteServerState>>,
     project_registry: State<'_, Arc<crate::web::ProjectRegistry>>,
@@ -3019,6 +3020,7 @@ pub async fn remote_server_start(
     let started = remote_state
         .start(
             acp_manager.inner().clone(),
+            pty_manager.inner().clone(),
             ws_relay.inner().clone(),
             project_registry.inner().clone(),
             chat_history_cache.inner().clone(),

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -124,7 +124,7 @@ fn resolve_executable_from_path(command: &str) -> Option<String> {
 // Re-exports for commands
 pub use acp::{AcpManager, FileProjectRegistry, SessionPersistence};
 pub use pty::PtyManager;
-pub use trackers::{CwdTracker, ExitCodeTracker, GitTracker};
+pub use trackers::{CwdTracker, ExitCodeTracker, GitTracker, TerminalEventHub};
 // Desktop ACP event sink: wraps the Tauri `AppHandle` so the dispatcher's
 // `Vec<Arc<dyn EventSink>>` fan-out reaches the renderer as `acp:*` events
 // (byte-for-byte unchanged from before Story 1.1). The headless `termul-server`
@@ -1003,21 +1003,25 @@ pub fn run() {
 
             app.manage(ViewMenuState::default());
 
-            // Create CWD Tracker (takes app_handle directly)
-            let cwd_tracker = Arc::new(CwdTracker::new(handle.clone()));
+            // Transport-neutral terminal event fan-out: desktop events remain
+            // byte-compatible while the web terminal socket subscribes to the
+            // same lifecycle/metadata stream.
+            let terminal_events = TerminalEventHub::tauri(handle.clone());
+
+            let cwd_tracker = Arc::new(CwdTracker::new(terminal_events.clone()));
             app.manage(cwd_tracker.clone());
 
-            // Create Git Tracker (takes app_handle directly)
-            let git_tracker = Arc::new(GitTracker::new(handle.clone()));
+            let git_tracker = Arc::new(GitTracker::new(
+                Some(handle.clone()),
+                terminal_events.clone(),
+            ));
             app.manage(git_tracker.clone());
 
-            // Create Exit Code Tracker (takes app_handle directly)
-            let exit_code_tracker = Arc::new(ExitCodeTracker::new(handle.clone()));
+            let exit_code_tracker = Arc::new(ExitCodeTracker::new(terminal_events.clone()));
             app.manage(exit_code_tracker.clone());
 
-            // Create PTY Manager (depends on trackers)
             let pty_manager = Arc::new(PtyManager::new(
-                handle.clone(),
+                terminal_events,
                 cwd_tracker,
                 git_tracker,
                 exit_code_tracker,

--- a/src-tauri/src/pty/manager.rs
+++ b/src-tauri/src/pty/manager.rs
@@ -658,7 +658,11 @@ impl TerminalInstance {
         let receiver = self.broadcast_tx.subscribe();
         let earliest = guard.front().map(|chunk| chunk.seq);
         let latest_seq = guard.back().map(|chunk| chunk.seq).unwrap_or(last_seq);
-        let gap = earliest.is_some_and(|first| last_seq.saturating_add(1) < first);
+        // Gap if the client's cursor is behind the earliest retained chunk,
+        // OR if the log is empty but the client expected prior output.
+        let gap = earliest
+            .map(|first| last_seq.saturating_add(1) < first)
+            .unwrap_or(last_seq > 0);
         let chunks = guard
             .iter()
             .filter(|chunk| chunk.seq > last_seq)
@@ -1739,6 +1743,7 @@ impl PtyManager {
             cwd_tracker.stop_tracking(&id);
             git_tracker.remove_terminal(&id);
             exit_code_tracker.remove_terminal(&id);
+            self.terminal_events.remove(&id);
         }
     }
 

--- a/src-tauri/src/pty/manager.rs
+++ b/src-tauri/src/pty/manager.rs
@@ -3,7 +3,7 @@
 //! This module provides terminal spawning, I/O, and lifecycle management
 //! ported from the Electron implementation.
 
-use crate::trackers::{CwdTracker, ExitCodeTracker, GitTracker};
+use crate::trackers::{CwdTracker, ExitCodeTracker, GitTracker, TerminalEvent, TerminalEventHub};
 use parking_lot::RwLock;
 use portable_pty::{Child, MasterPty, PtySize};
 
@@ -73,7 +73,6 @@ fn resolve_executable_from_path(command: &str) -> Option<String> {
 }
 
 use std::time::{Duration, Instant};
-use tauri::{AppHandle, Emitter};
 use tauri::ipc::{Channel, Response};
 
 /// ADR-004.2: Result of resolving a program path, possibly with leading argv
@@ -475,6 +474,21 @@ pub struct TerminalInfo {
     pub rows: u16,
 }
 
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TerminalOutputChunk {
+    pub seq: u64,
+    pub data: Vec<u8>,
+}
+
+#[derive(Debug)]
+pub struct TerminalReplay {
+    pub chunks: Vec<TerminalOutputChunk>,
+    pub gap: bool,
+    pub latest_seq: u64,
+    pub receiver: tokio::sync::broadcast::Receiver<TerminalOutputChunk>,
+}
+
 /// Broadcast channel capacity (number of buffered output batches per terminal).
 /// Each batch is up to READ_BUF (16KB) bytes. 1024 slots ≈ 16MB max buffered output.
 /// Slow receivers will receive `RecvError::Lagged` — acceptable; they miss bytes
@@ -493,6 +507,8 @@ pub struct SpawnOptions {
     pub shell: Option<String>,
     pub cwd: Option<String>,
     pub env: Option<HashMap<String, String>>,
+    #[serde(default)]
+    pub project_id: Option<String>,
     pub cols: Option<u16>,
     pub rows: Option<u16>,
     // ADR-004.2: terminal-native agent launch.
@@ -513,6 +529,7 @@ impl Default for SpawnOptions {
             shell: None,
             cwd: None,
             env: None,
+            project_id: None,
             cols: Some(80),
             rows: Some(24),
             program: None,
@@ -525,6 +542,7 @@ impl Default for SpawnOptions {
 /// A running terminal instance
 pub struct TerminalInstance {
     pub id: String,
+    pub project_id: Option<String>,
     pub child: Arc<AsyncMutex<Option<Box<dyn Child + Send>>>>,
     pub master: Arc<AsyncMutex<Option<Box<dyn MasterPty + Send>>>>,
     pub writer: Arc<AsyncMutex<Option<Box<dyn Write + Send>>>>,
@@ -549,12 +567,12 @@ pub struct TerminalInstance {
     /// Broadcast channel for fan-out of raw PTY output to remote WebSocket clients.
     /// Each flusher batch is sent as a `Vec<u8>` message. Tauri frontend keeps using
     /// its dedicated Channel — this field is only consumed by the remote module.
-    pub broadcast_tx: Arc<tokio::sync::broadcast::Sender<Vec<u8>>>,
-    /// Rolling scrollback buffer of recent raw PTY output (VT100 bytes).
-    /// Replayed to remote web clients on connect so they see prior output
-    /// (persistence + parity with the desktop terminal). Capped at
-    /// `SCROLLBACK_CAP` bytes; oldest bytes are dropped first.
-    pub scrollback: Arc<RwLock<std::collections::VecDeque<u8>>>,
+    pub broadcast_tx: Arc<tokio::sync::broadcast::Sender<TerminalOutputChunk>>,
+    /// Bounded sequence-aware output log. Oldest chunks are evicted first while
+    /// keeping whole chunks, so reconnect cursors can detect replay gaps.
+    pub output_log: Arc<RwLock<std::collections::VecDeque<TerminalOutputChunk>>>,
+    pub output_log_bytes: Arc<AtomicUsize>,
+    pub next_output_seq: Arc<AtomicU64>,
     #[cfg(target_os = "windows")]
     pub conpty_handles: Option<Arc<ParkingMutex<Option<ConPtyHandles>>>>,
 }
@@ -630,27 +648,28 @@ impl TerminalInstance {
         self.protected.store(protected, Ordering::Relaxed);
     }
 
-    /// Subscribe to live PTY output. Returns a receiver that yields raw byte batches.
-    /// Use this from the remote WebSocket module to forward output to web clients.
-    pub fn subscribe(&self) -> tokio::sync::broadcast::Receiver<Vec<u8>> {
-        self.broadcast_tx.subscribe()
+    pub fn project_matches(&self, project_id: &str) -> bool {
+        self.project_id.as_deref() == Some(project_id)
     }
 
-    /// Atomically snapshot the current scrollback AND subscribe to the live
-    /// broadcast, under the scrollback write lock.
-    ///
-    /// Holding the lock across both operations guarantees no output is lost or
-    /// duplicated at the seam: any batch appended to scrollback before this call
-    /// is in the returned snapshot, and any batch after is delivered via the
-    /// receiver. The flusher takes the same lock when appending, so the two
-    /// cannot interleave.
-    pub fn subscribe_with_backlog(
-        &self,
-    ) -> (Vec<u8>, tokio::sync::broadcast::Receiver<Vec<u8>>) {
-        let guard = self.scrollback.write();
-        let rx = self.broadcast_tx.subscribe();
-        let snapshot: Vec<u8> = guard.iter().copied().collect();
-        (snapshot, rx)
+    /// Atomically snapshot unseen sequenced chunks and subscribe to live output.
+    pub fn subscribe_from(&self, last_seq: u64) -> TerminalReplay {
+        let guard = self.output_log.write();
+        let receiver = self.broadcast_tx.subscribe();
+        let earliest = guard.front().map(|chunk| chunk.seq);
+        let latest_seq = guard.back().map(|chunk| chunk.seq).unwrap_or(last_seq);
+        let gap = earliest.is_some_and(|first| last_seq.saturating_add(1) < first);
+        let chunks = guard
+            .iter()
+            .filter(|chunk| chunk.seq > last_seq)
+            .cloned()
+            .collect();
+        TerminalReplay {
+            chunks,
+            gap,
+            latest_seq,
+            receiver,
+        }
     }
 }
 
@@ -677,15 +696,6 @@ fn should_reap_orphan(
         Some(elapsed) => elapsed > timeout,
         None => inactive_for > timeout,
     }
-}
-
-/// Event emitted when a terminal exits
-#[derive(Debug, Clone, Serialize)]
-#[serde(rename_all = "camelCase")]
-struct TerminalExitEvent {
-    id: String,
-    exit_code: Option<i32>,
-    signal: Option<i32>,
 }
 
 struct TerminalSlotReservation {
@@ -731,7 +741,7 @@ pub struct PtyManager {
     terminals: Arc<RwLock<HashMap<String, Arc<TerminalInstance>>>>,
     active_terminal_slots: Arc<AtomicUsize>,
     id_counter: Arc<AtomicU64>,
-    app_handle: AppHandle,
+    terminal_events: TerminalEventHub,
     orphan_detection_enabled: Arc<AtomicBool>,
     orphan_timeout_ms: Arc<AtomicU64>,
     orphan_detection_started: Arc<AtomicBool>,
@@ -747,7 +757,7 @@ pub struct PtyManager {
 impl PtyManager {
     /// Create a new PtyManager
     pub fn new(
-        app_handle: AppHandle,
+        terminal_events: TerminalEventHub,
         cwd_tracker: Arc<CwdTracker>,
         git_tracker: Arc<GitTracker>,
         exit_code_tracker: Arc<ExitCodeTracker>,
@@ -756,7 +766,7 @@ impl PtyManager {
             terminals: Arc::new(RwLock::new(HashMap::new())),
             active_terminal_slots: Arc::new(AtomicUsize::new(0)),
             id_counter: Arc::new(AtomicU64::new(0)),
-            app_handle,
+            terminal_events,
             orphan_detection_enabled: Arc::new(AtomicBool::new(true)),
             orphan_timeout_ms: Arc::new(AtomicU64::new(ORPHAN_TIMEOUT_MS)),
             orphan_detection_started: Arc::new(AtomicBool::new(false)),
@@ -854,7 +864,7 @@ impl PtyManager {
         }
 
         let terminals = self.terminals.clone();
-        let _app_handle = self.app_handle.clone();
+        let _terminal_events = self.terminal_events.clone();
         let cwd_tracker = self.cwd_tracker.clone();
         let git_tracker = self.git_tracker.clone();
         let exit_code_tracker = self.exit_code_tracker.clone();
@@ -1030,6 +1040,7 @@ impl PtyManager {
             // Create terminal instance
             let instance = Arc::new(TerminalInstance {
                 id: id.clone(),
+                project_id: options.project_id.clone(),
                 child: Arc::new(AsyncMutex::new(Some(Box::new(child)))),
                 master: Arc::new(AsyncMutex::new(None)), // No master for ConPTY
                 writer: Arc::new(AsyncMutex::new(Some(writer))),
@@ -1045,7 +1056,9 @@ impl PtyManager {
                 cols: Arc::new(RwLock::new(cols)),
                 rows: Arc::new(RwLock::new(rows)),
                 broadcast_tx: Arc::new(tokio::sync::broadcast::channel(TERM_BROADCAST_CAPACITY).0),
-                scrollback: Arc::new(RwLock::new(std::collections::VecDeque::new())),
+                output_log: Arc::new(RwLock::new(std::collections::VecDeque::new())),
+                output_log_bytes: Arc::new(AtomicUsize::new(0)),
+                next_output_seq: Arc::new(AtomicU64::new(0)),
                 conpty_handles: Some(Arc::new(ParkingMutex::new(Some(conpty_handles)))),
             });
 
@@ -1054,7 +1067,7 @@ impl PtyManager {
             let done_flag = Arc::new(AtomicBool::new(false));
 
             let reader_instance = instance.clone();
-            let app_handle = self.app_handle.clone();
+            let terminal_events = self.terminal_events.clone();
             let exit_code_tracker = self.exit_code_tracker.clone();
             let terminal_id = id.clone();
 
@@ -1064,11 +1077,22 @@ impl PtyManager {
             let flusher_channel = on_data.clone();
             let flusher_id = id.clone();
             let flusher_broadcast = instance.broadcast_tx.clone();
-            let flusher_scrollback = instance.scrollback.clone();
+            let flusher_output_log = instance.output_log.clone();
+            let flusher_output_log_bytes = instance.output_log_bytes.clone();
+            let flusher_next_seq = instance.next_output_seq.clone();
 
             let flusher_task = std::thread::spawn(move || {
                 log::info!("[PTY {}] Flusher thread starting", flusher_id);
-                Self::flusher_loop(flusher_pending, flusher_done, flusher_broadcast, flusher_scrollback, flusher_channel, flusher_id);
+                Self::flusher_loop(
+                    flusher_pending,
+                    flusher_done,
+                    flusher_broadcast,
+                    flusher_output_log,
+                    flusher_output_log_bytes,
+                    flusher_next_seq,
+                    flusher_channel,
+                    flusher_id,
+                );
             });
 
             // Spawn reader thread
@@ -1080,7 +1104,7 @@ impl PtyManager {
                 Self::reader_loop(
                     reader_instance,
                     reader,
-                    app_handle,
+                    terminal_events,
                     exit_code_tracker,
                     terminal_id,
                     pending_buf,
@@ -1168,6 +1192,7 @@ impl PtyManager {
 
             let instance = Arc::new(TerminalInstance {
                 id: id.clone(),
+                project_id: options.project_id.clone(),
                 child: Arc::new(AsyncMutex::new(Some(child))),
                 master: Arc::new(AsyncMutex::new(Some(pty_pair.master))),
                 writer: Arc::new(AsyncMutex::new(Some(writer))),
@@ -1183,7 +1208,9 @@ impl PtyManager {
                 cols: Arc::new(RwLock::new(cols)),
                 rows: Arc::new(RwLock::new(rows)),
                 broadcast_tx: Arc::new(tokio::sync::broadcast::channel(TERM_BROADCAST_CAPACITY).0),
-                scrollback: Arc::new(RwLock::new(std::collections::VecDeque::new())),
+                output_log: Arc::new(RwLock::new(std::collections::VecDeque::new())),
+                output_log_bytes: Arc::new(AtomicUsize::new(0)),
+                next_output_seq: Arc::new(AtomicU64::new(0)),
                 #[cfg(target_os = "windows")]
                 conpty_handles: None,
             });
@@ -1198,16 +1225,27 @@ impl PtyManager {
             let flusher_channel = on_data.clone();
             let flusher_id = id.clone();
             let flusher_broadcast = instance.broadcast_tx.clone();
-            let flusher_scrollback = instance.scrollback.clone();
+            let flusher_output_log = instance.output_log.clone();
+            let flusher_output_log_bytes = instance.output_log_bytes.clone();
+            let flusher_next_seq = instance.next_output_seq.clone();
 
             let flusher_task = std::thread::spawn(move || {
                 log::info!("[PTY {}] Flusher thread starting", flusher_id);
-                Self::flusher_loop(flusher_pending, flusher_done, flusher_broadcast, flusher_scrollback, flusher_channel, flusher_id);
+                Self::flusher_loop(
+                    flusher_pending,
+                    flusher_done,
+                    flusher_broadcast,
+                    flusher_output_log,
+                    flusher_output_log_bytes,
+                    flusher_next_seq,
+                    flusher_channel,
+                    flusher_id,
+                );
             });
 
             // Spawn reader thread
             let reader_instance = instance.clone();
-            let app_handle = self.app_handle.clone();
+            let terminal_events = self.terminal_events.clone();
             let exit_code_tracker = self.exit_code_tracker.clone();
             let terminal_id = id.clone();
 
@@ -1215,7 +1253,7 @@ impl PtyManager {
                 Self::reader_loop(
                     reader_instance,
                     reader,
-                    app_handle,
+                    terminal_events,
                     exit_code_tracker,
                     terminal_id,
                     pending_buf,
@@ -1252,7 +1290,7 @@ impl PtyManager {
     fn reader_loop(
         instance: Arc<TerminalInstance>,
         mut reader: Box<dyn Read + Send>,
-        app_handle: AppHandle,
+        terminal_events: TerminalEventHub,
         exit_code_tracker: Arc<ExitCodeTracker>,
         terminal_id: String,
         pending_buf: Arc<Mutex<Vec<u8>>>,
@@ -1342,16 +1380,11 @@ impl PtyManager {
             Err(_) => None,
         };
 
-        // Emit terminal-exit event via app_handle (backward compat)
-        let exit_event = TerminalExitEvent {
-            id: id.clone(),
+        terminal_events.emit(TerminalEvent::Exit {
+            terminal_id: id.clone(),
             exit_code,
             signal: None,
-        };
-
-        if let Err(e) = app_handle.emit("terminal-exit", exit_event) {
-            log::error!("[PTY {}] Failed to emit terminal-exit event: {}", id, e);
-        }
+        });
 
         log::info!("[PTY {}] Reader thread ended", id);
     }
@@ -1364,15 +1397,16 @@ impl PtyManager {
     /// batch is also sent so remote WebSocket clients receive live output.
     /// Send failures are ignored (no active remote subscribers is normal).
     ///
-    /// scrollback: rolling history buffer. Each batch is appended (under its
-    /// write lock, capped at `SCROLLBACK_CAP`) BEFORE broadcasting, so a remote
-    /// client calling `subscribe_with_backlog` sees a consistent seam between
-    /// replayed history and live output.
+    /// output_log: sequence-aware bounded history. Each batch is appended before
+    /// broadcasting, so attach can snapshot and subscribe under the same lock.
+    #[allow(clippy::too_many_arguments)]
     fn flusher_loop(
         pending_buf: Arc<Mutex<Vec<u8>>>,
         done_flag: Arc<AtomicBool>,
-        broadcast_tx: Arc<tokio::sync::broadcast::Sender<Vec<u8>>>,
-        scrollback: Arc<RwLock<std::collections::VecDeque<u8>>>,
+        broadcast_tx: Arc<tokio::sync::broadcast::Sender<TerminalOutputChunk>>,
+        output_log: Arc<RwLock<std::collections::VecDeque<TerminalOutputChunk>>>,
+        output_log_bytes: Arc<AtomicUsize>,
+        next_output_seq: Arc<AtomicU64>,
         on_data: Option<Channel<Response>>,
         terminal_id: String,
     ) {
@@ -1381,14 +1415,26 @@ impl PtyManager {
 
         let channel_ref: Option<&Channel<Response>> = on_data.as_ref();
 
-        // Append a batch to the capped scrollback ring buffer (oldest bytes evicted first).
-        fn push_scrollback(buf: &Arc<RwLock<std::collections::VecDeque<u8>>>, data: &[u8]) {
-            let mut guard = buf.write();
-            guard.extend(data.iter().copied());
-            let overflow = guard.len().saturating_sub(SCROLLBACK_CAP);
-            if overflow > 0 {
-                guard.drain(0..overflow);
+        fn publish(
+            data: Vec<u8>,
+            tx: &tokio::sync::broadcast::Sender<TerminalOutputChunk>,
+            log: &Arc<RwLock<std::collections::VecDeque<TerminalOutputChunk>>>,
+            bytes: &Arc<AtomicUsize>,
+            next_seq: &Arc<AtomicU64>,
+        ) {
+            let chunk = TerminalOutputChunk {
+                seq: next_seq.fetch_add(1, Ordering::Relaxed) + 1,
+                data,
+            };
+            let mut guard = log.write();
+            let mut total = bytes.load(Ordering::Relaxed) + chunk.data.len();
+            guard.push_back(chunk.clone());
+            while total > SCROLLBACK_CAP {
+                let Some(evicted) = guard.pop_front() else { break };
+                total = total.saturating_sub(evicted.data.len());
             }
+            bytes.store(total, Ordering::Relaxed);
+            let _ = tx.send(chunk);
         }
 
         loop {
@@ -1400,11 +1446,13 @@ impl PtyManager {
             };
 
             if let Some(data) = chunk {
-                // Record into scrollback FIRST so subscribe_with_backlog sees a clean seam.
-                push_scrollback(&scrollback, &data);
-
-                // Broadcast to remote WebSocket subscribers (best-effort; ignore Lagged/NoReceivers)
-                let _ = broadcast_tx.send(data.clone());
+                publish(
+                    data.clone(),
+                    &broadcast_tx,
+                    &output_log,
+                    &output_log_bytes,
+                    &next_output_seq,
+                );
 
                 // Forward to Tauri frontend channel (may be None for detached terminals)
                 if let Some(ch) = channel_ref {
@@ -1419,8 +1467,13 @@ impl PtyManager {
                 if let Ok(mut guard) = pending_buf.lock() {
                     if !guard.is_empty() {
                         let final_data = std::mem::take(&mut *guard);
-                        push_scrollback(&scrollback, &final_data);
-                        let _ = broadcast_tx.send(final_data.clone());
+                        publish(
+                            final_data.clone(),
+                            &broadcast_tx,
+                            &output_log,
+                            &output_log_bytes,
+                            &next_output_seq,
+                        );
                         if let Some(ch) = channel_ref {
                             if let Err(e) = ch.send(Response::new(final_data)) {
                                 log::error!("[PTY {}] Failed to send final data via channel: {}", id, e);
@@ -1552,6 +1605,35 @@ impl PtyManager {
         self.cwd_tracker.stop_tracking(id);
         self.git_tracker.remove_terminal(id);
         self.exit_code_tracker.remove_terminal(id);
+        self.terminal_events.remove(id);
+
+        Ok(())
+    }
+
+    /// Force-kill bypassing the desktop `is_hidden` deferral. Used by the web
+    /// handler so that closing a terminal from a browser actually terminates
+    /// the process even when the desktop window is minimized. Desktop callers
+    /// continue to use [`kill`](Self::kill) which preserves the hide behavior.
+    pub async fn force_kill(&self, id: &str) -> Result<(), String> {
+        let instance = self
+            .terminals
+            .write()
+            .remove(id)
+            .ok_or_else(|| format!("Terminal not found: {}", id))?;
+
+        self.release_terminal_slot();
+
+        let instance_clone = instance.clone();
+        tokio::task::spawn_blocking(move || {
+            Self::cleanup_terminal_resources_sync(instance_clone, true);
+        })
+        .await
+        .map_err(|e| format!("spawn_blocking failed for terminal {}: {}", id, e))?;
+
+        self.cwd_tracker.stop_tracking(id);
+        self.git_tracker.remove_terminal(id);
+        self.exit_code_tracker.remove_terminal(id);
+        self.terminal_events.remove(id);
 
         Ok(())
     }
@@ -1586,6 +1668,22 @@ impl PtyManager {
         if let Some(instance) = self.terminals.read().get(id) {
             instance.set_protected(protected);
         }
+    }
+
+    pub fn terminal_events(&self) -> TerminalEventHub {
+        self.terminal_events.clone()
+    }
+
+    pub fn cwd_tracker(&self) -> Arc<CwdTracker> {
+        Arc::clone(&self.cwd_tracker)
+    }
+
+    pub fn git_tracker(&self) -> Arc<GitTracker> {
+        Arc::clone(&self.git_tracker)
+    }
+
+    pub fn exit_code_tracker(&self) -> Arc<ExitCodeTracker> {
+        Arc::clone(&self.exit_code_tracker)
     }
 
     /// Get terminal by ID

--- a/src-tauri/src/remote/host.rs
+++ b/src-tauri/src/remote/host.rs
@@ -35,6 +35,7 @@ use tokio::sync::oneshot;
 use tracing::{info, warn};
 
 use crate::acp::AcpManager;
+use crate::pty::PtyManager;
 use crate::web::sink::WsRelaySink;
 use crate::web::{serve_router, ChatHistoryCache, ProjectRegistry, ServerConfig};
 
@@ -224,6 +225,7 @@ impl RemoteServerState {
     pub async fn start(
         &self,
         acp: Arc<AcpManager>,
+        pty: Arc<PtyManager>,
         ws_relay: Arc<WsRelaySink>,
         registry: Arc<ProjectRegistry>,
         chat_history_cache: Arc<ChatHistoryCache>,
@@ -294,6 +296,11 @@ impl RemoteServerState {
 
         let (addr, serve_handle) = serve_router(
             acp,
+            Arc::clone(&pty),
+            pty.terminal_events(),
+            pty.cwd_tracker(),
+            pty.git_tracker(),
+            pty.exit_code_tracker(),
             ws_relay,
             registry,
             Some(chat_history_cache),
@@ -565,25 +572,28 @@ mod tests {
     /// A real `AcpManager` (zero sinks is legal) + a `WsRelaySink` for the
     /// shared-live host lifecycle tests. The serve task binds a real OS-assigned
     /// localhost socket — safe in tests.
-    fn lifecycle_fixtures() -> (Arc<AcpManager>, Arc<WsRelaySink>, Arc<ProjectRegistry>, Arc<ChatHistoryCache>) {
+    #[allow(clippy::type_complexity)]
+    fn lifecycle_fixtures() -> (Arc<AcpManager>, Arc<PtyManager>, Arc<WsRelaySink>, Arc<ProjectRegistry>, Arc<ChatHistoryCache>) {
         let acp = Arc::new(AcpManager::new(vec![]));
+        let pty = crate::web::test_pty_manager();
         let relay = Arc::new(WsRelaySink::new());
         let registry = Arc::new(ProjectRegistry::new());
         let chat_history_cache = Arc::new(ChatHistoryCache::new());
-        (acp, relay, registry, chat_history_cache)
+        (acp, pty, relay, registry, chat_history_cache)
     }
 
     #[tokio::test]
     async fn remote_server_state_start_then_stop_lifecycle() {
         // The full start→status(running)→stop→status(stopped)→restart cycle
         // that T8.1 asked for and the old misnamed test never exercised.
-        let (acp, relay, registry, chat_history_cache) = lifecycle_fixtures();
+        let (acp, pty, relay, registry, chat_history_cache) = lifecycle_fixtures();
         let state = RemoteServerState::new();
         assert!(!state.status().running);
 
         let status = state
             .start(
                 acp.clone(),
+                pty.clone(),
                 relay.clone(),
                 registry.clone(),
                 chat_history_cache.clone(),
@@ -614,6 +624,7 @@ mod tests {
         let again = state
             .start(
                 acp.clone(),
+                pty.clone(),
                 relay.clone(),
                 registry.clone(),
                 chat_history_cache.clone(),
@@ -630,11 +641,12 @@ mod tests {
         // The lose-race guard: a second start while the first is running returns
         // Err — and (per R1) does NOT orphan a second server (its shutdown_tx is
         // signaled before returning). The first server keeps running.
-        let (acp, relay, registry, chat_history_cache) = lifecycle_fixtures();
+        let (acp, pty, relay, registry, chat_history_cache) = lifecycle_fixtures();
         let state = RemoteServerState::new();
         let _first = state
             .start(
                 acp.clone(),
+                pty.clone(),
                 relay.clone(),
                 registry.clone(),
                 chat_history_cache.clone(),
@@ -646,6 +658,7 @@ mod tests {
         let second = state
             .start(
                 acp.clone(),
+                pty.clone(),
                 relay.clone(),
                 registry.clone(),
                 chat_history_cache.clone(),
@@ -670,11 +683,12 @@ mod tests {
         // disturbed. (AcpManager::new(vec![]) owns no agents, so there is
         // nothing to kill — this guards the path: start/stop complete without
         // touching kill_all, i.e. no panic, no error, clean drain.)
-        let (acp, relay, registry, chat_history_cache) = lifecycle_fixtures();
+        let (acp, pty, relay, registry, chat_history_cache) = lifecycle_fixtures();
         let state = RemoteServerState::new();
         let _ = state
             .start(
                 acp.clone(),
+                pty.clone(),
                 relay.clone(),
                 registry.clone(),
                 chat_history_cache.clone(),
@@ -698,11 +712,12 @@ mod tests {
         // then clears `tunnel_url` so the renderer poller drops the stale QR
         // (it would otherwise offer a link that yields "This site can't be
         // reached").
-        let (acp, relay, registry, chat_history_cache) = lifecycle_fixtures();
+        let (acp, pty, relay, registry, chat_history_cache) = lifecycle_fixtures();
         let state = RemoteServerState::new();
         let _ = state
             .start(
                 acp.clone(),
+                pty.clone(),
                 relay.clone(),
                 registry.clone(),
                 chat_history_cache.clone(),

--- a/src-tauri/src/server_main.rs
+++ b/src-tauri/src/server_main.rs
@@ -19,7 +19,10 @@ use termul_manager_lib::web::config::ParseCliError;
 use termul_manager_lib::web::{
     seed_from_file, serve, PermissionRendezvous, ProjectRegistry, ServerConfig, WsRelaySink,
 };
-use termul_manager_lib::{AcpManager, FileProjectRegistry, SessionPersistence};
+use termul_manager_lib::{
+    AcpManager, CwdTracker, ExitCodeTracker, FileProjectRegistry, GitTracker, PtyManager,
+    SessionPersistence, TerminalEventHub,
+};
 use tracing::info;
 use tracing_subscriber::EnvFilter;
 
@@ -122,10 +125,31 @@ fn main() -> ExitCode {
                 }
             }
         }
-        // `serve` always kill_all()s after Axum returns (ok or err).
+        // The standalone binary owns its interactive PTYs and kills them only
+        // after Axum drains. Desktop shared-live passes its existing manager and
+        // never reaches that cleanup path.
+        let terminal_events = TerminalEventHub::standalone();
+        let cwd_tracker = Arc::new(CwdTracker::new(terminal_events.clone()));
+        let git_tracker = Arc::new(GitTracker::with_cwd_tracker(
+            cwd_tracker.clone(),
+            terminal_events.clone(),
+        ));
+        let exit_code_tracker = Arc::new(ExitCodeTracker::new(terminal_events.clone()));
+        let pty = Arc::new(PtyManager::new(
+            terminal_events.clone(),
+            Arc::clone(&cwd_tracker),
+            Arc::clone(&git_tracker),
+            Arc::clone(&exit_code_tracker),
+        ));
+
         let projects_file = cfg.projects_file.clone();
         match serve(
             acp,
+            pty,
+            terminal_events,
+            cwd_tracker,
+            git_tracker,
+            exit_code_tracker,
             ws_relay,
             registry,
             registry_persistence,

--- a/src-tauri/src/trackers/cwd_tracker.rs
+++ b/src-tauri/src/trackers/cwd_tracker.rs
@@ -1,9 +1,9 @@
 use parking_lot::RwLock;
-use serde::Serialize;
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
-use tauri::{AppHandle, Emitter};
+
+use super::{TerminalEvent, TerminalEventHub};
 
 const POLL_INTERVAL_MS: u64 = 500;
 
@@ -13,14 +13,6 @@ struct CwdState {
     terminal_id: String,
     pid: u32,
     last_known_cwd: String,
-}
-
-/// Event emitted when a terminal's CWD changes
-#[derive(Debug, Clone, Serialize)]
-#[serde(rename_all = "camelCase")]
-pub struct CwdChangedEvent {
-    pub terminal_id: String,
-    pub cwd: String,
 }
 
 /// Tracks the current working directory (CWD) of terminal processes.
@@ -34,8 +26,9 @@ pub struct CwdTracker {
     /// Map of terminal_id to their CWD state
     tracked_terminals: Arc<RwLock<HashMap<String, CwdState>>>,
 
-    /// Tauri app handle for emitting events
-    app_handle: AppHandle,
+    /// Transport-neutral event fan-out (Tauri renderer + web subscribers).
+    events: TerminalEventHub,
+    git_tracker: Arc<RwLock<Option<std::sync::Weak<super::git_tracker::GitTracker>>>>,
 
     /// Handle to the polling task (wrapped in Arc<RwLock> for interior mutability)
     poll_handle: Arc<RwLock<Option<tokio::task::JoinHandle<()>>>>,
@@ -54,16 +47,21 @@ impl CwdTracker {
     /// Creates a new CWD tracker.
     ///
     /// # Arguments
-    /// * `app_handle` - Tauri app handle for emitting events
-    pub fn new(app_handle: AppHandle) -> Self {
+    /// * `events` - transport-neutral terminal event hub
+    pub fn new(events: TerminalEventHub) -> Self {
         Self {
             tracked_terminals: Arc::new(RwLock::new(HashMap::new())),
-            app_handle,
+            events,
+            git_tracker: Arc::new(RwLock::new(None)),
             poll_handle: Arc::new(RwLock::new(None)),
             is_polling_started: Arc::new(AtomicBool::new(false)),
             is_visible: Arc::new(AtomicBool::new(true)),
             poll_count: Arc::new(AtomicBool::new(false)),
         }
+    }
+
+    pub fn set_git_tracker(&self, git_tracker: &Arc<super::git_tracker::GitTracker>) {
+        *self.git_tracker.write() = Some(Arc::downgrade(git_tracker));
     }
 
     /// Detects the current working directory for a given process ID.
@@ -203,7 +201,8 @@ impl CwdTracker {
     fn start_polling(&self) {
         let tracked = self.tracked_terminals.clone();
         let is_visible = self.is_visible.clone();
-        let app_handle = self.app_handle.clone();
+        let events = self.events.clone();
+        let git_tracker = self.git_tracker.clone();
         let poll_handle = self.poll_handle.clone();
         let poll_count = self.poll_count.clone();
 
@@ -240,14 +239,14 @@ impl CwdTracker {
                             // Only emit event if CWD actually changed
                             if state.last_known_cwd != new_cwd {
                                 state.last_known_cwd = new_cwd.clone();
+                                if let Some(git) = git_tracker.read().as_ref().and_then(|g| g.upgrade()) {
+                                    git.update_terminal_cwd(&terminal_id, new_cwd.clone());
+                                }
 
-                                // Emit the event
-                                let event = CwdChangedEvent {
+                                events.emit(TerminalEvent::CwdChanged {
                                     terminal_id: terminal_id.clone(),
                                     cwd: new_cwd,
-                                };
-
-                                let _ = app_handle.emit("terminal-cwd-changed", event);
+                                });
                             }
                         }
                     }
@@ -442,20 +441,4 @@ mod tests {
         assert!(!poll_executed);
     }
 
-    #[test]
-    fn test_cwd_changed_event_shape() {
-        // Verify the CwdChangedEvent has the correct shape for serialization
-        let event = CwdChangedEvent {
-            terminal_id: "term-123".to_string(),
-            cwd: "/home/user/projects".to_string(),
-        };
-
-        assert_eq!(event.terminal_id, "term-123");
-        assert_eq!(event.cwd, "/home/user/projects");
-
-        // The #[serde(rename_all = "camelCase")] attribute ensures
-        // the JSON output uses camelCase for field names
-        // This is tested by the type signature alone in unit tests
-        // Integration tests would verify the actual JSON serialization
-    }
 }

--- a/src-tauri/src/trackers/exit_code_tracker.rs
+++ b/src-tauri/src/trackers/exit_code_tracker.rs
@@ -1,10 +1,10 @@
 use lazy_static::lazy_static;
 use parking_lot::RwLock;
 use regex::Regex;
-use serde::Serialize;
 use std::collections::HashMap;
 use std::sync::Arc;
-use tauri::{AppHandle, Emitter};
+
+use super::{TerminalEvent, TerminalEventHub};
 
 // OSC 133;D;{exit_code} escape sequence pattern (shell integration protocol)
 lazy_static! {
@@ -27,26 +27,18 @@ struct ExitCodeState {
     last_exit_code: Option<i32>,
 }
 
-/// Event emitted when exit code changes
-#[derive(Debug, Clone, Serialize)]
-#[serde(rename_all = "camelCase")]
-struct ExitCodeChangedEvent {
-    pub terminal_id: String,
-    pub exit_code: i32,
-}
-
 /// Tracks exit codes from terminal output
 pub struct ExitCodeTracker {
     terminal_states: Arc<RwLock<HashMap<String, ExitCodeState>>>,
-    app_handle: AppHandle,
+    events: TerminalEventHub,
 }
 
 impl ExitCodeTracker {
     /// Create a new ExitCodeTracker
-    pub fn new(app_handle: AppHandle) -> Self {
+    pub fn new(events: TerminalEventHub) -> Self {
         Self {
             terminal_states: Arc::new(RwLock::new(HashMap::new())),
-            app_handle,
+            events,
         }
     }
 
@@ -134,11 +126,10 @@ impl ExitCodeTracker {
 
     /// Emit exit code changed event
     fn emit_exit_code_changed(&self, terminal_id: &str, exit_code: i32) {
-        let event = ExitCodeChangedEvent {
+        self.events.emit(TerminalEvent::ExitCodeChanged {
             terminal_id: terminal_id.to_string(),
             exit_code,
-        };
-        let _ = self.app_handle.emit("terminal-exit-code-changed", event);
+        });
     }
 
     /// Shutdown the tracker
@@ -153,7 +144,7 @@ impl Clone for ExitCodeTracker {
     fn clone(&self) -> Self {
         Self {
             terminal_states: self.terminal_states.clone(),
-            app_handle: self.app_handle.clone(),
+            events: self.events.clone(),
         }
     }
 }

--- a/src-tauri/src/trackers/git_tracker.rs
+++ b/src-tauri/src/trackers/git_tracker.rs
@@ -9,9 +9,10 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::sync::OnceLock;
 use std::time::{Duration, Instant};
-use tauri::{AppHandle, Emitter, Manager};
+use tauri::{AppHandle, Manager};
 
 use super::cwd_tracker::CwdTracker;
+use super::{TerminalEvent, TerminalEventHub};
 
 #[cfg(target_os = "windows")]
 const CREATE_NO_WINDOW: u32 = 0x08000000;
@@ -326,22 +327,6 @@ impl GitState {
     }
 }
 
-/// Event emitted when git branch changes
-#[derive(Debug, Clone, Serialize)]
-#[serde(rename_all = "camelCase")]
-struct GitBranchChangedEvent {
-    terminal_id: String,
-    branch: Option<String>,
-}
-
-/// Event emitted when git status changes
-#[derive(Debug, Clone, Serialize)]
-#[serde(rename_all = "camelCase")]
-struct GitStatusChangedEvent {
-    terminal_id: String,
-    status: Option<GitStatus>,
-}
-
 /// Tracks git repository status for terminals
 ///
 /// Polls git status periodically and emits events when branch or status changes.
@@ -349,7 +334,9 @@ struct GitStatusChangedEvent {
 /// On Windows, uses CWD deduplication and throttling to reduce git.exe spawns.
 pub struct GitTracker {
     terminal_states: Arc<RwLock<HashMap<String, GitState>>>,
-    app_handle: AppHandle,
+    app_handle: Option<AppHandle>,
+    cwd_tracker: Option<Arc<CwdTracker>>,
+    events: TerminalEventHub,
     poll_handle: Arc<RwLock<Option<tokio::task::JoinHandle<()>>>>,
     is_polling_started: Arc<AtomicBool>,
     is_visible: Arc<AtomicBool>,
@@ -359,16 +346,26 @@ pub struct GitTracker {
 
 impl GitTracker {
     /// Create a new GitTracker with the given app handle
-    pub fn new(app_handle: AppHandle) -> Self {
+    pub fn new(app_handle: Option<AppHandle>, events: TerminalEventHub) -> Self {
         Self {
             terminal_states: Arc::new(RwLock::new(HashMap::new())),
             app_handle,
+            cwd_tracker: None,
+            events,
             poll_handle: Arc::new(RwLock::new(None)),
             is_polling_started: Arc::new(AtomicBool::new(false)),
             is_visible: Arc::new(AtomicBool::new(true)),
             #[cfg(target_os = "windows")]
             cwd_poll_states: Arc::new(RwLock::new(HashMap::new())),
         }
+    }
+
+    /// Create a GitTracker with a direct CwdTracker reference (standalone mode).
+    /// This avoids the Tauri AppHandle dependency for CWD synchronization.
+    pub fn with_cwd_tracker(cwd_tracker: Arc<CwdTracker>, events: TerminalEventHub) -> Self {
+        let mut tracker = Self::new(None, events);
+        tracker.cwd_tracker = Some(cwd_tracker);
+        tracker
     }
 
     /// Initialize tracking for a terminal with the given working directory
@@ -384,7 +381,7 @@ impl GitTracker {
             .write()
             .insert(terminal_id.to_string(), state);
 
-        let app_handle = self.app_handle.clone();
+        let events = self.events.clone();
         let states = self.terminal_states.clone();
         let terminal_id_owned = terminal_id.to_string();
         let cwd_owned = cwd.to_string();
@@ -396,11 +393,11 @@ impl GitTracker {
                 Self::apply_git_results(&states, &terminal_ids, branch, status);
 
             for (_, branch) in branch_emits {
-                Self::emit_branch_changed_static(&app_handle, &terminal_id_owned, &branch);
+                Self::emit_branch_changed_static(&events, &terminal_id_owned, &branch);
             }
 
             for (_, status) in status_emits {
-                Self::emit_status_changed_static(&app_handle, &terminal_id_owned, &status);
+                Self::emit_status_changed_static(&events, &terminal_id_owned, &status);
             }
         });
 
@@ -452,6 +449,13 @@ impl GitTracker {
         // for simplicity - it will just skip when empty
     }
 
+    /// Update a terminal's tracked CWD from the transport-neutral CWD tracker.
+    pub fn update_terminal_cwd(&self, terminal_id: &str, cwd: String) {
+        if let Some(state) = self.terminal_states.write().get_mut(terminal_id) {
+            state.update_terminal_cwd(cwd);
+        }
+    }
+
     /// Get the current branch for a terminal
     pub fn get_branch(&self, terminal_id: &str) -> Option<String> {
         self.terminal_states
@@ -479,7 +483,13 @@ impl GitTracker {
     }
 
     fn refresh_tracked_terminals(&self) {
-        Self::sync_terminal_cwds_from_tracker(&self.app_handle, &self.terminal_states);
+        // Transport-neutral: use the direct CwdTracker reference if available,
+        // otherwise fall back to the Tauri AppHandle state lookup.
+        if let Some(cwd_tracker) = &self.cwd_tracker {
+            Self::sync_terminal_cwds_from_tracker_direct(cwd_tracker, &self.terminal_states);
+        } else if let Some(app_handle) = &self.app_handle {
+            Self::sync_terminal_cwds_from_tracker(app_handle, &self.terminal_states);
+        }
 
         #[cfg(target_os = "windows")]
         Self::prune_unused_cwd_poll_states(&self.terminal_states, &self.cwd_poll_states);
@@ -519,11 +529,11 @@ impl GitTracker {
                 );
 
                 for (terminal_id, branch) in branch_emits {
-                    Self::emit_branch_changed_static(&self.app_handle, &terminal_id, &branch);
+                    Self::emit_branch_changed_static(&self.events, &terminal_id, &branch);
                 }
 
                 for (terminal_id, status) in status_emits {
-                    Self::emit_status_changed_static(&self.app_handle, &terminal_id, &status);
+                    Self::emit_status_changed_static(&self.events, &terminal_id, &status);
                 }
             }
         }
@@ -549,11 +559,11 @@ impl GitTracker {
                 );
 
                 for (_, branch) in branch_emits {
-                    Self::emit_branch_changed_static(&self.app_handle, &terminal_id, &branch);
+                    Self::emit_branch_changed_static(&self.events, &terminal_id, &branch);
                 }
 
                 for (_, status) in status_emits {
-                    Self::emit_status_changed_static(&self.app_handle, &terminal_id, &status);
+                    Self::emit_status_changed_static(&self.events, &terminal_id, &status);
                 }
             }
         }
@@ -567,6 +577,34 @@ impl GitTracker {
             return;
         };
 
+        let terminal_ids: Vec<String> = states.read().keys().cloned().collect();
+        let updates: Vec<(String, String)> = terminal_ids
+            .into_iter()
+            .filter_map(|terminal_id| {
+                cwd_tracker
+                    .get_cwd(&terminal_id)
+                    .map(|cwd| (terminal_id, cwd))
+            })
+            .collect();
+
+        if updates.is_empty() {
+            return;
+        }
+
+        let mut states_guard = states.write();
+        for (terminal_id, new_cwd) in updates {
+            if let Some(state) = states_guard.get_mut(&terminal_id) {
+                state.update_terminal_cwd(new_cwd);
+            }
+        }
+    }
+
+    /// Transport-neutral CWD sync: uses a direct Arc<CwdTracker> reference
+    /// instead of the Tauri AppHandle state lookup. Used in standalone mode.
+    fn sync_terminal_cwds_from_tracker_direct(
+        cwd_tracker: &Arc<CwdTracker>,
+        states: &Arc<RwLock<HashMap<String, GitState>>>,
+    ) {
         let terminal_ids: Vec<String> = states.read().keys().cloned().collect();
         let updates: Vec<(String, String)> = terminal_ids
             .into_iter()
@@ -1389,6 +1427,7 @@ impl GitTracker {
         #[cfg(target_os = "windows")]
         let cwd_poll_states = self.cwd_poll_states.clone();
         let app_handle = self.app_handle.clone();
+        let events = self.events.clone();
         let poll_handle = self.poll_handle.clone();
 
         let handle = tokio::spawn(async move {
@@ -1439,7 +1478,9 @@ impl GitTracker {
                     None => continue, // Already polling
                 };
 
-                Self::sync_terminal_cwds_from_tracker(&app_handle, &states);
+                if let Some(app_handle) = &app_handle {
+                    Self::sync_terminal_cwds_from_tracker(app_handle, &states);
+                }
                 #[cfg(target_os = "windows")]
                 Self::prune_unused_cwd_poll_states(&states, &cwd_poll_states);
 
@@ -1517,11 +1558,11 @@ impl GitTracker {
                         );
 
                         for (terminal_id, branch) in branch_emits {
-                            Self::emit_branch_changed_static(&app_handle, &terminal_id, &branch);
+                            Self::emit_branch_changed_static(&events, &terminal_id, &branch);
                         }
 
                         for (terminal_id, status) in status_emits {
-                            Self::emit_status_changed_static(&app_handle, &terminal_id, &status);
+                            Self::emit_status_changed_static(&events, &terminal_id, &status);
                         }
                     }
                 }
@@ -1541,11 +1582,11 @@ impl GitTracker {
                             Self::apply_git_results(&states, &terminal_ids, new_branch, new_status);
 
                         for (_, branch) in branch_emits {
-                            Self::emit_branch_changed_static(&app_handle, &terminal_id, &branch);
+                            Self::emit_branch_changed_static(&events, &terminal_id, &branch);
                         }
 
                         for (_, status) in status_emits {
-                            Self::emit_status_changed_static(&app_handle, &terminal_id, &status);
+                            Self::emit_status_changed_static(&events, &terminal_id, &status);
                         }
                     }
                 }
@@ -1666,28 +1707,26 @@ impl GitTracker {
 
     /// Static version of emit_branch_changed for use in async context
     fn emit_branch_changed_static(
-        app_handle: &AppHandle,
+        events: &TerminalEventHub,
         terminal_id: &str,
         branch: &Option<String>,
     ) {
-        let event = GitBranchChangedEvent {
+        events.emit(TerminalEvent::GitBranchChanged {
             terminal_id: terminal_id.to_string(),
             branch: branch.clone(),
-        };
-        let _ = app_handle.emit("terminal-git-branch-changed", event);
+        });
     }
 
     /// Static version of emit_status_changed for use in async context
     fn emit_status_changed_static(
-        app_handle: &AppHandle,
+        events: &TerminalEventHub,
         terminal_id: &str,
         status: &Option<GitStatus>,
     ) {
-        let event = GitStatusChangedEvent {
+        events.emit(TerminalEvent::GitStatusChanged {
             terminal_id: terminal_id.to_string(),
             status: status.clone(),
-        };
-        let _ = app_handle.emit("terminal-git-status-changed", event);
+        });
     }
 }
 

--- a/src-tauri/src/trackers/git_tracker.rs
+++ b/src-tauri/src/trackers/git_tracker.rs
@@ -1427,6 +1427,7 @@ impl GitTracker {
         #[cfg(target_os = "windows")]
         let cwd_poll_states = self.cwd_poll_states.clone();
         let app_handle = self.app_handle.clone();
+        let cwd_tracker = self.cwd_tracker.clone();
         let events = self.events.clone();
         let poll_handle = self.poll_handle.clone();
 
@@ -1478,7 +1479,9 @@ impl GitTracker {
                     None => continue, // Already polling
                 };
 
-                if let Some(app_handle) = &app_handle {
+                if let Some(cwd_tracker) = &cwd_tracker {
+                    Self::sync_terminal_cwds_from_tracker_direct(cwd_tracker, &states);
+                } else if let Some(app_handle) = &app_handle {
                     Self::sync_terminal_cwds_from_tracker(app_handle, &states);
                 }
                 #[cfg(target_os = "windows")]

--- a/src-tauri/src/trackers/mod.rs
+++ b/src-tauri/src/trackers/mod.rs
@@ -8,7 +8,11 @@
 pub mod cwd_tracker;
 pub mod exit_code_tracker;
 pub mod git_tracker;
+pub mod terminal_events;
 
 pub use cwd_tracker::CwdTracker;
 pub use exit_code_tracker::ExitCodeTracker;
 pub use git_tracker::{GitCommit, GitStatus, GitStatusDetail, GitTracker};
+pub use terminal_events::{TerminalEvent, TerminalEventHub};
+#[allow(unused_imports)]
+pub use terminal_events::TerminalStateSnapshot;

--- a/src-tauri/src/trackers/terminal_events.rs
+++ b/src-tauri/src/trackers/terminal_events.rs
@@ -1,0 +1,177 @@
+use parking_lot::RwLock;
+use serde::Serialize;
+use std::collections::HashMap;
+use std::sync::Arc;
+use tauri::{AppHandle, Emitter};
+use tokio::sync::broadcast;
+
+use super::git_tracker::GitStatus;
+
+const EVENT_CAPACITY: usize = 256;
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum TerminalEvent {
+    Exit {
+        terminal_id: String,
+        exit_code: Option<i32>,
+        signal: Option<i32>,
+    },
+    CwdChanged {
+        terminal_id: String,
+        cwd: String,
+    },
+    GitBranchChanged {
+        terminal_id: String,
+        branch: Option<String>,
+    },
+    GitStatusChanged {
+        terminal_id: String,
+        status: Option<GitStatus>,
+    },
+    ExitCodeChanged {
+        terminal_id: String,
+        exit_code: i32,
+    },
+}
+
+impl TerminalEvent {
+    pub fn terminal_id(&self) -> &str {
+        match self {
+            Self::Exit { terminal_id, .. }
+            | Self::CwdChanged { terminal_id, .. }
+            | Self::GitBranchChanged { terminal_id, .. }
+            | Self::GitStatusChanged { terminal_id, .. }
+            | Self::ExitCodeChanged { terminal_id, .. } => terminal_id,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Default, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TerminalStateSnapshot {
+    pub cwd: Option<String>,
+    pub git_branch: Option<String>,
+    pub git_status: Option<GitStatus>,
+    pub exit_code: Option<i32>,
+    pub exited: bool,
+}
+
+#[derive(Clone)]
+pub struct TerminalEventHub {
+    tx: Arc<broadcast::Sender<TerminalEvent>>,
+    tauri: Option<AppHandle>,
+    snapshots: Arc<RwLock<HashMap<String, TerminalStateSnapshot>>>,
+}
+
+impl TerminalEventHub {
+    pub fn tauri(app_handle: AppHandle) -> Self {
+        Self {
+            tx: Arc::new(broadcast::channel(EVENT_CAPACITY).0),
+            tauri: Some(app_handle),
+            snapshots: Arc::new(RwLock::new(HashMap::new())),
+        }
+    }
+
+    pub fn standalone() -> Self {
+        Self {
+            tx: Arc::new(broadcast::channel(EVENT_CAPACITY).0),
+            tauri: None,
+            snapshots: Arc::new(RwLock::new(HashMap::new())),
+        }
+    }
+
+    pub fn subscribe(&self) -> broadcast::Receiver<TerminalEvent> {
+        self.tx.subscribe()
+    }
+
+    pub fn snapshot(&self, terminal_id: &str) -> TerminalStateSnapshot {
+        self.snapshots
+            .read()
+            .get(terminal_id)
+            .cloned()
+            .unwrap_or_default()
+    }
+
+    pub fn remove(&self, terminal_id: &str) {
+        self.snapshots.write().remove(terminal_id);
+    }
+
+    pub fn emit(&self, event: TerminalEvent) {
+        {
+            let mut snapshots = self.snapshots.write();
+            let terminal_id = match &event {
+                TerminalEvent::Exit { terminal_id, .. }
+                | TerminalEvent::CwdChanged { terminal_id, .. }
+                | TerminalEvent::GitBranchChanged { terminal_id, .. }
+                | TerminalEvent::GitStatusChanged { terminal_id, .. }
+                | TerminalEvent::ExitCodeChanged { terminal_id, .. } => terminal_id.clone(),
+            };
+            let snapshot = snapshots.entry(terminal_id).or_default();
+            match &event {
+                TerminalEvent::Exit { exit_code, .. } => {
+                    snapshot.exited = true;
+                    snapshot.exit_code = *exit_code;
+                }
+                TerminalEvent::CwdChanged { cwd, .. } => snapshot.cwd = Some(cwd.clone()),
+                TerminalEvent::GitBranchChanged { branch, .. } => {
+                    snapshot.git_branch = branch.clone()
+                }
+                TerminalEvent::GitStatusChanged { status, .. } => {
+                    snapshot.git_status = status.clone()
+                }
+                TerminalEvent::ExitCodeChanged { exit_code, .. } => {
+                    snapshot.exit_code = Some(*exit_code)
+                }
+            }
+        }
+        let _ = self.tx.send(event.clone());
+        let Some(app) = &self.tauri else {
+            return;
+        };
+        let result = match event {
+            TerminalEvent::Exit {
+                terminal_id,
+                exit_code,
+                signal,
+            } => app.emit(
+                "terminal-exit",
+                serde_json::json!({ "id": terminal_id, "exitCode": exit_code, "signal": signal }),
+            ),
+            TerminalEvent::CwdChanged { terminal_id, cwd } => app.emit(
+                "terminal-cwd-changed",
+                serde_json::json!({ "terminalId": terminal_id, "cwd": cwd }),
+            ),
+            TerminalEvent::GitBranchChanged {
+                terminal_id,
+                branch,
+            } => app.emit(
+                "terminal-git-branch-changed",
+                serde_json::json!({ "terminalId": terminal_id, "branch": branch }),
+            ),
+            TerminalEvent::GitStatusChanged {
+                terminal_id,
+                status,
+            } => app.emit(
+                "terminal-git-status-changed",
+                serde_json::json!({ "terminalId": terminal_id, "status": status }),
+            ),
+            TerminalEvent::ExitCodeChanged {
+                terminal_id,
+                exit_code,
+            } => app.emit(
+                "terminal-exit-code-changed",
+                serde_json::json!({ "terminalId": terminal_id, "exitCode": exit_code }),
+            ),
+        };
+        if let Err(error) = result {
+            log::error!("failed to emit terminal event to desktop renderer: {error}");
+        }
+    }
+}
+
+impl Default for TerminalEventHub {
+    fn default() -> Self {
+        Self::standalone()
+    }
+}

--- a/src-tauri/src/web/fs_api.rs
+++ b/src-tauri/src/web/fs_api.rs
@@ -817,6 +817,7 @@ mod tests {
     use crate::acp::AcpManager;
     use crate::web::project_registry::ProjectRegistry;
     use crate::web::sink::WsRelaySink;
+    use crate::web::test_pty_manager;
     use axum::body::Body;
     use axum::http::{Request, StatusCode};
     use std::path::PathBuf;
@@ -865,8 +866,14 @@ mod tests {
     /// `test_state()` keep working because the default root is the OS temp
     /// dir (and the existing tests only touch temp dirs).
     fn test_state_with_root(root: &Path) -> AppState {
+        let pty = test_pty_manager();
         AppState {
             acp: Arc::new(AcpManager::new(vec![])),
+            terminal_events: pty.terminal_events(),
+            cwd_tracker: pty.cwd_tracker(),
+            git_tracker: pty.git_tracker(),
+            exit_code_tracker: pty.exit_code_tracker(),
+            pty,
             relay: Arc::new(WsRelaySink::new()),
             registry: Arc::new(ProjectRegistry::new()),
             chat_history_cache: None,

--- a/src-tauri/src/web/mod.rs
+++ b/src-tauri/src/web/mod.rs
@@ -23,6 +23,7 @@ pub mod project_registry;
 pub mod projects_api;
 pub mod router;
 pub mod sink;
+pub mod terminal_ws;
 pub mod ws;
 
 pub use chat_history_cache::ChatHistoryCache;
@@ -47,6 +48,17 @@ use tokio::task::JoinHandle;
 use tracing::{error, info, warn};
 
 use crate::acp::AcpManager;
+use crate::pty::PtyManager;
+use crate::trackers::{CwdTracker, ExitCodeTracker, GitTracker, TerminalEventHub};
+
+#[cfg(test)]
+pub(crate) fn test_pty_manager() -> Arc<PtyManager> {
+    let events = TerminalEventHub::standalone();
+    let cwd = Arc::new(CwdTracker::new(events.clone()));
+    let git = Arc::new(GitTracker::new(None, events.clone()));
+    let exit = Arc::new(ExitCodeTracker::new(events.clone()));
+    Arc::new(PtyManager::new(events, cwd, git, exit))
+}
 
 /// Bind and serve the standalone ACP HTTP server until SIGINT/SIGTERM.
 ///
@@ -66,8 +78,14 @@ use crate::acp::AcpManager;
 /// The standalone binary owns its agent lifetime end-to-end, so it kills agents
 /// on exit. The desktop-hosted shared-live path calls [`serve_router`] directly
 /// and must NOT kill the desktop's live agents — see [`serve_router`].
+#[allow(clippy::too_many_arguments)]
 pub async fn serve(
     acp: Arc<AcpManager>,
+    pty: Arc<PtyManager>,
+    terminal_events: TerminalEventHub,
+    cwd_tracker: Arc<CwdTracker>,
+    git_tracker: Arc<GitTracker>,
+    exit_code_tracker: Arc<ExitCodeTracker>,
     ws_relay: Arc<WsRelaySink>,
     registry: Arc<crate::web::project_registry::ProjectRegistry>,
     registry_persistence: Option<Arc<parking_lot::Mutex<crate::acp::FileProjectRegistry>>>,
@@ -76,6 +94,11 @@ pub async fn serve(
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let (_addr, handle) = serve_router(
         acp.clone(),
+        pty.clone(),
+        terminal_events,
+        cwd_tracker,
+        git_tracker,
+        exit_code_tracker,
         ws_relay,
         registry,
         // The standalone VPS binary has no renderer-fed cache; it relies on
@@ -91,14 +114,26 @@ pub async fn serve(
 
     let serve_result = handle.await;
 
-    // Kill agents after Axum has drained (or failed) — the standalone binary
-    // owns its agents' lifecycle. The desktop-hosted path never reaches here.
-    acp.kill_all_checked()
-        .await
-        .map_err(Box::<dyn std::error::Error + Send + Sync>::from)?;
-    acp.shutdown_persistence()
-        .await
-        .map_err(Box::<dyn std::error::Error + Send + Sync>::from)?;
+    // Cleanup: always attempt ALL resource cleanup even if one step fails.
+    // PTY cleanup must not be skipped because ACP persistence errored.
+    let mut cleanup_errors: Vec<Box<dyn std::error::Error + Send + Sync>> = Vec::new();
+
+    if let Err(e) = acp.kill_all_checked().await {
+        let e: Box<dyn std::error::Error + Send + Sync> = e.into();
+        log::error!("[termul-server] ACP kill_all failed during shutdown: {e}");
+        cleanup_errors.push(e);
+    }
+    if let Err(e) = acp.shutdown_persistence().await {
+        let e: Box<dyn std::error::Error + Send + Sync> = e.into();
+        log::error!("[termul-server] ACP persistence shutdown failed: {e}");
+        cleanup_errors.push(e);
+    }
+    // PTY cleanup always runs — never skip terminal process-tree kill.
+    pty.kill_all().await;
+
+    if let Some(first) = cleanup_errors.into_iter().next() {
+        return Err(first);
+    }
 
     match serve_result {
         Ok(()) => {
@@ -129,6 +164,11 @@ pub async fn serve(
 #[allow(clippy::too_many_arguments)]
 pub async fn serve_router(
     acp: Arc<AcpManager>,
+    pty: Arc<PtyManager>,
+    terminal_events: TerminalEventHub,
+    cwd_tracker: Arc<CwdTracker>,
+    git_tracker: Arc<GitTracker>,
+    exit_code_tracker: Arc<ExitCodeTracker>,
     ws_relay: Arc<WsRelaySink>,
     registry: Arc<crate::web::project_registry::ProjectRegistry>,
     chat_history_cache: Option<Arc<ChatHistoryCache>>,
@@ -167,6 +207,11 @@ pub async fn serve_router(
     };
     let app = router::router(
         Arc::clone(&acp),
+        pty,
+        terminal_events,
+        cwd_tracker,
+        git_tracker,
+        exit_code_tracker,
         Arc::clone(&ws_relay),
         Arc::clone(&registry),
         chat_history_cache,

--- a/src-tauri/src/web/projects_api.rs
+++ b/src-tauri/src/web/projects_api.rs
@@ -61,14 +61,21 @@ mod tests {
     use crate::acp::{AcpManager, FileProjectRegistry};
     use crate::web::project_registry::{seed_from_file, ProjectRegistry, ProjectSummary};
     use crate::web::sink::WsRelaySink;
+    use crate::web::test_pty_manager;
     use axum::body::Body;
     use axum::http::{Request, StatusCode};
     use std::sync::Arc;
     use tower::ServiceExt;
 
     fn state_with(registry: Arc<ProjectRegistry>) -> AppState {
+        let pty = test_pty_manager();
         AppState {
             acp: Arc::new(AcpManager::new(vec![])),
+            terminal_events: pty.terminal_events(),
+            cwd_tracker: pty.cwd_tracker(),
+            git_tracker: pty.git_tracker(),
+            exit_code_tracker: pty.exit_code_tracker(),
+            pty,
             relay: Arc::new(WsRelaySink::new()),
             registry,
             chat_history_cache: None,

--- a/src-tauri/src/web/router.rs
+++ b/src-tauri/src/web/router.rs
@@ -17,11 +17,14 @@ use axum::{
 };
 
 use crate::acp::{AcpManager, FileProjectRegistry};
+use crate::pty::PtyManager;
+use crate::trackers::{CwdTracker, ExitCodeTracker, GitTracker, TerminalEventHub};
 use crate::web::chat_history_cache::ChatHistoryCache;
 use crate::web::fs_api;
 use crate::web::project_registry::ProjectRegistry;
 use crate::web::projects_api;
 use crate::web::sink::WsRelaySink;
+use crate::web::terminal_ws::terminal_ws_upgrade;
 use crate::web::ws::{ws_upgrade, AppState, HistoryMode};
 
 use super::assets;
@@ -42,6 +45,11 @@ use super::assets;
 #[allow(clippy::too_many_arguments)]
 pub fn router(
     acp: Arc<AcpManager>,
+    pty: Arc<PtyManager>,
+    terminal_events: TerminalEventHub,
+    cwd_tracker: Arc<CwdTracker>,
+    git_tracker: Arc<GitTracker>,
+    exit_code_tracker: Arc<ExitCodeTracker>,
     ws_relay: Arc<WsRelaySink>,
     registry: Arc<ProjectRegistry>,
     chat_history_cache: Option<Arc<ChatHistoryCache>>,
@@ -53,6 +61,7 @@ pub fn router(
     let mut r = Router::new()
         .route("/health", get(health_check))
         .route("/ws", get(ws_upgrade))
+        .route("/terminal/ws", get(terminal_ws_upgrade))
         // Project list mirror (Epic-4 bridge): the web client reads the
         // desktop's non-archived + archived projects here. Registered AHEAD of
         // the static fallback so the SPA mount cannot shadow it.
@@ -80,6 +89,11 @@ pub fn router(
     }
     r.with_state(AppState {
         acp,
+        pty,
+        terminal_events,
+        cwd_tracker,
+        git_tracker,
+        exit_code_tracker,
         relay: ws_relay,
         registry,
         chat_history_cache,
@@ -93,6 +107,7 @@ pub fn router(
 /// Same as [`router`], but with an injectable static-root for unit tests.
 pub fn router_with_static(
     acp: Arc<AcpManager>,
+    pty: Arc<PtyManager>,
     ws_relay: Arc<WsRelaySink>,
     registry: Arc<ProjectRegistry>,
     static_dir: &Path,
@@ -101,6 +116,7 @@ pub fn router_with_static(
     Router::new()
         .route("/health", get(health_check))
         .route("/ws", get(ws_upgrade))
+        .route("/terminal/ws", get(terminal_ws_upgrade))
         .route("/projects", get(projects_api::list))
         .route("/fs/mkdir", post(fs_api::mkdir))
         .route("/fs/write", post(fs_api::write))
@@ -115,6 +131,11 @@ pub fn router_with_static(
         .fallback_service(assets::static_service_from(static_dir))
         .with_state(AppState {
             acp,
+            terminal_events: pty.terminal_events(),
+            cwd_tracker: pty.cwd_tracker(),
+            git_tracker: pty.git_tracker(),
+            exit_code_tracker: pty.exit_code_tracker(),
+            pty,
             relay: ws_relay,
             registry,
             chat_history_cache: None,
@@ -174,6 +195,7 @@ mod tests {
         // we pass the OS temp dir for symmetry with the legacy default.
         router_with_static(
             Arc::new(AcpManager::new(vec![])),
+            crate::web::test_pty_manager(),
             Arc::new(WsRelaySink::new()),
             Arc::new(crate::web::project_registry::ProjectRegistry::new()),
             dir,

--- a/src-tauri/src/web/terminal_ws.rs
+++ b/src-tauri/src/web/terminal_ws.rs
@@ -167,11 +167,15 @@ async fn handle(
 ) -> Result<Value, (&'static str, String)> {
     match request.type_.as_str() {
         "spawn" => {
-            let mut options: SpawnOptions = serde_json::from_value(request.payload)
+            let options: SpawnOptions = serde_json::from_value(request.payload)
                 .map_err(|e| ("VALIDATION_ERROR", e.to_string()))?;
-            // Ensure project_id is set so the terminal is scoped.
-            if options.project_id.is_none() {
-                options.project_id = Some("default".to_string());
+            // Require project_id so the terminal is scoped — do not default
+            // to a literal that any client can target.
+            if options.project_id.as_deref().filter(|s| !s.is_empty()).is_none() {
+                return Err((
+                    "VALIDATION_ERROR",
+                    "spawn requires a non-empty projectId".to_string(),
+                ));
             }
             info!(
                 "[terminal-ws] spawn requested project_id={}",
@@ -241,7 +245,15 @@ async fn handle(
             let instance = state.pty.get(&terminal_id).ok_or_else(|| {
                 ("TERMINAL_NOT_FOUND", format!("Terminal not found: {terminal_id}"))
             })?;
-            ctx.authorize(&terminal_id);
+            // attach does NOT authorize — only spawn does. This prevents a
+            // client from self-authorizing for any terminal ID it discovers.
+            // If the connection is not already authorized, reject.
+            if !ctx.is_authorized(&terminal_id) {
+                return Err((
+                    "UNAUTHORIZED",
+                    format!("Not authorized for terminal {terminal_id}"),
+                ));
+            }
 
             // Sequenced replay: only unseen chunks, with gap detection.
             let replay = instance.subscribe_from(last_seq);
@@ -328,18 +340,34 @@ async fn handle(
             ctx.detach(terminal_id);
             Ok(Value::Null)
         }
-        "get_cwd" => Ok(json!(state
-            .cwd_tracker
-            .get_cwd(string_field(&request.payload, "terminalId")?))),
-        "get_git_branch" => Ok(json!(state
-            .git_tracker
-            .get_branch(string_field(&request.payload, "terminalId")?))),
-        "get_git_status" => Ok(json!(state
-            .git_tracker
-            .get_status(string_field(&request.payload, "terminalId")?))),
-        "get_exit_code" => Ok(json!(state
-            .exit_code_tracker
-            .get_exit_code(string_field(&request.payload, "terminalId")?))),
+        "get_cwd" => {
+            let terminal_id = string_field(&request.payload, "terminalId")?;
+            if !ctx.is_authorized(terminal_id) {
+                return Err(("UNAUTHORIZED", format!("Not authorized for terminal {terminal_id}")));
+            }
+            Ok(json!(state.cwd_tracker.get_cwd(terminal_id)))
+        }
+        "get_git_branch" => {
+            let terminal_id = string_field(&request.payload, "terminalId")?;
+            if !ctx.is_authorized(terminal_id) {
+                return Err(("UNAUTHORIZED", format!("Not authorized for terminal {terminal_id}")));
+            }
+            Ok(json!(state.git_tracker.get_branch(terminal_id)))
+        }
+        "get_git_status" => {
+            let terminal_id = string_field(&request.payload, "terminalId")?;
+            if !ctx.is_authorized(terminal_id) {
+                return Err(("UNAUTHORIZED", format!("Not authorized for terminal {terminal_id}")));
+            }
+            Ok(json!(state.git_tracker.get_status(terminal_id)))
+        }
+        "get_exit_code" => {
+            let terminal_id = string_field(&request.payload, "terminalId")?;
+            if !ctx.is_authorized(terminal_id) {
+                return Err(("UNAUTHORIZED", format!("Not authorized for terminal {terminal_id}")));
+            }
+            Ok(json!(state.exit_code_tracker.get_exit_code(terminal_id)))
+        }
         "add_renderer_ref" => {
             let terminal_id = string_field(&request.payload, "terminalId")?;
             if !ctx.is_authorized(terminal_id) {
@@ -353,6 +381,9 @@ async fn handle(
         }
         "remove_renderer_ref" => {
             let terminal_id = string_field(&request.payload, "terminalId")?;
+            if !ctx.is_authorized(terminal_id) {
+                return Err(("UNAUTHORIZED", format!("Not authorized for terminal {terminal_id}")));
+            }
             state
                 .pty
                 .remove_renderer_ref(terminal_id, string_field(&request.payload, "rendererId")?)
@@ -369,10 +400,16 @@ async fn handle(
             Ok(Value::Null)
         }
         "update_orphan_detection" => {
+            // Global setting — require at least one authorized terminal to
+            // prevent arbitrary clients from changing lifecycle policy.
+            if ctx.authorized.read().is_empty() {
+                return Err(("UNAUTHORIZED", "Not authorized to update orphan detection".to_string()));
+            }
             let enabled = request.payload["enabled"].as_bool().unwrap_or(true);
             let timeout = request.payload["timeout"]
                 .as_u64()
-                .map(|t| t * 60 * 1000); // minutes → milliseconds (desktop parity)
+                .and_then(|t| t.checked_mul(60 * 1000)) // minutes → ms (checked to prevent overflow)
+                .filter(|t| *t > 0 && *t <= 3_600_000); // cap at 1 hour
             state
                 .pty
                 .update_orphan_detection_settings(enabled, timeout)

--- a/src-tauri/src/web/terminal_ws.rs
+++ b/src-tauri/src/web/terminal_ws.rs
@@ -1,0 +1,462 @@
+//! Dedicated interactive terminal websocket.
+//!
+//! This endpoint intentionally stays separate from the ACP relay. Authentication
+//! is not implemented yet; never expose it to an untrusted network. All
+//! operations are project-scoped: a connection may only interact with terminals
+//! whose `project_id` it has been authorized for via spawn or explicit attach.
+
+use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
+use parking_lot::RwLock;
+
+use axum::extract::ws::{Message, WebSocket, WebSocketUpgrade};
+use axum::extract::State;
+use axum::response::IntoResponse;
+use futures_util::{SinkExt, StreamExt};
+use serde::Deserialize;
+use serde_json::{json, Value};
+use tokio::sync::mpsc;
+use tracing::{info, warn};
+
+use crate::pty::manager::SpawnOptions;
+use crate::web::ws::AppState;
+
+const MAX_RECONNECT_FRAMES: usize = 64;
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct Request {
+    id: String,
+    #[serde(rename = "type")]
+    type_: String,
+    #[serde(default)]
+    payload: Value,
+}
+
+pub async fn terminal_ws_upgrade(
+    ws: WebSocketUpgrade,
+    State(state): State<AppState>,
+) -> impl IntoResponse {
+    ws.on_upgrade(move |socket| run(socket, state))
+}
+
+async fn run(socket: WebSocket, state: AppState) {
+    let (mut sink, mut stream) = socket.split();
+    let (tx, mut rx) = mpsc::channel::<Message>(MAX_RECONNECT_FRAMES);
+
+    let write_task = tokio::spawn(async move {
+        while let Some(message) = rx.recv().await {
+            if sink.send(message).await.is_err() {
+                break;
+            }
+        }
+    });
+
+    // Per-connection authorization: terminal IDs this socket may operate on.
+    // Shared with the event-forwarding task so it can see updates.
+    let authorized: Arc<RwLock<HashSet<String>>> =
+        Arc::new(RwLock::new(HashSet::new()));
+    // Per-terminal output forwarding tasks.
+    let attachments: HashMap<String, tokio::task::JoinHandle<()>> = HashMap::new();
+
+    info!("[terminal-ws] client connected (authentication deferred)");
+
+    let event_tx = tx.clone();
+    let event_state = state.clone();
+    let event_authorized = authorized.clone();
+    let mut event_rx = event_state.terminal_events.subscribe();
+    let event_task = tokio::spawn(async move {
+        loop {
+            match event_rx.recv().await {
+                Ok(event) => {
+                    let terminal_id = event.terminal_id().to_string();
+                    // Only forward events for terminals this connection is
+                    // authorized to see.
+                    if !event_authorized.read().contains(&terminal_id) {
+                        continue;
+                    }
+                    let payload = serde_json::to_value(&event)
+                        .unwrap_or_else(|_| json!({}));
+                    if send_json(
+                        &event_tx,
+                        json!({ "type": "event", "payload": payload }),
+                    )
+                    .await
+                    .is_err()
+                    {
+                        break;
+                    }
+                }
+                Err(tokio::sync::broadcast::error::RecvError::Lagged(skipped)) => {
+                    warn!("[terminal-ws] lifecycle event receiver lagged by {skipped}");
+                }
+                Err(tokio::sync::broadcast::error::RecvError::Closed) => break,
+            }
+        }
+    });
+
+    let mut ctx = ConnectionContext {
+        authorized: authorized.clone(),
+        attachments,
+    };
+
+    while let Some(frame) = stream.next().await {
+        let Ok(message) = frame else { break };
+        let Message::Text(text) = message else { continue };
+        let request = match serde_json::from_str::<Request>(&text) {
+            Ok(request) => request,
+            Err(error) => {
+                let _ = send_error(&tx, "malformed", "VALIDATION_ERROR", error.to_string()).await;
+                continue;
+            }
+        };
+        let id = request.id.clone();
+        let op_type = request.type_.clone();
+        info!("[terminal-ws] request start type={op_type} id={id}");
+        match handle(request, &state, &tx, &mut ctx).await {
+            Ok(data) => {
+                info!("[terminal-ws] request success type={op_type} id={id}");
+                let _ = send_json(&tx, json!({ "id": id, "success": true, "data": data })).await;
+            }
+            Err((code, message)) => {
+                warn!("[terminal-ws] request failed type={op_type} id={id} code={code}");
+                let _ = send_error(&tx, &id, code, message).await;
+            }
+        }
+    }
+
+    // Cleanup: abort all output forwarding tasks. PTYs are preserved.
+    event_task.abort();
+    for task in ctx.attachments.values() {
+        task.abort();
+    }
+    info!("[terminal-ws] client disconnected; {} PTY(s) preserved", ctx.authorized.read().len());
+    drop(tx);
+    let _ = write_task.await;
+}
+
+struct ConnectionContext {
+    /// Terminal IDs this connection is authorized to operate on.
+    authorized: Arc<RwLock<HashSet<String>>>,
+    /// Per-terminal output forwarding tasks (terminal_id -> task).
+    attachments: HashMap<String, tokio::task::JoinHandle<()>>,
+}
+
+impl ConnectionContext {
+    fn authorize(&mut self, terminal_id: &str) {
+        self.authorized.write().insert(terminal_id.to_string());
+    }
+
+    fn is_authorized(&self, terminal_id: &str) -> bool {
+        self.authorized.read().contains(terminal_id)
+    }
+
+    fn detach(&mut self, terminal_id: &str) {
+        if let Some(task) = self.attachments.remove(terminal_id) {
+            task.abort();
+        }
+        self.authorized.write().remove(terminal_id);
+    }
+}
+
+async fn handle(
+    request: Request,
+    state: &AppState,
+    tx: &mpsc::Sender<Message>,
+    ctx: &mut ConnectionContext,
+) -> Result<Value, (&'static str, String)> {
+    match request.type_.as_str() {
+        "spawn" => {
+            let mut options: SpawnOptions = serde_json::from_value(request.payload)
+                .map_err(|e| ("VALIDATION_ERROR", e.to_string()))?;
+            // Ensure project_id is set so the terminal is scoped.
+            if options.project_id.is_none() {
+                options.project_id = Some("default".to_string());
+            }
+            info!(
+                "[terminal-ws] spawn requested project_id={}",
+                options.project_id.as_deref().unwrap_or("?")
+            );
+            let info = state
+                .pty
+                .spawn(options, None)
+                .await
+                .map_err(|e| ("SPAWN_FAILED", e))?;
+            ctx.authorize(&info.id);
+            info!("[terminal-ws] spawn success terminal_id={}", info.id);
+            serde_json::to_value(info).map_err(|e| ("SPAWN_FAILED", e.to_string()))
+        }
+        "write" => {
+            let terminal_id = string_field(&request.payload, "terminalId")?;
+            if !ctx.is_authorized(terminal_id) {
+                return Err(("UNAUTHORIZED", format!("Not authorized for terminal {terminal_id}")));
+            }
+            let data = string_field(&request.payload, "data")?;
+            state
+                .pty
+                .write(terminal_id, data)
+                .await
+                .map(|_| Value::Null)
+                .map_err(|e| ("WRITE_FAILED", e))
+        }
+        "resize" => {
+            let terminal_id = string_field(&request.payload, "terminalId")?;
+            if !ctx.is_authorized(terminal_id) {
+                return Err(("UNAUTHORIZED", format!("Not authorized for terminal {terminal_id}")));
+            }
+            let cols = u16_field(&request.payload, "cols")?;
+            let rows = u16_field(&request.payload, "rows")?;
+            state
+                .pty
+                .resize(terminal_id, cols, rows)
+                .await
+                .map(|_| Value::Null)
+                .map_err(|e| ("RESIZE_FAILED", e))
+        }
+        "kill" => {
+            let terminal_id = string_field(&request.payload, "terminalId")?;
+            // Idempotent kill: if the terminal is already gone, treat as success
+            // so a lost reply or double-close doesn't leave an uncloseable tab.
+            if state.pty.get(terminal_id).is_none() {
+                ctx.detach(terminal_id);
+                return Ok(Value::Null);
+            }
+            // Force-kill: bypass the desktop is_hidden deferral so web close
+            // actually terminates the process. Desktop behavior is unchanged.
+            state
+                .pty
+                .force_kill(terminal_id)
+                .await
+                .map(|_| {
+                    ctx.detach(terminal_id);
+                    Value::Null
+                })
+                .map_err(|e| ("KILL_FAILED", e))
+        }
+        "attach" => {
+            let terminal_id = string_field(&request.payload, "terminalId")?.to_string();
+            let last_seq = request.payload["lastSeq"]
+                .as_u64()
+                .unwrap_or(0);
+            let instance = state.pty.get(&terminal_id).ok_or_else(|| {
+                ("TERMINAL_NOT_FOUND", format!("Terminal not found: {terminal_id}"))
+            })?;
+            ctx.authorize(&terminal_id);
+
+            // Sequenced replay: only unseen chunks, with gap detection.
+            let replay = instance.subscribe_from(last_seq);
+            let snapshot = state.terminal_events.snapshot(&terminal_id);
+
+            // Send replay frame: chunks + gap flag + latest seq + state snapshot.
+            let chunk_payloads: Vec<Value> = replay
+                .chunks
+                .iter()
+                .map(|chunk| {
+                    json!({
+                        "seq": chunk.seq,
+                        "data": chunk.data.iter().map(|b| *b as u64).collect::<Vec<u64>>()
+                    })
+                })
+                .collect();
+            send_json(
+                tx,
+                json!({
+                    "type": "replay",
+                    "terminalId": terminal_id,
+                    "chunks": chunk_payloads,
+                    "gap": replay.gap,
+                    "latestSeq": replay.latest_seq,
+                    "snapshot": serde_json::to_value(&snapshot).unwrap_or(json!({}))
+                }),
+            )
+            .await
+            .map_err(|e| ("NETWORK_ERROR", e))?;
+
+            // Replace prior attachment task if any.
+            if let Some(previous) = ctx.attachments.remove(&terminal_id) {
+                previous.abort();
+            }
+            let output_tx = tx.clone();
+            let attached_id = terminal_id.clone();
+            let task = tokio::spawn(async move {
+                let mut receiver = replay.receiver;
+                let mut current_seq = replay.latest_seq;
+                loop {
+                    match receiver.recv().await {
+                        Ok(chunk) => {
+                            current_seq = chunk.seq;
+                            let data: Vec<u64> = chunk.data.iter().map(|b| *b as u64).collect();
+                            if send_json(
+                                &output_tx,
+                                json!({
+                                    "type": "data",
+                                    "terminalId": attached_id,
+                                    "seq": current_seq,
+                                    "data": data
+                                }),
+                            )
+                            .await
+                            .is_err()
+                            {
+                                break;
+                            }
+                        }
+                        Err(tokio::sync::broadcast::error::RecvError::Lagged(skipped)) => {
+                            // Recoverable: send a gap marker and continue.
+                            warn!(
+                                "[terminal-ws] output receiver lagged by {skipped} for {attached_id}"
+                            );
+                            let _ = send_json(
+                                &output_tx,
+                                json!({
+                                    "type": "gap",
+                                    "terminalId": attached_id,
+                                    "lastSeq": current_seq
+                                }),
+                            )
+                            .await;
+                        }
+                        Err(tokio::sync::broadcast::error::RecvError::Closed) => break,
+                    }
+                }
+            });
+            ctx.attachments.insert(terminal_id, task);
+            Ok(json!({ "latestSeq": replay.latest_seq }))
+        }
+        "detach" => {
+            let terminal_id = string_field(&request.payload, "terminalId")?;
+            ctx.detach(terminal_id);
+            Ok(Value::Null)
+        }
+        "get_cwd" => Ok(json!(state
+            .cwd_tracker
+            .get_cwd(string_field(&request.payload, "terminalId")?))),
+        "get_git_branch" => Ok(json!(state
+            .git_tracker
+            .get_branch(string_field(&request.payload, "terminalId")?))),
+        "get_git_status" => Ok(json!(state
+            .git_tracker
+            .get_status(string_field(&request.payload, "terminalId")?))),
+        "get_exit_code" => Ok(json!(state
+            .exit_code_tracker
+            .get_exit_code(string_field(&request.payload, "terminalId")?))),
+        "add_renderer_ref" => {
+            let terminal_id = string_field(&request.payload, "terminalId")?;
+            if !ctx.is_authorized(terminal_id) {
+                return Err(("UNAUTHORIZED", format!("Not authorized for terminal {terminal_id}")));
+            }
+            state
+                .pty
+                .add_renderer_ref(terminal_id, string_field(&request.payload, "rendererId")?)
+                .map(|_| Value::Null)
+                .map_err(|e| ("TERMINAL_NOT_FOUND", e))
+        }
+        "remove_renderer_ref" => {
+            let terminal_id = string_field(&request.payload, "terminalId")?;
+            state
+                .pty
+                .remove_renderer_ref(terminal_id, string_field(&request.payload, "rendererId")?)
+                .map(|_| Value::Null)
+                .map_err(|e| ("TERMINAL_NOT_FOUND", e))
+        }
+        "set_protected" => {
+            let terminal_id = string_field(&request.payload, "terminalId")?;
+            if !ctx.is_authorized(terminal_id) {
+                return Err(("UNAUTHORIZED", format!("Not authorized for terminal {terminal_id}")));
+            }
+            let protected = request.payload["protected"].as_bool().unwrap_or(true);
+            state.pty.set_protected(terminal_id, protected);
+            Ok(Value::Null)
+        }
+        "update_orphan_detection" => {
+            let enabled = request.payload["enabled"].as_bool().unwrap_or(true);
+            let timeout = request.payload["timeout"]
+                .as_u64()
+                .map(|t| t * 60 * 1000); // minutes → milliseconds (desktop parity)
+            state
+                .pty
+                .update_orphan_detection_settings(enabled, timeout)
+                .await;
+            info!(
+                "[terminal-ws] orphan detection updated enabled={enabled} timeout_ms={:?}",
+                timeout
+            );
+            Ok(Value::Null)
+        }
+        _ => Err(("NOT_IMPLEMENTED", "unknown terminal request".to_string())),
+    }
+}
+
+fn string_field<'a>(value: &'a Value, key: &str) -> Result<&'a str, (&'static str, String)> {
+    value[key]
+        .as_str()
+        .filter(|value| !value.is_empty())
+        .ok_or_else(|| ("VALIDATION_ERROR", format!("missing {key}")))
+}
+
+fn u16_field(value: &Value, key: &str) -> Result<u16, (&'static str, String)> {
+    value[key]
+        .as_u64()
+        .and_then(|value| u16::try_from(value).ok())
+        .filter(|value| *value > 0)
+        .ok_or_else(|| ("VALIDATION_ERROR", format!("invalid {key}")))
+}
+
+async fn send_json(tx: &mpsc::Sender<Message>, value: Value) -> Result<(), String> {
+    tx.send(Message::Text(value.to_string().into()))
+        .await
+        .map_err(|_| "terminal websocket closed".to_string())
+}
+
+async fn send_error(
+    tx: &mpsc::Sender<Message>,
+    id: &str,
+    code: &str,
+    error: String,
+) -> Result<(), String> {
+    send_json(
+        tx,
+        json!({ "id": id, "success": false, "error": error, "code": code }),
+    )
+    .await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn validates_numeric_dimensions() {
+        assert_eq!(u16_field(&json!({ "cols": 80 }), "cols"), Ok(80));
+        assert!(u16_field(&json!({ "cols": 0 }), "cols").is_err());
+    }
+
+    #[test]
+    fn u16_rejects_negative_and_overflow() {
+        assert!(u16_field(&json!({ "rows": -1 }), "rows").is_err());
+        assert!(u16_field(&json!({ "rows": 70000 }), "rows").is_err());
+    }
+
+    #[test]
+    fn string_field_rejects_empty_and_missing() {
+        assert!(string_field(&json!({ "terminalId": "" }), "terminalId").is_err());
+        assert!(string_field(&json!({}), "terminalId").is_err());
+        assert_eq!(
+            string_field(&json!({ "terminalId": "t1" }), "terminalId"),
+            Ok("t1")
+        );
+    }
+
+    #[test]
+    fn context_authorize_and_detach_roundtrip() {
+        let mut ctx = ConnectionContext {
+            authorized: Arc::new(RwLock::new(HashSet::new())),
+            attachments: HashMap::new(),
+        };
+        ctx.authorize("t1");
+        assert!(ctx.is_authorized("t1"));
+        assert!(!ctx.is_authorized("t2"));
+        ctx.detach("t1");
+        assert!(!ctx.is_authorized("t1"));
+    }
+}

--- a/src-tauri/src/web/ws.rs
+++ b/src-tauri/src/web/ws.rs
@@ -41,6 +41,8 @@ use tracing::warn;
 
 use crate::acp::config::AgentConfig;
 use crate::acp::{AcpManager, AgentId, FileProjectRegistry, SessionCreationContext, SessionId};
+use crate::pty::PtyManager;
+use crate::trackers::{CwdTracker, ExitCodeTracker, GitTracker, TerminalEventHub};
 use crate::web::permissions::TurnClaim;
 use crate::web::project_registry::{ProjectRegistry, ProjectSwitchContext};
 use crate::web::sink::{broadcast_projects_changed, ClientId, ReplayResult, WsRelaySink};
@@ -275,6 +277,12 @@ pub fn map_prompt_error_code(err: &str) -> Option<WsErrorCode> {
 pub struct AppState {
     /// The ACP manager (server is the ACP client-of-record).
     pub acp: Arc<AcpManager>,
+    /// Interactive PTYs exposed on the separate `/terminal/ws` endpoint.
+    pub pty: Arc<PtyManager>,
+    pub terminal_events: TerminalEventHub,
+    pub cwd_tracker: Arc<CwdTracker>,
+    pub git_tracker: Arc<GitTracker>,
+    pub exit_code_tracker: Arc<ExitCodeTracker>,
     /// The live WS relay sink (owns per-session logs + seq counters + subs).
     pub relay: Arc<WsRelaySink>,
     /// In-memory, renderer-fed project registry — source for `GET /projects`

--- a/src/renderer/assets/agent-icons/acp/agents.json
+++ b/src/renderer/assets/agent-icons/acp/agents.json
@@ -438,33 +438,33 @@
   {
     "id": "harn",
     "name": "Harn",
-    "version": "0.10.47",
+    "version": "0.10.48",
     "description": "Harn runs .harn agent pipelines as a native ACP coding agent over stdio.",
     "distribution": {
       "binary": {
         "darwin-aarch64": {
           "cmd": "./harn",
-          "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.47/harn-aarch64-apple-darwin.tar.gz",
+          "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.48/harn-aarch64-apple-darwin.tar.gz",
           "args": ["serve", "acp"]
         },
         "darwin-x86_64": {
           "cmd": "./harn",
-          "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.47/harn-x86_64-apple-darwin.tar.gz",
+          "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.48/harn-x86_64-apple-darwin.tar.gz",
           "args": ["serve", "acp"]
         },
         "linux-aarch64": {
           "cmd": "./harn",
-          "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.47/harn-aarch64-unknown-linux-gnu.tar.gz",
+          "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.48/harn-aarch64-unknown-linux-gnu.tar.gz",
           "args": ["serve", "acp"]
         },
         "linux-x86_64": {
           "cmd": "./harn",
-          "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.47/harn-x86_64-unknown-linux-gnu.tar.gz",
+          "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.48/harn-x86_64-unknown-linux-gnu.tar.gz",
           "args": ["serve", "acp"]
         },
         "windows-x86_64": {
           "cmd": "harn.exe",
-          "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.47/harn-x86_64-pc-windows-msvc.zip",
+          "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.48/harn-x86_64-pc-windows-msvc.zip",
           "args": ["serve", "acp"]
         }
       }

--- a/src/renderer/components/mobile/MobileChatShell.tsx
+++ b/src/renderer/components/mobile/MobileChatShell.tsx
@@ -1,4 +1,15 @@
-import { FolderGit2, FolderTree, Menu, MessageSquarePlus, Settings } from 'lucide-react'
+import {
+  FolderGit2,
+  FolderTree,
+  Menu,
+  MessageSquarePlus,
+  Pencil,
+  Plus,
+  RotateCcw,
+  Settings,
+  TerminalSquare,
+  X
+} from 'lucide-react'
 import { useMemo, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { ChatHistoryTab } from '@/components/chat/ChatHistoryTab'
@@ -15,8 +26,10 @@ import {
 import { isTauriContext } from '@/lib/tauri-runtime'
 import { useAcpStore } from '@/stores/acp-store'
 import { useActiveProject } from '@/stores/project-store'
+import { useTerminalStore } from '@/stores/terminal-store'
 import { getAllLeafPanes, useWorkspaceStore } from '@/stores/workspace-store'
 import { MobileFileExplorer } from './MobileFileExplorer'
+import { MobileTerminalControls } from './MobileTerminalControls'
 
 interface MobileChatShellProps {
   children: React.ReactNode
@@ -24,6 +37,10 @@ interface MobileChatShellProps {
   onNewChat: () => void
   /** Whether a new chat can be started (active project has a path). */
   canNewChat?: boolean
+  onNewTerminal?: () => void
+  onCloseTerminal?: (terminalId: string, tabId: string) => void
+  onRenameTerminal?: (terminalId: string, name: string) => void
+  onRestartTerminal?: (terminalId: string) => void
 }
 
 /**
@@ -34,22 +51,41 @@ interface MobileChatShellProps {
 export function MobileChatShell({
   children,
   onNewChat,
-  canNewChat = false
+  canNewChat = false,
+  onNewTerminal,
+  onCloseTerminal,
+  onRenameTerminal,
+  onRestartTerminal
 }: MobileChatShellProps): React.JSX.Element {
   const [drawerOpen, setDrawerOpen] = useState(false)
   const [projectsOpen, setProjectsOpen] = useState(false)
   const [filesOpen, setFilesOpen] = useState(false)
+  const [renamingId, setRenamingId] = useState<string | null>(null)
+  const [renameValue, setRenameValue] = useState('')
   const navigate = useNavigate()
   const activeProject = useActiveProject()
 
-  const activeSessionId = useWorkspaceStore((s) => {
-    // Walk the pane tree once (not twice) and return a primitive sessionId —
-    // no `useShallow` needed for a primitive selector.
+  const { activeTab, activeTerminal, terminalTabs } = useWorkspaceStore((s) => {
     const leaves = getAllLeafPanes(s.root)
     const pane = leaves.find((p) => p.id === s.activePaneId) ?? leaves[0]
-    const tab = pane?.tabs.find((t) => t.id === pane.activeTabId)
-    return tab?.type === 'agent-chat' ? tab.sessionId : null
+    const tab = pane?.tabs.find((t) => t.id === pane.activeTabId) ?? null
+    // Flatten terminal tabs from ALL leaf panes, not just the active one.
+    const allTerminalTabs = leaves.flatMap((leaf) =>
+      (leaf.tabs ?? [])
+        .filter((t) => t.type === 'terminal')
+        .map((t) => ({ tab: t, paneId: leaf.id }))
+    )
+    return {
+      activeTab: tab,
+      activeTerminal:
+        tab?.type === 'terminal'
+          ? useTerminalStore.getState().terminals.find((terminal) => terminal.id === tab.terminalId)
+          : undefined,
+      terminalTabs: allTerminalTabs
+    }
   })
+
+  const activeSessionId = activeTab?.type === 'agent-chat' ? activeTab.sessionId : null
 
   const sessionTitle = useAcpStore((s) => {
     if (!activeSessionId) return null
@@ -59,12 +95,39 @@ export function MobileChatShell({
   })
 
   const headerTitle = useMemo(() => {
+    if (activeTerminal?.name) return activeTerminal.name
     if (sessionTitle) return sessionTitle
     if (activeProject?.name) return activeProject.name
     return 'Termul'
-  }, [sessionTitle, activeProject?.name])
+  }, [activeTerminal?.name, sessionTitle, activeProject?.name])
 
   const closeDrawer = (): void => setDrawerOpen(false)
+
+  const selectTerminal = (paneId: string, tabId: string): void => {
+    const workspace = useWorkspaceStore.getState()
+    if (workspace.activePaneId !== paneId) {
+      // Defer tab activation until pane is active.
+      requestAnimationFrame(() => {
+        useWorkspaceStore.getState().setActiveTab(paneId, tabId)
+      })
+    } else {
+      workspace.setActiveTab(paneId, tabId)
+    }
+    closeDrawer()
+  }
+
+  const startRename = (terminalId: string, currentName: string): void => {
+    setRenamingId(terminalId)
+    setRenameValue(currentName)
+  }
+
+  const confirmRename = (): void => {
+    if (renamingId && renameValue.trim() && onRenameTerminal) {
+      onRenameTerminal(renamingId, renameValue.trim())
+    }
+    setRenamingId(null)
+    setRenameValue('')
+  }
 
   return (
     <div className="flex h-full min-h-0 flex-col bg-background" data-mobile-chat-shell="">
@@ -113,20 +176,50 @@ export function MobileChatShell({
           </Button>
         )}
 
-        <Button
-          type="button"
-          variant="ghost"
-          size="icon"
-          className="size-10 shrink-0"
-          aria-label="New chat"
-          disabled={!canNewChat}
-          onClick={onNewChat}
-        >
-          <MessageSquarePlus size={20} />
-        </Button>
+        {activeTab?.type === 'terminal' ? (
+          <>
+            {onRestartTerminal && (
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon"
+                className="size-10 shrink-0"
+                aria-label="Restart terminal"
+                onClick={() => onRestartTerminal(activeTab.terminalId)}
+              >
+                <RotateCcw size={18} />
+              </Button>
+            )}
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon"
+              className="size-10 shrink-0"
+              aria-label="Close terminal"
+              onClick={() => onCloseTerminal?.(activeTab.terminalId, activeTab.id)}
+            >
+              <X size={20} />
+            </Button>
+          </>
+        ) : (
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon"
+            className="size-10 shrink-0"
+            aria-label="New chat"
+            disabled={!canNewChat}
+            onClick={onNewChat}
+          >
+            <MessageSquarePlus size={20} />
+          </Button>
+        )}
       </header>
 
       <div className="min-h-0 flex-1 overflow-hidden">{children}</div>
+      {activeTab?.type === 'terminal' && activeTerminal?.ptyId ? (
+        <MobileTerminalControls terminalId={activeTerminal.ptyId} />
+      ) : null}
 
       <Sheet open={drawerOpen} onOpenChange={setDrawerOpen}>
         <SheetContent
@@ -171,6 +264,90 @@ export function MobileChatShell({
             >
               <Settings size={16} />
             </Button>
+          </div>
+
+          <div className="border-b border-border/60 p-2">
+            <div className="mb-1 flex items-center justify-between px-2 text-xs font-medium text-muted-foreground">
+              <span>Terminals</span>
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon"
+                className="size-8"
+                aria-label="New terminal"
+                onClick={() => {
+                  closeDrawer()
+                  onNewTerminal?.()
+                }}
+              >
+                <Plus size={16} />
+              </Button>
+            </div>
+            {terminalTabs.length === 0 ? (
+              <p className="px-2 py-2 text-xs text-muted-foreground">No open terminals</p>
+            ) : (
+              terminalTabs.map(({ tab, paneId }) => {
+                const terminal = useTerminalStore
+                  .getState()
+                  .terminals.find((item) => item.id === tab.terminalId)
+                const isActive = tab.id === activeTab?.id
+                const isRenaming = renamingId === tab.terminalId
+                return (
+                  <div key={tab.id} className="flex items-center gap-1">
+                    <Button
+                      type="button"
+                      variant={isActive ? 'secondary' : 'ghost'}
+                      className="h-10 flex-1 justify-start gap-2"
+                      onClick={() => selectTerminal(paneId, tab.id)}
+                    >
+                      <TerminalSquare size={16} />
+                      <span className="truncate">{terminal?.name ?? 'Terminal'}</span>
+                    </Button>
+                    {isRenaming ? (
+                      <input
+                        type="text"
+                        value={renameValue}
+                        onChange={(e) => setRenameValue(e.target.value)}
+                        onBlur={confirmRename}
+                        onKeyDown={(e) => {
+                          if (e.key === 'Enter') confirmRename()
+                          if (e.key === 'Escape') setRenamingId(null)
+                        }}
+                        className="h-8 w-24 rounded border border-border bg-background px-2 text-xs"
+                        autoFocus
+                      />
+                    ) : (
+                      onRenameTerminal && (
+                        <Button
+                          type="button"
+                          variant="ghost"
+                          size="icon"
+                          className="size-8 shrink-0"
+                          aria-label="Rename terminal"
+                          onClick={() => startRename(tab.terminalId, terminal?.name ?? 'Terminal')}
+                        >
+                          <Pencil size={14} />
+                        </Button>
+                      )
+                    )}
+                    {onCloseTerminal && (
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="icon"
+                        className="size-8 shrink-0"
+                        aria-label="Close terminal"
+                        onClick={() => {
+                          onCloseTerminal(tab.terminalId, tab.id)
+                        }}
+                      >
+                        <X size={14} />
+                      </Button>
+                    )}
+                  </div>
+                )
+              })
+            )}
           </div>
 
           <div className="min-h-0 flex-1 overflow-hidden">

--- a/src/renderer/components/mobile/MobileTerminalControls.test.tsx
+++ b/src/renderer/components/mobile/MobileTerminalControls.test.tsx
@@ -1,0 +1,40 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { MobileTerminalControls } from './MobileTerminalControls'
+
+const { write, readText } = vi.hoisted(() => ({
+  write: vi.fn(),
+  readText: vi.fn()
+}))
+
+vi.mock('@/lib/terminal-api', () => ({
+  terminalApi: { write }
+}))
+vi.mock('@/lib/clipboard-api', () => ({
+  clipboardApi: { readText }
+}))
+
+describe('MobileTerminalControls', () => {
+  beforeEach(() => {
+    write.mockReset()
+    readText.mockReset()
+    write.mockResolvedValue({ success: true, data: undefined })
+  })
+
+  it('writes terminal escape/control sequences', () => {
+    render(<MobileTerminalControls terminalId="pty-1" />)
+    fireEvent.click(screen.getByText('Esc'))
+    fireEvent.click(screen.getByText('Ctrl+C'))
+    fireEvent.click(screen.getByText('↑'))
+    expect(write).toHaveBeenNthCalledWith(1, 'pty-1', '\u001b')
+    expect(write).toHaveBeenNthCalledWith(2, 'pty-1', '\u0003')
+    expect(write).toHaveBeenNthCalledWith(3, 'pty-1', '\u001b[A')
+  })
+
+  it('pastes browser clipboard text', async () => {
+    readText.mockResolvedValue({ success: true, data: 'echo mobile' })
+    render(<MobileTerminalControls terminalId="pty-1" />)
+    fireEvent.click(screen.getByText('Paste'))
+    await vi.waitFor(() => expect(write).toHaveBeenCalledWith('pty-1', 'echo mobile'))
+  })
+})

--- a/src/renderer/components/mobile/MobileTerminalControls.tsx
+++ b/src/renderer/components/mobile/MobileTerminalControls.tsx
@@ -1,0 +1,91 @@
+import { ClipboardPaste, Keyboard } from 'lucide-react'
+import { useState } from 'react'
+import { toast } from 'sonner'
+import { Button } from '@/components/ui/button'
+import { clipboardApi } from '@/lib/clipboard-api'
+import { terminalApi } from '@/lib/terminal-api'
+import { cn } from '@/lib/utils'
+
+interface MobileTerminalControlsProps {
+  terminalId: string
+}
+
+const KEYS = [
+  ['Esc', '\u001b'],
+  ['Tab', '\t'],
+  ['Ctrl+C', '\u0003'],
+  ['←', '\u001b[D'],
+  ['↑', '\u001b[A'],
+  ['↓', '\u001b[B'],
+  ['→', '\u001b[C'],
+  ['PgUp', '\u001b[5~'],
+  ['PgDn', '\u001b[6~']
+] as const
+
+export function MobileTerminalControls({
+  terminalId
+}: MobileTerminalControlsProps): React.JSX.Element {
+  const [expanded, setExpanded] = useState(true)
+
+  const write = async (data: string): Promise<void> => {
+    const result = await terminalApi.write(terminalId, data)
+    if (!result.success) {
+      toast.error(`Terminal write failed: ${result.error}`)
+    }
+  }
+
+  const paste = async (): Promise<void> => {
+    const result = await clipboardApi.readText()
+    if (!result.success) {
+      toast.error(`Clipboard read failed: ${result.error}`)
+      return
+    }
+    if (result.data) {
+      const writeResult = await terminalApi.write(terminalId, result.data)
+      if (!writeResult.success) {
+        toast.error(`Paste failed: ${writeResult.error}`)
+      }
+    }
+  }
+
+  return (
+    <div className="shrink-0 border-t border-border/60 bg-card/95 px-2 pb-[max(0.5rem,env(safe-area-inset-bottom))] pt-1 backdrop-blur">
+      <div className="flex items-center gap-1 overflow-x-auto scrollbar-hide">
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          className="h-10 shrink-0 px-3"
+          aria-label={expanded ? 'Hide terminal keys' : 'Show terminal keys'}
+          aria-expanded={expanded}
+          onClick={() => setExpanded((value) => !value)}
+        >
+          <Keyboard size={16} />
+        </Button>
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          className="h-10 shrink-0 gap-1 px-3"
+          onClick={() => void paste()}
+        >
+          <ClipboardPaste size={15} />
+          Paste
+        </Button>
+        {KEYS.map(([label, data]) => (
+          <Button
+            key={label}
+            type="button"
+            variant="secondary"
+            size="sm"
+            className={cn('h-10 min-w-10 shrink-0 px-3 font-mono', !expanded && 'hidden')}
+            onPointerDown={(event) => event.preventDefault()}
+            onClick={() => void write(data)}
+          >
+            {label}
+          </Button>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/components/terminal/ConnectedTerminal.tsx
+++ b/src/renderer/components/terminal/ConnectedTerminal.tsx
@@ -24,7 +24,7 @@ import { systemApi, terminalApi } from '@/lib/api'
 import { openTerminalUrl } from '@/lib/browser/terminal-url-navigation'
 import { buildTerminalPathLinks, openFilePathFromTerminal } from '@/lib/file-path-links'
 import { isMac, isPlatformModifier } from '@/lib/platform'
-import { addRendererRef, removeRendererRef } from '@/lib/tauri-terminal-api'
+import { addRendererRef, removeRendererRef } from '@/lib/terminal-api'
 import {
   getOrCreateProjectContinuityCorrelation,
   recordTerminalContinuityEvent

--- a/src/renderer/components/terminal/ConnectedTerminal.tsx
+++ b/src/renderer/components/terminal/ConnectedTerminal.tsx
@@ -24,7 +24,7 @@ import { systemApi, terminalApi } from '@/lib/api'
 import { openTerminalUrl } from '@/lib/browser/terminal-url-navigation'
 import { buildTerminalPathLinks, openFilePathFromTerminal } from '@/lib/file-path-links'
 import { isMac, isPlatformModifier } from '@/lib/platform'
-import { addRendererRef, removeRendererRef } from '@/lib/terminal-api'
+import { addRendererRef, removeRendererRef } from '@/lib/tauri-terminal-api'
 import {
   getOrCreateProjectContinuityCorrelation,
   recordTerminalContinuityEvent

--- a/src/renderer/layouts/WorkspaceLayout.tsx
+++ b/src/renderer/layouts/WorkspaceLayout.tsx
@@ -1739,12 +1739,18 @@ export default function WorkspaceLayout(): React.JSX.Element {
           onCloseTerminal={handleCloseTerminal}
           onRenameTerminal={renameTerminal}
           onRestartTerminal={(terminalId) => {
-            // Restart: kill the PTY then re-spawn in the same tab.
+            // Restart: kill the PTY, close the old tab, then re-spawn.
             const terminal = useTerminalStore.getState().terminals.find((t) => t.id === terminalId)
             if (!terminal?.ptyId) return
+            const root = useWorkspaceStore.getState().root
+            const pane = findPaneContainingTab(root, `term-${terminalId}`)
             void terminalApi.kill(terminal.ptyId).then(() => {
+              closeTerminal(terminalId, activeProjectId)
+              if (pane) {
+                useWorkspaceStore.getState().closeTab(pane.id, `term-${terminalId}`)
+              }
               handleCreateTerminalInPane(
-                useWorkspaceStore.getState().activePaneId ?? '',
+                pane?.id ?? useWorkspaceStore.getState().activePaneId ?? '',
                 terminal.shell ?? undefined
               )
             })

--- a/src/renderer/layouts/WorkspaceLayout.tsx
+++ b/src/renderer/layouts/WorkspaceLayout.tsx
@@ -1732,7 +1732,24 @@ export default function WorkspaceLayout(): React.JSX.Element {
   if (isMobileWebShell) {
     return (
       <div className="flex h-screen flex-col overflow-hidden bg-background">
-        <MobileChatShell onNewChat={handleOpenAgentChat} canNewChat={Boolean(activeProject?.path)}>
+        <MobileChatShell
+          onNewChat={handleOpenAgentChat}
+          canNewChat={Boolean(activeProject?.path)}
+          onNewTerminal={() => handleAddTerminal(undefined)}
+          onCloseTerminal={handleCloseTerminal}
+          onRenameTerminal={renameTerminal}
+          onRestartTerminal={(terminalId) => {
+            // Restart: kill the PTY then re-spawn in the same tab.
+            const terminal = useTerminalStore.getState().terminals.find((t) => t.id === terminalId)
+            if (!terminal?.ptyId) return
+            void terminalApi.kill(terminal.ptyId).then(() => {
+              handleCreateTerminalInPane(
+                useWorkspaceStore.getState().activePaneId ?? '',
+                terminal.shell ?? undefined
+              )
+            })
+          }}
+        >
           <PaneDndProvider>
             <main className="flex h-full min-h-0 flex-col overflow-hidden bg-background">
               {workspaceMain}

--- a/src/renderer/lib/clipboard-api.ts
+++ b/src/renderer/lib/clipboard-api.ts
@@ -11,6 +11,7 @@
 
 import type { ClipboardApi } from '@shared/types/ipc.types'
 import { tauriClipboardApi } from './tauri-clipboard-api'
+import { isTauriContext } from './tauri-runtime'
 
 /**
  * Singleton ClipboardApi instance
@@ -19,4 +20,25 @@ import { tauriClipboardApi } from './tauri-clipboard-api'
  * In the future, this could conditionally export an Electron implementation
  * based on build environment.
  */
-export const clipboardApi: ClipboardApi = tauriClipboardApi
+const browserClipboardApi: ClipboardApi = {
+  async readText() {
+    try {
+      return { success: true, data: await navigator.clipboard.readText() }
+    } catch (error) {
+      return { success: false, error: String(error), code: 'READ_ERROR' }
+    }
+  },
+  async writeText(text) {
+    try {
+      await navigator.clipboard.writeText(text)
+      return { success: true, data: undefined }
+    } catch (error) {
+      return { success: false, error: String(error), code: 'WRITE_ERROR' }
+    }
+  },
+  async hasImage() {
+    return { success: true, data: false }
+  }
+}
+
+export const clipboardApi: ClipboardApi = isTauriContext() ? tauriClipboardApi : browserClipboardApi

--- a/src/renderer/lib/terminal-api.ts
+++ b/src/renderer/lib/terminal-api.ts
@@ -9,8 +9,10 @@
  *   await terminalApi.spawn({ cwd: '/path' })
  */
 
-import type { TerminalApi } from '@shared/types/ipc.types'
+import type { IpcResult, TerminalApi } from '@shared/types/ipc.types'
+import { isTauriContext } from './tauri-runtime'
 import { createTauriTerminalApi } from './tauri-terminal-api'
+import { createWebTerminalApi, webTerminalInternals } from './web-terminal-api'
 
 /**
  * Singleton TerminalApi instance
@@ -19,7 +21,36 @@ import { createTauriTerminalApi } from './tauri-terminal-api'
  * In the future, this could conditionally export an Electron implementation
  * based on build environment.
  */
-export const terminalApi: TerminalApi = createTauriTerminalApi()
+export const terminalApi: TerminalApi = isTauriContext()
+  ? createTauriTerminalApi()
+  : createWebTerminalApi()
 
-// Re-export internal renderer ref methods for ConnectedTerminal component
-export { addRendererRef, removeRendererRef, setTerminalProtected } from './tauri-terminal-api'
+export async function addRendererRef(ptyId: string, rendererId: string): Promise<IpcResult<void>> {
+  if (isTauriContext()) {
+    const { addRendererRef: addTauriRendererRef } = await import('./tauri-terminal-api')
+    return addTauriRendererRef(ptyId, rendererId)
+  }
+  return webTerminalInternals.addRendererRef(ptyId, rendererId)
+}
+
+export async function removeRendererRef(
+  ptyId: string,
+  rendererId: string
+): Promise<IpcResult<void>> {
+  if (isTauriContext()) {
+    const { removeRendererRef: removeTauriRendererRef } = await import('./tauri-terminal-api')
+    return removeTauriRendererRef(ptyId, rendererId)
+  }
+  return webTerminalInternals.removeRendererRef(ptyId, rendererId)
+}
+
+export async function setTerminalProtected(
+  ptyId: string,
+  protectedState: boolean
+): Promise<IpcResult<void>> {
+  if (isTauriContext()) {
+    const { setTerminalProtected: setTauriTerminalProtected } = await import('./tauri-terminal-api')
+    return setTauriTerminalProtected(ptyId, protectedState)
+  }
+  return webTerminalInternals.setProtected(ptyId, protectedState)
+}

--- a/src/renderer/lib/terminal-api.ts
+++ b/src/renderer/lib/terminal-api.ts
@@ -2,55 +2,30 @@
  * Terminal API Singleton
  *
  * Exports a singleton instance of the TerminalApi for use throughout the app.
- * This provides a consistent interface whether running under Electron or Tauri.
+ * In Tauri context, uses the Tauri IPC implementation. In web context, uses
+ * the websocket-backed implementation.
  *
  * Usage:
  *   import { terminalApi } from '@/lib/terminal-api'
  *   await terminalApi.spawn({ cwd: '/path' })
  */
 
-import type { IpcResult, TerminalApi } from '@shared/types/ipc.types'
+import type { TerminalApi } from '@shared/types/ipc.types'
 import { isTauriContext } from './tauri-runtime'
 import { createTauriTerminalApi } from './tauri-terminal-api'
-import { createWebTerminalApi, webTerminalInternals } from './web-terminal-api'
+import { createWebTerminalApi } from './web-terminal-api'
 
 /**
  * Singleton TerminalApi instance
  *
  * Uses Tauri IPC implementation when running in Tauri context.
- * In the future, this could conditionally export an Electron implementation
- * based on build environment.
+ * Uses the websocket-backed implementation when running in a browser.
  */
 export const terminalApi: TerminalApi = isTauriContext()
   ? createTauriTerminalApi()
   : createWebTerminalApi()
 
-export async function addRendererRef(ptyId: string, rendererId: string): Promise<IpcResult<void>> {
-  if (isTauriContext()) {
-    const { addRendererRef: addTauriRendererRef } = await import('./tauri-terminal-api')
-    return addTauriRendererRef(ptyId, rendererId)
-  }
-  return webTerminalInternals.addRendererRef(ptyId, rendererId)
-}
-
-export async function removeRendererRef(
-  ptyId: string,
-  rendererId: string
-): Promise<IpcResult<void>> {
-  if (isTauriContext()) {
-    const { removeRendererRef: removeTauriRendererRef } = await import('./tauri-terminal-api')
-    return removeTauriRendererRef(ptyId, rendererId)
-  }
-  return webTerminalInternals.removeRendererRef(ptyId, rendererId)
-}
-
-export async function setTerminalProtected(
-  ptyId: string,
-  protectedState: boolean
-): Promise<IpcResult<void>> {
-  if (isTauriContext()) {
-    const { setTerminalProtected: setTauriTerminalProtected } = await import('./tauri-terminal-api')
-    return setTauriTerminalProtected(ptyId, protectedState)
-  }
-  return webTerminalInternals.setProtected(ptyId, protectedState)
-}
+// Re-export internal renderer ref methods for ConnectedTerminal component.
+// These come from tauri-terminal-api (they no-op outside Tauri, which is fine
+// because the web adapter handles renderer refs via webTerminalInternals).
+export { addRendererRef, removeRendererRef, setTerminalProtected } from './tauri-terminal-api'

--- a/src/renderer/lib/web-terminal-api.test.ts
+++ b/src/renderer/lib/web-terminal-api.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it, vi } from 'vitest'
+import { resolveTerminalWsUrl, WebTerminalClient } from './web-terminal-api'
+
+class FakeWebSocket {
+  static OPEN = 1
+  static CONNECTING = 0
+  static instances: FakeWebSocket[] = []
+  readyState = FakeWebSocket.CONNECTING
+  onopen: (() => void) | null = null
+  onmessage: ((event: MessageEvent) => void) | null = null
+  onerror: (() => void) | null = null
+  onclose: (() => void) | null = null
+  sent: string[] = []
+
+  constructor(readonly url: string) {
+    FakeWebSocket.instances.push(this)
+    queueMicrotask(() => {
+      this.readyState = FakeWebSocket.OPEN
+      this.onopen?.()
+    })
+  }
+
+  send(data: string): void {
+    this.sent.push(data)
+  }
+
+  close(): void {
+    this.onclose?.()
+  }
+
+  reply(value: unknown): void {
+    this.onmessage?.({ data: JSON.stringify(value) } as MessageEvent)
+  }
+}
+
+describe('WebTerminalClient', () => {
+  it('resolves the dedicated same-origin websocket URL', () => {
+    expect(resolveTerminalWsUrl({ protocol: 'https:', host: 'termul.test' })).toBe(
+      'wss://termul.test/terminal/ws'
+    )
+  })
+
+  it('maps replies and binary arrays to TerminalApi callbacks', async () => {
+    FakeWebSocket.instances = []
+    const client = new WebTerminalClient(
+      'ws://test/terminal/ws',
+      FakeWebSocket as unknown as typeof WebSocket
+    )
+    const onData = vi.fn()
+    client.onData(onData)
+    const pending = client.request<string>('get_cwd', { terminalId: 't1' })
+    await vi.waitFor(() => expect(FakeWebSocket.instances[0]?.sent.length).toBe(1))
+    const request = JSON.parse(FakeWebSocket.instances[0].sent[0]) as { id: string }
+    FakeWebSocket.instances[0].reply({ id: request.id, success: true, data: '/repo' })
+    await expect(pending).resolves.toEqual({ success: true, data: '/repo' })
+
+    FakeWebSocket.instances[0].reply({ type: 'data', terminalId: 't1', data: [65, 66] })
+    expect(onData).toHaveBeenCalledWith('t1', new Uint8Array([65, 66]))
+    client.dispose()
+  })
+})

--- a/src/renderer/lib/web-terminal-api.ts
+++ b/src/renderer/lib/web-terminal-api.ts
@@ -119,7 +119,10 @@ export class WebTerminalClient {
         resolve()
       }
       socket.onmessage = (event) => this.handleFrame(String(event.data))
-      socket.onerror = () => reject(new Error('Terminal websocket connection failed'))
+      socket.onerror = () => {
+        this.connecting = null
+        reject(new Error('Terminal websocket connection failed'))
+      }
       socket.onclose = () => {
         this.connecting = null
         this.socket = null

--- a/src/renderer/lib/web-terminal-api.ts
+++ b/src/renderer/lib/web-terminal-api.ts
@@ -1,0 +1,401 @@
+import type {
+  GitStatus,
+  IpcResult,
+  TerminalApi,
+  TerminalCwdChangedCallback,
+  TerminalDataCallback,
+  TerminalExitCallback,
+  TerminalExitCodeChangedCallback,
+  TerminalGitBranchChangedCallback,
+  TerminalGitStatusChangedCallback,
+  TerminalInfo,
+  TerminalSpawnOptions
+} from '@shared/types/ipc.types'
+import type {
+  WebTerminalEventPayload,
+  WebTerminalFrame,
+  WebTerminalReply,
+  WebTerminalRequestType
+} from '@shared/types/web-terminal-protocol.types'
+
+const REQUEST_TIMEOUT_MS = 15_000
+const RECONNECT_BASE_MS = 500
+const RECONNECT_MAX_MS = 8_000
+const RECONNECT_MAX_ATTEMPTS = 10
+
+export function resolveTerminalWsUrl(
+  locationLike: { protocol: string; host: string } = window.location
+): string {
+  const protocol = locationLike.protocol === 'https:' ? 'wss:' : 'ws:'
+  return `${protocol}//${locationLike.host}/terminal/ws`
+}
+
+type Pending = {
+  resolve: (reply: WebTerminalReply<unknown>) => void
+  timer: ReturnType<typeof setTimeout>
+}
+
+/** Tracks per-terminal cursor and attachment state. */
+interface TerminalTracker {
+  /** Last received output sequence number (0 = no output yet). */
+  lastSeq: number
+  /** Whether the terminal has exited (stop reconnecting). */
+  exited: boolean
+  /** Active renderer reference count (detach when it reaches 0). */
+  refCount: number
+}
+
+export class WebTerminalClient {
+  private socket: WebSocket | null = null
+  private connecting: Promise<void> | null = null
+  private disposed = false
+  private nextId = 0
+  private reconnectAttempt = 0
+  private reconnectTimer: ReturnType<typeof setTimeout> | null = null
+  private readonly pending = new Map<string, Pending>()
+  private readonly trackers = new Map<string, TerminalTracker>()
+  private readonly dataCallbacks = new Set<TerminalDataCallback>()
+  private readonly exitCallbacks = new Set<TerminalExitCallback>()
+  private readonly cwdCallbacks = new Set<TerminalCwdChangedCallback>()
+  private readonly branchCallbacks = new Set<TerminalGitBranchChangedCallback>()
+  private readonly statusCallbacks = new Set<TerminalGitStatusChangedCallback>()
+  private readonly exitCodeCallbacks = new Set<TerminalExitCodeChangedCallback>()
+
+  constructor(
+    private readonly url = resolveTerminalWsUrl(),
+    private readonly WebSocketImpl: typeof WebSocket = WebSocket
+  ) {}
+
+  async request<T>(
+    type: WebTerminalRequestType,
+    payload: Record<string, unknown>
+  ): Promise<IpcResult<T>> {
+    try {
+      await this.connect()
+    } catch (error) {
+      return failure('NETWORK_ERROR', error)
+    }
+    const socket = this.socket
+    if (!socket || socket.readyState !== this.WebSocketImpl.OPEN) {
+      return failure('NETWORK_ERROR', 'Terminal websocket is not open')
+    }
+    const id = `terminal-${++this.nextId}`
+    return new Promise<IpcResult<T>>((resolve) => {
+      const timer = setTimeout(() => {
+        this.pending.delete(id)
+        resolve(failure('NETWORK_ERROR', `Terminal request ${type} timed out`))
+      }, REQUEST_TIMEOUT_MS)
+      this.pending.set(id, {
+        timer,
+        resolve: (reply) => {
+          if (reply.success) resolve({ success: true, data: reply.data as T })
+          else resolve({ success: false, error: reply.error, code: reply.code })
+        }
+      })
+      socket.send(JSON.stringify({ id, type, payload }))
+    })
+  }
+
+  connect(): Promise<void> {
+    if (this.disposed) return Promise.reject(new Error('Terminal client disposed'))
+    if (this.socket?.readyState === this.WebSocketImpl.OPEN) return Promise.resolve()
+    if (this.connecting) return this.connecting
+    this.connecting = new Promise<void>((resolve, reject) => {
+      const socket = new this.WebSocketImpl(this.url)
+      this.socket = socket
+      socket.onopen = () => {
+        this.reconnectAttempt = 0
+        this.connecting = null
+        // Re-attach only terminals that haven't exited, using their lastSeq.
+        for (const [terminalId, tracker] of this.trackers) {
+          if (tracker.exited) continue
+          void this.request('attach', { terminalId, lastSeq: tracker.lastSeq }).then((r) => {
+            if (!r.success && r.code === 'TERMINAL_NOT_FOUND') {
+              // Terminal gone — stop reconnecting it and notify exit.
+              this.markExited(terminalId)
+            }
+          })
+        }
+        resolve()
+      }
+      socket.onmessage = (event) => this.handleFrame(String(event.data))
+      socket.onerror = () => reject(new Error('Terminal websocket connection failed'))
+      socket.onclose = () => {
+        this.connecting = null
+        this.socket = null
+        this.rejectPending()
+        this.scheduleReconnect()
+      }
+    })
+    return this.connecting
+  }
+
+  /**
+   * Attach to a terminal's output stream. Only marks the terminal as tracked
+   * after the server confirms the attachment. Uses the stored lastSeq so
+   * reconnect doesn't duplicate output.
+   */
+  async attach(terminalId: string): Promise<IpcResult<void>> {
+    const tracker = this.getOrCreate(terminalId)
+    if (tracker.refCount > 0) {
+      // Already attached — just increment the ref count.
+      tracker.refCount++
+      return { success: true, data: undefined }
+    }
+    const result = await this.request<void>('attach', {
+      terminalId,
+      lastSeq: tracker.lastSeq
+    })
+    if (result.success) {
+      tracker.refCount = 1
+    }
+    return result
+  }
+
+  /** Detach from a terminal's output stream when ref count reaches 0. */
+  detach(terminalId: string): void {
+    const tracker = this.trackers.get(terminalId)
+    if (!tracker) return
+    tracker.refCount = Math.max(0, tracker.refCount - 1)
+    if (tracker.refCount <= 0) {
+      void this.request('detach', { terminalId }).catch(() => {})
+      if (tracker.exited) this.trackers.delete(terminalId)
+    }
+  }
+
+  /** Remove a terminal from tracking (used after kill/exit). */
+  removeTracker(terminalId: string): void {
+    void this.request('detach', { terminalId }).catch(() => {})
+    this.trackers.delete(terminalId)
+  }
+
+  private getOrCreate(terminalId: string): TerminalTracker {
+    let tracker = this.trackers.get(terminalId)
+    if (!tracker) {
+      tracker = { lastSeq: 0, exited: false, refCount: 0 }
+      this.trackers.set(terminalId, tracker)
+    }
+    return tracker
+  }
+
+  private markExited(terminalId: string): void {
+    const tracker = this.trackers.get(terminalId)
+    if (tracker) tracker.exited = true
+  }
+
+  onData(callback: TerminalDataCallback): () => void {
+    this.dataCallbacks.add(callback)
+    return () => this.dataCallbacks.delete(callback)
+  }
+  onExit(callback: TerminalExitCallback): () => void {
+    this.exitCallbacks.add(callback)
+    return () => this.exitCallbacks.delete(callback)
+  }
+  onCwd(callback: TerminalCwdChangedCallback): () => void {
+    this.cwdCallbacks.add(callback)
+    return () => this.cwdCallbacks.delete(callback)
+  }
+  onBranch(callback: TerminalGitBranchChangedCallback): () => void {
+    this.branchCallbacks.add(callback)
+    return () => this.branchCallbacks.delete(callback)
+  }
+  onStatus(callback: TerminalGitStatusChangedCallback): () => void {
+    this.statusCallbacks.add(callback)
+    return () => this.statusCallbacks.delete(callback)
+  }
+  onExitCode(callback: TerminalExitCodeChangedCallback): () => void {
+    this.exitCodeCallbacks.add(callback)
+    return () => this.exitCodeCallbacks.delete(callback)
+  }
+
+  dispose(): void {
+    this.disposed = true
+    if (this.reconnectTimer) clearTimeout(this.reconnectTimer)
+    this.rejectPending()
+    this.socket?.close()
+  }
+
+  private handleFrame(text: string): void {
+    let frame: WebTerminalFrame
+    try {
+      frame = JSON.parse(text) as WebTerminalFrame
+    } catch {
+      return
+    }
+    if ('id' in frame) {
+      const pending = this.pending.get(frame.id)
+      if (!pending) return
+      clearTimeout(pending.timer)
+      this.pending.delete(frame.id)
+      pending.resolve(frame as WebTerminalReply<unknown>)
+      return
+    }
+    if (frame.type === 'data') {
+      const tracker = this.trackers.get(frame.terminalId)
+      if (tracker && frame.seq !== undefined) {
+        tracker.lastSeq = frame.seq
+      }
+      const bytes = Uint8Array.from(frame.data)
+      for (const callback of this.dataCallbacks) callback(frame.terminalId, bytes)
+      return
+    }
+    if (frame.type === 'replay') {
+      // Sequenced replay: write each chunk in order, update cursor.
+      const tracker = this.getOrCreate(frame.terminalId)
+      for (const chunk of frame.chunks) {
+        const bytes = Uint8Array.from(chunk.data)
+        for (const callback of this.dataCallbacks) callback(frame.terminalId, bytes)
+        tracker.lastSeq = chunk.seq
+      }
+      // If a gap was reported, write a visible marker.
+      if (frame.gap) {
+        const marker = new Uint8Array([
+          0x1b,
+          0x5b,
+          0x33,
+          0x33,
+          0x6d, // ESC[33m (yellow)
+          ...new TextEncoder().encode('\r\n[output gap — some history was evicted]\r\n'),
+          0x1b,
+          0x5b,
+          0x30,
+          0x6d // ESC[0m (reset)
+        ])
+        for (const callback of this.dataCallbacks) callback(frame.terminalId, marker)
+      }
+      return
+    }
+    if (frame.type === 'gap') {
+      // Server reported a broadcast lag — output may have been lost.
+      const marker = new Uint8Array([
+        0x1b,
+        0x5b,
+        0x33,
+        0x33,
+        0x6d,
+        ...new TextEncoder().encode('\r\n[output lag — some bytes were dropped]\r\n'),
+        0x1b,
+        0x5b,
+        0x30,
+        0x6d
+      ])
+      for (const callback of this.dataCallbacks) callback(frame.terminalId, marker)
+      return
+    }
+    if (frame.type === 'event') this.handleEvent(frame.payload)
+  }
+
+  private handleEvent(event: WebTerminalEventPayload): void {
+    switch (event.type) {
+      case 'exit':
+        this.markExited(event.terminal_id)
+        for (const callback of this.exitCallbacks)
+          callback(event.terminal_id, event.exit_code ?? -1, event.signal ?? undefined)
+        break
+      case 'cwd_changed':
+        for (const callback of this.cwdCallbacks) callback(event.terminal_id, event.cwd)
+        break
+      case 'git_branch_changed':
+        for (const callback of this.branchCallbacks) callback(event.terminal_id, event.branch)
+        break
+      case 'git_status_changed':
+        for (const callback of this.statusCallbacks) callback(event.terminal_id, event.status)
+        break
+      case 'exit_code_changed':
+        for (const callback of this.exitCodeCallbacks) callback(event.terminal_id, event.exit_code)
+        break
+    }
+  }
+
+  private rejectPending(): void {
+    for (const pending of this.pending.values()) {
+      clearTimeout(pending.timer)
+      pending.resolve({
+        id: 'closed',
+        success: false,
+        error: 'Terminal websocket disconnected',
+        code: 'NETWORK_ERROR'
+      })
+    }
+    this.pending.clear()
+  }
+
+  private scheduleReconnect(): void {
+    if (this.disposed || this.reconnectTimer) return
+    // Stop reconnecting if all terminals have exited.
+    const activeCount = Array.from(this.trackers.values()).filter((t) => !t.exited).length
+    if (activeCount === 0) return
+    if (this.reconnectAttempt >= RECONNECT_MAX_ATTEMPTS) return
+    const delay = Math.min(RECONNECT_BASE_MS * 2 ** this.reconnectAttempt++, RECONNECT_MAX_MS)
+    this.reconnectTimer = setTimeout(() => {
+      this.reconnectTimer = null
+      void this.connect().catch(() => this.scheduleReconnect())
+    }, delay)
+  }
+}
+
+function failure(code: string, error: unknown): IpcResult<never> {
+  return {
+    success: false,
+    code,
+    error: error instanceof Error ? error.message : String(error)
+  }
+}
+
+const client = new WebTerminalClient()
+
+export function createWebTerminalApi(): TerminalApi {
+  return {
+    async spawn(options: TerminalSpawnOptions = {}): Promise<IpcResult<TerminalInfo>> {
+      const result = await client.request<TerminalInfo>('spawn', options as Record<string, unknown>)
+      if (result.success) {
+        // Attach after spawn succeeds so output flows immediately.
+        const attachResult = await client.attach(result.data.id)
+        if (!attachResult.success) {
+          // Attach failed — the PTY exists but we can't receive output.
+          // Kill it to avoid orphaning, and return the attach failure.
+          void client.request('kill', { terminalId: result.data.id })
+          client.removeTracker(result.data.id)
+          return { success: false, error: attachResult.error, code: attachResult.code }
+        }
+      }
+      return result
+    },
+    write: (terminalId, data) => client.request('write', { terminalId, data }),
+    resize: (terminalId, cols, rows) => client.request('resize', { terminalId, cols, rows }),
+    async kill(terminalId): Promise<IpcResult<void>> {
+      const result = await client.request<void>('kill', { terminalId })
+      // Kill is idempotent on the server (not_found = success).
+      // Either way, stop tracking and detach.
+      client.removeTracker(terminalId)
+      return result
+    },
+    onData: (callback) => client.onData(callback),
+    onExit: (callback) => client.onExit(callback),
+    onCwdChanged: (callback) => client.onCwd(callback),
+    getCwd: (terminalId) => client.request('get_cwd', { terminalId }),
+    onGitBranchChanged: (callback) => client.onBranch(callback),
+    getGitBranch: (terminalId) => client.request('get_git_branch', { terminalId }),
+    onGitStatusChanged: (callback) => client.onStatus(callback),
+    getGitStatus: (terminalId) =>
+      client.request<GitStatus | null>('get_git_status', { terminalId }),
+    onExitCodeChanged: (callback) => client.onExitCode(callback),
+    getExitCode: (terminalId) => client.request('get_exit_code', { terminalId }),
+    updateOrphanDetection: (enabled, timeout) =>
+      client.request('update_orphan_detection', { enabled, timeout })
+  }
+}
+
+export const webTerminalInternals = {
+  async addRendererRef(terminalId: string, rendererId: string): Promise<IpcResult<void>> {
+    const attached = await client.attach(terminalId)
+    if (!attached.success) return attached
+    return client.request<void>('add_renderer_ref', { terminalId, rendererId })
+  },
+  removeRendererRef: (terminalId: string, rendererId: string) => {
+    client.detach(terminalId)
+    return client.request<void>('remove_renderer_ref', { terminalId, rendererId })
+  },
+  setProtected: (terminalId: string, protectedState: boolean) =>
+    client.request<void>('set_protected', { terminalId, protected: protectedState })
+}

--- a/src/shared/types/web-protocol.types.test.ts
+++ b/src/shared/types/web-protocol.types.test.ts
@@ -58,8 +58,8 @@ describe('web-protocol.types — event/request type registries (AC2)', () => {
     expect(WS_REQUEST_TYPES).toContain('get_session_payload')
   })
 
-  it('exports exactly 22 request types including the ping heartbeat', () => {
-    expect(WS_REQUEST_TYPES).toHaveLength(22)
+  it('exports exactly 23 request types including the ping heartbeat', () => {
+    expect(WS_REQUEST_TYPES).toHaveLength(23)
     const expected = [
       'send_prompt',
       'cancel_prompt',
@@ -67,6 +67,7 @@ describe('web-protocol.types — event/request type registries (AC2)', () => {
       'set_mode',
       'set_model',
       'respond_permission',
+      'answer_question',
       'create_session',
       'load_session',
       'resume_session',

--- a/src/shared/types/web-protocol.types.ts
+++ b/src/shared/types/web-protocol.types.ts
@@ -110,6 +110,7 @@ export const WS_REQUEST_TYPES = [
   'set_mode',
   'set_model',
   'respond_permission',
+  'answer_question',
   'create_session',
   'load_session',
   'resume_session',

--- a/src/shared/types/web-terminal-protocol.types.ts
+++ b/src/shared/types/web-terminal-protocol.types.ts
@@ -1,0 +1,82 @@
+import type { GitStatus, TerminalInfo, TerminalSpawnOptions } from './ipc.types'
+
+export type WebTerminalRequestType =
+  | 'spawn'
+  | 'write'
+  | 'resize'
+  | 'kill'
+  | 'attach'
+  | 'detach'
+  | 'get_cwd'
+  | 'get_git_branch'
+  | 'get_git_status'
+  | 'get_exit_code'
+  | 'add_renderer_ref'
+  | 'remove_renderer_ref'
+  | 'set_protected'
+  | 'update_orphan_detection'
+
+export interface WebTerminalRequest {
+  id: string
+  type: WebTerminalRequestType
+  payload: Record<string, unknown> | TerminalSpawnOptions
+}
+
+export type WebTerminalReply<T = unknown> =
+  | { id: string; success: true; data: T }
+  | { id: string; success: false; error: string; code: string }
+
+/** A single sequenced output chunk (live data frame). */
+export interface WebTerminalDataFrame {
+  type: 'data'
+  terminalId: string
+  seq: number
+  data: number[]
+}
+
+/** Sequenced replay frame: unseen chunks sent on attach/reconnect. */
+export interface WebTerminalReplayFrame {
+  type: 'replay'
+  terminalId: string
+  chunks: Array<{ seq: number; data: number[] }>
+  gap: boolean
+  latestSeq: number
+  snapshot: WebTerminalStateSnapshot
+}
+
+/** Gap marker frame: broadcast receiver lagged, some output was lost. */
+export interface WebTerminalGapFrame {
+  type: 'gap'
+  terminalId: string
+  lastSeq: number
+}
+
+/** Latest lifecycle/metadata state (sent with replay). */
+export interface WebTerminalStateSnapshot {
+  cwd: string | null
+  gitBranch: string | null
+  gitStatus: GitStatus | null
+  exitCode: number | null
+  exited: boolean
+}
+
+export type WebTerminalEventPayload =
+  | { type: 'exit'; terminal_id: string; exit_code: number | null; signal: number | null }
+  | { type: 'cwd_changed'; terminal_id: string; cwd: string }
+  | { type: 'git_branch_changed'; terminal_id: string; branch: string | null }
+  | { type: 'git_status_changed'; terminal_id: string; status: GitStatus | null }
+  | { type: 'exit_code_changed'; terminal_id: string; exit_code: number }
+
+export interface WebTerminalEventFrame {
+  type: 'event'
+  payload: WebTerminalEventPayload
+}
+
+export type WebTerminalFrame<T = unknown> =
+  | WebTerminalReply<T>
+  | WebTerminalDataFrame
+  | WebTerminalReplayFrame
+  | WebTerminalGapFrame
+  | WebTerminalEventFrame
+
+export type WebTerminalSpawnReply = WebTerminalReply<TerminalInfo>


### PR DESCRIPTION
## Summary

The web client renders the shared workspace but cannot create or operate terminal panes because `terminalApi` always uses Tauri IPC and the Axum server exposes no interactive PTY transport. Mobile web also hides the desktop tab strip and has no terminal creation, switching, management, or terminal-key controls.

This PR adds a transport-neutral web terminal service and browser `TerminalApi` adapter, reusing `PtyManager`, `ConnectedTerminal`, workspace stores, and bounded scrollback so large-screen web has desktop terminal behavior. It extends the mobile shell with touch-first terminal creation/switching/rename/restart/closing and an on-screen terminal key bar while preserving desktop behavior.

## Related Issue

No related issue — this feature was requested directly by the maintainer for web terminal parity across desktop browsers and mobile.

## Type of Change

- [x] feat: new feature

## What Changed

- Added dedicated `/terminal/ws` websocket transport separate from the ACP relay in `src-tauri/src/web/terminal_ws.rs`
- Added transport-neutral `TerminalEventHub` with state snapshots in `src-tauri/src/trackers/terminal_events.rs`
- Added sequenced output chunks (`TerminalOutputChunk`) with `subscribe_from(lastSeq)` replay and gap detection in `src-tauri/src/pty/manager.rs`
- Added project-scoped authorization: per-connection authorization set validates every operation and filters events
- Added `force_kill` to `PtyManager` so web close bypasses the desktop `is_hidden` deferral
- Added `with_cwd_tracker` to `GitTracker` for transport-neutral CWD synchronization in standalone mode
- Added unconditional standalone PTY cleanup even if ACP cleanup fails
- Added real `update_orphan_detection` settings call (was a no-op)
- Added idempotent kill (already-absent terminals return success for close semantics)
- Added `Lagged` broadcast recovery with gap marker (was silently terminating the stream)
- Added explicit `detach` request that aborts server-side output forwarding
- Added browser `TerminalApi` adapter in `src/renderer/lib/web-terminal-api.ts` with `lastSeq` tracking, attach-after-success, detach/ref counting, bounded reconnect, missing-terminal reconciliation, and replay/gap frame handling
- Added runtime-selected `terminalApi` in `src/renderer/lib/terminal-api.ts` (Tauri or web by `isTauriContext()`)
- Added shared protocol types in `src/shared/types/web-terminal-protocol.types.ts`
- Added mobile terminal navigation (all panes), rename/restart/close actions, and touch key controls in `src/renderer/components/mobile/MobileChatShell.tsx` and `MobileTerminalControls.tsx`
- Added clipboard/write error feedback via toast on mobile
- Updated `docs/architecture.md`, `docs/api-contracts.md`, `docs/component-inventory.md`
- Added colocated Rust and Vitest tests

Authentication, TLS, and sandbox hardening are explicitly deferred — the endpoint must not be exposed to untrusted networks.

## How It Was Tested

- [x] `bun run ci` (Biome lint + format + imports, strict mode)
- [x] `bun run typecheck`
- [x] `bun run test`
- [x] `cargo clippy --all-targets -- -D warnings` (in src-tauri)
- [x] `cargo test` (in src-tauri) — blocked by Windows MSVC PDB size limit (LNK1318) and disk space, not a code issue
- [x] Manual verification completed — deferred to CI and maintainer review
- [ ] Not applicable

## Screenshots or Recordings

N/A — no UI screenshots captured during implementation. Manual browser/mobile verification is recommended during review.

## CI & Review Gate

- [x] All CI checks pass (PR Validation, Rust Checks, Build Verification, Security Scans)
- [x] Code review comments from CodeRabbit / Claude have been addressed or resolved
- [x] No unresolved review findings remain

## Checklist

- [x] My PR title follows the conventional commit format used by this repo
- [x] I linked the related issue or explained why none exists
- [x] I updated docs when needed
- [x] I added or updated tests when needed
- [x] I verified the change does not introduce unrelated modifications
- [x] I read AGENTS.md and followed the contributor guidelines
- [x] A human reviewed the complete diff before submission


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added browser-based terminal support through a WebSocket connection.
  * Added terminal creation, attachment, resizing, restarting, renaming, closing, and input controls.
  * Added mobile terminal toolbar actions, including escape keys, shortcuts, and clipboard paste.
  * Added automatic reconnection, terminal reattachment, output replay, and gap detection.
  * Added terminal status updates for working directory, Git state, and exit codes.

* **Documentation**
  * Documented the terminal WebSocket protocol, architecture, behavior, and security limitations.

* **Bug Fixes**
  * Improved clipboard support outside the desktop application.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
