### PR TITLE
fix(web): reconnect terminal websocket on mobile AFK visibility return

### DIFF
--- a/src/renderer/lib/web-terminal-api.test.ts
+++ b/src/renderer/lib/web-terminal-api.test.ts
@@ -1,61 +1,452 @@
-import { describe, expect, it, vi } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import { resolveTerminalWsUrl, WebTerminalClient } from './web-terminal-api'
 
+/**
+ * Minimal FakeWebSocket for the terminal protocol (`{id,type,payload}` requests
+ * → `{id,success,data}` / `{id,success:false,error,code}` replies). Mirrors the
+ * FakeWebSocket shape in `acp-transport.test.ts`: auto-opens on construction so
+ * `connect()` resolves, records sent frames, and can be driven to fail attach.
+ */
 class FakeWebSocket {
   static OPEN = 1
   static CONNECTING = 0
-  static instances: FakeWebSocket[] = []
+  static CLOSING = 2
+  static CLOSED = 3
+
   readyState = FakeWebSocket.CONNECTING
-  onopen: (() => void) | null = null
-  onmessage: ((event: MessageEvent) => void) | null = null
-  onerror: (() => void) | null = null
-  onclose: (() => void) | null = null
+  onopen: ((ev: Event) => void) | null = null
+  onmessage: ((ev: MessageEvent) => void) | null = null
+  onerror: ((ev: Event) => void) | null = null
+  onclose: ((ev: CloseEvent) => void) | null = null
   sent: string[] = []
 
-  constructor(readonly url: string) {
-    FakeWebSocket.instances.push(this)
+  constructor(public url: string) {
     queueMicrotask(() => {
       this.readyState = FakeWebSocket.OPEN
-      this.onopen?.()
+      this.onopen?.(new Event('open'))
     })
   }
 
   send(data: string): void {
     this.sent.push(data)
+    const req = JSON.parse(data) as { id: string; type: string; payload: Record<string, unknown> }
+    if (req.type === 'attach') {
+      if (attachReply === 'not_found') {
+        this.emitReply({
+          id: req.id,
+          success: false,
+          error: 'terminal not found',
+          code: 'TERMINAL_NOT_FOUND'
+        })
+        return
+      }
+      this.emitReply({ id: req.id, success: true, data: undefined })
+      return
+    }
+    this.emitReply({ id: req.id, success: true, data: undefined })
   }
 
   close(): void {
-    this.onclose?.()
+    this.readyState = FakeWebSocket.CLOSED
+    this.onclose?.(new CloseEvent('close'))
   }
 
-  reply(value: unknown): void {
-    this.onmessage?.({ data: JSON.stringify(value) } as MessageEvent)
+  emit(obj: unknown): void {
+    this.onmessage?.(new MessageEvent('message', { data: JSON.stringify(obj) }))
+  }
+
+  emitReply(obj: unknown): void {
+    queueMicrotask(() => this.emit(obj))
   }
 }
 
-describe('WebTerminalClient', () => {
-  it('resolves the dedicated same-origin websocket URL', () => {
-    expect(resolveTerminalWsUrl({ protocol: 'https:', host: 'termul.test' })).toBe(
-      'wss://termul.test/terminal/ws'
-    )
+/** Test knob: make `attach` replies fail with TERMINAL_NOT_FOUND. */
+let attachReply: 'ok' | 'not_found' = 'ok'
+
+type Tracker = { lastSeq: number; exited: boolean; refCount: number }
+
+type ClientInternals = {
+  socket: FakeWebSocket
+  trackers: Map<string, Tracker>
+  reconnectAttempt: number
+  reconnectTimer: ReturnType<typeof setTimeout> | null
+  lastHiddenAt: number | null
+  visibilityHandler: (() => void) | null
+  focusHandler: (() => void) | null
+}
+
+/** Override `document.visibilityState` + dispatch `visibilitychange` (jsdom's
+ * default is not reliable for the hidden/visible transitions under test). */
+function dispatchVisibility(state: 'visible' | 'hidden'): void {
+  Object.defineProperty(document, 'visibilityState', {
+    configurable: true,
+    value: state
+  })
+  document.dispatchEvent(new Event('visibilitychange'))
+}
+
+/** Restore an own `visibilityState = 'visible'` so later suites read visible. */
+function restoreVisibility(): void {
+  Object.defineProperty(document, 'visibilityState', {
+    configurable: true,
+    value: 'visible'
+  })
+}
+
+/** Find the LAST sent request frame of a given type on a FakeWebSocket. */
+function findSentRequest(
+  sock: FakeWebSocket,
+  type: string
+): { id: string; type: string; payload: Record<string, unknown> } | undefined {
+  for (const raw of [...sock.sent].reverse()) {
+    const parsed = JSON.parse(raw) as {
+      id: string
+      type: string
+      payload: Record<string, unknown>
+    }
+    if (parsed.type === type) return parsed
+  }
+  return undefined
+}
+
+describe('WebTerminalClient visibility-triggered reconnect (AFK recovery)', () => {
+  afterEach(() => {
+    restoreVisibility()
+    attachReply = 'ok'
+    vi.useRealTimers()
   })
 
-  it('maps replies and binary arrays to TerminalApi callbacks', async () => {
-    FakeWebSocket.instances = []
+  it('reconnects + re-attaches trackers with their lastSeq after a long hide', async () => {
+    vi.useFakeTimers()
     const client = new WebTerminalClient(
       'ws://test/terminal/ws',
       FakeWebSocket as unknown as typeof WebSocket
     )
-    const onData = vi.fn()
-    client.onData(onData)
-    const pending = client.request<string>('get_cwd', { terminalId: 't1' })
-    await vi.waitFor(() => expect(FakeWebSocket.instances[0]?.sent.length).toBe(1))
-    const request = JSON.parse(FakeWebSocket.instances[0].sent[0]) as { id: string }
-    FakeWebSocket.instances[0].reply({ id: request.id, success: true, data: '/repo' })
-    await expect(pending).resolves.toEqual({ success: true, data: '/repo' })
+    const internals = client as unknown as ClientInternals
+    await client.connect()
+    // Track a terminal and advance its cursor past the initial 0.
+    await client.attach('t1')
+    const oldSocket = internals.socket
+    oldSocket.emit({ type: 'data', terminalId: 't1', seq: 7, data: [65] })
+    await Promise.resolve() // flush handleFrame
+    expect(internals.trackers.get('t1')?.lastSeq).toBe(7)
 
-    FakeWebSocket.instances[0].reply({ type: 'data', terminalId: 't1', data: [65, 66] })
-    expect(onData).toHaveBeenCalledWith('t1', new Uint8Array([65, 66]))
+    // Long hide (> 30s threshold) → return → proactive force-reconnect.
+    dispatchVisibility('hidden')
+    await vi.advanceTimersByTimeAsync(31_000)
+    dispatchVisibility('visible')
+    await Promise.resolve()
+
+    // Advance past the 500ms backoff → connect re-opens + re-attaches.
+    await vi.advanceTimersByTimeAsync(600)
+    await Promise.resolve()
+
+    expect(internals.socket).not.toBe(oldSocket) // torn down + replaced
+    expect(internals.socket.readyState).toBe(FakeWebSocket.OPEN)
+    // The new socket re-attached the tracker carrying its stored cursor.
+    const attachReq = findSentRequest(internals.socket, 'attach')
+    expect(attachReq).toBeDefined()
+    expect(attachReq?.payload).toEqual({ terminalId: 't1', lastSeq: 7 })
+
+    if (internals.reconnectTimer) {
+      clearTimeout(internals.reconnectTimer)
+      internals.reconnectTimer = null
+    }
+    client.dispose()
+  })
+
+  it('does not double-reconnect when a focus follows visibilitychange', async () => {
+    vi.useFakeTimers()
+    const client = new WebTerminalClient(
+      'ws://test/terminal/ws',
+      FakeWebSocket as unknown as typeof WebSocket
+    )
+    const internals = client as unknown as ClientInternals
+    await client.connect()
+    await client.attach('t1')
+    const forceSpy = vi.spyOn(
+      client as unknown as { forceReconnect: (reason: string) => void },
+      'forceReconnect'
+    )
+
+    // Long hide → visible triggers forceReconnect (consumes lastHiddenAt).
+    dispatchVisibility('hidden')
+    await vi.advanceTimersByTimeAsync(31_000)
+    dispatchVisibility('visible')
+    await Promise.resolve()
+    expect(forceSpy).toHaveBeenCalledTimes(1)
+    expect(internals.lastHiddenAt).toBeNull() // consumed
+
+    // A `focus` right after (the fallback path) must NOT trigger a 2nd
+    // forceReconnect — lastHiddenAt was consumed. `focus` is window-level.
+    window.dispatchEvent(new Event('focus'))
+    await Promise.resolve()
+    expect(forceSpy).toHaveBeenCalledTimes(1)
+
+    await vi.advanceTimersByTimeAsync(600)
+    await Promise.resolve()
+    // Exactly one new socket opened (one reconnect, not two).
+    expect(internals.socket.readyState).toBe(FakeWebSocket.OPEN)
+    expect(findSentRequest(internals.socket, 'attach')).toBeDefined()
+
+    forceSpy.mockRestore()
+    if (internals.reconnectTimer) {
+      clearTimeout(internals.reconnectTimer)
+      internals.reconnectTimer = null
+    }
+    client.dispose()
+  })
+
+  it('marks a tracker exited when re-attach returns TERMINAL_NOT_FOUND', async () => {
+    vi.useFakeTimers()
+    const client = new WebTerminalClient(
+      'ws://test/terminal/ws',
+      FakeWebSocket as unknown as typeof WebSocket
+    )
+    const internals = client as unknown as ClientInternals
+    await client.connect()
+    await client.attach('t1')
+    expect(internals.trackers.get('t1')?.exited).toBe(false)
+
+    // The server tore the terminal down during AFK — the reconnect's re-attach
+    // replies TERMINAL_NOT_FOUND.
+    attachReply = 'not_found'
+
+    dispatchVisibility('hidden')
+    await vi.advanceTimersByTimeAsync(31_000)
+    dispatchVisibility('visible')
+    await Promise.resolve()
+    await vi.advanceTimersByTimeAsync(600)
+    // The TERMINAL_NOT_FOUND reply + the onopen re-attach `.then` mark it exited.
+    await vi.advanceTimersByTimeAsync(0)
+    await Promise.resolve()
+
+    expect(internals.trackers.get('t1')?.exited).toBe(true)
+
+    if (internals.reconnectTimer) {
+      clearTimeout(internals.reconnectTimer)
+      internals.reconnectTimer = null
+    }
+    client.dispose()
+  })
+
+  it('resets reconnectAttempt on visibility recovery so AFK never strands the terminal', async () => {
+    vi.useFakeTimers()
+    const client = new WebTerminalClient(
+      'ws://test/terminal/ws',
+      FakeWebSocket as unknown as typeof WebSocket
+    )
+    const internals = client as unknown as ClientInternals
+    await client.connect()
+    await client.attach('t1')
+    const oldSocket = internals.socket
+
+    // Simulate prior suspensions having exhausted the backoff ceiling. At MAX,
+    // a normal `scheduleReconnect` (e.g. from `onclose`) would no-op.
+    internals.reconnectAttempt = 10 // RECONNECT_MAX_ATTEMPTS
+    internals.reconnectTimer = null
+
+    // Long hide → return → visibility recovery path.
+    dispatchVisibility('hidden')
+    await vi.advanceTimersByTimeAsync(31_000)
+    dispatchVisibility('visible')
+    await Promise.resolve()
+
+    // forceReconnect reset the counter (MAX → 0) and scheduleReconnect then
+    // scheduled a fresh reconnect (0 → 1) — at MAX this would have been a no-op.
+    expect(internals.reconnectAttempt).toBe(1)
+    expect(internals.reconnectTimer).not.toBeNull()
+
+    await vi.advanceTimersByTimeAsync(600)
+    await Promise.resolve()
+
+    // A fresh socket re-opened despite the prior exhaustion.
+    expect(internals.socket).not.toBe(oldSocket)
+    expect(internals.socket.readyState).toBe(FakeWebSocket.OPEN)
+    expect(findSentRequest(internals.socket, 'attach')).toBeDefined()
+
+    if (internals.reconnectTimer) {
+      clearTimeout(internals.reconnectTimer)
+      internals.reconnectTimer = null
+    }
+    client.dispose()
+  })
+
+  it('attaches visibility listeners on first connect and detaches on dispose', async () => {
+    vi.useFakeTimers()
+    const client = new WebTerminalClient(
+      'ws://test/terminal/ws',
+      FakeWebSocket as unknown as typeof WebSocket
+    )
+    const internals = client as unknown as ClientInternals
+    expect(internals.visibilityHandler).toBeNull()
+    expect(internals.focusHandler).toBeNull()
+
+    await client.connect()
+    expect(internals.visibilityHandler).not.toBeNull()
+    expect(internals.focusHandler).not.toBeNull()
+
+    client.dispose()
+    expect(internals.visibilityHandler).toBeNull()
+    expect(internals.focusHandler).toBeNull()
+  })
+
+  it('force-reconnects on a short hide when the socket is already down (socketDown branch)', async () => {
+    vi.useFakeTimers()
+    const client = new WebTerminalClient(
+      'ws://test/terminal/ws',
+      FakeWebSocket as unknown as typeof WebSocket
+    )
+    const internals = client as unknown as ClientInternals
+    await client.connect()
+    await client.attach('t1')
+    const oldSocket = internals.socket
+    // The server tore the socket down during AFK (CLOSED), but the client
+    // hasn't received onclose yet (suspended-tab / half-open link).
+    oldSocket.readyState = FakeWebSocket.CLOSED
+
+    const forceSpy = vi.spyOn(
+      client as unknown as { forceReconnect: (reason: string) => void },
+      'forceReconnect'
+    )
+
+    // SHORT hide (< 30s threshold) — only the `|| socketDown` clause carries.
+    dispatchVisibility('hidden')
+    await vi.advanceTimersByTimeAsync(5_000)
+    dispatchVisibility('visible')
+    await Promise.resolve()
+    expect(forceSpy).toHaveBeenCalledTimes(1)
+
+    // Advance past the 500ms backoff → a new socket opens + re-attaches.
+    await vi.advanceTimersByTimeAsync(600)
+    await Promise.resolve()
+    expect(internals.socket).not.toBe(oldSocket)
+    expect(internals.socket.readyState).toBe(FakeWebSocket.OPEN)
+    expect(findSentRequest(internals.socket, 'attach')).toBeDefined()
+
+    forceSpy.mockRestore()
+    if (internals.reconnectTimer) {
+      clearTimeout(internals.reconnectTimer)
+      internals.reconnectTimer = null
+    }
+    client.dispose()
+  })
+})
+
+describe('resolveTerminalWsUrl', () => {
+  // Pure mapping — no socket involved.
+  it('maps https→wss and http→ws and appends /terminal/ws', () => {
+    expect(resolveTerminalWsUrl({ protocol: 'https:', host: 'app.example.com' })).toBe(
+      'wss://app.example.com/terminal/ws'
+    )
+    expect(resolveTerminalWsUrl({ protocol: 'http:', host: 'localhost:8080' })).toBe(
+      'ws://localhost:8080/terminal/ws'
+    )
+  })
+})
+
+describe('WebTerminalClient frame handling & request lifecycle', () => {
+  afterEach(() => {
+    vi.useRealTimers()
+    attachReply = 'ok'
+  })
+
+  it('delivers a data frame as a Uint8Array to onData subscribers', async () => {
+    vi.useFakeTimers()
+    const client = new WebTerminalClient(
+      'ws://test/terminal/ws',
+      FakeWebSocket as unknown as typeof WebSocket
+    )
+    const internals = client as unknown as ClientInternals
+    const received: Array<{ terminalId: string; bytes: Uint8Array }> = []
+    const off = client.onData((terminalId, bytes) => {
+      received.push({ terminalId, bytes })
+    })
+
+    await client.connect()
+    const sock = internals.socket
+    sock.emit({ type: 'data', terminalId: 't1', seq: 1, data: [72, 101, 108, 108, 111] })
+
+    expect(received).toHaveLength(1)
+    expect(received[0].terminalId).toBe('t1')
+    expect(received[0].bytes).toBeInstanceOf(Uint8Array)
+    expect(Array.from(received[0].bytes)).toEqual([72, 101, 108, 108, 111])
+
+    off()
+    client.dispose()
+  })
+
+  it('resolves a request with the matching reply data (round-trip)', async () => {
+    vi.useFakeTimers()
+    const client = new WebTerminalClient(
+      'ws://test/terminal/ws',
+      FakeWebSocket as unknown as typeof WebSocket
+    )
+    const internals = client as unknown as ClientInternals
+    await client.connect()
+    const sock = internals.socket
+
+    // Stub send so it records the frame WITHOUT auto-replying — we drive the
+    // reply manually to assert data round-trips.
+    const sendStub = vi.spyOn(sock, 'send').mockImplementation((data: string) => {
+      sock.sent.push(data)
+    })
+
+    const resultPromise = client.request<{ branch: string }>('get_git_branch', {
+      terminalId: 't1'
+    })
+    // Flush past `await this.connect()` inside request() so the (stubbed) send runs.
+    await vi.advanceTimersByTimeAsync(0)
+
+    const sent = findSentRequest(sock, 'get_git_branch')
+    expect(sent).toBeDefined()
+    sock.emit({ id: sent!.id, success: true, data: { branch: 'main' } })
+    sendStub.mockRestore()
+
+    const result = await resultPromise
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data).toEqual({ branch: 'main' })
+    }
+
+    client.dispose()
+  })
+
+  it('rejects a request awaiting connect to NETWORK_ERROR when forceReconnect fires mid-handshake', async () => {
+    vi.useFakeTimers()
+    const client = new WebTerminalClient(
+      'ws://test/terminal/ws',
+      FakeWebSocket as unknown as typeof WebSocket
+    )
+    const internals = client as unknown as ClientInternals
+
+    // Kick off a request — connect() opens a CONNECTING socket; the request
+    // awaits the in-flight connect promise (15s timeout not yet armed).
+    const reqPromise = client.request('spawn', { rows: 24, cols: 80 })
+    // A real browser does NOT fire `onopen` for a socket closed mid-handshake;
+    // detach the FakeWebSocket's queued `onopen` to model that (otherwise the
+    // double's microtask would unconditionally resolve connect and mask the
+    // hang the fix prevents).
+    internals.socket.onopen = null
+    // Synchronously force-reconnect BEFORE any socket event fires.
+    ;(client as unknown as { forceReconnect: (reason: string) => void }).forceReconnect(
+      'afk return'
+    )
+
+    // Flush: the in-flight connect promise rejects → request() catches →
+    // NETWORK_ERROR (does NOT hang until the 15s timeout).
+    await vi.advanceTimersByTimeAsync(0)
+    const result = await reqPromise
+
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.code).toBe('NETWORK_ERROR')
+    }
+
+    if (internals.reconnectTimer) {
+      clearTimeout(internals.reconnectTimer)
+      internals.reconnectTimer = null
+    }
     client.dispose()
   })
 })

--- a/src/renderer/lib/web-terminal-api.ts
+++ b/src/renderer/lib/web-terminal-api.ts
@@ -22,6 +22,13 @@ const REQUEST_TIMEOUT_MS = 15_000
 const RECONNECT_BASE_MS = 500
 const RECONNECT_MAX_MS = 8_000
 const RECONNECT_MAX_ATTEMPTS = 10
+/** How long the page must stay hidden before a return triggers a proactive
+ * reconnect. Mobile browsers suspend JS in backgrounded tabs, so the server's
+ * keepalive tears the terminal WS down at its Pong-timeout — but the client
+ * only learns this when `onclose` is finally delivered on resume (late, or
+ * never on a half-open link). Mirrors `WsAcpTransport`: 30s sits between the
+ * server's Ping interval and its Pong-timeout. Tunable. */
+const VISIBILITY_STALE_THRESHOLD_MS = 30_000
 
 export function resolveTerminalWsUrl(
   locationLike: { protocol: string; host: string } = window.location
@@ -48,10 +55,21 @@ interface TerminalTracker {
 export class WebTerminalClient {
   private socket: WebSocket | null = null
   private connecting: Promise<void> | null = null
+  /** Reject fn for the in-flight `connect()` promise (executor pattern), so
+   * `forceReconnect` can settle it when tearing down a CONNECTING socket —
+   * otherwise an awaiting `request()` hangs until its 15s timeout (which only
+   * arms AFTER connect resolves). Mirrors WsAcpTransport's teardown approach. */
+  private connectingReject: ((error: Error) => void) | null = null
   private disposed = false
   private nextId = 0
   private reconnectAttempt = 0
   private reconnectTimer: ReturnType<typeof setTimeout> | null = null
+  /** When the page became hidden (epoch-ms), or null while visible. Drives the
+   * visibility-triggered proactive reconnect on mobile idle/background resume. */
+  private lastHiddenAt: number | null = null
+  /** Bound DOM-listener refs so `dispose()` can detach them. */
+  private visibilityHandler: (() => void) | null = null
+  private focusHandler: (() => void) | null = null
   private readonly pending = new Map<string, Pending>()
   private readonly trackers = new Map<string, TerminalTracker>()
   private readonly dataCallbacks = new Set<TerminalDataCallback>()
@@ -98,14 +116,17 @@ export class WebTerminalClient {
 
   connect(): Promise<void> {
     if (this.disposed) return Promise.reject(new Error('Terminal client disposed'))
+    this.attachVisibilityListeners()
     if (this.socket?.readyState === this.WebSocketImpl.OPEN) return Promise.resolve()
     if (this.connecting) return this.connecting
     this.connecting = new Promise<void>((resolve, reject) => {
       const socket = new this.WebSocketImpl(this.url)
       this.socket = socket
+      this.connectingReject = reject
       socket.onopen = () => {
         this.reconnectAttempt = 0
         this.connecting = null
+        this.connectingReject = null
         // Re-attach only terminals that haven't exited, using their lastSeq.
         for (const [terminalId, tracker] of this.trackers) {
           if (tracker.exited) continue
@@ -121,10 +142,12 @@ export class WebTerminalClient {
       socket.onmessage = (event) => this.handleFrame(String(event.data))
       socket.onerror = () => {
         this.connecting = null
+        this.connectingReject = null
         reject(new Error('Terminal websocket connection failed'))
       }
       socket.onclose = () => {
         this.connecting = null
+        this.connectingReject = null
         this.socket = null
         this.rejectPending()
         this.scheduleReconnect()
@@ -213,6 +236,7 @@ export class WebTerminalClient {
 
   dispose(): void {
     this.disposed = true
+    this.detachVisibilityListeners()
     if (this.reconnectTimer) clearTimeout(this.reconnectTimer)
     this.rejectPending()
     this.socket?.close()
@@ -310,13 +334,13 @@ export class WebTerminalClient {
     }
   }
 
-  private rejectPending(): void {
+  private rejectPending(reason?: string): void {
     for (const pending of this.pending.values()) {
       clearTimeout(pending.timer)
       pending.resolve({
         id: 'closed',
         success: false,
-        error: 'Terminal websocket disconnected',
+        error: reason ?? 'Terminal websocket disconnected',
         code: 'NETWORK_ERROR'
       })
     }
@@ -334,6 +358,115 @@ export class WebTerminalClient {
       this.reconnectTimer = null
       void this.connect().catch(() => this.scheduleReconnect())
     }, delay)
+  }
+
+  /**
+   * Attach `visibilitychange` + `focus` listeners (web only) so a return from
+   * a backgrounded mobile tab proactively reconnects instead of waiting for an
+   * `onclose` the suspended browser delivers late or never. Mirrors
+   * `WsAcpTransport`: same threshold, coalescing, and `forceReconnect`
+   * semantics. Idempotent; detached in `dispose`.
+   */
+  private attachVisibilityListeners(): void {
+    if (this.visibilityHandler || typeof document === 'undefined') return
+    const onVisibility = (): void => {
+      if (document.visibilityState === 'hidden') {
+        this.lastHiddenAt = Date.now()
+        return
+      }
+      // visible — a backgrounded tab returning to the foreground.
+      this.maybeReconnectOnReturn()
+    }
+    const onFocus = (): void => {
+      // Fallback for platforms where `visibilitychange` is unreliable; only
+      // acts when a hide was previously recorded so normal use is a no-op.
+      this.maybeReconnectOnReturn()
+    }
+    this.visibilityHandler = onVisibility
+    this.focusHandler = onFocus
+    document.addEventListener('visibilitychange', onVisibility)
+    // `focus` is a window-level event that does NOT bubble — attach to `window`.
+    window.addEventListener('focus', onFocus)
+  }
+
+  /** Detach the visibility/focus listeners (called from `dispose`). */
+  private detachVisibilityListeners(): void {
+    if (this.visibilityHandler && typeof document !== 'undefined') {
+      document.removeEventListener('visibilitychange', this.visibilityHandler)
+      this.visibilityHandler = null
+    }
+    if (this.focusHandler && typeof window !== 'undefined') {
+      window.removeEventListener('focus', this.focusHandler)
+      this.focusHandler = null
+    }
+  }
+
+  /**
+   * On a return-to-foreground, if the page was hidden past the staleness
+   * threshold OR the socket is not OPEN, force a reconnect so a half-open
+   * socket killed server-side during AFK is recovered. After reopen, `connect`
+   * re-attaches non-exited trackers via their stored `lastSeq`, replaying
+   * missed output. Consumes `lastHiddenAt` so a `focus` following a
+   * `visibilitychange` does not double-trigger.
+   */
+  private maybeReconnectOnReturn(): void {
+    if (this.disposed) return
+    const hiddenAt = this.lastHiddenAt
+    this.lastHiddenAt = null
+    if (hiddenAt == null) return // never recorded a hide — nothing to recover
+    const hiddenFor = Date.now() - hiddenAt
+    const socketDown = this.socket?.readyState !== this.WebSocketImpl.OPEN
+    if (hiddenFor > VISIBILITY_STALE_THRESHOLD_MS || socketDown) {
+      this.forceReconnect(
+        socketDown ? 'socket closed while page was hidden' : 'visibility return after idle'
+      )
+    }
+  }
+
+  /**
+   * Force a clean reconnect, bypassing the `connect()` fast path that trusts
+   * `readyState === OPEN`. Tears down the suspect socket (detaching its
+   * handlers so its eventual close does not double-fire `scheduleReconnect`),
+   * resets `reconnectAttempt` so AFK never strands the terminal at the backoff
+   * ceiling, clears any pending reconnect timer, then reuses `scheduleReconnect`
+   * so the existing backoff + `onopen` re-attach machinery runs unchanged.
+   */
+  private forceReconnect(reason: string): void {
+    if (this.disposed) return
+    const old = this.socket
+    // Capture the in-flight connect promise's reject BEFORE nulling so it can
+    // be settled after the socket teardown. Without this, a `request()`
+    // awaiting `connect()` (socket CONNECTING) hangs — its 15s timeout only
+    // arms AFTER connect resolves, and forceReconnect nulls `connecting`
+    // without rejecting the in-flight promise.
+    const inflightReject = this.connectingReject
+    this.socket = null
+    this.connecting = null
+    this.connectingReject = null
+    this.rejectPending(reason)
+    if (this.reconnectTimer) {
+      clearTimeout(this.reconnectTimer)
+      this.reconnectTimer = null
+    }
+    this.reconnectAttempt = 0
+    if (old) {
+      // Detach ALL handlers (incl. onopen) so a late CONNECTING→open on the
+      // torn-down socket doesn't fire `onopen` against shared `this` state
+      // (would clobber reconnectAttempt + null connecting).
+      old.onopen = null
+      old.onclose = null
+      old.onerror = null
+      old.onmessage = null
+      try {
+        old.close()
+      } catch {
+        // ignore — already closed
+      }
+    }
+    // Settle the in-flight connect promise so awaiters throw → request()
+    // catches → returns NETWORK_ERROR (mirrors WsAcpTransport).
+    inflightReject?.(new Error(reason))
+    this.scheduleReconnect()
   }
 }
 


### PR DESCRIPTION
## Summary

On the web client (termul-server served to phone browsers), after switching to another app and returning, the terminal becomes frozen/untouchable. Root cause: `WebTerminalClient` (the web terminal's own WebSocket) has **no visibility-triggered reconnect** — unlike the ACP chat transport (`WsAcpTransport`), which already reconnects on `visibilitychange`/`focus`. The web terminal only reconnects on `socket.onclose`, but on mobile the OS suspends the tab and the socket goes half-open (the server tears it down at its Pong-timeout) while `onclose` often **never fires** → `scheduleReconnect` never triggers → output stalls and `write()`/`resize()` hang → the terminal is frozen and untouchable. (`RECONNECT_MAX_ATTEMPTS` can also be exhausted across repeated suspensions.)

This PR gives `WebTerminalClient` the same `visibilitychange`/`focus` → `maybeReconnectOnReturn` → `forceReconnect` parity as `WsAcpTransport`: on return, if the page was hidden past the staleness threshold OR the socket is not `OPEN`, it tears down the suspect socket, resets `reconnectAttempt`, and reuses the existing backoff + `onopen` re-attach machinery — re-attaching non-exited trackers via their stored `lastSeq` so missed output is replayed.

It also fixes a latent hang the new path makes reachable: `forceReconnect` now settles any in-flight `connect()` promise (via a stored `connectingReject`) and detaches `old.onopen`, so a `request()` awaiting `connect()` on the same tick as an AFK-return can't hang indefinitely (its 15s timeout only arms after `connect()` resolves). The fix is regression-guarded by a test that hangs when the settle call is removed.

## Related Issue

No related issue exists — reported directly as a web-UI pain ("when i afk to other app, and back to the browser the terminal is unusable, i cannot click and everything is not working like it keep stoping and freeze and un touchable"). Prior related specs already `done`: `spec-fix-web-acp-idle-persist`, `spec-fix-web-acp-active-turn-disconnect-recovery` (these covered the ACP/chat transport; the **web terminal** client was the remaining gap).

## Type of Change

- [x] fix: bug fix

## What Changed

- `src/renderer/lib/web-terminal-api.ts` — `WebTerminalClient` gains `attachVisibilityListeners`/`detachVisibilityListeners` (`visibilitychange` + window `focus`), `maybeReconnectOnReturn` (force-reconnect after a long hide or when the socket is down), and `forceReconnect` (tear down the old socket detaching `onclose`/`onerror`/`onmessage`/**`onopen`**, reset `reconnectAttempt`, clear the reconnect timer, reuse `scheduleReconnect`). Added `connectingReject` so the in-flight `connect()` promise is settled on `forceReconnect`; `connect()` sets/clears it in `onopen`/`onerror`/`onclose`. Web-only; the Tauri desktop path and `WsAcpTransport` are untouched.
- `src/renderer/lib/web-terminal-api.test.ts` — new AFK-recovery suite (reconnect + re-attach with `lastSeq` after a long hide; no double-reconnect when `focus` follows `visibilitychange`; `TERMINAL_NOT_FOUND` on re-attach marks the tracker exited; `reconnectAttempt` resets on visibility recovery; the `socketDown`-only short-hide branch; listener attach/detach; the forceReconnect-hang regression). **Re-added** the previously-deleted `resolveTerminalWsUrl` URL-mapping test and the request→reply / `onData` binary-array contract tests (coverage regression fix).

## How It Was Tested

- [x] `bun run ci` (Biome lint + format + imports, strict mode) — 728 files, 0 errors
- [x] `bun run typecheck` — clean (node + web + test tsconfigs)
- [x] `bun run test` — targeted suite green (web-terminal-api 10 tests); full suite 2625 passed, 0 assertion failures. (5 suites that fail to *load* in the isolated worktree due to a `node_modules` junction Vite `Denied ID` guard were confirmed passing against the real `node_modules` checkout.)
- [ ] `cargo clippy --all-targets -- -D warnings` — N/A (renderer-only; Rust untouched)
- [ ] `cargo test` — N/A (renderer-only)
- [x] Manual verification completed — the HIGH-severity forceReconnect-hang fix was regression-guarded (disabling the settle call reproduces the hang; restoring it passes).

## CI & Review Gate

- [ ] All CI checks pass — pending (CI runs in a proper checkout, not the junctioned worktree, so the 5 local load-failures won't reproduce)
- [ ] Code review comments addressed — will triage via babysit
- [ ] No unresolved review findings remain — will babysit to merge-ready

## Checklist

- [x] PR title follows conventional commit format (`fix(web): …`)
- [x] Related issue linked/explained (reported pain; prior done specs referenced)
- [x] Docs — inline code comments document the mirror-of-WsAcpTransport rationale
- [x] Tests added/updated
- [x] No unrelated modifications (Stream A only: web-terminal-api + its test)
- [x] Read AGENTS.md / CLAUDE.md and followed contributor guidelines
- [x] Complete diff reviewed — adversarial / edge-case / verification-gap / intent-alignment review pass completed (8 patches applied, 0 criticals remaining)
