### PR TITLE
fix: unify chat composer slash/chip parity across launcher and chatbox

### DIFF
--- a/src/renderer/components/agents/AgentLauncher.test.tsx
+++ b/src/renderer/components/agents/AgentLauncher.test.tsx
@@ -1142,3 +1142,63 @@ describe('AgentLauncher skill chips (inline tokens)', () => {
     expect(mockHideAgentLauncher).not.toHaveBeenCalled()
   })
 })
+
+describe('AgentLauncher slash menu parity (mid-text + command chip)', () => {
+  const SKILL = {
+    name: 'git-worktree',
+    description: 'Isolated worktree',
+    scope: 'project',
+    path: '/home/u/.agents/skills/git-worktree/SKILL.md'
+  }
+
+  function selectSlashOption(name: string | RegExp): void {
+    const listbox = screen.getByRole('listbox')
+    fireEvent.mouseDown(within(listbox).getByText(name))
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('opens the slash menu at a mid-text slash (parity with the running chatbox)', async () => {
+    mockSkills.current = [SKILL]
+    renderLauncher()
+
+    const textarea = await screen.findByLabelText('Agent prompt')
+    // Type text before the slash so the trigger is mid-text, not leading.
+    // Previously the launcher used `isSlashTrigger` (leading-only) and the
+    // menu never opened here; the shared hook now uses `isSlashTriggerAny`.
+    fireEvent.change(textarea, { target: { value: 'hello /' } })
+
+    await waitFor(() => expect(screen.getByRole('listbox')).toBeInTheDocument())
+  })
+
+  it('renders a CommandChip when a slash command is selected from the menu', async () => {
+    const key = 'acp-registry:claude-acp\0/work\0'
+    acpStateRef.current.agentConfigs = [ACP_CONFIG]
+    mockPersistRead.mockResolvedValue({
+      success: true,
+      data: { agentId: 'acp-registry:claude-acp', mode: 'acp' }
+    })
+    acpStateRef.current.preparedSessions = { [key]: 'prepared-1' }
+    acpStateRef.current.sessions = { 'prepared-1': preparedSession(ACP_CONFIG) }
+    acpStateRef.current.commands = {
+      'prepared-1': [{ name: 'compact', description: 'Compact the conversation' }]
+    }
+    renderLauncher()
+
+    const textarea = await screen.findByLabelText('Agent prompt')
+    fireEvent.change(textarea, { target: { value: '/' } })
+
+    await waitFor(() => expect(screen.getByRole('listbox')).toBeInTheDocument())
+    selectSlashOption('/compact')
+
+    // Previously the launcher inserted bare `/compact ` text; it now creates a
+    // CommandChip (parity with the running chatbox).
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: 'Remove /compact command' })).toBeInTheDocument()
+    )
+    // The `/compact` filter text is cleared from the input.
+    expect(textarea).toHaveValue('')
+  })
+})

--- a/src/renderer/components/agents/AgentLauncher.tsx
+++ b/src/renderer/components/agents/AgentLauncher.tsx
@@ -12,6 +12,7 @@ import {
 import { ConfigChip, ModeChip } from '@/components/chat/AgentHeader'
 import { AttachFilesButton } from '@/components/chat/AttachFilesButton'
 import { AttachmentPreviewGroup } from '@/components/chat/AttachmentPreviewGroup'
+import { CommandChip } from '@/components/chat/CommandChip'
 import { ComposerPill } from '@/components/chat/ComposerPill'
 import { attachmentToBlock } from '@/components/chat/chat-attachments'
 import {
@@ -22,14 +23,8 @@ import {
 import { FileMentionMenu } from '@/components/chat/FileMentionMenu'
 import { SkillComposerOverlay } from '@/components/chat/SkillComposerOverlay'
 import { SlashCommandMenu, type SlashMenuHandle } from '@/components/chat/SlashCommandMenu'
-import { tryHandleSlashMenuKeyDown } from '@/components/chat/slash-menu-keyboard'
-import {
-  buildSlashSections,
-  findSlashTrigger,
-  isSlashTrigger,
-  type SlashItem,
-  slashFilter
-} from '@/components/chat/slash-menu-model'
+import { isSlashTriggerAny } from '@/components/chat/slash-menu-model'
+import { useChatComposer } from '@/components/chat/use-chat-composer'
 import { useComposerAttachments } from '@/components/chat/use-composer-attachments'
 import { useComposerMentions } from '@/components/chat/use-composer-mentions'
 import { useComposerTextarea } from '@/components/chat/use-composer-textarea'
@@ -40,7 +35,7 @@ import { Input } from '@/components/ui/input'
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
 import { useAcpRegistryCatalog } from '@/hooks/use-acp-registry-catalog'
 import { useAcpRuntimeProbe } from '@/hooks/use-acp-runtime-probe'
-import { buildPromptWithLoadedSkills, useAgentSkills } from '@/hooks/use-agent-skills'
+import { useAgentSkills } from '@/hooks/use-agent-skills'
 import { useMentionRecents } from '@/hooks/use-mention-recents'
 import type { StoredAgentConfig } from '@/lib/acp-agents-persistence'
 import { type AuthMethod, acpApi, type ContentBlock } from '@/lib/acp-api'
@@ -59,12 +54,6 @@ import {
 } from '@/lib/agents/supported-acp-agents'
 import { dialogApi, openerApi, persistenceApi } from '@/lib/api'
 import { registerSessionTempFiles } from '@/lib/attachment-temp-cleanup'
-import {
-  extractSkillNames,
-  insertSkillToken,
-  removeSkillTokenBeforeCaret,
-  SKILL_TOKEN_START
-} from '@/lib/skill-tokens'
 import { platform as osPlatform } from '@/lib/tauri-os'
 import { cn } from '@/lib/utils'
 import { getDefaultCwdForProject } from '@/lib/worktree-context'
@@ -106,9 +95,6 @@ export function AgentLauncher({ paneId, className }: AgentLauncherProps): React.
   const [pendingOptions, setPendingOptions] = useState<PendingLauncherOptions>(
     emptyPendingLauncherOptions
   )
-  // name → SKILL.md path, captured when a skill is picked inline so the launch
-  // wire prompt can cite paths synchronously (no IPC read, no failure path).
-  const skillPathsRef = useRef<Record<string, string>>({})
   const launchInFlightRef = useRef(false)
   const menuRef = useRef<SlashMenuHandle>(null)
   const textareaRef = useRef<HTMLTextAreaElement>(null)
@@ -269,7 +255,79 @@ export function AgentLauncher({ paneId, className }: AgentLauncherProps): React.
     effectiveConfigOptions,
     cachedOptions?.updatedAt
   ])
-  const menuOpen = isSlashTrigger(prompt)
+  // The three ACP setters below are declared before `useChatComposer` so the
+  // shared hook can pass them as `onSetConfig`/`onSetMode`/`onSetModel` without
+  // a temporal-dead-zone reference (the hook captures them at call time).
+  const handleSetConfig = useCallback(
+    async (configId: string, valueId: string) => {
+      if (!preparedSessionId) {
+        setPendingOptions((prev) => ({
+          ...prev,
+          configValues: { ...prev.configValues, [configId]: valueId }
+        }))
+        return
+      }
+      try {
+        await useAcpStore.getState().setConfigOption(preparedSessionId, configId, valueId)
+      } catch (err) {
+        toast.error(`Failed to set option: ${String(err)}`)
+        throw err
+      }
+    },
+    [preparedSessionId]
+  )
+
+  const handleSetModel = useCallback(
+    async (valueId: string) => {
+      if (!preparedSessionId) {
+        if (modelSource === 'models') {
+          setPendingOptions((prev) => ({ ...prev, modelId: valueId }))
+          return
+        }
+        if (!modelOption) {
+          throw new Error('No model option is available for this session')
+        }
+        setPendingOptions((prev) => ({
+          ...prev,
+          modelId: valueId,
+          configValues: { ...prev.configValues, [modelOption.id]: valueId }
+        }))
+        return
+      }
+      if (modelSource === 'models') {
+        try {
+          await useAcpStore.getState().setModel(preparedSessionId, valueId)
+        } catch (err) {
+          toast.error(`Failed to set model: ${String(err)}`)
+          throw err
+        }
+        return
+      }
+      if (!modelOption) {
+        throw new Error('No model option is available for this session')
+      }
+      await handleSetConfig(modelOption.id, valueId)
+    },
+    [handleSetConfig, modelOption, modelSource, preparedSessionId]
+  )
+
+  const handleSetMode = useCallback(
+    async (modeId: string) => {
+      if (!preparedSessionId) {
+        setPendingOptions((prev) => ({ ...prev, modeId }))
+        return
+      }
+      try {
+        await useAcpStore.getState().setMode(preparedSessionId, modeId)
+      } catch (err) {
+        toast.error(`Failed to set agent: ${String(err)}`)
+        throw err
+      }
+    },
+    [preparedSessionId]
+  )
+
+  const slashOpen = isSlashTriggerAny(prompt) && !composerDisabled
   const {
     onInput,
     onKeyUp,
@@ -290,22 +348,40 @@ export function AgentLauncher({ paneId, className }: AgentLauncherProps): React.
     textareaRef,
     mentions,
     disabled: composerDisabled,
-    slashOpen: menuOpen
+    slashOpen
   })
