### PR TITLE
fix(acp): stream chat text with opacity fadeIn instead of blur

### DIFF
--- a/src/renderer/components/chat/ChatMessage.test.tsx
+++ b/src/renderer/components/chat/ChatMessage.test.tsx
@@ -1,5 +1,6 @@
 import { act, fireEvent, render, screen } from '@testing-library/react'
 import type { ReactNode } from 'react'
+import type { AnimateOptions } from 'streamdown'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type { ChatMessage as ChatMessageType } from '@/stores/acp-store'
 import { ChatMessage } from './ChatMessage'
@@ -34,12 +35,14 @@ vi.mock('streamdown', async () => {
     children,
     isAnimating,
     caret,
+    animated,
     linkSafety,
     components
   }: {
     children: ReactNode
     isAnimating?: boolean
     caret?: string
+    animated?: boolean | AnimateOptions
     linkSafety?: LinkSafety
     components?: Record<string, unknown>
   }): React.JSX.Element {
@@ -49,11 +52,19 @@ vi.mock('streamdown', async () => {
     const CustomTable = components?.table as React.ElementType | undefined
     const CustomLink = components?.a as React.ElementType | undefined
     const semanticFixture = markdown.startsWith('# Compact heading')
+    const animatedConfig = animated === false || animated === true ? undefined : animated
+    const animatedName =
+      animated === false ? 'false' : animated === true ? 'true' : (animatedConfig?.animation ?? '')
+    const animatedDuration = animatedConfig ? String(animatedConfig.duration ?? '') : ''
+    const animatedEasing = animatedConfig?.easing ?? ''
 
     return (
       <div
         data-testid="streamdown"
         data-animating={isAnimating}
+        data-animated={animatedName}
+        data-animated-duration={animatedDuration}
+        data-animated-easing={animatedEasing}
         data-caret={caret}
         data-custom-table={Boolean(CustomTable)}
       >
@@ -130,11 +141,15 @@ vi.mock('streamdown', async () => {
   }
 })
 
+const { useReducedMotionMock } = vi.hoisted(() => ({
+  useReducedMotionMock: vi.fn(() => true)
+}))
+
 vi.mock('framer-motion', async () => {
   const actual = await vi.importActual<typeof import('framer-motion')>('framer-motion')
   return {
     ...actual,
-    useReducedMotion: () => true
+    useReducedMotion: useReducedMotionMock
   }
 })
 
@@ -152,6 +167,7 @@ describe('ChatMessage', () => {
   beforeEach(() => {
     openUrlWithSystemBrowser.mockClear()
     openFilePathFromTerminal.mockClear()
+    useReducedMotionMock.mockReturnValue(true)
   })
 
   it('shows the Streamdown caret while the live agent message is streaming', () => {
@@ -159,6 +175,17 @@ describe('ChatMessage', () => {
 
     expect(screen.getByTestId('streamdown')).toHaveAttribute('data-animating', 'true')
     expect(screen.getByTestId('streamdown')).toHaveAttribute('data-caret', 'block')
+    expect(screen.getByTestId('streamdown')).toHaveAttribute('data-animated', 'false')
+  })
+
+  it('passes the fadeIn animation config (duration/easing) under default motion', () => {
+    useReducedMotionMock.mockReturnValue(false)
+    render(<ChatMessage message={agentMessage(true)} isLast />)
+
+    const streamdown = screen.getByTestId('streamdown')
+    expect(streamdown).toHaveAttribute('data-animated', 'fadeIn')
+    expect(streamdown).toHaveAttribute('data-animated-duration', '200')
+    expect(streamdown).toHaveAttribute('data-animated-easing', 'cubic-bezier(0.22, 1, 0.36, 1)')
   })
 
   it('renders compact markdown semantics for headings, lists, code, quotes, and tables', () => {

--- a/src/renderer/components/chat/ChatMessage.tsx
+++ b/src/renderer/components/chat/ChatMessage.tsx
@@ -225,10 +225,16 @@ const STREAMDOWN_COMPONENTS = {
   table: ChatMarkdownTable
 } as const
 
-// Word-by-word reveal so replies feel like they stream even when an agent
-// sends its text as one big chunk. `animated` uses the styles.css keyframes
-// imported in main.tsx; already-visible words get duration 0 (no re-animation).
-const STREAMDOWN_ANIMATED = { animation: 'blurIn', sep: 'word', duration: 350, stagger: 8 } as const
+// Opacity-only fade so streamed words reveal smoothly without the blur-filter
+// jank of sd-blurIn. `animated` uses the styles.css keyframes imported in
+// main.tsx; already-visible words get duration 0 (no re-animation).
+const STREAMDOWN_ANIMATED = {
+  animation: 'fadeIn',
+  sep: 'word',
+  duration: 200,
+  easing: 'cubic-bezier(0.22, 1, 0.36, 1)',
+  stagger: 8
+} as const
 
 /**
  * Confirm external links, then hand off to the OS browser.


### PR DESCRIPTION
## Summary

Streamed ACP agent replies used Streamdown's per-word `sd-blurIn` animation (opacity + CSS `filter: blur(4px)`, 350ms / 8ms stagger). Each word ran its own GPU-composited `blur()` filter, so hundreds of concurrent blur animations per frame made live text feel like a laggy, flaky "typing" effect — especially on longer turns. This switches the reveal to Streamdown's shipped `sd-fadeIn` keyframe (pure opacity, compositor-friendly, no blur), tuned to 200ms with a smooth ease-out, so streamed words fade in smoothly instead of janking. The caret and reduced-motion gating are unchanged; there are no store, timeline, or data-flow changes.

## Related Issue

No related issue — this is a user-reported UX polish fix for the streamed-text animation jank; no tracking issue exists.

## Type of Change

- [x] fix: bug fix

## What Changed

- `src/renderer/components/chat/ChatMessage.tsx` — `STREAMDOWN_ANIMATED` config: `animation: 'blurIn'` → `'fadeIn'`; `duration: 350` → `200`; added `easing: 'cubic-bezier(0.22, 1, 0.36, 1)'` (smooth ease-out); kept `sep: 'word'`, `stagger: 8`, and `as const`; updated the comment.
- `src/renderer/components/chat/ChatMessage.test.tsx` — `MockStreamdown` now types `animated` as `boolean | AnimateOptions` (the real Streamdown type) and serializes `animation`/`duration`/`easing` onto `data-animated*` attrs; the `useReducedMotion` mock is now per-test overridable; a new test locks the `fadeIn` config (animation + duration + easing) under default motion, and the existing reduced-motion streaming test also asserts `animated=false`.

## How It Was Tested

- [x] `bun run ci` (Biome lint + format + imports, strict mode)
- [x] `bun run typecheck`
- [x] `bun run test`
- [ ] `cargo clippy --all-targets -- -D warnings` (in src-tauri)
- [ ] `cargo test` (in src-tauri)
- [ ] Manual verification completed
- [ ] Not applicable

## Screenshots or Recordings

Animation-timing change; verify by streaming a live agent turn in `bun run tauri dev` (desktop) or `bun run dev:web` (web) and toggling `prefers-reduced-motion` in DevTools.

## CI & Review Gate

- [ ] All CI checks pass (PR Validation, Rust Checks, Build Verification, Security Scans)
- [ ] Code review comments from CodeRabbit / Claude have been addressed or resolved
- [ ] No unresolved review findings remain

## Checklist

- [x] My PR title follows the conventional commit format used by this repo
- [x] I linked the related issue or explained why none exists
- [x] I updated docs when needed
- [x] I added or updated tests when needed
- [x] I verified the change does not introduce unrelated modifications
- [x] I read AGENTS.md and followed the contributor guidelines
- [ ] A human reviewed the complete diff before submission
