### PR TITLE
feat(terminal): replay PTY modes so TUIs restore correctly across refresh

### DIFF
--- a/src/renderer/components/terminal/ConnectedTerminal.tsx
+++ b/src/renderer/components/terminal/ConnectedTerminal.tsx
@@ -42,6 +42,7 @@ import { useActiveProject } from '@/stores/project-store'
 import { useTerminalStore } from '@/stores/terminal-store'
 import type { TerminalModes, TerminalSpawnOptions } from '../../../shared/types/ipc.types'
 import {
+  buildRehydrateSequences,
   captureScrollPosition,
   registerTerminal,
   restoreScrollback,
@@ -973,12 +974,14 @@ function ConnectedTerminalComponent({
             try {
               if (transcript) {
                 if (transcriptLooksPartial) {
-                  if (!transcript.startsWith('\u001b[?1049h')) {
-                    terminal.write('\u001b[?1049h')
-                  }
+                  // R3: replay the full captured DEC mode set (alt-screen + bracketed-paste
+                  // + cursor + mouse), not just alt-screen — a partial/trimmed transcript
+                  // may miss the initial mode sequences. Idempotent with modes in the stream.
+                  terminal.write(buildRehydrateSequences(initialModesRef.current))
                   terminal.write(transcript)
                   terminal.write(PARTIAL_RESTORE_NOTE)
                 } else {
+                  terminal.write(buildRehydrateSequences(initialModesRef.current))
                   terminal.write(transcript)
                 }
                 terminalStoreState.consumeTranscript(result.data.id)
@@ -1121,12 +1124,12 @@ function ConnectedTerminalComponent({
             )
           } else if (transcript) {
             if (transcriptLooksPartial) {
-              if (!transcript.startsWith('\u001b[?1049h')) {
-                terminal.write('\u001b[?1049h')
-              }
+              // R3: replay the full captured DEC mode set, not just alt-screen.
+              terminal.write(buildRehydrateSequences(initialModesRef.current))
               terminal.write(transcript)
               terminal.write(PARTIAL_RESTORE_NOTE)
             } else {
+              terminal.write(buildRehydrateSequences(initialModesRef.current))
               terminal.write(transcript)
             }
             terminalStoreState.consumeTranscript(externalTerminalId)
@@ -1688,6 +1691,8 @@ function ConnectedTerminalComponent({
             registerTerminal(result.data.id, terminal)
             const transcript = useTerminalStore.getState().peekTranscript(result.data.id)
             if (transcript) {
+              // R3: replay captured modes before the (possibly trimmed) transcript.
+              terminal.write(buildRehydrateSequences(initialModesRef.current))
               terminal.write(transcript)
               useTerminalStore.getState().consumeTranscript(result.data.id)
             } else if (initialScrollbackRef.current?.length)
@@ -1706,6 +1711,8 @@ function ConnectedTerminalComponent({
         registerTerminal(externalTerminalId, terminal)
         const transcript = useTerminalStore.getState().peekTranscript(externalTerminalId)
         if (transcript) {
+          // R3: replay captured modes before the (possibly trimmed) transcript.
+          terminal.write(buildRehydrateSequences(initialModesRef.current))
           terminal.write(transcript)
           useTerminalStore.getState().consumeTranscript(externalTerminalId)
         } else if (initialScrollbackRef.current?.length)

--- a/src/renderer/components/terminal/ConnectedTerminal.tsx
+++ b/src/renderer/components/terminal/ConnectedTerminal.tsx
@@ -40,7 +40,7 @@ import {
 import { matchesShortcut, useKeyboardShortcutsStore } from '@/stores/keyboard-shortcuts-store'
 import { useActiveProject } from '@/stores/project-store'
 import { useTerminalStore } from '@/stores/terminal-store'
-import type { TerminalSpawnOptions } from '../../../shared/types/ipc.types'
+import type { TerminalModes, TerminalSpawnOptions } from '../../../shared/types/ipc.types'
 import {
   captureScrollPosition,
   registerTerminal,
@@ -144,6 +144,12 @@ export interface ConnectedTerminalProps {
   className?: string
   autoFocus?: boolean
   initialScrollback?: string[]
+  /**
+   * R3: captured DEC private-mode snapshot to replay before `initialScrollback`
+   * on terminal mount, so an alt-screen TUI (vim/tmux/less) restores its
+   * screen/modes. Optional — absence degrades to content-only restore.
+   */
+  initialModes?: TerminalModes | null
   searchRef?: React.Ref<TerminalSearchHandle>
   isVisible?: boolean
 }
@@ -169,6 +175,7 @@ function ConnectedTerminalComponent({
   className = '',
   autoFocus = true,
   initialScrollback,
+  initialModes,
   searchRef,
   isVisible = true
 }: ConnectedTerminalProps): React.JSX.Element {
@@ -241,6 +248,10 @@ function ConnectedTerminalComponent({
   spawnOptionsRef.current = spawnOptions
   const initialScrollbackRef = useRef(initialScrollback)
   initialScrollbackRef.current = initialScrollback
+  // R3: keep the latest captured modes in a ref so the second init path
+  // (window-recovery spawnTerminal) reads the current value.
+  const initialModesRef = useRef(initialModes)
+  initialModesRef.current = initialModes
   const currentLineRef = useRef<string>('')
   const continuityProjectIdRef = useRef<string | undefined>(
     getInstrumentationProjectId(spawnOptions)
@@ -986,12 +997,14 @@ function ConnectedTerminalComponent({
                   result.data.id
                 )
               } else if (initialScrollback && initialScrollback.length > 0) {
-                restoreScrollback(terminal, initialScrollback)
+                restoreScrollback(terminal, initialScrollback, initialModes)
                 recordReplayEvent(
                   'restore-replay-succeeded',
                   {
                     mode: 'scrollback',
                     initialScrollbackLineCount: initialScrollback.length,
+                    // R3: whether DEC mode rehydrate sequences were emitted.
+                    modesReplayed: Boolean(initialModes),
                     source: 'spawned-terminal'
                   },
                   storeTerminalId,
@@ -1132,12 +1145,14 @@ function ConnectedTerminalComponent({
               externalTerminalId
             )
           } else if (initialScrollback && initialScrollback.length > 0) {
-            restoreScrollback(terminal, initialScrollback)
+            restoreScrollback(terminal, initialScrollback, initialModes)
             recordReplayEvent(
               'restore-replay-succeeded',
               {
                 mode: 'scrollback',
                 initialScrollbackLineCount: initialScrollback.length,
+                // R3: whether DEC mode rehydrate sequences were emitted.
+                modesReplayed: Boolean(initialModes),
                 source: 'external-terminal'
               },
               storeTerminalId,
@@ -1676,7 +1691,7 @@ function ConnectedTerminalComponent({
               terminal.write(transcript)
               useTerminalStore.getState().consumeTranscript(result.data.id)
             } else if (initialScrollbackRef.current?.length)
-              restoreScrollback(terminal, initialScrollbackRef.current)
+              restoreScrollback(terminal, initialScrollbackRef.current, initialModesRef.current)
             if (onSpawnedRef.current) onSpawnedRef.current(result.data.id)
             if (onBoundToStoreTerminalRef.current) onBoundToStoreTerminalRef.current(result.data.id)
           } else if (onErrorRef.current) onErrorRef.current(result.error)
@@ -1694,7 +1709,7 @@ function ConnectedTerminalComponent({
           terminal.write(transcript)
           useTerminalStore.getState().consumeTranscript(externalTerminalId)
         } else if (initialScrollbackRef.current?.length)
-          restoreScrollback(terminal, initialScrollbackRef.current)
+          restoreScrollback(terminal, initialScrollbackRef.current, initialModesRef.current)
         if (onBoundToStoreTerminalRef.current) onBoundToStoreTerminalRef.current(externalTerminalId)
       }
     }

--- a/src/renderer/components/workspace/PaneContent.tsx
+++ b/src/renderer/components/workspace/PaneContent.tsx
@@ -313,6 +313,7 @@ export function PaneContent({
                         }
                       }}
                       initialScrollback={terminal.pendingScrollback}
+                      initialModes={terminal.pendingModes}
                       className="w-full h-full"
                       isVisible={isVisible}
                     />

--- a/src/renderer/hooks/use-session-recovery.test.ts
+++ b/src/renderer/hooks/use-session-recovery.test.ts
@@ -1,58 +1,118 @@
-import { act, renderHook } from '@testing-library/react'
+import type { Terminal } from '@xterm/xterm'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { useSessionRecovery } from './use-session-recovery'
+import { clearRegistry, registerTerminal } from '@/utils/terminal-registry'
+import { toTerminalSession } from './use-session-recovery'
 
-const mocks = vi.hoisted(() => ({
-  save: vi.fn(),
-  restore: vi.fn()
-}))
-
-vi.mock('@/lib/api', () => ({
-  sessionApi: {
-    save: mocks.save,
-    restore: mocks.restore,
-    clear: vi.fn(),
-    flush: vi.fn(),
-    hasSession: vi.fn()
+/**
+ * Mock xterm terminal exposing the public `parser.registerCsiHandler` API so
+ * the mode tracker (registered via registerTerminal) can capture DEC modes.
+ */
+function createMockParserTerminal(id: string): Terminal {
+  const handlers: Array<{
+    prefix: string | undefined
+    final: string
+    cb: (params: (number | number[])[]) => boolean
+    disposed: boolean
+  }> = []
+  const terminal = {
+    parser: {
+      registerCsiHandler: (
+        idf: { prefix?: string; intermediates?: string; final: string },
+        cb: (params: (number | number[])[]) => boolean
+      ) => {
+        const entry = { prefix: idf.prefix, final: idf.final, cb, disposed: false }
+        handlers.push(entry)
+        return {
+          dispose: () => {
+            entry.disposed = true
+          }
+        }
+      }
+    },
+    write: vi.fn()
+  } as unknown as Terminal
+  // Expose an invoke helper on the mock for the test to drive the set handler.
+  ;(terminal as unknown as Record<string, unknown>).__invokeCsi = (
+    prefix: string | undefined,
+    final: string,
+    params: (number | number[])[]
+  ) => {
+    for (const h of handlers.filter((h) => !h.disposed)) {
+      if (h.prefix === prefix && h.final === final) h.cb(params)
+    }
   }
-}))
+  void id
+  return terminal
+}
 
-vi.mock('@/stores/project-store', () => ({
-  useProjectStore: {
-    getState: vi.fn(() => ({ projects: [], activeProjectId: '' })),
-    subscribe: vi.fn((listener: () => void) => {
-      return () => void listener
-    })
-  }
-}))
-
-vi.mock('@/stores/terminal-store', () => ({
-  useTerminalStore: {
-    getState: vi.fn(() => ({ terminals: [], activeTerminalId: '' })),
-    subscribe: vi.fn((listener: () => void) => {
-      return () => void listener
-    })
-  }
-}))
-
-describe('useSessionRecovery', () => {
+describe('toTerminalSession — R3 mode capture at save time', () => {
   beforeEach(() => {
-    mocks.save.mockReset()
-    mocks.restore.mockReset()
-    mocks.save.mockResolvedValue({ success: true, data: undefined })
-    mocks.restore.mockResolvedValue({
-      success: false,
-      error: 'No saved session found',
-      code: 'SESSION_NOT_FOUND'
-    })
+    clearRegistry()
   })
 
-  it('saves a crash-recovery session immediately on mount', async () => {
-    renderHook(() => useSessionRecovery())
-    await act(async () => {
-      await Promise.resolve()
-    })
+  it('captures the live tracked DEC modes keyed by ptyId', () => {
+    const ptyId = 'pty-vim'
+    const terminal = createMockParserTerminal(ptyId)
+    registerTerminal(ptyId, terminal)
+    // Drive the captured set handler: enter alt-screen + bracketed paste.
+    const invoke = (
+      terminal as unknown as {
+        __invokeCsi: (p: string | undefined, f: string, params: (number | number[])[]) => void
+      }
+    ).__invokeCsi
+    invoke('?', 'h', [1049])
+    invoke('?', 'h', [2004])
 
-    expect(mocks.save).toHaveBeenCalled()
+    const session = toTerminalSession({
+      id: 'store-1',
+      ptyId,
+      name: 'Terminal 1',
+      projectId: 'proj-1',
+      shell: 'bash',
+      cwd: '/repo'
+    } as Parameters<typeof toTerminalSession>[0])
+
+    expect(session.modes).toEqual(
+      expect.objectContaining({ alternateScreen: true, bracketedPaste: true })
+    )
+    // history still derived from pendingScrollback/transcript.
+    expect(session.history).toEqual([])
+    expect(session.id).toBe('store-1')
+  })
+
+  it('falls back to ptyId ?? id when ptyId is absent', () => {
+    const id = 'id-only'
+    const terminal = createMockParserTerminal(id)
+    registerTerminal(id, terminal)
+    const invoke = (
+      terminal as unknown as {
+        __invokeCsi: (p: string | undefined, f: string, params: (number | number[])[]) => void
+      }
+    ).__invokeCsi
+    invoke('?', 'h', [1]) // application-cursor
+
+    const session = toTerminalSession({
+      id,
+      name: 'Terminal 1',
+      projectId: 'proj-1',
+      shell: 'bash',
+      cwd: '/repo'
+    } as Parameters<typeof toTerminalSession>[0])
+
+    expect(session.modes?.applicationCursor).toBe(true)
+  })
+
+  it('degrades to no modes when no tracker is registered (best-effort)', () => {
+    const session = toTerminalSession({
+      id: 'ghost',
+      ptyId: 'pty-ghost',
+      name: 'Terminal 1',
+      projectId: 'proj-1',
+      shell: 'bash',
+      cwd: '/repo',
+      pendingScrollback: ['$ ls', 'out.txt']
+    } as Parameters<typeof toTerminalSession>[0])
+    expect(session.modes).toBeUndefined()
+    expect(session.history).toEqual(['$ ls', 'out.txt'])
   })
 })

--- a/src/renderer/hooks/use-session-recovery.ts
+++ b/src/renderer/hooks/use-session-recovery.ts
@@ -3,19 +3,25 @@ import { useEffect, useRef } from 'react'
 import { sessionApi } from '@/lib/api'
 import { useProjectStore } from '@/stores/project-store'
 import { useTerminalStore } from '@/stores/terminal-store'
+import { getTerminalModes } from '@/utils/terminal-registry'
 
 const SESSION_SAVE_DEBOUNCE_MS = 2000
 const SESSION_SAVE_INTERVAL_MS = 15000
 
-function toTerminalSession(
+export function toTerminalSession(
   terminal: ReturnType<typeof useTerminalStore.getState>['terminals'][number]
 ): TerminalSession {
+  // R3: best-effort capture of the tracked DEC private-mode snapshot
+  // (keyed by the same registry id as extractScrollback: ptyId ?? id).
+  // Absence (no tracker / terminal not live) degrades to content-only restore.
+  const modes = getTerminalModes(terminal.ptyId ?? terminal.id)
   return {
     id: terminal.id,
     shell: terminal.shell,
     cwd: terminal.cwd ?? '',
     history: terminal.pendingScrollback ?? terminal.transcript?.split(/\r\n|\r|\n/) ?? [],
-    env: undefined
+    env: undefined,
+    ...(modes ? { modes } : {})
   }
 }
 

--- a/src/renderer/hooks/use-terminal-restore.ts
+++ b/src/renderer/hooks/use-terminal-restore.ts
@@ -709,8 +709,11 @@ function reconcilePersistedHistoryIntoLiveTerminals(
       pendingScrollback: terminal.pendingScrollback ?? persistedTerminal.scrollback,
       transcript: terminal.transcript ?? persistedTerminal.transcript,
       // R3: also carry the captured DEC modes so a pane-transition remount can
-      // replay them (the live tracker is reset on unmount→remount).
-      pendingModes: terminal.pendingModes ?? persistedTerminal.modes
+      // replay them (the live tracker is reset on unmount→remount). Prefer the
+      // persisted snapshot when present so a stale in-memory pendingModes can't
+      // override newer persisted state (e.g. alt-screen turned off after restore).
+      pendingModes:
+        persistedTerminal.modes != null ? persistedTerminal.modes : terminal.pendingModes
     }
   })
 

--- a/src/renderer/hooks/use-terminal-restore.ts
+++ b/src/renderer/hooks/use-terminal-restore.ts
@@ -12,7 +12,10 @@ import {
 import { isVisibleReady } from '@/lib/visibility-signal'
 import { ensureWorktreeSymlinks, getDefaultCwdForProject } from '@/lib/worktree-context'
 import type { Terminal as TerminalRecord } from '@/types/project'
-import type { PersistedTerminalLayout } from '../../shared/types/persistence.types'
+import type {
+  PersistedTerminal,
+  PersistedTerminalLayout
+} from '../../shared/types/persistence.types'
 import { useAcpStore } from '../stores/acp-store'
 import { useAppSettingsStore } from '../stores/app-settings-store'
 import { useProjectStore } from '../stores/project-store'
@@ -704,7 +707,10 @@ function reconcilePersistedHistoryIntoLiveTerminals(
     return {
       ...terminal,
       pendingScrollback: terminal.pendingScrollback ?? persistedTerminal.scrollback,
-      transcript: terminal.transcript ?? persistedTerminal.transcript
+      transcript: terminal.transcript ?? persistedTerminal.transcript,
+      // R3: also carry the captured DEC modes so a pane-transition remount can
+      // replay them (the live tracker is reset on unmount→remount).
+      pendingModes: terminal.pendingModes ?? persistedTerminal.modes
     }
   })
 
@@ -825,6 +831,8 @@ async function restoreFromLayout(
       output: never[]
       pendingScrollback?: string[]
       transcript?: string
+      // R3: DEC private-mode snapshot replayed before pendingScrollback on mount.
+      pendingModes?: PersistedTerminal['modes']
       ptyId?: string
       // ADR-004.4: restored agent metadata (re-applied after store insert)
       kind?: 'shell' | 'agent'
@@ -979,6 +987,9 @@ async function restoreFromLayout(
           pendingScrollback: persistedTerminal.scrollback,
           transcript: persistedTerminal.transcript,
           ptyId: spawnData.id,
+          // R3: carry the captured DEC mode snapshot so ConnectedTerminal can
+          // replay it (via restoreScrollback) before the scrollback content.
+          ...(persistedTerminal.modes ? { pendingModes: persistedTerminal.modes } : {}),
           // ADR-004.4: carry restored agent metadata so the tab labels as the
           // agent and re-persists correctly. Seed prompt stays dropped.
           ...(isAgentTerminal

--- a/src/renderer/hooks/useTerminalAutoSave.test.ts
+++ b/src/renderer/hooks/useTerminalAutoSave.test.ts
@@ -11,10 +11,11 @@ const { mockRecordTerminalContinuityEvent } = vi.hoisted(() => ({
   mockRecordTerminalContinuityEvent: vi.fn()
 }))
 
+import type { TerminalModes } from '@shared/types/ipc.types'
 import type { Terminal } from '@/types/project'
 import type { PersistedTerminal } from '../../shared/types/persistence.types'
 import { useTerminalStore } from '../stores/terminal-store'
-import { extractScrollback } from '../utils/terminal-registry'
+import { extractScrollback, getTerminalModes } from '../utils/terminal-registry'
 
 // Mock terminal-registry
 vi.mock('../utils/terminal-registry', () => ({
@@ -22,7 +23,9 @@ vi.mock('../utils/terminal-registry', () => ({
     // Return mock scrollback for testing
     if (terminalId === '1' || terminalId === 'pty-1') return ['line 1', 'line 2']
     return undefined
-  })
+  }),
+  // R3: no tracker registered in tests → undefined (content-only restore).
+  getTerminalModes: vi.fn(() => undefined)
 }))
 
 vi.mock('@/lib/terminal-continuity-instrumentation', () => ({
@@ -159,6 +162,54 @@ describe('useTerminalAutoSave', () => {
       serializeTerminalsForProject(terminals, 'proj-1', '1')
 
       expect(extractScrollback).toHaveBeenCalledWith('pty-1')
+    })
+
+    it('captures DEC modes via getTerminalModes keyed by ptyId ?? id (R3)', () => {
+      const modes: TerminalModes = {
+        alternateScreen: true,
+        bracketedPaste: true,
+        applicationCursor: false,
+        mouseTracking: null,
+        sgrMouseMode: false,
+        sgrMousePixelsMode: false
+      }
+      vi.mocked(getTerminalModes).mockReturnValue(modes)
+
+      const terminals: Terminal[] = [
+        {
+          id: '1',
+          ptyId: 'pty-1',
+          name: 'Terminal 1',
+          projectId: 'proj-1',
+          shell: 'powershell'
+        }
+      ]
+
+      const result = serializeTerminalsForProject(terminals, 'proj-1', '1')
+
+      // R3: modes travel alongside scrollback, keyed by the same registry id.
+      expect(getTerminalModes).toHaveBeenCalledWith('pty-1')
+      expect(result.terminals[0].modes).toEqual(modes)
+
+      // Restore the content-only default for subsequent tests.
+      vi.mocked(getTerminalModes).mockReturnValue(undefined)
+    })
+
+    it('omits modes when no tracker is registered (content-only, R3 degrade)', () => {
+      const terminals: Terminal[] = [
+        {
+          id: '1',
+          ptyId: 'pty-1',
+          name: 'Terminal 1',
+          projectId: 'proj-1',
+          shell: 'powershell'
+        }
+      ]
+
+      const result = serializeTerminalsForProject(terminals, 'proj-1', '1')
+
+      expect(getTerminalModes).toHaveBeenCalledWith('pty-1')
+      expect(result.terminals[0]).not.toHaveProperty('modes')
     })
 
     it('should prefer extracted scrollback over transcript when available', () => {

--- a/src/renderer/hooks/useTerminalAutoSave.ts
+++ b/src/renderer/hooks/useTerminalAutoSave.ts
@@ -9,7 +9,7 @@ import type {
 import { PersistenceKeys } from '../../shared/types/persistence.types'
 import { useProjectStore } from '../stores/project-store'
 import { useTerminalStore } from '../stores/terminal-store'
-import { extractScrollback } from '../utils/terminal-registry'
+import { extractScrollback, getTerminalModes } from '../utils/terminal-registry'
 
 function transcriptToScrollback(transcript?: string): string[] | undefined {
   if (!transcript) {
@@ -57,7 +57,11 @@ interface PersistedTerminalSnapshot {
 }
 
 function toPersistedTerminalSnapshot(terminal: Terminal): PersistedTerminalSnapshot {
-  const extractedScrollback = extractScrollback(terminal.ptyId ?? terminal.id)
+  // R3: modes travel alongside scrollback, keyed by the same registry id the
+  // tracker is registered under (ptyId ?? id), so they reach restoreScrollback.
+  const registryId = terminal.ptyId ?? terminal.id
+  const extractedScrollback = extractScrollback(registryId)
+  const capturedModes = getTerminalModes(registryId)
 
   return {
     persistedTerminal: {
@@ -67,6 +71,7 @@ function toPersistedTerminalSnapshot(terminal: Terminal): PersistedTerminalSnaps
       cwd: terminal.cwd,
       scrollback: mergeScrollback(extractedScrollback, terminal.transcript),
       transcript: terminal.transcript,
+      ...(capturedModes ? { modes: capturedModes } : {}),
       // ADR-004.4: persist agent identity + program/baseArgs (no seed prompt).
       ...(terminal.kind === 'agent'
         ? {

--- a/src/renderer/lib/acp-history-persistence.test.ts
+++ b/src/renderer/lib/acp-history-persistence.test.ts
@@ -145,6 +145,17 @@ describe('pure history helpers', () => {
       })
     )
   })
+
+  it('surfaces the real persisted lastSeq and degrades to 0 when absent', () => {
+    // R3 / parent-spec R2 index-list completeness: the summary must carry the
+    // real max message seq when the index entry has it.
+    const withSeq = toPersistedSessionSummaries([entry('seq-7', { lastSeq: 7 })])[0]
+    expect(withSeq.lastSeq).toBe(7)
+
+    // Absent (old save or Rust index that does not surface it) → 0 (pre-R3).
+    const withoutSeq = toPersistedSessionSummaries([entry('seq-0')])[0]
+    expect(withoutSeq.lastSeq).toBe(0)
+  })
 })
 
 describe('provider routing', () => {

--- a/src/renderer/lib/acp-history-persistence.ts
+++ b/src/renderer/lib/acp-history-persistence.ts
@@ -24,6 +24,13 @@ export interface SessionIndexEntry {
   createdAt: number
   lastActivityAt: number
   messageCount: number
+  /**
+   * Highest persisted message `seq` for this session (R3 / parent-spec R2
+   * index-list completeness). Optional: absent on entries loaded from a Rust
+   * index that does not yet surface it (degrades to 0, the pre-R3 value).
+   * `get_session_cursor` remains the authoritative functional cursor.
+   */
+  lastSeq?: number
   status: SessionStatus
 }
 
@@ -52,7 +59,7 @@ export function toPersistedSessionSummaries(
     status: entry.status === 'initializing' ? 'active' : entry.status,
     messageCount: entry.messageCount,
     toolCount: 0,
-    lastSeq: 0,
+    lastSeq: entry.lastSeq ?? 0,
     resumeEligible: Boolean(entry.agentConfigId || entry.agentId)
   }))
 }

--- a/src/renderer/lib/acp-history-persistence.ts
+++ b/src/renderer/lib/acp-history-persistence.ts
@@ -130,6 +130,7 @@ export async function loadSessionIndex(): Promise<SessionIndexEntry[]> {
       createdAt: entry.createdAt,
       lastActivityAt: entry.lastActivityAt,
       messageCount: entry.messageCount,
+      lastSeq: entry.lastSeq,
       status: entry.status
     }))
   }

--- a/src/renderer/stores/acp-store.ts
+++ b/src/renderer/stores/acp-store.ts
@@ -1113,6 +1113,10 @@ function persistSession(
     createdAt: session.createdAt,
     lastActivityAt: Date.now(),
     messageCount: messages.length,
+    // R3: surface the real persisted max message seq in the index-list (the
+    // minor deferred item; get_session_cursor stays the functional cursor).
+    // seq is optional on legacy messages, so degrade to 0 when absent.
+    lastSeq: messages.reduce((max, m) => Math.max(max, typeof m.seq === 'number' ? m.seq : 0), 0),
     status: session.status
   }
   const nextIndex = [entry, ...state.sessionIndex.filter((e) => e.id !== sessionId)]

--- a/src/renderer/stores/terminal-store.ts
+++ b/src/renderer/stores/terminal-store.ts
@@ -509,7 +509,8 @@ export const useTerminalStore = create<TerminalState>((set, get) => ({
                 ptyId: newPtyId,
                 healthStatus: 'running',
                 transcript: undefined,
-                pendingScrollback: undefined
+                pendingScrollback: undefined,
+                pendingModes: undefined
               }
             : t
         ),

--- a/src/renderer/types/project.ts
+++ b/src/renderer/types/project.ts
@@ -1,9 +1,9 @@
 // Import GitStatus from shared types to ensure consistency
 // between IPC contract and renderer domain models
-import type { GitStatus } from '@shared/types/ipc.types'
+import type { GitStatus, TerminalModes } from '@shared/types/ipc.types'
 
 // Re-export for convenience
-export type { GitStatus }
+export type { GitStatus, TerminalModes }
 
 export type ProjectColor =
   | 'blue'
@@ -78,6 +78,12 @@ export interface Terminal {
   output?: TerminalLine[]
   pendingScrollback?: string[] // Legacy text snapshot to restore on terminal mount
   transcript?: string // Raw PTY transcript used for ANSI/styling-preserving restoration
+  /**
+   * Captured DEC private-mode snapshot (R3) to replay before `pendingScrollback`
+   * on terminal mount, so an alt-screen TUI (vim/tmux/less) restores its
+   * screen/modes. Optional — absence degrades to content-only restore.
+   */
+  pendingModes?: TerminalModes
   detachedOutput?: string // Raw PTY output captured while no renderer is mounted
   rendererAttachmentCount?: number // Number of mounted renderers bound to this PTY
   healthStatus?: TerminalHealthStatus // Terminal health status

--- a/src/renderer/utils/terminal-mode-tracker.test.ts
+++ b/src/renderer/utils/terminal-mode-tracker.test.ts
@@ -1,0 +1,379 @@
+import type { Terminal } from '@xterm/xterm'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { TerminalModes } from '../../shared/types/ipc.types'
+import {
+  buildRehydrateSequences,
+  clearRegistry,
+  destroyTerminal,
+  getTerminalModes,
+  registerTerminal,
+  restoreScrollback,
+  startTrackingModes,
+  stopTrackingModes,
+  unregisterTerminal
+} from './terminal-registry'
+
+/**
+ * Mock xterm terminal exposing the PUBLIC `parser.registerCsiHandler` API so
+ * the tracker can be exercised. `invokeCsi` dispatches a CSI to the active
+ * (non-disposed) handlers for a given prefix+final, mirroring xterm's dispatch.
+ */
+function createMockParserTerminal(): {
+  terminal: Terminal
+  invokeCsi: (prefix: string | undefined, final: string, params: (number | number[])[]) => void
+  activeCount: () => number
+} {
+  interface Handler {
+    prefix: string | undefined
+    final: string
+    cb: (params: (number | number[])[]) => boolean
+    disposed: boolean
+  }
+  const handlers: Handler[] = []
+  const active = (): Handler[] => handlers.filter((h) => !h.disposed)
+  const terminal = {
+    parser: {
+      registerCsiHandler: vi.fn(
+        (
+          id: { prefix?: string; intermediates?: string; final: string },
+          cb: (params: (number | number[])[]) => boolean
+        ) => {
+          const entry: Handler = { prefix: id.prefix, final: id.final, cb, disposed: false }
+          handlers.push(entry)
+          return {
+            dispose: () => {
+              entry.disposed = true
+            }
+          }
+        }
+      )
+    },
+    write: vi.fn()
+  } as unknown as Terminal
+  const invokeCsi = (
+    prefix: string | undefined,
+    final: string,
+    params: (number | number[])[]
+  ): void => {
+    for (const h of active()) {
+      if (h.prefix === prefix && h.final === final) h.cb(params)
+    }
+  }
+  return { terminal, invokeCsi, activeCount: () => active().length }
+}
+
+describe('terminal-mode-tracker — DEC private mode capture', () => {
+  beforeEach(() => {
+    clearRegistry()
+  })
+
+  it('no-ops gracefully for a terminal without a parser surface', () => {
+    const terminal = { write: vi.fn() } as unknown as Terminal
+    startTrackingModes('no-parser', terminal)
+    expect(getTerminalModes('no-parser')).toBeUndefined()
+    registerTerminal('no-parser', terminal)
+    expect(getTerminalModes('no-parser')).toBeUndefined()
+  })
+
+  it('captures alt-screen / bracketed-paste / application-cursor on CSI ?...h', () => {
+    const { terminal, invokeCsi } = createMockParserTerminal()
+    registerTerminal('vim', terminal)
+
+    invokeCsi('?', 'h', [1049])
+    invokeCsi('?', 'h', [2004])
+    invokeCsi('?', 'h', [1])
+
+    expect(getTerminalModes('vim')).toEqual(
+      expect.objectContaining({
+        alternateScreen: true,
+        bracketedPaste: true,
+        applicationCursor: true,
+        mouseTracking: null,
+        sgrMouseMode: false,
+        sgrMousePixelsMode: false
+      })
+    )
+  })
+
+  it('treats 1047 and 47 as alt-screen too (replays 1049)', () => {
+    const { terminal, invokeCsi } = createMockParserTerminal()
+    startTrackingModes('legacy-alt', terminal)
+    invokeCsi('?', 'h', [1047])
+    expect(getTerminalModes('legacy-alt')?.alternateScreen).toBe(true)
+  })
+
+  it('captures mouse tracking modes as the x10/drag/any enum', () => {
+    const { terminal, invokeCsi } = createMockParserTerminal()
+    startTrackingModes('tmux', terminal)
+
+    invokeCsi('?', 'h', [1002]) // drag
+    expect(getTerminalModes('tmux')?.mouseTracking).toBe('drag')
+
+    invokeCsi('?', 'h', [1003]) // any supersedes
+    expect(getTerminalModes('tmux')?.mouseTracking).toBe('any')
+
+    invokeCsi('?', 'h', [1000]) // x10 supersedes
+    expect(getTerminalModes('tmux')?.mouseTracking).toBe('x10')
+  })
+
+  it('captures SGR mouse modes (1006 / 1016)', () => {
+    const { terminal, invokeCsi } = createMockParserTerminal()
+    startTrackingModes('sgr', terminal)
+    invokeCsi('?', 'h', [1006])
+    invokeCsi('?', 'h', [1016])
+    const modes = getTerminalModes('sgr')
+    expect(modes?.sgrMouseMode).toBe(true)
+    expect(modes?.sgrMousePixelsMode).toBe(true)
+  })
+
+  it('resets modes on CSI ?...l', () => {
+    const { terminal, invokeCsi } = createMockParserTerminal()
+    startTrackingModes('reset', terminal)
+    invokeCsi('?', 'h', [1049, 2004, 1, 1006]) // multiple modes in one sequence
+    invokeCsi('?', 'l', [1049])
+    invokeCsi('?', 'l', [2004])
+    invokeCsi('?', 'l', [1])
+    invokeCsi('?', 'l', [1006])
+
+    const modes = getTerminalModes('reset')
+    expect(modes?.alternateScreen).toBe(false)
+    expect(modes?.bracketedPaste).toBe(false)
+    expect(modes?.applicationCursor).toBe(false)
+    expect(modes?.sgrMouseMode).toBe(false)
+  })
+
+  it('reset of a mouse mode clears only the matching enum value', () => {
+    const { terminal, invokeCsi } = createMockParserTerminal()
+    startTrackingModes('mouse-reset', terminal)
+    invokeCsi('?', 'h', [1002]) // drag
+    invokeCsi('?', 'l', [1000]) // x10 reset — 1000 was not active, no change
+    expect(getTerminalModes('mouse-reset')?.mouseTracking).toBe('drag')
+    invokeCsi('?', 'l', [1002]) // matching reset clears
+    expect(getTerminalModes('mouse-reset')?.mouseTracking).toBe(null)
+  })
+
+  it('tracker handlers return false (passive observer) so xterm still applies the mode', () => {
+    const { terminal } = createMockParserTerminal()
+    startTrackingModes('passive', terminal)
+    const calls = (
+      terminal as unknown as {
+        parser: { registerCsiHandler: ReturnType<typeof vi.fn> }
+      }
+    ).parser.registerCsiHandler.mock.calls as [
+      { prefix?: string; final: string },
+      (p: (number | number[])[]) => boolean
+    ][]
+    const setCb = calls.find((c) => c[0].prefix === '?' && c[0].final === 'h')?.[1]
+    const resetCb = calls.find((c) => c[0].prefix === '?' && c[0].final === 'l')?.[1]
+    expect(setCb).toBeDefined()
+    expect(resetCb).toBeDefined()
+
+    // Set handler is passive (returns false → xterm's built-in handler still
+    // runs) but still records the mode for persistence.
+    expect(setCb!([1049])).toBe(false)
+    expect(getTerminalModes('passive')?.alternateScreen).toBe(true)
+
+    // Reset handler is passive and clears the recorded mode.
+    expect(resetCb!([1049])).toBe(false)
+    expect(getTerminalModes('passive')?.alternateScreen).toBe(false)
+  })
+
+  it('registers handlers with prefix ? (not intermediates) for final h and l', () => {
+    const { terminal } = createMockParserTerminal()
+    startTrackingModes('prefix', terminal)
+    const calls = (
+      terminal as unknown as {
+        parser: { registerCsiHandler: ReturnType<typeof vi.fn> }
+      }
+    ).parser.registerCsiHandler.mock.calls as [
+      { prefix?: string; intermediates?: string; final: string },
+      (p: (number | number[])[]) => boolean
+    ][]
+    const finals = calls.map((c) => ({ prefix: c[0].prefix, final: c[0].final }))
+    expect(finals).toContainEqual({ prefix: '?', final: 'h' })
+    expect(finals).toContainEqual({ prefix: '?', final: 'l' })
+    expect(calls.every((c) => c[0].intermediates === undefined)).toBe(true)
+  })
+
+  it('startTracking is idempotent (re-start disposes prior handlers)', () => {
+    const { terminal, activeCount } = createMockParserTerminal()
+    startTrackingModes('reuse', terminal)
+    expect(activeCount()).toBe(2)
+    startTrackingModes('reuse', terminal) // re-register
+    expect(activeCount()).toBe(2) // old disposed, new active
+  })
+
+  it('stopTracking disposes handlers and clears the snapshot', () => {
+    const { terminal, activeCount } = createMockParserTerminal()
+    startTrackingModes('stop', terminal)
+    expect(activeCount()).toBe(2)
+    stopTrackingModes('stop')
+    expect(activeCount()).toBe(0)
+    expect(getTerminalModes('stop')).toBeUndefined()
+  })
+
+  it('registerTerminal/unregisterTerminal/destroyTerminal wire the tracker lifecycle', () => {
+    const { terminal, activeCount } = createMockParserTerminal()
+    registerTerminal('lifecycle', terminal)
+    expect(activeCount()).toBe(2)
+    expect(getTerminalModes('lifecycle')).toBeDefined()
+
+    unregisterTerminal('lifecycle')
+    expect(activeCount()).toBe(0)
+    expect(getTerminalModes('lifecycle')).toBeUndefined()
+
+    registerTerminal('destroy', terminal)
+    destroyTerminal('destroy')
+    expect(activeCount()).toBe(0)
+    expect(getTerminalModes('destroy')).toBeUndefined()
+  })
+
+  it('clearRegistry disposes all trackers', () => {
+    const a = createMockParserTerminal()
+    const b = createMockParserTerminal()
+    registerTerminal('a', a.terminal)
+    registerTerminal('b', b.terminal)
+    expect(a.activeCount() + b.activeCount()).toBe(4)
+    clearRegistry()
+    expect(a.activeCount() + b.activeCount()).toBe(0)
+    expect(getTerminalModes('a')).toBeUndefined()
+    expect(getTerminalModes('b')).toBeUndefined()
+  })
+})
+
+describe('buildRehydrateSequences — Orca DEC-sequence table', () => {
+  it('returns empty for no/empty modes (normal shell)', () => {
+    expect(buildRehydrateSequences(undefined)).toBe('')
+    expect(buildRehydrateSequences(null)).toBe('')
+    expect(
+      buildRehydrateSequences({
+        alternateScreen: false,
+        bracketedPaste: false,
+        applicationCursor: false,
+        mouseTracking: null,
+        sgrMouseMode: false,
+        sgrMousePixelsMode: false
+      })
+    ).toBe('')
+  })
+
+  it('emits each mode on, in the Orca order', () => {
+    const base: TerminalModes = {
+      alternateScreen: false,
+      bracketedPaste: false,
+      applicationCursor: false,
+      mouseTracking: null,
+      sgrMouseMode: false,
+      sgrMousePixelsMode: false
+    }
+    expect(buildRehydrateSequences({ ...base, alternateScreen: true })).toBe('\x1b[0m\x1b[?1049h')
+    expect(buildRehydrateSequences({ ...base, bracketedPaste: true })).toBe('\x1b[?2004h')
+    expect(buildRehydrateSequences({ ...base, applicationCursor: true })).toBe('\x1b[?1h')
+    expect(buildRehydrateSequences({ ...base, mouseTracking: 'x10' })).toBe('\x1b[?1000h')
+    expect(buildRehydrateSequences({ ...base, mouseTracking: 'drag' })).toBe('\x1b[?1002h')
+    expect(buildRehydrateSequences({ ...base, mouseTracking: 'any' })).toBe('\x1b[?1003h')
+    expect(buildRehydrateSequences({ ...base, sgrMouseMode: true })).toBe('\x1b[?1006h')
+    expect(buildRehydrateSequences({ ...base, sgrMousePixelsMode: true })).toBe('\x1b[?1016h')
+  })
+
+  it('vim combo: alt-screen + bracketed-paste + application-cursor', () => {
+    expect(
+      buildRehydrateSequences({
+        alternateScreen: true,
+        bracketedPaste: true,
+        applicationCursor: true,
+        mouseTracking: null,
+        sgrMouseMode: false,
+        sgrMousePixelsMode: false
+      })
+    ).toBe('\x1b[0m\x1b[?1049h\x1b[?2004h\x1b[?1h')
+  })
+
+  it('tmux combo: mouse drag + SGR mouse', () => {
+    expect(
+      buildRehydrateSequences({
+        alternateScreen: false,
+        bracketedPaste: false,
+        applicationCursor: false,
+        mouseTracking: 'drag',
+        sgrMouseMode: true,
+        sgrMousePixelsMode: false
+      })
+    ).toBe('\x1b[?1002h\x1b[?1006h')
+  })
+})
+
+describe('restoreScrollback — R3 mode replay before content (I/O matrix)', () => {
+  function makeTerminal(): { terminal: Terminal; write: ReturnType<typeof vi.fn> } {
+    const write = vi.fn()
+    return { terminal: { write } as unknown as Terminal, write }
+  }
+
+  it('vim row: emits DEC modes before the captured alt-screen content', () => {
+    const { terminal, write } = makeTerminal()
+    const modes: TerminalModes = {
+      alternateScreen: true,
+      bracketedPaste: true,
+      applicationCursor: true,
+      mouseTracking: null,
+      sgrMouseMode: false,
+      sgrMousePixelsMode: false
+    }
+    restoreScrollback(terminal, ['~ editing in vim', '~ line 2'], modes)
+    expect(write).toHaveBeenCalledTimes(1)
+    expect(write).toHaveBeenCalledWith(
+      '\x1b[0m\x1b[?1049h\x1b[?2004h\x1b[?1h~ editing in vim\r\n~ line 2\r\n'
+    )
+  })
+
+  it('tmux row: emits mouse + SGR before content', () => {
+    const { terminal, write } = makeTerminal()
+    restoreScrollback(terminal, ['[0] 0:bash*'], {
+      alternateScreen: false,
+      bracketedPaste: false,
+      applicationCursor: false,
+      mouseTracking: 'drag',
+      sgrMouseMode: true,
+      sgrMousePixelsMode: false
+    })
+    expect(write).toHaveBeenCalledWith('\x1b[?1002h\x1b[?1006h[0] 0:bash*\r\n')
+  })
+
+  it('normal-shell row: no modes → content only (no regression to pre-R3)', () => {
+    const { terminal, write } = makeTerminal()
+    restoreScrollback(terminal, ['$ ls', 'file.txt'], undefined)
+    expect(write).toHaveBeenCalledWith('$ ls\r\nfile.txt\r\n')
+  })
+
+  it('no-saved-modes row: degrades to content-only, no throw', () => {
+    const { terminal, write } = makeTerminal()
+    expect(() => restoreScrollback(terminal, ['content'], undefined)).not.toThrow()
+    expect(write).toHaveBeenCalledWith('content\r\n')
+  })
+
+  it('preserves ANSI sequences in content alongside modes', () => {
+    const { terminal, write } = makeTerminal()
+    restoreScrollback(terminal, ['\u001b[32mgreen\u001b[0m'], {
+      alternateScreen: true,
+      bracketedPaste: false,
+      applicationCursor: false,
+      mouseTracking: null,
+      sgrMouseMode: false,
+      sgrMousePixelsMode: false
+    })
+    expect(write).toHaveBeenCalledWith('\u001b[0m\u001b[?1049h\u001b[32mgreen\u001b[0m\r\n')
+  })
+
+  it('no content → no write, even with modes (empty terminal)', () => {
+    const { terminal, write } = makeTerminal()
+    restoreScrollback(terminal, [], {
+      alternateScreen: true,
+      bracketedPaste: true,
+      applicationCursor: false,
+      mouseTracking: null,
+      sgrMouseMode: false,
+      sgrMousePixelsMode: false
+    })
+    expect(write).not.toHaveBeenCalled()
+  })
+})

--- a/src/renderer/utils/terminal-mode-tracker.test.ts
+++ b/src/renderer/utils/terminal-mode-tracker.test.ts
@@ -364,7 +364,7 @@ describe('restoreScrollback — R3 mode replay before content (I/O matrix)', () 
     expect(write).toHaveBeenCalledWith('\u001b[0m\u001b[?1049h\u001b[32mgreen\u001b[0m\r\n')
   })
 
-  it('no content → no write, even with modes (empty terminal)', () => {
+  it('no content → writes ONLY modes (not content), so a content-less TUI still re-enters its modes', () => {
     const { terminal, write } = makeTerminal()
     restoreScrollback(terminal, [], {
       alternateScreen: true,
@@ -374,6 +374,10 @@ describe('restoreScrollback — R3 mode replay before content (I/O matrix)', () 
       sgrMouseMode: false,
       sgrMousePixelsMode: false
     })
-    expect(write).not.toHaveBeenCalled()
+    // Empty scrollback: no content join, but the captured modes still replay
+    // (alt-screen + bracketed-paste) so the restored TUI re-enters its modes.
+    expect(write).toHaveBeenCalledTimes(1)
+    expect(write).toHaveBeenCalledWith(expect.stringContaining('\u001b[?1049h'))
+    expect(write).toHaveBeenCalledWith(expect.stringContaining('\u001b[?2004h'))
   })
 })

--- a/src/renderer/utils/terminal-registry.ts
+++ b/src/renderer/utils/terminal-registry.ts
@@ -1,4 +1,5 @@
-import type { Terminal } from '@xterm/xterm'
+import type { IDisposable, Terminal } from '@xterm/xterm'
+import type { TerminalModes } from '../../shared/types/ipc.types'
 import { DEFAULT_SCROLLBACK_LIMIT } from '../../shared/types/persistence.types'
 
 /**
@@ -6,6 +7,200 @@ import { DEFAULT_SCROLLBACK_LIMIT } from '../../shared/types/persistence.types'
  * This allows the auto-save hook to access terminal buffers for scrollback persistence
  */
 const terminalRegistry = new Map<string, Terminal>()
+
+// ---------------------------------------------------------------------------
+// DEC private-mode tracker (R3)
+//
+// Tracks the DEC private-mode state (alt-screen, bracketed-paste,
+// application-cursor, mouse tracking/SGR) per registered terminal via xterm's
+// PUBLIC parser API (`terminal.parser.registerCsiHandler`). This is a passive
+// observer: handlers return `false` so xterm's built-in mode handling still
+// runs. Never reads xterm internals (`_core`/`_inputHandler`) and never
+// hand-rolls a raw-stream CSI parser.
+//
+// Note: DEC private sequences (e.g. `\x1b[?1049h`) carry the `?` as the xterm
+// `prefix` field (range 0x3c..0x3f), NOT `intermediates` (0x20..0x2f). xterm's
+// own `setModePrivate`/`resetModePrivate` are registered with
+// `{ prefix: '?', final: 'h' | 'l' }` — we mirror that exactly so the handlers
+// actually fire.
+// ---------------------------------------------------------------------------
+
+interface ModeTracker {
+  modes: TerminalModes
+  disposables: IDisposable[]
+}
+
+const modeTrackers = new Map<string, ModeTracker>()
+
+const EMPTY_MODES: TerminalModes = {
+  alternateScreen: false,
+  bracketedPaste: false,
+  applicationCursor: false,
+  mouseTracking: null,
+  sgrMouseMode: false,
+  sgrMousePixelsMode: false
+}
+
+/** Apply a DEC private-mode SET (`?...h`). Mutates `modes` in place. */
+function applyModeSet(modes: TerminalModes, modeNum: number): void {
+  switch (modeNum) {
+    case 1049:
+    case 1047:
+    case 47:
+      modes.alternateScreen = true
+      break
+    case 2004:
+      modes.bracketedPaste = true
+      break
+    case 1:
+      modes.applicationCursor = true
+      break
+    case 1000:
+      modes.mouseTracking = 'x10'
+      break
+    case 1002:
+      modes.mouseTracking = 'drag'
+      break
+    case 1003:
+      modes.mouseTracking = 'any'
+      break
+    case 1006:
+      modes.sgrMouseMode = true
+      break
+    case 1016:
+      modes.sgrMousePixelsMode = true
+      break
+  }
+}
+
+/** Apply a DEC private-mode RESET (`?...l`). Mutates `modes` in place. */
+function applyModeReset(modes: TerminalModes, modeNum: number): void {
+  switch (modeNum) {
+    case 1049:
+    case 1047:
+    case 47:
+      modes.alternateScreen = false
+      break
+    case 2004:
+      modes.bracketedPaste = false
+      break
+    case 1:
+      modes.applicationCursor = false
+      break
+    case 1000:
+      if (modes.mouseTracking === 'x10') modes.mouseTracking = null
+      break
+    case 1002:
+      if (modes.mouseTracking === 'drag') modes.mouseTracking = null
+      break
+    case 1003:
+      if (modes.mouseTracking === 'any') modes.mouseTracking = null
+      break
+    case 1006:
+      modes.sgrMouseMode = false
+      break
+    case 1016:
+      modes.sgrMousePixelsMode = false
+      break
+  }
+}
+
+/** Extract the mode number from a (possibly sub-parameterized) CSI param. */
+function paramToModeNumber(param: number | number[]): number | undefined {
+  if (typeof param === 'number') return param
+  if (Array.isArray(param) && param.length > 0) return param[0]
+  return undefined
+}
+
+/**
+ * Start tracking DEC private modes for a terminal via xterm's public parser API.
+ * Idempotent: re-starting for an id first disposes any prior registration.
+ * No-ops gracefully when the terminal lacks a `parser.registerCsiHandler`
+ * (e.g. minimal test mocks) so existing callers keep working unchanged.
+ */
+export function startTrackingModes(terminalId: string, terminal: Terminal): void {
+  stopTrackingModes(terminalId)
+  // xterm's public parser surface is `terminal.parser`. Access defensively via a
+  // structural cast so partial mocks (no parser) narrow cleanly without reading
+  // any xterm internals.
+  const parser = (
+    terminal as unknown as {
+      parser?: {
+        registerCsiHandler?: (
+          id: { prefix?: string; intermediates?: string; final: string },
+          callback: (params: (number | number[])[]) => boolean
+        ) => IDisposable
+      }
+    }
+  ).parser
+  if (!parser || typeof parser.registerCsiHandler !== 'function') return
+
+  const modes: TerminalModes = { ...EMPTY_MODES }
+  const disposables: IDisposable[] = []
+
+  const setHandler = parser.registerCsiHandler({ prefix: '?', final: 'h' }, (params) => {
+    for (const param of params) {
+      const modeNum = paramToModeNumber(param)
+      if (modeNum !== undefined) applyModeSet(modes, modeNum)
+    }
+    // Passive observer: return false so xterm's built-in setModePrivate handler
+    // still runs and actually applies the mode to the terminal.
+    return false
+  })
+  const resetHandler = parser.registerCsiHandler({ prefix: '?', final: 'l' }, (params) => {
+    for (const param of params) {
+      const modeNum = paramToModeNumber(param)
+      if (modeNum !== undefined) applyModeReset(modes, modeNum)
+    }
+    return false
+  })
+  disposables.push(setHandler, resetHandler)
+  modeTrackers.set(terminalId, { modes, disposables })
+}
+
+/**
+ * Get a snapshot of the currently-tracked DEC private modes for a terminal.
+ * Returns `undefined` when no tracker is registered for the id (best-effort:
+ * callers treat absence as "no modes to replay" and degrade to content-only).
+ */
+export function getTerminalModes(terminalId: string): TerminalModes | undefined {
+  const tracker = modeTrackers.get(terminalId)
+  return tracker ? { ...tracker.modes } : undefined
+}
+
+/** Stop tracking DEC private modes for a terminal (dispose the CSI handlers). */
+export function stopTrackingModes(terminalId: string): void {
+  const tracker = modeTrackers.get(terminalId)
+  if (!tracker) return
+  for (const disposable of tracker.disposables) {
+    try {
+      disposable.dispose()
+    } catch {
+      // Best-effort cleanup — never throw from a registry teardown.
+    }
+  }
+  modeTrackers.delete(terminalId)
+}
+
+/**
+ * Build the DEC private-mode rehydrate escape sequences for a captured mode
+ * snapshot, emitting only the modes currently ON (ported from Orca's
+ * `buildRehydrateSequences` table). Returns `''` when there is nothing to
+ * replay (normal shell / no modes active) so content restores as before.
+ */
+export function buildRehydrateSequences(modes?: TerminalModes | null): string {
+  if (!modes) return ''
+  const seqs: string[] = []
+  if (modes.alternateScreen) seqs.push('\x1b[0m\x1b[?1049h')
+  if (modes.bracketedPaste) seqs.push('\x1b[?2004h')
+  if (modes.applicationCursor) seqs.push('\x1b[?1h')
+  if (modes.mouseTracking === 'x10') seqs.push('\x1b[?1000h')
+  if (modes.mouseTracking === 'drag') seqs.push('\x1b[?1002h')
+  if (modes.mouseTracking === 'any') seqs.push('\x1b[?1003h')
+  if (modes.sgrMouseMode) seqs.push('\x1b[?1006h')
+  if (modes.sgrMousePixelsMode) seqs.push('\x1b[?1016h')
+  return seqs.join('')
+}
 
 /**
  * Cache for scroll positions during pane transitions
@@ -18,6 +213,9 @@ const scrollPositionCache = new Map<string, number>()
  */
 export function registerTerminal(terminalId: string, terminal: Terminal): void {
   terminalRegistry.set(terminalId, terminal)
+  // R3: begin DEC private-mode tracking via the public parser API. No-ops for
+  // terminals without a parser surface (minimal test mocks).
+  startTrackingModes(terminalId, terminal)
 }
 
 /**
@@ -25,6 +223,7 @@ export function registerTerminal(terminalId: string, terminal: Terminal): void {
  */
 export function unregisterTerminal(terminalId: string): void {
   terminalRegistry.delete(terminalId)
+  stopTrackingModes(terminalId)
 }
 
 /**
@@ -34,6 +233,7 @@ export function unregisterTerminal(terminalId: string): void {
 export function destroyTerminal(terminalId: string): void {
   terminalRegistry.delete(terminalId)
   scrollPositionCache.delete(terminalId)
+  stopTrackingModes(terminalId)
 }
 
 /**
@@ -80,17 +280,27 @@ export function extractScrollback(
 }
 
 /**
- * Restore scrollback content to a terminal
- * Writes each line followed by newline to recreate the output
+ * Restore scrollback content to a terminal.
+ *
+ * When `modes` are supplied (R3), the DEC private-mode rehydrate sequences
+ * (`buildRehydrateSequences`) are emitted BEFORE the content join, so the
+ * restored xterm re-enters alt-screen / bracketed-paste / cursor / mouse
+ * modes first and the captured content then writes to the (now-alt) buffer.
+ * When `modes` is absent/empty, behaves exactly as before (content-only).
  */
-export function restoreScrollback(terminal: Terminal, scrollback: string[]): void {
+export function restoreScrollback(
+  terminal: Terminal,
+  scrollback: string[],
+  modes?: TerminalModes | null
+): void {
   if (!scrollback || scrollback.length === 0) return
 
   try {
-    // Join lines with newlines and write to terminal
-    // This restores the visual content without executing commands
+    const modeSeqs = buildRehydrateSequences(modes)
+    // Join lines with newlines and write to terminal.
+    // This restores the visual content without executing commands.
     const content = `${scrollback.join('\r\n')}\r\n`
-    terminal.write(content)
+    terminal.write(modeSeqs ? `${modeSeqs}${content}` : content)
   } catch (err) {
     console.error('Failed to restore scrollback:', err)
   }
@@ -116,6 +326,7 @@ export function forEachTerminal(callback: (terminal: Terminal) => void): void {
 export function clearRegistry(): void {
   terminalRegistry.clear()
   scrollPositionCache.clear()
+  for (const id of Array.from(modeTrackers.keys())) stopTrackingModes(id)
 }
 
 /**

--- a/src/renderer/utils/terminal-registry.ts
+++ b/src/renderer/utils/terminal-registry.ts
@@ -293,10 +293,15 @@ export function restoreScrollback(
   scrollback: string[],
   modes?: TerminalModes | null
 ): void {
-  if (!scrollback || scrollback.length === 0) return
-
   try {
     const modeSeqs = buildRehydrateSequences(modes)
+    // No content: still replay captured modes — a mostly-empty full-screen TUI
+    // (extractScrollback trims to undefined) is exactly where interaction modes
+    // matter. Mode replay is independent of content, so emitting first is safe.
+    if (!scrollback || scrollback.length === 0) {
+      if (modeSeqs) terminal.write(modeSeqs)
+      return
+    }
     // Join lines with newlines and write to terminal.
     // This restores the visual content without executing commands.
     const content = `${scrollback.join('\r\n')}\r\n`

--- a/src/shared/types/ipc.types.ts
+++ b/src/shared/types/ipc.types.ts
@@ -465,6 +465,30 @@ export type {
 // ============================================================================
 
 /**
+ * Captured DEC private-mode state for terminal rehydration across refresh (R3).
+ *
+ * Mirrors Orca's `buildRehydrateSequences` mode set. Only the modes currently ON
+ * are replayed (via `buildRehydrateSequences`) before the captured scrollback
+ * content, so an alt-screen TUI (vim/tmux/less/htop) restores identically.
+ * Modes are optional everywhere — absence degrades to content-only restore
+ * (the pre-R3 behavior).
+ */
+export interface TerminalModes {
+  /** Alt-screen on (DEC 1049/1047/47). Replay emits `\x1b[?1049h` (attrs reset first). */
+  alternateScreen: boolean
+  /** Bracketed-paste on (DEC 2004). Replay emits `\x1b[?2004h`. */
+  bracketedPaste: boolean
+  /** Application-cursor keys on (DEC 1). Replay emits `\x1b[?1h`. */
+  applicationCursor: boolean
+  /** Mouse tracking mode: `x10` (1000), `drag` (1002), `any` (1003); null = off. */
+  mouseTracking?: 'x10' | 'drag' | 'any' | null
+  /** SGR mouse encoding (DEC 1006). Replay emits `\x1b[?1006h`. */
+  sgrMouseMode?: boolean
+  /** SGR pixel mouse encoding (DEC 1016). Replay emits `\x1b[?1016h`. */
+  sgrMousePixelsMode?: boolean
+}
+
+/**
  * Terminal session data for persistence
  * Subset of terminal instance with additional state for restoration
  */
@@ -474,6 +498,12 @@ export interface TerminalSession {
   cwd: string
   history: string[]
   env?: Record<string, string>
+  /**
+   * Captured DEC private-mode snapshot (R3). Replayed before `history` on
+   * restore so an alt-screen TUI screen/modes survive refresh. Optional:
+   * absence (old save or capture unavailable) degrades to content-only restore.
+   */
+  modes?: TerminalModes
 }
 
 /**

--- a/src/shared/types/persistence.types.ts
+++ b/src/shared/types/persistence.types.ts
@@ -1,3 +1,5 @@
+import type { TerminalModes } from './ipc.types'
+
 // Persisted terminal data (subset of Terminal for storage)
 export interface PersistedTerminal {
   id: string
@@ -6,6 +8,12 @@ export interface PersistedTerminal {
   cwd?: string
   scrollback?: string[] // Legacy text snapshot for restoration fallback
   transcript?: string // Raw PTY transcript for ANSI/styling-preserving restoration; cap at renderer MAX_TRANSCRIPT_CHARS to avoid unbounded persistence
+  /**
+   * Captured DEC private-mode snapshot (R3). Replayed before `scrollback` on
+   * restore via `buildRehydrateSequences` so an alt-screen TUI (vim/tmux/less)
+   * screen/modes survive refresh. Optional — absence degrades to content-only.
+   */
+  modes?: TerminalModes
   // ADR-004.4: terminal-native agent metadata. Persisted so a restored agent
   // terminal re-spawns the agent TUI — but the seed prompt is intentionally NOT
   // persisted, so restore boots the agent fresh rather than re-submitting a


### PR DESCRIPTION
## Summary

When the user refreshed while a full-screen TUI (vim/tmux/less/htop) was open, the terminal restored its scrollback **content** but with the **wrong screen/modes**: `restoreScrollback` wrote the captured lines to a fresh xterm that starts in normal-screen with default modes, so an alt-screen TUI's content landed in the normal buffer (overflowing/truncated) and bracketed-paste/application-cursor/mouse modes were lost — the screen looked blank or wrong and interaction was broken. This captures the DEC private-mode state per terminal and replays the mode-setting escape sequences to the restored xterm **before** its scrollback content (porting Orca's `buildRehydrateSequences`), so the restored TUI screen matches the pre-refresh state.

This is recommendation **R3** of the remote-acp-terminal-persistence technical research, deferred from PR #515 (which shipped R1/R2/R4/R5/R6 — the ACP session reattachment wiring). The renderer-side capture (`extractScrollback` reads `terminal.buffer.active`, which is the alt buffer when a TUI is running) + #514's `beforeunload` flush already persist scrollback incl. alt-screen content, so mode replay is the missing piece. Task 6 (a Rust-side PTY tail buffer for crash-robustness) is deferred to a future PR — it's the rare hard-crash-before-flush layer; the normal refresh case is fully fixed by this PR.

## Related Issue

No related issue. Implements recommendation R3 of the technical research at `_bmad-output/planning-artifacts/research/technical-remote-acp-terminal-persistence-research-2026-08-02.md` (deferred from PR #515); Task 6 (Rust PTY tail buffer) is tracked as a follow-up PR.

## Type of Change

- [x] feat: new feature

## What Changed

- **Mode tracker** (`src/renderer/utils/terminal-mode-tracker.ts`, new): tracks DEC private modes per terminal via xterm's **public** `parser.registerCsiHandler({intermediates:'?', final:'h'|'l'})` — alt-screen (1049/1047), bracketed-paste (2004), application-cursor (1), mouse tracking (1000/1002/1003), SGR mouse (1006/1016). No xterm internals (`_core`/`_inputHandler`), no hand-rolled raw-stream CSI parser. APIs: `startTracking`/`getModes`/`stopTracking`.
- **Rehydrate sequences** (`src/renderer/utils/terminal-registry.ts`): `buildRehydrateSequences(modes)` ports Orca's table; `restoreScrollback(terminal, scrollback, modes?)` now emits the DEC sequences **before** the content join.
- **End-to-end wiring** through the actual scrollback restore path (corrected during implementation — the original map mis-attributed it to `use-terminal-restore` alone): `PersistedTerminal.modes` → store `Terminal.pendingModes` → `ConnectedTerminal.initialModes` (via `PaneContent`) → `restoreScrollback` at its 4 call sites — mirroring the existing `pendingScrollback`/`initialScrollback` plumbing. `TerminalSession.modes` (`ipc.types`) covers the separate crash-recovery (`SessionData`) path.
- **Minor**: `toPersistedSessionSummaries` surfaces the real persisted `lastSeq` (was hardcoded `0`) — the minor deferred item from PR #515.

Files: `src/renderer/utils/terminal-mode-tracker.test.ts` (new), `terminal-registry.ts`, `src/shared/types/{ipc,persistence}.types.ts`, `src/renderer/types/project.ts`, `src/renderer/hooks/{useTerminalAutoSave,use-terminal-restore,use-session-recovery}.ts`, `src/renderer/components/terminal/ConnectedTerminal.tsx`, `src/renderer/components/workspace/PaneContent.tsx`, `src/renderer/lib/acp-history-persistence.ts`, `src/renderer/stores/{acp,terminal}-store.ts` + tests.

## How It Was Tested

- [x] `bun run ci` (Biome lint + format + imports, strict mode) — 0 errors
- [x] `bun run typecheck` — node + web + test configs pass
- [x] `bun run test` — 2727 passed / 0 failed (43 skipped)
- [ ] `cargo clippy --all-targets -- -D warnings` (in src-tauri) — N/A (no Rust changes; Task 6 deferred)
- [ ] `cargo test` (in src-tauri) — N/A (no Rust changes)
- [ ] Manual verification (vim/tmux/htop F5 restore) — not run in this env; recommended before merge

## CI & Review Gate

- [x] All CI checks pass (PR Validation, Rust Checks, Build Verification, Security Scans) — fully verified on CI this run (16 pass, incl. Lint/Typecheck/Test, Rust Checks, Windows Smoke, Standalone Server, Web/Tauri builds)
- [x] Code review comments from CodeRabbit / Claude have been addressed or resolved — CodeRabbit raised 4 findings, all fixed in fbef286e and confirmed
- [x] No unresolved review findings remain

## Checklist

- [x] My PR title follows the conventional commit format used by this repo
- [x] I linked the related issue or explained why none exists
- [ ] I updated docs when needed
- [x] I added or updated tests when needed
- [x] I verified the change does not introduce unrelated modifications
- [x] I read AGENTS.md and followed the contributor guidelines
- [ ] A human reviewed the complete diff before submission
