### PR TITLE
fix: align skill chips with caret and stop duplicate launch bubbles

### DIFF
--- a/src/renderer/assets/agent-icons/acp/agents.json
+++ b/src/renderer/assets/agent-icons/acp/agents.json
@@ -70,11 +70,11 @@
   {
     "id": "claude-acp",
     "name": "Claude Agent",
-    "version": "0.64.0",
+    "version": "0.64.1",
     "description": "ACP wrapper for Anthropic's Claude",
     "distribution": {
       "npx": {
-        "package": "@agentclientprotocol/claude-agent-acp@0.64.0"
+        "package": "@agentclientprotocol/claude-agent-acp@0.64.1"
       }
     }
   },
@@ -105,11 +105,11 @@
   {
     "id": "codex-acp",
     "name": "Codex",
-    "version": "1.1.8",
+    "version": "1.1.9",
     "description": "ACP adapter for OpenAI's coding assistant",
     "distribution": {
       "npx": {
-        "package": "@agentclientprotocol/codex-acp@1.1.8"
+        "package": "@agentclientprotocol/codex-acp@1.1.9"
       }
     }
   },

--- a/src/renderer/components/agents/AgentLauncher.tsx
+++ b/src/renderer/components/agents/AgentLauncher.tsx
@@ -974,29 +974,38 @@ export function AgentLauncher({ paneId, className }: AgentLauncherProps): React.
               onRemove={removeAttachment}
               className="px-5 pt-4"
             />