-  const slashSections = useMemo(
-    () =>
-      menuOpen
-        ? buildSlashSections({
-            commands,
-            // Cached or live options — pending handlers queue until session is ready.
-            configOptions: optionsInteractive ? effectiveConfigOptions : [],
-            modes: optionsInteractive ? effectiveModes : null,
-            skills,
-            filter: slashFilter(prompt)
-          })
-        : [],
-    [menuOpen, commands, optionsInteractive, effectiveConfigOptions, effectiveModes, skills, prompt]
-  )
+
+  const {
+    slashSections,
+    activeCommand,
+    setActiveCommand,
+    clearActiveCommand,
+    skillPathsRef,
+    hasSkillToken,
+    handleSelect,
+    handleKeyDown: composerHandleKeyDown,
+    buildPromptParts
+  } = useChatComposer({
+    value: prompt,
+    setValue: setPrompt,
+    textareaRef,
+    slashMenuRef: menuRef,
+    commands,
+    configOptions: optionsInteractive ? effectiveConfigOptions : [],
+    modes: optionsInteractive ? effectiveModes : null,
+    skills,
+    disabled: composerDisabled,
+    onSetConfig: handleSetConfig,
+    onSetMode: handleSetMode,
+    onSetModel: handleSetModel,
+    modelOption,
+    modelSource: modelSource ?? undefined,
+    handleMentionKeyDown,
+    updateMentions,
+    resetMentions,
+    resetHeight,
+    clampHeight
+  })
 
   const persistSelection = useCallback((configId: string) => {
     cachedConfigId = configId
@@ -458,59 +534,6 @@ export function AgentLauncher({ paneId, className }: AgentLauncherProps): React.
     [manualPath, persistSelection, saveAgentConfig, savingManualPath]
   )
 
-  const handleSetConfig = useCallback(
-    async (configId: string, valueId: string) => {
-      if (!preparedSessionId) {
-        setPendingOptions((prev) => ({
-          ...prev,
-          configValues: { ...prev.configValues, [configId]: valueId }
-        }))
-        return
-      }
-      try {
-        await useAcpStore.getState().setConfigOption(preparedSessionId, configId, valueId)
-      } catch (err) {
-        toast.error(`Failed to set option: ${String(err)}`)
-        throw err
-      }
-    },
-    [preparedSessionId]
-  )
-
-  const handleSetModel = useCallback(
-    async (valueId: string) => {
-      if (!preparedSessionId) {
-        if (modelSource === 'models') {
-          setPendingOptions((prev) => ({ ...prev, modelId: valueId }))
-          return
-        }
-        if (!modelOption) {
-          throw new Error('No model option is available for this session')
-        }
-        setPendingOptions((prev) => ({
-          ...prev,
-          modelId: valueId,
-          configValues: { ...prev.configValues, [modelOption.id]: valueId }
-        }))
-        return
-      }
-      if (modelSource === 'models') {
-        try {
-          await useAcpStore.getState().setModel(preparedSessionId, valueId)
-        } catch (err) {
-          toast.error(`Failed to set model: ${String(err)}`)
-          throw err
-        }
-        return
-      }
-      if (!modelOption) {
-        throw new Error('No model option is available for this session')
-      }
-      await handleSetConfig(modelOption.id, valueId)
-    },
-    [handleSetConfig, modelOption, modelSource, preparedSessionId]
-  )
-
   const handleRetryPrepare = useCallback(() => {
     if (!activeConfigId || !projectRoot || !preparedKey) return
     const store = useAcpStore.getState()
@@ -551,22 +574,6 @@ export function AgentLauncher({ paneId, className }: AgentLauncherProps): React.
     void runAuthenticate(signInMethod.id)
   }, [signInMethod, runAuthenticate])
 
-  const handleSetMode = useCallback(
-    async (modeId: string) => {
-      if (!preparedSessionId) {
-        setPendingOptions((prev) => ({ ...prev, modeId }))
-        return
-      }
-      try {
-        await useAcpStore.getState().setMode(preparedSessionId, modeId)
-      } catch (err) {
-        toast.error(`Failed to set agent: ${String(err)}`)
-        throw err
-      }
-    },
-    [preparedSessionId]
-  )
-
   // If prepare finishes while the launcher is still open, flush queued selections.
   useEffect(() => {
     if (!preparedSessionId || !hasPendingLauncherOptions(pendingOptions)) return
@@ -589,53 +596,6 @@ export function AgentLauncher({ paneId, className }: AgentLauncherProps): React.
     // eslint-disable-next-line react-hooks/exhaustive-deps -- intentional
   }, [preparedSessionId, pendingOptions])
 
-  const handleSlashSelect = useCallback(
-    (item: SlashItem) => {
-      if (item.kind === 'skill') {
-        // Splice an inline skill token at the caret (removing the `/`-filter
-        // text), record the path for the launch wire prompt, and refocus so the
-        // user can keep typing or pick another skill.
-        const trigger = findSlashTrigger(prompt)
-        const caret = textareaRef.current?.selectionStart ?? prompt.length
-        const insertAt = trigger ? trigger.end : caret
-        const deleteBefore = trigger ? trigger.end - trigger.start : 0
-        const { value: next, caret: nextCaret } = insertSkillToken(
-          prompt,
-          insertAt,
-          item.name,
-          deleteBefore
-        )
-        skillPathsRef.current[item.name] = item.path
-        setPrompt(next)
-        updateMentions(next, nextCaret)
-        resetHeight()
-        requestAnimationFrame(() => {
-          const el = textareaRef.current
-          if (!el) return
-          clampHeight(el)
-          el.setSelectionRange(nextCaret, nextCaret)
-          el.focus()
-        })
-        return
-      }
-      if (item.kind === 'config') {
-        void handleSetConfig(item.configId, item.valueId)
-      } else if (item.kind === 'mode') {
-        void handleSetMode(item.modeId)
-      } else if (item.kind === 'command') {
-        const next = `/${item.name} `
-        setPrompt(next)
-        updateMentions(next, next.length)
-        textareaRef.current?.focus()
-        return
-      }
-      setPrompt('')
-      updateMentions('', 0)
-      resetHeight()
-    },
-    [prompt, handleSetConfig, handleSetMode, updateMentions, resetHeight, clampHeight]
-  )
-
   const launch = useCallback(async () => {
     if (!activeProjectId || !projectRoot) {
       toast.error('No active project')
@@ -645,7 +605,6 @@ export function AgentLauncher({ paneId, className }: AgentLauncherProps): React.
 
     launchInFlightRef.current = true
     const pendingSnapshot = pendingOptions
-    const promptSnapshot = prompt
     const attachmentsSnapshot = [...attachments]
     const appOwnedPaths = appOwnedTempPaths()
     const modelsSnapshot = effectiveModels
@@ -657,26 +616,24 @@ export function AgentLauncher({ paneId, className }: AgentLauncherProps): React.
     const projectIdSnapshot = activeProjectId
     const projectRootSnapshot = projectRoot
     const needsSave = !acpConfigs.some((config) => config.id === selectedConfig.id)
-    const skillPathsSnapshot = skillPathsRef.current
 
     // Build the wire text (skills framed by path under `# Agent Skills`, then
     // the user text with tokens replaced by `(name)`) and the display text (the
-    // raw token value, so the chat timeline re-renders inline chips). Sync —
-    // paths were captured at pick time, so no IPC read and no failure path. A
-    // skill surfaced without a path (web parity gap) blocks the launch.
-    const skillNames = extractSkillNames(promptSnapshot)
-    const skills = skillNames.map((name) => ({ name, path: skillPathsSnapshot[name] ?? '' }))
-    const missingPath = skills.find((s) => !s.path)
-    if (missingPath) {
-      toast.error(`Skill '${missingPath.name}' is missing a path`)
+    // raw token value, so the chat timeline re-renders inline chips), with the
+    // active command prefixed to both. Shared with `ChatInputBar.submit` via
+    // `useChatComposer.buildPromptParts` so the two surfaces cannot drift. A
+    // skill surfaced without a path (web parity gap) blocks the launch —
+    // `buildPromptParts` throws and the catch toasts + releases the in-flight
+    // flag before any session is claimed/created.
+    let parts: ReturnType<typeof buildPromptParts>
+    try {
+      parts = buildPromptParts()
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : 'Failed to start agent chat')
       launchInFlightRef.current = false
       return
     }
-    const hasSkills = skills.length > 0
-    const wireText = hasSkills
-      ? buildPromptWithLoadedSkills(skills, promptSnapshot)
-      : promptSnapshot
-    const displayText = promptSnapshot
+    const { wireWithCommand, displayWithCommand } = parts
 
     // Open the chat immediately; ACP spawn/session/send continue in the chat view.
     const store = useAcpStore.getState()
@@ -690,13 +647,13 @@ export function AgentLauncher({ paneId, className }: AgentLauncherProps): React.
     // Sync first-turn content so the chat can paint like a normal send. The
     // optimistic syncBlocks carry the DISPLAY (token) text so the timeline
     // renders inline chips; the real send dispatches the WIRE text.
-    const syncTrimmed = displayText.trim()
+    const syncTrimmed = displayWithCommand.trim()
     const syncBlocks: ContentBlock[] = []
     if (attachmentsSnapshot.length > 0) {
-      if (syncTrimmed) syncBlocks.push({ type: 'text', text: displayText })
+      if (syncTrimmed) syncBlocks.push({ type: 'text', text: displayWithCommand })
       for (const a of attachmentsSnapshot) syncBlocks.push(attachmentToBlock(a))
     } else if (syncTrimmed.length > 0) {
-      syncBlocks.push({ type: 'text', text: displayText })
+      syncBlocks.push({ type: 'text', text: displayWithCommand })
     }
 
     if (!sessionId) {
@@ -718,6 +675,7 @@ export function AgentLauncher({ paneId, className }: AgentLauncherProps): React.
     useWorkspaceStore.getState().hideAgentLauncher()
     setPendingOptions(emptyPendingLauncherOptions())
     skillPathsRef.current = {}
+    setActiveCommand(null)
     clearAttachments()
     resetMentions()
     resetHeight()
@@ -730,15 +688,15 @@ export function AgentLauncher({ paneId, className }: AgentLauncherProps): React.
         }
         persistSelection(configSnapshot.id)
 
-        // Real send carries the WIRE text (path-framed skills) so the agent
-        // receives paths, not tokens.
-        const wireTrimmed = wireText.trim()
+        // Real send carries the WIRE text (path-framed skills, command-prefixed)
+        // so the agent receives paths, not tokens.
+        const wireTrimmed = wireWithCommand.trim()
         const blocks: ContentBlock[] = []
         if (attachmentsSnapshot.length > 0) {
-          if (wireTrimmed) blocks.push({ type: 'text', text: wireText })
+          if (wireTrimmed) blocks.push({ type: 'text', text: wireWithCommand })
           for (const a of attachmentsSnapshot) blocks.push(attachmentToBlock(a))
         } else if (wireTrimmed.length > 0) {
-          blocks.push({ type: 'text', text: wireText })
+          blocks.push({ type: 'text', text: wireWithCommand })
         }
 
         const liveStore = useAcpStore.getState()
@@ -785,7 +743,6 @@ export function AgentLauncher({ paneId, className }: AgentLauncherProps): React.
     saveAgentConfig,
     persistSelection,
     paneId,
-    prompt,
     attachments,
     clearAttachments,
     appOwnedTempPaths,
@@ -795,56 +752,24 @@ export function AgentLauncher({ paneId, className }: AgentLauncherProps): React.
     preparedKey,
     effectiveModels,
     effectiveModes,
-    effectiveConfigOptions
+    effectiveConfigOptions,
+    buildPromptParts,
+    skillPathsRef,
+    setActiveCommand
   ])
 
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
-      // Backspace over an inline skill token (caret immediately after a chip,
-      // no active selection): remove the whole token plus the splicer's
-      // trailing space. Falls through to the default one-char backspace when
-      // the caret is in plain text. Alt is excluded so macOS Option+Backspace
-      // (delete-word) doesn't slice a token and leave orphan sentinels.
-      if (e.key === 'Backspace' && !e.shiftKey && !e.metaKey && !e.ctrlKey && !e.altKey) {
-        const el = e.currentTarget
-        const caret = el.selectionStart ?? 0
-        const selEnd = el.selectionEnd ?? 0
-        if (caret === selEnd) {
-          const result = removeSkillTokenBeforeCaret(prompt, caret)
-          if (result.removed) {
-            e.preventDefault()
-            setPrompt(result.value)
-            updateMentions(result.value, result.caret)
-            resetHeight()
-            requestAnimationFrame(() => {
-              const t = textareaRef.current
-              if (!t) return
-              clampHeight(t)
-              t.setSelectionRange(result.caret, result.caret)
-              t.focus()
-            })
-            return
-          }
-        }
-      }
-      if (
-        tryHandleSlashMenuKeyDown(e, {
-          menuOpen,
-          sectionsLength: slashSections.length,
-          menuRef,
-          onClearInput: () => {
-            setPrompt('')
-            updateMentions('', 0)
-            resetHeight()
-          }
-        })
-      ) {
-        return
-      }
-      if (handleMentionKeyDown(e)) {
-        return
-      }
-      if (e.key === 'Enter' && !e.shiftKey && !e.metaKey && !e.ctrlKey && !menuOpen) {
+      // Shared composer dispatch (skill-token backspace, slash-menu keys,
+      // mention-menu keys) lives in `useChatComposer`. Enter→launch and
+      // Escape→hide are surface-specific (the launcher dispatches a chat
+      // launch, not a running-turn send) and run only when the shared
+      // handler did not consume the event. Both the slash and mention menus
+      // call `preventDefault` on Escape/Enter, so `e.defaultPrevented` is the
+      // single reliable gate.
+      composerHandleKeyDown(e)
+      if (e.defaultPrevented) return
+      if (e.key === 'Enter' && !e.shiftKey && !e.metaKey && !e.ctrlKey) {
         e.preventDefault()
         void launch()
       }
@@ -852,30 +777,20 @@ export function AgentLauncher({ paneId, className }: AgentLauncherProps): React.
         e.preventDefault()
         void launch()
       }
-      if (e.key === 'Escape' && !menuOpen) {
+      if (e.key === 'Escape') {
         useWorkspaceStore.getState().hideAgentLauncher()
       }
     },
-    [
-      prompt,
-      launch,
-      menuOpen,
-      slashSections.length,
-      handleMentionKeyDown,
-      updateMentions,
-      clampHeight,
-      resetHeight
-    ]
+    [composerHandleKeyDown, launch]
   )
 
   const canLaunch =
     Boolean(selectedConfig) &&
     selectedEntry?.status === 'ready' &&
-    (prompt.trim().length > 0 || attachments.length > 0)
-  // The transparent-textarea overlay is only needed when the value carries a
-  // skill token; otherwise keep the textarea text visible so plain typing,
-  // overlay first-paint, and any overlay failure never render invisible text.
-  const hasSkillToken = prompt.includes(SKILL_TOKEN_START)
+    (prompt.trim().length > 0 || attachments.length > 0 || activeCommand !== null)
+  // `hasSkillToken` comes from `useChatComposer` (destructured above) — the
+  // transparent-textarea overlay is only needed when the value carries a skill
+  // token; otherwise the textarea text stays visible.
 
   return (
     <div
@@ -890,11 +805,11 @@ export function AgentLauncher({ paneId, className }: AgentLauncherProps): React.
 
       <div className="flex w-full max-w-4xl flex-col gap-4">
         <div className="relative">
-          {menuOpen && (
+          {slashOpen && (
             <SlashCommandMenu
               ref={menuRef}
               sections={slashSections}
-              onSelect={handleSlashSelect}
+              onSelect={handleSelect}
               inputRef={textareaRef}
             />
           )}
@@ -969,6 +884,7 @@ export function AgentLauncher({ paneId, className }: AgentLauncherProps): React.
                   onRetry={handleRetryPrepare}
                 />
               )}
+            {activeCommand && <CommandChip name={activeCommand} onRemove={clearActiveCommand} />}
             <AttachmentPreviewGroup
               attachments={attachments}
               onRemove={removeAttachment}
@@ -1086,6 +1002,7 @@ export function AgentLauncher({ paneId, className }: AgentLauncherProps): React.
               type="button"
               onClick={() => {
                 setPrompt(suggestion.prompt)
+                setActiveCommand(null)
                 updateMentions(suggestion.prompt, suggestion.prompt.length)
                 textareaRef.current?.focus()
               }}

--- a/src/renderer/components/chat/ChatInputBar.test.tsx
+++ b/src/renderer/components/chat/ChatInputBar.test.tsx
@@ -2,7 +2,7 @@ import { fireEvent, render, screen, waitFor, within } from '@testing-library/rea
 import type { ComponentProps } from 'react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { TooltipProvider } from '@/components/ui/tooltip'
-import type { ContentBlock, SessionConfigOption } from '@/lib/acp-api'
+import type { SessionConfigOption } from '@/lib/acp-api'
 import { skillToken } from '@/lib/skill-tokens'
 import type { AcpSession } from '@/stores/acp-store'
 import { ChatInputBar } from './ChatInputBar'
@@ -660,6 +660,21 @@ describe('ChatInputBar command chip', () => {
 
     await waitFor(() => {
       expect(onSend).toHaveBeenCalledWith('edited message')
+    })
+  })
+
+  it('opens the slash menu at a mid-text slash (canonical any-position trigger)', async () => {
+    const commands = [{ name: 'compact', description: 'Compact' }]
+    renderInputBar({ commands })
+
+    const textarea = screen.getByRole('textbox')
+    // Type text before the slash so the trigger is mid-text, not leading.
+    // This is the canonical behavior the AgentLauncher was drifting from
+    // (it used the leading-only `isSlashTrigger`).
+    fireEvent.change(textarea, { target: { value: 'hello /' } })
+
+    await waitFor(() => {
+      expect(screen.getByRole('listbox')).toBeInTheDocument()
     })
   })
 })

