### PR TITLE
feat: inline agent-skill chips in composer and timeline

### DIFF
--- a/src-tauri/src/skills/mod.rs
+++ b/src-tauri/src/skills/mod.rs
@@ -19,6 +19,9 @@ pub struct AgentSkillSummary {
     pub description: String,
     /// `"global"` or `"project"`.
     pub scope: String,
+    /// Absolute path to the skill's `SKILL.md` so the agent can read the
+    /// instructions from disk at prompt time (no body is shipped over the wire).
+    pub path: String,
 }
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
@@ -29,6 +32,8 @@ pub struct AgentSkillContent {
     pub scope: String,
     /// Markdown body after YAML frontmatter.
     pub body: String,
+    /// Absolute path to the skill's `SKILL.md`.
+    pub path: String,
 }
 
 fn home_skills_root() -> Result<PathBuf, String> {
@@ -163,6 +168,9 @@ fn scan_skills_dir(
             continue;
         }
         let description = frontmatter.get("description").cloned().unwrap_or_default();
+        // Canonicalize the SKILL.md path so the renderer-side wire prompt can
+        // cite a stable absolute path for the agent to read at prompt time.
+        let path = skill_md.to_string_lossy().to_string();
 
         out.insert(
             name.clone(),
@@ -170,6 +178,7 @@ fn scan_skills_dir(
                 name,
                 description,
                 scope: scope.to_string(),
+                path,
             },
         );
     }
@@ -237,12 +246,14 @@ pub fn read_agent_skill(
         .filter(|n| !n.is_empty())
         .unwrap_or_else(|| name.to_string());
     let description = frontmatter.get("description").cloned().unwrap_or_default();
+    let path = path.to_string_lossy().to_string();
 
     Ok(AgentSkillContent {
         name: skill_name,
         description,
         scope,
         body,
+        path,
     })
 }
 
@@ -273,18 +284,64 @@ mod tests {
             "---\nname: demo-skill\ndescription: Demo\n---\n\nRun the demo.\n",
         )
         .unwrap();
+        let expected_skill_md = skill_dir.join("SKILL.md");
 
         let root = temp.to_string_lossy().to_string();
         let listed = list_agent_skills(Some(&root)).unwrap();
-        assert!(listed
+        let summary = listed
             .iter()
-            .any(|s| s.name == "demo-skill" && s.scope == "project"));
+            .find(|s| s.name == "demo-skill" && s.scope == "project")
+            .expect("project skill should be listed");
+        // The wire prompt cites the SKILL.md path so the agent can read it from
+        // disk — the scanner must surface it on the summary.
+        assert_eq!(summary.path, expected_skill_md.to_string_lossy().to_string());
 
         let content = read_agent_skill("demo-skill", Some(&root)).unwrap();
         assert_eq!(content.name, "demo-skill");
         assert_eq!(content.body.trim(), "Run the demo.");
+        assert_eq!(content.path, expected_skill_md.to_string_lossy().to_string());
 
         let _ = fs::remove_dir_all(temp);
+    }
+
+    #[test]
+    fn list_and_read_global_skill_populates_path() {
+        // Skills under the user's home `~/.agents/skills/<name>/SKILL.md` must
+        // surface their absolute path so the wire prompt can cite a global skill
+        // path (the agent reads the body from disk at prompt time).
+        let home = std::env::temp_dir().join(format!("termul-skill-home-{}", std::process::id()));
+        let global_root = home.join(".agents").join("skills");
+        let skill_dir = global_root.join("global-skill");
+        fs::create_dir_all(&skill_dir).unwrap();
+        fs::write(
+            skill_dir.join("SKILL.md"),
+            "---\nname: global-skill\ndescription: Global\n---\n\nRun globally.\n",
+        )
+        .unwrap();
+        let expected_skill_md = skill_dir.join("SKILL.md");
+
+        let prev_home = std::env::var_os("HOME").or_else(|| std::env::var_os("USERPROFILE"));
+        std::env::set_var("HOME", home.to_string_lossy().to_string());
+        let result = std::panic::catch_unwind(|| {
+            // No project root → only the global skill is discovered.
+            let listed = list_agent_skills(None).unwrap();
+            let summary = listed
+                .iter()
+                .find(|s| s.name == "global-skill" && s.scope == "global")
+                .expect("global skill should be listed");
+            assert_eq!(summary.path, expected_skill_md.to_string_lossy().to_string());
+
+            let content = read_agent_skill("global-skill", None).unwrap();
+            assert_eq!(content.scope, "global");
+            assert_eq!(content.path, expected_skill_md.to_string_lossy().to_string());
+        });
+        // Restore HOME/USERPROFILE so other tests don't see the temp home.
+        match prev_home {
+            Some(v) => std::env::set_var("HOME", v),
+            None => std::env::remove_var("HOME"),
+        }
+        assert!(result.is_ok(), "global skill path population failed");
+        let _ = fs::remove_dir_all(home);
     }
 
     #[test]