-            <div className="relative px-5 pb-2 pt-4">
+            <div className="px-5 pb-2 pt-4">
               {/* Transparent-textarea overlay: mirrors the value with inline
                   SkillChip pills. The textarea text is transparent with a
                   visible caret; this overlay renders the visible text + chips
-                  in the same metrics so the caret stays aligned. */}
-              <SkillComposerOverlay textareaRef={textareaRef} value={prompt} />
-              <textarea
-                ref={textareaRef}
-                value={prompt}
-                onChange={onInput}
-                onKeyDown={handleKeyDown}
-                onKeyUp={onKeyUp}
-                onSelect={onSelect}
-                onPaste={handlePaste}
-                placeholder="Ask for follow-up changes or attach files (@ for files, / for commands)"
-                rows={2}
-                aria-label="Agent prompt"
-                autoFocus
-                className={cn(
-                  'relative z-10 max-h-40 min-h-[76px] w-full resize-none bg-transparent text-sm leading-relaxed outline-none placeholder:text-muted-foreground/55',
-                  hasSkillToken ? 'text-transparent caret-foreground' : 'text-foreground'
-                )}
-              />
+                  in the same metrics so the caret stays aligned.
+
+                  The overlay is `absolute inset-0`, so its containing block
+                  must be a box that exactly matches the textarea — not the
+                  padded parent (which would shift the overlay up-left by the
+                  parent's padding and paint chips above the caret). The inner
+                  `relative` wrapper has no padding, so its box == the
+                  textarea's box and the overlay stays caret-aligned. */}
+              <div className="relative">
+                <SkillComposerOverlay textareaRef={textareaRef} value={prompt} />
+                <textarea
+                  ref={textareaRef}
+                  value={prompt}
+                  onChange={onInput}
+                  onKeyDown={handleKeyDown}
+                  onKeyUp={onKeyUp}
+                  onSelect={onSelect}
+                  onPaste={handlePaste}
+                  placeholder="Ask for follow-up changes or attach files (@ for files, / for commands)"
+                  rows={2}
+                  aria-label="Agent prompt"
+                  autoFocus
+                  className={cn(
+                    'relative z-10 max-h-40 min-h-[76px] w-full resize-none bg-transparent text-sm leading-relaxed outline-none placeholder:text-muted-foreground/55',
+                    hasSkillToken ? 'text-transparent caret-foreground' : 'text-foreground'
+                  )}
+                />
+              </div>
             </div>
             <div className="flex items-center justify-between gap-3 px-3 pb-3">
               <AttachFilesButton onClick={() => void pickFiles()} disabled={!canPick} />

--- a/src/renderer/components/chat/ChatInputBar.tsx
+++ b/src/renderer/components/chat/ChatInputBar.tsx
@@ -701,54 +701,63 @@ export function ChatInputBar({
               />
             )}
             <AttachmentPreviewGroup attachments={attachments} onRemove={removeAttachment} />
-            <div className="relative px-4 pb-1.5 pt-3.5">
+            <div className="px-4 pb-1.5 pt-3.5">
               {/* Transparent-textarea overlay: mirrors the value with inline
                   SkillChip pills. The textarea text is transparent with a
-                  visible caret; this overlay renders the visible text + chips in
-                  the same metrics so the caret stays aligned. */}
-              <SkillComposerOverlay textareaRef={textareaRef} value={value} />
-              <textarea
-                ref={textareaRef}
-                value={value}
-                onChange={onInput}
-                onKeyDown={handleKeyDown}
-                onKeyUp={onKeyUp}
-                onSelect={onSelect}
-                onPaste={handlePaste}
-                // Story 5.3 (T2.3): on mobile web when the OSK is open, scroll
-                // the textarea into view once per OSK-open window so iOS Safari
-                // doesn't leave the input under the keyboard. rAF-deferred to
-                // let layout settle. Guarded against focus-loop thrash (the OSK
-                // can re-focus the textarea as it animates; only the first
-                // focus per OSK-open window triggers the scroll).
-                onFocus={() => {
-                  setFocused(true)
-                  // OSK-open scroll is handled by the `osk.isOskOpen`
-                  // transition effect above (the OSK state can lag the focus
-                  // event, so reading it here was unreliable).
-                }}
-                onBlur={() => setFocused(false)}
-                // Story 5.3 (T2.4): mobile keyboards show a "send" affordance.
-                // Do NOT change Enter keyboard semantics — handleKeyDown still
-                // routes Enter→send only when the slash menu is closed.
-                inputMode="text"
-                enterKeyHint="send"
-                disabled={disabled || sending}
-                rows={1}
-                placeholder={
-                  disabled
-                    ? 'Session closed'
-                    : activeCommand
-                      ? 'Add a message (optional)…'
-                      : 'Ask anything… (/ for commands, @ for files)'
-                }
-                className={cn(
-                  'relative z-10 min-h-[52px] w-full resize-none bg-transparent text-sm leading-relaxed',
-                  hasSkillToken ? 'text-transparent caret-foreground' : 'text-foreground',
-                  'placeholder:text-muted-foreground focus:outline-none',
-                  'disabled:cursor-not-allowed disabled:opacity-50 max-h-40'
-                )}
-              />
+                  visible caret; this overlay renders the visible text + chips
+                  in the same metrics so the caret stays aligned.
+
+                  The overlay is `absolute inset-0`, so its containing block
+                  must be a box that exactly matches the textarea — not the
+                  padded parent (which would shift the overlay up-left by the
+                  parent's padding and paint chips above the caret). The inner
+                  `relative` wrapper has no padding, so its box == the
+                  textarea's box and the overlay stays caret-aligned. */}
+              <div className="relative">
+                <SkillComposerOverlay textareaRef={textareaRef} value={value} />
+                <textarea
+                  ref={textareaRef}
+                  value={value}
+                  onChange={onInput}
+                  onKeyDown={handleKeyDown}
+                  onKeyUp={onKeyUp}
+                  onSelect={onSelect}
+                  onPaste={handlePaste}
+                  // Story 5.3 (T2.3): on mobile web when the OSK is open, scroll
+                  // the textarea into view once per OSK-open window so iOS Safari
+                  // doesn't leave the input under the keyboard. rAF-deferred to
+                  // let layout settle. Guarded against focus-loop thrash (the OSK
+                  // can re-focus the textarea as it animates; only the first
+                  // focus per OSK-open window triggers the scroll).
+                  onFocus={() => {
+                    setFocused(true)
+                    // OSK-open scroll is handled by the `osk.isOskOpen`
+                    // transition effect above (the OSK state can lag the focus
+                    // event, so reading it here was unreliable).
+                  }}
+                  onBlur={() => setFocused(false)}
+                  // Story 5.3 (T2.4): mobile keyboards show a "send" affordance.
+                  // Do NOT change Enter keyboard semantics — handleKeyDown still
+                  // routes Enter→send only when the slash menu is closed.
+                  inputMode="text"
+                  enterKeyHint="send"
+                  disabled={disabled || sending}
+                  rows={1}
+                  placeholder={
+                    disabled
+                      ? 'Session closed'
+                      : activeCommand
+                        ? 'Add a message (optional)…'
+                        : 'Ask anything… (/ for commands, @ for files)'
+                  }
+                  className={cn(
+                    'relative z-10 min-h-[52px] w-full resize-none bg-transparent text-sm leading-relaxed',
+                    hasSkillToken ? 'text-transparent caret-foreground' : 'text-foreground',
+                    'placeholder:text-muted-foreground focus:outline-none',
+                    'disabled:cursor-not-allowed disabled:opacity-50 max-h-40'
+                  )}
+                />
+              </div>
             </div>
             <div
               className="flex items-center justify-between gap-3 px-2.5 pb-2.5"

--- a/src/renderer/stores/acp-store.test.ts
+++ b/src/renderer/stores/acp-store.test.ts
@@ -845,6 +845,68 @@ describe('acp-store', () => {
     expect(after[0].blocks).toEqual(display)
   })
 
+  it('skipUserAppend re-stamps the placeholder user message id so a display!=wire echo does not double-bubble', async () => {
+    // Regression for the launch-with-skills duplicate-text bug. The launch
+    // placeholder mints an optimistic user message with `msg-<uuid>` id and
+    // DISPLAY (token) blocks; finalizeChatLaunch then runs runPromptTurn with
+    // `skipUserAppend: true` and WIRE (path-framed) blocks. The reused message
+    // must be re-stamped to `turn:<turnId>` so the server `user_prompt` echo
+    // (same turnId, wire blocks) dedups by id — otherwise BOTH dedup checks
+    // fail (id mismatch + display!=wire block mismatch) and the echo appends a
+    // second user bubble. Covers the path the sendPromptBlocks tests above do
+    // NOT exercise (those mint the optimistic message with `turn:<id>` here).
+    seedSession('s1', 'agent-1', false)
+    const display = [{ type: 'text', text: '\uE000git-worktree\uE001 hi' }]
+    const wire = [
+      {
+        type: 'text',
+        text: '# Agent Skills\n\ngit-worktree: /p/SKILL.md\n\n---\n\n(git-worktree) hi'
+      }
+    ]
+    // Simulate createLaunchPlaceholder's optimistic user message: msg-<uuid>
+    // id + display (token) blocks.
+    useAcpStore.setState({
+      messages: {
+        s1: [
+          {
+            id: 'msg-placeholder-1',
+            role: 'user',
+            blocks: display,
+            streaming: false,
+            timestamp: 1,
+            seq: 1
+          }
+        ]
+      }
+    })
+    // Never resolve so the turn stays active for the echo assertion.
+    ;(invoke as ReturnType<typeof vi.fn>).mockReturnValue(new Promise(() => {}))
+    void useAcpStore.getState().sendPromptBlocks('s1', wire, { skipUserAppend: true })
+    await Promise.resolve()
+
+    const seeded = useAcpStore.getState().messages['s1']
+    expect(seeded).toHaveLength(1)
+    // The placeholder id was re-stamped to `turn:<turnId>` (no new bubble).
+    expect(seeded[0].id.startsWith('turn:')).toBe(true)
+    expect(seeded[0].id).not.toBe('msg-placeholder-1')
+    // The display (token) blocks are preserved — the agent receives the wire.
+    expect(seeded[0].blocks).toEqual(display)
+    const turnId = seeded[0].id.slice('turn:'.length)
+
+    // Server echoes the WIRE blocks for the same turn id. Must dedup by id
+    // (not append a second user bubble) and must NOT overwrite the display.
+    useAcpStore.getState()._onUserPrompt({
+      agentId: 'agent-1',
+      sessionId: 's1',
+      turnId,
+      content: wire
+    })
+    const finalMessages = useAcpStore.getState().messages['s1']
+    expect(finalMessages).toHaveLength(1)
+    expect(finalMessages[0].id).toBe(`turn:${turnId}`)
+    expect(finalMessages[0].blocks).toEqual(display)
+  })
+
   it('sendPrompt updates the persisted history title from the first user message', async () => {
     seedSession('s1', 'agent-09d39730', false)
     useAcpStore.setState({

--- a/src/renderer/stores/acp-store.ts
+++ b/src/renderer/stores/acp-store.ts
@@ -2178,8 +2178,24 @@ async function runPromptTurn(
 
     openTurnId = newId('turn')
     if (skipUserAppend) {
-      userMessage =
-        [...(s.messages[sessionId] ?? [])].reverse().find((m) => m.role === 'user') ?? null
+      // Reuse the trailing optimistic user message (the launch placeholder
+      // or a seeded follow-up) instead of appending a new one — but RE-STAMP
+      // its id to `turn:<turnId>`. The placeholder mints `msg-<uuid>`, so
+      // without this re-stamp a display≠wire turn (e.g. skill chips: tokens
+      // in the optimistic display, path-framed text in the server echo)
+      // would fail `_onUserPrompt`'s `turn:<id>` dedup on BOTH checks (id
+      // mismatch + block mismatch) and render a second user bubble from the
+      // echo. The display blocks are preserved verbatim — only the id moves
+      // to the namespace the server echo will cite.
+      const list = s.messages[sessionId] ?? []
+      let userIndex = -1
+      for (let i = list.length - 1; i >= 0; i--) {
+        if (list[i].role === 'user') {
+          userIndex = i
+          break
+        }
+      }
+      userMessage = userIndex >= 0 ? { ...list[userIndex], id: `turn:${turnId}` } : null
       if (!userMessage) {
         userMessage = {
           id: `turn:${turnId}`,
@@ -2192,7 +2208,7 @@ async function runPromptTurn(
         return {
           messages: {
             ...s.messages,
-            [sessionId]: [...(s.messages[sessionId] ?? []), userMessage]
+            [sessionId]: [...list, userMessage]
           },
           plans: dropPlanForSession(s.plans, sessionId),
           sessions: {
@@ -2201,7 +2217,14 @@ async function runPromptTurn(
           }
         }
       }
+      const rebrandedList = list.slice()
+      rebrandedList[userIndex] = userMessage
       return {
+        messages: {
+          ...s.messages,
+          [sessionId]: rebrandedList
+        },
+        plans: dropPlanForSession(s.plans, sessionId),
         sessions: {
           ...s.sessions,
           [sessionId]: { ...current, activeTurn: true, openTurnId, lastError: null }


### PR DESCRIPTION
## Summary

Inline skill chips (the `SkillChip` pills spliced into the composer when an Agent Skill is picked from the slash menu) had two real bugs that surfaced when using skills end-to-end from the launcher:

1. **Chip text painted above the caret instead of aligned with it.** The `SkillComposerOverlay` is `position: absolute; inset: 0`, so its containing block was the padded parent (`relative px-5 pb-2 pt-4` / `relative px-4 pb-1.5 pt-3.5`). That made the overlay's box land at the parent's padding-box origin — i.e. shifted up-left of the textarea by the parent's padding — so chips and mirrored text floated *above* the caret rather than on its line.
2. **A second user bubble appeared in the chat timeline on launch when a skill was present.** The launch placeholder mints its optimistic user message with `msg-<uuid>` id + DISPLAY (token) blocks; `finalizeChatLaunch` then runs `runPromptTurn` with `skipUserAppend: true` and WIRE (path-framed) blocks. The server `user_prompt` echo carries `turn:<id>` + wire blocks, and `_onUserPrompt`'s dedup failed *both* checks (id mismatch + display≠wire block mismatch), appending a duplicate. This was invisible without skills because there display==wire masked it.

## Related Issue

No related issue — these are bug fixes observed while using the `bmad-build-auto` Agent Skill from the launcher (chips rendering above the caret and a duplicated launch message). No tracking issue was filed; the bugs were reproduced and root-caused directly in the composer/launch code.

## Type of Change

- [x] fix: bug fix

## What Changed

- **`SkillComposerOverlay` positioning (launcher + continuation chat).** Split the padded composer wrapper into an outer padded `<div>` + an inner non-padded `relative` `<div>` holding the overlay and textarea. The overlay's `absolute inset-0` now targets a box that exactly matches the textarea, so mirrored text and `SkillChip` pills stay caret-aligned. Applied symmetrically to `AgentLauncher.tsx` and `ChatInputBar.tsx` — the continuation chat composer now renders chips aligned too.
- **Launch-echo dedup.** In `runPromptTurn`'s `skipUserAppend` path (`acp-store.ts`), the reused optimistic user message is now re-stamped to `turn:<turnId>` (its display/token blocks are preserved verbatim; only the id moves to the namespace the server echo cites). This lets `_onUserPrompt` collapse the echo by id instead of appending a second bubble on display≠wire turns (skill chips).
- **Regression test.** `acp-store.test.ts` adds `skipUserAppend re-stamps the placeholder user message id so a display!=wire echo does not double-bubble`, which seeds a `msg-<uuid>` placeholder with token display blocks, calls `sendPromptBlocks` with `skipUserAppend: true` + wire blocks, fires the echo, and asserts one bubble with the display blocks preserved.
- **ACP registry snapshot refresh.** Re-ran `bun run sync:acp-icons` to bring `agents.json` in sync with the CDN (upstream version bumps: `claude-acp` 0.64.0→0.64.1, `codex-acp` 1.1.8→1.1.9). This was a pre-existing freshness drift on `dev` (unrelated to the chip fixes) that blocked the `ACP Registry Bundle Freshness` gate; the refresh is the documented fix for that check.

## How It Was Tested

- [x] `bun run ci` (Biome lint + format + imports, strict mode)
- [x] `bun run typecheck`
- [x] `bun run test`
- [x] `cargo clippy --all-targets -- -D warnings` (in src-tauri)
- [x] `cargo test` (in src-tauri)
- [x] Manual verification completed

Note: `cargo test` could not complete locally during Phase 1 — the worktree's `E:` volume had 0 bytes free, so linking the test binaries failed with `os error 112`. `cargo check --all-targets` and `cargo clippy --all-targets -- -D warnings` both passed locally, and CI's `Rust Checks` job (which runs `cargo test`) passed green.

## CI & Review Gate

- [x] All CI checks pass (PR Validation, Rust Checks, Build Verification, Security Scans)
- [x] Code review comments from CodeRabbit / Claude have been addressed or resolved
- [x] No unresolved review findings remain

## Checklist

- [x] My PR title follows the conventional commit format used by this repo
- [x] I linked the related issue or explained why none exists
- [x] I updated docs when needed
- [x] I added or updated tests when needed
- [x] I verified the change does not introduce unrelated modifications
- [x] I read AGENTS.md and followed the contributor guidelines
- [x] A human reviewed the complete diff before submission
