### PR TITLE
fix(web): stop infinite re-render loop in mobile chat shell

### DIFF
--- a/src/renderer/components/mobile/MobileChatShell.tsx
+++ b/src/renderer/components/mobile/MobileChatShell.tsx
@@ -65,25 +65,37 @@ export function MobileChatShell({
   const navigate = useNavigate()
   const activeProject = useActiveProject()
 
-  const { activeTab, activeTerminal, terminalTabs } = useWorkspaceStore((s) => {
+  // Active tab — return the stable Tab object reference held in the store
+  // tree. Stable references compare with Object.is, so no `useShallow` is
+  // needed. Returning a new object/array literal here would make every
+  // getSnapshot() differ and trigger an infinite re-render loop
+  // (React error #185 / Maximum update depth exceeded).
+  const activeTab = useWorkspaceStore((s) => {
     const leaves = getAllLeafPanes(s.root)
     const pane = leaves.find((p) => p.id === s.activePaneId) ?? leaves[0]
-    const tab = pane?.tabs.find((t) => t.id === pane.activeTabId) ?? null
-    // Flatten terminal tabs from ALL leaf panes, not just the active one.
-    const allTerminalTabs = leaves.flatMap((leaf) =>
+    return pane?.tabs.find((t) => t.id === pane.activeTabId) ?? null
+  })
+
+  // Active terminal — subscribe to the terminal store directly (not via
+  // getState() inside the workspace selector) so updates are observed and the
+  // returned reference stays stable across unrelated workspace changes.
+  const activeTerminalId = activeTab?.type === 'terminal' ? activeTab.terminalId : undefined
+  const activeTerminal = useTerminalStore((s) =>
+    activeTerminalId ? s.terminals.find((terminal) => terminal.id === activeTerminalId) : undefined
+  )
+
+  // Terminal tabs across ALL leaf panes. Derive via useMemo from the stable
+  // `root` reference so the wrapper objects are only rebuilt when the tree
+  // actually changes — never on every render (which would re-trigger the loop).
+  const workspaceRoot = useWorkspaceStore((s) => s.root)
+  const terminalTabs = useMemo(() => {
+    const leaves = getAllLeafPanes(workspaceRoot)
+    return leaves.flatMap((leaf) =>
       (leaf.tabs ?? [])
         .filter((t) => t.type === 'terminal')
         .map((t) => ({ tab: t, paneId: leaf.id }))
     )
-    return {
-      activeTab: tab,
-      activeTerminal:
-        tab?.type === 'terminal'
-          ? useTerminalStore.getState().terminals.find((terminal) => terminal.id === tab.terminalId)
-          : undefined,
-      terminalTabs: allTerminalTabs
-    }
-  })
+  }, [workspaceRoot])
 
   const activeSessionId = activeTab?.type === 'agent-chat' ? activeTab.sessionId : null
 


### PR DESCRIPTION
## Summary

The web UI crashed on load with **React error #185 (Maximum update depth exceeded)** — an infinite re-render loop. The root cause is in `MobileChatShell`: a single `useWorkspaceStore` selector returned a brand-new object literal `{ activeTab, activeTerminal, terminalTabs }` on every call, and `terminalTabs` held freshly-allocated `{ tab, paneId }` wrapper objects via `flatMap`+`map`.

Zustand v5 is backed by React 18's `useSyncExternalStore`. On every `getSnapshot()` call it compares the result with `Object.is`. Because the selector returned a new object reference every time, `Object.is` was always `false`, so React triggered a re-render — which called `getSnapshot()` again, got another new reference, and looped forever → React error #185. This was a regression introduced in #499 (web terminal parity).

## Related Issue

No related issue — runtime regression surfaced while checking the web UI; introduced by #499 (web terminal parity).

## Type of Change

- [x] fix: bug fix

## What Changed

- Split the single object-returning `useWorkspaceStore` selector in `MobileChatShell` into three stable-reference subscriptions:
  - `activeTab` — returns the stable `Tab` object held in the store tree. Stable references compare equal with `Object.is`, so no `useShallow` is needed and no new object is allocated per snapshot.
  - `activeTerminal` — subscribes to `useTerminalStore` directly instead of calling `useTerminalStore.getState()` inside the workspace selector. This fixes a secondary cross-store read bug (terminal-store updates were never observed) and keeps the returned reference stable across unrelated workspace changes.
  - `terminalTabs` — derived via `useMemo` from a stable `root` subscription so the `{ tab, paneId }` wrapper objects are rebuilt only when the pane tree actually changes, never on every render.
- No behavior change for desktop/Tauri; only the mobile web shell (`isMobileWebShell`) is affected.

## How It Was Tested

- [x] `bun run ci` (Biome lint + format + imports, strict mode)
- [x] `bun run typecheck`
- [x] `bun run test`
- [x] `cargo clippy --all-targets -- -D warnings` (in src-tauri)
- [ ] `cargo test` (in src-tauri) — see note
- [ ] Manual verification completed

> Note on `cargo test`: the Rust crate compiles cleanly and `cargo clippy --all-targets -- -D warnings` is green. Locally on Windows the test binary fails to *launch* with `0xc0000139 STATUS_ENTRYPOINT_NOT_FOUND` (a native WebView2/DLL runtime-resolution issue), not a test assertion failure. CI runs `cargo test` on `ubuntu-22.04` where this Windows-only DLL issue does not occur. This PR touches zero Rust files — the Rust tree is byte-identical to `origin/dev` (#499, CI-green).

## Screenshots or Recordings

N/A — pure logic fix in a Zustand selector; no visible UI change beyond the crash disappearing.

## CI & Review Gate

- [ ] All CI checks pass (PR Validation, Rust Checks, Build Verification, Security Scans)
- [ ] Code review comments from CodeRabbit / Claude have been addressed or resolved
- [ ] No unresolved review findings remain

## Checklist

- [x] My PR title follows the conventional commit format used by this repo
- [x] I linked the related issue or explained why none exists
- [x] I updated docs when needed
- [x] I added or updated tests when needed
- [x] I verified the change does not introduce unrelated modifications
- [x] I read AGENTS.md and followed the contributor guidelines
- [ ] A human reviewed the complete diff before submission


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved mobile chat stability when switching between workspaces and terminal tabs.
  * Ensured active terminal updates are reflected reliably without unnecessary interface refreshes.
  * Improved terminal tab performance through more efficient state updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->