### PR TITLE
fix(web): carry projectId in terminal spawn so web UI terminals run

### DIFF
--- a/src/renderer/hooks/use-snapshots.test.ts
+++ b/src/renderer/hooks/use-snapshots.test.ts
@@ -1,0 +1,93 @@
+import { renderHook } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { PersistedSnapshot } from '../../shared/types/persistence.types'
+
+const {
+  mockTerminalApiSpawn,
+  mockTerminalApiKill,
+  mockGetSnapshot,
+  mockAddTerminal,
+  mockSetTerminalPtyId,
+  mockCloseTerminal,
+  mockSelectTerminal
+} = vi.hoisted(() => ({
+  mockTerminalApiSpawn: vi.fn(),
+  mockTerminalApiKill: vi.fn(),
+  mockGetSnapshot: vi.fn(),
+  mockAddTerminal: vi.fn(),
+  mockSetTerminalPtyId: vi.fn(),
+  mockCloseTerminal: vi.fn(),
+  mockSelectTerminal: vi.fn()
+}))
+
+const mockTerminalStoreState = {
+  terminals: [] as Array<{ id: string; projectId: string; ptyId?: string }>,
+  closeTerminal: mockCloseTerminal,
+  addTerminal: mockAddTerminal,
+  setTerminalPtyId: mockSetTerminalPtyId,
+  selectTerminal: mockSelectTerminal
+}
+
+const mockProjectState = {
+  activeProjectId: 'proj-1',
+  projects: [{ id: 'proj-1', name: 'Test', path: '/test', envVars: [] }]
+}
+
+vi.mock('@/stores/terminal-store', () => ({
+  useTerminalStore: {
+    getState: () => mockTerminalStoreState
+  }
+}))
+
+vi.mock('@/stores/project-store', () => ({
+  useProjectStore: Object.assign(
+    (selector?: (state: typeof mockProjectState) => unknown) =>
+      selector ? selector(mockProjectState) : mockProjectState,
+    { getState: () => mockProjectState }
+  )
+}))
+
+vi.mock('@/stores/snapshot-store', () => ({
+  useSnapshotActions: () => ({ getSnapshot: mockGetSnapshot }),
+  useSnapshotLoading: () => false,
+  useSnapshots: () => []
+}))
+
+vi.mock('@/lib/api', () => ({
+  terminalApi: { spawn: mockTerminalApiSpawn, kill: mockTerminalApiKill }
+}))
+
+vi.mock('@/lib/env-parser', () => ({
+  resolveEnvForSpawn: () => ({ env: {}, hasProjectEnv: false })
+}))
+
+import { useRestoreSnapshot } from './use-snapshots'
+
+const snapshot: PersistedSnapshot = {
+  id: 'snap-1',
+  projectId: 'proj-1',
+  name: 'Snap',
+  createdAt: '2026-03-09T00:00:00.000Z',
+  terminals: [{ id: 't1', name: 'T1', shell: 'bash', cwd: '/test', scrollback: [] }],
+  activeTerminalId: 't1'
+}
+
+describe('useRestoreSnapshot', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockTerminalStoreState.terminals = []
+    mockTerminalApiSpawn.mockResolvedValue({ success: true, data: { id: 'pty-1' } })
+    mockTerminalApiKill.mockResolvedValue({ success: true, data: undefined })
+    mockGetSnapshot.mockResolvedValue(snapshot)
+    mockAddTerminal.mockReturnValue({ id: 'term-1' })
+  })
+
+  it('passes projectId into the spawn payload (web server requires non-empty projectId)', async () => {
+    const { result } = renderHook(() => useRestoreSnapshot())
+    await result.current('snap-1')
+
+    expect(mockTerminalApiSpawn).toHaveBeenCalledWith(
+      expect.objectContaining({ projectId: 'proj-1' })
+    )
+  })
+})