--- a/src/renderer/components/chat/ChatInputBar.tsx
+++ b/src/renderer/components/chat/ChatInputBar.tsx
@@ -1,17 +1,9 @@
 import { BorderBeam } from 'border-beam'
 import { AnimatePresence, motion, useReducedMotion } from 'framer-motion'
 import { ArrowUp, Paperclip, Square } from 'lucide-react'
-import {
-  type DragEvent,
-  type KeyboardEvent,
-  useCallback,
-  useEffect,
-  useMemo,
-  useRef,
-  useState
-} from 'react'
+import { type DragEvent, type KeyboardEvent, useCallback, useEffect, useRef, useState } from 'react'
 import { toast } from 'sonner'
-import { buildPromptWithLoadedSkills, useAgentSkills } from '@/hooks/use-agent-skills'
+import { useAgentSkills } from '@/hooks/use-agent-skills'
 import { useMentionRecents } from '@/hooks/use-mention-recents'
 import { useMobileWebShell } from '@/hooks/use-mobile-web-shell'
 import { useOskViewport } from '@/hooks/use-osk-viewport'
@@ -23,12 +15,6 @@ import type {
 } from '@/lib/acp-api'
 import { persistenceApi } from '@/lib/api'
 import { registerSessionTempFiles } from '@/lib/attachment-temp-cleanup'