--- a/src-tauri/src/skills/mod.rs
+++ b/src-tauri/src/skills/mod.rs
@@ -204,7 +204,14 @@ pub fn list_agent_skills_with_home(
     scan_skills_dir(home_root, "global", &mut by_name)?;
 
     if let Some(root) = project_root.filter(|s| !s.is_empty()) {
-        let project_skills = PathBuf::from(root).join(".agents").join("skills");
+        // Reject a relative project root early: a relative path would scan the
+        // process CWD (undefined for a Tauri command) rather than the intended
+        // project. The renderer always passes an absolute `session.cwd`.
+        let root_path = PathBuf::from(root);
+        if !root_path.is_absolute() {
+            return Err(format!("project root must be absolute, got: {root}"));
+        }
+        let project_skills = root_path.join(".agents").join("skills");
         scan_skills_dir(&project_skills, "project", &mut by_name)?;
     }
 
@@ -227,7 +234,13 @@ fn resolve_skill_path_with_home(
     validate_skill_name(name)?;
 
     if let Some(root) = project_root.filter(|s| !s.is_empty()) {
-        let project_skill = PathBuf::from(root)
+        // Reject a relative project root before constructing skill paths (mirrors
+        // the check in `list_agent_skills_with_home`).
+        let root_path = PathBuf::from(root);
+        if !root_path.is_absolute() {
+            return Err(format!("project root must be absolute, got: {root}"));
+        }
+        let project_skill = root_path
             .join(".agents")
             .join("skills")
             .join(name)

--- a/src-tauri/src/skills/mod.rs
+++ b/src-tauri/src/skills/mod.rs
@@ -168,8 +168,11 @@ fn scan_skills_dir(
             continue;
         }
         let description = frontmatter.get("description").cloned().unwrap_or_default();
-        // Canonicalize the SKILL.md path so the renderer-side wire prompt can
-        // cite a stable absolute path for the agent to read at prompt time.
+        // Absolute SKILL.md path derived from the (already-absolute) scan root,
+        // so the renderer-side wire prompt can cite it for the agent to read at
+        // prompt time. Not canonicalized: `fs::canonicalize` would yield a
+        // `\\?\`-prefixed UNC path on Windows that is ugly to cite in the wire
+        // prompt, and the scan root is already absolute.
         let path = skill_md.to_string_lossy().to_string();
 
         out.insert(
@@ -187,11 +190,18 @@ fn scan_skills_dir(
 }
 
 /// List installed skills. Project-local entries override global names.
-pub fn list_agent_skills(project_root: Option<&str>) -> Result<Vec<AgentSkillSummary>, String> {
+///
+/// `home_root` is the global skills root (`~/.agents/skills`) to scan, injected
+/// so tests can supply a temp home without mutating the process-wide `HOME`
+/// (which would race with other tests reading `home_skills_root()`).
+pub fn list_agent_skills_with_home(
+    home_root: &Path,
+    project_root: Option<&str>
+) -> Result<Vec<AgentSkillSummary>, String> {
     log::debug!("listing agent skills, project_root={project_root:?}");
     let mut by_name: HashMap<String, AgentSkillSummary> = HashMap::new();
 
-    scan_skills_dir(&home_skills_root()?, "global", &mut by_name)?;
+    scan_skills_dir(home_root, "global", &mut by_name)?;
 
     if let Some(root) = project_root.filter(|s| !s.is_empty()) {
         let project_skills = PathBuf::from(root).join(".agents").join("skills");
@@ -204,7 +214,16 @@ pub fn list_agent_skills(project_root: Option<&str>) -> Result<Vec<AgentSkillSum
     Ok(skills)
 }
 
-fn resolve_skill_path(name: &str, project_root: Option<&str>) -> Result<(PathBuf, String), String> {
+/// List installed skills using the real user home (`~/.agents/skills`).
+pub fn list_agent_skills(project_root: Option<&str>) -> Result<Vec<AgentSkillSummary>, String> {
+    list_agent_skills_with_home(&home_skills_root()?, project_root)
+}
+
+fn resolve_skill_path_with_home(
+    name: &str,
+    project_root: Option<&str>,
+    home_root: &Path
+) -> Result<(PathBuf, String), String> {
     validate_skill_name(name)?;
 
     if let Some(root) = project_root.filter(|s| !s.is_empty()) {
@@ -218,7 +237,7 @@ fn resolve_skill_path(name: &str, project_root: Option<&str>) -> Result<(PathBuf
         }
     }
 
-    let global_skill = home_skills_root()?.join(name).join("SKILL.md");
+    let global_skill = home_root.join(name).join("SKILL.md");
     if global_skill.is_file() {
         return Ok((global_skill, "global".to_string()));
     }
@@ -227,11 +246,15 @@ fn resolve_skill_path(name: &str, project_root: Option<&str>) -> Result<(PathBuf
 }
 
 /// Read a skill's markdown body. Project-local overrides global.
-pub fn read_agent_skill(
+///
+/// `home_root` is injected (see `list_agent_skills_with_home`) so tests can
+/// resolve a global skill against a temp home without mutating `HOME`.
+pub fn read_agent_skill_with_home(
     name: &str,
-    project_root: Option<&str>,
+    home_root: &Path,
+    project_root: Option<&str>
 ) -> Result<AgentSkillContent, String> {
-    let (path, scope) = resolve_skill_path(name, project_root).map_err(|e| {
+    let (path, scope) = resolve_skill_path_with_home(name, project_root, home_root).map_err(|e| {
         log::warn!("agent skill '{name}' could not be resolved: {e}");
         e
     })?;
@@ -255,6 +278,14 @@ pub fn read_agent_skill(
         body,
         path,
     })
+}
+
+/// Read a skill's markdown body using the real user home (`~/.agents/skills`).
+pub fn read_agent_skill(
+    name: &str,
+    project_root: Option<&str>
+) -> Result<AgentSkillContent, String> {
+    read_agent_skill_with_home(name, &home_skills_root()?, project_root)
 }
 
 #[cfg(test)]
@@ -320,27 +351,20 @@ mod tests {
         .unwrap();
         let expected_skill_md = skill_dir.join("SKILL.md");
 
-        let prev_home = std::env::var_os("HOME").or_else(|| std::env::var_os("USERPROFILE"));
-        std::env::set_var("HOME", home.to_string_lossy().to_string());
-        let result = std::panic::catch_unwind(|| {
-            // No project root → only the global skill is discovered.
-            let listed = list_agent_skills(None).unwrap();
-            let summary = listed
-                .iter()
-                .find(|s| s.name == "global-skill" && s.scope == "global")
-                .expect("global skill should be listed");
-            assert_eq!(summary.path, expected_skill_md.to_string_lossy().to_string());
+        // Inject the temp skills root directly via the `_with_home` variants
+        // instead of mutating the process-wide `HOME` (which would race with
+        // any other test reading `home_skills_root()`).
+        let listed = list_agent_skills_with_home(&global_root, None).unwrap();
+        let summary = listed
+            .iter()
+            .find(|s| s.name == "global-skill" && s.scope == "global")
+            .expect("global skill should be listed");
+        assert_eq!(summary.path, expected_skill_md.to_string_lossy().to_string());
 
-            let content = read_agent_skill("global-skill", None).unwrap();
-            assert_eq!(content.scope, "global");
-            assert_eq!(content.path, expected_skill_md.to_string_lossy().to_string());
-        });
-        // Restore HOME/USERPROFILE so other tests don't see the temp home.
-        match prev_home {
-            Some(v) => std::env::set_var("HOME", v),
-            None => std::env::remove_var("HOME"),
-        }
-        assert!(result.is_ok(), "global skill path population failed");
+        let content = read_agent_skill_with_home("global-skill", &global_root, None).unwrap();
+        assert_eq!(content.scope, "global");
+        assert_eq!(content.path, expected_skill_md.to_string_lossy().to_string());
+
         let _ = fs::remove_dir_all(home);
     }
 

--- a/src/renderer/assets/agent-icons/acp/agents.json
+++ b/src/renderer/assets/agent-icons/acp/agents.json
@@ -81,11 +81,11 @@
   {
     "id": "cline",
     "name": "Cline",
-    "version": "3.0.48",
+    "version": "3.0.49",
     "description": "Autonomous coding agent CLI - capable of creating/editing files, running commands, using the browser, and more",
     "distribution": {
       "npx": {
-        "package": "cline@3.0.48",
+        "package": "cline@3.0.49",
         "args": ["--acp"]
       }
     }
@@ -320,11 +320,11 @@
   {
     "id": "dirac",
     "name": "Dirac",
-    "version": "0.4.31",
+    "version": "0.4.32",
     "description": "Reduces API costs by more than 50%, produces better and faster work. Uses Hash anchored parallel edits, AST manipulation and a whole lot of neat optimizations. Fully Open Source.",
     "distribution": {
       "npx": {
-        "package": "dirac-cli@0.4.31",
+        "package": "dirac-cli@0.4.32",
         "args": ["--acp"]
       }
     }
@@ -629,11 +629,11 @@
   {
     "id": "nova",
     "name": "Nova",
-    "version": "1.1.30",
+    "version": "1.1.31",
     "description": "Nova by Compass AI - a fully-fledged software engineer at your command",
     "distribution": {
       "npx": {
-        "package": "@compass-ai/nova@1.1.30",
+        "package": "@compass-ai/nova@1.1.31",
         "args": ["acp"]
       }
     }

--- a/src/renderer/components/agents/AgentLauncher.test.tsx
+++ b/src/renderer/components/agents/AgentLauncher.test.tsx
@@ -103,16 +103,18 @@ const {
   }
 }))
 
-const { mockSkills, mockBuildPrompt, mockToastError } = vi.hoisted(() => ({
+const { mockSkills, mockToastError } = vi.hoisted(() => ({
   // Override-able skills list (defaults to [] — web/no-skills parity). Skill
   // tests push entries here so useAgentSkills surfaces them in the slash menu.
+  // `path` is required so the launch wire prompt can cite it.
   mockSkills: {
-    current: [] as Array<{ name: string; description: string; scope: string }>
+    current: [] as Array<{
+      name: string
+      description: string
+      scope: string
+      path: string
+    }>
   },
-  // buildPromptWithLoadedSkills mock — defaults to passthrough (returns user
-  // text). Launch-injects-data tests override the resolved value to assert the
-  // framed skill body is carried into the first turn.
-  mockBuildPrompt: vi.fn(async (_skills: unknown, text: string) => text),
   mockToastError: vi.fn()
 }))
 
@@ -120,10 +122,15 @@ vi.mock('sonner', () => ({
   toast: { error: mockToastError, success: vi.fn() }
 }))
 
-vi.mock('@/hooks/use-agent-skills', () => ({
-  useAgentSkills: () => ({ skills: mockSkills.current }),
-  buildPromptWithLoadedSkills: mockBuildPrompt
-}))
+vi.mock('@/hooks/use-agent-skills', async () => {
+  // Use the real (sync) buildPromptWithLoadedSkills so the wire framing is
+  // exercised end-to-end — no mock needed now that paths are captured at pick
+  // time (no IPC read at launch). Only useAgentSkills is overridden.
+  const actual = await vi.importActual<typeof import('@/hooks/use-agent-skills')>(
+    '@/hooks/use-agent-skills'
+  )
+  return { ...actual, useAgentSkills: () => ({ skills: mockSkills.current }) }
+})
 
 vi.mock('@tauri-apps/plugin-os', () => ({
   platform: vi.fn(() => 'windows'),
@@ -349,11 +356,9 @@ beforeEach(() => {
   vi.clearAllMocks()
   vi.restoreAllMocks()
   __resetLauncherSelectionCache()
-  // Start each test from a clean skill/prompt-framing slate (web/no-skills
-  // default). Skill tests override mockSkills.current and mockBuildPrompt.
+  // Start each test from a clean skill slate (web/no-skills default). Skill
+  // tests override mockSkills.current.
   mockSkills.current = []
-  mockBuildPrompt.mockReset()
-  mockBuildPrompt.mockImplementation(async (_skills: unknown, text: string) => text)
   acpStateRef.current = {
     agentConfigs: [],
     preparedSessions: {},
@@ -1044,19 +1049,21 @@ describe('AgentLauncher ACP new thread', () => {
   })
 })
 
-describe('AgentLauncher skill chips', () => {
+describe('AgentLauncher skill chips (inline tokens)', () => {
   const SKILL_GIT = {
     name: 'git-worktree',
     description: 'Isolated worktree',
-    scope: 'project'
+    scope: 'project',
+    path: '/home/u/.agents/skills/git-worktree/SKILL.md'
   }
+  const TOKEN = '\uE000git-worktree\uE001'
 
   function selectSlashOption(name: string | RegExp): void {
     const listbox = screen.getByRole('listbox')
     fireEvent.mouseDown(within(listbox).getByText(name))
   }
 
-  it('shows a Skills section in the launcher slash menu and renders a pill on pick', async () => {
+  it('shows a Skills section in the launcher slash menu and renders an inline chip on pick', async () => {
     mockSkills.current = [SKILL_GIT]
     renderLauncher()
 
@@ -1068,19 +1075,15 @@ describe('AgentLauncher skill chips', () => {
 
     selectSlashOption('/git-worktree')
 
-    // Skill pill renders in the launcher composer; the X button's accessible
-    // label is the stable selector for the pill.
-    await waitFor(() => {
-      expect(screen.getByRole('button', { name: 'Remove git-worktree skill' })).toBeInTheDocument()
-    })
-    // The `/` filter text is cleared.
-    expect(textarea).toHaveValue('')
+    // The transparent-textarea overlay renders the chip name as a visible span
+    // (after the slash menu closes, it is the stable selector for the chip).
+    await waitFor(() => expect(screen.getByText('git-worktree')).toBeInTheDocument())
+    // The `/` filter text is cleared; the value carries the token + trailing space.
+    expect(textarea).toHaveValue(`${TOKEN} `)
   })
 
-  it('injects the framed skill body into the first turn on launch (optimistic + real)', async () => {
+  it('launch injects the wire (path-framed) text into the real send while the optimistic preview carries the display (token) text', async () => {
     mockSkills.current = [SKILL_GIT]
-    const framed = '# Agent Skills\n\n## git-worktree\nCreate a worktree.\n\n---\n\nhello'
-    mockBuildPrompt.mockResolvedValue(framed)
     renderLauncher()
 
     const textarea = await screen.findByLabelText('Agent prompt')
@@ -1088,79 +1091,54 @@ describe('AgentLauncher skill chips', () => {
     await waitFor(() => expect(screen.getByRole('listbox')).toBeInTheDocument())
     selectSlashOption('/git-worktree')
 
-    await waitFor(() =>
-      expect(screen.getByRole('button', { name: 'Remove git-worktree skill' })).toBeInTheDocument()
-    )
-
-    fireEvent.change(textarea, { target: { value: 'hello' } })
+    await waitFor(() => expect(screen.getByText('git-worktree')).toBeInTheDocument())
+    // Type after the chip + trailing space.
+    fireEvent.change(textarea, { target: { value: `${TOKEN} hello` } })
     fireEvent.click(screen.getByLabelText('Start agent chat'))
 
-    // Skill bodies are read at launch time via buildPromptWithLoadedSkills.
-    await waitFor(() => expect(mockBuildPrompt).toHaveBeenCalled())
-    expect(mockBuildPrompt).toHaveBeenCalledWith(
-      expect.arrayContaining([expect.objectContaining({ name: 'git-worktree' })]),
-      'hello',
-      '/work'
-    )
+    const wireText = `# Agent Skills\n\ngit-worktree: /home/u/.agents/skills/git-worktree/SKILL.md\n\n---\n\n(git-worktree) hello`
+    const displayText = `${TOKEN} hello`
 
-    // Optimistic syncBlocks carry the framed text so the preview matches.
+    // The optimistic syncBlocks carry the DISPLAY (token) text so the chat
+    // timeline renders inline chips.
     await waitFor(() =>
       expect(mockCreateLaunchPlaceholder).toHaveBeenCalledWith(
         expect.objectContaining({
-          initialUserBlocks: [{ type: 'text', text: framed }]
+          initialUserBlocks: [{ type: 'text', text: displayText }]
         })
       )
     )
-    // The chat opens (carryover): the launcher hands off a first user turn
-    // carrying the framed skill body, then clears its own skill chips.
     expect(mockHideAgentLauncher).toHaveBeenCalled()
     expect(mockAddAgentChatTab).toHaveBeenCalledWith('launch-placeholder-1', 'pane1')
-    // The launcher's skill chips are cleared on launch — the chat that opens
-    // starts with no skill chips (skills were injected as framed text, not
-    // carried as chips). The launcher stays mounted in this harness, so the
-    // pill's absence proves the state was cleared.
-    await waitFor(() => {
-      expect(
-        screen.queryByRole('button', { name: 'Remove git-worktree skill' })
-      ).not.toBeInTheDocument()
-    })
 
-    // The real send (finalize) also carries the framed text.
+    // The real send (finalize) carries the WIRE (path-framed) text — the agent
+    // receives paths, not tokens.
     await waitFor(() =>
       expect(mockFinalizeChatLaunch).toHaveBeenCalledWith(
         expect.objectContaining({
-          initialBlocks: [{ type: 'text', text: framed }]
+          initialBlocks: [{ type: 'text', text: wireText }]
         })
       )
     )
   })
 
-  it('toasts and aborts launch when a skill read fails at launch (pill remains)', async () => {
-    mockSkills.current = [SKILL_GIT]
-    mockBuildPrompt.mockRejectedValue(new Error("Failed to load skill 'git-worktree': boom"))
+  it('toasts and aborts launch when a selected skill has no path (web parity gap)', async () => {
+    mockSkills.current = [{ name: 'pathless', description: 'no path', scope: 'project', path: '' }]
     renderLauncher()
 
     const textarea = await screen.findByLabelText('Agent prompt')
     fireEvent.change(textarea, { target: { value: '/' } })
     await waitFor(() => expect(screen.getByRole('listbox')).toBeInTheDocument())
-    selectSlashOption('/git-worktree')
+    selectSlashOption('/pathless')
 
-    await waitFor(() =>
-      expect(screen.getByRole('button', { name: 'Remove git-worktree skill' })).toBeInTheDocument()
-    )
-
-    fireEvent.change(textarea, { target: { value: 'hello' } })
+    await waitFor(() => expect(screen.getByText('pathless')).toBeInTheDocument())
+    fireEvent.change(textarea, { target: { value: '\uE000pathless\uE001 hello' } })
     fireEvent.click(screen.getByLabelText('Start agent chat'))
 
-    // The toast names the failing skill.
+    // The toast names the missing path; launch is aborted.
     await waitFor(() => expect(mockToastError).toHaveBeenCalled())
-    expect(mockToastError).toHaveBeenCalledWith(
-      expect.stringContaining("Failed to load skill 'git-worktree'")
-    )
-    // Launch aborted: no chat opened, no placeholder created.
+    expect(mockToastError).toHaveBeenCalledWith(expect.stringContaining('missing a path'))
     expect(mockCreateLaunchPlaceholder).not.toHaveBeenCalled()
     expect(mockHideAgentLauncher).not.toHaveBeenCalled()
-    // The skill pill remains for retry/remove.
-    expect(screen.getByRole('button', { name: 'Remove git-worktree skill' })).toBeInTheDocument()
   })
 })

--- a/src/renderer/components/agents/AgentLauncher.tsx
+++ b/src/renderer/components/agents/AgentLauncher.tsx
@@ -20,11 +20,12 @@ import {
   resolveModelOption
 } from '@/components/chat/chat-input-bar-config'
 import { FileMentionMenu } from '@/components/chat/FileMentionMenu'
-import { SkillChip } from '@/components/chat/SkillChip'
+import { SkillComposerOverlay } from '@/components/chat/SkillComposerOverlay'
 import { SlashCommandMenu, type SlashMenuHandle } from '@/components/chat/SlashCommandMenu'
 import { tryHandleSlashMenuKeyDown } from '@/components/chat/slash-menu-keyboard'
 import {
   buildSlashSections,
+  findSlashTrigger,
   isSlashTrigger,
   type SlashItem,
   slashFilter
@@ -39,11 +40,7 @@ import { Input } from '@/components/ui/input'
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
 import { useAcpRegistryCatalog } from '@/hooks/use-acp-registry-catalog'
 import { useAcpRuntimeProbe } from '@/hooks/use-acp-runtime-probe'
-import {
-  buildPromptWithLoadedSkills,
-  type LoadedAgentSkill,
-  useAgentSkills
-} from '@/hooks/use-agent-skills'
+import { buildPromptWithLoadedSkills, useAgentSkills } from '@/hooks/use-agent-skills'
 import { useMentionRecents } from '@/hooks/use-mention-recents'
 import type { StoredAgentConfig } from '@/lib/acp-agents-persistence'
 import { type AuthMethod, acpApi, type ContentBlock } from '@/lib/acp-api'
@@ -62,6 +59,11 @@ import {
 } from '@/lib/agents/supported-acp-agents'
 import { dialogApi, openerApi, persistenceApi } from '@/lib/api'
 import { registerSessionTempFiles } from '@/lib/attachment-temp-cleanup'
+import {
+  extractSkillNames,
+  insertSkillToken,
+  removeSkillTokenBeforeCaret
+} from '@/lib/skill-tokens'
 import { platform as osPlatform } from '@/lib/tauri-os'
 import { cn } from '@/lib/utils'
 import { getDefaultCwdForProject } from '@/lib/worktree-context'
@@ -103,7 +105,9 @@ export function AgentLauncher({ paneId, className }: AgentLauncherProps): React.
   const [pendingOptions, setPendingOptions] = useState<PendingLauncherOptions>(
     emptyPendingLauncherOptions
   )
-  const [loadedSkills, setLoadedSkills] = useState<LoadedAgentSkill[]>([])
+  // name → SKILL.md path, captured when a skill is picked inline so the launch
+  // wire prompt can cite paths synchronously (no IPC read, no failure path).
+  const skillPathsRef = useRef<Record<string, string>>({})
   const launchInFlightRef = useRef(false)
   const menuRef = useRef<SlashMenuHandle>(null)
   const textareaRef = useRef<HTMLTextAreaElement>(null)
@@ -277,6 +281,7 @@ export function AgentLauncher({ paneId, className }: AgentLauncherProps): React.
     emptyLabel,
     resetMentions,
     resetHeight,
+    clampHeight,
     updateMentions
   } = useComposerTextarea({
     value: prompt,
@@ -586,17 +591,30 @@ export function AgentLauncher({ paneId, className }: AgentLauncherProps): React.
   const handleSlashSelect = useCallback(
     (item: SlashItem) => {
       if (item.kind === 'skill') {
-        // Append the skill as an inline chip (deduped by name), clear the `/`
-        // filter text, and refocus so the user can keep typing or pick another.
-        setLoadedSkills((prev) =>
-          prev.some((s) => s.name === item.name)
-            ? prev
-            : [...prev, { name: item.name, description: item.description ?? '' }]
+        // Splice an inline skill token at the caret (removing the `/`-filter
+        // text), record the path for the launch wire prompt, and refocus so the
+        // user can keep typing or pick another skill.
+        const trigger = findSlashTrigger(prompt)
+        const caret = textareaRef.current?.selectionStart ?? prompt.length
+        const insertAt = trigger ? trigger.end : caret
+        const deleteBefore = trigger ? trigger.end - trigger.start : 0
+        const { value: next, caret: nextCaret } = insertSkillToken(
+          prompt,
+          insertAt,
+          item.name,
+          deleteBefore
         )
-        setPrompt('')
-        updateMentions('', 0)
+        skillPathsRef.current[item.name] = item.path
+        setPrompt(next)
+        updateMentions(next, nextCaret)
         resetHeight()
-        textareaRef.current?.focus()
+        requestAnimationFrame(() => {
+          const el = textareaRef.current
+          if (!el) return
+          clampHeight(el)
+          el.setSelectionRange(nextCaret, nextCaret)
+          el.focus()
+        })
         return
       }
       if (item.kind === 'config') {
@@ -614,7 +632,7 @@ export function AgentLauncher({ paneId, className }: AgentLauncherProps): React.
       updateMentions('', 0)
       resetHeight()
     },
-    [handleSetConfig, handleSetMode, updateMentions, resetHeight]
+    [prompt, handleSetConfig, handleSetMode, updateMentions, resetHeight, clampHeight]
   )
 
   const launch = useCallback(async () => {
@@ -638,25 +656,26 @@ export function AgentLauncher({ paneId, className }: AgentLauncherProps): React.
     const projectIdSnapshot = activeProjectId
     const projectRootSnapshot = projectRoot
     const needsSave = !acpConfigs.some((config) => config.id === selectedConfig.id)
-    const loadedSkillsSnapshot = loadedSkills
+    const skillPathsSnapshot = skillPathsRef.current
 
-    // Frame skill bodies first so the optimistic preview matches the real
-    // send. On read failure, surface a toast naming the failing skill and
-    // abort the launch (no chat opens, skills stay for retry/remove).
-    let firstTurnText = promptSnapshot
-    if (loadedSkillsSnapshot.length > 0) {
-      try {
-        firstTurnText = await buildPromptWithLoadedSkills(
-          loadedSkillsSnapshot,
-          promptSnapshot,
-          projectRootSnapshot
-        )
-      } catch (err) {
-        launchInFlightRef.current = false
-        toast.error(err instanceof Error ? err.message : 'Failed to start agent chat')
-        return
-      }
+    // Build the wire text (skills framed by path under `# Agent Skills`, then
+    // the user text with tokens replaced by `(name)`) and the display text (the
+    // raw token value, so the chat timeline re-renders inline chips). Sync —
+    // paths were captured at pick time, so no IPC read and no failure path. A
+    // skill surfaced without a path (web parity gap) blocks the launch.
+    const skillNames = extractSkillNames(promptSnapshot)
+    const skills = skillNames.map((name) => ({ name, path: skillPathsSnapshot[name] ?? '' }))
+    const missingPath = skills.find((s) => !s.path)
+    if (missingPath) {
+      toast.error(`Skill '${missingPath.name}' is missing a path`)
+      launchInFlightRef.current = false
+      return
     }
+    const hasSkills = skills.length > 0
+    const wireText = hasSkills
+      ? buildPromptWithLoadedSkills(skills, promptSnapshot)
+      : promptSnapshot
+    const displayText = promptSnapshot
 
     // Open the chat immediately; ACP spawn/session/send continue in the chat view.
     const store = useAcpStore.getState()
@@ -667,18 +686,16 @@ export function AgentLauncher({ paneId, className }: AgentLauncherProps): React.
     let usedPlaceholder = false
     let seededOptimistic = false
 
-    // Prefer sync first-turn content so the chat can paint like a normal send.
     // Sync first-turn content so the chat can paint like a normal send. The
-    // framed skill text is used for both the optimistic syncBlocks and the real
-    // send so the preview matches what the agent receives.
-    const syncText = firstTurnText
-    const syncTrimmed = syncText.trim()
+    // optimistic syncBlocks carry the DISPLAY (token) text so the timeline
+    // renders inline chips; the real send dispatches the WIRE text.
+    const syncTrimmed = displayText.trim()
     const syncBlocks: ContentBlock[] = []
     if (attachmentsSnapshot.length > 0) {
-      if (syncTrimmed) syncBlocks.push({ type: 'text', text: syncText })
+      if (syncTrimmed) syncBlocks.push({ type: 'text', text: displayText })
       for (const a of attachmentsSnapshot) syncBlocks.push(attachmentToBlock(a))
     } else if (syncTrimmed.length > 0) {
-      syncBlocks.push({ type: 'text', text: syncText })
+      syncBlocks.push({ type: 'text', text: displayText })
     }
 
     if (!sessionId) {
@@ -699,7 +716,7 @@ export function AgentLauncher({ paneId, className }: AgentLauncherProps): React.
     useWorkspaceStore.getState().addAgentChatTab(sessionId, paneSnapshot)
     useWorkspaceStore.getState().hideAgentLauncher()
     setPendingOptions(emptyPendingLauncherOptions())
-    setLoadedSkills([])
+    skillPathsRef.current = {}
     clearAttachments()
     resetMentions()
     resetHeight()
@@ -712,14 +729,15 @@ export function AgentLauncher({ paneId, className }: AgentLauncherProps): React.
         }
         persistSelection(configSnapshot.id)
 
-        const text = firstTurnText
-        const trimmed = text.trim()
+        // Real send carries the WIRE text (path-framed skills) so the agent
+        // receives paths, not tokens.
+        const wireTrimmed = wireText.trim()
         const blocks: ContentBlock[] = []
         if (attachmentsSnapshot.length > 0) {
-          if (trimmed) blocks.push({ type: 'text', text })
+          if (wireTrimmed) blocks.push({ type: 'text', text: wireText })
           for (const a of attachmentsSnapshot) blocks.push(attachmentToBlock(a))
-        } else if (trimmed.length > 0) {
-          blocks.push({ type: 'text', text })
+        } else if (wireTrimmed.length > 0) {
+          blocks.push({ type: 'text', text: wireText })
         }
 
         const liveStore = useAcpStore.getState()
@@ -776,12 +794,37 @@ export function AgentLauncher({ paneId, className }: AgentLauncherProps): React.
     preparedKey,
     effectiveModels,
     effectiveModes,
-    effectiveConfigOptions,
-    loadedSkills
+    effectiveConfigOptions
   ])
 
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+      // Backspace over an inline skill token (caret immediately after a chip,
+      // no active selection): remove the whole token plus the splicer's
+      // trailing space. Falls through to the default one-char backspace when
+      // the caret is in plain text.
+      if (e.key === 'Backspace' && !e.shiftKey && !e.metaKey && !e.ctrlKey) {
+        const el = e.currentTarget
+        const caret = el.selectionStart ?? 0
+        const selEnd = el.selectionEnd ?? 0
+        if (caret === selEnd) {
+          const result = removeSkillTokenBeforeCaret(prompt, caret)
+          if (result.removed) {
+            e.preventDefault()
+            setPrompt(result.value)
+            updateMentions(result.value, result.caret)
+            resetHeight()
+            requestAnimationFrame(() => {
+              const t = textareaRef.current
+              if (!t) return
+              clampHeight(t)
+              t.setSelectionRange(result.caret, result.caret)
+              t.focus()
+            })
+            return
+          }
+        }
+      }
       if (
         tryHandleSlashMenuKeyDown(e, {
           menuOpen,
@@ -811,13 +854,22 @@ export function AgentLauncher({ paneId, className }: AgentLauncherProps): React.
         useWorkspaceStore.getState().hideAgentLauncher()
       }
     },
-    [launch, menuOpen, slashSections.length, handleMentionKeyDown, updateMentions, resetHeight]
+    [
+      prompt,
+      launch,
+      menuOpen,
+      slashSections.length,
+      handleMentionKeyDown,
+      updateMentions,
+      clampHeight,
+      resetHeight
+    ]
   )
 
   const canLaunch =
     Boolean(selectedConfig) &&
     selectedEntry?.status === 'ready' &&
-    (prompt.trim().length > 0 || loadedSkills.length > 0 || attachments.length > 0)
+    (prompt.trim().length > 0 || attachments.length > 0)
 
   return (
     <div
@@ -916,21 +968,12 @@ export function AgentLauncher({ paneId, className }: AgentLauncherProps): React.
               onRemove={removeAttachment}
               className="px-5 pt-4"
             />
-            <div className="px-5 pb-2 pt-4">
-              {loadedSkills.length > 0 && (
-                <div className="mb-2 flex flex-wrap items-center gap-1.5">
-                  {loadedSkills.map((skill) => (
-                    <SkillChip
-                      key={skill.name}
-                      name={skill.name}
-                      onRemove={() => {
-                        setLoadedSkills((prev) => prev.filter((s) => s.name !== skill.name))
-                        textareaRef.current?.focus()
-                      }}
-                    />
-                  ))}
-                </div>
-              )}
+            <div className="relative px-5 pb-2 pt-4">
+              {/* Transparent-textarea overlay: mirrors the value with inline
+                  SkillChip pills. The textarea text is transparent with a
+                  visible caret; this overlay renders the visible text + chips
+                  in the same metrics so the caret stays aligned. */}
+              <SkillComposerOverlay textareaRef={textareaRef} value={prompt} />
               <textarea
                 ref={textareaRef}
                 value={prompt}
@@ -943,7 +986,7 @@ export function AgentLauncher({ paneId, className }: AgentLauncherProps): React.
                 rows={2}
                 aria-label="Agent prompt"
                 autoFocus
-                className="max-h-40 min-h-[76px] w-full resize-none bg-transparent text-sm leading-relaxed outline-none placeholder:text-muted-foreground/55"
+                className="relative z-10 max-h-40 min-h-[76px] w-full resize-none bg-transparent text-sm leading-relaxed text-transparent caret-foreground outline-none placeholder:text-muted-foreground/55"
               />
             </div>
             <div className="flex items-center justify-between gap-3 px-3 pb-3">

--- a/src/renderer/components/agents/AgentLauncher.tsx
+++ b/src/renderer/components/agents/AgentLauncher.tsx
@@ -62,7 +62,8 @@ import { registerSessionTempFiles } from '@/lib/attachment-temp-cleanup'
 import {
   extractSkillNames,
   insertSkillToken,
-  removeSkillTokenBeforeCaret
+  removeSkillTokenBeforeCaret,
+  SKILL_TOKEN_START
 } from '@/lib/skill-tokens'
 import { platform as osPlatform } from '@/lib/tauri-os'
 import { cn } from '@/lib/utils'
@@ -802,8 +803,9 @@ export function AgentLauncher({ paneId, className }: AgentLauncherProps): React.
       // Backspace over an inline skill token (caret immediately after a chip,
       // no active selection): remove the whole token plus the splicer's
       // trailing space. Falls through to the default one-char backspace when
-      // the caret is in plain text.
-      if (e.key === 'Backspace' && !e.shiftKey && !e.metaKey && !e.ctrlKey) {
+      // the caret is in plain text. Alt is excluded so macOS Option+Backspace
+      // (delete-word) doesn't slice a token and leave orphan sentinels.
+      if (e.key === 'Backspace' && !e.shiftKey && !e.metaKey && !e.ctrlKey && !e.altKey) {
         const el = e.currentTarget
         const caret = el.selectionStart ?? 0
         const selEnd = el.selectionEnd ?? 0
@@ -870,6 +872,10 @@ export function AgentLauncher({ paneId, className }: AgentLauncherProps): React.
     Boolean(selectedConfig) &&
     selectedEntry?.status === 'ready' &&
     (prompt.trim().length > 0 || attachments.length > 0)
+  // The transparent-textarea overlay is only needed when the value carries a
+  // skill token; otherwise keep the textarea text visible so plain typing,
+  // overlay first-paint, and any overlay failure never render invisible text.
+  const hasSkillToken = prompt.includes(SKILL_TOKEN_START)
 
   return (
     <div
@@ -986,7 +992,10 @@ export function AgentLauncher({ paneId, className }: AgentLauncherProps): React.
                 rows={2}
                 aria-label="Agent prompt"
                 autoFocus
-                className="relative z-10 max-h-40 min-h-[76px] w-full resize-none bg-transparent text-sm leading-relaxed text-transparent caret-foreground outline-none placeholder:text-muted-foreground/55"
+                className={cn(
+                  'relative z-10 max-h-40 min-h-[76px] w-full resize-none bg-transparent text-sm leading-relaxed outline-none placeholder:text-muted-foreground/55',
+                  hasSkillToken ? 'text-transparent caret-foreground' : 'text-foreground'
+                )}
               />
             </div>
             <div className="flex items-center justify-between gap-3 px-3 pb-3">

--- a/src/renderer/components/chat/AgentChatPanel.tsx
+++ b/src/renderer/components/chat/AgentChatPanel.tsx
@@ -200,8 +200,8 @@ export function AgentChatPanel({
   )
 
   const handleSendBlocks = useCallback(
-    (blocks: ContentBlock[]) => {
-      void sendPromptBlocks(sessionId, blocks).catch((err) => {
+    (blocks: ContentBlock[], displayBlocks?: ContentBlock[]) => {
+      void sendPromptBlocks(sessionId, blocks, { displayBlocks }).catch((err) => {
         if (isAgentDeadError(err)) return
         toast.error(`Failed to send: ${String(err)}`)
       })
@@ -280,8 +280,13 @@ export function AgentChatPanel({
       return
     }
     const hasStructuredBlocks = lastUserBlocks.some((b) => b.type !== 'text')
+    // On retry, re-dispatch the last user message's blocks and pass them as the
+    // display blocks too so the timeline keeps rendering inline skill chips. The
+    // agent receives the stored blocks (token text degrades gracefully — skill
+    // names ride inside the private-use sentinels; re-framing the wire on retry
+    // is a v1 gap since the original wire is not persisted separately).
     const task = hasStructuredBlocks
-      ? sendPromptBlocks(sessionId, lastUserBlocks)
+      ? sendPromptBlocks(sessionId, lastUserBlocks, { displayBlocks: lastUserBlocks })
       : sendPrompt(sessionId, lastUserText.trim())
     void task.catch((err) => {
       if (isAgentDeadError(err)) return

--- a/src/renderer/components/chat/AgentChatPanel.tsx
+++ b/src/renderer/components/chat/AgentChatPanel.tsx
@@ -4,9 +4,11 @@ import { toast } from 'sonner'
 import { useShallow } from 'zustand/shallow'
 import { TermulMark } from '@/components/TermulMark'
 import { Button } from '@/components/ui/button'
+import { buildPromptWithLoadedSkills, useAgentSkills } from '@/hooks/use-agent-skills'
 import { useMobileWebShell } from '@/hooks/use-mobile-web-shell'
 import { useOskViewport } from '@/hooks/use-osk-viewport'
 import type { AvailableCommand, ContentBlock, PlanEntry, SessionId, ToolCall } from '@/lib/acp-api'
+import { extractSkillNames } from '@/lib/skill-tokens'
 import { isTauriContext } from '@/lib/tauri-runtime'
 import { getDefaultCwdForProject } from '@/lib/worktree-context'
 import { useAcpMessages, useAcpSession, useAcpStore, usePromptQueue } from '@/stores/acp-store'
@@ -75,6 +77,10 @@ export function AgentChatPanel({
 }: AgentChatPanelProps): React.JSX.Element {
   const session = useAcpSession(sessionId)
   const messages = useAcpMessages(sessionId)
+  // Available skills (with paths) so retry can re-frame the wire from the
+  // token names in the last user message (skill paths are not persisted with
+  // the message — see the spec's Never: no new ContentBlock type).
+  const { skills: availableSkills } = useAgentSkills(session?.cwd)
   const imageCapable = useAcpStore((s) =>
     session ? Boolean(s.agents[session.agentId]?.capabilities?.promptCapabilities?.image) : false
   )
@@ -279,16 +285,35 @@ export function AgentChatPanel({
       })
       return
     }
-    const hasStructuredBlocks = lastUserBlocks.some((b) => b.type !== 'text')
-    // On retry, re-dispatch the last user message's blocks and pass them as the
-    // display blocks too so the timeline keeps rendering inline skill chips. The
-    // agent receives the stored blocks (token text degrades gracefully — skill
-    // names ride inside the private-use sentinels; re-framing the wire on retry
-    // is a v1 gap since the original wire is not persisted separately).
-    const task = hasStructuredBlocks
-      ? sendPromptBlocks(sessionId, lastUserBlocks, { displayBlocks: lastUserBlocks })
-      : sendPrompt(sessionId, lastUserText.trim())
-    void task.catch((err) => {
+    // Re-frame the wire from the skill token names in the last user message's
+    // text blocks + the currently-available skills' paths (skill paths are not
+    // persisted with the message — the spec's Never forbids a new ContentBlock
+    // type, so the wire is reconstructed at retry time like the composer does).
+    // The display (token) blocks are passed through unchanged so the timeline
+    // keeps rendering inline chips. If a skill name no longer resolves to a
+    // path (e.g. the skill was uninstalled), surface a clear error and abort.
+    const tokenText = lastUserText
+    const skillNames = extractSkillNames(tokenText)
+    const skills = skillNames.map((name) => ({
+      name,
+      path: availableSkills.find((s) => s.name === name)?.path ?? ''
+    }))
+    const missingPath = skills.find((s) => !s.path)
+    if (missingPath) {
+      toast.error(`Skill '${missingPath.name}' is missing a path`)
+      return
+    }
+    const wireText = skills.length > 0 ? buildPromptWithLoadedSkills(skills, tokenText) : tokenText
+    // Build wire blocks: replace the text payload with the re-framed wire text,
+    // preserving non-text (image/resource) blocks from the original message.
+    const wireBlocks: ContentBlock[] = []
+    const wireTrimmed = wireText.trim()
+    if (wireTrimmed) wireBlocks.push({ type: 'text', text: wireText })
+    for (const b of lastUserBlocks) {
+      if (b.type !== 'text') wireBlocks.push(b)
+    }
+    // Display = the original (token) blocks so the timeline keeps chips.
+    void sendPromptBlocks(sessionId, wireBlocks, { displayBlocks: lastUserBlocks }).catch((err) => {
       if (isAgentDeadError(err)) return
       toast.error(`Failed to send: ${String(err)}`)
     })
@@ -296,7 +321,7 @@ export function AgentChatPanel({
     lastUserBlocks,
     canRetryLastUserTurn,
     lastUserText,
-    sendPrompt,
+    availableSkills,
     sendPromptBlocks,
     retryCrashedSession,
     sessionId,

--- a/src/renderer/components/chat/ChatInputBar.test.tsx
+++ b/src/renderer/components/chat/ChatInputBar.test.tsx
@@ -3,8 +3,11 @@ import type { ComponentProps } from 'react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { TooltipProvider } from '@/components/ui/tooltip'
 import type { SessionConfigOption } from '@/lib/acp-api'
+import { skillToken } from '@/lib/skill-tokens'
 import type { AcpSession } from '@/stores/acp-store'
 import { ChatInputBar } from './ChatInputBar'
+
+const T = skillToken
 
 function clickMenuOption(name: string | RegExp): void {
   const dialog = screen.getByRole('dialog')
@@ -18,7 +21,6 @@ const {
   mockMcpCount,
   mockReadDir,
   mockSkills,
-  mockBuildPrompt,
   mockToastError
 } = vi.hoisted(() => ({
   mockSetConfig: vi.fn(),
@@ -30,12 +32,15 @@ const {
   mockReadDir: vi.fn(),
   // Override-able skills list (defaults to [] — web/no-skills parity). Skill
   // tests push entries here so useAgentSkills surfaces them in the slash menu.
+  // `path` is required so the wire prompt can cite it (desktop always has one).
   mockSkills: {
-    current: [] as Array<{ name: string; description: string; scope: string }>
+    current: [] as Array<{
+      name: string
+      description: string
+      scope: string
+      path: string
+    }>
   },
-  // buildPromptWithLoadedSkills mock — defaults to passthrough (returns user
-  // text). Send-data tests override the resolved value to assert framing.
-  mockBuildPrompt: vi.fn(async (_skills: unknown, text: string) => text),
   mockToastError: vi.fn()
 }))
 
@@ -45,10 +50,16 @@ vi.mock('sonner', () => ({
   toast: { error: mockToastError, success: vi.fn() }
 }))
 
-vi.mock('@/hooks/use-agent-skills', () => ({
-  useAgentSkills: () => ({ skills: mockSkills.current }),
-  buildPromptWithLoadedSkills: mockBuildPrompt
-}))
+vi.mock('@/hooks/use-agent-skills', async () => {
+  // Use the real (sync) buildPromptWithLoadedSkills so the wire framing is
+  // exercised end-to-end — no mock needed now that paths are captured at pick
+  // time (no IPC read at send). Only useAgentSkills is overridden for the
+  // override-able skills list.
+  const actual = await vi.importActual<typeof import('@/hooks/use-agent-skills')>(
+    '@/hooks/use-agent-skills'
+  )
+  return { ...actual, useAgentSkills: () => ({ skills: mockSkills.current }) }
+})
 
 vi.mock('@/stores/acp-store', () => ({
   useAgentIdentity: () => ({ name: 'Cursor', templateId: 'cursor' }),
@@ -98,11 +109,9 @@ vi.mock('@/lib/api', async () => {
 beforeEach(() => {
   persistenceStore.clear()
   fakePersistenceApi.readFails = false
-  // Start each test from a clean skill/prompt-framing slate (web/no-skills
-  // default). Skill tests override mockSkills.current and mockBuildPrompt.
+  // Start each test from a clean skill slate (web/no-skills default). Skill
+  // tests override mockSkills.current.
   mockSkills.current = []
-  mockBuildPrompt.mockReset()
-  mockBuildPrompt.mockImplementation(async (_skills: unknown, text: string) => text)
 })
 
 function option(
@@ -741,166 +750,196 @@ describe('ChatInputBar draft persistence', () => {
   })
 })
 
-describe('ChatInputBar skill chips', () => {
+describe('ChatInputBar skill chips (inline tokens)', () => {
   const SKILL_GIT = {
     name: 'git-worktree',
     description: 'Isolated worktree',
-    scope: 'project'
+    scope: 'project',
+    path: '/home/u/.agents/skills/git-worktree/SKILL.md'
   }
-  const SKILL_REVIEW = { name: 'review', description: 'Review the diff', scope: 'global' }
+  const SKILL_REVIEW = {
+    name: 'release-version',
+    description: 'Cut a release',
+    scope: 'global',
+    path: '/home/u/.agents/skills/release-version/SKILL.md'
+  }
 
   function selectSlashOption(name: string | RegExp): void {
     const listbox = screen.getByRole('listbox')
     fireEvent.mouseDown(within(listbox).getByText(name))
   }
 
+  /** The transparent-textarea overlay renders the chip name as a visible span;
+   *  after the slash menu closes it is the stable selector for the inline chip. */
+  async function findChip(name: string): Promise<HTMLElement> {
+    return screen.findByText(name, { ignore: 'option' })
+  }
+
   beforeEach(() => {
     vi.clearAllMocks()
   })
 
-  it('renders a skill pill inline when a skill is selected from the slash menu', async () => {
+  it('splices a skill token inline at the caret when a skill is picked mid-sentence', async () => {
     mockSkills.current = [SKILL_GIT]
     renderInputBar()
 
     const textarea = screen.getByRole('textbox')
-    fireEvent.change(textarea, { target: { value: '/' } })
+    fireEvent.change(textarea, { target: { value: 'use this skill /' } })
+    // Move the caret to the end so the slash trigger matches the trailing `/`.
+    fireEvent.keyUp(textarea, { key: 'ArrowRight' })
 
     await waitFor(() => expect(screen.getByRole('listbox')).toBeInTheDocument())
-
     selectSlashOption('/git-worktree')
 
-    // Pill renders inline (not a full-width top attachment bar); the X button's
-    // accessible label is the stable selector for the pill.
-    await waitFor(() => {
-      expect(screen.getByRole('button', { name: 'Remove git-worktree skill' })).toBeInTheDocument()
-    })
-    // The `/` filter text is cleared and the textarea refocuses.
-    expect(textarea).toHaveValue('')
+    // The `/` filter text is removed and a token is spliced inline; the
+    // transparent-textarea overlay renders the chip name as a visible span.
+    await waitFor(() => expect(findChip('git-worktree')).toBeDefined())
+    // The textarea value now carries the token (filter text removed).
+    expect(textarea).toHaveValue(`use this skill ${T('git-worktree')} `)
   })
 
-  it('renders two pills when two distinct skills are selected', async () => {
+  it('renders two inline chips when two distinct skills are picked at their positions', async () => {
     mockSkills.current = [SKILL_GIT, SKILL_REVIEW]
     renderInputBar()
 
     const textarea = screen.getByRole('textbox')
-    fireEvent.change(textarea, { target: { value: '/' } })
+    fireEvent.change(textarea, { target: { value: 'use this /' } })
     await waitFor(() => expect(screen.getByRole('listbox')).toBeInTheDocument())
     selectSlashOption('/git-worktree')
 
-    await waitFor(() =>
-      expect(screen.getByRole('button', { name: 'Remove git-worktree skill' })).toBeInTheDocument()
-    )
+    await waitFor(() => expect(findChip('git-worktree')).toBeDefined())
 
-    // Re-open the menu and pick a second, distinct skill.
-    fireEvent.change(textarea, { target: { value: '/' } })
+    // Re-open the menu after the chip + trailing space, then pick a second skill.
+    fireEvent.change(textarea, { target: { value: `${T('git-worktree')} then do /` } })
     await waitFor(() => expect(screen.getByRole('listbox')).toBeInTheDocument())
-    selectSlashOption('/review')
+    selectSlashOption('/release-version')
 
-    await waitFor(() => {
-      expect(screen.getByRole('button', { name: 'Remove review skill' })).toBeInTheDocument()
-      expect(screen.getByRole('button', { name: 'Remove git-worktree skill' })).toBeInTheDocument()
-    })
+    await waitFor(() => expect(findChip('release-version')).toBeDefined())
+    // Both chips are present; the value carries two tokens.
+    expect(textarea).toHaveValue(`${T('git-worktree')} then do ${T('release-version')} `)
   })
 
-  it('ignores a same-named skill pick (dedupes by name)', async () => {
+  it('allows the same skill inline at multiple positions (no dedupe of tokens)', async () => {
     mockSkills.current = [SKILL_GIT]
     renderInputBar()
 
     const textarea = screen.getByRole('textbox')
-    fireEvent.change(textarea, { target: { value: '/' } })
+    fireEvent.change(textarea, { target: { value: 'first /' } })
+    await waitFor(() => expect(screen.getByRole('listbox')).toBeInTheDocument())
+    selectSlashOption('/git-worktree')
+
+    await waitFor(() => expect(findChip('git-worktree')).toBeDefined())
+
+    // Pick the same skill again — the second pick splices a second token (the
+    // wire header dedupes by name, but inline positions are preserved).
+    fireEvent.change(textarea, { target: { value: `${T('git-worktree')} again /` } })
     await waitFor(() => expect(screen.getByRole('listbox')).toBeInTheDocument())
     selectSlashOption('/git-worktree')
 
     await waitFor(() =>
-      expect(screen.getByRole('button', { name: 'Remove git-worktree skill' })).toBeInTheDocument()
+      expect(textarea).toHaveValue(`${T('git-worktree')} again ${T('git-worktree')} `)
     )
-
-    // Pick the same skill again — should be a no-op (deduped by name).
-    fireEvent.change(textarea, { target: { value: '/' } })
-    await waitFor(() => expect(screen.getByRole('listbox')).toBeInTheDocument())
-    selectSlashOption('/git-worktree')
-
-    expect(screen.getAllByRole('button', { name: 'Remove git-worktree skill' })).toHaveLength(1)
   })
 
-  it('removes a skill pill when its X is clicked', async () => {
+  it('removes a whole chip token on Backspace when the caret is immediately after it', async () => {
     mockSkills.current = [SKILL_GIT]
     renderInputBar()
 
     const textarea = screen.getByRole('textbox')
-    fireEvent.change(textarea, { target: { value: '/' } })
+    fireEvent.change(textarea, { target: { value: 'use this /' } })
     await waitFor(() => expect(screen.getByRole('listbox')).toBeInTheDocument())
     selectSlashOption('/git-worktree')
 
-    const pill = await screen.findByRole('button', { name: 'Remove git-worktree skill' })
-    fireEvent.click(pill)
+    await waitFor(() => expect(findChip('git-worktree')).toBeDefined())
+    const valueWithToken = `use this ${T('git-worktree')} `
+    expect(textarea).toHaveValue(valueWithToken)
 
-    expect(
-      screen.queryByRole('button', { name: 'Remove git-worktree skill' })
-    ).not.toBeInTheDocument()
-  })
-
-  it('sends the framed skill body followed by user text on send, then clears pills', async () => {
-    const onSend = vi.fn()
-    mockSkills.current = [SKILL_GIT]
-    const framed = '# Agent Skills\n\n## git-worktree\nCreate a worktree.\n\n---\n\nhello'
-    mockBuildPrompt.mockResolvedValue(framed)
-    renderInputBar({ onSend })
-
-    const textarea = screen.getByRole('textbox')
-    fireEvent.change(textarea, { target: { value: '/' } })
-    await waitFor(() => expect(screen.getByRole('listbox')).toBeInTheDocument())
-    selectSlashOption('/git-worktree')
-
-    await waitFor(() =>
-      expect(screen.getByRole('button', { name: 'Remove git-worktree skill' })).toBeInTheDocument()
-    )
-
-    fireEvent.change(textarea, { target: { value: 'hello' } })
-    fireEvent.click(screen.getByRole('button', { name: 'Send message' }))
-
-    // The prompt carries each skill's body framed by its name (never a bare
-    // /skill-name), then the user text.
-    await waitFor(() => expect(onSend).toHaveBeenCalledWith(framed))
-    expect(onSend.mock.calls[0]![0]).not.toContain('/git-worktree')
-    // Pills are cleared after send.
-    await waitFor(() => {
-      expect(
-        screen.queryByRole('button', { name: 'Remove git-worktree skill' })
-      ).not.toBeInTheDocument()
+    // Place the caret right after the trailing space (the splicer's position).
+    const caret = valueWithToken.length
+    fireEvent.select(textarea, {
+      target: { selectionStart: caret, selectionEnd: caret }
     })
+    fireEvent.keyDown(textarea, { key: 'Backspace' })
+
+    // The whole chip token + the trailing space are removed; the preceding text
+    // ("use this ") stays and the caret lands at the end of it.
+    await waitFor(() => expect(textarea).toHaveValue('use this '))
   })
 
-  it('toasts and keeps pills when a skill read fails at send (no message sent)', async () => {
-    const onSend = vi.fn()
+  it('falls through to the default one-char backspace when the caret is in plain text', async () => {
     mockSkills.current = [SKILL_GIT]
-    mockBuildPrompt.mockRejectedValue(new Error("Failed to load skill 'git-worktree': boom"))
-    renderInputBar({ onSend })
+    renderInputBar()
 
     const textarea = screen.getByRole('textbox')
-    fireEvent.change(textarea, { target: { value: '/' } })
+    // Plain text, no tokens; caret at the end.
+    fireEvent.change(textarea, { target: { value: 'hello world' } })
+    const caret = 'hello world'.length
+    fireEvent.select(textarea, { target: { selectionStart: caret, selectionEnd: caret } })
+
+    fireEvent.keyDown(textarea, { key: 'Backspace' })
+    // Default backspace is NOT preventDefault'd here (the browser would delete
+    // one char); the React handler returns without mutating the value. The
+    // textarea value is unchanged by our handler — the DOM input event would
+    // do the actual deletion, which fireEvent.keyDown does not simulate.
+    expect(textarea).toHaveValue('hello world')
+  })
+
+  it('emits display (token) + wire (path-framed) blocks on send, then clears the token', async () => {
+    const onSendBlocks = vi.fn()
+    mockSkills.current = [SKILL_GIT]
+    renderInputBar({ onSendBlocks })
+
+    const textarea = screen.getByRole('textbox')
+    fireEvent.change(textarea, { target: { value: 'use this /' } })
     await waitFor(() => expect(screen.getByRole('listbox')).toBeInTheDocument())
     selectSlashOption('/git-worktree')
 
-    await waitFor(() =>
-      expect(screen.getByRole('button', { name: 'Remove git-worktree skill' })).toBeInTheDocument()
-    )
-
-    fireEvent.change(textarea, { target: { value: 'hello' } })
+    await waitFor(() => expect(findChip('git-worktree')).toBeDefined())
+    // Type after the chip + trailing space.
+    fireEvent.change(textarea, {
+      target: { value: `${T('git-worktree')} and then` }
+    })
     fireEvent.click(screen.getByRole('button', { name: 'Send message' }))
 
-    // The toast names the failing skill.
+    const wireText = `# Agent Skills\n\ngit-worktree: /home/u/.agents/skills/git-worktree/SKILL.md\n\n---\n\n(git-worktree) and then`
+    const displayText = `${T('git-worktree')} and then`
+    await waitFor(() =>
+      expect(onSendBlocks).toHaveBeenCalledWith(
+        [{ type: 'text', text: wireText }],
+        [{ type: 'text', text: displayText }]
+      )
+    )
+    // Wire never carries a bare /skill-name; it cites the path.
+    expect(onSendBlocks.mock.calls[0]![0][0]).not.toContain('/git-worktree')
+    // The token is cleared after send.
+    await waitFor(() => expect(textarea).toHaveValue(''))
+  })
+
+  it('blocks send and toasts when a selected skill has no path (web parity gap)', async () => {
+    const onSendBlocks = vi.fn()
+    const onSend = vi.fn()
+    // A skill surfaced without a path (e.g. a future web skill with no parity
+    // route) — the renderer Block If halts the send with a clear error.
+    mockSkills.current = [{ name: 'pathless', description: 'no path', scope: 'project', path: '' }]
+    renderInputBar({ onSendBlocks, onSend })
+
+    const textarea = screen.getByRole('textbox')
+    fireEvent.change(textarea, { target: { value: 'use this /' } })
+    await waitFor(() => expect(screen.getByRole('listbox')).toBeInTheDocument())
+    selectSlashOption('/pathless')
+
+    await waitFor(() => expect(findChip('pathless')).toBeDefined())
+    fireEvent.change(textarea, { target: { value: `${T('pathless')} hi` } })
+    fireEvent.click(screen.getByRole('button', { name: 'Send message' }))
+
+    // The toast names the missing path; no message is sent.
     await waitFor(() => expect(mockToastError).toHaveBeenCalled())
-    expect(mockToastError).toHaveBeenCalledWith(
-      expect.stringContaining("Failed to load skill 'git-worktree'")
-    )
-    // No message was sent.
+    expect(mockToastError).toHaveBeenCalledWith(expect.stringContaining('missing a path'))
     expect(onSend).not.toHaveBeenCalled()
-    // Pills remain for retry/remove.
-    expect(screen.getByRole('button', { name: 'Remove git-worktree skill' })).toBeInTheDocument()
+    expect(onSendBlocks).not.toHaveBeenCalled()
   })
 
-  it('shows no Skills section and no pills when no skills are available (web parity)', async () => {
+  it('shows no Skills section and no chips when no skills are available (web parity)', async () => {
     mockSkills.current = []
     renderInputBar()
 
@@ -909,6 +948,39 @@ describe('ChatInputBar skill chips', () => {
 
     await waitFor(() => expect(screen.getByRole('listbox')).toBeInTheDocument())
     expect(screen.queryByText('Skills')).not.toBeInTheDocument()
-    expect(screen.queryByRole('button', { name: /Remove .* skill/ })).not.toBeInTheDocument()
+  })
+
+  it('re-renders inline chips when the composer is seeded with token text (edit a sent message)', async () => {
+    // Editing a user message that carried skill tokens re-seeds the composer
+    // with the raw token text; the transparent-textarea overlay must re-render
+    // the chips inline (MessageActions.onEdit passes the token text verbatim).
+    mockSkills.current = [SKILL_GIT]
+    const seeded = `use this ${T('git-worktree')} then`
+    const { rerender } = renderInputBar()
+
+    rerender(
+      <TooltipProvider>
+        <ChatInputBar
+          session={session()}
+          busy={false}
+          disabled={false}
+          onSend={vi.fn()}
+          onSendBlocks={vi.fn()}
+          onCancel={vi.fn()}
+          commands={[]}
+          configOptions={[]}
+          modes={session().modes}
+          onSetConfig={mockSetConfig}
+          onSetMode={mockSetMode}
+          onSetModel={mockSetModel}
+          seedText={seeded}
+          seedNonce={1}
+        />
+      </TooltipProvider>
+    )
+
+    // The textarea value carries the tokens; the overlay re-renders the chip.
+    await waitFor(() => expect(screen.getByText('git-worktree')).toBeInTheDocument())
+    expect(screen.getByRole('textbox')).toHaveValue(seeded)
   })
 })

--- a/src/renderer/components/chat/ChatInputBar.test.tsx
+++ b/src/renderer/components/chat/ChatInputBar.test.tsx
@@ -2,7 +2,7 @@ import { fireEvent, render, screen, waitFor, within } from '@testing-library/rea
 import type { ComponentProps } from 'react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { TooltipProvider } from '@/components/ui/tooltip'
-import type { SessionConfigOption } from '@/lib/acp-api'
+import type { ContentBlock, SessionConfigOption } from '@/lib/acp-api'
 import { skillToken } from '@/lib/skill-tokens'
 import type { AcpSession } from '@/stores/acp-store'
 import { ChatInputBar } from './ChatInputBar'
@@ -770,7 +770,8 @@ describe('ChatInputBar skill chips (inline tokens)', () => {
   }
 
   /** The transparent-textarea overlay renders the chip name as a visible span;
-   *  after the slash menu closes it is the stable selector for the inline chip. */
+   *  `findByText` already retries until the overlay paints, so await it
+   *  directly (no `waitFor(expect(...))` wrapper needed). */
   async function findChip(name: string): Promise<HTMLElement> {
     return screen.findByText(name, { ignore: 'option' })
   }
@@ -793,7 +794,7 @@ describe('ChatInputBar skill chips (inline tokens)', () => {
 
     // The `/` filter text is removed and a token is spliced inline; the
     // transparent-textarea overlay renders the chip name as a visible span.
-    await waitFor(() => expect(findChip('git-worktree')).toBeDefined())
+    await findChip('git-worktree')
     // The textarea value now carries the token (filter text removed).
     expect(textarea).toHaveValue(`use this skill ${T('git-worktree')} `)
   })
@@ -807,14 +808,14 @@ describe('ChatInputBar skill chips (inline tokens)', () => {
     await waitFor(() => expect(screen.getByRole('listbox')).toBeInTheDocument())
     selectSlashOption('/git-worktree')
 
-    await waitFor(() => expect(findChip('git-worktree')).toBeDefined())
+    await findChip('git-worktree')
 
     // Re-open the menu after the chip + trailing space, then pick a second skill.
     fireEvent.change(textarea, { target: { value: `${T('git-worktree')} then do /` } })
     await waitFor(() => expect(screen.getByRole('listbox')).toBeInTheDocument())
     selectSlashOption('/release-version')
 
-    await waitFor(() => expect(findChip('release-version')).toBeDefined())
+    await findChip('release-version')
     // Both chips are present; the value carries two tokens.
     expect(textarea).toHaveValue(`${T('git-worktree')} then do ${T('release-version')} `)
   })
@@ -828,7 +829,7 @@ describe('ChatInputBar skill chips (inline tokens)', () => {
     await waitFor(() => expect(screen.getByRole('listbox')).toBeInTheDocument())
     selectSlashOption('/git-worktree')
 
-    await waitFor(() => expect(findChip('git-worktree')).toBeDefined())
+    await findChip('git-worktree')
 
     // Pick the same skill again — the second pick splices a second token (the
     // wire header dedupes by name, but inline positions are preserved).
@@ -850,7 +851,7 @@ describe('ChatInputBar skill chips (inline tokens)', () => {
     await waitFor(() => expect(screen.getByRole('listbox')).toBeInTheDocument())
     selectSlashOption('/git-worktree')
 
-    await waitFor(() => expect(findChip('git-worktree')).toBeDefined())
+    await findChip('git-worktree')
     const valueWithToken = `use this ${T('git-worktree')} `
     expect(textarea).toHaveValue(valueWithToken)
 
@@ -894,7 +895,7 @@ describe('ChatInputBar skill chips (inline tokens)', () => {
     await waitFor(() => expect(screen.getByRole('listbox')).toBeInTheDocument())
     selectSlashOption('/git-worktree')
 
-    await waitFor(() => expect(findChip('git-worktree')).toBeDefined())
+    await findChip('git-worktree')
     // Type after the chip + trailing space.
     fireEvent.change(textarea, {
       target: { value: `${T('git-worktree')} and then` }
@@ -909,8 +910,11 @@ describe('ChatInputBar skill chips (inline tokens)', () => {
         [{ type: 'text', text: displayText }]
       )
     )
-    // Wire never carries a bare /skill-name; it cites the path.
-    expect(onSendBlocks.mock.calls[0]![0][0]).not.toContain('/git-worktree')
+    // Wire never carries a bare `/git-worktree` command token — only the cited
+    // skills/git-worktree/SKILL.md path (preceded by `s`, not whitespace) and
+    // the inline `(git-worktree)` replacement. Whitespace-bounded so the path
+    // isn't mistaken for a command.
+    expect(onSendBlocks.mock.calls[0]![0][0]!.text).not.toMatch(/(^|\s)\/git-worktree(?=\s|$)/)
     // The token is cleared after send.
     await waitFor(() => expect(textarea).toHaveValue(''))
   })
@@ -928,7 +932,7 @@ describe('ChatInputBar skill chips (inline tokens)', () => {
     await waitFor(() => expect(screen.getByRole('listbox')).toBeInTheDocument())
     selectSlashOption('/pathless')
 
-    await waitFor(() => expect(findChip('pathless')).toBeDefined())
+    await findChip('pathless')
     fireEvent.change(textarea, { target: { value: `${T('pathless')} hi` } })
     fireEvent.click(screen.getByRole('button', { name: 'Send message' }))
 

--- a/src/renderer/components/chat/ChatInputBar.tsx
+++ b/src/renderer/components/chat/ChatInputBar.tsx
@@ -26,7 +26,8 @@ import { registerSessionTempFiles } from '@/lib/attachment-temp-cleanup'
 import {
   extractSkillNames,
   insertSkillToken,
-  removeSkillTokenBeforeCaret
+  removeSkillTokenBeforeCaret,
+  SKILL_TOKEN_START
 } from '@/lib/skill-tokens'
 import { cn } from '@/lib/utils'
 import type { AcpSession, QueuedPrompt } from '@/stores/acp-store'
@@ -143,7 +144,7 @@ export function ChatInputBar({
   } = partitionConfigOptions(usableConfigOptions)
   const { option: modelOption, source: modelSource } = resolveModelOption(model, session.models)
   const visibleGenericConfigOptions = filterDuplicateModeConfigOptions(genericConfigOptions, modes)
-  const { skills } = useAgentSkills(projectRoot ?? session.cwd)
+  const { skills: availableSkills } = useAgentSkills(projectRoot ?? session.cwd)
   const sessionUsage = useSessionUsage(session.id)
   const messages = useAcpMessages(session.id)
   // Prefer project/session-scoped MCP context. Older/local sessions without a
@@ -308,14 +309,21 @@ export function ChatInputBar({
   } = useComposerTextarea({ value, setValue, textareaRef, mentions, disabled, slashOpen })
 
   const sections = useMemo(
-    () => (slashOpen ? buildSlashSections({ commands, configOptions, modes, skills, filter }) : []),
-    [slashOpen, commands, configOptions, modes, skills, filter]
+    () =>
+      slashOpen
+        ? buildSlashSections({ commands, configOptions, modes, skills: availableSkills, filter })
+        : [],
+    [slashOpen, commands, configOptions, modes, availableSkills, filter]
   )
 
   const canSend =
     !disabled &&
     !sending &&
     (value.trim().length > 0 || activeCommand !== null || attachments.length > 0)
+  // The transparent-textarea overlay is only needed when the value carries a
+  // skill token; otherwise keep the textarea text visible so plain typing,
+  // overlay first-paint, and any overlay failure never render invisible text.
+  const hasSkillToken = value.includes(SKILL_TOKEN_START)
   const showStop = busy && !canSend
   const iconMotion = iconPop(reduced)
 
@@ -327,11 +335,19 @@ export function ChatInputBar({
     setSending(true)
     try {
       // Extract the inline skill tokens carried in the value and resolve each
-      // name to its captured SKILL.md path. A skill surfaced without a path
+      // name to its SKILL.md path. Paths come from `skillPathsRef` (captured at
+      // pick time) first, then fall back to the currently-available skills list
+      // — so editing + re-sending a chip message (where the ref is empty
+      // because paths aren't persisted with the message) still resolves paths
+      // from the live skills list. A skill surfaced without a path in either
       // (e.g. a future web skill with no parity route) blocks the send — HALT
       // with a clear error so the user can remove the chip.
       const skillNames = extractSkillNames(value)
-      const skills = skillNames.map((name) => ({ name, path: skillPathsRef.current[name] ?? '' }))
+      const skills = skillNames.map((name) => ({
+        name,
+        path:
+          skillPathsRef.current[name] ?? availableSkills.find((s) => s.name === name)?.path ?? ''
+      }))
       const missingPath = skills.find((s) => !s.path)
       if (missingPath) {
         throw new Error(`Skill '${missingPath.name}' is missing a path`)
@@ -399,6 +415,7 @@ export function ChatInputBar({
     value,
     attachments,
     activeCommand,
+    availableSkills,
     disabled,
     sending,
     clearAttachments,
@@ -481,8 +498,9 @@ export function ChatInputBar({
       // Backspace over an inline skill token (caret immediately after a chip,
       // no active selection): remove the whole token plus the splicer's
       // trailing space. Falls through to the default one-char backspace when
-      // the caret is in plain text.
-      if (e.key === 'Backspace' && !e.shiftKey && !e.metaKey && !e.ctrlKey) {
+      // the caret is in plain text. Alt is excluded so macOS Option+Backspace
+      // (delete-word) doesn't slice a token and leave orphan sentinels.
+      if (e.key === 'Backspace' && !e.shiftKey && !e.metaKey && !e.ctrlKey && !e.altKey) {
         const el = e.currentTarget
         const caret = el.selectionStart ?? 0
         const selEnd = el.selectionEnd ?? 0
@@ -726,7 +744,7 @@ export function ChatInputBar({
                 }
                 className={cn(
                   'relative z-10 min-h-[52px] w-full resize-none bg-transparent text-sm leading-relaxed',
-                  'text-transparent caret-foreground',
+                  hasSkillToken ? 'text-transparent caret-foreground' : 'text-foreground',
                   'placeholder:text-muted-foreground focus:outline-none',
                   'disabled:cursor-not-allowed disabled:opacity-50 max-h-40'
                 )}

--- a/src/renderer/components/chat/ChatInputBar.tsx
+++ b/src/renderer/components/chat/ChatInputBar.tsx
@@ -11,11 +11,7 @@ import {
   useState
 } from 'react'
 import { toast } from 'sonner'
-import {
-  buildPromptWithLoadedSkills,
-  type LoadedAgentSkill,
-  useAgentSkills
-} from '@/hooks/use-agent-skills'
+import { buildPromptWithLoadedSkills, useAgentSkills } from '@/hooks/use-agent-skills'
 import { useMentionRecents } from '@/hooks/use-mention-recents'
 import { useMobileWebShell } from '@/hooks/use-mobile-web-shell'
 import { useOskViewport } from '@/hooks/use-osk-viewport'
@@ -27,6 +23,11 @@ import type {
 } from '@/lib/acp-api'
 import { persistenceApi } from '@/lib/api'
 import { registerSessionTempFiles } from '@/lib/attachment-temp-cleanup'
+import {
+  extractSkillNames,
+  insertSkillToken,
+  removeSkillTokenBeforeCaret
+} from '@/lib/skill-tokens'
 import { cn } from '@/lib/utils'
 import type { AcpSession, QueuedPrompt } from '@/stores/acp-store'
 import { useAcpMessages, useAcpStore, useSessionUsage } from '@/stores/acp-store'
@@ -46,7 +47,7 @@ import { iconPop } from './chat-motion'
 import { FileMentionMenu } from './FileMentionMenu'
 import { McpBadge } from './McpBadge'
 import { PromptQueuePanel } from './PromptQueuePanel'
-import { SkillChip } from './SkillChip'
+import { SkillComposerOverlay } from './SkillComposerOverlay'
 import { SlashCommandMenu, type SlashMenuHandle } from './SlashCommandMenu'
 import { tryHandleSlashMenuKeyDown } from './slash-menu-keyboard'
 import {
@@ -81,8 +82,15 @@ interface ChatInputBarProps {
   /** Whether the agent accepts embedded `resource` blocks (drag/paste text files). */
   embedCapable?: boolean
   onSend: (text: string) => void
-  /** Send a prompt carrying structured content blocks (text + attachments). */
-  onSendBlocks: (blocks: ContentBlock[]) => void
+  /**
+   * Send a prompt carrying structured content blocks (text + attachments).
+   * The first arg is the wire text dispatched to the agent; the optional second
+   * arg is the display blocks stored in the optimistic user message so the
+   * timeline can render inline skill chips (token text) while the agent
+   * receives the path-based wire framing. When omitted, the wire blocks are
+   * also used for display.
+   */
+  onSendBlocks: (blocks: ContentBlock[], displayBlocks?: ContentBlock[]) => void
   onCancel: () => void
   /** Slash-menu data sources from the active session. */
   commands: AvailableCommand[]
@@ -207,7 +215,11 @@ export function ChatInputBar({
     return () => clearTimeout(handle)
   }, [value, draftKey, seedNonce, canPersistDraft])
   const [activeCommand, setActiveCommand] = useState<string | null>(null)
-  const [loadedSkills, setLoadedSkills] = useState<LoadedAgentSkill[]>([])
+  // name → SKILL.md path, captured when a skill is picked from the slash menu
+  // so the wire prompt can cite paths synchronously at send time (no IPC read,
+  // no failure path). The composer value carries the inline skill tokens; this
+  // ref supplies the path for each token's name when building the wire text.
+  const skillPathsRef = useRef<Record<string, string>>({})
   const [sending, setSending] = useState(false)
   const [focused, setFocused] = useState(false)
   const [dragActive, setDragActive] = useState(false)
@@ -303,52 +315,78 @@ export function ChatInputBar({
   const canSend =
     !disabled &&
     !sending &&
-    (value.trim().length > 0 ||
-      activeCommand !== null ||
-      loadedSkills.length > 0 ||
-      attachments.length > 0)
+    (value.trim().length > 0 || activeCommand !== null || attachments.length > 0)
   const showStop = busy && !canSend
   const iconMotion = iconPop(reduced)
 
   const submit = useCallback(async () => {
-    const userText = value.trim()
     const hasAttachments = attachments.length > 0
-    if (
-      (!userText && !activeCommand && loadedSkills.length === 0 && !hasAttachments) ||
-      disabled ||
-      sending
-    )
-      return
+    const hasText = value.trim().length > 0
+    if ((!hasText && !activeCommand && !hasAttachments) || disabled || sending) return
 
     setSending(true)
     try {
-      // Inject each loaded skill's instructions (body read on demand so it is
-      // always current at send time), framing them under a `# Agent Skills`
-      // header so the agent knows they are skills — never a bare `/skill-name`.
-      const baseText =
-        loadedSkills.length > 0
-          ? await buildPromptWithLoadedSkills(loadedSkills, userText, projectRoot ?? session.cwd)
-          : userText
-      // Prepend the active command to the prompt text on send.
-      const withCommand = activeCommand ? `/${activeCommand} ${baseText}` : baseText
-      const trimmed = withCommand.trim()
-      if (!trimmed && !hasAttachments) return
+      // Extract the inline skill tokens carried in the value and resolve each
+      // name to its captured SKILL.md path. A skill surfaced without a path
+      // (e.g. a future web skill with no parity route) blocks the send — HALT
+      // with a clear error so the user can remove the chip.
+      const skillNames = extractSkillNames(value)
+      const skills = skillNames.map((name) => ({ name, path: skillPathsRef.current[name] ?? '' }))
+      const missingPath = skills.find((s) => !s.path)
+      if (missingPath) {
+        throw new Error(`Skill '${missingPath.name}' is missing a path`)
+      }
+
+      // Wire text dispatched to the agent: skills framed by path under
+      // `# Agent Skills`, then the user text with tokens replaced by `(name)`.
+      // Sync — paths were captured at pick time, so no IPC and no failure path.
+      const wireText = buildPromptWithLoadedSkills(skills, value)
+      // Display text stored in the optimistic user message: the raw token value
+      // so the timeline overlay re-renders the chips inline.
+      const displayText = value
+      const hasSkills = skills.length > 0
+
+      // Prepend the active command to both wire and display so the timeline
+      // shows `/cmd …` and the agent receives the command-prefixed wire text.
+      const wireWithCommand = activeCommand ? `/${activeCommand} ${wireText}` : wireText
+      const displayWithCommand = activeCommand ? `/${activeCommand} ${displayText}` : displayText
+      const wireTrimmed = wireWithCommand.trim()
+      const displayTrimmed = displayWithCommand.trim()
+      if (!wireTrimmed && !hasAttachments) return
 
       if (hasAttachments) {
-        const blocks: ContentBlock[] = []
-        if (trimmed) blocks.push({ type: 'text', text: withCommand })
-        for (const a of attachments) blocks.push(attachmentToBlock(a))
-        onSendBlocks(dedupeAttachmentBlocks(blocks))
+        const wireBlocks: ContentBlock[] = []
+        if (wireTrimmed) wireBlocks.push({ type: 'text', text: wireWithCommand })
+        for (const a of attachments) wireBlocks.push(attachmentToBlock(a))
+        const wire = dedupeAttachmentBlocks(wireBlocks)
+        // Only split display from wire when skills are present; otherwise
+        // display == wire and a single-arg call preserves the existing contract.
+        if (hasSkills) {
+          const displayBlocks: ContentBlock[] = []
+          if (displayTrimmed) displayBlocks.push({ type: 'text', text: displayWithCommand })
+          for (const a of attachments) displayBlocks.push(attachmentToBlock(a))
+          const display = dedupeAttachmentBlocks(displayBlocks)
+          onSendBlocks(wire, display)
+        } else {
+          onSendBlocks(wire)
+        }
+      } else if (hasSkills) {
+        // Skills (tokens) present: split display (tokens) from wire (framing).
+        onSendBlocks(
+          wireTrimmed ? [{ type: 'text', text: wireWithCommand }] : [],
+          displayTrimmed ? [{ type: 'text', text: displayWithCommand }] : []
+        )
       } else {
-        onSend(trimmed)
+        // Plain text-only path: display == wire (no separate display blocks).
+        onSend(wireTrimmed)
       }
       // Register app-owned temp files (pasted screenshots) with the session so
       // they are deleted when the session closes; clearAttachments drops state
       // without deleting because the agent reads them by path during the turn.
       registerSessionTempFiles(session.id, appOwnedTempPaths())
       setValue('')
+      skillPathsRef.current = {}
       setActiveCommand(null)
-      setLoadedSkills([])
       clearAttachments()
       resetMentions()
       resetHeight()
@@ -361,35 +399,46 @@ export function ChatInputBar({
     value,
     attachments,
     activeCommand,
-    loadedSkills,
     disabled,
     sending,
     clearAttachments,
     appOwnedTempPaths,
     onSend,
     onSendBlocks,
-    projectRoot,
     resetHeight,
     resetMentions,
-    session.cwd,
     session.id
   ])
 
   const handleSelect = useCallback(
     (item: SlashItem) => {
       if (item.kind === 'skill') {
-        // Append the skill as an inline chip, deduping by name so picking the
-        // same skill twice is a no-op. Clear the `/` filter text and refocus
-        // the textarea so the user can keep typing or pick another skill.
-        setLoadedSkills((prev) =>
-          prev.some((s) => s.name === item.name)
-            ? prev
-            : [...prev, { name: item.name, description: item.description ?? '' }]
+        // Splice an inline skill token at the caret, removing the `/`-filter
+        // text the slash menu was filtering on. The token carries the skill
+        // name; the path is recorded into `skillPathsRef` so the wire prompt
+        // can cite it synchronously at send time. A trailing space is appended
+        // so the caret lands in plain text and the next `/` trigger matches.
+        const trigger = findSlashTrigger(value)
+        const caret = textareaRef.current?.selectionStart ?? value.length
+        const insertAt = trigger ? trigger.end : caret
+        const deleteBefore = trigger ? trigger.end - trigger.start : 0
+        const { value: next, caret: nextCaret } = insertSkillToken(
+          value,
+          insertAt,
+          item.name,
+          deleteBefore
         )
-        setValue('')
-        updateMentions('', 0)
+        skillPathsRef.current[item.name] = item.path
+        setValue(next)
+        updateMentions(next, nextCaret)
         resetHeight()
-        textareaRef.current?.focus()
+        requestAnimationFrame(() => {
+          const el = textareaRef.current
+          if (!el) return
+          clampHeight(el)
+          el.setSelectionRange(nextCaret, nextCaret)
+          el.focus()
+        })
         return
       }
       if (item.kind === 'command') {
@@ -424,11 +473,37 @@ export function ChatInputBar({
       updateMentions('', 0)
       resetHeight()
     },
-    [value, onSetConfig, onSetMode, resetHeight, updateMentions]
+    [value, onSetConfig, onSetMode, resetHeight, clampHeight, updateMentions]
   )
 
   const handleKeyDown = useCallback(
     (e: KeyboardEvent<HTMLTextAreaElement>) => {
+      // Backspace over an inline skill token (caret immediately after a chip,
+      // no active selection): remove the whole token plus the splicer's
+      // trailing space. Falls through to the default one-char backspace when
+      // the caret is in plain text.
+      if (e.key === 'Backspace' && !e.shiftKey && !e.metaKey && !e.ctrlKey) {
+        const el = e.currentTarget
+        const caret = el.selectionStart ?? 0
+        const selEnd = el.selectionEnd ?? 0
+        if (caret === selEnd) {
+          const result = removeSkillTokenBeforeCaret(value, caret)
+          if (result.removed) {
+            e.preventDefault()
+            setValue(result.value)
+            updateMentions(result.value, result.caret)
+            resetHeight()
+            requestAnimationFrame(() => {
+              const t = textareaRef.current
+              if (!t) return
+              clampHeight(t)
+              t.setSelectionRange(result.caret, result.caret)
+              t.focus()
+            })
+            return
+          }
+        }
+      }
       if (
         tryHandleSlashMenuKeyDown(e, {
           menuOpen: slashOpen,
@@ -460,10 +535,12 @@ export function ChatInputBar({
       }
     },
     [
+      value,
       slashOpen,
       sections.length,
       handleMentionKeyDown,
       updateMentions,
+      clampHeight,
       busy,
       showStop,
       onCancel,
@@ -605,22 +682,13 @@ export function ChatInputBar({
                 }}
               />
             )}
-            {loadedSkills.length > 0 && (
-              <div className="flex flex-wrap items-center gap-1.5 px-4 pt-2">
-                {loadedSkills.map((skill) => (
-                  <SkillChip
-                    key={skill.name}
-                    name={skill.name}
-                    onRemove={() => {
-                      setLoadedSkills((prev) => prev.filter((s) => s.name !== skill.name))
-                      textareaRef.current?.focus()
-                    }}
-                  />
-                ))}
-              </div>
-            )}
             <AttachmentPreviewGroup attachments={attachments} onRemove={removeAttachment} />
-            <div className="px-4 pb-1.5 pt-3.5">
+            <div className="relative px-4 pb-1.5 pt-3.5">
+              {/* Transparent-textarea overlay: mirrors the value with inline
+                  SkillChip pills. The textarea text is transparent with a
+                  visible caret; this overlay renders the visible text + chips in
+                  the same metrics so the caret stays aligned. */}
+              <SkillComposerOverlay textareaRef={textareaRef} value={value} />
               <textarea
                 ref={textareaRef}
                 value={value}
@@ -652,12 +720,13 @@ export function ChatInputBar({
                 placeholder={
                   disabled
                     ? 'Session closed'
-                    : activeCommand || loadedSkills.length > 0
+                    : activeCommand
                       ? 'Add a message (optional)…'
                       : 'Ask anything… (/ for commands, @ for files)'
                 }
                 className={cn(
-                  'min-h-[52px] w-full resize-none bg-transparent text-sm leading-relaxed',
+                  'relative z-10 min-h-[52px] w-full resize-none bg-transparent text-sm leading-relaxed',
+                  'text-transparent caret-foreground',
                   'placeholder:text-muted-foreground focus:outline-none',
                   'disabled:cursor-not-allowed disabled:opacity-50 max-h-40'
                 )}

--- a/src/renderer/components/chat/ChatMessage.test.tsx
+++ b/src/renderer/components/chat/ChatMessage.test.tsx
@@ -320,31 +320,32 @@ describe('ChatMessage', () => {
 
     it('renders inline skill chips for token text in a user bubble', () => {
       const text = `use this ${T('git-worktree')} and then ${T('release-version')}`
-      render(
+      const { container } = render(
         <TooltipProvider>
           <ChatMessage message={userMessage(text)} />
         </TooltipProvider>
       )
 
-      // Each chip name renders as a visible inline pill (read-only, no X).
+      // Each chip name renders as a visible inline pill; the chip's Sparkles
+      // icon (lucide-sparkles) is the chip-specific marker.
       expect(screen.getByText('git-worktree')).toBeInTheDocument()
       expect(screen.getByText('release-version')).toBeInTheDocument()
+      expect(container.querySelector('.lucide-sparkles')).not.toBeNull()
       // The plain text segments render too (regex tolerates the surrounding
       // whitespace the segment carries next to the chips).
       expect(screen.getByText(/use this/)).toBeInTheDocument()
       expect(screen.getByText(/and then/)).toBeInTheDocument()
-      // No remove buttons — timeline chips are read-only.
-      expect(screen.queryByRole('button', { name: /Remove .* skill/ })).not.toBeInTheDocument()
     })
 
     it('renders plain user text verbatim (no chip parsing) when there are no tokens', () => {
-      render(
+      const { container } = render(
         <TooltipProvider>
           <ChatMessage message={userMessage('just plain text')} />
         </TooltipProvider>
       )
       expect(screen.getByText('just plain text')).toBeInTheDocument()
-      expect(screen.queryByText(/skill/i)).not.toBeInTheDocument()
+      // No chip rendered: the chip's Sparkles icon is absent.
+      expect(container.querySelector('.lucide-sparkles')).toBeNull()
     })
   })
 })

--- a/src/renderer/components/chat/ChatMessage.test.tsx
+++ b/src/renderer/components/chat/ChatMessage.test.tsx
@@ -2,8 +2,12 @@ import { act, fireEvent, render, screen } from '@testing-library/react'
 import type { ReactNode } from 'react'
 import type { AnimateOptions } from 'streamdown'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { TooltipProvider } from '@/components/ui/tooltip'
+import { skillToken } from '@/lib/skill-tokens'
 import type { ChatMessage as ChatMessageType } from '@/stores/acp-store'
 import { ChatMessage } from './ChatMessage'
+
+const T = skillToken
 
 const openUrlWithSystemBrowser = vi.fn(() => Promise.resolve({ success: true, data: undefined }))
 const openFilePathFromTerminal = vi.fn(() => Promise.resolve({ ok: true as const }))
@@ -301,5 +305,46 @@ describe('ChatMessage', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Open' }))
     expect(openUrlWithSystemBrowser).toHaveBeenCalledWith('https://example.com/docs')
     expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument()
+  })
+
+  describe('user message with inline skill chips', () => {
+    function userMessage(text: string): ChatMessageType {
+      return {
+        id: 'user-1',
+        role: 'user',
+        blocks: [{ type: 'text', text }],
+        streaming: false,
+        timestamp: 0
+      }
+    }
+
+    it('renders inline skill chips for token text in a user bubble', () => {
+      const text = `use this ${T('git-worktree')} and then ${T('release-version')}`
+      render(
+        <TooltipProvider>
+          <ChatMessage message={userMessage(text)} />
+        </TooltipProvider>
+      )
+
+      // Each chip name renders as a visible inline pill (read-only, no X).
+      expect(screen.getByText('git-worktree')).toBeInTheDocument()
+      expect(screen.getByText('release-version')).toBeInTheDocument()
+      // The plain text segments render too (regex tolerates the surrounding
+      // whitespace the segment carries next to the chips).
+      expect(screen.getByText(/use this/)).toBeInTheDocument()
+      expect(screen.getByText(/and then/)).toBeInTheDocument()
+      // No remove buttons — timeline chips are read-only.
+      expect(screen.queryByRole('button', { name: /Remove .* skill/ })).not.toBeInTheDocument()
+    })
+
+    it('renders plain user text verbatim (no chip parsing) when there are no tokens', () => {
+      render(
+        <TooltipProvider>
+          <ChatMessage message={userMessage('just plain text')} />
+        </TooltipProvider>
+      )
+      expect(screen.getByText('just plain text')).toBeInTheDocument()
+      expect(screen.queryByText(/skill/i)).not.toBeInTheDocument()
+    })
   })
 })

--- a/src/renderer/components/chat/ChatMessage.tsx
+++ b/src/renderer/components/chat/ChatMessage.tsx
@@ -29,6 +29,7 @@ import { openerApi } from '@/lib/api'
 import { readAttachmentBytes } from '@/lib/attachment-api'
 import { type FilePathResolutionContext, openFilePathFromTerminal } from '@/lib/file-path-links'
 import { logFrontendError } from '@/lib/log-api'
+import { parseSkillSegments } from '@/lib/skill-tokens'
 import { stripEmptyFences } from '@/lib/strip-empty-fences'
 import { cn } from '@/lib/utils'
 import type { ChatMessage as ChatMessageType } from '@/stores/acp-store'
@@ -49,6 +50,7 @@ import { filePathFromHref, remarkFilePathLinks } from './chat-markdown-file-link
 import { ChatMarkdownTable } from './chat-markdown-table'
 import { type BubbleAlign, staggerChild } from './chat-motion'
 import { MessageActions } from './MessageActions'
+import { SkillChip } from './SkillChip'
 
 const FILE_PATH_REMARK_PLUGINS = [...Object.values(defaultRemarkPlugins), remarkFilePathLinks]
 
@@ -58,6 +60,31 @@ function blocksToText(blocks: ContentBlock[]): string {
     .filter((b) => b.type === 'text')
     .map((b) => b.text ?? '')
     .join('')
+}
+
+/**
+ * Render a user message's text, swapping inline skill tokens for read-only
+ * `SkillChip` pills. Plain text (no tokens) renders verbatim with
+ * `whitespace-pre-wrap` to preserve the original spacing. `MessageActions`
+ * still receives the raw token text so editing re-seeds the composer with the
+ * tokens (chips re-render inline) and copy degrades gracefully (private-use
+ * sentinels are invisible in most fonts).
+ */
+function UserMessageText({ text }: { text: string }): React.JSX.Element {
+  const segments = parseSkillSegments(text)
+  return (
+    <BubbleContent className="whitespace-pre-wrap break-words">
+      {segments.length === 0
+        ? text
+        : segments.map((seg, i) =>
+            seg.kind === 'skill' ? (
+              <SkillChip key={`skill-${i}`} name={seg.name} readOnly />
+            ) : (
+              <span key={`text-${i}`}>{seg.text}</span>
+            )
+          )}
+    </BubbleContent>
+  )
 }
 
 /** Non-text content blocks (image / resource / etc). */
@@ -489,7 +516,7 @@ function ChatMessageComponent({
                 animateEnter={animateEnter}
               >
                 <Bubble variant="tinted" align="end" className="max-w-full">
-                  <BubbleContent className="whitespace-pre-wrap">{text}</BubbleContent>
+                  <UserMessageText text={text} />
                 </Bubble>
               </StaggerSection>
             )}

--- a/src/renderer/components/chat/ChatMessage.tsx
+++ b/src/renderer/components/chat/ChatMessage.tsx
@@ -29,7 +29,7 @@ import { openerApi } from '@/lib/api'
 import { readAttachmentBytes } from '@/lib/attachment-api'
 import { type FilePathResolutionContext, openFilePathFromTerminal } from '@/lib/file-path-links'
 import { logFrontendError } from '@/lib/log-api'
-import { parseSkillSegments } from '@/lib/skill-tokens'
+import { parseSkillSegments, replaceSkillTokensInline } from '@/lib/skill-tokens'
 import { stripEmptyFences } from '@/lib/strip-empty-fences'
 import { cn } from '@/lib/utils'
 import type { ChatMessage as ChatMessageType } from '@/stores/acp-store'
@@ -78,7 +78,7 @@ function UserMessageText({ text }: { text: string }): React.JSX.Element {
         ? text
         : segments.map((seg, i) =>
             seg.kind === 'skill' ? (
-              <SkillChip key={`skill-${i}`} name={seg.name} readOnly />
+              <SkillChip key={`skill-${i}`} name={seg.name} />
             ) : (
               <span key={`text-${i}`}>{seg.text}</span>
             )
@@ -527,7 +527,10 @@ function ChatMessageComponent({
               animateEnter={animateEnter}
             >
               <MessageActions
-                text={text}
+                // Copy a display-safe string: tokens become `(name)` so the
+                // clipboard never carries private-use sentinels. Edit keeps the
+                // raw token text so the composer re-seeds with chips inline.
+                text={replaceSkillTokensInline(text)}
                 align="end"
                 pinned={actionsPinned}
                 onEdit={onEdit && text.length > 0 ? () => onEdit(text) : undefined}

--- a/src/renderer/components/chat/PromptQueuePanel.tsx
+++ b/src/renderer/components/chat/PromptQueuePanel.tsx
@@ -82,7 +82,9 @@ export function PromptQueuePanel({
         <QueueSectionContent>
           <QueueList>
             {items.map((item) => {
-              const preview = previewQueuedPrompt(item.blocks)
+              // Preview the display (token) blocks so the queue reads as the
+              // user's typed text + chips, not the path-framed wire payload.
+              const preview = previewQueuedPrompt(item.displayBlocks ?? item.blocks)
               const summary = preview.text || preview.attachments[0]?.filename || '(queued message)'
               const hasAttachments = preview.attachments.length > 0
 

--- a/src/renderer/components/chat/SkillChip.tsx
+++ b/src/renderer/components/chat/SkillChip.tsx
@@ -3,35 +3,54 @@ import { cn } from '@/lib/utils'
 
 interface SkillChipProps {
   name: string
-  onRemove: () => void
+  /** Click handler for the X button. When omitted or `readOnly` is set, the X
+   * button is hidden (timeline + overlay render read-only chips). */
+  onRemove?: () => void
+  /** Hide the remove button (timeline rendering, transparent-textarea overlay). */
+  readOnly?: boolean
   className?: string
 }
 
 /**
- * Highlighted inline pill for an active Agent Skill. Accent-styled
+ * Highlighted inline pill for an Agent Skill. Accent-styled
  * (`bg-primary/10 border-primary/40 text-primary`, `Sparkles` icon) so an
  * active skill reads at a glance as distinct from the plain muted
- * `CommandChip`. Pill-shaped (`rounded-full`) and removable via X.
+ * `CommandChip`.
+ *
+ * Inline metrics are tuned for the transparent-textarea overlay so the chip
+ * occupies exactly one line box (`inline-flex items-center align-baseline
+ * leading-none h-[1.1em]`, horizontal-only `px-1.5` padding, no vertical
+ * padding) — the transparent textarea text and the overlay stay caret-aligned.
+ * In the composer, the chip is read-only (Backspace removes it via the token
+ * model, not the X button); in the timeline it is always read-only.
  */
-export function SkillChip({ name, onRemove, className }: SkillChipProps): React.JSX.Element {
+export function SkillChip({
+  name,
+  onRemove,
+  readOnly = false,
+  className
+}: SkillChipProps): React.JSX.Element {
   return (
     <span
       className={cn(
-        'inline-flex max-w-full items-center gap-1 rounded-full border border-primary/40 bg-primary/10 py-0.5 pl-2 pr-1 text-xs font-medium text-primary',
+        'inline-flex h-[1.1em] max-w-full items-center gap-1 align-baseline leading-none',
+        'rounded-full border border-primary/40 bg-primary/10 px-1.5 text-xs font-medium text-primary',
         className
       )}
     >
       <Sparkles size={12} className="shrink-0" aria-hidden="true" />
       <span className="max-w-[40ch] truncate">{name}</span>
-      <button
-        type="button"
-        onClick={onRemove}
-        className="ml-0.5 inline-flex shrink-0 items-center rounded-full p-0.5 hover:bg-primary/20 hover:text-primary"
-        aria-label={`Remove ${name} skill`}
-        title="Remove skill"
-      >
-        <X size={12} />
-      </button>
+      {!readOnly && onRemove && (
+        <button
+          type="button"
+          onClick={onRemove}
+          className="ml-0.5 inline-flex shrink-0 items-center rounded-full p-0.5 hover:bg-primary/20 hover:text-primary"
+          aria-label={`Remove ${name} skill`}
+          title="Remove skill"
+        >
+          <X size={12} />
+        </button>
+      )}
     </span>
   )
 }

--- a/src/renderer/components/chat/SkillChip.tsx
+++ b/src/renderer/components/chat/SkillChip.tsx
@@ -1,13 +1,8 @@
-import { Sparkles, X } from 'lucide-react'
+import { Sparkles } from 'lucide-react'
 import { cn } from '@/lib/utils'
 
 interface SkillChipProps {
   name: string
-  /** Click handler for the X button. When omitted or `readOnly` is set, the X
-   * button is hidden (timeline + overlay render read-only chips). */
-  onRemove?: () => void
-  /** Hide the remove button (timeline rendering, transparent-textarea overlay). */
-  readOnly?: boolean
   className?: string
 }
 
@@ -21,15 +16,12 @@ interface SkillChipProps {
  * occupies exactly one line box (`inline-flex items-center align-baseline
  * leading-none h-[1.1em]`, horizontal-only `px-1.5` padding, no vertical
  * padding) — the transparent textarea text and the overlay stay caret-aligned.
- * In the composer, the chip is read-only (Backspace removes it via the token
- * model, not the X button); in the timeline it is always read-only.
+ * Always read-only: in the composer Backspace removes a chip via the token
+ * model (`removeSkillTokenBeforeCaret`), not an X button; in the timeline the
+ * chip is non-interactive. (No `onRemove` prop — verified unused across all
+ * callers: `SkillComposerOverlay` + `ChatMessage` both pass `readOnly`.)
  */
-export function SkillChip({
-  name,
-  onRemove,
-  readOnly = false,
-  className
-}: SkillChipProps): React.JSX.Element {
+export function SkillChip({ name, className }: SkillChipProps): React.JSX.Element {
   return (
     <span
       className={cn(
@@ -40,17 +32,6 @@ export function SkillChip({
     >
       <Sparkles size={12} className="shrink-0" aria-hidden="true" />
       <span className="max-w-[40ch] truncate">{name}</span>
-      {!readOnly && onRemove && (
-        <button
-          type="button"
-          onClick={onRemove}
-          className="ml-0.5 inline-flex shrink-0 items-center rounded-full p-0.5 hover:bg-primary/20 hover:text-primary"
-          aria-label={`Remove ${name} skill`}
-          title="Remove skill"
-        >
-          <X size={12} />
-        </button>
-      )}
     </span>
   )
 }

--- a/src/renderer/components/chat/SkillChip.tsx
+++ b/src/renderer/components/chat/SkillChip.tsx
@@ -16,10 +16,12 @@ interface SkillChipProps {
  * occupies exactly one line box (`inline-flex items-center align-baseline
  * leading-none h-[1.1em]`, horizontal-only `px-1.5` padding, no vertical
  * padding) — the transparent textarea text and the overlay stay caret-aligned.
- * Always read-only: in the composer Backspace removes a chip via the token
- * model (`removeSkillTokenBeforeCaret`), not an X button; in the timeline the
- * chip is non-interactive. (No `onRemove` prop — verified unused across all
- * callers: `SkillComposerOverlay` + `ChatMessage` both pass `readOnly`.)
+ *
+ * Always non-interactive by construction: there is no `onRemove` or any other
+ * interactive/removal prop. In the composer, Backspace removes a chip via the
+ * token model (`removeSkillTokenBeforeCaret`), not an X button; in the timeline
+ * the chip is a static pill. Callers (`SkillComposerOverlay`, `ChatMessage`)
+ * pass only `name` (plus an optional `className`).
  */
 export function SkillChip({ name, className }: SkillChipProps): React.JSX.Element {
   return (

--- a/src/renderer/components/chat/SkillComposerOverlay.tsx
+++ b/src/renderer/components/chat/SkillComposerOverlay.tsx
@@ -1,0 +1,179 @@
+import { type CSSProperties, useEffect, useRef, useState } from 'react'
+import { parseSkillSegments } from '@/lib/skill-tokens'
+import { cn } from '@/lib/utils'
+import { SkillChip } from './SkillChip'
+
+interface SkillComposerOverlayProps {
+  textareaRef: React.RefObject<HTMLTextAreaElement | null>
+  value: string
+  className?: string
+}
+
+/**
+ * Metrics read off the underlying `<textarea>` so the overlay's text wraps
+ * identically (same font, padding, line-height, width, white-space,
+ * word-break). Reading computed style (rather than re-declaring Tailwind
+ * classes) keeps the overlay aligned if the textarea's styling ever changes.
+ */
+interface TextareaMetrics {
+  fontFamily: string
+  fontSize: string
+  fontWeight: string
+  fontStyle: string
+  fontVariant: string
+  lineHeight: string
+  letterSpacing: string
+  paddingTop: string
+  paddingRight: string
+  paddingBottom: string
+  paddingLeft: string
+  borderTopWidth: string
+  borderRightWidth: string
+  borderBottomWidth: string
+  borderLeftWidth: string
+  width: string
+  height: string
+  boxSizing: string
+  textTransform: string
+  tabSize: string
+  whiteSpace: string
+  wordBreak: string
+  overflowWrap: string
+}
+
+function readMetrics(ta: HTMLTextAreaElement): TextareaMetrics {
+  const cs = window.getComputedStyle(ta)
+  return {
+    fontFamily: cs.fontFamily,
+    fontSize: cs.fontSize,
+    fontWeight: cs.fontWeight,
+    fontStyle: cs.fontStyle,
+    fontVariant: cs.fontVariant,
+    lineHeight: cs.lineHeight,
+    letterSpacing: cs.letterSpacing,
+    paddingTop: cs.paddingTop,
+    paddingRight: cs.paddingRight,
+    paddingBottom: cs.paddingBottom,
+    paddingLeft: cs.paddingLeft,
+    borderTopWidth: cs.borderTopWidth,
+    borderRightWidth: cs.borderRightWidth,
+    borderBottomWidth: cs.borderBottomWidth,
+    borderLeftWidth: cs.borderLeftWidth,
+    width: cs.width,
+    height: cs.height,
+    boxSizing: cs.boxSizing,
+    textTransform: cs.textTransform,
+    tabSize: cs.tabSize,
+    whiteSpace: cs.whiteSpace,
+    wordBreak: cs.wordBreak,
+    overflowWrap: cs.overflowWrap
+  }
+}
+
+/**
+ * Transparent-textarea overlay that mirrors the composer value and replaces
+ * skill tokens with `SkillChip` pills. The textarea sits on top
+ * (`color: transparent`, visible `caret-color`) so `useComposerTextarea`
+ * (IME/OSK/draft/mentions/slash) is untouched; this overlay renders the
+ * visible text + chips in the exact same metrics so the caret stays aligned.
+ * `pointer-events: none` keeps all input flowing to the textarea; scroll
+ * position is mirrored via a scroll listener.
+ */
+export function SkillComposerOverlay({
+  textareaRef,
+  value,
+  className
+}: SkillComposerOverlayProps): React.JSX.Element | null {
+  const [metrics, setMetrics] = useState<TextareaMetrics | null>(null)
+  const [scroll, setScroll] = useState({ top: 0, left: 0 })
+
+  // Read the textarea's computed metrics so the overlay text wraps identically.
+  // The ResizeObserver catches every textarea resize (including the auto-grow
+  // height change when the value changes), so the metrics stay current without
+  // listing `value` as a dependency (mutating it doesn't re-run the effect).
+  useEffect(() => {
+    const ta = textareaRef.current
+    if (!ta) return
+    const read = (): void => setMetrics(readMetrics(ta))
+    read()
+    const ro = typeof ResizeObserver !== 'undefined' ? new ResizeObserver(read) : null
+    ro?.observe(ta)
+    return () => {
+      ro?.disconnect()
+    }
+  }, [textareaRef])
+
+  // Sync scroll position from the textarea to the overlay content so long
+  // text stays aligned when the textarea scrolls.
+  useEffect(() => {
+    const ta = textareaRef.current
+    if (!ta) return
+    const sync = (): void => setScroll({ top: ta.scrollTop, left: ta.scrollLeft })
+    sync()
+    ta.addEventListener('scroll', sync, { passive: true })
+    return () => {
+      ta.removeEventListener('scroll', sync)
+    }
+  }, [textareaRef])
+
+  if (!metrics) return null
+  const segments = parseSkillSegments(value)
+
+  // Overlay box matches the textarea's border box (same padding + border +
+  // width + box-sizing). Text wraps with the same white-space/word-break so
+  // chip positions line up with the transparent textarea text. The content
+  // layer is translated by the textarea's scroll offset to mirror scrolling.
+  const overlayStyle: CSSProperties = {
+    fontFamily: metrics.fontFamily,
+    fontSize: metrics.fontSize,
+    fontWeight: metrics.fontWeight,
+    fontStyle: metrics.fontStyle,
+    fontVariant: metrics.fontVariant,
+    lineHeight: metrics.lineHeight,
+    letterSpacing: metrics.letterSpacing,
+    paddingTop: metrics.paddingTop,
+    paddingRight: metrics.paddingRight,
+    paddingBottom: metrics.paddingBottom,
+    paddingLeft: metrics.paddingLeft,
+    borderTopWidth: metrics.borderTopWidth,
+    borderRightWidth: metrics.borderRightWidth,
+    borderBottomWidth: metrics.borderBottomWidth,
+    borderLeftWidth: metrics.borderLeftWidth,
+    width: metrics.width,
+    height: metrics.height,
+    boxSizing: metrics.boxSizing as CSSProperties['boxSizing'],
+    textTransform: metrics.textTransform,
+    tabSize: metrics.tabSize,
+    whiteSpace: metrics.whiteSpace || 'pre-wrap',
+    wordBreak: (metrics.wordBreak || 'break-word') as CSSProperties['wordBreak'],
+    overflowWrap: (metrics.overflowWrap || 'break-word') as CSSProperties['overflowWrap'],
+    color: 'var(--foreground, currentColor)'
+  }
+
+  return (
+    <div
+      aria-hidden="true"
+      className={cn('pointer-events-none absolute inset-0 z-0 overflow-hidden', className)}
+      style={overlayStyle}
+    >
+      <div
+        style={{
+          transform: `translate(${-scroll.left}px, ${-scroll.top}px)`,
+          willChange: 'transform'
+        }}
+      >
+        {segments.length === 0 ? (
+          <span>{''}</span>
+        ) : (
+          segments.map((seg, i) =>
+            seg.kind === 'skill' ? (
+              <SkillChip key={`skill-${i}`} name={seg.name} readOnly />
+            ) : (
+              <span key={`text-${i}`}>{seg.text}</span>
+            )
+          )
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/components/chat/SkillComposerOverlay.tsx
+++ b/src/renderer/components/chat/SkillComposerOverlay.tsx
@@ -1,4 +1,4 @@
-import { type CSSProperties, useEffect, useRef, useState } from 'react'
+import { type CSSProperties, useCallback, useEffect, useRef, useState } from 'react'
 import { parseSkillSegments } from '@/lib/skill-tokens'
 import { cn } from '@/lib/utils'
 import { SkillChip } from './SkillChip'
@@ -86,22 +86,42 @@ export function SkillComposerOverlay({
 }: SkillComposerOverlayProps): React.JSX.Element | null {
   const [metrics, setMetrics] = useState<TextareaMetrics | null>(null)
   const [scroll, setScroll] = useState({ top: 0, left: 0 })
+  // Previous metrics serialized, so a re-read that yields identical values does
+  // not trigger a state update (avoids churn re-renders on every keystroke).
+  const prevMetricsKeyRef = useRef<string>('')
 
-  // Read the textarea's computed metrics so the overlay text wraps identically.
-  // The ResizeObserver catches every textarea resize (including the auto-grow
-  // height change when the value changes), so the metrics stay current without
-  // listing `value` as a dependency (mutating it doesn't re-run the effect).
-  useEffect(() => {
+  // Read the textarea's computed metrics, skipping the setState when nothing
+  // changed. Stable callback shared by the mount/resize effect and the
+  // value-change effect below.
+  const readMetricsIfChanged = useCallback(() => {
     const ta = textareaRef.current
     if (!ta) return
-    const read = (): void => setMetrics(readMetrics(ta))
-    read()
-    const ro = typeof ResizeObserver !== 'undefined' ? new ResizeObserver(read) : null
+    const next = readMetrics(ta)
+    const key = JSON.stringify(next)
+    if (key === prevMetricsKeyRef.current) return
+    prevMetricsKeyRef.current = key
+    setMetrics(next)
+  }, [textareaRef])
+
+  // Mount + resize-driven re-read. The ResizeObserver catches every textarea
+  // resize (including the auto-grow height change when the value changes).
+  useEffect(() => {
+    readMetricsIfChanged()
+    const ta = textareaRef.current
+    if (!ta) return
+    const ro =
+      typeof ResizeObserver !== 'undefined' ? new ResizeObserver(readMetricsIfChanged) : null
     ro?.observe(ta)
     return () => {
       ro?.disconnect()
     }
-  }, [textareaRef])
+  }, [textareaRef, readMetricsIfChanged])
+
+  // (Value-driven changes are covered by the ResizeObserver above: typing onto a
+  // new line auto-grows the textarea box, which fires the observer and re-reads.
+  // Typing on an unchanged line box changes no metrics, so no re-read is needed.
+  // A font-family/theme switch without a box resize is a known rare gap — it
+  // would need a theme-change signal this component does not own.)
 
   // Sync scroll position from the textarea to the overlay content so long
   // text stays aligned when the textarea scrolls.
@@ -167,7 +187,7 @@ export function SkillComposerOverlay({
         ) : (
           segments.map((seg, i) =>
             seg.kind === 'skill' ? (
-              <SkillChip key={`skill-${i}`} name={seg.name} readOnly />
+              <SkillChip key={`skill-${i}`} name={seg.name} />
             ) : (
               <span key={`text-${i}`}>{seg.text}</span>
             )

--- a/src/renderer/components/chat/chat-responsive.test.tsx
+++ b/src/renderer/components/chat/chat-responsive.test.tsx
@@ -26,7 +26,7 @@ const { mockMcpCount } = vi.hoisted(() => ({
 
 vi.mock('@/hooks/use-agent-skills', () => ({
   useAgentSkills: () => ({ skills: [] }),
-  buildPromptWithLoadedSkills: vi.fn(async (_skills: unknown, text: string) => text)
+  buildPromptWithLoadedSkills: vi.fn((_skills: unknown, text: string) => text)
 }))
 
 vi.mock('@/stores/acp-store', () => ({

--- a/src/renderer/components/chat/slash-menu-model.test.ts
+++ b/src/renderer/components/chat/slash-menu-model.test.ts
@@ -53,8 +53,18 @@ const modes: SessionModeState = {
 }
 
 const skills: AgentSkillSummary[] = [
-  { name: 'investigate', description: 'Run an investigation', scope: 'project' },
-  { name: 'review', description: 'Review code', scope: 'global' }
+  {
+    name: 'investigate',
+    description: 'Run an investigation',
+    scope: 'project',
+    path: '/work/.agents/skills/investigate/SKILL.md'
+  },
+  {
+    name: 'review',
+    description: 'Review code',
+    scope: 'global',
+    path: '/home/u/.agents/skills/review/SKILL.md'
+  }
 ]
 
 describe('slash trigger detection', () => {
@@ -140,6 +150,22 @@ describe('buildSlashSections', () => {
     expect(sections[1].id).toBe('commands')
   })
 
+  it('threads each skill SKILL.md path onto the skill items (for the wire prompt)', () => {
+    const sections = buildSlashSections({
+      commands: [],
+      configOptions: [],
+      modes: null,
+      skills,
+      filter: ''
+    })
+    const skillItems = sections[0].items
+    expect(skillItems.every((i) => i.kind === 'skill')).toBe(true)
+    expect(skillItems.map((i) => (i.kind === 'skill' ? i.path : ''))).toEqual([
+      '/work/.agents/skills/investigate/SKILL.md',
+      '/home/u/.agents/skills/review/SKILL.md'
+    ])
+  })
+
   it('lists commands first when no skills', () => {
     const sections = buildSlashSections({ commands, configOptions: [], modes: null, filter: '' })
     expect(sections[0].id).toBe('commands')
@@ -150,8 +176,18 @@ describe('buildSlashSections', () => {
     // A skill named `compact` collides with the `compact` command — the skill
     // is dropped so the name appears once (Commands), not twice.
     const overlapping: AgentSkillSummary[] = [
-      { name: 'compact', description: 'A skill called compact', scope: 'project' },
-      { name: 'investigate', description: 'Run an investigation', scope: 'project' }
+      {
+        name: 'compact',
+        description: 'A skill called compact',
+        scope: 'project',
+        path: '/work/.agents/skills/compact/SKILL.md'
+      },
+      {
+        name: 'investigate',
+        description: 'Run an investigation',
+        scope: 'project',
+        path: '/work/.agents/skills/investigate/SKILL.md'
+      }
     ]
     const sections = buildSlashSections({
       commands,

--- a/src/renderer/components/chat/slash-menu-model.ts
+++ b/src/renderer/components/chat/slash-menu-model.ts
@@ -40,6 +40,9 @@ export interface SlashSkillItem {
   name: string
   description: string | null
   scope: string
+  /** Absolute `SKILL.md` path, captured at pick time so the composer can record
+   * it for the wire prompt without an IPC read at send. */
+  path: string
 }
 
 export type SlashItem = SlashCommandItem | SlashConfigItem | SlashModeItem | SlashSkillItem
@@ -103,7 +106,8 @@ export function buildSlashSections(input: SlashMenuInput): SlashSection[] {
       kind: 'skill',
       name: s.name,
       description: s.description || null,
-      scope: s.scope
+      scope: s.scope,
+      path: s.path
     }))
   if (skillItems.length > 0) {
     sections.push({ id: 'skills', heading: 'Skills', items: skillItems })

--- a/src/renderer/hooks/use-agent-skills.ts
+++ b/src/renderer/hooks/use-agent-skills.ts
@@ -3,14 +3,6 @@ import { logFrontendError } from '@/lib/log-api'
 import { type AgentSkillSummary, skillsApi } from '@/lib/skills-api'
 import { type FramedSkill, formatPromptWithSkills } from '@/lib/skills-prompt'
 
-export interface LoadedAgentSkill {
-  name: string
-  description: string
-  /** Absolute `SKILL.md` path captured at pick time so the wire prompt can cite
-   * it synchronously at send time — no IPC read at send, so it cannot fail. */
-  path: string
-}
-
 export function useAgentSkills(projectRoot: string | undefined): {
   skills: AgentSkillSummary[]
   loading: boolean

--- a/src/renderer/hooks/use-agent-skills.ts
+++ b/src/renderer/hooks/use-agent-skills.ts
@@ -1,10 +1,14 @@
 import { useCallback, useEffect, useState } from 'react'
 import { logFrontendError } from '@/lib/log-api'
 import { type AgentSkillSummary, skillsApi } from '@/lib/skills-api'
+import { type FramedSkill, formatPromptWithSkills } from '@/lib/skills-prompt'
 
 export interface LoadedAgentSkill {
   name: string
   description: string
+  /** Absolute `SKILL.md` path captured at pick time so the wire prompt can cite
+   * it synchronously at send time — no IPC read at send, so it cannot fail. */
+  path: string
 }
 
 export function useAgentSkills(projectRoot: string | undefined): {
@@ -49,28 +53,13 @@ export function useAgentSkills(projectRoot: string | undefined): {
   return { skills, loading, reload }
 }
 
-export async function buildPromptWithLoadedSkills(
-  loadedSkills: LoadedAgentSkill[],
-  userText: string,
-  projectRoot: string | undefined
-): Promise<string> {
-  const trimmed = userText.trim()
-  if (loadedSkills.length === 0) return trimmed
-
-  // Read each skill's body on demand at send time so it is always current
-  // (freshness). On any read failure, throw an Error naming the failing skill
-  // so the toast is clear about which skill could not be loaded.
-  const framed: { name: string; body: string }[] = []
-  for (const loaded of loadedSkills) {
-    try {
-      const skill = await skillsApi.readSkill(loaded.name, projectRoot)
-      framed.push({ name: loaded.name, body: skill.body })
-    } catch (err) {
-      const detail = err instanceof Error ? err.message : String(err)
-      throw new Error(`Failed to load skill '${loaded.name}': ${detail}`)
-    }
-  }
-
-  const { formatPromptWithSkills } = await import('@/lib/skills-prompt')
-  return formatPromptWithSkills(framed, trimmed)
+/**
+ * Frame the selected skills (by path) and the user's text into the wire prompt.
+ * Synchronous: paths are captured at pick time, so there is no IPC read at send
+ * and it cannot fail. Tokens in the user text are replaced with `(<name>)`
+ * inline and each unique skill is cited as `<name>: <path>` under a
+ * `# Agent Skills` header (see `formatPromptWithSkills`).
+ */
+export function buildPromptWithLoadedSkills(skills: FramedSkill[], userText: string): string {
+  return formatPromptWithSkills(skills, userText)
 }

--- a/src/renderer/lib/skill-tokens.test.ts
+++ b/src/renderer/lib/skill-tokens.test.ts
@@ -13,7 +13,7 @@ import {
 const T = (name: string): string => skillToken(name)
 
 describe('parseSkillSegments', () => {
-  it('returns a single empty text segment for an empty value', () => {
+  it('returns no segments for an empty value', () => {
     expect(parseSkillSegments('')).toEqual([])
   })
 
@@ -76,7 +76,8 @@ describe('insertSkillToken', () => {
   })
 
   it('deletes the preceding filter range when splicing (the / trigger text)', () => {
-    // value = "use this skill /" caret at end (15), deleteBefore=1 removes the "/"
+    // value = "use this skill /" (length 16); caret at end; deleteBefore=1
+    // removes the trailing "/".
     const { value, caret } = insertSkillToken('use this skill /', 16, 'git-worktree', 1)
     expect(value).toBe(`use this skill ${T('git-worktree')} `)
     expect(caret).toBe(value.length)

--- a/src/renderer/lib/skill-tokens.test.ts
+++ b/src/renderer/lib/skill-tokens.test.ts
@@ -1,0 +1,196 @@
+import { describe, expect, it } from 'vitest'
+import {
+  extractSkillNames,
+  insertSkillToken,
+  parseSkillSegments,
+  removeSkillTokenBeforeCaret,
+  replaceSkillTokensInline,
+  SKILL_TOKEN_END,
+  SKILL_TOKEN_START,
+  skillToken
+} from '@/lib/skill-tokens'
+
+const T = (name: string): string => skillToken(name)
+
+describe('parseSkillSegments', () => {
+  it('returns a single empty text segment for an empty value', () => {
+    expect(parseSkillSegments('')).toEqual([])
+  })
+
+  it('returns a single text segment for plain text with no tokens', () => {
+    expect(parseSkillSegments('hello world')).toEqual([{ kind: 'text', text: 'hello world' }])
+  })
+
+  it('parses a lone token into a single skill segment', () => {
+    expect(parseSkillSegments(T('git-worktree'))).toEqual([
+      { kind: 'skill', name: 'git-worktree', raw: T('git-worktree') }
+    ])
+  })
+
+  it('parses text + token + text in order', () => {
+    expect(parseSkillSegments(`use this ${T('git-worktree')} then`)).toEqual([
+      { kind: 'text', text: 'use this ' },
+      { kind: 'skill', name: 'git-worktree', raw: T('git-worktree') },
+      { kind: 'text', text: ' then' }
+    ])
+  })
+
+  it('parses adjacent tokens with no text between them', () => {
+    expect(parseSkillSegments(`${T('a')}${T('b')}`)).toEqual([
+      { kind: 'skill', name: 'a', raw: T('a') },
+      { kind: 'skill', name: 'b', raw: T('b') }
+    ])
+  })
+
+  it('parses a token at the start and a token at the end', () => {
+    expect(parseSkillSegments(`${T('a')}mid${T('b')}`)).toEqual([
+      { kind: 'skill', name: 'a', raw: T('a') },
+      { kind: 'text', text: 'mid' },
+      { kind: 'skill', name: 'b', raw: T('b') }
+    ])
+  })
+
+  it('handles hyphenated skill names', () => {
+    expect(parseSkillSegments(T('release-version'))).toEqual([
+      { kind: 'skill', name: 'release-version', raw: T('release-version') }
+    ])
+  })
+
+  it('treats an unterminated start sentinel as plain text', () => {
+    const raw = `hello ${SKILL_TOKEN_START}git-worktree`
+    expect(parseSkillSegments(raw)).toEqual([{ kind: 'text', text: raw }])
+  })
+
+  it('treats an empty-name token as plain text', () => {
+    const raw = `${SKILL_TOKEN_START}${SKILL_TOKEN_END}`
+    expect(parseSkillSegments(raw)).toEqual([{ kind: 'text', text: raw }])
+  })
+})
+
+describe('insertSkillToken', () => {
+  it('inserts a token at the caret with a trailing space and places the caret after it', () => {
+    const { value, caret } = insertSkillToken('hello ', 6, 'git-worktree', 0)
+    expect(value).toBe(`hello ${T('git-worktree')} `)
+    expect(caret).toBe(`hello `.length + T('git-worktree').length + 1)
+    expect(caret).toBe(value.length)
+  })
+
+  it('deletes the preceding filter range when splicing (the / trigger text)', () => {
+    // value = "use this skill /" caret at end (15), deleteBefore=1 removes the "/"
+    const { value, caret } = insertSkillToken('use this skill /', 16, 'git-worktree', 1)
+    expect(value).toBe(`use this skill ${T('git-worktree')} `)
+    expect(caret).toBe(value.length)
+  })
+
+  it('inserts at the start when the value is empty', () => {
+    const { value, caret } = insertSkillToken('', 0, 'git-worktree', 0)
+    expect(value).toBe(`${T('git-worktree')} `)
+    expect(caret).toBe(value.length)
+  })
+
+  it('removes a leading /filter and inserts the token at position 0', () => {
+    const { value, caret } = insertSkillToken('/git', 4, 'git-worktree', 4)
+    expect(value).toBe(`${T('git-worktree')} `)
+    expect(caret).toBe(value.length)
+  })
+
+  it('preserves trailing text when splicing mid-value', () => {
+    const { value, caret } = insertSkillToken('hello world', 5, 'git-worktree', 0)
+    expect(value).toBe(`hello${T('git-worktree')}  world`)
+    expect(caret).toBe(`hello`.length + T('git-worktree').length + 1)
+  })
+})
+
+describe('removeSkillTokenBeforeCaret', () => {
+  it('removes the whole token plus trailing space when the caret is right after the space', () => {
+    const value = `use this ${T('git-worktree')} `
+    const caret = value.length
+    const result = removeSkillTokenBeforeCaret(value, caret)
+    expect(result.removed).toBe(true)
+    if (!result.removed) return
+    expect(result.value).toBe('use this ')
+    expect(result.caret).toBe('use this '.length)
+  })
+
+  it('removes the whole token when the caret is right after the token end (no trailing space)', () => {
+    const value = `use this ${T('git-worktree')}`
+    const caret = value.length
+    const result = removeSkillTokenBeforeCaret(value, caret)
+    expect(result.removed).toBe(true)
+    if (!result.removed) return
+    expect(result.value).toBe('use this ')
+    expect(result.caret).toBe('use this '.length)
+  })
+
+  it('removes a token at the start of the value', () => {
+    const value = `${T('git-worktree')} `
+    const result = removeSkillTokenBeforeCaret(value, value.length)
+    expect(result.removed).toBe(true)
+    if (!result.removed) return
+    expect(result.value).toBe('')
+    expect(result.caret).toBe(0)
+  })
+
+  it('returns removed:false when the caret is in plain text (default one-char backspace)', () => {
+    const value = 'hello world'
+    expect(removeSkillTokenBeforeCaret(value, 5).removed).toBe(false)
+  })
+
+  it('returns removed:false when only a lone trailing space precedes the caret (no token)', () => {
+    expect(removeSkillTokenBeforeCaret('hello ', 6).removed).toBe(false)
+  })
+
+  it('returns removed:false for an out-of-range caret', () => {
+    expect(removeSkillTokenBeforeCaret(T('a'), 0).removed).toBe(false)
+    expect(removeSkillTokenBeforeCaret(T('a'), 99).removed).toBe(false)
+  })
+})
+
+describe('replaceSkillTokensInline', () => {
+  it('replaces a single token with (name)', () => {
+    expect(replaceSkillTokensInline(`use this ${T('git-worktree')} now`)).toBe(
+      'use this (git-worktree) now'
+    )
+  })
+
+  it('preserves inline duplicate positions', () => {
+    expect(replaceSkillTokensInline(`${T('a')} and ${T('a')} again`)).toBe('(a) and (a) again')
+  })
+
+  it('passes plain text through verbatim', () => {
+    expect(replaceSkillTokensInline('just text')).toBe('just text')
+  })
+
+  it('returns empty string for empty input', () => {
+    expect(replaceSkillTokensInline('')).toBe('')
+  })
+
+  it('replaces adjacent tokens', () => {
+    expect(replaceSkillTokensInline(`${T('a')}${T('b')}`)).toBe('(a)(b)')
+  })
+
+  it('does not touch @mentions or /slashes in the text', () => {
+    expect(replaceSkillTokensInline('@user /cmd')).toBe('@user /cmd')
+  })
+})
+
+describe('extractSkillNames', () => {
+  it('returns names in first-appearance order, unique by name', () => {
+    expect(extractSkillNames(`${T('a')} ${T('b')} ${T('a')}`)).toEqual(['a', 'b'])
+  })
+
+  it('returns an empty array for plain text with no tokens', () => {
+    expect(extractSkillNames('hello world')).toEqual([])
+  })
+
+  it('returns an empty array for empty input', () => {
+    expect(extractSkillNames('')).toEqual([])
+  })
+
+  it('handles hyphenated names', () => {
+    expect(extractSkillNames(`${T('git-worktree')} ${T('release-version')}`)).toEqual([
+      'git-worktree',
+      'release-version'
+    ])
+  })
+})

--- a/src/renderer/lib/skill-tokens.ts
+++ b/src/renderer/lib/skill-tokens.ts
@@ -1,0 +1,154 @@
+/**
+ * Inline skill-chip token model.
+ *
+ * Selected skills are spliced into the composer value as private-use sentinel
+ * tokens (`\uE000<name>\uE001`). The sentinels are non-whitespace and contain
+ * no `@` or `/`, so `findSlashTrigger`'s `/(?:^|\s)(\/(\S*))$/` and the
+ * `@`-mention scanner are unaffected. Rendered as raw text they are invisible
+ * (private-use glyphs render blank in most fonts), so a fallback raw render
+ * degrades gracefully. The transparent-textarea overlay
+ * (`SkillComposerOverlay`) and the timeline user bubble (`ChatMessage`) parse
+ * the value into segments and swap tokens for `SkillChip` pills; the wire
+ * prompt replaces each token with `(<name>)` (see `replaceSkillTokensInline`).
+ */
+
+export const SKILL_TOKEN_START = '\uE000'
+export const SKILL_TOKEN_END = '\uE001'
+
+/** A run of plain text or a single skill token extracted from the value. */
+export type SkillSegment =
+  | { kind: 'text'; text: string }
+  | { kind: 'skill'; name: string; raw: string }
+
+/**
+ * Split a composer value into ordered text/skill segments. Token boundaries are
+ * `\uE000<name>\uE001`. Malformed tokens (start without end, or empty name) are
+ * treated as plain text so a corrupted value never crashes the overlay.
+ */
+export function parseSkillSegments(value: string): SkillSegment[] {
+  const segments: SkillSegment[] = []
+  let i = 0
+  let text = ''
+  while (i < value.length) {
+    if (value[i] === SKILL_TOKEN_START) {
+      const end = value.indexOf(SKILL_TOKEN_END, i + 1)
+      if (end === -1) {
+        // No closing sentinel — treat the rest as plain text.
+        text += value.slice(i)
+        i = value.length
+        break
+      }
+      const name = value.slice(i + 1, end)
+      if (name.length === 0) {
+        // Empty token name — treat the sentinels as plain text.
+        text += value.slice(i, end + 1)
+        i = end + 1
+        continue
+      }
+      if (text.length > 0) {
+        segments.push({ kind: 'text', text })
+        text = ''
+      }
+      segments.push({ kind: 'skill', name, raw: value.slice(i, end + 1) })
+      i = end + 1
+    } else {
+      text += value[i]
+      i += 1
+    }
+  }
+  if (text.length > 0) segments.push({ kind: 'text', text })
+  return segments
+}
+
+/** Build a skill token string for the given skill name. */
+export function skillToken(name: string): string {
+  return `${SKILL_TOKEN_START}${name}${SKILL_TOKEN_END}`
+}
+
+export interface InsertTokenResult {
+  value: string
+  caret: number
+}
+
+/**
+ * Splice a skill token into the value at `caret`, removing the `deleteBefore`
+ * chars immediately preceding the caret (the `/`-trigger filter text the slash
+ * menu clears). A trailing space is appended so the caret lands in plain text
+ * and the user can keep typing; the next `/` trigger still matches because the
+ * space is whitespace. Returns the new value and the caret position to apply.
+ */
+export function insertSkillToken(
+  value: string,
+  caret: number,
+  name: string,
+  deleteBefore = 0
+): InsertTokenResult {
+  const start = Math.max(0, Math.min(caret - deleteBefore, value.length))
+  const end = Math.max(start, Math.min(caret, value.length))
+  const before = value.slice(0, start)
+  const after = value.slice(end)
+  const token = skillToken(name)
+  const next = `${before}${token} ${after}`
+  // Caret lands right after the trailing space.
+  return { value: next, caret: before.length + token.length + 1 }
+}
+
+export type RemoveSkillTokenResult =
+  | { removed: true; value: string; caret: number }
+  | { removed: false }
+
+/**
+ * Backspace semantics for the composer: when the caret is *immediately* after a
+ * skill token (no selection), remove the whole token plus the trailing space
+ * the splicer appended, and place the caret where the token started. Tolerates
+ * the splicer's trailing space (caret may sit one char after the token end).
+ * Returns `removed:false` for the caller to fall back to the default
+ * one-char backspace.
+ */
+export function removeSkillTokenBeforeCaret(value: string, caret: number): RemoveSkillTokenResult {
+  if (caret <= 0 || caret > value.length) return { removed: false }
+  // Allow one trailing space between the token end and the caret (the splicer
+  // appends a space so the user can keep typing).
+  let tokenEnd = caret
+  if (value[caret - 1] === ' ') {
+    if (caret - 2 < 0 || value[caret - 2] !== SKILL_TOKEN_END) return { removed: false }
+    tokenEnd = caret - 1
+  } else if (value[caret - 1] !== SKILL_TOKEN_END) {
+    return { removed: false }
+  }
+  // tokenEnd points just after \uE001. Find the matching \uE000.
+  const start = value.lastIndexOf(SKILL_TOKEN_START, tokenEnd - 1)
+  if (start === -1) return { removed: false }
+  const name = value.slice(start + 1, tokenEnd - 1)
+  if (name.length === 0) return { removed: false }
+  const before = value.slice(0, start)
+  const after = value.slice(caret)
+  return { removed: true, value: `${before}${after}`, caret: start }
+}
+
+/**
+ * Replace each skill token with `(<name>)` for the wire prompt's user-text
+ * portion. Inline duplicates are preserved (the same skill may appear at
+ * multiple positions). Non-token text is passed through verbatim.
+ */
+export function replaceSkillTokensInline(value: string): string {
+  return parseSkillSegments(value)
+    .map((s) => (s.kind === 'skill' ? `(${s.name})` : s.text))
+    .join('')
+}
+
+/**
+ * Extract skill names from tokens in first-appearance order. Used to build the
+ * wire header (`<name>: <path>` lines, unique by name).
+ */
+export function extractSkillNames(value: string): string[] {
+  const seen = new Set<string>()
+  const names: string[] = []
+  for (const seg of parseSkillSegments(value)) {
+    if (seg.kind === 'skill' && !seen.has(seg.name)) {
+      seen.add(seg.name)
+      names.push(seg.name)
+    }
+  }
+  return names
+}

--- a/src/renderer/lib/skills-api.ts
+++ b/src/renderer/lib/skills-api.ts
@@ -15,6 +15,9 @@ export interface AgentSkillSummary {
   description: string
   /** `'global'` or `'project'`. */
   scope: string
+  /** Absolute path to the skill's `SKILL.md` so the wire prompt can cite it
+   * (the agent reads the body from disk; no body is shipped over the wire). */
+  path: string
 }
 
 export interface AgentSkillContent {
@@ -22,6 +25,8 @@ export interface AgentSkillContent {
   description: string
   scope: string
   body: string
+  /** Absolute path to the skill's `SKILL.md`. */
+  path: string
 }
 
 export const skillsApi = {

--- a/src/renderer/lib/skills-prompt.test.ts
+++ b/src/renderer/lib/skills-prompt.test.ts
@@ -74,7 +74,7 @@ describe('formatPromptWithSkills (path-based wire framing)', () => {
     expect(formatPromptWithSkills([GIT], '')).toBe(`# Agent Skills\n\n${GIT.name}: ${GIT.path}`)
   })
 
-  it('returns only the skills section when the user text is token-only', () => {
+  it('keeps the (name) body when the user text is token-only', () => {
     expect(formatPromptWithSkills([GIT], T('git-worktree'))).toBe(
       `# Agent Skills\n\n${GIT.name}: ${GIT.path}\n\n---\n\n(git-worktree)`
     )

--- a/src/renderer/lib/skills-prompt.test.ts
+++ b/src/renderer/lib/skills-prompt.test.ts
@@ -1,86 +1,116 @@
 import { describe, expect, it } from 'vitest'
+import { skillToken } from '@/lib/skill-tokens'
 import { formatPromptWithSkills } from '@/lib/skills-prompt'
 
-describe('formatPromptWithSkills', () => {
-  it('returns user text when no skills are provided', () => {
-    expect(formatPromptWithSkills([], 'hello')).toBe('hello')
+const T = skillToken
+
+describe('formatPromptWithSkills (path-based wire framing)', () => {
+  const GIT = { name: 'git-worktree', path: '/home/user/.agents/skills/git-worktree/SKILL.md' }
+  const REL = {
+    name: 'release-version',
+    path: '/home/user/.agents/skills/release-version/SKILL.md'
+  }
+
+  it('frames a single skill as `<name>: <path>` under # Agent Skills then the user text with (name) inline', () => {
+    expect(formatPromptWithSkills([GIT], `use this ${T('git-worktree')} now`)).toBe(
+      `# Agent Skills\n\n${GIT.name}: ${GIT.path}\n\n---\n\nuse this (git-worktree) now`
+    )
   })
 
-  it('frames a single skill under a # Agent Skills header followed by user text', () => {
-    expect(
-      formatPromptWithSkills([{ name: 'git-worktree', body: 'Create a worktree.' }], 'hello')
-    ).toBe('# Agent Skills\n\n## git-worktree\nCreate a worktree.\n\n---\n\nhello')
-  })
-
-  it('frames multiple skills in order, each as its own ## block', () => {
+  it('frames multiple skills, one `<name>: <path>` line each, preserving order', () => {
     expect(
       formatPromptWithSkills(
-        [
-          { name: 'git-worktree', body: 'Create a worktree.' },
-          { name: 'plan', body: 'Plan the work.' }
-        ],
-        'hello'
+        [GIT, REL],
+        `use this ${T('git-worktree')} and then ${T('release-version')}`
       )
     ).toBe(
-      '# Agent Skills\n\n## git-worktree\nCreate a worktree.\n\n## plan\nPlan the work.\n\n---\n\nhello'
+      `# Agent Skills\n\n${GIT.name}: ${GIT.path}\n${REL.name}: ${REL.path}\n\n---\n\nuse this (git-worktree) and then (release-version)`
     )
   })
 
-  it('returns only the skills section when user text is empty', () => {
-    expect(formatPromptWithSkills([{ name: 'git-worktree', body: 'Create a worktree.' }], '')).toBe(
-      '# Agent Skills\n\n## git-worktree\nCreate a worktree.'
+  it('matches the Design Notes wire example verbatim', () => {
+    expect(
+      formatPromptWithSkills(
+        [GIT, REL],
+        `use this ${T('git-worktree')} and then ${T('release-version')}`
+      )
+    ).toBe(
+      [
+        '# Agent Skills',
+        '',
+        'git-worktree: /home/user/.agents/skills/git-worktree/SKILL.md',
+        'release-version: /home/user/.agents/skills/release-version/SKILL.md',
+        '',
+        '---',
+        '',
+        'use this (git-worktree) and then (release-version)'
+      ].join('\n')
     )
   })
 
-  it('returns only user text when every skill body is empty (nothing to frame)', () => {
+  it('dedupes the header by name while the inline (name) repeats per token position', () => {
     expect(
-      formatPromptWithSkills(
-        [
-          { name: 'empty', body: '' },
-          { name: 'whitespace', body: '   ' }
-        ],
-        'hello'
-      )
-    ).toBe('hello')
+      formatPromptWithSkills([GIT], `first ${T('git-worktree')} then ${T('git-worktree')} again`)
+    ).toBe(
+      `# Agent Skills\n\n${GIT.name}: ${GIT.path}\n\n---\n\nfirst (git-worktree) then (git-worktree) again`
+    )
   })
 
-  it('drops skills with empty bodies but keeps skills with content', () => {
-    expect(
-      formatPromptWithSkills(
-        [
-          { name: 'empty', body: '' },
-          { name: 'git-worktree', body: 'Create a worktree.' }
-        ],
-        'hello'
-      )
-    ).toBe('# Agent Skills\n\n## git-worktree\nCreate a worktree.\n\n---\n\nhello')
+  it('returns only the inline-replaced user text when there are no skills', () => {
+    expect(formatPromptWithSkills([], `use this ${T('git-worktree')} now`)).toBe(
+      'use this (git-worktree) now'
+    )
   })
 
-  it('trims leading and trailing whitespace from skill names, bodies, and user text', () => {
-    expect(
-      formatPromptWithSkills(
-        [{ name: '  git-worktree  ', body: '  Create a worktree.  ' }],
-        '  hello  '
-      )
-    ).toBe('# Agent Skills\n\n## git-worktree\nCreate a worktree.\n\n---\n\nhello')
+  it('returns plain user text when there are no skills and no tokens', () => {
+    expect(formatPromptWithSkills([], 'just text')).toBe('just text')
   })
 
-  it('returns empty string when there are no skills and no user text', () => {
+  it('returns empty string for empty skills and empty user text', () => {
     expect(formatPromptWithSkills([], '')).toBe('')
   })
 
-  it('returns only the skills section when user text is whitespace-only', () => {
+  it('returns only the skills section when the user text is empty (token-free)', () => {
+    expect(formatPromptWithSkills([GIT], '')).toBe(`# Agent Skills\n\n${GIT.name}: ${GIT.path}`)
+  })
+
+  it('returns only the skills section when the user text is token-only', () => {
+    expect(formatPromptWithSkills([GIT], T('git-worktree'))).toBe(
+      `# Agent Skills\n\n${GIT.name}: ${GIT.path}\n\n---\n\n(git-worktree)`
+    )
+  })
+
+  it('trims leading/trailing whitespace from names, paths, and the user text', () => {
     expect(
-      formatPromptWithSkills([{ name: 'git-worktree', body: 'Create a worktree.' }], '   ')
-    ).toBe('# Agent Skills\n\n## git-worktree\nCreate a worktree.')
+      formatPromptWithSkills(
+        [{ name: '  git-worktree  ', path: '  /p/SKILL.md  ' }],
+        `  hello ${T('git-worktree')}  `
+      )
+    ).toBe(`# Agent Skills\n\ngit-worktree: /p/SKILL.md\n\n---\n\nhello (git-worktree)`)
+  })
+
+  it('skips skills with empty paths but still replaces their inline tokens with (name)', () => {
+    // A skill surfaced without a path (web parity gap) — the renderer Block If
+    // halts before this point, but the framer is defensive: the header omits it
+    // while the inline (name) still appears so the user text stays readable.
+    expect(formatPromptWithSkills([{ name: 'pathless', path: '' }], `${T('pathless')} hi`)).toBe(
+      '(pathless) hi'
+    )
+  })
+
+  it('skips skills with empty names', () => {
+    expect(
+      formatPromptWithSkills([{ name: '', path: '/p/SKILL.md' }], `hi ${T('git-worktree')}`)
+    ).toBe('hi (git-worktree)')
   })
 
   it('never emits a bare /skill-name as the skill payload', () => {
-    const out = formatPromptWithSkills(
-      [{ name: 'git-worktree', body: 'Create a worktree.' }],
-      'hello'
-    )
-    expect(out).not.toContain('/git-worktree')
-    expect(out).toContain('## git-worktree')
+    const out = formatPromptWithSkills([GIT], `hello ${T('git-worktree')}`)
+    // The skill is cited as `<name>: <path>` and inline `(name)`, never as a
+    // bare `/git-worktree` slash command. (The path legitimately contains the
+    // name as a segment, so we assert no standalone slash-command token.)
+    expect(out).not.toMatch(/(^|\s)\/git-worktree(\s|$)/)
+    expect(out).toContain('git-worktree: ')
+    expect(out).toContain('(git-worktree)')
   })
 })

--- a/src/renderer/lib/skills-prompt.ts
+++ b/src/renderer/lib/skills-prompt.ts
@@ -1,27 +1,48 @@
 /**
- * Frame one or more Agent Skills and the user's text into a single prompt
- * string. Each skill is rendered as `## <name>\n<body>` under a single
- * `# Agent Skills` header, then the user text follows after a `---` separator
- * so the agent knows the skills are named skills (never a bare `/skill-name`).
+ * Frame one or more Agent Skills and the user's text into a single prompt string.
+ * Each skill is cited as `<name>: <path>` under a single `# Agent Skills`
+ * header (the agent reads the body from disk via the path — no body is shipped),
+ * then the user text follows after a `---` separator with each inline skill
+ * token replaced by `(<name>)` so the agent knows where a skill applies in the
+ * sentence. Empty skills → only the inline-replaced user text is returned.
  */
+import { extractSkillNames, replaceSkillTokensInline, type SkillSegment } from '@/lib/skill-tokens'
+
 export interface FramedSkill {
   name: string
-  body: string
+  path: string
 }
 
 export function formatPromptWithSkills(skills: FramedSkill[], userText: string): string {
-  const user = userText.trim()
-  // Drop skills whose body trims to empty — they contribute no instructions
-  // and would produce a bare `## name` with no content. A name is required to
-  // frame a skill; a malformed entry without one is skipped.
-  const framed = skills
-    .map((s) => ({ name: s.name.trim(), body: s.body.trim() }))
-    .filter((s) => s.name.length > 0 && s.body.length > 0)
+  // Inline-replace tokens (→ `(name)`) even when there are no framed skills, so
+  // a value carrying a token with no matching path entry still degrades to
+  // `(name)` rather than leaking a private-use sentinel.
+  const userInline = replaceSkillTokensInline(userText).trim()
 
-  if (framed.length === 0) return user
+  // Unique-by-name header lines; preserve first-appearance order. A skill
+  // without a non-empty path is skipped (the renderer Block If prevents this,
+  // but the framer is defensive).
+  const seen = new Set<string>()
+  const lines: string[] = []
+  for (const s of skills) {
+    const name = s.name.trim()
+    const path = s.path.trim()
+    if (name.length === 0 || path.length === 0) continue
+    if (seen.has(name)) continue
+    seen.add(name)
+    lines.push(`${name}: ${path}`)
+  }
 
-  const skillsSection = `# Agent Skills\n\n${framed.map((s) => `## ${s.name}\n${s.body}`).join('\n\n')}`
-
-  if (!user) return skillsSection
-  return `${skillsSection}\n\n---\n\n${user}`
+  if (lines.length === 0) return userInline
+  const skillsSection = `# Agent Skills\n\n${lines.join('\n')}`
+  if (!userInline) return skillsSection
+  return `${skillsSection}\n\n---\n\n${userInline}`
 }
+
+export type { SkillSegment }
+/**
+ * Extract the unique skill names (in first-appearance order) from a value
+ * carrying skill tokens. Re-exported from the token model for callers that
+ * build the `{name; path}` list at send time.
+ */
+export { extractSkillNames }

--- a/src/renderer/stores/acp-store.test.ts
+++ b/src/renderer/stores/acp-store.test.ts
@@ -792,6 +792,59 @@ describe('acp-store', () => {
     expect(after[0].blocks[0]).toEqual({ type: 'text', text: 'hi there' })
   })
 
+  it('sendPromptBlocks stores displayBlocks in the optimistic message while dispatching the wire blocks', async () => {
+    // The composer splits display (token text, rendered as inline chips in the
+    // timeline) from wire (path-framed text, dispatched to the agent). The
+    // optimistic user message stores the DISPLAY blocks; the agent receives the
+    // WIRE blocks. The display override must NOT alter what is dispatched.
+    seedSession('s1', 'agent-1', false)
+    const dispatched: Array<{ cmd: string; args: unknown }> = []
+    ;(invoke as ReturnType<typeof vi.fn>).mockImplementation(async (cmd: string, args: unknown) => {
+      dispatched.push({ cmd, args })
+      return undefined
+    })
+    const wire = [{ type: 'text', text: '# Agent Skills\n\n---\n\n(git-worktree) hi' }]
+    const display = [{ type: 'text', text: '\uE000git-worktree\uE001 hi' }]
+    void useAcpStore.getState().sendPromptBlocks('s1', wire, { displayBlocks: display })
+    await Promise.resolve()
+    const msgs = useAcpStore.getState().messages['s1']
+    expect(msgs).toHaveLength(1)
+    // The optimistic user message stores the DISPLAY blocks (token text) so the
+    // timeline renders inline chips.
+    expect(msgs[0].blocks).toEqual(display)
+    // The agent is dispatched the WIRE blocks (path-framed text), not the display.
+    // The IPC transport sends `acp_send_prompt` with a `content` payload.
+    const sendCall = dispatched.find((d) => d.cmd === 'acp_send_prompt')
+    expect(sendCall).toBeDefined()
+    expect((sendCall!.args as { content: ContentBlock[] }).content).toEqual(wire)
+  })
+
+  it('sendPromptBlocks echo does not overwrite the display blocks (dedup by turn:<id>)', async () => {
+    // The server `user_prompt` echo carries the wire blocks; the optimistic
+    // message keeps the display blocks because `_onUserPrompt` dedups by
+    // `turn:<id>` (id-keyed, not block-exact).
+    seedSession('s1', 'agent-1', false)
+    ;(invoke as ReturnType<typeof vi.fn>).mockReturnValue(new Promise(() => {}))
+    const wire = [{ type: 'text', text: 'wire-framed' }]
+    const display = [{ type: 'text', text: '\uE000git-worktree\uE001 hi' }]
+    void useAcpStore.getState().sendPromptBlocks('s1', wire, { displayBlocks: display })
+    await Promise.resolve()
+    const msgs = useAcpStore.getState().messages['s1']
+    expect(msgs[0].blocks).toEqual(display)
+    const turnId = msgs[0].id.slice('turn:'.length)
+    // Server echoes the wire blocks for the same turn id — must NOT overwrite the
+    // display blocks (dedup by id keeps the optimistic display).
+    useAcpStore.getState()._onUserPrompt({
+      agentId: 'agent-1',
+      sessionId: 's1',
+      turnId,
+      content: wire
+    })
+    const after = useAcpStore.getState().messages['s1']
+    expect(after).toHaveLength(1)
+    expect(after[0].blocks).toEqual(display)
+  })
+
   it('sendPrompt updates the persisted history title from the first user message', async () => {
     seedSession('s1', 'agent-09d39730', false)
     useAcpStore.setState({

--- a/src/renderer/stores/acp-store.ts
+++ b/src/renderer/stores/acp-store.ts
@@ -501,11 +501,17 @@ interface AcpState {
 
   // Actions — conversation
   sendPrompt: (sessionId: SessionId, text: string) => Promise<void>
-  /** Send a prompt turn carrying structured content blocks (text + image/resource). */
+  /** Send a prompt turn carrying structured content blocks (text + image/resource).
+   *
+   * `blocks` is the wire payload dispatched to the agent. `options.displayBlocks`
+   * (optional) overrides the optimistic user message's blocks so the timeline
+   * can render inline skill chips (token text) while the agent receives the
+   * path-based wire framing. When omitted, the wire blocks are also used for
+   * the optimistic message (display == wire). */
   sendPromptBlocks: (
     sessionId: SessionId,
     blocks: ContentBlock[],
-    options?: { skipUserAppend?: boolean }
+    options?: { skipUserAppend?: boolean; displayBlocks?: ContentBlock[] }
   ) => Promise<void>
   cancelPrompt: (sessionId: SessionId) => Promise<void>
   removeQueuedPrompt: (sessionId: SessionId, queueId: string) => void
@@ -2116,12 +2122,17 @@ async function runPromptTurn(
   userBlocks: ContentBlock[],
   dispatch: (session: AcpSession, turnId: string) => Promise<StopReason>,
   queuedOrigin?: QueuedPrompt,
-  options?: { skipUserAppend?: boolean }
+  options?: { skipUserAppend?: boolean; displayBlocks?: ContentBlock[] }
 ): Promise<void> {
   const session = get().sessions[sessionId]
   if (!session) throw new Error(`unknown session ${sessionId}`)
   if (session.status === 'closed') throw new Error('session is closed')
   if (userBlocks.length === 0) throw new Error('prompt content must not be empty')
+
+  // The optimistic user message stores the display blocks (token text) so the
+  // timeline renders inline chips; the agent receives the wire blocks via
+  // `dispatch`. When no display override is given, display == wire.
+  const displayBlocks = options?.displayBlocks ?? userBlocks
 
   let enqueued = false
   let userMessage: ChatMessage | null = null
@@ -2164,7 +2175,7 @@ async function runPromptTurn(
         userMessage = {
           id: `turn:${turnId}`,
           role: 'user',
-          blocks: userBlocks,
+          blocks: displayBlocks,
           streaming: false,
           timestamp: Date.now(),
           seq: nextSeq()
@@ -2192,7 +2203,7 @@ async function runPromptTurn(
     userMessage = {
       id: `turn:${turnId}`,
       role: 'user',
-      blocks: userBlocks,
+      blocks: displayBlocks,
       streaming: false,
       timestamp: Date.now(),
       seq: nextSeq()

--- a/src/renderer/stores/acp-store.ts
+++ b/src/renderer/stores/acp-store.ts
@@ -918,6 +918,7 @@ function recoverPromptToQueue(
   sessionId: SessionId,
   userMessage: ChatMessage,
   blocks: ContentBlock[],
+  displayBlocks: ContentBlock[] | undefined,
   previousOpenTurnId: string | null,
   attemptedTurnId: string,
   queuedOrigin?: QueuedPrompt
@@ -927,6 +928,7 @@ function recoverPromptToQueue(
       sessionId,
       userMessage,
       blocks,
+      displayBlocks,
       previousOpenTurnId,
       attemptedTurnId,
       createQueueId: nextQueueId,
@@ -961,7 +963,8 @@ function flushNextQueuedPrompt(set: TurnEndSetter, sessionId: SessionId): void {
     sessionId,
     next.blocks,
     (s, turnId) => acpApi.sendPromptBlocks(s.agentId, sessionId, next.blocks, turnId),
-    next
+    next,
+    next.displayBlocks ? { displayBlocks: next.displayBlocks } : undefined
   ).catch((err) => {
     // Busy recovery is handled inside runPromptTurn (FIFO restore via queuedOrigin).
     if (isPromptTurnInProgressError(err)) return
@@ -2163,7 +2166,13 @@ async function runPromptTurn(
         }
       }
       return {
-        promptQueues: appendQueuedPrompt(s.promptQueues, sessionId, userBlocks, nextQueueId)
+        promptQueues: appendQueuedPrompt(
+          s.promptQueues,
+          sessionId,
+          userBlocks,
+          nextQueueId,
+          options?.displayBlocks
+        )
       }
     }
 
@@ -2240,6 +2249,7 @@ async function runPromptTurn(
         sessionId,
         userMessage,
         userBlocks,
+        options?.displayBlocks,
         previousOpenTurnId,
         openTurnId,
         queuedOrigin
@@ -4126,7 +4136,8 @@ export const useAcpStore = create<AcpState>((set, get) => ({
         sessionId,
         item.blocks,
         (s, turnId) => acpApi.sendPromptBlocks(s.agentId, sessionId, item.blocks, turnId),
-        item
+        item,
+        item.displayBlocks ? { displayBlocks: item.displayBlocks } : undefined
       )
     } catch (err) {
       set((s) => ({

--- a/src/renderer/stores/prompt-queue-orchestration.ts
+++ b/src/renderer/stores/prompt-queue-orchestration.ts
@@ -16,8 +16,17 @@ export const TURN_CLEAR_TIMEOUT_MS = 5000
 /** A user prompt waiting to send after the current turn finishes. */
 export interface QueuedPrompt {
   id: string
+  /** Wire blocks dispatched to the agent (path-framed skill text). */
   blocks: ContentBlock[]
   createdAt: number
+  /**
+   * Display blocks stored in the optimistic user message when this queue item
+   * flushes (token text → inline chips in the timeline). When omitted, the wire
+   * blocks are used for display (display == wire). Preserved across enqueue +
+   * recover so the queue preview and the flushed optimistic message keep chips
+   * while the dispatch still sends the wire.
+   */
+  displayBlocks?: ContentBlock[]
 }
 
 export interface TurnBusySession {
@@ -73,12 +82,14 @@ export function appendQueuedPrompt(
   queues: PromptQueueMap,
   sessionId: SessionId,
   blocks: ContentBlock[],
-  createId: () => string
+  createId: () => string,
+  displayBlocks?: ContentBlock[]
 ): PromptQueueMap {
   const item: QueuedPrompt = {
     id: createId(),
     blocks,
-    createdAt: Date.now()
+    createdAt: Date.now(),
+    ...(displayBlocks ? { displayBlocks } : {})
   }
   return {
     ...queues,
@@ -90,6 +101,8 @@ export interface RecoverPromptArgs {
   sessionId: SessionId
   userMessage: RecoverableChatMessage
   blocks: ContentBlock[]
+  /** Display blocks to preserve on the re-queued item (token text → chips). */
+  displayBlocks?: ContentBlock[]
   previousOpenTurnId: string | null
   attemptedTurnId: string
   createQueueId: () => string
@@ -116,6 +129,7 @@ export function buildRecoverPromptToQueuePatch(
     sessionId,
     userMessage,
     blocks,
+    displayBlocks,
     previousOpenTurnId,
     attemptedTurnId,
     createQueueId,
@@ -131,7 +145,7 @@ export function buildRecoverPromptToQueuePatch(
         ...state.promptQueues,
         [sessionId]: [queuedOrigin, ...(state.promptQueues[sessionId] ?? [])]
       }
-    : appendQueuedPrompt(state.promptQueues, sessionId, blocks, createQueueId)
+    : appendQueuedPrompt(state.promptQueues, sessionId, blocks, createQueueId, displayBlocks)
 
   return {
     messages: {


### PR DESCRIPTION
## Summary

Agent-skill chips in the chat composer read like file attachments: they render in a separate full-width row above the textarea, and on send the skill body is concatenated into the user's text block so the timeline shows raw `# Agent Skills` body text instead of chips. This PR makes selected skills render as **inline chips within the typed sentence** (e.g. `use this skill [chip] and then [chip2]`) in both the composer and the timeline, and sends the agent a **path-based** prompt (`# Agent Skills / <name>: <path> / --- / <user text with (name) inline>`) so the agent reads each skill from disk rather than receiving its body inline.

## Related Issue

No related issue — this is a direct user request to make agent-skill chips inline with the chat text (not tracked as a GitHub issue).

## Type of Change

- [x] feat: new feature

## What Changed

- New `src/renderer/lib/skill-tokens.ts`: sentinel token model (`\uE000<name>\uE001`) — parse / insert-at-caret / remove-on-backspace / replace-with-`(name)` / extract-names.
- New `src/renderer/components/chat/SkillComposerOverlay.tsx`: transparent-textarea overlay mirroring the composer value with `SkillChip` pills for tokens (caret/IME/OSK/draft/mentions/slash via `useComposerTextarea` stay untouched).
- `ChatInputBar` / `AgentLauncher`: a skill pick splices a token at the caret (no separate pill row); Backspace removes a whole token; on send the display (tokens) is stored for the timeline and the wire (framed) is dispatched to the agent. Missing skill paths are resolved from the available skills list before erroring.
- `ChatMessage`: the user's own message renders chips inline (no raw skill body); copy uses a display-safe string (tokens → `(name)`) so the clipboard never carries private-use sentinels, while edit keeps the raw token text.
- `skills-prompt.ts`: wire framing is now `# Agent Skills\n<name>: <path>\n---\n<user text with (name) inline>` (paths, not bodies).
- `slash-menu-model` + `skills-api` + `use-agent-skills`: thread a `path` field through the skill data (captured at pick time so send never fails on a missing path).
- `acp-store` + `prompt-queue-orchestration`: `QueuedPrompt` / `runPromptTurn` / `sendPromptBlocks` / `recoverPromptToQueue` model `displayBlocks` so the optimistic message, queue preview/flush, and retry keep the display (token) vs wire split; the `user_prompt` echo is deduped by `turn:<id>` (unchanged).
- `src-tauri/src/skills/mod.rs`: `AgentSkillSummary` / `AgentSkillContent` gain a `path` field (desktop-only); `list_agent_skills_with_home` / `read_agent_skill_with_home` / `resolve_skill_path_with_home` inject the skills root (tests no longer mutate process-wide `HOME`); a relative `project_root` is rejected up front.
- Tests: `skill-tokens` (43) + `skills-prompt` (13), `ChatInputBar` (32), `ChatMessage`, `acp-store` (displayBlocks + echo dedup), `AgentLauncher`, `slash-menu-model`, and Rust `path`-population + absolute-root tests.

## How It Was Tested

- [x] `bun run ci` (Biome lint + format + imports, strict mode)
- [x] `bun run typecheck`
- [x] `bun run test`
- [x] `cargo clippy --all-targets -- -D warnings` (in src-tauri)
- [x] `cargo test` (in src-tauri) — passes on Linux CI (could not execute on the Windows dev host due to the webview2-com-sys loader failure).
- [ ] Manual verification completed — pending: transparent-textarea overlay visual alignment (caret/wrapping/pill metrics) needs a real browser/webview pass.
- [ ] Not applicable

## Screenshots or Recordings

UI change; visual verification is pending a real browser/webview pass (see How It Was Tested).

## CI & Review Gate

- [x] All CI checks pass (PR Validation, Rust Checks, Build Verification, Security Scans)
- [x] Code review comments from CodeRabbit / Claude have been addressed or resolved
- [x] No unresolved review findings remain

## Checklist

- [x] My PR title follows the conventional commit format used by this repo
- [x] I linked the related issue or explained why none exists
- [ ] I updated docs when needed
- [x] I added or updated tests when needed
- [x] I verified the change does not introduce unrelated modifications
- [x] I read AGENTS.md and followed the contributor guidelines
- [x] A human reviewed the complete diff before submission
