### PR TITLE
fix(web): persist workspace layout and chat draft across reload via localStorage

### DIFF
--- a/src/renderer/components/chat/ChatInputBar.test.tsx
+++ b/src/renderer/components/chat/ChatInputBar.test.tsx
@@ -34,6 +34,45 @@ vi.mock('@/stores/acp-store', () => ({
     selector({ mcpServers: Array.from({ length: mockMcpCount.current }) })
 }))
 
+const { persistenceStore, fakePersistenceApi } = vi.hoisted(() => {
+  const persistenceStore = new Map<string, unknown>()
+  const api = {
+    readFails: false,
+    read: vi.fn(async (key: string) => {
+      // Faithful to the real persistenceApi, which never throws to callers —
+      // a storage-layer failure surfaces as a non-throwing `success:false`.
+      if (api.readFails) return { success: false, code: 'READ_ERROR', error: 'storage unavailable' }
+      return persistenceStore.has(key)
+        ? { success: true, data: persistenceStore.get(key) }
+        : { success: false, code: 'KEY_NOT_FOUND', error: `Key not found: ${key}` }
+    }),
+    write: vi.fn(async (key: string, data: unknown) => {
+      persistenceStore.set(key, data)
+      return { success: true, data: undefined }
+    }),
+    writeDebounced: vi.fn(async (key: string, data: unknown) => {
+      persistenceStore.set(key, data)
+      return { success: true, data: undefined }
+    }),
+    delete: vi.fn(async (key: string) => {
+      persistenceStore.delete(key)
+      return { success: true, data: undefined }
+    }),
+    flushPendingWrites: vi.fn(async () => ({ success: true, data: undefined }))
+  }
+  return { persistenceStore, fakePersistenceApi: api }
+})
+
+vi.mock('@/lib/api', async () => {
+  const actual = await vi.importActual<typeof import('@/lib/api')>('@/lib/api')
+  return { ...actual, persistenceApi: fakePersistenceApi }
+})
+
+beforeEach(() => {
+  persistenceStore.clear()
+  fakePersistenceApi.readFails = false
+})
+
 function option(
   id: string,
   name: string,
@@ -581,5 +620,91 @@ describe('ChatInputBar command chip', () => {
     await waitFor(() => {
       expect(onSend).toHaveBeenCalledWith('edited message')
     })
+  })
+})
+
+describe('ChatInputBar draft persistence', () => {
+  beforeEach(() => {
+    persistenceStore.clear()
+    fakePersistenceApi.readFails = false
+  })
+
+  it('restores an unsent draft into the composer on mount', async () => {
+    persistenceStore.set('chat-draft/p1/session-1', 'half-typed message')
+    renderInputBar()
+    await waitFor(() => {
+      expect(screen.getByRole('textbox')).toHaveValue('half-typed message')
+    })
+  })
+
+  it('clears the draft on send', async () => {
+    persistenceStore.set('chat-draft/p1/session-1', 'send me')
+    const onSend = vi.fn()
+    renderInputBar({ onSend })
+
+    await waitFor(() => {
+      expect(screen.getByRole('textbox')).toHaveValue('send me')
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: 'Send message' }))
+
+    await waitFor(() => {
+      expect(onSend).toHaveBeenCalledWith('send me')
+      // The composer emptied (clear-on-send) → the persisted draft was deleted.
+      expect(persistenceStore.has('chat-draft/p1/session-1')).toBe(false)
+    })
+  })
+
+  it('does not crash when storage is empty', () => {
+    // No draft persisted → empty composer, current behavior, no throw.
+    renderInputBar()
+    expect(screen.getByRole('textbox')).toHaveValue('')
+  })
+
+  it('does not crash when storage is unavailable', async () => {
+    fakePersistenceApi.readFails = true
+    renderInputBar()
+    // read returns a non-throwing failure → degrade to empty, no crash.
+    await waitFor(() => {
+      expect(screen.getByRole('textbox')).toHaveValue('')
+    })
+  })
+
+  it('does not persist the seeded text as a draft while editing a message', async () => {
+    vi.useFakeTimers()
+    try {
+      renderInputBar({ seedText: 'edited message', seedNonce: 1 })
+      // Advance well past the 400ms debounce — seeding must never schedule a
+      // draft write (the write effect early-returns while seedNonce is set).
+      await vi.advanceTimersByTimeAsync(0)
+      await vi.advanceTimersByTimeAsync(400)
+      expect(fakePersistenceApi.writeDebounced).not.toHaveBeenCalled()
+      expect(persistenceStore.has('chat-draft/p1/session-1')).toBe(false)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('persists typed text via writeDebounced after the 400ms debounce', async () => {
+    vi.useFakeTimers()
+    try {
+      renderInputBar()
+      // Flush the hydrate read so hydratedRef flips true before typing.
+      await vi.advanceTimersByTimeAsync(0)
+      await vi.advanceTimersByTimeAsync(0)
+
+      const textarea = screen.getByRole('textbox')
+      fireEvent.change(textarea, { target: { value: 'typed draft' } })
+
+      fakePersistenceApi.writeDebounced.mockClear()
+      await vi.advanceTimersByTimeAsync(400)
+      expect(fakePersistenceApi.writeDebounced).toHaveBeenCalledWith(
+        'chat-draft/p1/session-1',
+        'typed draft'
+      )
+      expect(persistenceStore.get('chat-draft/p1/session-1')).toBe('typed draft')
+    } finally {
+      vi.useRealTimers()
+    }
   })
 })

--- a/src/renderer/components/chat/ChatInputBar.tsx
+++ b/src/renderer/components/chat/ChatInputBar.tsx
@@ -19,6 +19,7 @@ import type {
   SessionConfigOption,
   SessionModeState
 } from '@/lib/acp-api'
+import { persistenceApi } from '@/lib/api'
 import { registerSessionTempFiles } from '@/lib/attachment-temp-cleanup'
 import { cn } from '@/lib/utils'
 import type { AcpSession, QueuedPrompt } from '@/stores/acp-store'
@@ -131,6 +132,69 @@ export function ChatInputBar({
   const globalMcpCount = useAcpStore((s) => s.mcpServers.length)
   const mcpCount = session.mcpServerCount ?? globalMcpCount
   const [value, setValue] = useState('')
+  // Persist the in-progress composer draft per session (project + session id)
+  // so an unsent message survives a web reload. useState stays the source of
+  // truth; the persisted copy is a recovery fallback only — hydrate on mount,
+  // debounce writes on change, and clear (delete) when the composer empties
+  // (covers both manual clear and clear-on-send). External seeding (editing a
+  // message) takes precedence over a stale draft.
+  const draftKey = `chat-draft/${session.projectId}/${session.id}`
+  // Guard against undefined/null ids collapsing the key to
+  // `chat-draft/undefined/undefined` and cross-session drafts colliding.
+  const canPersistDraft = session.projectId != null && session.id != null
+  const hydratedRef = useRef(false)
+  useEffect(() => {
+    if (seedNonce !== undefined) {
+      // Editing/seeding a message — don't restore a stale draft over the seed.
+      hydratedRef.current = true
+      return
+    }
+    if (!canPersistDraft) {
+      // projectId/sessionId missing — can't key a draft; treat as hydrated so
+      // the write effect's hydration gate doesn't block (it also guards).
+      hydratedRef.current = true
+      return
+    }
+    let cancelled = false
+    hydratedRef.current = false
+    void persistenceApi
+      .read<string>(draftKey)
+      .then((result) => {
+        if (cancelled) return
+        if (result.success && typeof result.data === 'string' && result.data) {
+          setValue(result.data)
+        }
+      })
+      .catch(() => {
+        // Storage unavailable/corrupt — degrade to empty (no UI crash).
+      })
+      .finally(() => {
+        if (!cancelled) hydratedRef.current = true
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [draftKey, seedNonce, canPersistDraft])
+
+  // Debounced draft write on change — only after hydration so the just-loaded
+  // draft isn't clobbered with '' before the read resolves. Empty value
+  // clears the persisted draft so a reload after send/empty stays clean.
+  // While editing/seeding a message (seedNonce set), skip persistence so the
+  // seeded text isn't leaked back as the session's draft (reload would restore
+  // the edited message into the composer).
+  useEffect(() => {
+    if (seedNonce !== undefined) return
+    if (!canPersistDraft) return
+    if (!hydratedRef.current) return
+    if (!value) {
+      void persistenceApi.delete(draftKey).catch(() => {})
+      return
+    }
+    const handle = setTimeout(() => {
+      void persistenceApi.writeDebounced(draftKey, value).catch(() => {})
+    }, 400)
+    return () => clearTimeout(handle)
+  }, [value, draftKey, seedNonce, canPersistDraft])
   const [activeCommand, setActiveCommand] = useState<string | null>(null)
   const [sending, setSending] = useState(false)
   const [focused, setFocused] = useState(false)

--- a/src/renderer/lib/tauri-stubs/plugin-store.test.ts
+++ b/src/renderer/lib/tauri-stubs/plugin-store.test.ts
@@ -1,0 +1,136 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { Store } from '@/lib/tauri-stubs/plugin-store'
+
+describe('plugin-store localStorage stub', () => {
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.restoreAllMocks()
+  })
+
+  it('round-trips get/set/delete and reports keys/length/has/values/entries', async () => {
+    const store = await Store.load('app-data.json')
+    expect(await store.get('missing')).toBeUndefined()
+    expect(await store.has('a')).toBe(false)
+
+    await store.set('a', { n: 1 })
+    expect(await store.has('a')).toBe(true)
+    expect(await store.get<{ n: number }>('a')).toEqual({ n: 1 })
+    expect(await store.keys()).toEqual(['a'])
+    expect(await store.length()).toBe(1)
+    expect(await store.values()).toEqual([{ n: 1 }])
+    expect(await store.entries()).toEqual([['a', { n: 1 }]])
+
+    await store.delete('a')
+    expect(await store.get('a')).toBeUndefined()
+    expect(await store.has('a')).toBe(false)
+    expect(await store.keys()).toEqual([])
+  })
+
+  it('namespaces by path — two stores never bleed', async () => {
+    const alpha = await Store.load('alpha.json')
+    const beta = await Store.load('beta.json')
+    await alpha.set('shared-key', 'from-alpha')
+    await beta.set('shared-key', 'from-beta')
+    expect(await alpha.get<string>('shared-key')).toBe('from-alpha')
+    expect(await beta.get<string>('shared-key')).toBe('from-beta')
+    expect(await alpha.keys()).toEqual(['shared-key'])
+    expect(await beta.keys()).toEqual(['shared-key'])
+    // clearing one store does not touch the other
+    await alpha.clear()
+    expect(await alpha.get('shared-key')).toBeUndefined()
+    expect(await beta.get<string>('shared-key')).toBe('from-beta')
+  })
+
+  it('clear and reset remove only namespaced entries', async () => {
+    const store = await Store.load('gamma.json')
+    await store.set('k1', 1)
+    await store.set('k2', 2)
+    const other = await Store.load('delta.json')
+    await other.set('k3', 3)
+
+    await store.reset()
+    expect(await store.keys()).toEqual([])
+    expect(await other.get('k3')).toBe(3)
+  })
+
+  it('save is a no-op (set already persists immediately)', async () => {
+    const store = await Store.load('eps.json')
+    await store.set('x', 42)
+    await store.save() // must not throw
+    expect(await store.get('x')).toBe(42)
+  })
+
+  it('degrades silently on corrupt JSON (returns undefined)', async () => {
+    const store = await Store.load('corrupt.json')
+    // write raw garbage straight into localStorage under the namespace
+    localStorage.setItem('termul-store:corrupt.json::bad', '{not-json')
+    expect(await store.get('bad')).toBeUndefined()
+  })
+
+  it('degrades silently when setItem throws (quota / security)', async () => {
+    const store = await Store.load('quota.json')
+    const spy = vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+      throw new DOMException('quota exceeded', 'QuotaExceededError')
+    })
+    await expect(store.set('big', 'x'.repeat(10))).resolves.toBeUndefined()
+    expect(await store.get('big')).toBeUndefined()
+    spy.mockRestore()
+  })
+
+  it('returns empty/undefined defaults when localStorage is unavailable (SSR)', async () => {
+    vi.stubGlobal('localStorage', undefined)
+    const store = await Store.load('ssr.json')
+    expect(await store.get('any')).toBeUndefined()
+    expect(await store.has('any')).toBe(false)
+    expect(await store.keys()).toEqual([])
+    expect(await store.length()).toBe(0)
+    await expect(store.set('any', 'x')).resolves.toBeUndefined()
+    await expect(store.delete('any')).resolves.toBeUndefined()
+    await expect(store.clear()).resolves.toBeUndefined()
+  })
+
+  it('applies defaults for absent keys on load and never overwrites existing', async () => {
+    const store = await Store.load('defs.json', {
+      autoSave: false,
+      defaults: { greeting: 'hi', count: 3 }
+    })
+    expect(await store.get<string>('greeting')).toBe('hi')
+    expect(await store.get('count')).toBe(3)
+
+    // A pre-existing value must not be overwritten by defaults on a later load.
+    await store.set('count', 99)
+    const reloaded = await Store.load('defs.json', { defaults: { count: 3 } })
+    expect(await reloaded.get('count')).toBe(99)
+  })
+
+  it('reset() re-applies the defaults passed to load() after clearing', async () => {
+    const store = await Store.load('reset-defaults.json', { defaults: { a: 1 } })
+    expect(await store.get('a')).toBe(1)
+    // Overwrite the default; reset must restore it (Tauri parity).
+    await store.set('a', 99)
+    expect(await store.get('a')).toBe(99)
+    await store.reset()
+    expect(await store.get('a')).toBe(1)
+  })
+
+  it('clear() on a namespace containing `::` does not bleed into a namespace it prefixes', async () => {
+    // `a.json` and `a::b.json` — without namespace escaping, `clear()` on
+    // `a.json` prefix-matches `termul-store:a.json::` over `termul-store:a::b.json::`
+    // and would delete `a::b.json`'s keys too.
+    const a = await Store.load('a.json')
+    const ab = await Store.load('a::b.json')
+    await a.set('k', 'from-a')
+    await ab.set('k', 'from-ab')
+    expect(await ab.get<string>('k')).toBe('from-ab')
+
+    await a.clear()
+    // `a.json` cleared its own key; `a::b.json` is untouched.
+    expect(await a.get('k')).toBeUndefined()
+    expect(await ab.get<string>('k')).toBe('from-ab')
+    expect(await ab.keys()).toEqual(['k'])
+  })
+})

--- a/src/renderer/lib/tauri-stubs/plugin-store.ts
+++ b/src/renderer/lib/tauri-stubs/plugin-store.ts
@@ -1,43 +1,178 @@
 /**
  * Browser stub for `@tauri-apps/plugin-store`.
- * No persistent store in the web build — load returns an empty in-memory shim.
+ *
+ * Web build only — aliased in by `vite.config.web.ts`. Backs the prior no-op
+ * stub with `localStorage` so persistence (`persistenceApi`, editor layout,
+ * projects, app settings, context-bar, terminal autosave, etc.) actually
+ * round-trips on a web reload. Desktop uses the real Tauri plugin-store.
+ *
+ * - `load(path)` returns a Store namespaced by `path` so distinct stores never
+ *   bleed into each other.
+ * - `set` writes immediately (JSON-serialized); `save()` is a no-op (the web
+ *   build has no deferred disk flush — data is already in `localStorage`).
+ * - All ops catch `QuotaExceededError` / `SecurityError` / JSON parse failures
+ *   and degrade silently (return `undefined` / empty, never throw to the UI).
+ * - Guards `typeof localStorage` for SSR / non-browser hosts.
+ *
+ * The class shape and method signatures are preserved so every existing
+ * consumer unblocks without per-consumer edits.
  */
+const STORAGE_PREFIX = 'termul-store:'
+
+/** Escape `:` in a namespace so a namespace containing `::` (e.g. `a::b`)
+ * can't make `clear('a')` prefix-match into `a::b`'s keys. Keys are NOT
+ * escaped — they sit after the delimiter and may contain anything; `keys()`
+ * already slices the prefix, so escaping only the namespace preserves key
+ * values. Uses a control char (\u0001) that can't appear in a store path. */
+function escapeNamespace(namespace: string): string {
+  return namespace.replaceAll(':', '\u0001')
+}
+
+function storageKey(namespace: string, key: string): string {
+  return `${STORAGE_PREFIX}${escapeNamespace(namespace)}::${key}`
+}
+
+function hasLocalStorage(): boolean {
+  return typeof localStorage !== 'undefined'
+}
+
 export class Store {
-  static async load(_path: string, _options?: unknown): Promise<Store> {
-    return new Store()
+  private readonly namespace: string
+  /** Defaults passed to `load()` — re-applied by `reset()` (Tauri parity). */
+  private readonly defaults: Record<string, unknown>
+
+  private constructor(namespace: string, defaults: Record<string, unknown>) {
+    this.namespace = namespace
+    this.defaults = defaults
   }
 
-  async get<T>(_key: string): Promise<T | undefined> {
-    return undefined
+  static async load(path: string, options?: unknown): Promise<Store> {
+    // Tauri-faithful: `defaults` pre-populate keys that are absent on load. The
+    // only current caller passes an empty `defaults` (a no-op), but apply the
+    // semantics so the contract holds for any future caller.
+    const rawDefaults = (options as { defaults?: Record<string, unknown> } | null | undefined)
+      ?.defaults
+    const defaults: Record<string, unknown> =
+      rawDefaults && typeof rawDefaults === 'object' ? rawDefaults : {}
+    const store = new Store(path, defaults)
+    for (const [key, value] of Object.entries(defaults)) {
+      if (!(await store.has(key))) {
+        await store.set(key, value)
+      }
+    }
+    return store
   }
 
-  async set(_key: string, _value: unknown): Promise<void> {}
+  async get<T>(key: string): Promise<T | undefined> {
+    if (!hasLocalStorage()) return undefined
+    try {
+      const raw = localStorage.getItem(storageKey(this.namespace, key))
+      if (raw == null) return undefined
+      return JSON.parse(raw) as T
+    } catch {
+      // Corrupt JSON / SecurityError (private mode) — degrade silently.
+      return undefined
+    }
+  }
 
-  async save(): Promise<void> {}
+  async set(key: string, value: unknown): Promise<void> {
+    if (!hasLocalStorage()) return
+    try {
+      localStorage.setItem(storageKey(this.namespace, key), JSON.stringify(value))
+    } catch {
+      // QuotaExceededError / SecurityError — drop the write silently. The UI
+      // must never throw on persistence; reads return last-good or empty.
+    }
+  }
 
-  async delete(_key: string): Promise<void> {}
+  async save(): Promise<void> {
+    // No-op: `set` writes immediately to localStorage (no deferred disk flush
+    // in the web build).
+  }
 
-  async clear(): Promise<void> {}
+  async delete(key: string): Promise<void> {
+    if (!hasLocalStorage()) return
+    try {
+      localStorage.removeItem(storageKey(this.namespace, key))
+    } catch {
+      // degrade silently
+    }
+  }
 
-  async reset(): Promise<void> {}
+  async clear(): Promise<void> {
+    if (!hasLocalStorage()) return
+    try {
+      const prefix = `${STORAGE_PREFIX}${escapeNamespace(this.namespace)}::`
+      // Collect first, then remove — mutating `localStorage` while iterating by
+      // index would shift indices and skip entries.
+      const toRemove: string[] = []
+      for (let i = 0; i < localStorage.length; i++) {
+        const stored = localStorage.key(i) ?? ''
+        if (stored.startsWith(prefix)) toRemove.push(stored)
+      }
+      for (const k of toRemove) localStorage.removeItem(k)
+    } catch {
+      // degrade silently
+    }
+  }
+
+  async reset(): Promise<void> {
+    await this.clear()
+    // Tauri-faithful parity: real `Store.reset()` clears AND re-applies the
+    // `defaults` passed to `load()`. Without this, reset()-returns-defaults
+    // callers silently diverge from desktop.
+    for (const [key, value] of Object.entries(this.defaults)) {
+      if (!(await this.has(key))) {
+        await this.set(key, value)
+      }
+    }
+  }
 
   async keys(): Promise<string[]> {
-    return []
+    if (!hasLocalStorage()) return []
+    try {
+      const prefix = `${STORAGE_PREFIX}${escapeNamespace(this.namespace)}::`
+      const keys: string[] = []
+      for (let i = 0; i < localStorage.length; i++) {
+        const stored = localStorage.key(i) ?? ''
+        if (stored.startsWith(prefix)) keys.push(stored.slice(prefix.length))
+      }
+      return keys
+    } catch {
+      return []
+    }
   }
 
   async values<T>(): Promise<T[]> {
-    return []
+    const keys = await this.keys()
+    const out: T[] = []
+    for (const key of keys) {
+      const v = await this.get<T>(key)
+      if (v !== undefined) out.push(v)
+    }
+    return out
   }
 
   async entries<T>(): Promise<[string, T][]> {
-    return []
+    const keys = await this.keys()
+    const out: [string, T][] = []
+    for (const key of keys) {
+      const v = await this.get<T>(key)
+      if (v !== undefined) out.push([key, v])
+    }
+    return out
   }
 
   async length(): Promise<number> {
-    return 0
+    return (await this.keys()).length
   }
 
-  async has(_key: string): Promise<boolean> {
-    return false
+  async has(key: string): Promise<boolean> {
+    if (!hasLocalStorage()) return false
+    try {
+      return localStorage.getItem(storageKey(this.namespace, key)) != null
+    } catch {
+      return false
+    }
   }
 }


### PR DESCRIPTION
## Summary

On the web client, a fresh reload loses all session state — the user must retype. Root cause: the web build aliases `@tauri-apps/plugin-store` to a **no-op browser stub** (`get`→`undefined`), so `persistenceApi.read`/`writeDebounced` are no-ops on web. Consequently `useEditorPersistence` reads nothing and `resetLayout()`s to an empty pane → the prior `agent-chat` tab never mounts → its rehydrate effect never fires `openHistorySession` → no transcript load, no live re-subscribe, and the unsent composer draft is `useState('')` with zero persistence.

This PR (1) backs the web `plugin-store` stub with `localStorage` (namespaced by store path, JSON-serialized, `QuotaExceededError`/`SecurityError`/corrupt-JSON-safe, SSR-guarded, re-applies `defaults` on both `load()` and `reset()` for Tauri parity, and `:`-escapes the namespace so `clear()`/`keys()` prefix-match is exact). This single change unblocks `persistenceApi` for editor layout, app settings, context-bar, terminal autosave, etc. — so the workspace pane layout + active chat tab restore on reload, triggering `openHistorySession` (transcript + live re-subscribe). (2) Adds per-session chat-input draft persistence (hydrate on mount, debounced write on change, clear on empty/send) with guards so editing a message (`seedNonce`) doesn't leak the edited text into the draft and missing `projectId`/`sessionId` can't collide across sessions.

## Related Issue

No related issue exists — reported directly as a web-UI pain ("all the session is not persistent, from terminal, the chat ui etc… i need to rewrit again and again"). Prior related specs already `done`: `spec-web-chat-history-server-sync-parity` (server-side history sync/load routes exist); the **client-side layout/tab restore + draft persistence** remained the open gap addressed here.

## Type of Change

- [x] fix: bug fix

## What Changed

- `src/renderer/lib/tauri-stubs/plugin-store.ts` — `localStorage`-backed `Store` (namespaced by `load(path)`; `set` writes immediately, `save()` no-op; `get`/`set`/`delete`/`clear`/`reset`/`keys`/`values`/`entries`/`length`/`has`; quota/security/parse failures degrade silently; `typeof localStorage` SSR guard; `defaults` stored + re-applied on `load` and `reset`; namespace `:`-escaped for exact prefix-matching). Desktop Tauri path untouched.
- `src/renderer/lib/tauri-stubs/plugin-store.test.ts` (new) — round-trip, namespacing (no cross-store bleed), clear/reset isolation, `save` no-op, corrupt-JSON degradation, quota/security degradation, SSR defaults, defaults-on-load-and-reset reapply, `::`-namespace isolation.
- `src/renderer/components/chat/ChatInputBar.tsx` — per-session draft key `chat-draft/<projectId>/<sessionId>`; hydrate on mount via `persistenceApi.read` (gated by `hydratedRef`); debounced (400ms) write on change via `writeDebounced`; delete on empty (covers clear-on-send); `seedNonce` guard (don't restore/persist while editing); `canPersistDraft` guard (skip when ids missing).
- `src/renderer/components/chat/ChatInputBar.test.tsx` — draft restores on mount; clears on send; no crash when storage empty/unavailable; seeded/edit text is NOT persisted; typed text IS persisted via `writeDebounced` after the debounce.

## How It Was Tested

- [x] `bun run ci` — 728 files, 0 errors
- [x] `bun run typecheck` — clean (node + web + test tsconfigs)
- [x] `bun run test` — targeted suite green (plugin-store 10 + ChatInputBar 23); full suite 2625 passed, 0 assertion failures. The 5 suites that fail to *load* in the isolated worktree (`node_modules` junction Vite `Denied ID`) — including App/WorkspaceLayout×2 which exercise layout restore (with mocked `persistenceApi`) — were confirmed passing against the real `node_modules` checkout (52 tests passed).
- [ ] `cargo clippy` / `cargo test` — N/A (renderer-only; Rust untouched)
- [x] Manual verification completed

## CI & Review Gate

- [ ] All CI checks pass — pending (proper checkout, not the junctioned worktree)
- [ ] Code review comments addressed — will triage via babysit
- [ ] No unresolved review findings remain — will babysit to merge-ready

## Checklist

- [x] PR title follows conventional commit format (`fix(web): …`)
- [x] Related issue linked/explained
- [x] Docs — inline comments document the localStorage backing + Tauri-parity rationale
- [x] Tests added/updated
- [x] No unrelated modifications (Stream B only: plugin-store + ChatInputBar + their tests)
- [x] Read AGENTS.md / CLAUDE.md and followed contributor guidelines
- [x] Complete diff reviewed — adversarial / edge-case / verification-gap / intent-alignment pass (8 patches applied across the two streams; this PR carries the Stream B patches)

## Notes

Two independently-shippable web-resilience fixes were implemented; per the repo's one-problem-per-PR rule this is the **persistence** PR. The sibling **terminal-AFK-reconnect** PR (`fix/web-terminal-afk-reconnect`) carries the unrelated terminal-transport fix. They touch disjoint files (no merge conflict). Deferred to follow-up specs: web terminal *session* restore across a hard reload (needs server-side PTY survival) and standalone-VPS `get_session_payload` `not_found`.
