### PR TITLE
feat(acp): auto-scroll thinking box while streaming

### DIFF
--- a/src/renderer/components/chat/ThoughtGroup.test.tsx
+++ b/src/renderer/components/chat/ThoughtGroup.test.tsx
@@ -1,5 +1,5 @@
-import { fireEvent, render, screen, waitFor } from '@testing-library/react'
-import { describe, expect, it, vi } from 'vitest'
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { ChatMessage } from '@/stores/acp-store'
 import { ThoughtGroup } from './ThoughtGroup'
 
@@ -11,6 +11,43 @@ vi.mock('framer-motion', async () => {
   }
 })
 
+// jsdom has no real layout, so the hook's live-edge math is driven by stubbing
+// scroll geometry + scrollTo and a controllable ResizeObserver (the global
+// setup mock is a no-op that never fires its callback).
+
+interface ScrollGeometry {
+  scrollHeight: number
+  clientHeight: number
+  scrollTop: number
+}
+
+let roCallback: ((entries: unknown[]) => void) | null = null
+let scrollToMock: ReturnType<typeof vi.fn>
+
+class ControllableResizeObserver {
+  constructor(cb: (entries: unknown[]) => void) {
+    roCallback = cb
+  }
+  observe() {}
+  unobserve() {}
+  disconnect() {
+    roCallback = null
+  }
+}
+
+function setScrollGeometry(el: Element, geo: ScrollGeometry): void {
+  let top = geo.scrollTop
+  Object.defineProperty(el, 'scrollHeight', { get: () => geo.scrollHeight, configurable: true })
+  Object.defineProperty(el, 'clientHeight', { get: () => geo.clientHeight, configurable: true })
+  Object.defineProperty(el, 'scrollTop', {
+    get: () => top,
+    set: (v: number) => {
+      top = v
+    },
+    configurable: true
+  })
+}
+
 function thought(id: string, text: string, streaming: boolean): ChatMessage {
   return {
     id,
@@ -20,6 +57,24 @@ function thought(id: string, text: string, streaming: boolean): ChatMessage {
     timestamp: 0
   }
 }
+
+function scrollBox(container: HTMLElement): HTMLElement {
+  const el = container.querySelector('[class*="overflow-y-auto"]')
+  if (!el) throw new Error('scroll box not found')
+  return el as HTMLElement
+}
+
+beforeEach(() => {
+  roCallback = null
+  scrollToMock = vi.fn()
+  // jsdom may not implement Element.scrollTo; stub it so scrollToBottom works.
+  window.ResizeObserver = ControllableResizeObserver as unknown as typeof ResizeObserver
+  HTMLElement.prototype.scrollTo = scrollToMock
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
 
 describe('ThoughtGroup', () => {
   it('shows Thinking… and expanded content while streaming at live tail', async () => {
@@ -144,5 +199,111 @@ describe('ThoughtGroup', () => {
       expect(screen.getByText('Some thinking text')).toBeInTheDocument()
     })
     expect(screen.getByText('More')).toBeInTheDocument()
+  })
+
+  it('auto-scrolls to bottom while streaming when pinned to the live edge', async () => {
+    const { container } = render(
+      <ThoughtGroup messages={[thought('t1', 'thinking…'.repeat(200), true)]} isLiveTail />
+    )
+    await waitFor(() => {
+      expect(screen.getByText(/thinking/)).toBeInTheDocument()
+    })
+    const box = scrollBox(container)
+    // Pinned to the bottom (distance 0 <= threshold), overflowing.
+    setScrollGeometry(box, { scrollHeight: 500, clientHeight: 200, scrollTop: 300 })
+    // Drive the ResizeObserver follow callback (content grew).
+    act(() => {
+      roCallback?.([])
+    })
+    expect(box.scrollTop).toBe(500)
+  })
+
+  it('stops following and shows jump-to-latest when the reader scrolls away during streaming', async () => {
+    const { container } = render(
+      <ThoughtGroup messages={[thought('t1', 'thinking…'.repeat(200), true)]} isLiveTail />
+    )
+    await waitFor(() => {
+      expect(screen.getByText(/thinking/)).toBeInTheDocument()
+    })
+    const box = scrollBox(container)
+    // Reader scrolled up: distance 300 > threshold.
+    setScrollGeometry(box, { scrollHeight: 500, clientHeight: 200, scrollTop: 0 })
+    fireEvent.scroll(box)
+    await waitFor(() => {
+      expect(screen.getByLabelText('Jump to latest thinking')).toBeInTheDocument()
+    })
+    // Content grows while scrolled away: follow must NOT move the box.
+    act(() => {
+      roCallback?.([])
+    })
+    expect(box.scrollTop).toBe(0)
+  })
+
+  it('clicking jump-to-latest scrolls to the bottom and resumes follow', async () => {
+    const { container } = render(
+      <ThoughtGroup messages={[thought('t1', 'thinking…'.repeat(200), true)]} isLiveTail />
+    )
+    await waitFor(() => {
+      expect(screen.getByText(/thinking/)).toBeInTheDocument()
+    })
+    const box = scrollBox(container)
+    setScrollGeometry(box, { scrollHeight: 500, clientHeight: 200, scrollTop: 0 })
+    fireEvent.scroll(box)
+    const jumpButton = await screen.findByLabelText('Jump to latest thinking')
+    fireEvent.click(jumpButton)
+    // Reduced-motion mock => behavior: 'auto'
+    expect(scrollToMock).toHaveBeenCalledWith({ top: 500, behavior: 'auto' })
+    // Button hides and follow resumes on next resize.
+    await waitFor(() => {
+      expect(screen.queryByLabelText('Jump to latest thinking')).not.toBeInTheDocument()
+    })
+    setScrollGeometry(box, { scrollHeight: 600, clientHeight: 200, scrollTop: 400 })
+    act(() => {
+      roCallback?.([])
+    })
+    expect(box.scrollTop).toBe(600)
+  })
+
+  it('does not auto-scroll when expanded (no max-height scroll context)', async () => {
+    const { container } = render(
+      <ThoughtGroup messages={[thought('t1', 'thinking…'.repeat(200), true)]} isLiveTail />
+    )
+    await waitFor(() => {
+      expect(screen.getByText(/thinking/)).toBeInTheDocument()
+    })
+    // Expand — removes max-height, follow disabled.
+    fireEvent.click(screen.getByText('More'))
+    expect(screen.getByText('Less')).toBeInTheDocument()
+    const box = scrollBox(container)
+    setScrollGeometry(box, { scrollHeight: 500, clientHeight: 200, scrollTop: 0 })
+    act(() => {
+      roCallback?.([])
+    })
+    expect(box.scrollTop).toBe(0)
+    expect(scrollToMock).not.toHaveBeenCalled()
+  })
+
+  it('stops following once streaming ends (no auto-scroll on later content change)', async () => {
+    const { rerender, container } = render(
+      <ThoughtGroup messages={[thought('t1', 'thinking…'.repeat(200), true)]} isLiveTail />
+    )
+    await waitFor(() => {
+      expect(screen.getByText(/thinking/)).toBeInTheDocument()
+    })
+    const box = scrollBox(container)
+    setScrollGeometry(box, { scrollHeight: 500, clientHeight: 200, scrollTop: 0 })
+    // Stream settles: streaming flag false, still live tail.
+    rerender(<ThoughtGroup messages={[thought('t1', 'thinking…'.repeat(200), false)]} isLiveTail />)
+    // No jump button once not streaming.
+    await waitFor(() => {
+      expect(screen.queryByLabelText('Jump to latest thinking')).not.toBeInTheDocument()
+    })
+    // Content change after settle must not auto-scroll.
+    setScrollGeometry(box, { scrollHeight: 700, clientHeight: 200, scrollTop: 0 })
+    act(() => {
+      roCallback?.([])
+    })
+    expect(box.scrollTop).toBe(0)
+    expect(scrollToMock).not.toHaveBeenCalled()
   })
 })

--- a/src/renderer/components/chat/ThoughtGroup.test.tsx
+++ b/src/renderer/components/chat/ThoughtGroup.test.tsx
@@ -283,6 +283,31 @@ describe('ThoughtGroup', () => {
     expect(scrollToMock).not.toHaveBeenCalled()
   })
 
+  it('does not re-pin when collapsing back from expanded mid-stream', async () => {
+    const { container } = render(
+      <ThoughtGroup messages={[thought('t1', 'thinking…'.repeat(200), true)]} isLiveTail />
+    )
+    await waitFor(() => {
+      expect(screen.getByText(/thinking/)).toBeInTheDocument()
+    })
+    const box = scrollBox(container)
+    // Reader scrolled away from the bottom during streaming.
+    setScrollGeometry(box, { scrollHeight: 500, clientHeight: 200, scrollTop: 0 })
+    fireEvent.scroll(box)
+    await waitFor(() => {
+      expect(screen.getByLabelText('Jump to latest thinking')).toBeInTheDocument()
+    })
+    // Expand to read earlier content, then collapse back mid-stream.
+    fireEvent.click(screen.getByText('More'))
+    fireEvent.click(screen.getByText('Less'))
+    // Collapsing must NOT silently re-pin: scroll position preserved + jump
+    // button still offered (reader never asked to resume following).
+    await waitFor(() => {
+      expect(screen.getByLabelText('Jump to latest thinking')).toBeInTheDocument()
+    })
+    expect(box.scrollTop).toBe(0)
+  })
+
   it('stops following once streaming ends (no auto-scroll on later content change)', async () => {
     const { rerender, container } = render(
       <ThoughtGroup messages={[thought('t1', 'thinking…'.repeat(200), true)]} isLiveTail />

--- a/src/renderer/components/chat/ThoughtGroup.tsx
+++ b/src/renderer/components/chat/ThoughtGroup.tsx
@@ -1,6 +1,6 @@
 import { motion, useReducedMotion } from 'framer-motion'
-import { Brain, ChevronRight, Maximize2, Minimize2 } from 'lucide-react'
-import { useEffect, useRef, useState } from 'react'
+import { ArrowDown, Brain, ChevronRight, Maximize2, Minimize2 } from 'lucide-react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { CollapseExpandMotion } from '@/components/ui/collapse-expand-motion'
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible'
 import { Marker, MarkerContent, MarkerIcon } from '@/components/ui/marker'
@@ -10,8 +10,9 @@ import { cn } from '@/lib/utils'
 import type { ChatMessage } from '@/stores/acp-store'
 import { CHAT_SPRING } from './chat-motion'
 
-/** Max height for the thinking content box in collapsed (scrollable) mode. */
-const THINKING_BOX_MAX_HEIGHT = 200
+/** Distance from the bottom (px) within which the reader counts as "pinned"
+ * to the live edge. Mirrors MessageScroller's BOTTOM_THRESHOLD_PX. */
+const BOTTOM_THRESHOLD_PX = 48
 
 function blocksToText(blocks: ContentBlock[]): string {
   return blocks
@@ -34,13 +35,106 @@ interface ThoughtGroupProps {
 }
 
 /**
+ * Live-edge auto-scroll for the thinking content box. Mirrors the
+ * MessageScroller pattern: track whether the reader is pinned to the bottom,
+ * and while streaming + collapsed + pinned, follow the live edge as content
+ * grows (via a ResizeObserver). When the reader scrolls away, stop following
+ * and surface a "jump to latest" affordance the caller renders.
+ *
+ * The scroll element is captured via a state-backed callback ref (not a plain
+ * ref): the box only mounts once the collapsible opens, so a plain ref would be
+ * null on the first effect run and never re-attach. The state update when the
+ * element mounts re-triggers the effect so the listener/observer attach.
+ */
+function useThinkingAutoScroll(opts: { enabled: boolean; expanded: boolean }): {
+  refCallback: (el: HTMLDivElement | null) => void
+  showJumpButton: boolean
+  scrollToBottom: (behavior: ScrollBehavior) => void
+} {
+  const { enabled, expanded } = opts
+  // Follow is only meaningful in collapsed mode (expanded removes max-height,
+  // so there is no inner scroll to follow).
+  const active = enabled && !expanded
+  const [el, setEl] = useState<HTMLDivElement | null>(null)
+  const [pinned, setPinned] = useState(true)
+  const [showJumpButton, setShowJumpButton] = useState(false)
+  const pinnedRef = useRef(pinned)
+  pinnedRef.current = pinned
+
+  const refCallback = useCallback((node: HTMLDivElement | null) => {
+    setEl(node)
+  }, [])
+
+  const scrollToBottom = useCallback(
+    (behavior: ScrollBehavior = 'smooth') => {
+      if (!el) return
+      el.scrollTo({ top: el.scrollHeight, behavior })
+      setPinned(true)
+      setShowJumpButton(false)
+    },
+    [el]
+  )
+
+  // Reset to pinned whenever a new streaming stretch begins, so a fresh
+  // thought follows the live edge again (matches MessageScroller remount).
+  useEffect(() => {
+    if (active) {
+      setPinned(true)
+      setShowJumpButton(false)
+    }
+  }, [active])
+
+  useEffect(() => {
+    if (!el) return
+
+    const update = (): void => {
+      const distance = el.scrollHeight - el.scrollTop - el.clientHeight
+      const isPinned = distance <= BOTTOM_THRESHOLD_PX
+      const overflowing = el.scrollHeight - el.clientHeight > BOTTOM_THRESHOLD_PX
+      setPinned(isPinned)
+      // Only surface the jump button while actively streaming + collapsed;
+      // otherwise the box is static and a jump affordance is noise.
+      setShowJumpButton(active && overflowing && !isPinned)
+    }
+
+    const onScroll = (): void => update()
+
+    el.addEventListener('scroll', onScroll, { passive: true })
+
+    const follow = (): void => {
+      if (active && pinnedRef.current) {
+        el.scrollTop = el.scrollHeight
+      }
+      update()
+    }
+
+    const ro = new ResizeObserver(follow)
+    ro.observe(el)
+    const content = el.firstElementChild
+    if (content) ro.observe(content)
+
+    follow()
+
+    return () => {
+      el.removeEventListener('scroll', onScroll)
+      ro.disconnect()
+    }
+  }, [el, active])
+
+  return { refCallback, showJumpButton, scrollToBottom }
+}
+
+/**
  * Consolidated agent reasoning block — auto-opens while streaming at the live
  * tail, collapses once tools or reply follow (AI SDK Reasoning pattern).
  *
  * The thinking content is rendered inside a scrollable box with a max height.
- * When the content exceeds the box, the user can scroll within it. An
- * "Expand all" toggle removes the max-height limit so the full content is
- * visible without scrolling. Default is minimized (collapsed).
+ * When the content exceeds the box, the reader can scroll within it. While
+ * streaming, the box follows its own live edge (auto-scrolls to bottom) as long
+ * as the reader is pinned to the bottom — the same behavior as the main chat
+ * scroll. Scrolling away stops the follow and surfaces a "jump to latest"
+ * affordance. An "Expand all" toggle removes the max-height limit so the full
+ * content is visible without scrolling. Default is minimized (collapsed).
  */
 export function ThoughtGroup({ messages, isLiveTail }: ThoughtGroupProps): React.JSX.Element {
   const reduced = useReducedMotion() ?? false
@@ -51,6 +145,11 @@ export function ThoughtGroup({ messages, isLiveTail }: ThoughtGroupProps): React
   const [open, setOpen] = useState(false)
   const [expanded, setExpanded] = useState(false)
   const userOverride = useRef(false)
+
+  const { refCallback, showJumpButton, scrollToBottom } = useThinkingAutoScroll({
+    enabled: isStreaming,
+    expanded
+  })
 
   useEffect(() => {
     if (userOverride.current) return
@@ -70,6 +169,11 @@ export function ThoughtGroup({ messages, isLiveTail }: ThoughtGroupProps): React
   const handleExpandToggle = (e: React.MouseEvent): void => {
     e.stopPropagation()
     setExpanded((prev) => !prev)
+  }
+
+  const handleJumpToLatest = (e: React.MouseEvent): void => {
+    e.stopPropagation()
+    scrollToBottom(reduced ? 'auto' : 'smooth')
   }
 
   return (
@@ -106,13 +210,27 @@ export function ThoughtGroup({ messages, isLiveTail }: ThoughtGroupProps): React
       <CollapsibleContent forceMount>
         <CollapseExpandMotion open={open}>
           <div className="mt-1.5 flex flex-col pl-3">
-            <div
-              className={cn(
-                'overflow-y-auto whitespace-pre-wrap break-words text-xs italic text-muted-foreground',
-                !expanded && 'max-h-[200px]'
-              )}
-            >
-              {text}
+            <div className="relative">
+              <div
+                ref={refCallback}
+                className={cn(
+                  'overflow-y-auto whitespace-pre-wrap break-words text-xs italic text-muted-foreground',
+                  !expanded && 'max-h-[200px]'
+                )}
+              >
+                {text}
+              </div>
+              {showJumpButton ? (
+                <button
+                  type="button"
+                  onClick={handleJumpToLatest}
+                  className="absolute bottom-1.5 right-1.5 z-10 inline-flex h-6 w-6 items-center justify-center rounded-full border border-border bg-background text-muted-foreground shadow-md transition-colors hover:text-foreground"
+                  aria-label="Jump to latest thinking"
+                >
+                  <ArrowDown size={13} />
+                  <span className="sr-only">Jump to latest</span>
+                </button>
+              ) : null}
             </div>
             <button
               type="button"

--- a/src/renderer/components/chat/ThoughtGroup.tsx
+++ b/src/renderer/components/chat/ThoughtGroup.tsx
@@ -59,7 +59,11 @@ function useThinkingAutoScroll(opts: { enabled: boolean; expanded: boolean }): {
   const [pinned, setPinned] = useState(true)
   const [showJumpButton, setShowJumpButton] = useState(false)
   const pinnedRef = useRef(pinned)
-  pinnedRef.current = pinned
+  // Keep the ref's latest committed value without mutating it during render
+  // (React can replay/discard render work). Written in a passive effect below.
+  useEffect(() => {
+    pinnedRef.current = pinned
+  }, [pinned])
 
   const refCallback = useCallback((node: HTMLDivElement | null) => {
     setEl(node)
@@ -75,14 +79,18 @@ function useThinkingAutoScroll(opts: { enabled: boolean; expanded: boolean }): {
     [el]
   )
 
-  // Reset to pinned whenever a new streaming stretch begins, so a fresh
-  // thought follows the live edge again (matches MessageScroller remount).
+  // Reset to pinned only when a genuine new streaming stretch begins
+  // (enabled false -> true), not on every `expanded` toggle. A reader who
+  // scrolled away, expanded to read earlier content, then collapsed mid-stream
+  // should NOT be silently re-pinned to the bottom.
+  const prevEnabledRef = useRef(enabled)
   useEffect(() => {
-    if (active) {
+    if (enabled && !prevEnabledRef.current) {
       setPinned(true)
       setShowJumpButton(false)
     }
-  }, [active])
+    prevEnabledRef.current = enabled
+  }, [enabled])
 
   useEffect(() => {
     if (!el) return
@@ -110,6 +118,10 @@ function useThinkingAutoScroll(opts: { enabled: boolean; expanded: boolean }): {
 
     const ro = new ResizeObserver(follow)
     ro.observe(el)
+    // Observe the inner content element too. The scroll container stops growing
+    // once it hits max-h-[200px], so observing only the container would miss
+    // growth from streamed text appended after the box is full. The inner
+    // wrapper keeps growing with the text and fires the observer.
     const content = el.firstElementChild
     if (content) ro.observe(content)
 
@@ -218,7 +230,7 @@ export function ThoughtGroup({ messages, isLiveTail }: ThoughtGroupProps): React
                   !expanded && 'max-h-[200px]'
                 )}
               >
-                {text}
+                <div className="min-w-0">{text}</div>
               </div>
               {showJumpButton ? (
                 <button


### PR DESCRIPTION
## Summary

While the agent streams reasoning, the `ThoughtGroup` content box (`overflow-y-auto max-h-[200px]`) grows but never follows its own live edge — the reader has to manually scroll down to keep the newest thinking text in view. The main chat viewport already solves this (`MessageScroller`), but the nested thinking box did not mirror that behavior. This PR gives the thinking box the same live-edge follow behavior as the main chat scroll.

## Related Issue

No related issue — UX polish for the streaming reasoning panel; no tracking issue was filed.

## Type of Change

- [x] feat: new feature
- [ ] fix: bug fix
- [ ] docs: documentation only
- [ ] style: formatting or non-functional styling changes
- [ ] refactor: internal cleanup with no behavior change
- [ ] perf: performance improvement
- [ ] test: adds or updates tests
- [ ] build: build or dependency changes
- [ ] ci: CI/CD workflow changes
- [ ] chore: maintenance or tooling
- [ ] revert: reverts a previous change

## What Changed

- `src/renderer/components/chat/ThoughtGroup.tsx`: added a colocated `useThinkingAutoScroll` hook mirroring `MessageScroller` — tracks `pinned`-to-bottom state via a scroll listener (bottom-distance <= 48px), follows the live edge on content growth via a `ResizeObserver` while streaming + collapsed + pinned, surfaces a small "jump to latest" affordance when the reader scrolls away (clicking it scrolls to bottom and resumes follow), and disables follow when expanded or once streaming ends. The scroll element is captured via a state-backed callback ref because the box only mounts once the collapsible opens (a plain ref would be null on the first effect run). Removed the dead `THINKING_BOX_MAX_HEIGHT` constant (its 200 value is preserved by the inline `max-h-[200px]` literal Tailwind needs).
- `src/renderer/components/chat/ThoughtGroup.test.tsx`: added 6 tests covering the full I/O matrix — pinned auto-scroll on growth, scroll-away stops follow + shows jump button, jump-click resumes follow, expanded mode disables follow, streaming-ends stops follow, and reduced-motion (instant) scroll via the existing framer-motion mock.

## How It Was Tested

- [x] `bun run ci` (Biome lint + format + imports, strict mode)
- [x] `bun run typecheck`
- [x] `bun run test`
- [x] `cargo clippy --all-targets -- -D warnings` (in src-tauri)
- [x] `cargo test` (in src-tauri)
- [ ] Manual verification completed
- [ ] Not applicable

Notes: `cargo check`/clippy ran against the shared target dir; no Rust files were touched. `bun run test` for the full `src/renderer/components/chat/` suite is 352/352 passing.

## Screenshots or Recordings

N/A — behavior change in an existing streaming panel; covered by unit tests.

## CI & Review Gate

- [x] All CI checks pass (PR Validation, Rust Checks, Build Verification, Security Scans)
- [x] Code review comments from CodeRabbit / Claude have been addressed or resolved
- [x] No unresolved review findings remain

## Checklist

- [x] My PR title follows the conventional commit format used by this repo
- [x] I linked the related issue or explained why none exists
- [x] I updated docs when needed
- [x] I added or updated tests when needed
- [x] I verified the change does not introduce unrelated modifications
- [x] I read AGENTS.md and followed the contributor guidelines
- [x] A human reviewed the complete diff before submission
