### PR TITLE
fix(acp): replace total turn timeout with idle deadline + 3h hard cap

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -69,7 +69,7 @@ flate2 = "1"
 # PTY and async runtime
 portable-pty = "0.9"
 anyhow = "1"
-tokio = { version = "1", features = ["full"] }
+tokio = { version = "1", features = ["full", "test-util"] }
 parking_lot = "0.12"
 futures = "0.3"
 futures-concurrency = "7"

--- a/src-tauri/src/acp/commands.rs
+++ b/src-tauri/src/acp/commands.rs
@@ -264,3 +264,15 @@ pub async fn acp_answer_question(
 pub fn acp_probe_runtime() -> crate::acp::config::AcpRuntimeProbe {
     crate::acp::config::probe_registry_runtime()
 }
+
+/// Set the in-process ACP turn (hard-cap) timeout override, in seconds, or
+/// `None` to clear it (fall back to the env var / 3h default). Pushed from the
+/// App Preferences UI so the turn timeout is editable without a restart or
+/// env var. Desktop-only: the standalone `termul-server` has no settings
+/// surface and configures via `TERMUL_ACP_TURN_TIMEOUT_SECS`. The env var
+/// remains top-precedence (operator/diagnostic override).
+#[tauri::command]
+pub fn acp_set_turn_timeout(secs: Option<u64>) -> Result<(), String> {
+    crate::acp::manager::set_turn_timeout_override(secs);
+    Ok(())
+}

--- a/src-tauri/src/acp/manager.rs
+++ b/src-tauri/src/acp/manager.rs
@@ -26,7 +26,7 @@
 use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::Arc;
+use std::sync::{Arc, LazyLock};
 use std::thread::JoinHandle;
 use std::time::Duration;
 
@@ -168,15 +168,38 @@ pub fn turn_idle_timeout() -> Duration {
         .unwrap_or(TURN_IDLE_TIMEOUT)
 }
 
-/// Hard wall-clock cap per turn, overridable via `TERMUL_ACP_TURN_TIMEOUT_SECS`
-/// (seconds, must be > 0). Defaults to [`TURN_TIMEOUT`] (3h). The last-resort
-/// backstop so a streaming-but-non-completing agent is still bounded.
+/// In-process override for the hard wall-clock cap, set by the
+/// `acp_set_turn_timeout` Tauri command from the App Preferences UI. `None` =
+/// use the env var / default. Consulted by [`resolved_turn_timeout`] so a UI
+/// change takes effect on the next turn without a restart. Desktop-only: the
+/// standalone server has no settings surface and configures via
+/// `TERMUL_ACP_TURN_TIMEOUT_SECS` (the operator env var still wins — see the
+/// precedence in [`resolved_turn_timeout`]).
+static TURN_TIMEOUT_OVERRIDE: LazyLock<parking_lot::Mutex<Option<u64>>> =
+    LazyLock::new(|| parking_lot::Mutex::new(None));
+
+/// Set the in-process turn-timeout override (secs, or `None` to clear). Called
+/// by the `acp_set_turn_timeout` Tauri command (desktop renderer settings).
+pub fn set_turn_timeout_override(secs: Option<u64>) {
+    *TURN_TIMEOUT_OVERRIDE.lock() = secs;
+}
+
+/// Read the in-process turn-timeout override, if set.
+pub fn turn_timeout_override() -> Option<u64> {
+    *TURN_TIMEOUT_OVERRIDE.lock()
+}
+
+/// Hard wall-clock cap per turn. Precedence: `TERMUL_ACP_TURN_TIMEOUT_SECS`
+/// (env, operator/diagnostic) → in-process UI override → [`TURN_TIMEOUT`]
+/// (3h default). The last-resort backstop so a streaming-but-non-completing
+/// agent is still bounded.
 pub fn resolved_turn_timeout() -> Duration {
     std::env::var("TERMUL_ACP_TURN_TIMEOUT_SECS")
         .ok()
         .and_then(|v| v.parse().ok())
         .filter(|secs: &u64| *secs > 0)
         .map(Duration::from_secs)
+        .or_else(|| turn_timeout_override().map(Duration::from_secs))
         .unwrap_or(TURN_TIMEOUT)
 }
 
@@ -3251,5 +3274,20 @@ mod tests {
             "got {result:?}"
         );
         assert_eq!(on_timeout.load(Ordering::SeqCst), 0);
+    }
+
+    /// `resolved_turn_timeout` precedence: env var > UI override > default.
+    /// The override replaces the default when no env var is set.
+    #[test]
+    fn turn_timeout_override_takes_effect_when_no_env_var() {
+        // The env var is usually absent in the test runner; when it IS set
+        // (operator machine), it correctly masks the UI override — skip there.
+        if std::env::var("TERMUL_ACP_TURN_TIMEOUT_SECS").is_ok() {
+            return;
+        }
+        set_turn_timeout_override(Some(42));
+        assert_eq!(resolved_turn_timeout(), Duration::from_secs(42));
+        set_turn_timeout_override(None);
+        assert_eq!(resolved_turn_timeout(), TURN_TIMEOUT);
     }
 }

--- a/src-tauri/src/acp/manager.rs
+++ b/src-tauri/src/acp/manager.rs
@@ -205,12 +205,12 @@ pub fn resolved_turn_timeout() -> Duration {
 
 /// Race an in-flight ACP prompt turn against completion, a cancel signal, an
 /// idle deadline (reset on agent activity via `idle_rx`), and a hard wall-clock
-/// cap. On idle/hard timeout, call `on_timeout_cancel` (signal cancel so the
-/// agent's in-flight `session/prompt` is cancelled too), await `CANCEL_GRACE`
-/// to wind down, then return a typed timeout error. Extracted so the deadline
-/// loop is unit-testable with mock futures. A pre-iteration deadline check
-/// bounds a continuously-ready activity arm (under `biased`) so a
-/// streaming-but-non-completing agent can't slip past the hard cap.
+/// cap. On idle/hard timeout, invoke `on_timeout_cancel` (the caller's cancel
+/// hook — updates DriverState cancel/timeout state so the in-flight turn winds
+/// down), await `CANCEL_GRACE`, then return a typed timeout error. Extracted
+/// so the deadline loop is unit-testable with mock futures. A pre-iteration
+/// deadline check bounds a continuously-ready activity arm (under `biased`) so
+/// a streaming-but-non-completing agent can't slip past the hard cap.
 async fn race_turn<P>(
     prompt: P,
     mut cancel_rx: oneshot::Receiver<()>,
@@ -1597,6 +1597,10 @@ async fn drive_connection(
                     ));
                     return Ok(());
                 }
+                // A permission request is agent activity — the turn is waiting
+                // on user input, not wedged. Nudge the idle deadline so a
+                // user-input wait doesn't false-fire the idle timeout.
+                perm_state.lock().signal_idle(&session_string);
                 let request_id = {
                     let mut state = perm_state.lock();
                     state.bind_tool_call(
@@ -1635,6 +1639,10 @@ async fn drive_connection(
                     }));
                     return Ok(());
                 }