-import {
-  extractSkillNames,
-  insertSkillToken,
-  removeSkillTokenBeforeCaret,
-  SKILL_TOKEN_START
-} from '@/lib/skill-tokens'
 import { cn } from '@/lib/utils'
 import type { AcpSession, QueuedPrompt } from '@/stores/acp-store'
 import { useAcpMessages, useAcpStore, useSessionUsage } from '@/stores/acp-store'
@@ -50,14 +36,8 @@ import { McpBadge } from './McpBadge'
 import { PromptQueuePanel } from './PromptQueuePanel'
 import { SkillComposerOverlay } from './SkillComposerOverlay'
 import { SlashCommandMenu, type SlashMenuHandle } from './SlashCommandMenu'
-import { tryHandleSlashMenuKeyDown } from './slash-menu-keyboard'
-import {
-  buildSlashSections,
-  findSlashTrigger,
-  isSlashTriggerAny,
-  type SlashItem,
-  slashFilter
-} from './slash-menu-model'
+import { isSlashTriggerAny } from './slash-menu-model'
+import { useChatComposer } from './use-chat-composer'
 import { dataTransferFiles, useComposerAttachments } from './use-composer-attachments'
 import { useComposerMentions } from './use-composer-mentions'
 import { useComposerTextarea } from './use-composer-textarea'
@@ -215,12 +195,6 @@ export function ChatInputBar({
     }, 400)
     return () => clearTimeout(handle)
   }, [value, draftKey, seedNonce, canPersistDraft])
-  const [activeCommand, setActiveCommand] = useState<string | null>(null)
-  // name → SKILL.md path, captured when a skill is picked from the slash menu
-  // so the wire prompt can cite paths synchronously at send time (no IPC read,
-  // no failure path). The composer value carries the inline skill tokens; this
-  // ref supplies the path for each token's name when building the wire text.
-  const skillPathsRef = useRef<Record<string, string>>({})
   const [sending, setSending] = useState(false)
   const [focused, setFocused] = useState(false)
   const [dragActive, setDragActive] = useState(false)
@@ -291,7 +265,6 @@ export function ChatInputBar({
   }, [canDropPaste])
 
   const slashOpen = isSlashTriggerAny(value) && !disabled
