### PR TITLE
fix(acp): re-fill empty args/env/headers in MCP wire payload

### DIFF
--- a/src/renderer/lib/acp-mcp-persistence.test.ts
+++ b/src/renderer/lib/acp-mcp-persistence.test.ts
@@ -26,7 +26,7 @@ import {
 const registry: StoredMcpServer[] = [
   { id: 'stdio', type: 'stdio', name: 'Files', command: 'npx', enabled: true },
   { id: 'http', type: 'http', name: 'HTTP API', url: 'https://example.com/mcp', enabled: true },
-  { id: 'sse', type: 'sse', name: 'Events', url: 'https://example.com/sse', enabled: false }
+  { id: 'sse', type: 'sse', name: 'Events', url: 'https://example.com/sse', enabled: true }
 ]
 
 describe('MCP registry helpers', () => {
@@ -61,7 +61,10 @@ describe('MCP registry helpers', () => {
       selectMcpServersForAgent(registry, { mcpCapabilities: { http: false, acp: true } })
     ).toEqual({
       servers: [{ type: 'stdio', name: 'Files', command: 'npx', args: [], env: [] }],
-      skipped: [{ id: 'http', name: 'HTTP API', transport: 'http' }],
+      skipped: [
+        { id: 'http', name: 'HTTP API', transport: 'http' },
+        { id: 'sse', name: 'Events', transport: 'sse' }
+      ],
       pending: false
     })
     expect(selectMcpServersForAgent(registry, { mcpCapabilities: { http: true } }).servers).toEqual(
@@ -86,6 +89,12 @@ describe('MCP registry helpers', () => {
           name: 'HTTP API',
           url: 'https://example.com/mcp',
           headers: []
+        },
+        {
+          type: 'sse',
+          name: 'Events',
+          url: 'https://example.com/sse',
+          headers: []
         }
       ],
       skipped: [],
@@ -94,9 +103,10 @@ describe('MCP registry helpers', () => {
   })
 
   it('strips registry-only fields when building explicit selections', () => {
-    expect(buildMcpServers(registry, ['http', 'stdio'])).toEqual([
+    expect(buildMcpServers(registry, ['http', 'stdio', 'sse'])).toEqual([
       { type: 'http', name: 'HTTP API', url: 'https://example.com/mcp', headers: [] },
-      { type: 'stdio', name: 'Files', command: 'npx', args: [], env: [] }
+      { type: 'stdio', name: 'Files', command: 'npx', args: [], env: [] },
+      { type: 'sse', name: 'Events', url: 'https://example.com/sse', headers: [] }
     ])
   })
 })

--- a/src/renderer/lib/acp-mcp-persistence.test.ts
+++ b/src/renderer/lib/acp-mcp-persistence.test.ts
@@ -60,14 +60,19 @@ describe('MCP registry helpers', () => {
     expect(
       selectMcpServersForAgent(registry, { mcpCapabilities: { http: false, acp: true } })
     ).toEqual({
-      servers: [{ type: 'stdio', name: 'Files', command: 'npx' }],
+      servers: [{ type: 'stdio', name: 'Files', command: 'npx', args: [], env: [] }],
       skipped: [{ id: 'http', name: 'HTTP API', transport: 'http' }],
       pending: false
     })
     expect(selectMcpServersForAgent(registry, { mcpCapabilities: { http: true } }).servers).toEqual(
       [
-        { type: 'stdio', name: 'Files', command: 'npx' },
-        { type: 'http', name: 'HTTP API', url: 'https://example.com/mcp' }
+        { type: 'stdio', name: 'Files', command: 'npx', args: [], env: [] },
+        {
+          type: 'http',
+          name: 'HTTP API',
+          url: 'https://example.com/mcp',
+          headers: []
+        }
       ]
     )
   })
@@ -75,8 +80,13 @@ describe('MCP registry helpers', () => {
   it('keeps enabled transports while capabilities are still pending', () => {
     expect(selectMcpServersForAgent(registry, null)).toEqual({
       servers: [
-        { type: 'stdio', name: 'Files', command: 'npx' },
-        { type: 'http', name: 'HTTP API', url: 'https://example.com/mcp' }
+        { type: 'stdio', name: 'Files', command: 'npx', args: [], env: [] },
+        {
+          type: 'http',
+          name: 'HTTP API',
+          url: 'https://example.com/mcp',
+          headers: []
+        }
       ],
       skipped: [],
       pending: true
@@ -85,8 +95,8 @@ describe('MCP registry helpers', () => {
 
   it('strips registry-only fields when building explicit selections', () => {
     expect(buildMcpServers(registry, ['http', 'stdio'])).toEqual([
-      { type: 'http', name: 'HTTP API', url: 'https://example.com/mcp' },
-      { type: 'stdio', name: 'Files', command: 'npx' }
+      { type: 'http', name: 'HTTP API', url: 'https://example.com/mcp', headers: [] },
+      { type: 'stdio', name: 'Files', command: 'npx', args: [], env: [] }
     ])
   })
 })

--- a/src/renderer/lib/acp-mcp-persistence.ts
+++ b/src/renderer/lib/acp-mcp-persistence.ts
@@ -56,7 +56,23 @@ export function validateMcpServer(server: Partial<McpServerConfig>): McpValidati
 
 function toWireServer(entry: StoredMcpServer): McpServer {
   const { id: _id, enabled: _enabled, ...server } = entry
-  return server as McpServer
+  // The ACP `McpServer` schema requires `args` + `env` (stdio) and `headers`
+  // (http/sse) as non-optional arrays. The on-disk normalizer omits these
+  // when empty, so re-fill them here to keep the wire payload deserializable.
+  switch (transportOf(server)) {
+    case 'stdio': {
+      const { name, command, args, env } = server as Extract<McpServerConfig, { type?: 'stdio' }>
+      return { type: 'stdio', name, command, args: args ?? [], env: env ?? [] }
+    }
+    case 'http': {
+      const { name, url, headers } = server as Extract<McpServerConfig, { type: 'http' }>
+      return { type: 'http', name, url, headers: headers ?? [] }
+    }
+    case 'sse': {
+      const { name, url, headers } = server as Extract<McpServerConfig, { type: 'sse' }>
+      return { type: 'sse', name, url, headers: headers ?? [] }
+    }
+  }
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/src/renderer/stores/acp-store.test.ts
+++ b/src/renderer/stores/acp-store.test.ts
@@ -3973,7 +3973,7 @@ describe('acp-store', () => {
     expect(invoke).toHaveBeenCalledWith('acp_new_session', {
       agentId: 'agent-1',
       cwd: '/work',
-      mcpServers: [{ type: 'stdio', name: 'Files', command: 'node' }]
+      mcpServers: [{ type: 'stdio', name: 'Files', command: 'node', args: [], env: [] }]
     })
     expect(useAcpStore.getState().sessions.derived.mcpServerCount).toBe(1)
     expect(toastWarning).toHaveBeenCalledWith(


### PR DESCRIPTION
## Summary

Enabling an MCP server with no args/env (stdio) or no headers (http/sse) broke ACP chat session creation — the model-selection screen failed with:

> `Could not load model options. invalid args mcpServers for command acp_new_session: data did not match any variant of untagged enum McpServer`

**Root cause:** the ACP `McpServer` schema (`agent-client-protocol-schema` 0.13.2) requires `args` + `env` (stdio) and `headers` (http/sse) as **non-optional arrays** (no `#[serde(default)]`). But the on-disk normalizer only includes those fields when non-empty (`...(args ? { args } : {})`), and `toWireServer` forwarded the sparse object verbatim. So a stdio server with no args/env produced `{ type: 'stdio', name, command }` — missing required `args`/`env` — and serde fell through every `McpServer` variant (the `type: 'stdio'` tag matches no tagged variant; the untagged `Stdio` fallback then fails on the missing arrays).

**Fix:** `toWireServer` now reconstructs each transport variant and guarantees `args: []` + `env: []` (stdio) and `headers: []` (http/sse). It's the single chokepoint for both `selectMcpServersForAgent` (chat launch, `mcpServers: undefined`) and `buildMcpServers` (explicit selections), so both code paths are covered.

## Related Issue

No related issue — this is a regression in #510 (`feat(acp): add MCP setup in settings`, commit `6bee7610`), which added `toWireServer`. Reported via a user session: enabling any MCP server caused `acp_new_session` to fail with `data did not match any variant of untagged enum McpServer`. Searched open+closed PRs (`toWireServer`, `acp_new_session`, `untagged`, `mcp wire`, `schema`, `mcp`) — no duplicate exists. Context: #287 (the MCP server list feature, delivered by #510).

## Type of Change

- [x] fix: bug fix

## What Changed

- `src/renderer/lib/acp-mcp-persistence.ts` — `toWireServer` now reconstructs each transport variant and guarantees `args: []` + `env: []` (stdio) and `headers: []` (http/sse), instead of forwarding the sparse stored object.
- `src/renderer/lib/acp-mcp-persistence.test.ts` — updated wire-shape expectations to include the required empty arrays.
- `src/renderer/stores/acp-store.test.ts` — updated one `acp_new_session` assertion to the corrected shape.

## How It Was Tested

- [x] `bun run ci` (Biome strict) — 727 files, no errors
- [x] `bun run typecheck` — clean
- [x] `bun run test` — 2662 pass; all MCP tests (`acp-mcp-persistence`, `acp-store`, `acp-api`, `acp-transport`) pass
- [ ] `cargo clippy --all-targets -- -D warnings` — N/A: TS-only PR (no `.rs` changes); CI will confirm
- [ ] `cargo test` — N/A: TS-only PR; CI will confirm
- [x] Manual verification completed — schema acceptance of the produced shape is already covered by the vendored crate's existing Rust tests `test_parse_json_stdio` (`type: "stdio"` + `env: []`) and `test_parse_json_http` (`headers: []`).

## Screenshots or Recordings

N/A — fix is in the wire-serialization layer; no UI change.

## CI & Review Gate

- [ ] All CI checks pass (PR Validation, Rust Checks, Build Verification, Security Scans) — monitoring
- [ ] Code review comments from CodeRabbit / Claude addressed — monitoring
- [ ] No unresolved review findings remain

## Checklist

- [x] PR title follows the conventional commit format used by this repo
- [x] I linked the related issue or explained why none exists
- [x] I updated docs when needed — none needed
- [x] I added or updated tests when needed — yes, wire-shape assertions updated
- [x] I verified the change does not introduce unrelated modifications — 3 files, +35/-9, all MCP-related
- [x] I read AGENTS.md and followed the contributor guidelines
- [ ] A human reviewed the complete diff before submission — requesting review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved MCP server configuration handling across standard input/output, HTTP, and SSE connections.
  * Ensured optional connection settings are consistently represented when starting sessions.
  * Added support for explicitly selecting SSE-based MCP servers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->