+                // A structured question is agent activity — the turn is waiting
+                // on user input, not wedged. Nudge the idle deadline so a
+                // user-input wait doesn't false-fire the idle timeout.
+                question_state.lock().signal_idle(&session_string);
                 let question_id = {
                     let mut state = question_state.lock();
                     state.register_question(session_string.clone(), responder)
@@ -2352,7 +2360,8 @@ async fn run_command_loop(
                     let idle = turn_idle_timeout();
                     let hard = resolved_turn_timeout();
                     let cancel_state = turn_state.clone();
-                    let cancel_sid = session_id.0.clone();
+                    let cancel_session = session_id.clone();
+                    let cancel_cx = turn_cx.clone();
                     let outcome: Result<StopReason, String> = race_turn(
                         async {
                             turn_cx
@@ -2364,7 +2373,22 @@ async fn run_command_loop(
                         },
                         cancel_rx,
                         &mut idle_rx,
-                        move || cancel_state.lock().signal_cancel(&cancel_sid),
+                        move || {
+                            // Mirror AcpCommand::CancelPrompt: signal the
+                            // active-turn cancel (winds down the race) AND
+                            // notify the agent to abandon its in-flight
+                            // session/prompt. send_notification is non-blocking
+                            // (it queues onto the connection), so race_turn
+                            // stays sync.
+                            cancel_state.lock().signal_cancel(&cancel_session.0);
+                            if let Err(error) =
+                                cancel_cx.send_notification(CancelNotification::new(&cancel_session))
+                            {
+                                log::warn!(
+                                    "[acp] failed to cancel agent prompt on turn timeout: {error}"
+                                );
+                            }
+                        },
                         idle,
                         hard,
                     )

--- a/src-tauri/src/acp/manager.rs
+++ b/src-tauri/src/acp/manager.rs
@@ -42,7 +42,7 @@ use agent_client_protocol::{Agent, Client, ConnectionTo, LineDirection};
 use parking_lot::Mutex;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
-use tokio::sync::{mpsc, oneshot};
+use tokio::sync::{mpsc, oneshot, watch};
 
 use crate::acp::client;
 use crate::acp::config::{AgentConfig, AgentId, SessionId};
@@ -90,15 +90,23 @@ const FIRST_PROMPT_WARMUP_TIMEOUT: Duration = Duration::from_secs(45);
 /// Upper bound on joining a driver thread during `kill`/`kill_all`, so app exit
 /// can never hang on a wedged agent.
 const JOIN_TIMEOUT: Duration = Duration::from_secs(5);
-/// Story 1.9 NFR7: the bounded per-turn timeout. A wedged agent that neither
-/// replies nor crashes parks `send_prompt`'s oneshot forever without this.
-/// 1 hour accommodates long-running agentic turns (some agents run tens of
-/// minutes on a single task) while still bounding the wait so a truly wedged
-/// turn fails → Error state. Distinct from 1.7's 60s permission sub-timeout
-/// (`permissions.rs:47`) — this bounds the WHOLE turn (`send_prompt` →
-/// `prompt_complete`), not the permission-rendezvous window. Overridable via
+/// Idle timeout for an agent turn: if the agent produces NO activity (no
+/// `session/update`/`tool_call` notification) for this long, the turn is
+/// considered wedged and is cancelled. 900s gives breathing room above the
+/// longest expected silent sub-tool (a ~600s shell command) so legitimate
+/// long-running tool calls don't race the idle deadline, while a truly wedged
+/// (silent) turn fails in ~15min instead of hours. Reset on every inbound
+/// notification via `DriverState::signal_idle`. Overridable via
+/// `TERMUL_ACP_TURN_IDLE_TIMEOUT_SECS`.
+const TURN_IDLE_TIMEOUT: Duration = Duration::from_secs(900);
+/// Hard wall-clock cap for a single agent turn — the last-resort backstop so
+/// a chatty-but-non-completing agent (streaming forever) is still bounded. 3h
+/// accommodates very long agentic turns that stay active (the idle timer keeps
+/// resetting, so this only fires for an agent that never stops). On either idle
+/// or hard timeout → cancel + `CANCEL_GRACE` → `status: 'error'`. Distinct from
+/// 1.7's 60s permission sub-timeout (`permissions.rs:47`). Overridable via
 /// `TERMUL_ACP_TURN_TIMEOUT_SECS`.
-const TURN_TIMEOUT: Duration = Duration::from_secs(3600);
+const TURN_TIMEOUT: Duration = Duration::from_secs(10800);
 
 /// `session/new` timeout, overridable for diagnostics via
 /// `TERMUL_ACP_SESSION_NEW_TIMEOUT_SECS` (seconds, must be > 0). Defaults to
@@ -148,10 +156,21 @@ fn session_reopen_timeout() -> Duration {
         .unwrap_or(SESSION_REOPEN_TIMEOUT)
 }
 
-/// Story 1.9 NFR7: per-turn timeout, overridable via
-/// `TERMUL_ACP_TURN_TIMEOUT_SECS` (seconds, must be > 0). Defaults to
-/// [`TURN_TIMEOUT`]. Bounds a wedged agent turn so `send_prompt`'s oneshot
-/// fails with a typed timeout error → Error state (not parked forever).
+/// Per-turn idle timeout, overridable via `TERMUL_ACP_TURN_IDLE_TIMEOUT_SECS`
+/// (seconds, must be > 0). Defaults to [`TURN_IDLE_TIMEOUT`]. The window with
+/// no agent activity after which a turn is considered wedged.
+pub fn turn_idle_timeout() -> Duration {
+    std::env::var("TERMUL_ACP_TURN_IDLE_TIMEOUT_SECS")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .filter(|secs: &u64| *secs > 0)
+        .map(Duration::from_secs)
+        .unwrap_or(TURN_IDLE_TIMEOUT)
+}
+
+/// Hard wall-clock cap per turn, overridable via `TERMUL_ACP_TURN_TIMEOUT_SECS`
+/// (seconds, must be > 0). Defaults to [`TURN_TIMEOUT`] (3h). The last-resort
+/// backstop so a streaming-but-non-completing agent is still bounded.
 pub fn resolved_turn_timeout() -> Duration {
     std::env::var("TERMUL_ACP_TURN_TIMEOUT_SECS")
         .ok()
@@ -159,6 +178,60 @@ pub fn resolved_turn_timeout() -> Duration {
         .filter(|secs: &u64| *secs > 0)
         .map(Duration::from_secs)
         .unwrap_or(TURN_TIMEOUT)
+}
+
+/// Race an in-flight ACP prompt turn against completion, a cancel signal, an
+/// idle deadline (reset on agent activity via `idle_rx`), and a hard wall-clock
+/// cap. On idle/hard timeout, call `on_timeout_cancel` (signal cancel so the
+/// agent's in-flight `session/prompt` is cancelled too), await `CANCEL_GRACE`
+/// to wind down, then return a typed timeout error. Extracted so the deadline
+/// loop is unit-testable with mock futures. A pre-iteration deadline check
+/// bounds a continuously-ready activity arm (under `biased`) so a
+/// streaming-but-non-completing agent can't slip past the hard cap.
+async fn race_turn<P>(
+    prompt: P,
+    mut cancel_rx: oneshot::Receiver<()>,
+    idle_rx: &mut watch::Receiver<()>,
+    on_timeout_cancel: impl Fn(),
+    idle: Duration,
+    hard: Duration,
+) -> Result<StopReason, String>
+where
+    P: std::future::Future<Output = Result<StopReason, String>>,
+{
+    tokio::pin!(prompt);
+    let hard_deadline = tokio::time::Instant::now() + hard;
+    let mut idle_deadline = tokio::time::Instant::now() + idle;
+    loop {
+        let next_deadline = idle_deadline.min(hard_deadline);
+        // Pre-select check: under `biased`, a continuously-ready activity arm
+        // would win every poll and `sleep_until` would never fire — silently
+        // defeating the hard cap for a streaming-but-non-completing agent.
+        if tokio::time::Instant::now() >= next_deadline {
+            on_timeout_cancel();
+            return match tokio::time::timeout(CANCEL_GRACE, &mut prompt).await {
+                Ok(result) => result,
+                Err(_) if next_deadline == idle_deadline => {
+                    Err(format!("turn idle timeout: no agent activity for {idle:?}"))
+                }
+                Err(_) => Err(format!("turn hard timeout: exceeded {hard:?}")),
+            };
+        }
+        tokio::select! {
+            biased;
+            result = &mut prompt => return result,
+            _ = &mut cancel_rx => {
+                return match tokio::time::timeout(CANCEL_GRACE, &mut prompt).await {
+                    Ok(result) => result,
+                    Err(_) => Ok(StopReason::Cancelled),
+                };
+            }
+            _ = idle_rx.changed() => {
+                idle_deadline = tokio::time::Instant::now() + idle;
+            }
+            _ = tokio::time::sleep_until(next_deadline) => {}
+        }
+    }
 }
 
 /// Option snapshot returned by a successful `session/load` or `session/resume`.
@@ -1462,6 +1535,11 @@ async fn drive_connection(
         .on_receive_notification(
             async move |notification: agent_client_protocol::schema::SessionNotification, _cx| {
                 let session_id = notification.session_id.0.to_string();
+                // Any inbound session/update is agent activity — nudge the
+                // active turn's idle deadline so a streaming turn never hits
+                // the idle timeout. Best-effort: a no-op when no turn is
+                // active for this session.
+                notif_state.lock().signal_idle(&session_id);
                 let tool_call_id = match &notification.update {
                     agent_client_protocol::schema::SessionUpdate::ToolCall(tool_call) => {
                         Some(tool_call.tool_call_id.0.to_string())
@@ -2218,8 +2296,8 @@ async fn run_command_loop(
                 // Single-flight per session: reject a second prompt while a turn
                 // is in flight (M4). `try_begin_turn` returns a cancel signal
                 // receiver when the turn may proceed.
-                let cancel_rx = driver_state.lock().try_begin_turn(&session_id.0);
-                let Some(cancel_rx) = cancel_rx else {
+                let handles = driver_state.lock().try_begin_turn(&session_id.0);
+                let Some(handles) = handles else {
                     // Stable code matched by renderer `ACP_TURN_IN_PROGRESS_CODE`.
                     let _ = reply.send(Err(format!(
                         "ACP_TURN_IN_PROGRESS: session {}",
@@ -2227,6 +2305,8 @@ async fn run_command_loop(
                     )));
                     continue;
                 };
+                let cancel_rx = handles.cancel_rx;
+                let mut idle_rx = handles.idle_rx;
 
                 let slot = reply_slot(reply);
                 let task_slot = slot.clone();
@@ -2240,47 +2320,32 @@ async fn run_command_loop(
                 // Story 1.8 T3.2: capture the client turn-id to echo on prompt_complete.
                 let turn_turn_id = turn_id.clone();
                 let spawn_result = cx.spawn(async move {
-                    let request = PromptRequest::new(&session_id, content);
-                    let prompt = turn_cx.send_request(request).block_task();
-                    tokio::pin!(prompt);
-
-                    // Story 1.9 NFR7: race the turn against (a) completion,
-                    // (b) a cancel signal bounded by CANCEL_GRACE (M5), AND
-                    // (c) a bounded turn timeout (a wedged agent that neither
-                    // replies nor crashes must not park `send_prompt`'s
-                    // oneshot forever). On timeout, signal cancel + await the
-                    // CANCEL_GRACE race, then fail with a typed timeout error
-                    // → the `send_prompt` reply surfaces it; `acp-store` sets
-                    // `status: 'error'`.
-                    let turn_deadline = resolved_turn_timeout();
-                    let outcome: Result<StopReason, String> = tokio::select! {
-                        result = &mut prompt => {
-                            result.map(|r| r.stop_reason).map_err(|e| e.to_string())
-                        }
-                        _ = cancel_rx => {
-                            match tokio::time::timeout(CANCEL_GRACE, &mut prompt).await {
-                                Ok(result) => {
-                                    result.map(|r| r.stop_reason).map_err(|e| e.to_string())
-                                }
-                                Err(_) => Ok(StopReason::Cancelled),
-                            }
-                        }
-                        _ = tokio::time::sleep(turn_deadline) => {
-                            // Turn timed out — signal cancel (so the agent's
-                            // in-flight session/prompt is cancelled too) + give
-                            // it CANCEL_GRACE to wind down, then fail.
-                            turn_state.lock().signal_cancel(&session_id.0);
-                            match tokio::time::timeout(CANCEL_GRACE, &mut prompt).await {
-                                Ok(result) => {
-                                    result.map(|r| r.stop_reason).map_err(|e| e.to_string())
-                                }
-                                Err(_) => Err(format!(
-                                    "turn timeout: session {} exceeded {:?}",
-                                    session_id.0, turn_deadline
-                                )),
-                            }
-                        }
-                    };
+                    // Race the turn against completion, a cancel signal, an
+                    // idle deadline (reset by agent `session/update` activity
+                    // via `DriverState::signal_idle`), and a hard wall-clock
+                    // cap. On idle/hard timeout → signal cancel + `CANCEL_GRACE`
+                    // + a typed error (`acp-store` sets `status: 'error'`). See
+                    // [`race_turn`].
+                    let idle = turn_idle_timeout();
+                    let hard = resolved_turn_timeout();
+                    let cancel_state = turn_state.clone();
+                    let cancel_sid = session_id.0.clone();
+                    let outcome: Result<StopReason, String> = race_turn(
+                        async {
+                            turn_cx
+                                .send_request(PromptRequest::new(&session_id, content))
+                                .block_task()
+                                .await
+                                .map(|r| r.stop_reason)
+                                .map_err(|e| e.to_string())
+                        },
+                        cancel_rx,
+                        &mut idle_rx,
+                        move || cancel_state.lock().signal_cancel(&cancel_sid),
+                        idle,
+                        hard,
+                    )
+                    .await;
 
                     match &outcome {
                         Ok(stop_reason) => log::info!(
@@ -3056,5 +3121,135 @@ mod tests {
     #[test]
     fn to_auth_method_infos_empty_for_no_methods() {
         assert!(to_auth_method_infos(&[]).is_empty());
+    }
+
+    // --- race_turn (idle + hard cap + cancel) ---
+
+    /// An active turn (agent streaming activity) keeps resetting its idle
+    /// deadline and completes normally — never hits the idle timeout.
+    #[tokio::test(start_paused = true)]
+    async fn race_turn_activity_resets_idle_and_completes() {
+        let (idle_tx, mut idle_rx) = watch::channel(());
+        let (_cancel_tx, cancel_rx) = oneshot::channel::<()>();
+        let on_timeout = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let on_timeout_clone = on_timeout.clone();
+        // Activity every 20ms (under the 50ms idle window) keeps the idle
+        // deadline pushed back; the prompt completes at 100ms.
+        let activity = tokio::spawn(async move {
+            for _ in 0..6 {
+                tokio::time::sleep(Duration::from_millis(20)).await;
+                let _ = idle_tx.send(());
+            }
+        });
+        let result = race_turn(
+            async {
+                tokio::time::sleep(Duration::from_millis(100)).await;
+                Ok::<StopReason, String>(StopReason::EndTurn)
+            },
+            cancel_rx,
+            &mut idle_rx,
+            move || {
+                on_timeout_clone.fetch_add(1, Ordering::SeqCst);
+            },
+            Duration::from_millis(50),
+            Duration::from_secs(10),
+        )
+        .await;
+        let _ = activity.await;
+        assert!(result.is_ok(), "got {result:?}");
+        assert_eq!(
+            on_timeout.load(Ordering::SeqCst),
+            0,
+            "no timeout should fire for an active turn"
+        );
+    }
+
+    /// A silent (wedged) turn with no activity and no completion hits the idle
+    /// timeout — and signals cancel via `on_timeout_cancel`.
+    #[tokio::test(start_paused = true)]
+    async fn race_turn_silence_hits_idle_timeout() {
+        let (_idle_tx, mut idle_rx) = watch::channel(()); // never fires
+        let (_cancel_tx, cancel_rx) = oneshot::channel::<()>();
+        let on_timeout = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let on_timeout_clone = on_timeout.clone();
+        let result = race_turn(
+            std::future::pending::<Result<StopReason, String>>(),
+            cancel_rx,
+            &mut idle_rx,
+            move || {
+                on_timeout_clone.fetch_add(1, Ordering::SeqCst);
+            },
+            Duration::from_millis(100),
+            Duration::from_secs(10),
+        )
+        .await;
+        let err = result.unwrap_err();
+        assert!(err.contains("idle timeout"), "got {err}");
+        assert_eq!(on_timeout.load(Ordering::SeqCst), 1);
+    }
+
+    /// A turn that streams activity forever but never completes is still
+    /// bounded by the hard wall-clock cap (the pre-loop check fires despite
+    /// the continuously-ready activity arm under `biased`).
+    #[tokio::test(start_paused = true)]
+    async fn race_turn_streaming_non_completing_hits_hard_cap() {
+        let (idle_tx, mut idle_rx) = watch::channel(());
+        let (_cancel_tx, cancel_rx) = oneshot::channel::<()>();
+        let activity = tokio::spawn(async move {
+            loop {
+                tokio::time::sleep(Duration::from_millis(10)).await;
+                let _ = idle_tx.send(());
+            }
+        });
+        let on_timeout = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let on_timeout_clone = on_timeout.clone();
+        let result = race_turn(
+            std::future::pending::<Result<StopReason, String>>(),
+            cancel_rx,
+            &mut idle_rx,
+            move || {
+                on_timeout_clone.fetch_add(1, Ordering::SeqCst);
+            },
+            Duration::from_millis(50),
+            Duration::from_millis(200),
+        )
+        .await;
+        activity.abort();
+        let _ = activity.await;
+        let err = result.unwrap_err();
+        assert!(err.contains("hard timeout"), "got {err}");
+        assert_eq!(on_timeout.load(Ordering::SeqCst), 1);
+    }
+
+    /// A user cancel wins over both timeouts: the cancel arm returns
+    /// `Cancelled` after `CANCEL_GRACE`, and `on_timeout_cancel` is not called.
+    #[tokio::test(start_paused = true)]
+    async fn race_turn_cancel_wins_over_timeouts() {
+        let (_idle_tx, mut idle_rx) = watch::channel(()); // no activity
+        let (cancel_tx, cancel_rx) = oneshot::channel::<()>();
+        let on_timeout = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let on_timeout_clone = on_timeout.clone();
+        // Cancel before the idle window fires.
+        let canceller = tokio::spawn(async move {
+            tokio::time::sleep(Duration::from_millis(20)).await;
+            let _ = cancel_tx.send(());
+        });
+        let result = race_turn(
+            std::future::pending::<Result<StopReason, String>>(),
+            cancel_rx,
+            &mut idle_rx,
+            move || {
+                on_timeout_clone.fetch_add(1, Ordering::SeqCst);
+            },
+            Duration::from_millis(100),
+            Duration::from_secs(10),
+        )
+        .await;
+        let _ = canceller.await;
+        assert!(
+            matches!(result, Ok(StopReason::Cancelled)),
+            "got {result:?}"
+        );
+        assert_eq!(on_timeout.load(Ordering::SeqCst), 0);
     }
 }

--- a/src-tauri/src/acp/session.rs
+++ b/src-tauri/src/acp/session.rs
@@ -19,7 +19,7 @@ use agent_client_protocol::Responder;
 use serde_json::Value;
 use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
-use tokio::sync::oneshot;
+use tokio::sync::{oneshot, watch};
 
 /// A permission request awaiting the user's decision.
 ///
@@ -60,6 +60,13 @@ pub(crate) struct DriverState {
     /// signalled, but the key remains until the turn task finishes so a
     /// concurrent turn cannot slip in during the post-cancel grace window.
     active_turns: HashMap<String, Option<oneshot::Sender<()>>>,
+    /// In-flight idle-reset signal senders per active turn. The
+    /// `session/update`/`tool_call` notification callback fires these
+    /// (non-blocking) so the turn task's idle deadline resets on agent
+    /// activity — a wedged (silent) turn hits the idle timeout fast, an active
+    /// (streaming) turn never does. Mirrors `active_turns`' lifecycle: created
+    /// in `try_begin_turn`, dropped in `finish_turn`.
+    idle_resets: HashMap<String, watch::Sender<()>>,
     /// One-shot waiters registered by turn-scoped operations. `finish_turn`
     /// removes and resolves the full waiter list exactly once.
     turn_idle_waiters: HashMap<String, Vec<oneshot::Sender<()>>>,
@@ -68,6 +75,14 @@ pub(crate) struct DriverState {
     /// Bindings remain for the connection lifetime so delayed updates cannot be
     /// reassigned to a different active turn after their original turn ends.
     tool_call_sessions: HashMap<String, HashSet<String>>,
+}
+
+/// Signals handed to the turn task when a turn begins: the cancel receiver
+/// (user/system cancel) and the idle-reset receiver (fired on agent activity
+/// to push back the idle deadline).
+pub(crate) struct TurnHandles {
+    pub cancel_rx: oneshot::Receiver<()>,
+    pub idle_rx: watch::Receiver<()>,
 }
 
 impl DriverState {
@@ -213,16 +228,20 @@ impl DriverState {
             .insert(session_id);
     }
 
-    /// Attempt to begin a turn for a session. Returns `Some(receiver)` (a cancel
-    /// signal) when the turn may proceed, or `None` if a turn is already active
-    /// for this session (concurrent turns are rejected).
-    pub(crate) fn try_begin_turn(&mut self, session_id: &str) -> Option<oneshot::Receiver<()>> {
+    /// Attempt to begin a turn for a session. Returns `Some(TurnHandles)`
+    /// (cancel + idle-reset receivers) when the turn may proceed, or `None` if
+    /// a turn is already active for this session (concurrent turns are
+    /// rejected). Both signals are created atomically so the notification
+    /// callback can nudge the idle deadline from the moment the turn starts.
+    pub(crate) fn try_begin_turn(&mut self, session_id: &str) -> Option<TurnHandles> {
         if self.active_turns.contains_key(session_id) {
             return None;
         }
-        let (tx, rx) = oneshot::channel();
-        self.active_turns.insert(session_id.to_string(), Some(tx));
-        Some(rx)
+        let (cancel_tx, cancel_rx) = oneshot::channel();
+        let (idle_tx, idle_rx) = watch::channel(());
+        self.active_turns.insert(session_id.to_string(), Some(cancel_tx));
+        self.idle_resets.insert(session_id.to_string(), idle_tx);
+        Some(TurnHandles { cancel_rx, idle_rx })
     }
 
     /// Whether the session currently has an active turn, including cancel grace.
@@ -257,10 +276,22 @@ impl DriverState {
         }
     }
 
+    /// Nudge the active turn's idle deadline — the agent produced activity (a
+    /// `session/update`/`tool_call` notification arrived), so push the idle
+    /// deadline back. Non-blocking and a no-op when no turn is active for the
+    /// session. `watch` coalesces: a burst of notifications resets once, which
+    /// is all the idle clock needs ("activity happened since the last reset").
+    pub(crate) fn signal_idle(&mut self, session_id: &str) {
+        if let Some(tx) = self.idle_resets.get(session_id) {
+            let _ = tx.send(());
+        }
+    }
+
     /// Mark a session's turn finished and return any still-pending permissions
     /// for that session (to be resolved cancelled). Idempotent.
     pub(crate) fn finish_turn(&mut self, session_id: &str) -> Vec<PendingPermission> {
         self.active_turns.remove(session_id);
+        self.idle_resets.remove(session_id);
         if let Some(waiters) = self.turn_idle_waiters.remove(session_id) {
             for waiter in waiters {
                 let _ = waiter.send(());
@@ -335,6 +366,27 @@ mod tests {
             state.try_begin_turn("sess-1").is_some(),
             "a new turn must be allowed once the previous one finished"
         );
+    }
+
+    #[test]
+    fn signal_idle_nudges_the_active_turn_and_is_a_noop_otherwise() {
+        let mut state = DriverState::new();
+        let handles = state.try_begin_turn("sess-1").expect("turn starts");
+        let mut idle_rx = handles.idle_rx;
+        // No activity yet — the idle receiver has observed no change.
+        assert!(!idle_rx.has_changed().unwrap());
+        // An inbound session/update fires signal_idle — the receiver sees it.
+        state.signal_idle("sess-1");
+        assert!(idle_rx.has_changed().unwrap());
+        // mark_changed so has_changed can report a subsequent send again.
+        idle_rx.mark_changed();
+        state.signal_idle("sess-1");
+        assert!(idle_rx.has_changed().unwrap());
+        // No active turn for another session → no-op (no panic).
+        state.signal_idle("no-such-session");
+        // finish_turn drops the idle sender; signal_idle becomes a no-op after.
+        let _ = state.finish_turn("sess-1");
+        state.signal_idle("sess-1");
     }
 
     #[test]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1387,6 +1387,7 @@ pub fn run() {
             acp::commands::acp_answer_question,
             acp::commands::acp_authenticate,
             acp::commands::acp_probe_runtime,
+            acp::commands::acp_set_turn_timeout,
             acp_registry_snapshot::acp_fetch_registry_snapshot,
             acp_binary_install::acp_install_registry_binary,
             // Agent Skills (Zed-compatible SKILL.md packages)

--- a/src/renderer/hooks/use-app-settings.test.ts
+++ b/src/renderer/hooks/use-app-settings.test.ts
@@ -91,8 +91,8 @@ describe('use-app-settings', () => {
 
     await waitFor(() => {
       expect(useAppSettingsStore.getState().isLoaded).toBe(true)
+      expect(mockSetTurnTimeout).toHaveBeenCalledWith(7200)
     })
-    expect(mockSetTurnTimeout).toHaveBeenCalledWith(7200)
   })
 
   it('defaults terminal URL open mode when persisted settings are missing the key', async () => {

--- a/src/renderer/hooks/use-app-settings.test.ts
+++ b/src/renderer/hooks/use-app-settings.test.ts
@@ -19,15 +19,20 @@ const {
   mockPersistenceRead,
   mockPersistenceWrite,
   mockPersistenceWriteDebounced,
-  mockUpdateOrphanDetection
+  mockUpdateOrphanDetection,
+  mockSetTurnTimeout
 } = vi.hoisted(() => ({
   mockPersistenceRead: vi.fn(),
   mockPersistenceWrite: vi.fn(),
   mockPersistenceWriteDebounced: vi.fn(),
-  mockUpdateOrphanDetection: vi.fn()
+  mockUpdateOrphanDetection: vi.fn(),
+  mockSetTurnTimeout: vi.fn()
 }))
 
 vi.mock('@/lib/api', () => ({
+  acpApi: {
+    setTurnTimeout: mockSetTurnTimeout
+  },
   persistenceApi: {
     read: mockPersistenceRead,
     write: mockPersistenceWrite,
@@ -54,6 +59,7 @@ describe('use-app-settings', () => {
     mockPersistenceWrite.mockResolvedValue({ success: true, data: undefined })
     mockPersistenceWriteDebounced.mockResolvedValue({ success: true, data: undefined })
     mockUpdateOrphanDetection.mockResolvedValue({ success: true, data: undefined })
+    mockSetTurnTimeout.mockResolvedValue(undefined)
   })
 
   it('hydrates sidebar and file explorer visibility from persisted app settings', async () => {
@@ -73,6 +79,20 @@ describe('use-app-settings', () => {
       expect(useSidebarStore.getState().isVisible).toBe(false)
       expect(useFileExplorerStore.getState().isVisible).toBe(true)
     })
+  })
+
+  it('pushes the ACP turn-timeout override to the backend on load', async () => {
+    mockPersistenceRead.mockResolvedValueOnce({
+      success: true,
+      data: { ...DEFAULT_APP_SETTINGS, acpTurnTimeoutSecs: 7200 }
+    })
+
+    renderHook(() => useAppSettingsLoader())
+
+    await waitFor(() => {
+      expect(useAppSettingsStore.getState().isLoaded).toBe(true)
+    })
+    expect(mockSetTurnTimeout).toHaveBeenCalledWith(7200)
   })
 
   it('defaults terminal URL open mode when persisted settings are missing the key', async () => {

--- a/src/renderer/hooks/use-app-settings.ts
+++ b/src/renderer/hooks/use-app-settings.ts
@@ -1,5 +1,5 @@
 import { useCallback, useEffect } from 'react'
-import { persistenceApi, terminalApi } from '@/lib/api'
+import { acpApi, persistenceApi, terminalApi } from '@/lib/api'
 import { getSystemAppearance, normalizeThemeFamilyId } from '@/lib/themes/theme-appearance'
 import { useAppSettingsStore } from '@/stores/app-settings-store'
 import { useFileExplorerStore } from '@/stores/file-explorer-store'
@@ -190,6 +190,14 @@ export function useAppSettingsLoader(): void {
         )
       } catch (error) {
         console.error('Failed to apply orphan detection settings:', error)
+      }
+
+      // Push the ACP turn-timeout override to the Rust core (desktop-only
+      // via the transport; the WS transport no-ops on the standalone server).
+      try {
+        await acpApi.setTurnTimeout(settings.acpTurnTimeoutSecs)
+      } catch (error) {
+        console.error('Failed to apply ACP turn timeout:', error)
       }
     }
     load()

--- a/src/renderer/hooks/use-app-settings.ts
+++ b/src/renderer/hooks/use-app-settings.ts
@@ -273,5 +273,12 @@ export function useResetAppSettings(): () => Promise<void> {
     if (result.success) {
       syncPersistedPanelSettingsSnapshot(DEFAULT_APP_SETTINGS)
     }
+    // Clear the in-process turn-timeout override too (mirrors the load hook's
+    // push, so a reset doesn't leave a stale override in the Rust core).
+    try {
+      await acpApi.setTurnTimeout(DEFAULT_APP_SETTINGS.acpTurnTimeoutSecs)
+    } catch (error) {
+      console.error('Failed to clear ACP turn timeout on reset:', error)
+    }
   }, [resetToDefaults])
 }

--- a/src/renderer/lib/acp-api.ts
+++ b/src/renderer/lib/acp-api.ts
@@ -604,6 +604,13 @@ export async function acpAuthenticate(agentId: AgentId, methodId: string): Promi
   await getAcpTransport().authenticate(agentId, methodId)
 }
 
+// Push the ACP turn (hard-cap) timeout override to the backend, in seconds,
+// or `null` to clear (fall back to the env var / default). Desktop-only: the
+// WS transport no-ops on the standalone server.
+export async function acpSetTurnTimeout(secs: number | null): Promise<void> {
+  await getAcpTransport().setTurnTimeout(secs)
+}
+
 // --- Event subscription ----------------------------------------------------
 
 /**
@@ -633,6 +640,7 @@ export const acpApi = {
   respondPermission: acpRespondPermission,
   answerQuestion: acpAnswerQuestion,
   authenticate: acpAuthenticate,
+  setTurnTimeout: acpSetTurnTimeout,
   installRegistryBinary: acpInstallRegistryBinary,
   probeRuntime: acpProbeRuntime,
   fetchRegistrySnapshot: acpFetchRegistrySnapshot,

--- a/src/renderer/lib/acp-transport.ts
+++ b/src/renderer/lib/acp-transport.ts
@@ -66,6 +66,7 @@ export interface AcpTransport {
     request: InstallAcpRegistryBinaryRequest
   ): Promise<InstallAcpRegistryBinaryOutcome>
   probeRuntime(): Promise<AcpRuntimeAvailability>
+  setTurnTimeout(secs: number | null): Promise<void>
   fetchRegistrySnapshot(forceRefresh?: boolean): Promise<AcpRegistrySnapshot>
   spawnAgent(config: AgentConfig): Promise<AgentId>
   killAgent(agentId: AgentId): Promise<void>
@@ -167,6 +168,7 @@ function createTauriAcpTransport(): AcpTransport {
     installRegistryBinary: (request) =>
       invoke<InstallAcpRegistryBinaryOutcome>('acp_install_registry_binary', { request }),
     probeRuntime: () => invoke<AcpRuntimeAvailability>('acp_probe_runtime'),
+    setTurnTimeout: (secs) => invoke<void>('acp_set_turn_timeout', { secs }),
     fetchRegistrySnapshot: (forceRefresh = false) =>
       invoke<AcpRegistrySnapshot>('acp_fetch_registry_snapshot', { forceRefresh }),
     spawnAgent: (config) => invoke<AgentId>('acp_spawn_agent', { config }),
@@ -539,6 +541,11 @@ export class WsAcpTransport implements AcpTransport {
 
   async probeRuntime(): Promise<AcpRuntimeAvailability> {
     return { npx: true, uvx: true }
+  }
+
+  async setTurnTimeout(_secs: number | null): Promise<void> {
+    // Desktop-only: the standalone server has no settings surface and
+    // configures the turn timeout via TERMUL_ACP_TURN_TIMEOUT_SECS.
   }
 
   async fetchRegistrySnapshot(_forceRefresh = false): Promise<AcpRegistrySnapshot> {

--- a/src/renderer/pages/AppPreferences.tsx
+++ b/src/renderer/pages/AppPreferences.tsx
@@ -34,12 +34,13 @@ import {
   useResetShortcut,
   useUpdateShortcut
 } from '@/hooks/use-keyboard-shortcuts'
-import { logApi, shellApi, terminalApi } from '@/lib/api'
+import { acpApi, logApi, shellApi, terminalApi } from '@/lib/api'
 import { availableColors, getColorClasses } from '@/lib/colors'
 import type { SettingsSearchEntry } from '@/lib/settings-search'
 import { isAurUpdateMode } from '@/lib/tauri-updater-api'
 import { cn } from '@/lib/utils'
 import {
+  useAcpTurnTimeout,
   useConfirmTerminalClose,
   useDefaultProjectColor,
   useDefaultShell,
@@ -57,6 +58,7 @@ import { useKeyboardShortcutsStore } from '@/stores/keyboard-shortcuts-store'
 import { useUpdaterActions, useUpdaterState } from '@/stores/updater-store'
 import type { ProjectColor } from '@/types/project'
 import {
+  ACP_TURN_TIMEOUT_OPTIONS,
   BUFFER_SIZE_OPTIONS,
   FONT_FAMILY_OPTIONS,
   MAX_TERMINALS_OPTIONS,
@@ -157,6 +159,12 @@ const APP_PREF_SEARCH_INDEX: SettingsSearchEntry[] = [
     keywords: ['acp', 'agent', 'coding assistant']
   },
   {
+    categoryId: 'ai-agents',
+    label: 'Turn Timeout',
+    description: 'Maximum wall-clock duration for a single agent turn (hard cap).',
+    keywords: ['acp', 'timeout', 'turn', 'hard cap', 'unlimited', 'wedge']
+  },
+  {
     categoryId: 'mcp-servers',
     label: 'MCP Servers',
     description: 'Manage global stdio, HTTP, and SSE servers for new agent sessions.',
@@ -209,6 +217,7 @@ export default function AppPreferences(): React.JSX.Element {
   const orphanDetectionTimeout = useOrphanDetectionTimeout()
   const _confirmTerminalClose = useConfirmTerminalClose()
   const terminalUrlOpenMode = useTerminalUrlOpenMode()
+  const acpTurnTimeoutSecs = useAcpTurnTimeout()
   const updateSetting = useUpdateAppSetting()
   const resetSettings = useResetAppSettings()
 
@@ -320,6 +329,16 @@ export default function AppPreferences(): React.JSX.Element {
       await terminalApi.updateOrphanDetection(orphanDetectionEnabled, value)
     } catch (error) {
       console.error('Failed to update orphan detection timeout:', error)
+    }
+  }
+
+  const handleAcpTurnTimeoutChange = async (value: number | null) => {
+    await updateSetting('acpTurnTimeoutSecs', value)
+    // Push to the Rust core so the next turn picks up the new hard cap.
+    try {
+      await acpApi.setTurnTimeout(value)
+    } catch (error) {
+      console.error('Failed to apply ACP turn timeout:', error)
     }
   }
 
@@ -739,8 +758,37 @@ export default function AppPreferences(): React.JSX.Element {
                   automatically.
                 </p>
               </div>
-              <div className="w-2/3">
+              <div className="w-2/3 space-y-4">
                 <AcpAgentsSettings />
+                <div>
+                  <label className="block text-sm font-medium text-secondary-foreground mb-2">
+                    Turn Timeout (hard cap)
+                  </label>
+                  <select
+                    value={acpTurnTimeoutSecs === null ? 'null' : String(acpTurnTimeoutSecs)}
+                    onChange={(e) =>
+                      handleAcpTurnTimeoutChange(
+                        e.target.value === 'null' ? null : parseInt(e.target.value, 10)
+                      )
+                    }
+                    className="w-full bg-secondary/50 border border-border rounded-lg px-3 py-2 text-sm text-foreground focus:ring-2 focus:ring-primary focus:border-transparent outline-none transition-shadow"
+                  >
+                    {ACP_TURN_TIMEOUT_OPTIONS.map((option) => (
+                      <option
+                        key={option.value === null ? 'null' : String(option.value)}
+                        value={option.value === null ? 'null' : String(option.value)}
+                      >
+                        {option.label}
+                      </option>
+                    ))}
+                  </select>
+                  <p className="text-xs text-muted-foreground mt-1">
+                    Maximum wall-clock duration for a single agent turn. Active turns that stream
+                    continuously run until this cap; a silent (wedged) turn errors after ~15min
+                    regardless. The TERMUL_ACP_TURN_TIMEOUT_SECS env var still overrides this
+                    (operator/diagnostic).
+                  </p>
+                </div>
               </div>
             </div>
           </SettingsSection>

--- a/src/renderer/pages/AppPreferences.tsx
+++ b/src/renderer/pages/AppPreferences.tsx
@@ -37,6 +37,7 @@ import {
 import { acpApi, logApi, shellApi, terminalApi } from '@/lib/api'
 import { availableColors, getColorClasses } from '@/lib/colors'
 import type { SettingsSearchEntry } from '@/lib/settings-search'
+import { isTauriContext } from '@/lib/tauri-runtime'
 import { isAurUpdateMode } from '@/lib/tauri-updater-api'
 import { cn } from '@/lib/utils'
 import {
@@ -771,7 +772,8 @@ export default function AppPreferences(): React.JSX.Element {
                         e.target.value === 'null' ? null : parseInt(e.target.value, 10)
                       )
                     }
-                    className="w-full bg-secondary/50 border border-border rounded-lg px-3 py-2 text-sm text-foreground focus:ring-2 focus:ring-primary focus:border-transparent outline-none transition-shadow"
+                    disabled={!isTauriContext()}
+                    className="w-full bg-secondary/50 border border-border rounded-lg px-3 py-2 text-sm text-foreground focus:ring-2 focus:ring-primary focus:border-transparent outline-none transition-shadow disabled:opacity-50 disabled:cursor-not-allowed"
                   >
                     {ACP_TURN_TIMEOUT_OPTIONS.map((option) => (
                       <option
@@ -786,7 +788,7 @@ export default function AppPreferences(): React.JSX.Element {
                     Maximum wall-clock duration for a single agent turn. Active turns that stream
                     continuously run until this cap; a silent (wedged) turn errors after ~15min
                     regardless. The TERMUL_ACP_TURN_TIMEOUT_SECS env var still overrides this
-                    (operator/diagnostic).
+                    (operator/diagnostic). Desktop only — the standalone server uses the env var.
                   </p>
                 </div>
               </div>

--- a/src/renderer/stores/app-settings-store.ts
+++ b/src/renderer/stores/app-settings-store.ts
@@ -61,3 +61,5 @@ export const useFileExplorerVisibilitySetting = () =>
 export const useColorTheme = () => useAppSettingsStore((state) => state.settings.colorTheme)
 export const useAppearanceMode = () => useAppSettingsStore((state) => state.settings.appearanceMode)
 export const useUiZoomLevel = () => useAppSettingsStore((state) => state.settings.uiZoomLevel)
+export const useAcpTurnTimeout = () =>
+  useAppSettingsStore((state) => state.settings.acpTurnTimeoutSecs)

--- a/src/renderer/types/settings.ts
+++ b/src/renderer/types/settings.ts
@@ -154,17 +154,17 @@ export const REMOTE_BIND_MODE_OPTIONS: Array<{
 ]
 
 // ACP turn (hard-cap) timeout options for the App Preferences UI. `null` =
-// follow the Rust default (3h); a number is the override in seconds.
+// follow the env var / Rust default (3h); a number is the override in seconds.
 export const ACP_TURN_TIMEOUT_OPTIONS: Array<{
   value: number | null
   label: string
 }> = [
-  { value: null, label: 'Default (3 hours)' },
+  { value: null, label: 'Environment/default (3 hours)' },
   { value: 3600, label: '1 hour' },
   { value: 7200, label: '2 hours' },
   { value: 21600, label: '6 hours' },
   { value: 86400, label: '24 hours' },
-  { value: 31536000, label: 'Unlimited (1 year)' }
+  { value: 31536000, label: '1 year' }
 ]
 
 // Default application settings

--- a/src/renderer/types/settings.ts
+++ b/src/renderer/types/settings.ts
@@ -64,6 +64,9 @@ export interface AppSettings {
   appearanceMode: 'light' | 'dark'
   /** Whole-UI zoom factor (1.0 = 100%). Scales the entire window like VS Code's window zoom. */
   uiZoomLevel: number
+  /** ACP turn hard-cap timeout in seconds, or null = use the Rust default
+   * (3h). Set via App Preferences; pushed to the Rust core. */
+  acpTurnTimeoutSecs: number | null
 }
 
 /** Whole-UI zoom bounds — match the native View menu semantics (0.5x–3.0x, 10% steps). */
@@ -150,6 +153,20 @@ export const REMOTE_BIND_MODE_OPTIONS: Array<{
   }
 ]
 
+// ACP turn (hard-cap) timeout options for the App Preferences UI. `null` =
+// follow the Rust default (3h); a number is the override in seconds.
+export const ACP_TURN_TIMEOUT_OPTIONS: Array<{
+  value: number | null
+  label: string
+}> = [
+  { value: null, label: 'Default (3 hours)' },
+  { value: 3600, label: '1 hour' },
+  { value: 7200, label: '2 hours' },
+  { value: 21600, label: '6 hours' },
+  { value: 86400, label: '24 hours' },
+  { value: 31536000, label: 'Unlimited (1 year)' }
+]
+
 // Default application settings
 export const DEFAULT_APP_SETTINGS: AppSettings = {
   terminalFontFamily: 'Menlo, Monaco, "Courier New", monospace',
@@ -169,7 +186,8 @@ export const DEFAULT_APP_SETTINGS: AppSettings = {
   remoteBindMode: 'localhost',
   colorTheme: 'termul',
   appearanceMode: 'dark',
-  uiZoomLevel: UI_ZOOM_DEFAULT
+  uiZoomLevel: UI_ZOOM_DEFAULT,
+  acpTurnTimeoutSecs: null
 }
 
 // Persistence key for app settings


### PR DESCRIPTION
## Summary

termul bounded every ACP turn with a single total `TURN_TIMEOUT = 3600s` (1h) that resets on nothing — so a long-but-active turn (an agent streaming `session/update` for >1h) was killed mid-work, while a wedged-but-alive turn (silent, e.g. its LLM API unreachable) made the user wait the full hour before it errored and became retryable. The 1h total cap is the wrong shape: ACP itself imposes no per-turn deadline, and agents run "until done or cancelled".

This replaces the total timeout with a two-deadline model (ported from buzz's proven `read_until_response_with_idle_timeout`): an **idle timeout** (default 900s, reset on every inbound `session/update`/`tool_call` notification) that catches wedged/silent turns in ~15min, and a **hard wall-clock cap** (default 3h) enforced via a pre-loop deadline check so streaming-but-non-completing turns are still bounded. On either firing → reuse the existing cancel + `CANCEL_GRACE` + `status: 'error'` → `retryCrashedSession` path. Active long turns that stream continuously are no longer killed at 1h.

The hard cap is also **editable from App Preferences** (a `Turn Timeout` control under AI Agents) so it can be tuned without a restart or env var; the change takes effect on the next turn.

## Related Issue

No related issue. The design of record is the frozen ready-for-dev spec `_bmad-output/implementation-artifacts/spec-acp-turn-idle-timeout.md` ("ACP turn idle-timeout (replace total TURN_TIMEOUT)"); no GitHub issue tracks it. The spec's hard-cap default (7200s / 2h) was renegotiated to 10800s / 3h per contributor direction — a default-duration change, not the spec's "removing the hard cap (going truly unlimited)" Ask-First boundary.

## Type of Change

- [x] fix: bug fix
- [x] feat: new feature (the App Preferences turn-timeout control)

## What Changed

**Rust timeout model** (`fix` commit `b31e447e`):
- `src-tauri/src/acp/manager.rs` — replaced the single `TURN_TIMEOUT = 3600s` with `TURN_IDLE_TIMEOUT = 900s` + `TURN_TIMEOUT = 10800s` (3h); added `turn_idle_timeout()` env-override fn; kept `resolved_turn_timeout()` as the hard-cap resolver; added `race_turn()` (races completion vs cancel vs idle-deadline-reset-by-activity vs hard-cap, with a pre-iteration `Instant::now() >= next_deadline` check so a continuously-ready activity arm under `biased` can't slip past the hard cap); wired the `on_receive_notification` callback to `DriverState::signal_idle`; replaced the `SendPrompt` arm's total-deadline `select!` with a `race_turn` call; 4 `race_turn` unit tests (activity-resets-idle, silence-idle, streaming-hard-cap, cancel-wins).
- `src-tauri/src/acp/session.rs` — added `idle_resets: HashMap<String, watch::Sender<()>>` to `DriverState`; added `TurnHandles { cancel_rx, idle_rx }`; `try_begin_turn` now returns `TurnHandles`; added `signal_idle` (non-blocking, `watch`-coalesced); `finish_turn` drops the idle sender; 1 `signal_idle` unit test.
- `src-tauri/Cargo.toml` — `tokio` `test-util` feature for `#[tokio::test(start_paused = true)]`.
- `src-tauri/src/web/ws.rs` — **no change**: `RuntimePolicy::resolved` still calls `resolved_turn_timeout()`; `prompt_inactivity_timeout_ms = turn_timeout/2` now scales with the 3h cap (5400s), preserving the "half the ceiling" relationship.

**Settings UI** (`feat` commit `b976e6fe`):
- `src-tauri/src/acp/manager.rs` — in-process `TURN_TIMEOUT_OVERRIDE` cache + `set_turn_timeout_override()`/`turn_timeout_override()`; `resolved_turn_timeout()` precedence is now **env var > UI override > 3h default** (the operator env var still wins); +precedence unit test.
- `src-tauri/src/acp/commands.rs` + `src-tauri/src/lib.rs` — `acp_set_turn_timeout` Tauri command (sync, no `State`) + registered in `generate_handler!`.
- `src/renderer/lib/acp-transport.ts` + `src/renderer/lib/acp-api.ts` — `setTurnTimeout` on the `AcpTransport` interface + Tauri impl (`invoke('acp_set_turn_timeout')`) + WS impl (no-op = **desktop-only gate**; the standalone `termul-server` has no settings surface and configures via `TERMUL_ACP_TURN_TIMEOUT_SECS`).
- `src/renderer/types/settings.ts` + `app-settings-store.ts` + `hooks/use-app-settings.ts` — `acpTurnTimeoutSecs: number | null` (`null` = Rust default) pushed to the backend on load.
- `src/renderer/pages/AppPreferences.tsx` — a `Turn Timeout (hard cap)` select under AI Agents with `Default (3h)` / 1h / 2h / 6h / 24h / `Unlimited (1 year)` options + search entry.
- `src/renderer/hooks/use-app-settings.test.ts` — regression test that the override is pushed on load.

Distinct `IdleTimeout`/`HardTimeout` error messages are surfaced via the existing `log::warn!("[acp] session {} turn failed: {message}", ...)` path. The Story 1.9 NFR7 wedged-agent safety bound is preserved (and improved: wedged turns now fail in ~15min instead of 1h).

## How It Was Tested

- [x] `bun run ci` (Biome lint + format + imports, strict mode) — green (exit 0)
- [x] `bun run typecheck` (node + web + test configs) — green (exit 0)
- [x] `bun run test` (Vitest) — green (2783 passed, 43 skipped, exit 0)
- [x] `cargo clippy --all-targets -D warnings` (in src-tauri) — green (compiles crate + all test targets, lint-free)
- [ ] `cargo test` (in src-tauri) — environmentally blocked on this Windows machine: the test binary fails to load with `STATUS_ENTRYPOINT_NOT_FOUND` (a native-DLL entrypoint issue at binary startup, before any test runs); confirmed pre-existing — the `dev`-tip checkout fails identically. The 6 new Rust tests are pure Rust (tokio only), compile clean, and run in CI (Linux).
- [ ] Manual verification completed
- [ ] Not applicable

The standalone-server (`cargo build --bin termul-server --features standalone-server`) and Tauri-frontend (`bun run build:frontend:tauri`) build gates were not run locally because the local disk filled during the full-build matrix (the worktree's `target/` + the main checkout's `target/` consumed all free space); `bun run build:web` passed. These build gates run in CI (Linux, ample disk).

## Screenshots or Recordings

Not a UI layout change (a new settings dropdown).

## CI & Review Gate

- [ ] All CI checks pass (PR Validation, Rust Checks, Build Verification, Security Scans)
- [ ] Code review comments from CodeRabbit / Claude have been addressed or resolved
- [ ] No unresolved review findings remain

## Checklist

- [x] My PR title follows the conventional commit format used by this repo
- [x] I linked the related issue or explained why none exists
- [ ] I updated docs when needed
- [x] I added or updated tests when needed
- [x] I verified the change does not introduce unrelated modifications
- [x] I read AGENTS.md and followed the contributor guidelines
- [ ] A human reviewed the complete diff before submission


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable ACP turn-timeout settings in Application Preferences.
  * Choose a maximum turn duration or restore the default three-hour limit.
  * Timeout settings are saved and applied automatically when the app starts.

* **Bug Fixes**
  * Improved handling of long-running agent responses by resetting idle timeouts when activity is detected.
  * Added separate idle and maximum duration limits for turns.
  * Improved cancellation behavior, including graceful resolution near completion.
  * Added clearer handling for timed-out turns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->