### PR TITLE
feat(acp): add MCP server status, tool list, and chatbox enable/disable

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4149,6 +4149,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "process-wrap"
+version = "9.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e842efad9119158434d193c6682e2ebee4b44d6ad801d7b349623b3f57cdf55"
+dependencies = [
+ "futures",
+ "indexmap 2.14.0",
+ "nix 0.31.3",
+ "tokio",
+ "tracing",
+ "windows 0.62.2",
+]
+
+[[package]]
 name = "ptr_meta"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4542,14 +4556,19 @@ dependencies = [
  "base64 0.22.1",
  "chrono",
  "futures",
+ "http",
  "pastey",
  "pin-project-lite",
+ "process-wrap",
+ "reqwest",
  "rmcp-macros",
  "schemars 1.2.1",
  "serde",
  "serde_json",
+ "sse-stream",
  "thiserror 2.0.18",
  "tokio",
+ "tokio-stream",
  "tokio-util",
  "tracing",
 ]
@@ -5312,6 +5331,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "sse-stream"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c123f296ade4ec4b8b0f6162116e6629f5146922ca5ab40ca9d3c2e73ab4761e"
+dependencies = [
+ "bytes",
+ "futures-util",
+ "http-body",
+ "http-body-util",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "ssh2"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5501,7 +5533,7 @@ dependencies = [
  "tao-macros",
  "unicode-segmentation",
  "url",
- "windows",
+ "windows 0.61.3",
  "windows-core 0.61.2",
  "windows-version",
  "x11-dl",
@@ -5589,7 +5621,7 @@ dependencies = [
  "webkit2gtk",
  "webview2-com",
  "window-vibrancy",
- "windows",
+ "windows 0.61.3",
 ]
 
 [[package]]
@@ -5776,7 +5808,7 @@ dependencies = [
  "tokio-tungstenite 0.28.0",
  "uuid",
  "webview2-com",
- "windows",
+ "windows 0.61.3",
  "windows-core 0.61.2",
 ]
 
@@ -5817,7 +5849,7 @@ dependencies = [
  "tauri-plugin",
  "thiserror 2.0.18",
  "url",
- "windows",
+ "windows 0.61.3",
  "zbus 5.16.0",
 ]
 
@@ -5957,7 +5989,7 @@ dependencies = [
  "url",
  "webkit2gtk",
  "webview2-com",
- "windows",
+ "windows 0.61.3",
 ]
 
 [[package]]
@@ -5982,7 +6014,7 @@ dependencies = [
  "url",
  "webkit2gtk",
  "webview2-com",
- "windows",
+ "windows 0.61.3",
  "wry",
 ]
 
@@ -6043,7 +6075,7 @@ checksum = "0b1e66e07de489fe43a46678dd0b8df65e0c973909df1b60ba33874e297ba9b9"
 dependencies = [
  "quick-xml 0.37.5",
  "thiserror 2.0.18",
- "windows",
+ "windows 0.61.3",
  "windows-version",
 ]
 
@@ -6092,6 +6124,7 @@ dependencies = [
  "portable-pty",
  "regex",
  "reqwest",
+ "rmcp",
  "rust-embed",
  "serde",
  "serde_json",
@@ -6280,6 +6313,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
  "rustls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3d06f0b082ba57c26b79407372e57cf2a1e28124f78e9479fe80322cf53420b"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
  "tokio",
 ]
 
@@ -7138,7 +7182,7 @@ checksum = "7130243a7a5b33c54a444e54842e6a9e133de08b5ad7b5861cd8ed9a6a5bc96a"
 dependencies = [
  "webview2-com-macros",
  "webview2-com-sys",
- "windows",
+ "windows 0.61.3",
  "windows-core 0.61.2",
  "windows-implement",
  "windows-interface",
@@ -7162,7 +7206,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "381336cfffd772377d291702245447a5251a2ffa5bad679c99e61bc48bacbf9c"
 dependencies = [
  "thiserror 2.0.18",
- "windows",
+ "windows 0.61.3",
  "windows-core 0.61.2",
 ]
 
@@ -7224,11 +7268,23 @@ version = "0.61.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
 dependencies = [
- "windows-collections",
+ "windows-collections 0.2.0",
  "windows-core 0.61.2",
- "windows-future",
+ "windows-future 0.2.1",
  "windows-link 0.1.3",
- "windows-numerics",
+ "windows-numerics 0.2.0",
+]
+
+[[package]]
+name = "windows"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
+dependencies = [
+ "windows-collections 0.3.2",
+ "windows-core 0.62.2",
+ "windows-future 0.3.2",
+ "windows-numerics 0.3.1",
 ]
 
 [[package]]
@@ -7238,6 +7294,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
 dependencies = [
  "windows-core 0.61.2",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
+dependencies = [
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -7274,7 +7339,18 @@ checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
 dependencies = [
  "windows-core 0.61.2",
  "windows-link 0.1.3",
- "windows-threading",
+ "windows-threading 0.1.0",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
+dependencies = [
+ "windows-core 0.62.2",
+ "windows-link 0.2.1",
+ "windows-threading 0.2.1",
 ]
 
 [[package]]
@@ -7319,6 +7395,16 @@ checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
 dependencies = [
  "windows-core 0.61.2",
  "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-numerics"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
+dependencies = [
+ "windows-core 0.62.2",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -7457,6 +7543,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6"
 dependencies = [
  "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-threading"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
+dependencies = [
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -7805,7 +7900,7 @@ dependencies = [
  "webkit2gtk",
  "webkit2gtk-sys",
  "webview2-com",
- "windows",
+ "windows 0.61.3",
  "windows-core 0.61.2",
  "windows-version",
  "x11-dl",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -83,6 +83,21 @@ async-process = "2"
 # spec-adr-003-p0-rust-acp-core.md.
 agent-client-protocol = { version = "0.12", features = ["unstable_session_model", "unstable_session_usage"] }
 
+# MCP client probe (on-demand `initialize` + `tools/list`). rmcp is already in
+# the dep tree transitively via the vendored ACP (which enables `server` +
+# `transport-io`); this direct dep adds the CLIENT transport features Termul's
+# own probe needs. Resolved to 1.7.0 from `^1.2.0`. The `client-side-sse`
+# feature is rmcp's SSE stream parser (consumed by the streamable-http client);
+# rmcp 1.7.0 removed the standalone legacy SSE transport (CHANGELOG #562), so
+# `type: 'sse'` servers are probed via the modern streamable-http client (which
+# still speaks `text/event-stream`). See `src/acp/mcp_probe.rs`.
+rmcp = { version = "1.2.0", features = [
+    "client",
+    "transport-child-process",
+    "transport-streamable-http-client-reqwest",
+    "client-side-sse",
+] }
+
 # Regex and parsing
 regex = "1"
 lazy_static = "1.4"

--- a/src-tauri/src/acp/commands.rs
+++ b/src-tauri/src/acp/commands.rs
@@ -265,6 +265,19 @@ pub fn acp_probe_runtime() -> crate::acp::config::AcpRuntimeProbe {
     crate::acp::config::probe_registry_runtime()
 }
 
+/// On-demand MCP client probe. Takes a renderer-supplied `McpServerConfig`
+/// (stateless — no registry-store coupling), opens a fresh rmcp client
+/// connection, calls `initialize` + `tools/list`, then closes, and returns
+/// the connected/disconnected status + tool list. Never logs env/header
+/// values, tokens, or credentials. Mirrors the stateless shape of
+/// `acp_probe_runtime`.
+#[tauri::command]
+pub async fn acp_probe_mcp_server(
+    server: crate::acp::mcp_probe::McpServerConfig,
+) -> Result<crate::acp::mcp_probe::ProbeResult, String> {
+    Ok(crate::acp::mcp_probe::probe(server).await)
+}
+
 /// Set the in-process ACP turn (hard-cap) timeout override, in seconds, or
 /// `None` to clear it (fall back to the env var / 3h default). Pushed from the
 /// App Preferences UI so the turn timeout is editable without a restart or

--- a/src-tauri/src/acp/mcp_probe.rs
+++ b/src-tauri/src/acp/mcp_probe.rs
@@ -52,10 +52,24 @@ const PROBE_TIMEOUT: Duration = Duration::from_secs(10);
 
 /// A name=value pair (env var or HTTP header) as the renderer serializes it.
 /// Mirrors `McpEnvVar` / `McpHeader` in `src/renderer/lib/acp-api.ts`.
-#[derive(Debug, Clone, Deserialize)]
+///
+/// `Debug` is implemented manually to redact `value` (env values and HTTP
+/// header values frequently carry secrets). A derived `Debug` would print the
+/// raw value to any tracing/log macro that formats the struct — defense-in-
+/// depth so a future `?`/`%` log call cannot leak credentials.
+#[derive(Clone, Deserialize)]
 pub struct McpNameValuePair {
     pub name: String,
     pub value: String,
+}
+
+impl std::fmt::Debug for McpNameValuePair {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("McpNameValuePair")
+            .field("name", &self.name)
+            .field("value", &"<redacted>")
+            .finish()
+    }
 }
 
 /// Renderer-supplied MCP server config. Stateless payload — the renderer holds
@@ -65,7 +79,12 @@ pub struct McpNameValuePair {
 /// Kept deliberately loose (all transport-specific fields optional) so the
 /// probe does not couple to the vendored ACP `McpServer` schema — the probe
 /// owns its own deserialization and never touches the registry store.
-#[derive(Debug, Clone, Deserialize)]
+///
+/// `Debug` is implemented manually to redact `env` and `headers` (whose `value`
+/// fields carry secrets — see `McpNameValuePair`). Identifying fields the
+/// boundary log already surfaces (`name`/`command`/`url`/`type`/`args`) stay
+/// visible for diagnostics.
+#[derive(Clone, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct McpServerConfig {
     #[serde(default, rename = "type")]
@@ -79,6 +98,20 @@ pub struct McpServerConfig {
     pub url: Option<String>,
     #[serde(default)]
     pub headers: Vec<McpNameValuePair>,
+}
+
+impl std::fmt::Debug for McpServerConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("McpServerConfig")
+            .field("type", &self.r#type)
+            .field("name", &self.name)
+            .field("command", &self.command)
+            .field("args", &self.args)
+            .field("env", &format!("<{} redacted>", self.env.len()))
+            .field("url", &self.url)
+            .field("headers", &format!("<{} redacted>", self.headers.len()))
+            .finish()
+    }
 }
 
 impl McpServerConfig {
@@ -252,16 +285,22 @@ async fn probe_stdio(server: &McpServerConfig) -> ProbeResult {
     let mut cmd = Command::new(command);
     cmd.args(&server.args);
     for pair in &server.env {
-        // Expand `$VAR`/`${VAR}` before spawn; unset → empty string.
-        cmd.env(&pair.name, expand_env(&pair.value));
+      // Expand `$VAR`/`${VAR}` before spawn; unset → empty string.
+      cmd.env(&pair.name, expand_env(&pair.value));
     }
     // Windows: suppress the console window a GUI-launched probe would flash.
     // CREATE_NO_WINDOW = 0x0800_0000 (mirrors the vendored ACP patch). tokio's
     // `Command` exposes `creation_flags` natively on Windows.
     #[cfg(target_os = "windows")]
     {
-        cmd.creation_flags(0x0800_0000);
+      cmd.creation_flags(0x0800_0000);
     }
+    // Kill the child if the probe future is dropped mid-flight (notably when
+    // `tokio::time::timeout` fires above — dropping `probe_inner` drops the
+    // `TokioChildProcess` handle; without `kill_on_drop` the child is left
+    // running as an orphan). HTTP/SSE transports have no child process and are
+    // unaffected. tokio's default is to leave the child running on drop.
+    cmd.kill_on_drop(true);
 
     // Builder lets us null stderr so a chatty child does not pollute our logs.
     // stdin/stdout stay piped (the rmcp transport owns them).

--- a/src-tauri/src/acp/mcp_probe.rs
+++ b/src-tauri/src/acp/mcp_probe.rs
@@ -1,0 +1,463 @@
+//! On-demand MCP client probe.
+//!
+//! Opens a fresh rmcp client connection to a configured MCP server, completes
+//! the `initialize` handshake, calls `tools/list`, then closes — and reports
+//! the connected/disconnected status plus the tool list. The probe is
+//! **on-demand only**: each invocation opens a brand-new connection and tears
+//! it down immediately after `tools/list` returns (or fails). There are no
+//! persistent always-on connections.
+//!
+//! The probe is stateless: it takes a renderer-supplied [`McpServerConfig`] and
+//! does NOT touch the persisted registry. This mirrors `acp_probe_runtime`
+//! (stateless Tauri command) — the renderer already holds the full config and
+//! passes it through.
+//!
+//! ## Transport mapping
+//!
+//! - `stdio` → rmcp `transport-child-process` (`TokioChildProcess`). On Windows
+//!   the child is spawned with `CREATE_NO_WINDOW` (`0x0800_0000`) so a GUI-launched
+//!   probe does not flash a console window (mirrors the vendored ACP patch in
+//!   `vendor/agent-client-protocol/src/acp_agent.rs`).
+//! - `http` → rmcp `transport-streamable-http-client-reqwest`
+//!   (`StreamableHttpClientTransport`).
+//! - `sse` → rmcp 1.7.0 removed the standalone legacy SSE transport
+//!   (CHANGELOG #562). The `client-side-sse` feature ships the SSE stream
+//!   parser consumed by the streamable-http client (which still speaks
+//!   `text/event-stream`). `type: 'sse'` servers are therefore probed via the
+//!   modern streamable-http client; pure-legacy SSE-only servers may not probe
+//!   correctly. This is a known residual risk — see the spec's Design Notes.
+//!
+//! Env values in stdio configs are `$VAR`/`${VAR}`-expanded before spawn
+//! (unset variable → empty string, matching shell behavior). Header values are
+//! NOT expanded (headers are HTTP-only; shell expansion does not apply).
+//!
+//! Probe outcomes are logged (connected/disconnected + server name + transport)
+//! WITHOUT env/header values, tokens, or credentials.
+
+use std::collections::HashMap;
+use std::process::Stdio;
+use std::time::Duration;
+
+use rmcp::model::ClientInfo;
+use rmcp::service::{serve_client, RunningService};
+use rmcp::transport::child_process::TokioChildProcess;
+use rmcp::transport::streamable_http_client::StreamableHttpClientTransportConfig;
+use rmcp::transport::StreamableHttpClientTransport;
+use serde::{Deserialize, Serialize};
+use tokio::process::Command;
+
+/// Probe deadline. A hanging server (dead URL, blocking stdio) must not pin
+/// the probe forever — cap the whole initialize + tools/list round-trip.
+const PROBE_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// A name=value pair (env var or HTTP header) as the renderer serializes it.
+/// Mirrors `McpEnvVar` / `McpHeader` in `src/renderer/lib/acp-api.ts`.
+#[derive(Debug, Clone, Deserialize)]
+pub struct McpNameValuePair {
+    pub name: String,
+    pub value: String,
+}
+
+/// Renderer-supplied MCP server config. Stateless payload — the renderer holds
+/// the full config (including `id`/`enabled`) and passes the wire subset here.
+/// `type` defaults to `"stdio"` when omitted (mirrors `transportOf`).
+///
+/// Kept deliberately loose (all transport-specific fields optional) so the
+/// probe does not couple to the vendored ACP `McpServer` schema — the probe
+/// owns its own deserialization and never touches the registry store.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct McpServerConfig {
+    #[serde(default, rename = "type")]
+    pub r#type: Option<String>,
+    pub name: String,
+    pub command: Option<String>,
+    #[serde(default)]
+    pub args: Vec<String>,
+    #[serde(default)]
+    pub env: Vec<McpNameValuePair>,
+    pub url: Option<String>,
+    #[serde(default)]
+    pub headers: Vec<McpNameValuePair>,
+}
+
+impl McpServerConfig {
+    fn transport(&self) -> String {
+        self.r#type.clone().unwrap_or_else(|| "stdio".to_string())
+    }
+}
+
+/// A tool exposed by the probed server (`tools/list` output, trimmed to the
+/// fields the UI surfaces).
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct McpToolInfo {
+    pub name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum ProbeStatus {
+    Connected,
+    Disconnected,
+}
+
+/// Probe result. On `Disconnected`, `error` carries a short, value-free message
+/// (no env/header values, tokens, or credentials).
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ProbeResult {
+    pub status: ProbeStatus,
+    #[serde(default)]
+    pub tools: Vec<McpToolInfo>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
+impl ProbeResult {
+    fn connected(tools: Vec<McpToolInfo>) -> Self {
+        Self {
+            status: ProbeStatus::Connected,
+            tools,
+            error: None,
+        }
+    }
+
+    fn disconnected(error: impl Into<String>) -> Self {
+        Self {
+            status: ProbeStatus::Disconnected,
+            tools: Vec::new(),
+            error: Some(error.into()),
+        }
+    }
+}
+
+/// Expand `$VAR` and `${VAR}` references in `value` against the process
+/// environment. Unset variables expand to the empty string (matching POSIX
+/// shell behavior). Non-UTF8 env values are skipped.
+///
+/// There is no existing cross-platform expander in the tree
+/// (`pty/env_refresh.rs` is Windows-only and private), so this small helper
+/// owns the behavior. It is `pub(crate)` so the test module can exercise it.
+pub(crate) fn expand_env(value: &str) -> String {
+    expand_env_with(value, |name| std::env::var(name).ok())
+}
+
+/// Testable core: `lookup` provides the variable map (the real expander uses
+/// `std::env::var`; tests inject a fake map). Unset → `None` → empty string.
+fn expand_env_with(value: &str, lookup: impl Fn(&str) -> Option<String>) -> String {
+    let mut out = String::with_capacity(value.len());
+    let mut rest = value;
+    while !rest.is_empty() {
+        match rest.find('$') {
+            None => {
+                out.push_str(rest);
+                break;
+            }
+            Some(dollar) => {
+                out.push_str(&rest[..dollar]);
+                let after = &rest[dollar + 1..];
+                // `${VAR}` braced form.
+                if let Some(stripped) = after.strip_prefix('{') {
+                    match stripped.find('}') {
+                        Some(end) => {
+                            let name = &stripped[..end];
+                            out.push_str(&lookup(name).unwrap_or_default());
+                            rest = &stripped[end + 1..];
+                        }
+                        None => {
+                            // Unterminated `${` — treat literally (no expansion).
+                            out.push('$');
+                            out.push_str(after);
+                            break;
+                        }
+                    }
+                } else {
+                    // `$VAR` bare form: [A-Za-z_][A-Za-z0-9_]*.
+                    let end = after
+                        .char_indices()
+                        .take_while(|(i, c)| {
+                            let first = *i == 0;
+                            c.is_ascii_alphabetic()
+                                || (c == &'_')
+                                || (!first && c.is_ascii_digit())
+                        })
+                        .last()
+                        .map(|(i, c)| i + c.len_utf8())
+                        .unwrap_or(0);
+                    if end == 0 {
+                        // Lone `$` not followed by a valid name — emit literally.
+                        out.push('$');
+                        rest = after;
+                    } else {
+                        let name = &after[..end];
+                        out.push_str(&lookup(name).unwrap_or_default());
+                        rest = &after[end..];
+                    }
+                }
+            }
+        }
+    }
+    out
+}
+
+/// One-shot probe: open a fresh rmcp client connection, `initialize`, list
+/// tools, close. Never panics, never logs secrets — only the server name +
+/// transport + outcome.
+pub async fn probe(server: McpServerConfig) -> ProbeResult {
+    let transport = server.transport();
+    let name = server.name.clone();
+    let result = tokio::time::timeout(PROBE_TIMEOUT, probe_inner(&server)).await;
+    let outcome = match result {
+        Ok(inner) => inner,
+        Err(_elapsed) => ProbeResult::disconnected(format!(
+            "probe timed out after {}s",
+            PROBE_TIMEOUT.as_secs()
+        )),
+    };
+    // Boundary log: outcome + server name + transport. NO env/header values,
+    // tokens, or credentials.
+    match outcome.status {
+        ProbeStatus::Connected => tracing::info!(
+            server = %name,
+            transport = %transport,
+            tools = outcome.tools.len(),
+            "MCP probe connected"
+        ),
+        ProbeStatus::Disconnected => tracing::warn!(
+            server = %name,
+            transport = %transport,
+            "MCP probe disconnected"
+        ),
+    }
+    outcome
+}
+
+async fn probe_inner(server: &McpServerConfig) -> ProbeResult {
+    let transport = server.transport();
+    match transport.as_str() {
+        "stdio" => probe_stdio(server).await,
+        "http" | "sse" => probe_http(server, &transport).await,
+        other => ProbeResult::disconnected(format!("unsupported transport '{other}'")),
+    }
+}
+
+async fn probe_stdio(server: &McpServerConfig) -> ProbeResult {
+    let command = match server.command.as_deref() {
+        Some(c) if !c.trim().is_empty() => c,
+        _ => return ProbeResult::disconnected("stdio command is required"),
+    };
+    let mut cmd = Command::new(command);
+    cmd.args(&server.args);
+    for pair in &server.env {
+        // Expand `$VAR`/`${VAR}` before spawn; unset → empty string.
+        cmd.env(&pair.name, expand_env(&pair.value));
+    }
+    // Windows: suppress the console window a GUI-launched probe would flash.
+    // CREATE_NO_WINDOW = 0x0800_0000 (mirrors the vendored ACP patch). tokio's
+    // `Command` exposes `creation_flags` natively on Windows.
+    #[cfg(target_os = "windows")]
+    {
+        cmd.creation_flags(0x0800_0000);
+    }
+
+    // Builder lets us null stderr so a chatty child does not pollute our logs.
+    // stdin/stdout stay piped (the rmcp transport owns them).
+    let spawn = TokioChildProcess::builder(cmd)
+        .stderr(Stdio::null())
+        .spawn();
+    let transport = match spawn {
+        Ok((proc, _stderr)) => proc,
+        Err(error) => return ProbeResult::disconnected(format!("spawn failed: {error}")),
+    };
+    let running = match serve_client(ClientInfo::default(), transport).await {
+        Ok(service) => service,
+        Err(error) => return ProbeResult::disconnected(format!("initialize failed: {error}")),
+    };
+    drive_running(running).await
+}
+
+async fn probe_http(server: &McpServerConfig, transport: &str) -> ProbeResult {
+    let url = match server.url.as_deref() {
+        Some(u) if !u.trim().is_empty() => u,
+        _ => return ProbeResult::disconnected(format!("{transport} URL is required")),
+    };
+    let mut config = StreamableHttpClientTransportConfig::with_uri(url);
+    if !server.headers.is_empty() {
+        let mut headers = HashMap::new();
+        for pair in &server.headers {
+            // reqwest re-exports `http::HeaderName`/`HeaderValue` (the project
+            // already depends on reqwest); avoids a direct `http` dep here.
+            if let (Ok(name), Ok(value)) = (
+                reqwest::header::HeaderName::from_bytes(pair.name.as_bytes()),
+                reqwest::header::HeaderValue::from_str(&pair.value),
+            ) {
+                headers.insert(name, value);
+            } else {
+                // Skip a malformed header — do NOT surface the value.
+                tracing::warn!(
+                    server = %server.name,
+                    transport,
+                    "skipping malformed MCP header (value redacted)"
+                );
+            }
+        }
+        config = config.custom_headers(headers);
+    }
+    let client = StreamableHttpClientTransport::from_config(config);
+    let running = match serve_client(ClientInfo::default(), client).await {
+        Ok(service) => service,
+        Err(error) => return ProbeResult::disconnected(format!("initialize failed: {error}")),
+    };
+    drive_running(running).await
+}
+
+/// Drive an initialized rmcp client service: list all tools (paginated), then
+/// cancel (tear down the connection — the probe is one-shot). Maps the rmcp
+/// `Tool` model to the trimmed `McpToolInfo` the UI surfaces.
+async fn drive_running(running: RunningService<rmcp::service::RoleClient, ClientInfo>) -> ProbeResult {
+    let tools = match running.list_all_tools().await {
+        Ok(tools) => tools,
+        Err(error) => {
+            let _ = running.cancel().await;
+            return ProbeResult::disconnected(format!("tools/list failed: {error}"));
+        }
+    };
+    let mapped = tools
+        .into_iter()
+        .map(|tool| McpToolInfo {
+            name: tool.name.to_string(),
+            description: tool.description.map(|cow| cow.to_string()),
+        })
+        .collect();
+    // Tear down the connection (one-shot probe — no persistent hold).
+    let _ = running.cancel().await;
+    ProbeResult::connected(mapped)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn lookup_from(map: &HashMap<String, String>) -> impl Fn(&str) -> Option<String> + '_ {
+        move |name: &str| map.get(name).cloned()
+    }
+
+    #[test]
+    fn expands_bare_and_braced_references() {
+        let mut env = HashMap::new();
+        env.insert("FOO".to_string(), "bar".to_string());
+        env.insert("PATH".to_string(), "/bin".to_string());
+        let expand = |v: &str| expand_env_with(v, lookup_from(&env));
+
+        assert_eq!(expand("$FOO"), "bar");
+        assert_eq!(expand("${FOO}"), "bar");
+        assert_eq!(expand("prefix:$FOO:suffix"), "prefix:bar:suffix");
+        assert_eq!(expand("$FOO/$PATH"), "bar/bin");
+        assert_eq!(expand("${FOO}-${PATH}"), "bar-/bin");
+        // Unset → empty string (POSIX shell behavior).
+        assert_eq!(expand("$NOPE"), "");
+        assert_eq!(expand("${NOPE}"), "");
+        assert_eq!(expand("x=$NOPE:y"), "x=:y");
+        // Lone $ and non-variable characters emitted literally.
+        assert_eq!(expand("cost is $5"), "cost is $5");
+        assert_eq!(expand("100%"), "100%");
+        // Adjacent references and trailing text.
+        assert_eq!(expand("$FOO$PATH"), "bar/bin");
+        assert_eq!(expand("$FOO tail"), "bar tail");
+        // Unterminated `${` is left literally (no expansion, no panic).
+        assert_eq!(expand("a${UNCLOSED"), "a${UNCLOSED");
+        // Empty input.
+        assert_eq!(expand(""), "");
+    }
+
+    #[test]
+    fn rejects_unsupported_transport() {
+        // The config is loose enough to accept any `type`; the probe rejects
+        // unknown transports with a disconnected result (no panic).
+        let config = McpServerConfig {
+            r#type: Some("ftp".to_string()),
+            name: "bad".to_string(),
+            command: None,
+            args: Vec::new(),
+            env: Vec::new(),
+            url: None,
+            headers: Vec::new(),
+        };
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        let result = rt.block_on(probe(config));
+        assert_eq!(result.status, ProbeStatus::Disconnected);
+        assert!(result.error.unwrap().contains("unsupported transport"));
+    }
+
+    #[tokio::test]
+    async fn unreachable_stdio_command_returns_disconnected() {
+        // A command path that cannot exist → spawn fails → disconnected. The
+        // error must NOT echo env values (none here, but the contract holds).
+        let config = McpServerConfig {
+            r#type: Some("stdio".to_string()),
+            name: "ghost".to_string(),
+            command: Some("this-binary-does-not-exist-12345".to_string()),
+            args: Vec::new(),
+            env: vec![McpNameValuePair {
+                name: "SECRET".to_string(),
+                value: "$DO_NOT_LEAK".to_string(),
+            }],
+            url: None,
+            headers: Vec::new(),
+        };
+        let result = probe(config).await;
+        assert_eq!(result.status, ProbeStatus::Disconnected);
+        let error = result.error.expect("disconnected carries an error");
+        assert!(
+            !error.contains("DO_NOT_LEAK"),
+            "error must not leak env value references: {error}"
+        );
+        assert!(error.contains("spawn failed"));
+        assert!(result.tools.is_empty());
+    }
+
+    #[tokio::test]
+    async fn missing_stdio_command_returns_disconnected() {
+        let config = McpServerConfig {
+            r#type: Some("stdio".to_string()),
+            name: "empty".to_string(),
+            command: Some("   ".to_string()),
+            args: Vec::new(),
+            env: Vec::new(),
+            url: None,
+            headers: Vec::new(),
+        };
+        let result = probe(config).await;
+        assert_eq!(result.status, ProbeStatus::Disconnected);
+        assert!(result.error.unwrap().contains("command is required"));
+    }
+
+    #[tokio::test]
+    async fn unreachable_http_url_returns_disconnected() {
+        // A port nothing listens on → connect failure → disconnected. The error
+        // must not leak header values.
+        let config = McpServerConfig {
+            r#type: Some("http".to_string()),
+            name: "dead".to_string(),
+            command: None,
+            args: Vec::new(),
+            env: Vec::new(),
+            url: Some("http://127.0.0.1:1/mcp".to_string()),
+            headers: vec![McpNameValuePair {
+                name: "Authorization".to_string(),
+                value: "Bearer super-secret".to_string(),
+            }],
+        };
+        let result = probe(config).await;
+        assert_eq!(result.status, ProbeStatus::Disconnected);
+        let error = result.error.expect("disconnected carries an error");
+        assert!(
+            !error.contains("super-secret"),
+            "error must not leak header values: {error}"
+        );
+        assert!(result.tools.is_empty());
+    }
+}

--- a/src-tauri/src/acp/mod.rs
+++ b/src-tauri/src/acp/mod.rs
@@ -15,6 +15,7 @@ pub mod commands;
 pub mod config;
 pub mod events;
 pub mod manager;
+pub mod mcp_probe;
 pub mod project_registry;
 pub mod session;
 pub mod session_persistence;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1388,6 +1388,7 @@ pub fn run() {
             acp::commands::acp_authenticate,
             acp::commands::acp_probe_runtime,
             acp::commands::acp_set_turn_timeout,
+            acp::commands::acp_probe_mcp_server,
             acp_registry_snapshot::acp_fetch_registry_snapshot,
             acp_binary_install::acp_install_registry_binary,
             // Agent Skills (Zed-compatible SKILL.md packages)

--- a/src-tauri/src/web/mcp_probe_api.rs
+++ b/src-tauri/src/web/mcp_probe_api.rs
@@ -1,0 +1,142 @@
+//! `POST /mcp-servers/probe` — on-demand MCP client probe (web parity).
+//!
+//! Mirrors `mcp_servers_api.rs`'s handler shape and `IpcBody<T>` contract so
+//! the renderer facade (`acp-mcp-probe.ts`) returns the same shape on desktop
+//! (Tauri command) and web (HTTP route). The probe runs on the termul-server
+//! host — where stdio commands execute (matches GH-287's web-parity decision).
+//!
+//! The route only returns `IpcBody::err` when the request body cannot be
+//! deserialized into a `McpServerConfig`. A *reachable-but-disconnected*
+//! server is still `IpcBody::ok(ProbeResult { status: Disconnected, .. })`
+//! (the probe itself never fails — it reports its outcome).
+
+use axum::{extract::State, Json};
+use serde_json::Value;
+
+use crate::acp::mcp_probe::{self, McpServerConfig, ProbeResult};
+use crate::web::fs_api::IpcBody;
+use crate::web::ws::AppState;
+
+/// `POST /mcp-servers/probe` — body: `McpServerConfig` → `IpcBody<ProbeResult>`.
+pub async fn probe(
+    _state: State<AppState>,
+    Json(value): Json<Value>,
+) -> Json<IpcBody<ProbeResult>> {
+    let server: McpServerConfig = match serde_json::from_value(value) {
+        Ok(server) => server,
+        Err(error) => {
+            tracing::warn!(error = %error, "MCP probe rejected malformed config");
+            return Json(IpcBody::err(
+                "Malformed MCP server config",
+                "MCP_PROBE_INVALID_CONFIG",
+            ));
+        }
+    };
+    // The probe is stateless and owns no registry handle, so AppState is not
+    // consulted. (Kept in the signature for routing-state symmetry with the
+    // sibling `mcp_servers_api` routes and future per-project scoping.)
+    let result = mcp_probe::probe(server).await;
+    Json(IpcBody::ok(result))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::acp::AcpManager;
+    use crate::web::project_registry::ProjectRegistry;
+    use crate::web::sink::WsRelaySink;
+    use crate::web::test_pty_manager;
+    use crate::web::ws::HistoryMode;
+    use axum::body::{to_bytes, Body};
+    use axum::http::{Request, StatusCode};
+    use axum::routing::post;
+    use std::sync::Arc;
+    use std::time::{SystemTime, UNIX_EPOCH};
+    use tower::ServiceExt;
+
+    fn test_app() -> axum::Router {
+        let pty = test_pty_manager();
+        let state = AppState {
+            acp: Arc::new(AcpManager::new(vec![])),
+            terminal_events: pty.terminal_events(),
+            cwd_tracker: pty.cwd_tracker(),
+            git_tracker: pty.git_tracker(),
+            exit_code_tracker: pty.exit_code_tracker(),
+            pty,
+            relay: Arc::new(WsRelaySink::new()),
+            registry: Arc::new(ProjectRegistry::new()),
+            chat_history_store: None,
+            registry_persistence: None,
+            projects_file: None,
+            history_mode: HistoryMode::LiveOnly,
+            project_root: Arc::new(std::env::temp_dir()),
+        };
+        axum::Router::new()
+            .route("/mcp-servers/probe", post(super::probe))
+            .with_state(state)
+    }
+
+    async fn body_as_json(body: Body) -> Value {
+        let bytes = to_bytes(body, usize::MAX).await.unwrap();
+        serde_json::from_slice(&bytes).expect("deserialize IpcBody")
+    }
+
+    #[tokio::test]
+    async fn malformed_config_returns_invalid_config_error() {
+        let app = test_app();
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/mcp-servers/probe")
+                    .header("content-type", "application/json")
+                    // `name` is a required field — this must fail to deserialize.
+                    .body(Body::from(r#"{"type":"stdio","command":"npx"}"#))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let value: Value = body_as_json(response.into_body()).await;
+        assert_eq!(value["success"], false);
+        assert_eq!(value["code"], "MCP_PROBE_INVALID_CONFIG");
+    }
+
+    #[tokio::test]
+    async fn unreachable_stdio_server_returns_disconnected_result() {
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("clock")
+            .as_nanos();
+        let bogus = format!("this-binary-definitely-does-not-exist-{nanos}");
+        let payload = serde_json::json!({
+            "type": "stdio",
+            "name": "ghost",
+            "command": bogus,
+            "args": [],
+            "env": []
+        });
+        let app = test_app();
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/mcp-servers/probe")
+                    .header("content-type", "application/json")
+                    .body(Body::from(payload.to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let value: Value = body_as_json(response.into_body()).await;
+        assert_eq!(value["success"], true);
+        assert_eq!(value["data"]["status"], "disconnected");
+        let error = value["data"]["error"].as_str().expect("error string");
+        assert!(
+            !error.contains(&bogus) || error.contains("spawn failed"),
+            "error must not echo the bogus command verbatim: {error}"
+        );
+        assert!(error.contains("spawn failed"));
+    }
+}

--- a/src-tauri/src/web/mod.rs
+++ b/src-tauri/src/web/mod.rs
@@ -17,6 +17,7 @@
 pub mod assets;
 pub mod config;
 pub mod fs_api;
+pub mod mcp_probe_api;
 pub mod mcp_servers_api;
 pub mod permissions;
 pub mod project_registry;

--- a/src-tauri/src/web/router.rs
+++ b/src-tauri/src/web/router.rs
@@ -20,6 +20,7 @@ use crate::acp::{AcpManager, ChatHistoryStore, FileProjectRegistry};
 use crate::pty::PtyManager;
 use crate::trackers::{CwdTracker, ExitCodeTracker, GitTracker, TerminalEventHub};
 use crate::web::fs_api;
+use crate::web::mcp_probe_api;
 use crate::web::mcp_servers_api;
 use crate::web::project_registry::ProjectRegistry;
 use crate::web::projects_api;
@@ -70,6 +71,10 @@ pub fn router(
             "/mcp-servers",
             get(mcp_servers_api::get).put(mcp_servers_api::put),
         )
+        // On-demand MCP client probe (web parity): runs on the termul-server
+        // host where stdio commands execute. Mirrors the `acp_probe_mcp_server`
+        // Tauri command; returns the same `IpcBody<ProbeResult>` shape.
+        .route("/mcp-servers/probe", post(mcp_probe_api::probe))
         // Project-creation fs/git/shell routes (Story: Web/remote project
         // creation). Registered AHEAD of the static fallback so `/health` +
         // `/ws` keep priority and the SPA fallback cannot shadow them.
@@ -126,6 +131,7 @@ pub fn router_with_static(
             "/mcp-servers",
             get(mcp_servers_api::get).put(mcp_servers_api::put),
         )
+        .route("/mcp-servers/probe", post(mcp_probe_api::probe))
         .route("/fs/mkdir", post(fs_api::mkdir))
         .route("/fs/write", post(fs_api::write))
         .route("/fs/ls", get(fs_api::ls))

--- a/src/renderer/components/chat/ChatInputBar.test.tsx
+++ b/src/renderer/components/chat/ChatInputBar.test.tsx
@@ -19,6 +19,8 @@ const {
   mockSetMode,
   mockSetModel,
   mockMcpCount,
+  mockSetMcpServerEnabled,
+  mockLoadMcpTools,
   mockReadDir,
   mockSkills,
   mockToastError
@@ -29,6 +31,11 @@ const {
   // Story 1.8 review (verification-gap #8): override-able MCP server count for
   // the read-only badge. 0 by default (badge hidden); tests set it to render.
   mockMcpCount: { current: 0 },
+  // Stable mocks for the chatbox popover's per-server toggle + probe actions
+  // (introduced alongside the status/tools/chatbox-toggle work). Reused across
+  // renders so call assertions hold.
+  mockSetMcpServerEnabled: vi.fn(async () => {}),
+  mockLoadMcpTools: vi.fn(async () => {}),
   mockReadDir: vi.fn(),
   // Override-able skills list (defaults to [] — web/no-skills parity). Skill
   // tests push entries here so useAgentSkills surfaces them in the slash menu.
@@ -67,9 +74,26 @@ vi.mock('@/stores/acp-store', () => ({
   useAcpMessages: () => [],
   // Story 1.8: ChatInputBar reads the global MCP server count for the read-only
   // MCP badge. The selector reads the hoisted `mockMcpCount.current` so a test
-  // can override the count (default 0 → badge hidden).
-  useAcpStore: (selector: (s: { mcpServers: unknown[] }) => unknown) =>
-    selector({ mcpServers: Array.from({ length: mockMcpCount.current }) })
+  // can override the count (default 0 → badge hidden). The chatbox popover work
+  // added per-server iteration + toggle/probe actions — the mock now returns
+  // real server objects (with stable ids) plus no-op probe state so the popover
+  // renders without crashing when the count is non-zero.
+  useAcpStore: (selector: (s: Record<string, unknown>) => unknown) =>
+    selector({
+      mcpServers: Array.from({ length: mockMcpCount.current }, (_, i) => ({
+        id: `mcp-${i}`,
+        type: 'stdio',
+        name: `MCP ${i + 1}`,
+        command: 'npx',
+        enabled: true
+      })),
+      setMcpServerEnabled: mockSetMcpServerEnabled,
+      mcpProbeStatus: {} as Record<string, string>,
+      mcpTools: {} as Record<string, unknown[]>,
+      mcpToolsLoaded: {} as Record<string, boolean>,
+      mcpProbing: {} as Record<string, boolean>,
+      loadMcpTools: mockLoadMcpTools
+    })
 }))
 
 const { persistenceStore, fakePersistenceApi } = vi.hoisted(() => {
@@ -309,9 +333,11 @@ describe('ChatInputBar MCP badge (Story 1.8)', () => {
   it('renders the MCP badge with the count when MCP servers are configured', () => {
     mockMcpCount.current = 2
     renderInputBar()
-    // The badge pill shows the count + the sr-only label.
+    // The badge is now a popover trigger (per-server enable/disable + status
+    // dot) showing the count. The old sr-only "MCP servers attached" text moved
+    // into the trigger's aria-label + the popover content (opened below).
     expect(screen.getByText('2')).toBeInTheDocument()
-    expect(screen.getByText(/MCP servers attached/i)).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /MCP servers/i })).toBeInTheDocument()
   })
 
   it('prefers the switched session MCP count over the global registry', () => {

--- a/src/renderer/components/chat/ChatInputBar.tsx
+++ b/src/renderer/components/chat/ChatInputBar.tsx
@@ -131,6 +131,15 @@ export function ChatInputBar({
   // recorded count retain the existing global-registry fallback.
   const globalMcpCount = useAcpStore((s) => s.mcpServers.length)
   const mcpCount = session.mcpServerCount ?? globalMcpCount
+  // Chatbox popover (per-server enable/disable + status dot + collapsible tool
+  // list). The badge degrades to the read-only count pill when the registry is
+  // empty. Reuses `setMcpServerEnabled` (optimistic + rollback) — no new
+  // persistence path. The probe reflects Termul's own client connection.
+  const mcpServers = useAcpStore((s) => s.mcpServers)
+  const setMcpServerEnabled = useAcpStore((s) => s.setMcpServerEnabled)
+  const mcpProbeStatus = useAcpStore((s) => s.mcpProbeStatus)
+  const mcpTools = useAcpStore((s) => s.mcpTools)
+  const loadMcpTools = useAcpStore((s) => s.loadMcpTools)
   const [value, setValue] = useState('')
   // Persist the in-progress composer draft per session (project + session id)
   // so an unsent message survives a web reload. useState stays the source of
@@ -487,7 +496,23 @@ export function ChatInputBar({
     <ModeChip session={session} disabled={disabled} onSelect={onSetMode} label="Agent" />
   )
 
-  const mcpBadge = <McpBadge count={mcpCount} />
+  const mcpBadge = (
+    <McpBadge
+      count={mcpCount}
+      servers={mcpServers}
+      onToggle={(id, enabled) => {
+        void setMcpServerEnabled(id, enabled).catch(() => {
+          // Rollback + toast handled inside `setMcpServerEnabled`; the chatbox
+          // re-renders from the rolled-back store state.
+        })
+      }}
+      probeStatus={mcpProbeStatus}
+      tools={mcpTools}
+      onLoadTools={(id) => {
+        void loadMcpTools(id)
+      }}
+    />
+  )
 
   return (
     <div ref={rootRef} className={cn(CHAT_GUTTER_X, 'pb-2 pt-3')}>

--- a/src/renderer/components/chat/ChatInputBar.tsx
+++ b/src/renderer/components/chat/ChatInputBar.tsx
@@ -502,8 +502,7 @@ export function ChatInputBar({
       servers={mcpServers}
       onToggle={(id, enabled) => {
         void setMcpServerEnabled(id, enabled).catch(() => {
-          // Rollback + toast handled inside `setMcpServerEnabled`; the chatbox
-          // re-renders from the rolled-back store state.
+          toast.error('Could not update the MCP server. Your previous setting was restored.')
         })
       }}
       probeStatus={mcpProbeStatus}

--- a/src/renderer/components/chat/McpBadge.test.tsx
+++ b/src/renderer/components/chat/McpBadge.test.tsx
@@ -101,4 +101,23 @@ describe('McpBadge popover (per-server enable/disable + status dot)', () => {
     // Per-tool toggle UI must NOT be present (deferred — read-only).
     expect(screen.queryByRole('switch', { name: /read_file/i })).not.toBeInTheDocument()
   })
+
+  it('shows "No tools available" for a connected server with an empty tool list', () => {
+    render(
+      <McpBadge
+        count={1}
+        servers={servers}
+        onToggle={vi.fn()}
+        probeStatus={{ s1: 'connected' }}
+        tools={{ s1: [] }}
+      />
+    )
+    openPopover()
+    // s1 is connected but has 0 tools — expand its collapsible and confirm the
+    // "No tools available" branch (NOT "Probing…" — the probe completed).
+    // Two servers render "Show tools" triggers; pick the first (s1 = "Files").
+    fireEvent.click(screen.getAllByText(/show tools/i)[0])
+    expect(screen.getByText(/no tools available/i)).toBeInTheDocument()
+    expect(screen.queryByText(/probing/i)).not.toBeInTheDocument()
+  })
 })

--- a/src/renderer/components/chat/McpBadge.test.tsx
+++ b/src/renderer/components/chat/McpBadge.test.tsx
@@ -1,14 +1,18 @@
-import { render, screen } from '@testing-library/react'
-import { describe, expect, it } from 'vitest'
+import { fireEvent, render, screen, within } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
 import { McpBadge } from './McpBadge'
 
+function openPopover(): void {
+  fireEvent.click(screen.getByRole('button', { name: /mcp servers/i }))
+}
+
 describe('McpBadge (Story 1.8 — read-only MCP badge in composer)', () => {
-  it('is hidden when no MCP servers are attached (count <= 0)', () => {
+  it('is hidden when no MCP servers are attached (count <= 0) and no server list', () => {
     const { container } = render(<McpBadge count={0} />)
     expect(container).toBeEmptyDOMElement()
   })
 
-  it('renders the count when MCP servers are attached', () => {
+  it('renders the count when MCP servers are attached (count-only fallback)', () => {
     render(<McpBadge count={3} />)
     expect(screen.getByText('3')).toBeInTheDocument()
     expect(screen.getByText(/MCP servers attached/i)).toBeInTheDocument()
@@ -17,5 +21,84 @@ describe('McpBadge (Story 1.8 — read-only MCP badge in composer)', () => {
   it('renders 1+ (single server) without crashing', () => {
     render(<McpBadge count={1} />)
     expect(screen.getByText('1')).toBeInTheDocument()
+  })
+})
+
+describe('McpBadge popover (per-server enable/disable + status dot)', () => {
+  const servers = [
+    { id: 's1', name: 'Files', enabled: true },
+    { id: 's2', name: 'Remote', enabled: false }
+  ]
+
+  it('renders at count 0 when servers exist (discoverable entry point)', () => {
+    render(<McpBadge count={0} servers={servers} onToggle={vi.fn()} />)
+    expect(screen.getByRole('button', { name: /mcp servers/i })).toBeInTheDocument()
+  })
+
+  it('lists each server with a status dot inside the popover', () => {
+    render(
+      <McpBadge
+        count={2}
+        servers={servers}
+        onToggle={vi.fn()}
+        probeStatus={{ s1: 'connected', s2: 'disconnected' }}
+      />
+    )
+    openPopover()
+    expect(screen.getByText('Files')).toBeInTheDocument()
+    expect(screen.getByText('Remote')).toBeInTheDocument()
+    // Status dots expose their state via title (tooltip) — query by accessible
+    // name through the title attribute on the dot span.
+    expect(screen.getByTitle('Connected (Termul can reach this server)')).toBeInTheDocument()
+    expect(
+      screen.getByTitle('Disconnected (Termul could not reach this server)')
+    ).toBeInTheDocument()
+  })
+
+  it('calls onToggle(id, false) when switching an enabled server to Off', () => {
+    const onToggle = vi.fn()
+    render(<McpBadge count={1} servers={servers} onToggle={onToggle} />)
+    openPopover()
+    // "Files" (s1) is enabled → its "Off" radio switches it off. Each row's
+    // radios are scoped by their RadioGroup; click the "Off" radio input by id.
+    const offRadio = document.getElementById('mcp-s1-off') as HTMLInputElement
+    fireEvent.click(offRadio)
+    expect(onToggle).toHaveBeenCalledWith('s1', false)
+  })
+
+  it('calls onToggle(id, true) when switching a disabled server to On', () => {
+    const onToggle = vi.fn()
+    render(<McpBadge count={1} servers={servers} onToggle={onToggle} />)
+    openPopover()
+    const onRadio = document.getElementById('mcp-s2-on') as HTMLInputElement
+    fireEvent.click(onRadio)
+    expect(onToggle).toHaveBeenCalledWith('s2', true)
+  })
+
+  it('discloses next-chat semantics + per-tool toggle coming soon', () => {
+    render(<McpBadge count={1} servers={servers} onToggle={vi.fn()} />)
+    openPopover()
+    expect(screen.getByText(/takes effect on the next chat/i)).toBeInTheDocument()
+    expect(screen.getByText(/per-tool toggle coming soon/i)).toBeInTheDocument()
+  })
+
+  it('shows the tool list (read-only) inside the collapsible on expand', () => {
+    const onLoadTools = vi.fn()
+    render(
+      <McpBadge
+        count={1}
+        servers={servers}
+        onToggle={vi.fn()}
+        onLoadTools={onLoadTools}
+        tools={{ s1: [{ name: 'read_file', description: 'read a file' }] }}
+      />
+    )
+    openPopover()
+    // Expanding the s1 collapsible triggers onLoadTools (auto-probe on first expand).
+    fireEvent.click(screen.getByText(/1 tool/))
+    expect(onLoadTools).toHaveBeenCalledWith('s1')
+    expect(screen.getByText('read_file')).toBeInTheDocument()
+    // Per-tool toggle UI must NOT be present (deferred — read-only).
+    expect(screen.queryByRole('switch', { name: /read_file/i })).not.toBeInTheDocument()
   })
 })

--- a/src/renderer/components/chat/McpBadge.tsx
+++ b/src/renderer/components/chat/McpBadge.tsx
@@ -233,6 +233,8 @@ function McpServerRow({
             </ul>
           ) : probeStatus === 'disconnected' ? (
             <p className="text-3xs text-destructive">Probe failed — check the server config.</p>
+          ) : probeStatus === 'connected' ? (
+            <p className="text-3xs text-muted-foreground">No tools available.</p>
           ) : (
             <p className="text-3xs text-muted-foreground">Probing…</p>
           )}

--- a/src/renderer/components/chat/McpBadge.tsx
+++ b/src/renderer/components/chat/McpBadge.tsx
@@ -1,42 +1,243 @@
-import { Plug } from 'lucide-react'
-import { HoverCard, HoverCardContent, HoverCardTrigger } from '@/components/ui/hover-card'
+import { Plug, PlugZap } from 'lucide-react'
+import { useState } from 'react'
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible'
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
+import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group'
+import type { McpToolInfo, ProbeStatus } from '@/lib/acp-api'
+import type { StoredMcpServer } from '@/lib/acp-mcp-persistence'
 import { cn } from '@/lib/utils'
 
+interface McpServerSummary {
+  id: string
+  name: string
+  enabled?: boolean
+}
+
 interface McpBadgeProps {
-  /** Number of MCP servers attached to this session (v1: the global count). */
+  /** Number of MCP servers attached to this session (badge summary count). */
   count: number
   className?: string
+  /**
+   * Per-server enable/disable popover (chatbox). When omitted (or empty), the
+   * badge degrades to the read-only count pill (backward-compat — no popover).
+   * When provided with at least one server, the badge becomes a Popover that
+   * lists each server with a status dot + enable/disable radio — discoverable
+   * even when `count` is 0 (mirrors GH-287's `onManage` pattern).
+   */
+  servers?: McpServerSummary[]
+  /** Toggle a server's `enabled` flag. Reuses `setMcpServerEnabled` (optimistic + rollback). */
+  onToggle?: (id: string, enabled: boolean) => void
+  /** Per-server probe status (Termul's own rmcp client connection, NOT the agent's). */
+  probeStatus?: Record<string, ProbeStatus>
+  /** Per-server cached `tools/list` output (for the collapsible tool list). */
+  tools?: Record<string, McpToolInfo[]>
+  /** Auto-probe on first expand of a server's tool list. */
+  onLoadTools?: (id: string) => void
+}
+
+function statusColor(status: ProbeStatus | undefined): string {
+  if (status === 'connected') return 'bg-emerald-500'
+  if (status === 'disconnected') return 'bg-red-500'
+  return 'bg-muted-foreground/40'
+}
+
+function statusLabel(status: ProbeStatus | undefined): string {
+  if (status === 'connected') return 'Connected (Termul can reach this server)'
+  if (status === 'disconnected') return 'Disconnected (Termul could not reach this server)'
+  return 'Not probed yet — click to test'
 }
 
 /**
- * Read-only MCP badge shown in the composer (Story 1.8 AC1: "read-only badge
- * in composer for v1; edit via New Chat"). Hidden when no MCP servers are
- * attached. The hover tooltip clarifies that per-session MCP attach is done
- * via the New Chat flow (v1 does not inline-edit MCP from the composer).
+ * MCP badge in the composer. Read-only count pill by default; when `servers`
+ * is provided, swaps to a Popover with per-server enable/disable + a
+ * collapsible tool list. The probe reflects Termul's own client connection
+ * (NOT the agent's — see the spec's Design Notes). Per-tool enable/disable is
+ * deferred — UI shows the tool list read-only for awareness.
  */
-export function McpBadge({ count, className }: McpBadgeProps): React.JSX.Element | null {
-  if (count <= 0) return null
+export function McpBadge({
+  count,
+  className,
+  servers,
+  onToggle,
+  probeStatus,
+  tools,
+  onLoadTools
+}: McpBadgeProps): React.JSX.Element | null {
+  const hasServerList = servers != null && servers.length > 0
+  if (count <= 0 && !hasServerList) return null
+
+  // Count-only pill (backward-compat — no server list passed).
+  if (!hasServerList) {
+    return (
+      <span
+        className={cn(
+          'inline-flex items-center gap-1 rounded-full border border-border/60 bg-muted/40 px-2 py-0.5 text-3xs font-medium text-muted-foreground',
+          className
+        )}
+      >
+        <Plug className="size-3" aria-hidden="true" />
+        <span className="tabular-nums">{count}</span>
+        <span className="sr-only">MCP servers attached</span>
+      </span>
+    )
+  }
+
   return (
-    <HoverCard openDelay={120} closeDelay={80}>
-      <HoverCardTrigger asChild>
-        <span
+    <McpPopover
+      count={count}
+      servers={servers!}
+      onToggle={onToggle}
+      probeStatus={probeStatus}
+      tools={tools}
+      onLoadTools={onLoadTools}
+      className={className}
+    />
+  )
+}
+
+interface PopoverProps {
+  count: number
+  servers: McpServerSummary[]
+  onToggle?: (id: string, enabled: boolean) => void
+  probeStatus?: Record<string, ProbeStatus>
+  tools?: Record<string, McpToolInfo[]>
+  onLoadTools?: (id: string) => void
+  className?: string
+}
+
+function McpPopover({
+  count,
+  servers,
+  onToggle,
+  probeStatus,
+  tools,
+  onLoadTools,
+  className
+}: PopoverProps): React.JSX.Element {
+  const [open, setOpen] = useState(false)
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <button
+          type="button"
           className={cn(
-            'inline-flex items-center gap-1 rounded-full border border-border/60 bg-muted/40 px-2 py-0.5 text-3xs font-medium text-muted-foreground',
+            'inline-flex items-center gap-1 rounded-full border border-border/60 bg-muted/40 px-2 py-0.5 text-3xs font-medium text-muted-foreground transition-colors hover:bg-muted/70 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring',
             className
           )}
+          aria-label={`MCP servers — ${count} attached. Click to manage per-server enable/disable.`}
         >
-          <Plug className="size-3" aria-hidden="true" />
+          <PlugZap className="size-3" aria-hidden="true" />
           <span className="tabular-nums">{count}</span>
-          <span className="sr-only">MCP servers attached</span>
-        </span>
-      </HoverCardTrigger>
-      <HoverCardContent align="start" className="w-56 space-y-1 p-3 text-xs">
+        </button>
+      </PopoverTrigger>
+      <PopoverContent align="start" className="w-72 p-3 text-xs">
         <p className="font-medium text-foreground">MCP servers</p>
-        <p className="text-muted-foreground">{count} attached to this session.</p>
-        <p className="text-3xs text-muted-foreground/80">
-          Attach or remove MCP servers via the New Chat flow (v1 — read-only here).
+        <p className="mt-0.5 text-muted-foreground">
+          {count > 0 ? `${count} attached to this session.` : 'No servers attached yet.'}
         </p>
-      </HoverCardContent>
-    </HoverCard>
+        <ul className="mt-2 space-y-2">
+          {servers.map((server) => (
+            <McpServerRow
+              key={server.id}
+              server={server}
+              onToggle={onToggle}
+              probeStatus={probeStatus?.[server.id]}
+              tools={tools?.[server.id]}
+              onLoadTools={onLoadTools}
+            />
+          ))}
+        </ul>
+        <p className="mt-3 text-3xs text-muted-foreground/80">
+          Takes effect on the next chat; per-tool toggle coming soon.
+        </p>
+      </PopoverContent>
+    </Popover>
+  )
+}
+
+interface ServerRowProps {
+  server: McpServerSummary
+  onToggle?: (id: string, enabled: boolean) => void
+  probeStatus?: ProbeStatus
+  tools?: McpToolInfo[]
+  onLoadTools?: (id: string) => void
+}
+
+function McpServerRow({
+  server,
+  onToggle,
+  probeStatus,
+  tools,
+  onLoadTools
+}: ServerRowProps): React.JSX.Element {
+  const enabled = server.enabled !== false
+  const radioValue = enabled ? 'on' : 'off'
+  return (
+    <li className="space-y-1.5 rounded-md border border-border/50 p-2">
+      <div className="flex items-center justify-between gap-2">
+        <div className="flex min-w-0 items-center gap-1.5">
+          <span
+            role="img"
+            className={cn('size-2 shrink-0 rounded-full', statusColor(probeStatus))}
+            aria-label={statusLabel(probeStatus)}
+            title={statusLabel(probeStatus)}
+          />
+          <span className="truncate text-sm font-medium">{server.name}</span>
+        </div>
+        {onToggle && (
+          <RadioGroup
+            value={radioValue}
+            aria-label={`${server.name} enabled state`}
+            className="flex gap-2"
+            onValueChange={(value) => {
+              if (value === radioValue) return
+              onToggle(server.id, value === 'on')
+            }}
+          >
+            <span className="flex items-center gap-1">
+              <RadioGroupItem value="on" id={`mcp-${server.id}-on`} />
+              <label htmlFor={`mcp-${server.id}-on`} className="text-muted-foreground">
+                On
+              </label>
+            </span>
+            <span className="flex items-center gap-1">
+              <RadioGroupItem value="off" id={`mcp-${server.id}-off`} />
+              <label htmlFor={`mcp-${server.id}-off`} className="text-muted-foreground">
+                Off
+              </label>
+            </span>
+          </RadioGroup>
+        )}
+      </div>
+      <Collapsible
+        onOpenChange={(open) => {
+          if (open && onLoadTools) onLoadTools(server.id)
+        }}
+      >
+        <CollapsibleTrigger className="text-3xs text-muted-foreground underline-offset-2 hover:underline">
+          {tools && tools.length > 0
+            ? `${tools.length} tool${tools.length === 1 ? '' : 's'}`
+            : 'Show tools'}
+        </CollapsibleTrigger>
+        <CollapsibleContent className="pt-1">
+          {tools && tools.length > 0 ? (
+            <ul className="space-y-0.5">
+              {tools.map((tool) => (
+                <li key={tool.name} className="text-3xs text-muted-foreground">
+                  <span className="font-mono">{tool.name}</span>
+                  {tool.description ? (
+                    <span className="ml-1 truncate">— {tool.description}</span>
+                  ) : null}
+                </li>
+              ))}
+            </ul>
+          ) : probeStatus === 'disconnected' ? (
+            <p className="text-3xs text-destructive">Probe failed — check the server config.</p>
+          ) : (
+            <p className="text-3xs text-muted-foreground">Probing…</p>
+          )}
+        </CollapsibleContent>
+      </Collapsible>
+    </li>
   )
 }

--- a/src/renderer/components/chat/chat-responsive.test.tsx
+++ b/src/renderer/components/chat/chat-responsive.test.tsx
@@ -20,8 +20,10 @@ import { CHAT_GUTTER_X, NARROW_PANE_PX } from './chat-layout'
 import type { TimelineItem } from './chat-timeline'
 import { PlanPanel } from './PlanPanel'
 
-const { mockMcpCount } = vi.hoisted(() => ({
-  mockMcpCount: { current: 2 }
+const { mockMcpCount, mockSetMcpServerEnabled, mockLoadMcpTools } = vi.hoisted(() => ({
+  mockMcpCount: { current: 2 },
+  mockSetMcpServerEnabled: vi.fn(async () => {}),
+  mockLoadMcpTools: vi.fn(async () => {})
 }))
 
 vi.mock('@/hooks/use-agent-skills', () => ({
@@ -30,8 +32,22 @@ vi.mock('@/hooks/use-agent-skills', () => ({
 }))
 
 vi.mock('@/stores/acp-store', () => ({
-  useAcpStore: (selector: (s: { mcpServers: unknown[] }) => unknown) =>
-    selector({ mcpServers: Array.from({ length: mockMcpCount.current }) }),
+  useAcpStore: (selector: (s: Record<string, unknown>) => unknown) =>
+    selector({
+      mcpServers: Array.from({ length: mockMcpCount.current }, (_, i) => ({
+        id: `mcp-${i}`,
+        type: 'stdio',
+        name: `MCP ${i + 1}`,
+        command: 'npx',
+        enabled: true
+      })),
+      setMcpServerEnabled: mockSetMcpServerEnabled,
+      mcpProbeStatus: {} as Record<string, string>,
+      mcpTools: {} as Record<string, unknown[]>,
+      mcpToolsLoaded: {} as Record<string, boolean>,
+      mcpProbing: {} as Record<string, boolean>,
+      loadMcpTools: mockLoadMcpTools
+    }),
   useAcpMessages: () => [],
   useSessionUsage: () => null,
   useAgentIdentity: () => ({ name: 'Cursor', templateId: 'cursor' })
@@ -294,7 +310,9 @@ describe('Story 5.1 responsive chat layout', () => {
     ).toBeInTheDocument()
 
     expect(within(row2 as HTMLElement).getByRole('button', { name: 'High' })).toBeInTheDocument()
-    expect(within(row2 as HTMLElement).getByText(/MCP servers attached/i)).toBeInTheDocument()
+    expect(
+      within(row2 as HTMLElement).getByRole('button', { name: /MCP servers/i })
+    ).toBeInTheDocument()
     expect(screen.getByRole('button', { name: /Send message/i })).toBeInTheDocument()
   })
 

--- a/src/renderer/components/settings/McpServersSettings.test.tsx
+++ b/src/renderer/components/settings/McpServersSettings.test.tsx
@@ -13,13 +13,21 @@ vi.mock('sonner', () => ({ toast: { error: toastError, success: toastSuccess } }
 const saveMcpServer = vi.fn(async () => {})
 const setMcpServerEnabled = vi.fn(async () => {})
 const deleteMcpServer = vi.fn(async () => {})
+const probeMcpServer = vi.fn(async () => {})
+const loadMcpTools = vi.fn(async () => {})
 
 function seedStore(): void {
   useAcpStore.setState({
     mcpServers: [],
+    mcpProbeStatus: {},
+    mcpTools: {},
+    mcpToolsLoaded: {},
+    mcpProbing: {},
     saveMcpServer,
     setMcpServerEnabled,
-    deleteMcpServer
+    deleteMcpServer,
+    probeMcpServer,
+    loadMcpTools
   })
 }
 
@@ -100,5 +108,54 @@ describe('McpServersSettings', () => {
     await waitFor(() =>
       expect(toastError).toHaveBeenCalledWith(expect.stringMatching(/could not save/i))
     )
+  })
+
+  it('probes each server on mount and shows the connected status dot', async () => {
+    vi.mocked(probeMcpServer).mockResolvedValue()
+    useAcpStore.setState({
+      mcpServers: [{ id: 's1', type: 'stdio', name: 'Files', command: 'node', enabled: true }],
+      mcpProbeStatus: { s1: 'connected' },
+      mcpTools: { s1: [{ name: 'read_file' }] }
+    })
+    render(<McpServersSettings />)
+    await waitFor(() => expect(probeMcpServer).toHaveBeenCalledWith('s1'))
+    expect(screen.getByTitle('Connected (Termul can reach this server)')).toBeInTheDocument()
+  })
+
+  it('shows the disconnected dot when the probe fails', () => {
+    useAcpStore.setState({
+      mcpServers: [
+        { id: 's2', type: 'http', name: 'Remote', url: 'https://x.test/m', enabled: true }
+      ],
+      mcpProbeStatus: { s2: 'disconnected' }
+    })
+    render(<McpServersSettings />)
+    expect(
+      screen.getByTitle('Disconnected (Termul could not reach this server)')
+    ).toBeInTheDocument()
+  })
+
+  it('renders the tool list (read-only) inside the collapsible on expand', async () => {
+    useAcpStore.setState({
+      mcpServers: [{ id: 's3', type: 'stdio', name: 'Probe', command: 'node', enabled: true }],
+      mcpTools: { s3: [{ name: 'search', description: 'search files' }] },
+      mcpToolsLoaded: { s3: true }
+    })
+    render(<McpServersSettings />)
+    // Tools are pre-seeded → the trigger shows the count ("1 tool"), not "Show tools".
+    fireEvent.click(screen.getByText(/1 tool/i))
+    expect(screen.getByText('search')).toBeInTheDocument()
+    // Per-tool toggle UI must NOT be present (deferred — read-only).
+    expect(screen.queryByRole('switch', { name: /search/i })).not.toBeInTheDocument()
+  })
+
+  it('fires the Test button to re-probe a server', async () => {
+    useAcpStore.setState({
+      mcpServers: [{ id: 's4', type: 'stdio', name: 'Probe', command: 'node', enabled: true }]
+    })
+    render(<McpServersSettings />)
+    vi.mocked(probeMcpServer).mockClear()
+    fireEvent.click(screen.getByRole('button', { name: /test probe connection/i }))
+    await waitFor(() => expect(probeMcpServer).toHaveBeenCalledWith('s4'))
   })
 })

--- a/src/renderer/components/settings/McpServersSettings.tsx
+++ b/src/renderer/components/settings/McpServersSettings.tsx
@@ -1,7 +1,8 @@
-import { AlertTriangle, Pencil, Plus, Server, Trash2 } from 'lucide-react'
-import { useMemo, useState } from 'react'
+import { AlertTriangle, ChevronDown, Pencil, Plus, RefreshCw, Server, Trash2 } from 'lucide-react'
+import { useEffect, useMemo, useState } from 'react'
 import { toast } from 'sonner'
 import { Button } from '@/components/ui/button'
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible'
 import {
   Dialog,
   DialogContent,
@@ -120,8 +121,27 @@ export function McpServersSettings(): React.JSX.Element {
   const saveMcpServer = useAcpStore((state) => state.saveMcpServer)
   const setMcpServerEnabled = useAcpStore((state) => state.setMcpServerEnabled)
   const deleteMcpServer = useAcpStore((state) => state.deleteMcpServer)
+  const probeMcpServer = useAcpStore((state) => state.probeMcpServer)
+  const loadMcpTools = useAcpStore((state) => state.loadMcpTools)
+  const mcpProbeStatus = useAcpStore((state) => state.mcpProbeStatus)
+  const mcpTools = useAcpStore((state) => state.mcpTools)
+  const mcpProbing = useAcpStore((state) => state.mcpProbing)
   const [draft, setDraft] = useState<ServerDraft | null>(null)
   const [saving, setSaving] = useState(false)
+  // Tracks which server rows have their tool list expanded (Settings surface).
+  const [expandedTools, setExpandedTools] = useState<Record<string, boolean>>({})
+
+  // On Settings mount, probe each configured server once (on-demand). Errors
+  // are surfaced in the dot — never crashed. Re-runs when the registry list
+  // changes shape (add/delete) but not on every toggle (toggle doesn't change
+  // reachability).
+  // biome-ignore lint/correctness/useExhaustiveDependencies: shape-only dep — re-probe only when the id set changes shape, not on every toggle; `probeMcpServer` is a stable store action reference.
+  useEffect(() => {
+    for (const server of servers) {
+      // Fire-and-forget; the store dedupes concurrent probes per id.
+      void probeMcpServer(server.id)
+    }
+  }, [servers.map((s) => s.id).join('|')])
 
   const validation = useMemo(
     () => (draft ? validateMcpServer(configFor(draft)) : { valid: false, errors: [] }),
@@ -178,63 +198,144 @@ export function McpServersSettings(): React.JSX.Element {
         </div>
       ) : (
         <div className="space-y-2">
-          {servers.map((server) => (
-            <div
-              key={server.id}
-              className="flex flex-col gap-3 rounded-lg border border-border p-3 sm:flex-row sm:items-center"
-            >
-              <div className="min-w-0 flex-1">
-                <div className="flex flex-wrap items-center gap-2">
-                  <span className="truncate text-sm font-medium">{server.name}</span>
-                  <span className="rounded bg-secondary px-1.5 py-0.5 text-3xs font-medium uppercase text-muted-foreground">
-                    {transportOf(server)}
-                  </span>
+          {servers.map((server) => {
+            const probeStatus = mcpProbeStatus[server.id]
+            const probing = Boolean(mcpProbing[server.id])
+            const tools = mcpTools[server.id]
+            const isOpen = Boolean(expandedTools[server.id])
+            return (
+              <div
+                key={server.id}
+                className="flex flex-col gap-3 rounded-lg border border-border p-3 sm:flex-row sm:items-start"
+              >
+                <div className="min-w-0 flex-1">
+                  <div className="flex flex-wrap items-center gap-2">
+                    <span
+                      role="img"
+                      className={
+                        probeStatus === 'connected'
+                          ? 'size-2 rounded-full bg-emerald-500'
+                          : probeStatus === 'disconnected'
+                            ? 'size-2 rounded-full bg-red-500'
+                            : 'size-2 rounded-full bg-muted-foreground/40'
+                      }
+                      aria-label={
+                        probeStatus === 'connected'
+                          ? `${server.name} reachable`
+                          : probeStatus === 'disconnected'
+                            ? `${server.name} unreachable`
+                            : `${server.name} not probed yet`
+                      }
+                      title={
+                        probeStatus === 'connected'
+                          ? 'Connected (Termul can reach this server)'
+                          : probeStatus === 'disconnected'
+                            ? 'Disconnected (Termul could not reach this server)'
+                            : 'Not probed yet — click "Test" to check'
+                      }
+                    />
+                    <span className="truncate text-sm font-medium">{server.name}</span>
+                    <span className="rounded bg-secondary px-1.5 py-0.5 text-3xs font-medium uppercase text-muted-foreground">
+                      {transportOf(server)}
+                    </span>
+                  </div>
+                  <p className="mt-1 truncate font-mono text-xs text-muted-foreground">
+                    {transportOf(server) === 'stdio'
+                      ? (server as Extract<StoredMcpServer, { type?: 'stdio' }>).command
+                      : (server as Extract<StoredMcpServer, { type: 'http' | 'sse' }>).url}
+                  </p>
+                  <Collapsible
+                    open={isOpen}
+                    onOpenChange={(next) => {
+                      setExpandedTools((prev) => ({ ...prev, [server.id]: next }))
+                      if (next) void loadMcpTools(server.id)
+                    }}
+                  >
+                    <CollapsibleTrigger className="mt-1 inline-flex items-center gap-1 text-3xs text-muted-foreground underline-offset-2 hover:underline">
+                      <ChevronDown size={12} className={isOpen ? 'rotate-180' : ''} />
+                      {tools && tools.length > 0
+                        ? `${tools.length} tool${tools.length === 1 ? '' : 's'}`
+                        : probeStatus === 'disconnected'
+                          ? 'Probe failed — retry'
+                          : 'Show tools'}
+                    </CollapsibleTrigger>
+                    <CollapsibleContent className="pt-1">
+                      {tools && tools.length > 0 ? (
+                        <ul className="space-y-0.5">
+                          {tools.map((tool) => (
+                            <li key={tool.name} className="text-3xs text-muted-foreground">
+                              <span className="font-mono">{tool.name}</span>
+                              {tool.description ? (
+                                <span className="ml-1 truncate">— {tool.description}</span>
+                              ) : null}
+                            </li>
+                          ))}
+                        </ul>
+                      ) : probeStatus === 'disconnected' ? (
+                        <p className="text-3xs text-destructive">
+                          Probe failed — check the server config or network.
+                        </p>
+                      ) : probing ? (
+                        <p className="text-3xs text-muted-foreground">Probing…</p>
+                      ) : (
+                        <p className="text-3xs text-muted-foreground">
+                          Expand to probe (read-only — per-tool toggle coming soon).
+                        </p>
+                      )}
+                    </CollapsibleContent>
+                  </Collapsible>
                 </div>
-                <p className="mt-1 truncate font-mono text-xs text-muted-foreground">
-                  {transportOf(server) === 'stdio'
-                    ? (server as Extract<StoredMcpServer, { type?: 'stdio' }>).command
-                    : (server as Extract<StoredMcpServer, { type: 'http' | 'sse' }>).url}
-                </p>
+                <div className="flex items-center justify-between gap-2 sm:justify-end">
+                  <Button
+                    type="button"
+                    size="sm"
+                    variant="ghost"
+                    disabled={probing}
+                    onClick={() => void probeMcpServer(server.id)}
+                    aria-label={`Test ${server.name} connection`}
+                  >
+                    <RefreshCw size={14} className={probing ? 'animate-spin' : ''} />
+                    <span className="ml-1.5">Test</span>
+                  </Button>
+                  <Switch
+                    checked={server.enabled !== false}
+                    aria-label={`${server.enabled !== false ? 'Disable' : 'Enable'} ${server.name}`}
+                    onCheckedChange={(enabled) => {
+                      void setMcpServerEnabled(server.id, enabled).catch(() => {
+                        toast.error(
+                          'Could not update the MCP server. Your previous setting was restored.'
+                        )
+                      })
+                    }}
+                  />
+                  <Button
+                    type="button"
+                    size="icon"
+                    variant="ghost"
+                    onClick={() => setDraft(draftFor(server))}
+                  >
+                    <Pencil size={15} />
+                    <span className="sr-only">Edit {server.name}</span>
+                  </Button>
+                  <Button
+                    type="button"
+                    size="icon"
+                    variant="ghost"
+                    onClick={() => {
+                      void deleteMcpServer(server.id).catch(() => {
+                        toast.error(
+                          'Could not delete the MCP server. Your previous settings were restored.'
+                        )
+                      })
+                    }}
+                  >
+                    <Trash2 size={15} />
+                    <span className="sr-only">Delete {server.name}</span>
+                  </Button>
+                </div>
               </div>
-              <div className="flex items-center justify-between gap-2 sm:justify-end">
-                <Switch
-                  checked={server.enabled !== false}
-                  aria-label={`${server.enabled !== false ? 'Disable' : 'Enable'} ${server.name}`}
-                  onCheckedChange={(enabled) => {
-                    void setMcpServerEnabled(server.id, enabled).catch(() => {
-                      toast.error(
-                        'Could not update the MCP server. Your previous setting was restored.'
-                      )
-                    })
-                  }}
-                />
-                <Button
-                  type="button"
-                  size="icon"
-                  variant="ghost"
-                  onClick={() => setDraft(draftFor(server))}
-                >
-                  <Pencil size={15} />
-                  <span className="sr-only">Edit {server.name}</span>
-                </Button>
-                <Button
-                  type="button"
-                  size="icon"
-                  variant="ghost"
-                  onClick={() => {
-                    void deleteMcpServer(server.id).catch(() => {
-                      toast.error(
-                        'Could not delete the MCP server. Your previous settings were restored.'
-                      )
-                    })
-                  }}
-                >
-                  <Trash2 size={15} />
-                  <span className="sr-only">Delete {server.name}</span>
-                </Button>
-              </div>
-            </div>
-          ))}
+            )
+          })}
         </div>
       )}
 

--- a/src/renderer/components/settings/McpServersSettings.tsx
+++ b/src/renderer/components/settings/McpServersSettings.tsx
@@ -138,6 +138,10 @@ export function McpServersSettings(): React.JSX.Element {
   // biome-ignore lint/correctness/useExhaustiveDependencies: shape-only dep — re-probe only when the id set changes shape, not on every toggle; `probeMcpServer` is a stable store action reference.
   useEffect(() => {
     for (const server of servers) {
+      // Skip disabled servers on mount — they are not injected into sessions, so
+      // their reachability status is not actionable at idle. The manual "Test"
+      // button below still probes a disabled server on explicit request.
+      if (server.enabled === false) continue
       // Fire-and-forget; the store dedupes concurrent probes per id.
       void probeMcpServer(server.id)
     }
@@ -274,6 +278,10 @@ export function McpServersSettings(): React.JSX.Element {
                       ) : probeStatus === 'disconnected' ? (
                         <p className="text-3xs text-destructive">
                           Probe failed — check the server config or network.
+                        </p>
+                      ) : probeStatus === 'connected' ? (
+                        <p className="text-3xs text-muted-foreground">
+                          Probe completed — no tools found.
                         </p>
                       ) : probing ? (
                         <p className="text-3xs text-muted-foreground">Probing…</p>

--- a/src/renderer/lib/acp-api.ts
+++ b/src/renderer/lib/acp-api.ts
@@ -217,6 +217,24 @@ export interface McpSseServer {
   headers?: McpHeader[]
 }
 export type McpServerConfig = McpStdioServer | McpHttpServer | McpSseServer
+
+// --- MCP client probe (on-demand `initialize` + `tools/list`) -------------
+
+/** Per-server probe status (Termul's own client connection, not the agent's). */
+export type ProbeStatus = 'connected' | 'disconnected'
+
+/** A tool exposed by a probed MCP server (`tools/list` output, UI subset). */
+export interface McpToolInfo {
+  name: string
+  description?: string
+}
+
+/** Probe result. On `disconnected`, `error` is a short, value-free message. */
+export interface ProbeResult {
+  status: ProbeStatus
+  tools: McpToolInfo[]
+  error?: string
+}
 /** Wire type forwarded verbatim to the backend `acp_new_session` command. */
 export type McpServer = McpServerConfig
 
@@ -467,6 +485,23 @@ export async function acpProbeRuntime(): Promise<AcpRuntimeAvailability> {
   return getAcpTransport().probeRuntime()
 }
 
+/**
+ * On-demand MCP client probe. Opens a fresh rmcp client connection to the
+ * configured server, calls `initialize` + `tools/list`, then closes. Returns
+ * the connected/disconnected status + tool list. Stateless — the renderer
+ * supplies the full `McpServerConfig` (no registry-store coupling). Never
+ * logs env/header values, tokens, or credentials. Desktop↔web parity: the
+ * probe runs on the termul-server host via `POST /mcp-servers/probe` on web.
+ */
+export async function probeMcpServer(server: McpServerConfig): Promise<ProbeResult> {
+  return getAcpTransport().probeMcpServer(server)
+}
+
+/** Thin wrapper: probe + return just the tool list (auto-probe on expand). */
+export async function listMcpTools(server: McpServerConfig): Promise<McpToolInfo[]> {
+  return (await getAcpTransport().probeMcpServer(server)).tools
+}
+
 export interface AcpRegistrySnapshot {
   agents: unknown
   source: string
@@ -643,6 +678,8 @@ export const acpApi = {
   setTurnTimeout: acpSetTurnTimeout,
   installRegistryBinary: acpInstallRegistryBinary,
   probeRuntime: acpProbeRuntime,
+  probeMcpServer,
+  listMcpTools,
   fetchRegistrySnapshot: acpFetchRegistrySnapshot,
   onEvent: onAcpEvent
 }

--- a/src/renderer/lib/acp-api.ts
+++ b/src/renderer/lib/acp-api.ts
@@ -492,14 +492,22 @@ export async function acpProbeRuntime(): Promise<AcpRuntimeAvailability> {
  * supplies the full `McpServerConfig` (no registry-store coupling). Never
  * logs env/header values, tokens, or credentials. Desktop↔web parity: the
  * probe runs on the termul-server host via `POST /mcp-servers/probe` on web.
+ *
+ * Delegates to the canonical `acp-mcp-probe.ts` facade so the transport-facade
+ * (`acpApi`) and the standalone facade share ONE contract: never throws on a
+ * probe failure — returns a disconnected `ProbeResult` instead.
  */
 export async function probeMcpServer(server: McpServerConfig): Promise<ProbeResult> {
-  return getAcpTransport().probeMcpServer(server)
+  // Lazy import avoids a static cycle (acp-api ↔ acp-mcp-probe) at module load;
+  // the canonical facade owns the `isTauriContext()` branching + normalization.
+  const { probeMcpServer: canonicalProbe } = await import('@/lib/acp-mcp-probe')
+  return canonicalProbe(server)
 }
 
 /** Thin wrapper: probe + return just the tool list (auto-probe on expand). */
 export async function listMcpTools(server: McpServerConfig): Promise<McpToolInfo[]> {
-  return (await getAcpTransport().probeMcpServer(server)).tools
+  const { listMcpTools: canonicalList } = await import('@/lib/acp-mcp-probe')
+  return canonicalList(server)
 }
 
 export interface AcpRegistrySnapshot {

--- a/src/renderer/lib/acp-mcp-probe.test.ts
+++ b/src/renderer/lib/acp-mcp-probe.test.ts
@@ -67,6 +67,23 @@ describe('acp-mcp-probe', () => {
     expect(result.error).toBe('spawn failed: ...')
   })
 
+  it('normalizes a Tauri invoke rejection to a disconnected result + logs it (canonical contract)', async () => {
+    vi.mocked(invoke).mockRejectedValueOnce(new Error('IPC transport down'))
+    const result = await probeMcpServer(stdioServer)
+    expect(result.status).toBe('disconnected')
+    expect(result.tools).toEqual([])
+    expect(result.error).toContain('IPC transport down')
+    // The boundary log carries the server name but NO env/header values.
+    expect(logFrontendError).toHaveBeenCalledWith(
+      expect.objectContaining({
+        source: 'acp-mcp-probe.probeMcpServer',
+        message: expect.stringContaining(stdioServer.name)
+      })
+    )
+    const logged = vi.mocked(logFrontendError).mock.calls[0][0]
+    expect(logged.message).toContain('IPC transport down')
+  })
+
   it('POSTs to /mcp-servers/probe on web and unwraps the IpcBody', async () => {
     vi.mocked(isTauriContext).mockReturnValue(false)
     vi.mocked(webServerMcpProbe.post).mockResolvedValue({

--- a/src/renderer/lib/acp-mcp-probe.test.ts
+++ b/src/renderer/lib/acp-mcp-probe.test.ts
@@ -1,0 +1,142 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('@tauri-apps/api/core', () => ({
+  invoke: vi.fn()
+}))
+vi.mock('@/lib/tauri-runtime', () => ({
+  isTauriContext: vi.fn(() => true)
+}))
+vi.mock('@/lib/log-api', () => ({
+  logFrontendError: vi.fn()
+}))
+vi.mock('@/lib/web-server-api', () => ({
+  webServerMcpProbe: { post: vi.fn() }
+}))
+
+import { invoke } from '@tauri-apps/api/core'
+import { logFrontendError } from '@/lib/log-api'
+import { isTauriContext } from '@/lib/tauri-runtime'
+import { webServerMcpProbe } from '@/lib/web-server-api'
+import { listMcpTools, probeMcpServer } from './acp-mcp-probe'
+
+const stdioServer = {
+  type: 'stdio' as const,
+  name: 'Files',
+  command: 'npx',
+  args: [],
+  env: []
+}
+
+const httpServer = {
+  type: 'http' as const,
+  name: 'Remote',
+  url: 'https://example.com/mcp',
+  headers: []
+}
+
+describe('acp-mcp-probe', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(isTauriContext).mockReturnValue(true)
+  })
+
+  it('invokes the Tauri command on desktop with the wire config', async () => {
+    vi.mocked(invoke).mockResolvedValue({ status: 'connected', tools: [] })
+    await probeMcpServer(stdioServer)
+    expect(invoke).toHaveBeenCalledWith('acp_probe_mcp_server', { server: stdioServer })
+  })
+
+  it('returns the connected probe result from the Tauri command', async () => {
+    vi.mocked(invoke).mockResolvedValue({
+      status: 'connected',
+      tools: [{ name: 'read_file', description: 'read a file' }]
+    })
+    const result = await probeMcpServer(stdioServer)
+    expect(result.status).toBe('connected')
+    expect(result.tools).toEqual([{ name: 'read_file', description: 'read a file' }])
+  })
+
+  it('passes through a disconnected outcome without throwing (Tauri)', async () => {
+    vi.mocked(invoke).mockResolvedValue({
+      status: 'disconnected',
+      tools: [],
+      error: 'spawn failed: ...'
+    })
+    const result = await probeMcpServer(stdioServer)
+    expect(result.status).toBe('disconnected')
+    expect(result.error).toBe('spawn failed: ...')
+  })
+
+  it('POSTs to /mcp-servers/probe on web and unwraps the IpcBody', async () => {
+    vi.mocked(isTauriContext).mockReturnValue(false)
+    vi.mocked(webServerMcpProbe.post).mockResolvedValue({
+      success: true,
+      data: { status: 'connected', tools: [{ name: 'search' }] }
+    })
+    const result = await probeMcpServer(httpServer)
+    expect(webServerMcpProbe.post).toHaveBeenCalledWith(httpServer)
+    expect(result.status).toBe('connected')
+    expect(result.tools).toEqual([{ name: 'search' }])
+  })
+
+  it('returns disconnected on a web transport failure (success:false) and logs it', async () => {
+    vi.mocked(isTauriContext).mockReturnValue(false)
+    vi.mocked(webServerMcpProbe.post).mockResolvedValue({
+      success: false,
+      code: 'NETWORK_ERROR',
+      error: 'fetch failed'
+    })
+    const result = await probeMcpServer(httpServer)
+    expect(result.status).toBe('disconnected')
+    expect(result.error).toBe('fetch failed')
+    // The boundary log carries the server name + code but NO env/header values.
+    expect(logFrontendError).toHaveBeenCalledWith(
+      expect.objectContaining({
+        source: 'acp-mcp-probe.probeMcpServer',
+        message: expect.stringContaining(httpServer.name)
+      })
+    )
+    const logged = vi.mocked(logFrontendError).mock.calls[0][0]
+    expect(logged.message).toContain('NETWORK_ERROR')
+    // Sanity: the log line must not echo the URL or header values (none here,
+    // but the contract is enforced).
+  })
+
+  it('does NOT pass env/header values through the log path on a web failure', async () => {
+    vi.mocked(isTauriContext).mockReturnValue(false)
+    vi.mocked(webServerMcpProbe.post).mockResolvedValue({
+      success: false,
+      code: 'NETWORK_ERROR',
+      error: 'fetch failed'
+    })
+    const secret = {
+      type: 'stdio' as const,
+      name: 'leaky',
+      command: 'node',
+      args: [],
+      env: [{ name: 'API_KEY', value: 'super-secret-value' }]
+    }
+    await probeMcpServer(secret)
+    const logged = vi.mocked(logFrontendError).mock.calls[0][0]
+    expect(logged.message).not.toContain('super-secret-value')
+  })
+
+  it('listMcpTools returns just the tool list', async () => {
+    vi.mocked(invoke).mockResolvedValue({
+      status: 'connected',
+      tools: [{ name: 'a' }, { name: 'b' }]
+    })
+    const tools = await listMcpTools(stdioServer)
+    expect(tools).toEqual([{ name: 'a' }, { name: 'b' }])
+  })
+
+  it('listMcpTools returns an empty list when the probe disconnects', async () => {
+    vi.mocked(invoke).mockResolvedValue({
+      status: 'disconnected',
+      tools: [],
+      error: 'unreachable'
+    })
+    const tools = await listMcpTools(stdioServer)
+    expect(tools).toEqual([])
+  })
+})

--- a/src/renderer/lib/acp-mcp-probe.ts
+++ b/src/renderer/lib/acp-mcp-probe.ts
@@ -1,0 +1,64 @@
+/**
+ * On-demand MCP client probe — standalone facade (mirrors the
+ * `acp-mcp-persistence.ts` runtime-branching pattern).
+ *
+ * Statelessly probes a configured MCP server: opens a fresh rmcp client
+ * connection, calls `initialize` + `tools/list`, then closes. The probe reflects
+ * **Termul's own client connection** (NOT the agent's — the agent owns its own
+ * connection inside its process). The status dot therefore answers "can Termul
+ * reach this server and list its tools?" — see the spec's Design Notes.
+ *
+ * Branches on `isTauriContext()`:
+ * - Desktop: Tauri `invoke('acp_probe_mcp_server', { server })`.
+ * - Web/remote: `POST /mcp-servers/probe` runs the probe on the termul-server
+ *   host (where stdio commands execute — matches GH-287's web-parity decision)
+ *   and returns the same `IpcBody<ProbeResult>` shape.
+ *
+ * The probe itself never throws on a disconnected server — it returns
+ * `ProbeResult { status: 'disconnected', error }`. Only transport/config
+ * failures throw (which the store logs via `logFrontendError` — never with
+ * env/header values, tokens, or credentials).
+ *
+ * On-demand only — each call opens a brand-new connection and tears it down
+ * immediately after `tools/list` returns (or fails). No persistent always-on
+ * connections.
+ */
+
+import { invoke } from '@tauri-apps/api/core'
+import type { McpServerConfig, McpToolInfo, ProbeResult } from '@/lib/acp-api'
+import { logFrontendError } from '@/lib/log-api'
+import { isTauriContext } from '@/lib/tauri-runtime'
+import { webServerMcpProbe } from '@/lib/web-server-api'
+
+/**
+ * Probe a configured MCP server. Stateless — the renderer supplies the full
+ * `McpServerConfig` (no registry-store coupling). Never throws on a
+ * disconnected server; throws only on transport/config failure.
+ */
+export async function probeMcpServer(server: McpServerConfig): Promise<ProbeResult> {
+  if (isTauriContext()) {
+    return invoke<ProbeResult>('acp_probe_mcp_server', { server })
+  }
+  const res = await webServerMcpProbe.post(server)
+  if (!res.success) {
+    // Boundary log: outcome + server name + transport only — NO env/header
+    // values, tokens, or credentials. The error string from the route is
+    // already value-free (it carries only a code/message like
+    // `MCP_PROBE_INVALID_CONFIG` / `NETWORK_ERROR`).
+    void logFrontendError({
+      source: 'acp-mcp-probe.probeMcpServer',
+      message: `MCP probe transport failed for server '${server.name}' (${res.code}: ${res.error})`
+    })
+    return {
+      status: 'disconnected',
+      tools: [],
+      error: res.error || res.code
+    }
+  }
+  return res.data as ProbeResult
+}
+
+/** Thin wrapper: probe + return just the tool list (auto-probe on expand). */
+export async function listMcpTools(server: McpServerConfig): Promise<McpToolInfo[]> {
+  return (await probeMcpServer(server)).tools
+}

--- a/src/renderer/lib/acp-mcp-probe.ts
+++ b/src/renderer/lib/acp-mcp-probe.ts
@@ -1,6 +1,5 @@
 /**
- * On-demand MCP client probe — standalone facade (mirrors the
- * `acp-mcp-persistence.ts` runtime-branching pattern).
+ * On-demand MCP client probe — canonical renderer facade.
  *
  * Statelessly probes a configured MCP server: opens a fresh rmcp client
  * connection, calls `initialize` + `tools/list`, then closes. The probe reflects
@@ -14,10 +13,14 @@
  *   host (where stdio commands execute — matches GH-287's web-parity decision)
  *   and returns the same `IpcBody<ProbeResult>` shape.
  *
- * The probe itself never throws on a disconnected server — it returns
- * `ProbeResult { status: 'disconnected', error }`. Only transport/config
- * failures throw (which the store logs via `logFrontendError` — never with
- * env/header values, tokens, or credentials).
+ * Canonical contract (shared with `acpApi.probeMcpServer`/`listMcpTools`, which
+ * delegate here): NEVER throws on a probe failure — returns
+ * `ProbeResult { status: 'disconnected', error }` for transport/config failures
+ * AND for unreachable servers. A disconnected probe is a successful probe of
+ * an unreachable server. Only an unexpected throw (e.g. invoke IPC failure)
+ * is normalized to a disconnected result here + logged via `logFrontendError`
+ * (never with env/header values, tokens, or credentials). `listMcpTools`
+ * consumes the normalized result and returns `[]` on any failure.
  *
  * On-demand only — each call opens a brand-new connection and tears it down
  * immediately after `tools/list` returns (or fails). No persistent always-on
@@ -32,12 +35,28 @@ import { webServerMcpProbe } from '@/lib/web-server-api'
 
 /**
  * Probe a configured MCP server. Stateless — the renderer supplies the full
- * `McpServerConfig` (no registry-store coupling). Never throws on a
- * disconnected server; throws only on transport/config failure.
+ * `McpServerConfig` (no registry-store coupling). Never throws — returns a
+ * disconnected `ProbeResult` on transport/config/IPC failure, and logs the
+ * failure outcome (server name + transport/code only — no env/header values).
  */
 export async function probeMcpServer(server: McpServerConfig): Promise<ProbeResult> {
   if (isTauriContext()) {
-    return invoke<ProbeResult>('acp_probe_mcp_server', { server })
+    try {
+      return await invoke<ProbeResult>('acp_probe_mcp_server', { server })
+    } catch (err) {
+      // IPC failure (command not registered, backend panic, etc.). The probe
+      // command itself returns `Ok(ProbeResult)` for unreachable servers — a
+      // throw here is a transport/IPC failure, normalized to disconnected.
+      void logFrontendError({
+        source: 'acp-mcp-probe.probeMcpServer',
+        message: `MCP probe transport failed for server '${server.name}' (${String(err)})`
+      })
+      return {
+        status: 'disconnected',
+        tools: [],
+        error: String(err)
+      }
+    }
   }
   const res = await webServerMcpProbe.post(server)
   if (!res.success) {

--- a/src/renderer/lib/acp-transport.ts
+++ b/src/renderer/lib/acp-transport.ts
@@ -41,7 +41,9 @@ import type {
   InstallAcpRegistryBinaryRequest,
   ListSessionsResponse,
   McpServer,
+  McpServerConfig,
   NewSessionOutcome,
+  ProbeResult,
   SessionConfigOption,
   SessionId,
   SessionReopenOutcome,
@@ -49,6 +51,7 @@ import type {
 } from '@/lib/acp-api'
 import type { AcpRuntimeAvailability } from '@/lib/agents/supported-acp-agents'
 import { isTauriContext } from '@/lib/tauri-runtime'
+import { webServerMcpProbe } from '@/lib/web-server-api'
 
 /** Thrown on WS (and mapped) failures — callers may toast `.message`. */
 export class AcpTransportError extends Error {
@@ -68,6 +71,17 @@ export interface AcpTransport {
   probeRuntime(): Promise<AcpRuntimeAvailability>
   setTurnTimeout(secs: number | null): Promise<void>
   fetchRegistrySnapshot(forceRefresh?: boolean): Promise<AcpRegistrySnapshot>
+  /**
+   * On-demand MCP client probe (Termul's own rmcp client connection — NOT the
+   * agent's). Stateless: takes the renderer-supplied wire config, opens a fresh
+   * rmcp client, calls `initialize` + `tools/list`, then closes. Desktop↔web
+   * parity: on web the probe runs on the termul-server host via
+   * `POST /mcp-servers/probe`. Never logs env/header values, tokens, or
+   * credentials. The probe never throws on a disconnected server — it returns
+   * `ProbeResult { status: 'disconnected', error }`; only transport/parse
+   * failures throw `AcpTransportError`.
+   */
+  probeMcpServer(server: McpServerConfig): Promise<ProbeResult>
   spawnAgent(config: AgentConfig): Promise<AgentId>
   killAgent(agentId: AgentId): Promise<void>
   listAgents(): Promise<AgentId[]>
@@ -171,6 +185,7 @@ function createTauriAcpTransport(): AcpTransport {
     setTurnTimeout: (secs) => invoke<void>('acp_set_turn_timeout', { secs }),
     fetchRegistrySnapshot: (forceRefresh = false) =>
       invoke<AcpRegistrySnapshot>('acp_fetch_registry_snapshot', { forceRefresh }),
+    probeMcpServer: (server) => invoke<ProbeResult>('acp_probe_mcp_server', { server }),
     spawnAgent: (config) => invoke<AgentId>('acp_spawn_agent', { config }),
     killAgent: async (agentId) => {
       await invoke('acp_kill_agent', { agentId })
@@ -541,6 +556,20 @@ export class WsAcpTransport implements AcpTransport {
 
   async probeRuntime(): Promise<AcpRuntimeAvailability> {
     return { npx: true, uvx: true }
+  }
+
+  async probeMcpServer(server: McpServerConfig): Promise<ProbeResult> {
+    // Web parity: POST /mcp-servers/probe runs the rmcp client on the
+    // termul-server host (where stdio commands execute). The route returns
+    // `IpcBody<ProbeResult>`; a `success:false` body is a transport/config
+    // failure (mapped to AcpTransportError), while `success:true` carries the
+    // probe outcome (which may itself be `status:'disconnected'` — that is a
+    // successful probe of an unreachable server, NOT a transport failure).
+    const res = await webServerMcpProbe.post(server)
+    if (!res.success) {
+      throw new AcpTransportError(res.code, res.error)
+    }
+    return res.data as ProbeResult
   }
 
   async setTurnTimeout(_secs: number | null): Promise<void> {

--- a/src/renderer/lib/web-server-api.ts
+++ b/src/renderer/lib/web-server-api.ts
@@ -44,12 +44,17 @@ function networkError(detail: string): IpcResult<never> {
 }
 
 /** POST JSON and return the typed `IpcResult` body (or NETWORK_ERROR). */
-async function postJson<T>(path: string, body: unknown): Promise<IpcResult<T>> {
+async function postJson<T>(
+  path: string,
+  body: unknown,
+  signal?: AbortSignal
+): Promise<IpcResult<T>> {
   try {
     const res = await fetch(`${serverBase()}${path}`, {
       method: 'POST',
       headers: { 'content-type': 'application/json' },
-      body: JSON.stringify(body)
+      body: JSON.stringify(body),
+      signal
     })
     return await parseBody<T>(res)
   } catch (err) {
@@ -196,9 +201,22 @@ export const webServerMcpServers = {
  * reachable-but-disconnected server still returns `success:true` with
  * `data.status === 'disconnected'`. Only transport/deserialize failures surface
  * as `success:false` (`MCP_PROBE_INVALID_CONFIG` / `NETWORK_ERROR`).
+ *
+ * A client-side AbortController bounds the request at 12s — slightly above the
+ * backend's 10s probe deadline — so a stalled `fetch` (hung TCP, no response)
+ * resolves as `NETWORK_ERROR` instead of remaining pending forever. The signal
+ * is cleared on completion (AbortController is GC'd once the request settles).
  */
+const PROBE_TIMEOUT_MS = 12_000
+
 export const webServerMcpProbe = {
   async post(server: unknown): Promise<IpcResult<unknown>> {
-    return postJson<unknown>('/mcp-servers/probe', server)
+    const controller = new AbortController()
+    const timer = setTimeout(() => controller.abort(), PROBE_TIMEOUT_MS)
+    try {
+      return await postJson<unknown>('/mcp-servers/probe', server, controller.signal)
+    } finally {
+      clearTimeout(timer)
+    }
   }
 }

--- a/src/renderer/lib/web-server-api.ts
+++ b/src/renderer/lib/web-server-api.ts
@@ -187,3 +187,18 @@ export const webServerMcpServers = {
     return putJson<void>('/mcp-servers', registry)
   }
 }
+
+/**
+ * On-demand MCP client probe (web parity). `POST /mcp-servers/probe` runs the
+ * rmcp client probe on the termul-server host (where stdio commands execute).
+ * Returns the same `IpcResult<ProbeResult>` shape the desktop Tauri command
+ * yields — the renderer facade unwraps it. The probe itself never fails: a
+ * reachable-but-disconnected server still returns `success:true` with
+ * `data.status === 'disconnected'`. Only transport/deserialize failures surface
+ * as `success:false` (`MCP_PROBE_INVALID_CONFIG` / `NETWORK_ERROR`).
+ */
+export const webServerMcpProbe = {
+  async post(server: unknown): Promise<IpcResult<unknown>> {
+    return postJson<unknown>('/mcp-servers/probe', server)
+  }
+}

--- a/src/renderer/stores/acp-store.test.ts
+++ b/src/renderer/stores/acp-store.test.ts
@@ -4247,8 +4247,14 @@ describe('acp-store', () => {
     const state = useAcpStore.getState()
     expect(state.mcpProbeStatus.p5).toBe('disconnected')
     expect(state.mcpProbing.p5).toBe(false)
+    // The canonical facade (`acp-mcp-probe.ts`) normalizes the invoke rejection
+    // to a disconnected ProbeResult and logs the transport failure itself — the
+    // store's success path runs (probe "completed" with a disconnected result),
+    // so `mcpToolsLoaded` is true (no auto-re-probe on next expand — a transport
+    // failure is treated as a completed probe, consistent with the contract).
+    expect(state.mcpToolsLoaded.p5).toBe(true)
     expect(logFrontendError).toHaveBeenCalledWith(
-      expect.objectContaining({ source: 'acp-store.probeMcpServer' })
+      expect.objectContaining({ source: 'acp-mcp-probe.probeMcpServer' })
     )
     const logged = vi.mocked(logFrontendError).mock.calls.at(-1)?.[0]
     expect(logged?.message).toContain('leaky')

--- a/src/renderer/stores/acp-store.test.ts
+++ b/src/renderer/stores/acp-store.test.ts
@@ -4144,6 +4144,117 @@ describe('acp-store', () => {
     })
   })
 
+  it('probeMcpServer updates status + tools + loaded flag on a connected result', async () => {
+    useAcpStore.setState({
+      mcpServers: [{ id: 'p1', type: 'stdio', name: 'Files', command: 'npx', enabled: true }],
+      mcpProbeStatus: {},
+      mcpTools: {},
+      mcpToolsLoaded: {},
+      mcpProbing: {}
+    })
+    vi.mocked(invoke).mockResolvedValueOnce({
+      status: 'connected',
+      tools: [{ name: 'read_file', description: 'read a file' }]
+    })
+    await useAcpStore.getState().probeMcpServer('p1')
+    // The store strips registry-only `id`/`enabled` before passing the wire
+    // config to the probe (stateless — no `toWireServer` default-fill, unlike
+    // `selectMcpServersForAgent` which fills `args: []`/`env: []`).
+    expect(invoke).toHaveBeenCalledWith('acp_probe_mcp_server', {
+      server: { type: 'stdio', name: 'Files', command: 'npx' }
+    })
+    const state = useAcpStore.getState()
+    expect(state.mcpProbeStatus.p1).toBe('connected')
+    expect(state.mcpTools.p1).toEqual([{ name: 'read_file', description: 'read a file' }])
+    expect(state.mcpToolsLoaded.p1).toBe(true)
+    expect(state.mcpProbing.p1).toBe(false)
+  })
+
+  it('probeMcpServer surfaces a disconnected result without throwing', async () => {
+    useAcpStore.setState({
+      mcpServers: [
+        { id: 'p2', type: 'http', name: 'Remote', url: 'https://x.test/m', enabled: true }
+      ],
+      mcpProbeStatus: {},
+      mcpTools: {},
+      mcpToolsLoaded: {},
+      mcpProbing: {}
+    })
+    vi.mocked(invoke).mockResolvedValueOnce({
+      status: 'disconnected',
+      tools: [],
+      error: 'initialize failed: connection refused'
+    })
+    await useAcpStore.getState().probeMcpServer('p2')
+    const state = useAcpStore.getState()
+    expect(state.mcpProbeStatus.p2).toBe('disconnected')
+    expect(state.mcpTools.p2).toEqual([])
+    expect(state.mcpToolsLoaded.p2).toBe(true)
+    // A disconnected probe is a ProbeResult, NOT a throw — no error log.
+    expect(logFrontendError).not.toHaveBeenCalled()
+  })
+
+  it('probeMcpServer dedupes concurrent probes for the same id', async () => {
+    useAcpStore.setState({
+      mcpServers: [{ id: 'p3', type: 'stdio', name: 'Files', command: 'npx', enabled: true }],
+      mcpProbeStatus: {},
+      mcpTools: {},
+      mcpToolsLoaded: {},
+      mcpProbing: {}
+    })
+    vi.mocked(invoke).mockResolvedValue({ status: 'connected', tools: [] })
+    // Two concurrent calls — only one should reach the transport.
+    await Promise.all([
+      useAcpStore.getState().probeMcpServer('p3'),
+      useAcpStore.getState().probeMcpServer('p3')
+    ])
+    expect(
+      vi.mocked(invoke).mock.calls.filter((c) => c[0] === 'acp_probe_mcp_server')
+    ).toHaveLength(1)
+  })
+
+  it('loadMcpTools no-ops when tools are already loaded', async () => {
+    useAcpStore.setState({
+      mcpServers: [{ id: 'p4', type: 'stdio', name: 'Files', command: 'npx', enabled: true }],
+      mcpToolsLoaded: { p4: true },
+      mcpProbing: {}
+    })
+    vi.mocked(invoke).mockClear()
+    await useAcpStore.getState().loadMcpTools('p4')
+    expect(vi.mocked(invoke)).not.toHaveBeenCalledWith('acp_probe_mcp_server', expect.anything())
+  })
+
+  it('probeMcpServer logs without env values on a transport failure', async () => {
+    useAcpStore.setState({
+      mcpServers: [
+        {
+          id: 'p5',
+          type: 'stdio',
+          name: 'leaky',
+          command: 'npx',
+          args: [],
+          env: [{ name: 'API_KEY', value: 'super-secret-value' }],
+          enabled: true
+        }
+      ],
+      mcpProbeStatus: {},
+      mcpTools: {},
+      mcpToolsLoaded: {},
+      mcpProbing: {}
+    })
+    vi.mocked(invoke).mockRejectedValueOnce(new Error('transport down'))
+    await useAcpStore.getState().probeMcpServer('p5')
+    const state = useAcpStore.getState()
+    expect(state.mcpProbeStatus.p5).toBe('disconnected')
+    expect(state.mcpProbing.p5).toBe(false)
+    expect(logFrontendError).toHaveBeenCalledWith(
+      expect.objectContaining({ source: 'acp-store.probeMcpServer' })
+    )
+    const logged = vi.mocked(logFrontendError).mock.calls.at(-1)?.[0]
+    expect(logged?.message).toContain('leaky')
+    expect(logged?.message).not.toContain('super-secret-value')
+  })
+
   // Story 5.3 (AC3): transportReconnecting flag is additive state — verify
   // it starts false and can be flipped via setState (the store init wires the
   // WS transport listener to call setState; here we just verify the state

--- a/src/renderer/stores/acp-store.ts
+++ b/src/renderer/stores/acp-store.ts
@@ -52,12 +52,16 @@ import {
   type ConfigOptionsUpdateEvent,
   type ContentBlock,
   type McpServer,
+  type McpServerConfig,
+  type McpToolInfo,
   type MessageChunkEvent,
   type ModeUpdateEvent,
   type PermissionOption,
   type PermissionRequestEvent,
   type PlanEntry,
   type PlanUpdateEvent,
+  type ProbeResult,
+  type ProbeStatus,
   type PromptCompleteEvent,
   type QuestionOption,
   type SessionClosedEvent,
@@ -297,6 +301,16 @@ interface AcpState {
   // Global MCP server registry (persisted)
   mcpServers: StoredMcpServer[]
 
+  // MCP probe state — on-demand only (no persistent always-on connections).
+  // `mcpProbeStatus` reflects Termul's own rmcp client connection, NOT the
+  // agent's; the dot answers "can Termul reach this server and list its tools?".
+  // `mcpTools` is the cached `tools/list` output; `mcpToolsLoaded` gates the
+  // auto-probe on first expand; `mcpProbing` dedupes concurrent probes.
+  mcpProbeStatus: Record<string, ProbeStatus>
+  mcpTools: Record<string, McpToolInfo[]>
+  mcpToolsLoaded: Record<string, boolean>
+  mcpProbing: Record<string, boolean>
+
   // Sessions
   sessions: Record<SessionId, AcpSession>
   activeSessionId: SessionId | null
@@ -498,6 +512,20 @@ interface AcpState {
   saveMcpServer: (server: StoredMcpServer) => Promise<void>
   setMcpServerEnabled: (id: string, enabled: boolean) => Promise<void>
   deleteMcpServer: (id: string) => Promise<void>
+
+  // Actions — MCP probe (on-demand, read-only). State slices above.
+  /**
+   * Probe a registered MCP server by id (Termul's own rmcp client — NOT the
+   * agent's). Updates `mcpProbeStatus[id]` + `mcpTools[id]` +
+   * `mcpToolsLoaded[id]=true`. Read-only — no persistence, no rollback.
+   * Dedupes concurrent probes for the same id (`mcpProbing[id]`).
+   */
+  probeMcpServer: (id: string) => Promise<void>
+  /**
+   * Auto-probe on first expand of a server's tool list. No-op if already
+   * loaded; otherwise delegates to `probeMcpServer(id)`.
+   */
+  loadMcpTools: (id: string) => Promise<void>
 
   // Actions — conversation
   sendPrompt: (sessionId: SessionId, text: string) => Promise<void>
@@ -2437,6 +2465,10 @@ export const useAcpStore = create<AcpState>((set, get) => ({
   discoveringKeys: {},
   discoveredReopenContexts: {},
   mcpServers: [],
+  mcpProbeStatus: {},
+  mcpTools: {},
+  mcpToolsLoaded: {},
+  mcpProbing: {},
   sessions: {},
   activeSessionId: null,
   sessionUsage: {},
@@ -4097,6 +4129,47 @@ export const useAcpStore = create<AcpState>((set, get) => ({
       })
       throw err
     }
+  },
+
+  // MCP probe (on-demand, read-only). No persistence, no rollback. Dedupes
+  // concurrent probes per server id via `mcpProbing`.
+  probeMcpServer: async (id) => {
+    if (get().mcpProbing[id]) return
+    const server = get().mcpServers.find((s) => s.id === id)
+    if (!server) return
+    // Strip registry-only fields (`id`/`enabled`) — the probe takes a
+    // stateless `McpServerConfig`, not a registry entry. Mirrors the wire
+    // shape `toWireServer` builds for `session/new` injection.
+    const { id: _id, enabled: _enabled, ...config } = server
+    set((s) => ({ mcpProbing: { ...s.mcpProbing, [id]: true } }))
+    try {
+      const result: ProbeResult = await acpApi.probeMcpServer(config as McpServerConfig)
+      set((s) => ({
+        mcpProbeStatus: { ...s.mcpProbeStatus, [id]: result.status },
+        mcpTools: { ...s.mcpTools, [id]: result.tools },
+        mcpToolsLoaded: { ...s.mcpToolsLoaded, [id]: true },
+        mcpProbing: { ...s.mcpProbing, [id]: false }
+      }))
+    } catch (err) {
+      // Transport/parse failure (NOT a disconnected probe — that's a
+      // `status:'disconnected'` ProbeResult, not a throw). Surface the
+      // failure in the dot + log WITHOUT env/header values, tokens, or
+      // credentials.
+      set((s) => ({
+        mcpProbeStatus: { ...s.mcpProbeStatus, [id]: 'disconnected' },
+        mcpProbing: { ...s.mcpProbing, [id]: false }
+      }))
+      void logFrontendError({
+        source: 'acp-store.probeMcpServer',
+        message: `MCP probe failed for server '${server.name}' (${String(err)})`
+      })
+    }
+  },
+
+  loadMcpTools: async (id) => {
+    // Auto-probe on first expand — no-op if already loaded (or in flight).
+    if (get().mcpToolsLoaded[id] || get().mcpProbing[id]) return
+    await get().probeMcpServer(id)
   },
 
   sendPrompt: (sessionId, text) =>


### PR DESCRIPTION
## Summary

Termul has a global MCP registry with per-server `enabled` toggle, automatic injection into new ACP sessions (GH-287), and a Settings management surface (GH-362) — but users had no visibility into whether a configured server is actually reachable, what tools it exposes, or a fast in-chatbox way to enable/disable a server for the next session. This PR adds an on-demand rmcp-based MCP client probe (one-shot `initialize` + `tools/list`) that surfaces per-server connected/disconnected status and a collapsible tool list in Settings, and upgrades the chatbox `McpBadge` from a read-only `HoverCard` into a `Popover` with a per-server enable/disable radio. Per-tool enable/disable is explicitly deferred (the ACP `McpServer` schema has no per-tool field; the UI discloses this).

## Related Issue

No related issue — this is a follow-up feature to the completed GH-287 (`spec-gh-287-mcp-server-list-injection`) and GH-362 (`spec-gh-362-mcp-setup-settings`) work, surfaced directly by the user. It builds on the registry/injection foundation those stories established.

## Type of Change

- [x] feat: new feature

## What Changed

- **Rust probe module** (`src-tauri/src/acp/mcp_probe.rs`, new): one-shot rmcp client that opens a fresh connection, calls `initialize` + `tools/list`, then closes. Stdio via `transport-child-process` with Windows `CREATE_NO_WINDOW`; HTTP/SSE via `transport-streamable-http-client-reqwest`. Expands `$VAR`/`${VAR}` env references before spawn (unset → empty string). 10s deadline. Logs outcomes (server name + transport + connected/disconnected) WITHOUT env/header values, tokens, or credentials.
- **Tauri command** (`acp_probe_mcp_server`): stateless — takes a renderer-supplied `McpServerConfig` (no registry-store coupling). Registered in `lib.rs`.
- **Web route** (`POST /mcp-servers/probe`): runs the probe on the termul-server host (web parity — matches GH-287's decision that stdio servers run server-side). Mounted in both `router()` and `router_with_static()`.
- **Renderer facade** (`src/renderer/lib/acp-mcp-probe.ts`, new): `probeMcpServer(server)` + `listMcpTools(server)` branching on `isTauriContext()` (Tauri `invoke` vs `POST /mcp-servers/probe`). Mirrors `acp-mcp-persistence.ts` runtime-branching pattern.
- **Store** (`acp-store.ts`): new state slices `mcpProbeStatus` / `mcpTools` / `mcpToolsLoaded` / `mcpProbing` + actions `probeMcpServer(id)` (dedupes concurrent probes, read-only — no persistence) and `loadMcpTools(id)` (auto-probe on first expand). Reuses existing `setMcpServerEnabled` (optimistic + rollback) for the chatbox popover toggle — no new persistence path or wire-schema field.
- **Settings UI** (`McpServersSettings.tsx`): per-server status dot (connected=green, disconnected=red, not-probed=gray), "Test" button to re-probe, and a `Collapsible` tool list (read-only — names + descriptions) that auto-probes `tools/list` on first expand.
- **Chatbox** (`McpBadge.tsx` + `ChatInputBar.tsx`): swapped `HoverCard` → `Popover`. Popover lists each server with a status dot + `RadioGroup` enable/disable calling `setMcpServerEnabled`. Disclosure line: "Takes effect on the next chat; per-tool toggle coming soon." Renders at count 0 when servers exist (discoverable entry point).
- **Cargo**: added `rmcp` as a direct dep (`features = ["client", "transport-child-process", "transport-streamable-http-client-reqwest", "client-side-sse"]`; resolved 1.7.0 from `^1.2.0`). No changes to the vendored `agent-client-protocol` crate.
- **Tests**: new `mcp_probe.rs` unit tests (`$VAR` expansion, unreachable stdio/http, missing command, unsupported transport), new `mcp_probe_api.rs` route tests (malformed config + unreachable server), new `acp-mcp-probe.test.ts` (Tauri invoke path, web `POST` path, transport-failure logging without secrets, `listMcpTools` wrapper); extended `acp-store.test.ts` MCP section (probe connected/disconnected/dedupe/loadMcpTools no-op/transport-failure-no-secret-leak); extended `McpBadge.test.tsx` (popover + radio toggle + status dot); extended `McpServersSettings.test.tsx` (status dot + collapsible tool list + Test button); updated `ChatInputBar.test.tsx` + `chat-responsive.test.tsx` mocks for the new store slices/actions.

## How It Was Tested

- [x] `bun run ci` (Biome lint + format + imports, strict mode)
- [x] `bun run typecheck`
- [x] `bun run test` (2816 passed, 43 skipped)
- [x] `cargo clippy --all-targets -- -D warnings` (in src-tauri)
- [ ] `cargo test` (in src-tauri) — compiles cleanly; the test binary fails to launch on this Windows host with `STATUS_ENTRYPOINT_NOT_FOUND` (a known environment/runtime-loader issue documented in `spec-gh-362`'s verification; CI runs `cargo test` on Linux where it succeeds)
- [x] `bun run build:web` (CI's Rust jobs need a non-empty `dist-web/`)
- [x] Manual verification completed — see the spec's Manual checks section (reachable/unreachable stdio + http server, toggle via chatbox popover, web parity probe)

## CI & Review Gate

- [ ] All CI checks pass (PR Validation, Rust Checks, Build Verification, Security Scans)
- [ ] Code review comments from CodeRabbit / Claude have been addressed or resolved
- [ ] No unresolved review findings remain

## Checklist

- [x] My PR title follows the conventional commit format used by this repo
- [x] I linked the related issue or explained why none exists
- [x] I updated docs when needed (spec at `_bmad-output/implementation-artifacts/spec-mcp-settings-status-tools-chatbox-toggle.md`)
- [x] I added or updated tests when needed
- [x] I verified the change does not introduce unrelated modifications
- [x] I read AGENTS.md and followed the contributor guidelines
- [x] A human reviewed the complete diff before submission


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added MCP server connectivity testing for stdio, HTTP, and SSE connections.
  * Settings now show connection status, errors, and discovered tools, with manual re-testing.
  * Added expandable tool lists with lazy loading.
  * Chat MCP controls now support per-server enable/disable toggles and tool discovery.
* **Bug Fixes**
  * Improved handling of unreachable servers, invalid configurations, timeouts, and sanitized errors.
* **Tests**
  * Added coverage for probing, tool loading, connection failures, status indicators, and server controls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->