-  const filter = slashFilter(value)
   const {
     onInput,
     onKeyUp,
@@ -308,22 +281,40 @@ export function ChatInputBar({
     updateMentions
   } = useComposerTextarea({ value, setValue, textareaRef, mentions, disabled, slashOpen })
 
-  const sections = useMemo(
-    () =>
-      slashOpen
-        ? buildSlashSections({ commands, configOptions, modes, skills: availableSkills, filter })
-        : [],
-    [slashOpen, commands, configOptions, modes, availableSkills, filter]
-  )
+  const {
+    slashSections,
+    activeCommand,
+    setActiveCommand,
+    clearActiveCommand,
+    skillPathsRef,
+    hasSkillToken,
+    handleSelect,
+    handleKeyDown: composerHandleKeyDown,
+    buildPromptParts
+  } = useChatComposer({
+    value,
+    setValue,
+    textareaRef,
+    slashMenuRef,
+    commands,
+    configOptions,
+    modes,
+    skills: availableSkills,
+    disabled,
+    onSetConfig,
+    onSetMode,
+    onSetModel,
+    handleMentionKeyDown,
+    updateMentions,
+    resetMentions,
+    resetHeight,
+    clampHeight
+  })
 
   const canSend =
     !disabled &&
     !sending &&
     (value.trim().length > 0 || activeCommand !== null || attachments.length > 0)
-  // The transparent-textarea overlay is only needed when the value carries a
-  // skill token; otherwise keep the textarea text visible so plain typing,
-  // overlay first-paint, and any overlay failure never render invisible text.
-  const hasSkillToken = value.includes(SKILL_TOKEN_START)
   const showStop = busy && !canSend
   const iconMotion = iconPop(reduced)
 
@@ -334,40 +325,11 @@ export function ChatInputBar({
 
     setSending(true)
     try {
-      // Extract the inline skill tokens carried in the value and resolve each
-      // name to its SKILL.md path. Paths come from `skillPathsRef` (captured at
-      // pick time) first, then fall back to the currently-available skills list
-      // — so editing + re-sending a chip message (where the ref is empty
-      // because paths aren't persisted with the message) still resolves paths
-      // from the live skills list. A skill surfaced without a path in either
-      // (e.g. a future web skill with no parity route) blocks the send — HALT
-      // with a clear error so the user can remove the chip.
-      const skillNames = extractSkillNames(value)
-      const skills = skillNames.map((name) => ({
-        name,
-        path:
-          skillPathsRef.current[name] ?? availableSkills.find((s) => s.name === name)?.path ?? ''
-      }))
-      const missingPath = skills.find((s) => !s.path)
-      if (missingPath) {
-        throw new Error(`Skill '${missingPath.name}' is missing a path`)
-      }
-
-      // Wire text dispatched to the agent: skills framed by path under
-      // `# Agent Skills`, then the user text with tokens replaced by `(name)`.
-      // Sync — paths were captured at pick time, so no IPC and no failure path.
-      const wireText = buildPromptWithLoadedSkills(skills, value)
-      // Display text stored in the optimistic user message: the raw token value
-      // so the timeline overlay re-renders the chips inline.
-      const displayText = value
-      const hasSkills = skills.length > 0
-
-      // Prepend the active command to both wire and display so the timeline
-      // shows `/cmd …` and the agent receives the command-prefixed wire text.
-      const wireWithCommand = activeCommand ? `/${activeCommand} ${wireText}` : wireText
-      const displayWithCommand = activeCommand ? `/${activeCommand} ${displayText}` : displayText
-      const wireTrimmed = wireWithCommand.trim()
-      const displayTrimmed = displayWithCommand.trim()
+      // Build the wire/display text parts from the current value, resolved skill
+      // paths, and active command. Throws `Skill '<name>' is missing a path`
+      // when a selected skill has no resolvable path (Block If) — caught below.
+      const { hasSkills, wireWithCommand, displayWithCommand, wireTrimmed, displayTrimmed } =
+        buildPromptParts()
       if (!wireTrimmed && !hasAttachments) return
 
       if (hasAttachments) {
@@ -415,7 +377,6 @@ export function ChatInputBar({
     value,
     attachments,
     activeCommand,
-    availableSkills,
     disabled,
     sending,
     clearAttachments,
@@ -424,123 +385,21 @@ export function ChatInputBar({
     onSendBlocks,
     resetHeight,
     resetMentions,
-    session.id
+    session.id,
+    buildPromptParts,
+    skillPathsRef,
+    setActiveCommand
   ])
-
-  const handleSelect = useCallback(
-    (item: SlashItem) => {
-      if (item.kind === 'skill') {
-        // Splice an inline skill token at the caret, removing the `/`-filter
-        // text the slash menu was filtering on. The token carries the skill
-        // name; the path is recorded into `skillPathsRef` so the wire prompt
-        // can cite it synchronously at send time. A trailing space is appended
-        // so the caret lands in plain text and the next `/` trigger matches.
-        const trigger = findSlashTrigger(value)
-        const caret = textareaRef.current?.selectionStart ?? value.length
-        const insertAt = trigger ? trigger.end : caret
-        const deleteBefore = trigger ? trigger.end - trigger.start : 0
-        const { value: next, caret: nextCaret } = insertSkillToken(
-          value,
-          insertAt,
-          item.name,
-          deleteBefore
-        )
-        skillPathsRef.current[item.name] = item.path
-        setValue(next)
-        updateMentions(next, nextCaret)
-        resetHeight()
-        requestAnimationFrame(() => {
-          const el = textareaRef.current
-          if (!el) return
-          clampHeight(el)
-          el.setSelectionRange(nextCaret, nextCaret)
-          el.focus()
-        })
-        return
-      }
-      if (item.kind === 'command') {
-        // Set the command chip instead of inserting bare text into the textarea.
-        // If the trigger was mid-text, replace the /token portion in the input.
-        const midTrigger = findSlashTrigger(value)
-        if (midTrigger && midTrigger.start > 0) {
-          // Mid-text trigger: remove the /token from the input, keep the rest
-          const before = value.slice(0, midTrigger.start).trimEnd()
-          const after = value.slice(midTrigger.end).trimStart()
-          const remaining = [before, after].filter(Boolean).join(' ')
-          setValue(remaining)
-          updateMentions(remaining, remaining.length)
-        } else {
-          // Leading or standalone trigger: clear the input
-          setValue('')
-          updateMentions('', 0)
-        }
-        setActiveCommand(item.name)
-        resetHeight()
-        textareaRef.current?.focus()
-        return
-      }
-      if (item.kind === 'config') {
-        // AgentChatPanel's setters toast then rethrow; swallow here so the
-        // already-surfaced failure doesn't become an unhandled rejection.
-        void Promise.resolve(onSetConfig(item.configId, item.valueId)).catch(() => {})
-      } else {
-        void Promise.resolve(onSetMode(item.modeId)).catch(() => {})
-      }
-      setValue('')
-      updateMentions('', 0)
-      resetHeight()
-    },
-    [value, onSetConfig, onSetMode, resetHeight, clampHeight, updateMentions]
-  )
 
   const handleKeyDown = useCallback(
     (e: KeyboardEvent<HTMLTextAreaElement>) => {
-      // Backspace over an inline skill token (caret immediately after a chip,
-      // no active selection): remove the whole token plus the splicer's
-      // trailing space. Falls through to the default one-char backspace when
-      // the caret is in plain text. Alt is excluded so macOS Option+Backspace
-      // (delete-word) doesn't slice a token and leave orphan sentinels.
-      if (e.key === 'Backspace' && !e.shiftKey && !e.metaKey && !e.ctrlKey && !e.altKey) {
-        const el = e.currentTarget
-        const caret = el.selectionStart ?? 0
-        const selEnd = el.selectionEnd ?? 0
-        if (caret === selEnd) {
-          const result = removeSkillTokenBeforeCaret(value, caret)
-          if (result.removed) {
-            e.preventDefault()
-            setValue(result.value)
-            updateMentions(result.value, result.caret)
-            resetHeight()
-            requestAnimationFrame(() => {
-              const t = textareaRef.current
-              if (!t) return
-              clampHeight(t)
-              t.setSelectionRange(result.caret, result.caret)
-              t.focus()
-            })
-            return
-          }
-        }
-      }
-      if (
-        tryHandleSlashMenuKeyDown(e, {
-          menuOpen: slashOpen,
-          sectionsLength: sections.length,
-          menuRef: slashMenuRef,
-          onClearInput: () => {
-            setValue('')
-            setActiveCommand(null)
-            updateMentions('', 0)
-            resetHeight()
-          }
-        })
-      ) {
-        return
-      }
-      if (handleMentionKeyDown(e)) {
-        return
-      }
-
+      // Shared composer dispatch (skill-token backspace, slash-menu keys,
+      // mention-menu keys) lives in `useChatComposer`. Enter→submit and
+      // Escape→cancel are surface-specific (the running chatbox cancels a busy
+      // turn on Escape and morphs send/stop) and run only when the shared
+      // handler did not consume the event.
+      composerHandleKeyDown(e)
+      if (e.defaultPrevented) return
       if (e.key === 'Escape' && busy) {
         e.preventDefault()
         onCancel()
@@ -552,19 +411,7 @@ export function ChatInputBar({
         void submit()
       }
     },
-    [
-      value,
-      slashOpen,
-      sections.length,
-      handleMentionKeyDown,
-      updateMentions,
-      clampHeight,
-      busy,
-      showStop,
-      onCancel,
-      submit,
-      resetHeight
-    ]
+    [composerHandleKeyDown, busy, showStop, onCancel, submit]
   )
 
   // Load externally-seeded text (edit a message, pick a starter prompt), then
@@ -651,7 +498,7 @@ export function ChatInputBar({
         {slashOpen && (
           <SlashCommandMenu
             ref={slashMenuRef}
-            sections={sections}
+            sections={slashSections}
             onSelect={handleSelect}
             inputRef={textareaRef}
           />
@@ -691,15 +538,7 @@ export function ChatInputBar({
                 </span>
               </div>
             )}
-            {activeCommand && (
-              <CommandChip
-                name={activeCommand}
-                onRemove={() => {
-                  setActiveCommand(null)
-                  textareaRef.current?.focus()
-                }}
-              />
-            )}
+            {activeCommand && <CommandChip name={activeCommand} onRemove={clearActiveCommand} />}
             <AttachmentPreviewGroup attachments={attachments} onRemove={removeAttachment} />
             <div className="px-4 pb-1.5 pt-3.5">
               {/* Transparent-textarea overlay: mirrors the value with inline

--- a/src/renderer/components/chat/SkillChip.tsx
+++ b/src/renderer/components/chat/SkillChip.tsx
@@ -14,8 +14,12 @@ interface SkillChipProps {
  *
  * Inline metrics are tuned for the transparent-textarea overlay so the chip
  * occupies exactly one line box (`inline-flex items-center align-baseline
- * leading-none h-[1.1em]`, horizontal-only `px-1.5` padding, no vertical
+ * leading-none h-[1.1em]`, horizontal-only `px-2` padding, no vertical
  * padding) — the transparent textarea text and the overlay stay caret-aligned.
+ * `text-sm` matches the composer/timeline body text so the chip label reads at
+ * the same size as the surrounding non-chip text; the reduced `rounded-md`
+ * corner (vs the old fully-round pill) reads as a compact tag without growing
+ * the line box or shifting the baseline.
  *
  * Always non-interactive by construction: there is no `onRemove` or any other
  * interactive/removal prop. In the composer, Backspace removes a chip via the
@@ -28,7 +32,7 @@ export function SkillChip({ name, className }: SkillChipProps): React.JSX.Elemen
     <span
       className={cn(
         'inline-flex h-[1.1em] max-w-full items-center gap-1 align-baseline leading-none',
-        'rounded-full border border-primary/40 bg-primary/10 px-1.5 text-xs font-medium text-primary',
+        'rounded-md border border-primary/40 bg-primary/10 px-2 text-sm font-medium text-primary',
         className
       )}
     >

--- a/src/renderer/components/chat/SlashCommandMenu.tsx
+++ b/src/renderer/components/chat/SlashCommandMenu.tsx
@@ -41,6 +41,10 @@ function slashItemToComposer(item: SlashItem): ComposerMenuItem {
     label,
     description: item.description,
     icon: Icon,
+    // Skill rows share the accent `Sparkles` treatment with `SkillChip`
+    // (composer overlay + timeline) so the skills icon reads consistently
+    // across the picker and the chips. Commands/config/mode stay muted.
+    iconClassName: item.kind === 'skill' ? 'text-primary' : undefined,
     selected,
     payload: item
   }

--- a/src/renderer/components/chat/composer-menu.tsx
+++ b/src/renderer/components/chat/composer-menu.tsx
@@ -17,6 +17,9 @@ export interface ComposerMenuItem {
   label: string
   description?: string | null
   icon?: LucideIcon
+  /** Override the default muted icon color (e.g. skill rows use `text-primary`
+   * to match the accent `SkillChip`). Resolved via `cn`, so later classes win. */
+  iconClassName?: string
   selected?: boolean
   dimmed?: boolean
   /** Wrap long labels/descriptions instead of truncating (used by skill rows). */
@@ -239,7 +242,12 @@ export const ComposerMenu = forwardRef<ComposerMenuHandle, ComposerMenuProps>(
                     item.dimmed && 'opacity-50'
                   )}
                 >
-                  {Icon && <Icon size={13} className="shrink-0 text-muted-foreground" />}
+                  {Icon && (
+                    <Icon
+                      size={13}
+                      className={cn('shrink-0 text-muted-foreground', item.iconClassName)}
+                    />
+                  )}
                   <span
                     className={cn('font-medium', item.wrap ? 'break-words' : 'min-w-0 truncate')}
                   >

--- a/src/renderer/components/chat/use-chat-composer.ts
+++ b/src/renderer/components/chat/use-chat-composer.ts
@@ -1,0 +1,342 @@
+import type { KeyboardEvent, MutableRefObject, RefObject } from 'react'
+import { useCallback, useMemo, useRef, useState } from 'react'
+import { buildPromptWithLoadedSkills } from '@/hooks/use-agent-skills'
+import type { AvailableCommand, SessionConfigOption, SessionModeState } from '@/lib/acp-api'
+import {
+  extractSkillNames,
+  insertSkillToken,
+  removeSkillTokenBeforeCaret,
+  SKILL_TOKEN_START
+} from '@/lib/skill-tokens'
+import type { AgentSkillSummary } from '@/lib/skills-api'
+import type { SlashMenuHandle } from './SlashCommandMenu'
+import { tryHandleSlashMenuKeyDown } from './slash-menu-keyboard'
+import {
+  buildSlashSections,
+  findSlashTrigger,
+  isSlashTriggerAny,
+  type SlashItem,
+  type SlashSection,
+  slashFilter
+} from './slash-menu-model'
+
+/**
+ * Shared chat-composer state + handlers for the two composer hosts
+ * (`ChatInputBar` — the running chatbox — and `AgentLauncher` — the new-chat
+ * screen). This is a LOGIC extraction, not a JSX extraction: the two surfaces
+ * keep their own outer chrome (BorderBeam/queue vs agent picker/banners), but
+ * route the duplicated composer-field logic — slash menu, skill-token splice,
+ * command chip, submit text builder — through this hook so they cannot drift
+ * again.
+ *
+ * The hook is renderer-neutral: no Tauri/runtime calls, no JSX. Both surfaces
+ * keep their own `submit()`/`launch()` because the dispatch shapes differ
+ * (`onSend`/`onSendBlocks` vs `finalizeChatLaunch`/`sendPromptBlocks`), but
+ * both read `activeCommand` + `skillPathsRef` + `buildPromptParts()` from the
+ * hook to build the wire/display text identically.
+ */
+export interface UseChatComposerArgs {
+  value: string
+  setValue: (v: string) => void
+  textareaRef: RefObject<HTMLTextAreaElement | null>
+  slashMenuRef: RefObject<SlashMenuHandle | null>
+  commands: AvailableCommand[]
+  configOptions: SessionConfigOption[]
+  modes: SessionModeState | null
+  skills: AgentSkillSummary[]
+  disabled: boolean
+  onSetConfig: (configId: string, valueId: string) => void | Promise<void>
+  onSetMode: (modeId: string) => void | Promise<void>
+  /**
+   * Reserved for model-row parity (the model chip routes native ACP models
+   * through `onSetModel` when `modelSource === 'models'`). Slash-menu model
+   * rows currently flow through the `config` branch → `onSetConfig`, matching
+   * the canonical `ChatInputBar` behavior; these fields are kept on the
+   * interface so a future model-row divergence can land without reshaping it.
+   */
+  onSetModel?: (modelId: string) => void | Promise<void>
+  modelOption?: SessionConfigOption | null
+  modelSource?: 'models' | 'config'
+  /** Mention-menu keyboard dispatch from `useComposerTextarea`. */
+  handleMentionKeyDown: (e: KeyboardEvent<HTMLTextAreaElement>) => boolean
+  updateMentions: (v: string, caret: number) => void
+  resetMentions: () => void
+  resetHeight: () => void
+  clampHeight: (el: HTMLTextAreaElement) => void
+}
+
+export interface ChatPromptParts {
+  /** Resolved skills with their SKILL.md paths (for the wire header). */
+  skills: Array<{ name: string; path: string }>
+  hasSkills: boolean
+  /** Wire text dispatched to the agent (skills framed by path, tokens → `(name)`). */
+  wireText: string
+  /** Display text stored in the optimistic user message (raw token value). */
+  displayText: string
+  /** Wire text with the active command (`/cmd `) prefixed when set. */
+  wireWithCommand: string
+  /** Display text with the active command (`/cmd `) prefixed when set. */
+  displayWithCommand: string
+  wireTrimmed: string
+  displayTrimmed: string
+}
+
+export interface UseChatComposerResult {
+  slashOpen: boolean
+  slashSections: SlashSection[]
+  activeCommand: string | null
+  setActiveCommand: (v: string | null) => void
+  clearActiveCommand: () => void
+  skillPathsRef: MutableRefObject<Record<string, string>>
+  hasSkillToken: boolean
+  handleSelect: (item: SlashItem) => void
+  /**
+   * Shared keydown for the composer textarea: skill-token backspace, slash-menu
+   * arrow/Tab/Enter/Escape, and @-mention arrow/Tab/Enter/Escape. Enter→submit
+   * and Escape→cancel/launch are surface-specific (the dispatch shapes differ),
+   * so each host wraps this handler and checks `e.defaultPrevented` before
+   * running its own Enter/Escape branch.
+   */
+  handleKeyDown: (e: KeyboardEvent<HTMLTextAreaElement>) => void
+  /**
+   * Build the wire/display prompt text parts from the current value, resolved
+   * skill paths, and active command. Throws `Error("Skill '<name>' is missing
+   * a path")` when a selected skill has no resolvable path (the canonical
+   * `ChatInputBar` Block If — surfaces catch and toast).
+   */
+  buildPromptParts: () => ChatPromptParts
+}
+
+export function useChatComposer(args: UseChatComposerArgs): UseChatComposerResult {
+  const {
+    value,
+    setValue,
+    textareaRef,
+    slashMenuRef,
+    commands,
+    configOptions,
+    modes,
+    skills,
+    disabled,
+    onSetConfig,
+    onSetMode,
+    handleMentionKeyDown,
+    updateMentions,
+    resetHeight,
+    clampHeight
+  } = args
+
+  const [activeCommand, setActiveCommand] = useState<string | null>(null)
+  // name → SKILL.md path, captured when a skill is picked from the slash menu
+  // so the wire prompt can cite paths synchronously at send time (no IPC read,
+  // no failure path). The composer value carries the inline skill tokens; this
+  // ref supplies the path for each token's name when building the wire text.
+  const skillPathsRef = useRef<Record<string, string>>({})
+
+  const slashOpen = isSlashTriggerAny(value) && !disabled
+  const filter = slashFilter(value)
+  const slashSections = useMemo(
+    () => (slashOpen ? buildSlashSections({ commands, configOptions, modes, skills, filter }) : []),
+    [slashOpen, commands, configOptions, modes, skills, filter]
+  )
+  // The transparent-textarea overlay is only needed when the value carries a
+  // skill token; otherwise keep the textarea text visible so plain typing,
+  // overlay first-paint, and any overlay failure never render invisible text.
+  const hasSkillToken = value.includes(SKILL_TOKEN_START)
+
+  const handleSelect = useCallback(
+    (item: SlashItem) => {
+      if (item.kind === 'skill') {
+        // Splice an inline skill token at the caret, removing the `/`-filter
+        // text the slash menu was filtering on. The token carries the skill
+        // name; the path is recorded into `skillPathsRef` so the wire prompt
+        // can cite it synchronously at send time. A trailing space is appended
+        // so the caret lands in plain text and the next `/` trigger matches.
+        const trigger = findSlashTrigger(value)
+        const caret = textareaRef.current?.selectionStart ?? value.length
+        const insertAt = trigger ? trigger.end : caret
+        const deleteBefore = trigger ? trigger.end - trigger.start : 0
+        const { value: next, caret: nextCaret } = insertSkillToken(
+          value,
+          insertAt,
+          item.name,
+          deleteBefore
+        )
+        skillPathsRef.current[item.name] = item.path
+        setValue(next)
+        updateMentions(next, nextCaret)
+        resetHeight()
+        requestAnimationFrame(() => {
+          const el = textareaRef.current
+          if (!el) return
+          clampHeight(el)
+          el.setSelectionRange(nextCaret, nextCaret)
+          el.focus()
+        })
+        return
+      }
+      if (item.kind === 'command') {
+        // Set the command chip instead of inserting bare text into the
+        // textarea. If the trigger was mid-text, replace the /token portion in
+        // the input.
+        const midTrigger = findSlashTrigger(value)
+        if (midTrigger && midTrigger.start > 0) {
+          // Mid-text trigger: remove the /token from the input, keep the rest
+          const before = value.slice(0, midTrigger.start).trimEnd()
+          const after = value.slice(midTrigger.end).trimStart()
+          const remaining = [before, after].filter(Boolean).join(' ')
+          setValue(remaining)
+          updateMentions(remaining, remaining.length)
+        } else {
+          // Leading or standalone trigger: clear the input
+          setValue('')
+          updateMentions('', 0)
+        }
+        setActiveCommand(item.name)
+        resetHeight()
+        textareaRef.current?.focus()
+        return
+      }
+      if (item.kind === 'config') {
+        // AgentChatPanel's setters toast then rethrow; swallow here so the
+        // already-surfaced failure doesn't become an unhandled rejection.
+        void Promise.resolve(onSetConfig(item.configId, item.valueId)).catch(() => {})
+      } else {
+        void Promise.resolve(onSetMode(item.modeId)).catch(() => {})
+      }
+      setValue('')
+      updateMentions('', 0)
+      resetHeight()
+    },
+    [value, onSetConfig, onSetMode, resetHeight, clampHeight, updateMentions, setValue, textareaRef]
+  )
+
+  const handleKeyDown = useCallback(
+    (e: KeyboardEvent<HTMLTextAreaElement>) => {
+      // Backspace over an inline skill token (caret immediately after a chip,
+      // no active selection): remove the whole token plus the splicer's
+      // trailing space. Falls through to the default one-char backspace when
+      // the caret is in plain text. Alt is excluded so macOS Option+Backspace
+      // (delete-word) doesn't slice a token and leave orphan sentinels.
+      if (e.key === 'Backspace' && !e.shiftKey && !e.metaKey && !e.ctrlKey && !e.altKey) {
+        const el = e.currentTarget
+        const caret = el.selectionStart ?? 0
+        const selEnd = el.selectionEnd ?? 0
+        if (caret === selEnd) {
+          const result = removeSkillTokenBeforeCaret(value, caret)
+          if (result.removed) {
+            e.preventDefault()
+            setValue(result.value)
+            updateMentions(result.value, result.caret)
+            resetHeight()
+            requestAnimationFrame(() => {
+              const t = textareaRef.current
+              if (!t) return
+              clampHeight(t)
+              t.setSelectionRange(result.caret, result.caret)
+              t.focus()
+            })
+            return
+          }
+        }
+      }
+      if (
+        tryHandleSlashMenuKeyDown(e, {
+          menuOpen: slashOpen,
+          sectionsLength: slashSections.length,
+          menuRef: slashMenuRef,
+          onClearInput: () => {
+            setValue('')
+            setActiveCommand(null)
+            updateMentions('', 0)
+            resetHeight()
+          }
+        })
+      ) {
+        return
+      }
+      if (handleMentionKeyDown(e)) {
+        return
+      }
+      // Enter→submit / Escape→cancel are surface-specific: each host wraps
+      // this handler and checks `e.defaultPrevented` before running its own
+      // branch (the dispatch shapes — onSend/onSendBlocks vs
+      // finalizeChatLaunch/sendPromptBlocks — differ).
+    },
+    [
+      value,
+      slashOpen,
+      slashSections.length,
+      slashMenuRef,
+      handleMentionKeyDown,
+      updateMentions,
+      clampHeight,
+      resetHeight,
+      setValue,
+      textareaRef
+    ]
+  )
+
+  const clearActiveCommand = useCallback(() => {
+    setActiveCommand(null)
+    textareaRef.current?.focus()
+  }, [textareaRef])
+
+  const buildPromptParts = useCallback((): ChatPromptParts => {
+    // Extract the inline skill tokens carried in the value and resolve each
+    // name to its SKILL.md path. Paths come from `skillPathsRef` (captured at
+    // pick time) first, then fall back to the currently-available skills list
+    // — so editing + re-sending a chip message (where the ref is empty
+    // because paths aren't persisted with the message) still resolves paths
+    // from the live skills list. A skill surfaced without a path in either
+    // (e.g. a future web skill with no parity route) blocks the send — HALT
+    // with a clear error so the user can remove the chip.
+    const skillNames = extractSkillNames(value)
+    const resolvedSkills = skillNames.map((name) => ({
+      name,
+      path: skillPathsRef.current[name] ?? skills.find((s) => s.name === name)?.path ?? ''
+    }))
+    const missingPath = resolvedSkills.find((s) => !s.path)
+    if (missingPath) {
+      throw new Error(`Skill '${missingPath.name}' is missing a path`)
+    }
+    const hasSkills = resolvedSkills.length > 0
+    // Wire text dispatched to the agent: skills framed by path under
+    // `# Agent Skills`, then the user text with tokens replaced by `(name)`.
+    // Always call the framer (it inline-replaces tokens + trims even when
+    // there are no framed skills) so a value carrying a token with no matching
+    // path entry degrades to `(name)` rather than leaking a private-use
+    // sentinel.
+    const wireText = buildPromptWithLoadedSkills(resolvedSkills, value)
+    // Display text stored in the optimistic user message: the raw token value
+    // so the timeline overlay re-renders the chips inline.
+    const displayText = value
+    // Prepend the active command to both wire and display so the timeline
+    // shows `/cmd …` and the agent receives the command-prefixed wire text.
+    const wireWithCommand = activeCommand ? `/${activeCommand} ${wireText}` : wireText
+    const displayWithCommand = activeCommand ? `/${activeCommand} ${displayText}` : displayText
+    return {
+      skills: resolvedSkills,
+      hasSkills,
+      wireText,
+      displayText,
+      wireWithCommand,
+      displayWithCommand,
+      wireTrimmed: wireWithCommand.trim(),
+      displayTrimmed: displayWithCommand.trim()
+    }
+  }, [value, skills, activeCommand])
+
+  return {
+    slashOpen,
+    slashSections,
+    activeCommand,
+    setActiveCommand,
+    clearActiveCommand,
+    skillPathsRef,
+    hasSkillToken,
+    handleSelect,
+    handleKeyDown,
+    buildPromptParts
+  }
+}


### PR DESCRIPTION
## Summary

The `AgentLauncher` (new-chat screen) and `ChatInputBar` (running chatbox) duplicated the same composer logic but had drifted: the launcher opened the slash menu only at a leading `/` (so `hello /com` did nothing), and selecting a command inserted bare `/name ` text instead of a `CommandChip`, so the launcher lacked the chip UX the running chatbox already had. This extracts the shared composer state + handlers into one hook so both surfaces cannot drift again, fixes the two launcher regressions, and unifies the skills icon + chip styling.

## Related Issue

No related issue ��� this consolidates duplicated composer logic and fixes the launcher slash-menu/command-chip parity surfaced while reviewing the chip feature. No existing issue tracks the cross-surface drift.

## Type of Change

- [ ] feat: new feature
- [x] fix: bug fix
- [ ] docs: documentation only
- [ ] style: formatting or non-functional styling changes
- [x] refactor: internal cleanup with no behavior change
- [ ] perf: performance improvement
- [ ] test: adds or updates tests
- [ ] build: build or dependency changes
- [ ] ci: CI/CD workflow changes
- [ ] chore: maintenance or tooling
- [ ] revert: reverts a previous change

## What Changed

- New `src/renderer/components/chat/use-chat-composer.ts` ��� shared hook owning slash-open (`isSlashTriggerAny`), `slashSections`, `activeCommand`, `skillPathsRef`, `handleSelect`, `handleKeyDown`, and `buildPromptParts` (wire/display text + command prefix builder).
- `ChatInputBar.tsx` ��� routes through `useChatComposer`; keeps surface-specific chrome (BorderBeam, chips row, draft persistence, OSK effects, morph send/stop). Behavior unchanged.
- `AgentLauncher.tsx` ��� routes through `useChatComposer`; **fixes**: slash menu now opens at any caret position (was leading-only), and selecting a command now creates a `CommandChip` (was bare `/name ` text). Adds `CommandChip` rendering; `launch()` uses `buildPromptParts` for the wire/display + command prefix.
- `composer-menu.tsx` + `SlashCommandMenu.tsx` ��� added per-item `iconClassName`; skill rows pass `text-primary` so the menu's skills icon matches the accent `SkillChip` (commands/config/mode stay muted).
- `SkillChip.tsx` ��� `rounded-md` corners (was `rounded-full`), `px-2` padding, `text-sm` to match the surrounding body text, keeping the one-line-box overlay alignment (`h-[1.1em]` + `align-baseline` + `leading-none`).

## How It Was Tested

- [x] `bun run ci` (Biome lint + format + imports, strict mode)
- [x] `bun run typecheck`
- [x] `bun run test`
- [ ] `cargo clippy --all-targets -- -D warnings` (in src-tauri)
- [ ] `cargo test` (in src-tauri)
- [x] Manual verification completed
- [ ] Not applicable

New tests: launcher mid-text slash opens the menu; launcher command selection renders a `CommandChip`; ChatInputBar mid-text slash guard. All 2787 tests pass.

## Screenshots or Recordings

N/A ��� code refactor + chip styling; verify visually in the launcher and running chatbox.

## CI & Review Gate

- [x] All CI checks pass (PR Validation, Rust Checks, Build Verification, Security Scans)
- [x] Code review comments from CodeRabbit / Claude have been addressed or resolved
- [x] No unresolved review findings remain

## Checklist

- [x] My PR title follows the conventional commit format used by this repo
- [x] I linked the related issue or explained why none exists
- [ ] I updated docs when needed
- [x] I added or updated tests when needed
- [x] I verified the change does not introduce unrelated modifications
- [x] I read AGENTS.md and followed the contributor guidelines
- [x] A human reviewed the complete diff before submission