--- a/src/renderer/hooks/use-snapshots.ts
+++ b/src/renderer/hooks/use-snapshots.ts
@@ -137,6 +137,7 @@ async function restoreFromSnapshot(projectId: string, snapshot: PersistedSnapsho
 
   for (const persistedTerminal of snapshot.terminals) {
     const spawnResult = await terminalApi.spawn({
+      projectId,
       shell: persistedTerminal.shell as 'powershell' | 'cmd' | 'bash' | 'zsh' | 'fish' | undefined,
       cwd: persistedTerminal.cwd,
       ...(hasProjectEnv ? { env } : {})

--- a/src/renderer/hooks/use-terminal-restore.test.ts
+++ b/src/renderer/hooks/use-terminal-restore.test.ts
@@ -551,7 +551,9 @@ describe('useTerminalRestore', () => {
     )
 
     await vi.runOnlyPendingTimersAsync()
-    expect(mockTerminalSpawn).toHaveBeenCalled()
+    expect(mockTerminalSpawn).toHaveBeenCalledWith(
+      expect.objectContaining({ projectId: 'project-a' })
+    )
 
     rerender({ projectId: 'project-b' })
     await vi.runOnlyPendingTimersAsync()
@@ -666,5 +668,60 @@ describe('useTerminalRestore', () => {
     // The key assertion: terminalApi.kill should NOT be called during project switch
     // (the old implementation would have called kill for project-a's terminals)
     expect(mockTerminalKill).not.toHaveBeenCalled()
+  })
+
+  it('passes projectId when restoring an agent terminal (agent branch)', async () => {
+    mockTerminalStoreState.terminals = []
+    mockLoadPersistedTerminals.mockResolvedValue({
+      activeTerminalId: 'persisted-agent',
+      terminals: [
+        {
+          id: 'persisted-agent',
+          name: 'Agent',
+          kind: 'agent',
+          agentId: 'claude-code',
+          agentProgram: 'claude',
+          agentArgs: [],
+          shell: 'claude',
+          cwd: '/projects/a',
+          scrollback: []
+        }
+      ],
+      updatedAt: '2026-03-09T00:00:00.000Z'
+    })
+
+    renderHook(() => {
+      mockProjectState.activeProjectId = 'project-a'
+      useTerminalRestore()
+    })
+
+    await waitFor(() => {
+      expect(mockTerminalSpawn).toHaveBeenCalledWith(
+        expect.objectContaining({
+          projectId: 'project-a',
+          program: 'claude',
+          kind: 'agent'
+        })
+      )
+    })
+  })
+
+  it('passes projectId when spawning the default terminal on restore error fallback', async () => {
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    mockTerminalStoreState.terminals = []
+    // Force the restore try-block to throw (not cancelled) -> createDefaultTerminal
+    mockLoadPersistedTerminals.mockRejectedValueOnce(new Error('disk read failed'))
+
+    renderHook(() => {
+      mockProjectState.activeProjectId = 'project-a'
+      useTerminalRestore()
+    })
+
+    await waitFor(() => {
+      expect(mockTerminalSpawn).toHaveBeenCalledWith(
+        expect.objectContaining({ projectId: 'project-a' })
+      )
+    })
+    consoleErrorSpy.mockRestore()
   })
 })

--- a/src/renderer/hooks/use-terminal-restore.ts
+++ b/src/renderer/hooks/use-terminal-restore.ts
@@ -899,11 +899,13 @@ async function restoreFromLayout(
             const result = await terminalApi.spawn(
               agentSpawnOptions
                 ? {
+                    projectId,
                     cwd: persistedTerminal.cwd,
                     ...agentSpawnOptions,
                     ...(spawnEnv ? { env: spawnEnv } : {})
                   }
                 : {
+                    projectId,
                     shell: normalizedShell,
                     cwd: persistedTerminal.cwd,
                     ...(spawnEnv ? { env: spawnEnv } : {})
@@ -1165,6 +1167,7 @@ async function createDefaultTerminal(
         const result = await terminalApi.spawn({
           shell,
           cwd,
+          projectId,
           ...(hasProjectEnv ? { env } : {})
         })
         if (spawnTimeout) {

--- a/src/renderer/lib/agent-launch.test.ts
+++ b/src/renderer/lib/agent-launch.test.ts
@@ -98,6 +98,7 @@ describe('launchAgentInPane', () => {
     expect(result.success).toBe(true)
     expect(mockTerminalApiSpawn).toHaveBeenCalledWith(
       expect.objectContaining({
+        projectId: 'proj-1',
         cwd: '/test',
         program: 'claude',
         args: ['explain this'],
@@ -109,7 +110,12 @@ describe('launchAgentInPane', () => {
   it('uses the flag form for gemini', async () => {
     await launchAgentInPane('pane-1', 'proj-1', '/test', gemini, 'query')
     expect(mockTerminalApiSpawn).toHaveBeenCalledWith(
-      expect.objectContaining({ program: 'gemini', args: ['-i', 'query'], kind: 'agent' })
+      expect.objectContaining({
+        projectId: 'proj-1',
+        program: 'gemini',
+        args: ['-i', 'query'],
+        kind: 'agent'
+      })
     )
   })
 
@@ -154,7 +160,12 @@ describe('launchAgentInPane', () => {
     const pi = getBuiltInAgent('pi')!
     await launchAgentInPane('pane-1', 'proj-1', '/test', pi, 'ignored prompt')
     expect(mockTerminalApiSpawn).toHaveBeenCalledWith(
-      expect.objectContaining({ program: 'pi', args: ['ignored prompt'], kind: 'agent' })
+      expect.objectContaining({
+        projectId: 'proj-1',
+        program: 'pi',
+        args: ['ignored prompt'],
+        kind: 'agent'
+      })
     )
   })
 

--- a/src/renderer/lib/agent-launch.ts
+++ b/src/renderer/lib/agent-launch.ts
@@ -117,6 +117,7 @@ export async function launchAgentInPane(
     const { program, args } = buildAgentArgv(def, prompt)
 
     const spawnResult = await terminalApi.spawn({
+      projectId,
       cwd,
       program,
       args,

--- a/src/renderer/lib/terminal-spawn.test.ts
+++ b/src/renderer/lib/terminal-spawn.test.ts
@@ -163,6 +163,14 @@ describe('spawnTerminalInPane', () => {
     expect(mockTerminalApiSpawn).toHaveBeenCalledWith(expect.objectContaining({ shell: 'zsh' }))
   })
 
+  it('passes projectId into the spawn payload (web server requires non-empty projectId)', async () => {
+    await spawnTerminalInPane('pane-1', 'proj-1', '/test/worktree')
+
+    expect(mockTerminalApiSpawn).toHaveBeenCalledWith(
+      expect.objectContaining({ projectId: 'proj-1' })
+    )
+  })
+
   it('resolves shell from project default when no explicit shell', async () => {
     await spawnTerminalInPane('pane-1', 'proj-1', '/test/worktree')
 

--- a/src/renderer/lib/terminal-spawn.ts
+++ b/src/renderer/lib/terminal-spawn.ts
@@ -81,6 +81,7 @@ export async function spawnTerminalInPane(
     const spawnResult = await terminalApi.spawn({
       shell,
       cwd,
+      projectId,
       ...(hasProjectEnv ? { env } : {})
     })
 

--- a/src/shared/types/ipc.types.ts
+++ b/src/shared/types/ipc.types.ts
@@ -21,6 +21,13 @@ export interface TerminalSpawnOptions {
   args?: string[]
   /** Descriptive marker for the session type. Defaults to 'shell'. */
   kind?: 'shell' | 'agent'
+  /**
+   * Project-scoping id. The web/remote terminal server (terminal_ws.rs)
+   * requires a non-empty projectId on every spawn (project-scoped security);
+   * desktop treats it as optional (SpawnOptions.project_id is Option<String>
+   * with #[serde(default)]). Renderers populate it at project-scoped call sites.
+   */
+  projectId?: string
   // Index signature to satisfy Tauri's InvokeArgs constraint
   [key: string]: unknown
 }


### PR DESCRIPTION
## Summary

The web/remote terminal server (`terminal_ws.rs`) requires a non-empty `projectId` on every spawn for project-scoped security. Desktop treats it as optional (`Option<String>` with `#[serde(default)]`), but several renderer-side spawn call sites were not passing `projectId` at all, causing web terminal spawns to fail silently.

## Related Issue

No related issue — this was discovered during web terminal integration testing.

## Type of Change

- [ ] feat: new feature
- [x] fix: bug fix
- [ ] docs: documentation only
- [ ] style: formatting or non-functional styling changes
- [ ] refactor: internal cleanup with no behavior change
- [ ] perf: performance improvement
- [ ] test: adds or updates tests
- [ ] build: build or dependency changes
- [ ] ci: CI/CD workflow changes
- [ ] chore: maintenance or tooling
- [ ] revert: reverts a previous change

## What Changed

- **`ipc.types.ts`** — Add optional `projectId` field to `TerminalSpawnOptions` with documentation.
- **`terminal-spawn.ts`** — Pass `projectId` into the spawn payload in `spawnTerminalInPane`.
- **`agent-launch.ts`** — Pass `projectId` into the spawn payload in `launchAgentInPane`.
- **`use-terminal-restore.ts`** — Pass `projectId` in all three spawn paths (agent restore, shell restore, and default-terminal fallback).
- **`use-snapshots.ts`** — Pass `projectId` when restoring terminals from a snapshot.
- **`MobileChatShell.tsx`** — Consolidate workspace/terminal store selectors into a single `useWorkspaceStore` call to avoid stale reads across multiple independent subscriptions.

## How It Was Tested

- [x] `bun run ci` (Biome lint + format + imports, strict mode)
- [x] `bun run typecheck`
- [x] `bun run test`
- [ ] `cargo clippy --all-targets -- -D warnings` (in src-tauri)
- [ ] `cargo test` (in src-tauri)
- [x] Manual verification completed
- [ ] Not applicable

### Test coverage added

- `terminal-spawn.test.ts` — Asserts `projectId` is present in spawn payload.
- `agent-launch.test.ts` — Asserts `projectId` for claude, gemini, and pi agent launches.
- `use-terminal-restore.test.ts` — Two new tests: agent-branch restore and error-fallback default terminal both pass `projectId`.
- `use-snapshots.test.ts` — New test file covering snapshot restore passes `projectId`.

### Manual verification

1. Open the web UI and switch to a project.
2. Spawn a new terminal — it should connect successfully (previously failed on the web server).
3. Restore a snapshot — terminals should spawn with the correct project scope.
4. Launch an agent (claude/gemini/pi) — terminal should spawn with `projectId`.
5. Desktop behaviour is unchanged (`projectId` is optional in the Rust side).

## Screenshots or Recordings

N/A — no visible UI change; the fix prevents a silent failure on web terminal spawns.

## CI & Review Gate

- [ ] All CI checks pass (PR Validation, Rust Checks, Build Verification, Security Scans)
- [ ] Code review comments from CodeRabbit / Claude have been addressed or resolved
- [ ] No unresolved review findings remain

## Checklist

- [x] My PR title follows the conventional commit format used by this repo
- [x] I linked the related issue or explained why none exists
- [x] I updated docs when needed
- [x] I added or updated tests when needed
- [x] I verified the change does not introduce unrelated modifications
- [x] I read AGENTS.md and followed the contributor guidelines
- [ ] A human reviewed the complete diff before submission