### PR TITLE
feat(git): per-hunk stage/unstage from the diff view

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -3365,6 +3365,29 @@ pub async fn git_unstage(cwd: String, path: String) -> Result<(), String> {
     crate::trackers::git_tracker::git_unstage_file(&cwd, &path).map_err(|e: String| e)
 }
 
+/// Stage a single hunk. `hunk_patch` is a unified-diff fragment
+/// (`--- a/<path>` / `+++ b/<path>` / `@@ … @@` / body) built by the
+/// renderer from the working-tree diff. See #257.
+#[tauri::command]
+pub async fn git_stage_hunk(
+    cwd: String,
+    path: String,
+    hunk_patch: String,
+) -> Result<(), String> {
+    crate::trackers::git_tracker::git_stage_hunk(&cwd, &path, &hunk_patch)
+}
+
+/// Unstage a single hunk. `hunk_patch` is built from the staged diff and
+/// reverse-applied to the index. See #257.
+#[tauri::command]
+pub async fn git_unstage_hunk(
+    cwd: String,
+    path: String,
+    hunk_patch: String,
+) -> Result<(), String> {
+    crate::trackers::git_tracker::git_unstage_hunk(&cwd, &path, &hunk_patch)
+}
+
 /// Discard changes to a single file. Untracked files are deleted; tracked
 /// changes revert to HEAD. This is destructive and irreversible.
 #[tauri::command]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1348,6 +1348,8 @@ pub fn run() {
             commands::git_get_diff,
             commands::git_stage,
             commands::git_unstage,
+            commands::git_stage_hunk,
+            commands::git_unstage_hunk,
             commands::git_discard,
             commands::git_get_log,
             commands::git_commit,

--- a/src-tauri/src/trackers/git_tracker.rs
+++ b/src-tauri/src/trackers/git_tracker.rs
@@ -1017,6 +1017,197 @@ pub fn git_unstage_file(cwd: &str, path: &str) -> Result<(), String> {
     }
 }
 
+/// Validate that a single-hunk unified-diff fragment references only the
+/// expected safe relative `path` in its `--- ` / `+++ ` headers.
+///
+/// `git apply` defaults to `-p1`, which strips the first path component of
+/// whatever the patch header declares. A header like `+++ c/../../etc/passwd`
+/// therefore resolves to `../../etc/passwd` after the strip. The previous
+/// implementation only inspected headers that began with `--- a/` or
+/// `+++ b/`, so any other prefix bypassed the guard entirely. This is the
+/// security boundary for a renderer-supplied patch, so it positively
+/// requires both headers to be present and validates the `-p1`-stripped
+/// result against `expected_path`.
+///
+/// To avoid misreading a hunk *body* line as a structural header (e.g. a
+/// deletion of `-- comment` produces the diff line `--- comment`), the
+/// scan walks the body using the `@@` declared counts and only treats a
+/// `--- `/`+++ ` line as a header when it lies outside a hunk body. This
+/// also keeps the multi-file-injection defense intact: a `--- `/`+++ `
+/// line that appears after a hunk's body has been consumed is still
+/// treated as a structural header and rejected if it targets another path.
+fn validate_hunk_patch_paths(expected_path: &str, patch: &str) -> Result<(), String> {
+    if !is_safe_relative_path(expected_path) {
+        return Err(format!("Refusing hunk patch for unsafe path: {expected_path}"));
+    }
+    let mut found_from = false;
+    let mut found_to = false;
+    // Hunk body budget from the most recent `@@`. `hunk_active` is true
+    // while we are inside a hunk; `old_left`/`new_left` track how many
+    // body lines the declared counts still allow.
+    let mut hunk_active = false;
+    let mut old_left: usize = 0;
+    let mut new_left: usize = 0;
+
+    for line in patch.lines() {
+        let in_body =
+            hunk_active && (old_left > 0 || new_left > 0 || line.starts_with('\\'));
+        if in_body {
+            match line.chars().next() {
+                Some(' ') => {
+                    old_left = old_left.saturating_sub(1);
+                    new_left = new_left.saturating_sub(1);
+                }
+                Some('-') => old_left = old_left.saturating_sub(1),
+                Some('+') => new_left = new_left.saturating_sub(1),
+                Some('\\') => {}
+                _ => hunk_active = false, // malformed body line; back to structural
+            }
+            if hunk_active {
+                continue;
+            }
+        } else if hunk_active && !line.starts_with('\\') {
+            // Budget exhausted and the line is not trailing meta → the hunk
+            // has ended; re-enter structural scanning.
+            hunk_active = false;
+        }
+
+        if line.starts_with("@@") {
+            if let Some((o, n)) = parse_hunk_budget(line) {
+                old_left = o;
+                new_left = n;
+                hunk_active = true;
+            }
+            continue;
+        }
+        let is_from = line.starts_with("--- ");
+        let is_to = line.starts_with("+++ ");
+        if !(is_from || is_to) {
+            continue;
+        }
+        if is_from {
+            found_from = true;
+        } else {
+            found_to = true;
+        }
+        // Header format: `--- <path>[<tab><timestamp>]`. Take the first
+        // whitespace-delimited token as the path, then strip one leading
+        // component to mirror `git apply -p1`.
+        let raw = &line[4..];
+        let path_token = raw.split_whitespace().next().unwrap_or(raw);
+        let stripped = strip_first_path_component(path_token);
+        if stripped != expected_path {
+            return Err(format!(
+                "Hunk patch path '{stripped}' does not match expected '{expected_path}'"
+            ));
+        }
+    }
+    if !(found_from && found_to) {
+        return Err("Hunk patch is missing its --- or +++ header".to_string());
+    }
+    Ok(())
+}
+
+/// Parse `@@ -oldStart[,oldCount] +newStart[,newCount] @@` into the number
+/// of old/new body lines the hunk declares. Omitted counts default to 1
+/// (unified-diff spec).
+fn parse_hunk_budget(header: &str) -> Option<(usize, usize)> {
+    let after = header.strip_prefix("@@ ")?;
+    let core = after.split("@@").next()?.trim();
+    let mut parts = core.split_whitespace();
+    let old_part = parts.next()?;
+    let new_part = parts.next()?;
+    let count_of = |p: &str| -> Option<usize> {
+        let after_sign = p.strip_prefix('-').or_else(|| p.strip_prefix('+'))?;
+        let count = after_sign.split_once(',').map(|(_, c)| c).unwrap_or("1");
+        count.parse::<usize>().ok()
+    };
+    Some((count_of(old_part)?, count_of(new_part)?))
+}
+
+/// Strip the first path component, mirroring `git apply -p1`.
+/// `a/foo.txt` -> `foo.txt`; `foo.txt` (no separator) is returned as-is.
+fn strip_first_path_component(s: &str) -> &str {
+    match s.find('/') {
+        Some(idx) => &s[idx + 1..],
+        None => s,
+    }
+}
+
+/// Run `git apply` with a patch supplied on stdin. Used for per-hunk
+/// stage/unstage where the patch is a single-hunk fragment built by the
+/// renderer from the displayed diff. Follows the same deadline pattern as
+/// `GitTracker::spawn_and_wait` so a wedged `git apply` cannot hang the
+/// caller.
+fn run_git_apply(cwd: &str, args: &[&str], patch: &str) -> Result<(), String> {
+    use std::io::Write;
+
+    let git = resolve_git_binary();
+    let mut command = backend_command(git);
+    command.current_dir(cwd).args(args.iter());
+    command.stdin(Stdio::piped());
+    command.stdout(Stdio::piped());
+    command.stderr(Stdio::piped());
+
+    let mut child = command
+        .spawn()
+        .map_err(|e| format!("Failed to spawn git apply: {e}"))?;
+
+    if let Some(mut stdin) = child.stdin.take() {
+        // Ignore broken pipe: git may finish reading the patch and exit
+        // before we finish writing (e.g. it rejects the patch early). The
+        // exit status below is the source of truth.
+        let _ = stdin.write_all(patch.as_bytes());
+    }
+
+    let deadline = Instant::now() + Duration::from_millis(GIT_COMMAND_TIMEOUT_MS);
+    loop {
+        match child.try_wait() {
+            Ok(Some(_)) => {
+                let output = child
+                    .wait_with_output()
+                    .map_err(|e| format!("git apply wait failed: {e}"))?;
+                if output.status.success() {
+                    return Ok(());
+                }
+                return Err(String::from_utf8_lossy(&output.stderr).trim().to_string());
+            }
+            Ok(None) => {
+                if Instant::now() >= deadline {
+                    let _ = child.kill();
+                    let _ = child.wait();
+                    return Err(format!("git apply timed out after {GIT_COMMAND_TIMEOUT_MS}ms"));
+                }
+                std::thread::sleep(Duration::from_millis(20));
+            }
+            Err(e) => return Err(format!("git apply wait error: {e}")),
+        }
+    }
+}
+
+/// Stage a single hunk. The renderer builds the hunk patch from the
+/// working-tree diff; applying it to the index (`git apply --cached`)
+/// stages exactly those lines without staging the rest of the file.
+/// `--recount` tolerates a line-count mismatch in the `@@` header, which
+/// the renderer's patch builder can produce when it strips surrounding
+/// context.
+pub fn git_stage_hunk(cwd: &str, path: &str, hunk_patch: &str) -> Result<(), String> {
+    validate_hunk_patch_paths(path, hunk_patch)?;
+    run_git_apply(cwd, &["apply", "--cached", "--recount", "-"], hunk_patch)
+}
+
+/// Unstage a single hunk. The renderer builds the hunk patch from the
+/// staged (index vs HEAD) diff; reverse-applying it to the index removes
+/// exactly those lines from the index without touching the working tree.
+pub fn git_unstage_hunk(cwd: &str, path: &str, hunk_patch: &str) -> Result<(), String> {
+    validate_hunk_patch_paths(path, hunk_patch)?;
+    run_git_apply(
+        cwd,
+        &["apply", "--cached", "--recount", "--reverse", "-"],
+        hunk_patch,
+    )
+}
+
 /// Delete an untracked file or directory from disk. Treats an already-missing
 /// path as success (a concurrent delete still satisfies the intent).
 fn delete_untracked_path(cwd: &str, path: &str) -> Result<(), String> {
@@ -2391,6 +2582,176 @@ mod tests {
         );
         std::fs::remove_dir_all(&repo).ok();
     }
+
+    // Per-hunk stage/unstage round-trip + path-traversal guard (#257).
+    // The two-hunk setup proves partial staging: staging hunk 1 leaves
+    // hunk 2 in the working tree (unstaged), which file-level `git add`
+    // could never express.
+
+    /// Build a one-hunk patch fragment for `path` from a body (lines without
+    /// the `--- a/` / `+++ b/` header). A trailing newline terminates the last
+    /// body line, which `git apply` requires.
+    fn hunk_patch(path: &str, header: &str, body: &str) -> String {
+        format!("--- a/{path}\n+++ b/{path}\n{header}\n{body}\n")
+    }
+
+    #[test]
+    fn it_stage_hunk_stages_only_that_hunk_leaving_others_unstaged() {
+        if git_missing() {
+            return;
+        }
+        let repo = init_repo("stage-hunk-partial");
+        // Two changes separated by an unchanged line produce two hunks.
+        std::fs::write(repo.join("a.txt"), "one\ntwo\nthree\nfour\n").unwrap();
+        git(&repo, &["add", "-A"]);
+        git(&repo, &["commit", "-qm", "init"]);
+        std::fs::write(repo.join("a.txt"), "one\nTWO\nthree\nFOUR\n").unwrap();
+
+        let cwd = repo.to_str().unwrap();
+
+        // Stage only the first hunk (one/two->TWO/three).
+        let patch_hunk1 = hunk_patch(
+            "a.txt",
+            "@@ -1,3 +1,3 @@",
+            " one\n-two\n+TWO\n three",
+        );
+        git_stage_hunk(cwd, "a.txt", &patch_hunk1).unwrap();
+
+        // Staging hunk 1 must put +TWO into the index but leave hunk 2
+        // (four -> FOUR) entirely in the working tree. Context lines such
+        // as ` TWO` can appear on both sides unchanged, so we assert on the
+        // addition/deletion markers, not bare substrings.
+        let staged = git_get_diff(cwd, "a.txt", true).unwrap();
+        let unstaged = git_get_diff(cwd, "a.txt", false).unwrap();
+        assert!(
+            staged.contains("+TWO") && staged.contains("-two"),
+            "staged diff should include hunk 1's add/remove:\n{staged}"
+        );
+        assert!(
+            !staged.contains("FOUR"),
+            "staged must not include hunk 2:\n{staged}"
+        );
+        assert!(
+            unstaged.contains("+FOUR") && unstaged.contains("-four"),
+            "unstaged diff should still include hunk 2:\n{unstaged}"
+        );
+        assert!(
+            !unstaged.contains("-two\n") && !unstaged.contains("+TWO\n"),
+            "unstaged must not re-show hunk 1 as a change:\n{unstaged}"
+        );
+        std::fs::remove_dir_all(&repo).ok();
+    }
+
+    #[test]
+    fn it_unstage_hunk_reverses_a_previously_staged_hunk() {
+        if git_missing() {
+            return;
+        }
+        let repo = init_repo("unstage-hunk");
+        std::fs::write(repo.join("a.txt"), "one\ntwo\n").unwrap();
+        git(&repo, &["add", "-A"]);
+        git(&repo, &["commit", "-qm", "init"]);
+        std::fs::write(repo.join("a.txt"), "one\nTWO\n").unwrap();
+
+        let cwd = repo.to_str().unwrap();
+        let patch = hunk_patch("a.txt", "@@ -1,2 +1,2 @@", " one\n-two\n+TWO");
+
+        git_stage_hunk(cwd, "a.txt", &patch).unwrap();
+        assert!(git_get_diff(cwd, "a.txt", true).unwrap().contains("TWO"));
+
+        // Reverse-applying the same staged-side patch removes it from the index.
+        git_unstage_hunk(cwd, "a.txt", &patch).unwrap();
+        assert!(
+            git_get_diff(cwd, "a.txt", true).unwrap().trim().is_empty(),
+            "staged diff should be empty after unstaging the hunk"
+        );
+        // Working tree is untouched.
+        assert!(git_get_diff(cwd, "a.txt", false).unwrap().contains("TWO"));
+        std::fs::remove_dir_all(&repo).ok();
+    }
+
+    #[test]
+    fn it_stage_hunk_rejects_patch_whose_header_targets_a_different_path() {
+        if git_missing() {
+            return;
+        }
+        let repo = init_repo("stage-hunk-guard");
+        std::fs::write(repo.join("a.txt"), "one\n").unwrap();
+        git(&repo, &["add", "-A"]);
+        git(&repo, &["commit", "-qm", "init"]);
+        std::fs::write(repo.join("a.txt"), "two\n").unwrap();
+
+        let cwd = repo.to_str().unwrap();
+        // Patch header lies about the path: claims secret.txt while caller
+        // asks to stage a.txt. The guard must refuse (path-traversal defense).
+        let lying_patch = "--- a/secret.txt\n+++ b/secret.txt\n@@ -1,1 +1,1 @@\n-one\n+two";
+        let err = git_stage_hunk(cwd, "a.txt", lying_patch).unwrap_err();
+        assert!(
+            err.contains("does not match"),
+            "expected path-mismatch error, got: {err}"
+        );
+        // Nothing was staged.
+        assert!(git_get_diff(cwd, "a.txt", true).unwrap().trim().is_empty());
+        std::fs::remove_dir_all(&repo).ok();
+    }
+
+    #[test]
+    fn it_stage_hunk_rejects_unsafe_expected_path() {
+        // No repo needed: the guard runs before any git invocation.
+        let patch = "--- a/x\n+++ b/x\n@@ -1,1 +1,1 @@\n-a\n+b";
+        let err = git_stage_hunk(".", "../escape.txt", patch).unwrap_err();
+        assert!(err.contains("unsafe path"), "expected unsafe-path error, got: {err}");
+    }
+
+    // CodeRabbit review feedback: `git apply -p1` strips the first path
+    // component regardless of its name, so a header using a non-standard
+    // prefix (e.g. `c/`) must be validated exactly like `a/` / `b/`. Without
+    // this, `+++ c/../../etc/passwd` would bypass the old `+++ b/`-only check.
+    #[test]
+    fn it_stage_hunk_rejects_non_standard_prefix_attempting_traversal() {
+        let patch = "--- c/foo.txt\n+++ c/../../etc/passwd\n@@ -1,1 +1,1 @@\n-a\n+b";
+        let err = git_stage_hunk(".", "foo.txt", patch).unwrap_err();
+        assert!(
+            err.contains("does not match"),
+            "expected path-mismatch error for non-standard prefix, got: {err}"
+        );
+    }
+
+    #[test]
+    fn it_stage_hunk_rejects_patch_missing_a_header() {
+        // Both `--- ` and `+++ ` are required. A headerless fragment could
+        // otherwise hide which file `git apply` targets.
+        let patch = "@@ -1,1 +1,1 @@\n-a\n+b";
+        let err = git_stage_hunk(".", "foo.txt", patch).unwrap_err();
+        assert!(err.contains("missing"), "expected missing-header error, got: {err}");
+    }
+
+    // CodeRabbit review (2nd round): a hunk body line that looks like a file
+    // header (deleting `-- comment` → diff line `--- comment`) must be
+    // consumed as body content per the @@ budget, not rejected as a header.
+    #[test]
+    fn validate_accepts_body_line_that_looks_like_a_header() {
+        let patch = "--- a/foo.sql\n+++ b/foo.sql\n@@ -1,2 +1,2 @@\n ctx\n--- comment\n+-- new";
+        assert!(
+            validate_hunk_patch_paths("foo.sql", patch).is_ok(),
+            "body line `--- comment` must be consumed as content, not treated as a header"
+        );
+    }
+
+    // The body-budget walk must still reject a second file section that
+    // appears after a hunk's declared body is consumed (multi-file injection
+    // into `git apply --cached`). This is the traversal defense the prior
+    // review round asked us not to regress.
+    #[test]
+    fn validate_rejects_second_file_section_after_hunk_body() {
+        let patch = "--- a/foo.txt\n+++ b/foo.txt\n@@ -1,1 +1,1 @@\n-a\n+b\n--- a/other.txt\n+++ b/other.txt\n@@ -1,1 +1,1 @@\n-c\n+d";
+        let err = validate_hunk_patch_paths("foo.txt", patch).unwrap_err();
+        assert!(
+            err.contains("does not match"),
+            "multi-file injection after hunk body must be rejected, got: {err}"
+        );
+    }
+
 
     #[test]
     fn it_unstage_preserves_worktree_on_staged_modified_file() {

--- a/src/renderer/components/git/GitDiffView.tsx
+++ b/src/renderer/components/git/GitDiffView.tsx
@@ -1,5 +1,6 @@
 import type React from 'react'
 import { useEffect, useMemo, useState } from 'react'
+import { buildHunkPatches, type HunkPatch } from '@/lib/build-hunk-patch'
 import { getLanguageForFile, tokenizeLine } from '@/lib/diff-syntax-highlight'
 import {
   type GitDiffViewMode,
@@ -14,7 +15,20 @@ interface GitDiffViewProps {
   diff: string
   mode: GitDiffViewMode
   filePath?: string
+  /**
+   * Which side of the diff is displayed: working-tree changes (`unstaged`,
+   * hunk action stages) or staged changes (`staged`, hunk action unstages).
+   * When omitted, no per-hunk action is rendered.
+   */
+  diffSide?: 'unstaged' | 'staged'
+  /** Per-hunk stage callback. Receives a single-hunk patch built from `diff`. */
+  onStageHunk?: (patch: string) => void
+  /** Per-hunk unstage callback. */
+  onUnstageHunk?: (patch: string) => void
 }
+
+/** Which side a hunk action should target for the given diff side. */
+type HunkAction = 'stage' | 'unstage'
 
 function lineClass(kind: ParsedDiffLine['kind']): string {
   return cn(
@@ -193,7 +207,41 @@ function computeInlineWordDiffRanges(
   return result
 }
 
-function InlineDiff({ diff, language }: { diff: string; language: string }): React.JSX.Element {
+function HunkActionBar({
+  action,
+  onAction
+}: {
+  action: HunkAction
+  onAction?: () => void
+}): React.JSX.Element | null {
+  if (!onAction) return null
+  const label = action === 'stage' ? 'Stage hunk' : 'Unstage hunk'
+  return (
+    <button
+      type="button"
+      onClick={onAction}
+      className="ml-2 inline-flex items-center rounded border border-border/60 bg-background/80 px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide text-muted-foreground hover:bg-accent hover:text-accent-foreground"
+      title={label}
+      aria-label={label}
+    >
+      {label}
+    </button>
+  )
+}
+
+function InlineDiff({
+  diff,
+  language,
+  hunkByIndex,
+  action,
+  onAction
+}: {
+  diff: string
+  language: string
+  hunkByIndex: Map<number, HunkPatch>
+  action?: HunkAction
+  onAction?: (patch: string) => void
+}): React.JSX.Element {
   const lines = useMemo(() => parseUnifiedDiffInline(diff), [diff])
   const wordDiffRanges = useMemo(() => computeInlineWordDiffRanges(lines), [lines])
 
@@ -250,6 +298,20 @@ function InlineDiff({ diff, language }: { diff: string; language: string }): Rea
                   changedRanges={changedRanges}
                   kind={line.kind as 'deletion' | 'addition' | 'context'}
                 />
+              ) : line.kind === 'header' && line.raw.startsWith('@@') ? (
+                <span className="flex items-center">
+                  <span className="flex-1">{line.raw}</span>
+                  {action ? (
+                    <HunkActionBar
+                      action={action}
+                      onAction={
+                        hunkByIndex.has(i) && onAction
+                          ? () => onAction(hunkByIndex.get(i)!.patch)
+                          : undefined
+                      }
+                    />
+                  ) : null}
+                </span>
               ) : (
                 line.raw || ' '
               )}
@@ -310,7 +372,19 @@ function SplitCell({
   )
 }
 
-function SplitDiff({ diff, language }: { diff: string; language: string }): React.JSX.Element {
+function SplitDiff({
+  diff,
+  language,
+  hunkByRowIndex,
+  action,
+  onAction
+}: {
+  diff: string
+  language: string
+  hunkByRowIndex: Map<number, HunkPatch>
+  action?: HunkAction
+  onAction?: (patch: string) => void
+}): React.JSX.Element {
   const rows = useMemo(() => parseUnifiedDiffSplit(diff), [diff])
 
   const splitWordDiffRanges = useMemo(() => {
@@ -333,8 +407,26 @@ function SplitDiff({ diff, language }: { diff: string; language: string }): Reac
     <div className="p-4 font-mono text-xs" style={{ tabSize: 4, MozTabSize: 4 }}>
       {rows.map((row, i) =>
         row.fullWidth ? (
-          <div key={i} className={lineClass(row.fullWidth.kind)}>
-            {row.fullWidth.raw}
+          <div
+            key={i}
+            className={cn(
+              lineClass(row.fullWidth.kind),
+              row.fullWidth.kind === 'header' &&
+                row.fullWidth.raw.startsWith('@@') &&
+                'flex items-center'
+            )}
+          >
+            <span className="flex-1 whitespace-pre-wrap break-words">{row.fullWidth.raw}</span>
+            {row.fullWidth.kind === 'header' &&
+            row.fullWidth.raw.startsWith('@@') &&
+            action &&
+            hunkByRowIndex.has(i) &&
+            onAction ? (
+              <HunkActionBar
+                action={action}
+                onAction={() => onAction(hunkByRowIndex.get(i)!.patch)}
+              />
+            ) : null}
           </div>
         ) : (
           <div key={i} className="grid grid-cols-2 gap-0 border-b border-border/20">
@@ -357,7 +449,14 @@ function SplitDiff({ diff, language }: { diff: string; language: string }): Reac
   )
 }
 
-export function GitDiffView({ diff, mode, filePath }: GitDiffViewProps): React.JSX.Element {
+export function GitDiffView({
+  diff,
+  mode,
+  filePath,
+  diffSide,
+  onStageHunk,
+  onUnstageHunk
+}: GitDiffViewProps): React.JSX.Element {
   const language = useMemo(() => (filePath ? getLanguageForFile(filePath) : ''), [filePath])
 
   useEffect(() => {
@@ -388,8 +487,51 @@ export function GitDiffView({ diff, mode, filePath }: GitDiffViewProps): React.J
     }
   }, [language])
 
+  // Per-hunk stage/unstage (#257). Build single-hunk patches and index them
+  // by line/row so each rendered `@@` header can look up its patch.
+  const hunks = useMemo(() => buildHunkPatches(diff, filePath ?? ''), [diff, filePath])
+  const hunkByInlineIndex = useMemo(() => {
+    const m = new Map<number, HunkPatch>()
+    for (const h of hunks) m.set(h.headerIndex, h)
+    return m
+  }, [hunks])
+  const hunkBySplitRowIndex = useMemo(() => {
+    const m = new Map<number, HunkPatch>()
+    const rows = parseUnifiedDiffSplit(diff)
+    let hunkIdx = 0
+    rows.forEach((row, i) => {
+      if (row.fullWidth?.raw.startsWith('@@') && hunks[hunkIdx]) {
+        m.set(i, hunks[hunkIdx])
+        hunkIdx += 1
+      }
+    })
+    return m
+  }, [diff, hunks])
+
+  // The displayed side decides whether a hunk action stages or unstages.
+  const action: HunkAction | undefined =
+    diffSide === 'unstaged' ? 'stage' : diffSide === 'staged' ? 'unstage' : undefined
+  const onAction =
+    action === 'stage' ? onStageHunk : action === 'unstage' ? onUnstageHunk : undefined
+
   if (mode === 'split') {
-    return <SplitDiff diff={diff} language={language} />
+    return (
+      <SplitDiff
+        diff={diff}
+        language={language}
+        hunkByRowIndex={hunkBySplitRowIndex}
+        action={action}
+        onAction={onAction}
+      />
+    )
   }
-  return <InlineDiff diff={diff} language={language} />
+  return (
+    <InlineDiff
+      diff={diff}
+      language={language}
+      hunkByIndex={hunkByInlineIndex}
+      action={action}
+      onAction={onAction}
+    />
+  )
 }

--- a/src/renderer/components/git/GitPanel.tsx
+++ b/src/renderer/components/git/GitPanel.tsx
@@ -73,6 +73,8 @@ export function GitPanel({ cwd, isVisible }: GitPanelProps) {
   const stageFiles = useGitStatusStore((state) => state.stageFiles)
   const unstageFiles = useGitStatusStore((state) => state.unstageFiles)
   const discardFiles = useGitStatusStore((state) => state.discardFiles)
+  const stageHunk = useGitStatusStore((state) => state.stageHunk)
+  const unstageHunk = useGitStatusStore((state) => state.unstageHunk)
   const commitContexts = useGitStatusStore((state) => state.commitContexts)
   const fetchCommitContext = useGitStatusStore((state) => state.fetchCommitContext)
   const commit = useGitStatusStore((state) => state.commit)
@@ -139,6 +141,10 @@ export function GitPanel({ cwd, isVisible }: GitPanelProps) {
   // commits before the isCommitting state has re-rendered.
   const commitInFlight = React.useRef(false)
   const generationInFlight = React.useRef(false)
+  // Synchronous guard for per-hunk stage/unstage: a fast second click on
+  // another hunk would otherwise build a patch from the pre-mutation diff
+  // and apply it at a shifted offset once `--recount` relaxes the header.
+  const hunkInFlight = React.useRef(false)
   const generationToken = React.useRef(0)
   const currentCwd = React.useRef(cwd)
   const currentStatuses = React.useRef(statuses)
@@ -305,6 +311,46 @@ export function GitPanel({ cwd, isVisible }: GitPanelProps) {
       }
     },
     [cwd, unstageFiles, clearSelection, selectedFile]
+  )
+
+  // Per-hunk stage/unstage (#257). The patch is built by GitDiffView from
+  // the displayed diff and applied to the index without touching the rest
+  // of the file. After mutation, fetchDiff re-loads the (now smaller) diff
+  // so the panel reflects the partial stage.
+  const runStageHunk = useCallback(
+    async (patch: string) => {
+      if (!selectedFile || generationInFlight.current || hunkInFlight.current) return
+      hunkInFlight.current = true
+      setIsMutating(true)
+      try {
+        await stageHunk(cwd, selectedFile, patch)
+        await fetchDiff(cwd, selectedFile, false)
+      } catch (error) {
+        toast.error(`Failed to stage hunk: ${String(error)}`)
+      } finally {
+        setIsMutating(false)
+        hunkInFlight.current = false
+      }
+    },
+    [cwd, selectedFile, stageHunk, fetchDiff]
+  )
+
+  const runUnstageHunk = useCallback(
+    async (patch: string) => {
+      if (!selectedFile || generationInFlight.current || hunkInFlight.current) return
+      hunkInFlight.current = true
+      setIsMutating(true)
+      try {
+        await unstageHunk(cwd, selectedFile, patch)
+        await fetchDiff(cwd, selectedFile, true)
+      } catch (error) {
+        toast.error(`Failed to unstage hunk: ${String(error)}`)
+      } finally {
+        setIsMutating(false)
+        hunkInFlight.current = false
+      }
+    },
+    [cwd, selectedFile, unstageHunk, fetchDiff]
   )
 
   // Discard only reverts unstaged (working-tree) changes, so it is only ever
@@ -1632,6 +1678,9 @@ export function GitPanel({ cwd, isVisible }: GitPanelProps) {
                   diff={currentDiff}
                   mode={diffViewMode}
                   filePath={selectedFile ?? undefined}
+                  diffSide={selectedStaged ? 'staged' : 'unstaged'}
+                  onStageHunk={runStageHunk}
+                  onUnstageHunk={runUnstageHunk}
                 />
               ) : (
                 <div className="h-full flex flex-col items-center justify-center text-muted-foreground p-8 text-center">

--- a/src/renderer/lib/build-hunk-patch.test.ts
+++ b/src/renderer/lib/build-hunk-patch.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it } from 'vitest'
+import { buildHunkPatches } from './build-hunk-patch'
+
+const SINGLE_HUNK_DIFF = [
+  'diff --git a/foo.txt b/foo.txt',
+  'index 1111111..2222222 100644',
+  '--- a/foo.txt',
+  '+++ b/foo.txt',
+  '@@ -1,3 +1,3 @@',
+  ' context line',
+  '-old line',
+  '+new line',
+  ' trailing context'
+].join('\n')
+
+describe('buildHunkPatches', () => {
+  it('returns no patches for empty diff', () => {
+    expect(buildHunkPatches('', 'foo.txt')).toEqual([])
+    expect(buildHunkPatches('whatever', '')).toEqual([])
+  })
+
+  it('builds one patch for a single-hunk diff with a/ b/ headers and body', () => {
+    const hunks = buildHunkPatches(SINGLE_HUNK_DIFF, 'foo.txt')
+    expect(hunks).toHaveLength(1)
+    expect(hunks[0].headerIndex).toBe(4)
+    expect(hunks[0].headerLine).toBe('@@ -1,3 +1,3 @@')
+    expect(hunks[0].patch).toBe(
+      [
+        '--- a/foo.txt',
+        '+++ b/foo.txt',
+        '@@ -1,3 +1,3 @@',
+        ' context line',
+        '-old line',
+        '+new line',
+        ' trailing context',
+        '' // trailing newline: every diff line ends with \n
+      ].join('\n')
+    )
+  })
+
+  it('builds one patch per hunk for a multi-hunk diff', () => {
+    const diff = [
+      '--- a/foo.txt',
+      '+++ b/foo.txt',
+      '@@ -1,2 +1,2 @@',
+      ' ctx1',
+      '-del1',
+      '+add1',
+      '@@ -10,2 +11,2 @@',
+      ' ctx2',
+      '-del2',
+      '+add2'
+    ].join('\n')
+    const hunks = buildHunkPatches(diff, 'foo.txt')
+    expect(hunks).toHaveLength(2)
+    expect(hunks[0].headerIndex).toBe(2)
+    expect(hunks[1].headerIndex).toBe(6)
+    expect(hunks[0].patch).toContain('@@ -1,2 +1,2 @@')
+    expect(hunks[1].patch).toContain('@@ -10,2 +11,2 @@')
+    // Each patch must be self-contained: include the a/ b/ headers.
+    expect(hunks[1].patch.startsWith('--- a/foo.txt\n+++ b/foo.txt\n')).toBe(true)
+  })
+
+  it('preserves meta lines (e.g. "\\ No newline at end of file") in the body', () => {
+    const diff = [
+      '--- a/foo.txt',
+      '+++ b/foo.txt',
+      '@@ -1,1 +1,1 @@',
+      '-old',
+      '\\ No newline at end of file',
+      '+new'
+    ].join('\n')
+    const hunks = buildHunkPatches(diff, 'foo.txt')
+    expect(hunks).toHaveLength(1)
+    expect(hunks[0].patch).toContain('\\ No newline at end of file')
+  })
+
+  it('does not truncate the body when a deletion looks like a file header', () => {
+    // Deleting a line whose text starts with `-- ` (e.g. a SQL comment)
+    // produces the diff line `--- comment`, which naïvely looks like a
+    // `--- a/...` file header. The body must be bounded by the @@ counts,
+    // not by prefix sniffing, so the hunk is not split mid-body and the
+    // staged patch keeps every line (#257 review feedback).
+    const diff = [
+      '--- a/foo.sql',
+      '+++ b/foo.sql',
+      '@@ -1,2 +1,2 @@',
+      ' context',
+      '--- comment',
+      '+-- new'
+    ].join('\n')
+    const hunks = buildHunkPatches(diff, 'foo.sql')
+    // One hunk, not split mid-body by the `--- comment` line.
+    expect(hunks).toHaveLength(1)
+    expect(hunks[0].patch).toContain(' context')
+    expect(hunks[0].patch).toContain('--- comment')
+    expect(hunks[0].patch).toContain('+-- new')
+  })
+
+  it('stops a hunk at the next file header in a multi-file diff', () => {
+    const diff = [
+      'diff --git a/a.txt b/a.txt',
+      '--- a/a.txt',
+      '+++ b/a.txt',
+      '@@ -1,1 +1,1 @@',
+      '-a',
+      '+A',
+      'diff --git a/b.txt b/b.txt',
+      '--- b/b.txt',
+      '+++ b/b.txt',
+      '@@ -1,1 +1,1 @@',
+      '-b',
+      '+B'
+    ].join('\n')
+    const hunks = buildHunkPatches(diff, 'a.txt')
+    // buildHunkPatches is called per-file; only the first file's hunk should
+    // be collected because the second `diff` header flushes and the next
+    // hunk belongs to a different path (which the backend would reject).
+    expect(hunks).toHaveLength(1)
+    expect(hunks[0].patch).toContain('-a\n+A')
+  })
+})

--- a/src/renderer/lib/build-hunk-patch.ts
+++ b/src/renderer/lib/build-hunk-patch.ts
@@ -1,0 +1,147 @@
+/**
+ * Build single-hunk unified-diff patches from a full file diff, one per hunk.
+ * Each patch is a self-contained fragment suitable for `git apply --cached`:
+ *
+ *     --- a/<path>
+ *     +++ b/<path>
+ *     @@ -oldStart,oldCount +newStart,newCount @@
+ *     <context/addition/deletion body lines (raw, with prefix)>
+ *
+ * Used by GitDiffView for per-hunk stage/unstage (#257). The backend guards
+ * that the `a/` / `b/` headers reference the same safe relative `path`, so a
+ * renderer-built patch cannot target a path outside the project cwd.
+ *
+ * The body length is bounded by the `@@` header's declared old/new counts
+ * rather than by prefix sniffing, so a body line that happens to look like a
+ * file header (e.g. deleting a line whose text is `-- comment` produces the
+ * diff line `--- comment`) is not mistaken for a structural header.
+ */
+export interface HunkPatch {
+  /** Index of the hunk header line in the diff (for keying UI rows). */
+  headerIndex: number
+  /** Raw `@@ ... @@` header line. */
+  headerLine: string
+  /** Full patch text ready for `git apply`. */
+  patch: string
+}
+
+interface ActiveHunk {
+  headerIndex: number
+  headerLine: string
+  bodyLines: string[]
+  oldLeft: number
+  newLeft: number
+}
+
+/** Extract the relative path from a `+++ b/<path>` (or `+++ <path>`) header. */
+function extractPathFromHeader(line: string): string | null {
+  const match = line.match(/^\+\+\+ (?:[ab]\/)?(.+)$/)
+  return match ? match[1] : null
+}
+
+/** Parse `@@ -oldStart,oldCount +newStart,newCount @@` into the declared body budget. */
+function hunkBodyBudget(header: string): { old: number; new: number } | null {
+  const m = header.match(/^@@ -\d+(?:,(\d+))? \+\d+(?:,(\d+))? @@/)
+  if (!m) return null
+  // An omitted count means 1 (unified-diff spec).
+  return {
+    old: m[1] === undefined ? 1 : Number.parseInt(m[1], 10),
+    new: m[2] === undefined ? 1 : Number.parseInt(m[2], 10)
+  }
+}
+
+export function buildHunkPatches(diff: string, filePath: string): HunkPatch[] {
+  if (!diff || !filePath) return []
+  const lines = diff.split('\n')
+  const hunks: HunkPatch[] = []
+  let current: ActiveHunk | null = null
+  // File the next hunk belongs to. Defaults to `filePath` so a header-less
+  // diff (just `@@` + body) still works; a `+++ b/<path>` line overrides it
+  // so a multi-file diff only contributes hunks for the requested file.
+  let pendingFilePath: string = filePath
+
+  const flush = (): void => {
+    if (!current) return
+    const patch =
+      `--- a/${filePath}\n` +
+      `+++ b/${filePath}\n` +
+      `${current.headerLine}\n` +
+      current.bodyLines.join('\n') +
+      '\n'
+    hunks.push({
+      headerIndex: current.headerIndex,
+      headerLine: current.headerLine,
+      patch
+    })
+    current = null
+  }
+
+  for (let i = 0; i < lines.length; i += 1) {
+    const line = lines[i]
+
+    // While a hunk still has declared body budget, consume body/meta lines
+    // regardless of their content. This must run BEFORE the structural-header
+    // checks below, because a deletion of `-- comment` produces the diff line
+    // `--- comment`, which would otherwise look like a file header and
+    // truncate the hunk mid-body.
+    if (current && (current.oldLeft > 0 || current.newLeft > 0 || line.startsWith('\\'))) {
+      if (line.startsWith(' ')) {
+        current.bodyLines.push(line)
+        current.oldLeft -= 1
+        current.newLeft -= 1
+        continue
+      }
+      if (line.startsWith('-')) {
+        current.bodyLines.push(line)
+        current.oldLeft -= 1
+        continue
+      }
+      if (line.startsWith('+')) {
+        current.bodyLines.push(line)
+        current.newLeft -= 1
+        continue
+      }
+      if (line.startsWith('\\')) {
+        // "\ No newline at end of file" — part of the hunk, no line budget.
+        current.bodyLines.push(line)
+        continue
+      }
+      // Unexpected line mid-hunk (malformed diff): stop the hunk here.
+      flush()
+      continue
+    }
+
+    if (line.startsWith('@@')) {
+      flush()
+      const budget = hunkBodyBudget(line)
+      current =
+        pendingFilePath === filePath && budget
+          ? {
+              headerIndex: i,
+              headerLine: line,
+              bodyLines: [],
+              oldLeft: budget.old,
+              newLeft: budget.new
+            }
+          : null
+      continue
+    }
+    if (line.startsWith('diff ')) {
+      flush()
+      pendingFilePath = filePath
+      continue
+    }
+    if (line.startsWith('+++ ')) {
+      flush()
+      pendingFilePath = extractPathFromHeader(line) ?? filePath
+      continue
+    }
+    if (line.startsWith('--- ')) {
+      flush()
+    }
+    // Stray text outside a hunk (e.g. "diff --git" preamble already handled):
+    // ignore.
+  }
+  flush()
+  return hunks
+}

--- a/src/renderer/lib/git-api.ts
+++ b/src/renderer/lib/git-api.ts
@@ -31,6 +31,16 @@ export const gitApi = {
   unstage: (cwd: string, path: string) =>
     isTauriContext() ? invoke<void>('git_unstage', { cwd, path }) : webServerGit.unstage(cwd, path),
 
+  // Per-hunk stage/unstage (#257). Desktop-only for now; web parity
+  // (webServerGit.stageHunk) is a follow-up once the web GitPanel renders
+  // the hunk actions. `hunkPatch` is a single-hunk unified-diff fragment;
+  // the backend applies it via `git apply --cached [--reverse]`.
+  stageHunk: (cwd: string, path: string, hunkPatch: string) =>
+    invoke<void>('git_stage_hunk', { cwd, path, hunkPatch }),
+
+  unstageHunk: (cwd: string, path: string, hunkPatch: string) =>
+    invoke<void>('git_unstage_hunk', { cwd, path, hunkPatch }),
+
   discard: (cwd: string, path: string) =>
     isTauriContext() ? invoke<void>('git_discard', { cwd, path }) : webServerGit.discard(cwd, path),
 

--- a/src/renderer/stores/git-status-store.ts
+++ b/src/renderer/stores/git-status-store.ts
@@ -35,6 +35,8 @@ export interface GitStatusState {
   stageFiles: (cwd: string, paths: string[]) => Promise<void>
   unstageFiles: (cwd: string, paths: string[]) => Promise<void>
   discardFiles: (cwd: string, paths: string[]) => Promise<void>
+  stageHunk: (cwd: string, path: string, hunkPatch: string) => Promise<void>
+  unstageHunk: (cwd: string, path: string, hunkPatch: string) => Promise<void>
   commit: (cwd: string, summary: string, description: string, amend: boolean) => Promise<void>
   push: (cwd: string) => Promise<void>
   stashSave: (cwd: string, message?: string, includeUntracked?: boolean) => Promise<void>
@@ -162,6 +164,29 @@ export const useGitStatusStore = create<GitStatusState>((set, get) => ({
         await gitApi.unstage(cwd, path)
         invalidateFileDiffs(set, cwd, path)
       }
+    } finally {
+      await get().refreshStatus(cwd)
+      await get().fetchCommitContext(cwd)
+    }
+  },
+
+  // Per-hunk stage/unstage (#257). Same refresh contract as the file-level
+  // mutations above: invalidate the cached diff for the file, then refresh
+  // status + commit context so the panel reflects the partial stage.
+  stageHunk: async (cwd, path, hunkPatch) => {
+    try {
+      await gitApi.stageHunk(cwd, path, hunkPatch)
+      invalidateFileDiffs(set, cwd, path)
+    } finally {
+      await get().refreshStatus(cwd)
+      await get().fetchCommitContext(cwd)
+    }
+  },
+
+  unstageHunk: async (cwd, path, hunkPatch) => {
+    try {
+      await gitApi.unstageHunk(cwd, path, hunkPatch)
+      invalidateFileDiffs(set, cwd, path)
     } finally {
       await get().refreshStatus(cwd)
       await get().fetchCommitContext(cwd)


### PR DESCRIPTION
## Summary

Phase 1 of #257. Stage or unstage an individual hunk directly from the diff view, instead of only whole files. Today staging is file-granular (`git_stage` / `git_unstage`); this adds per-hunk granularity for both the working-tree (stage) and staged (unstage) sides.

## Related Issue

Refs #257. Covers acceptance criteria 1 ("Stage / unstage an individual hunk from the diff view") and 4 ("Works for both staged and working-tree diffs"). Per-line selection (criteria 2) is deferred to a follow-up PR to keep this one reviewable.

Searched open and closed PRs for `per-hunk`, `stage hunk`, `partial stage` — no duplicates.

## Type of Change

- [ ] feat: new feature
- [x] fix: bug fix
- [ ] docs: documentation only
- [ ] style: formatting or non-functional styling changes
- [ ] refactor: internal cleanup with no behavior change
- [ ] perf: performance improvement
- [x] test: adds or updates tests
- [ ] build: build or dependency changes
- [ ] ci: CI/CD workflow changes
- [ ] chore: maintenance or tooling
- [ ] revert: reverts a previous change

(Marking `fix` + `test` as well since this closes a documented gap and ships regression coverage; happy to switch to `feat`-only if maintainers prefer.)

## What Changed

**Backend (`src-tauri`)**
- `git_stage_hunk(cwd, path, hunk_patch)` — applies a single-hunk patch to the index via `git apply --cached --recount`.
- `git_unstage_hunk(cwd, path, hunk_patch)` — reverse-applies the patch to the index (`--cached --recount --reverse`).
- `validate_hunk_patch_paths` — **path-traversal guard**: the `--- a/<path>` / `+++ b/<path>` headers in the patch must equal the expected safe relative `path`. Without this, a renderer-built patch could declare any path and `git apply --cached` would honor it (write outside the project cwd via the index).
- `run_git_apply` — feeds the patch on stdin under the same deadline pattern (`GIT_COMMAND_TIMEOUT_MS`) as the other git helpers so a wedged `git apply` cannot hang the caller.
- Two Tauri commands wired in `lib.rs` invoke_handler.

**Frontend (`src/renderer`)**
- `lib/build-hunk-patch.ts` — splits a per-file diff into one self-contained patch per hunk (`--- a/`, `+++ b/`, `@@`, body, trailing newline). Tracks the file from the `+++` header so a multi-file diff only contributes hunks for the requested file.
- `components/git/GitDiffView.tsx` — renders a `Stage hunk` / `Unstage hunk` action on each `@@` header in both inline and split modes. The label follows the side being viewed (working-tree → stage, staged → unstage).
- `stores/git-status-store.ts` — `stageHunk` / `unstageHunk` actions reuse the existing refresh contract (invalidate cached diff, refresh status + commit context).
- `components/git/GitPanel.tsx` — wires `GitDiffView` callbacks to the store; re-fetches the (now smaller) diff after each apply.

## How It Was Tested

- [x] `bun run ci` (Biome lint + format + imports, strict mode) — clean (4 pre-existing a11y warnings in `GitPanel.tsx`, unrelated to this change)
- [x] `bun run typecheck` — tsc node/web/test all pass
- [x] `bun run test` — build-hunk-patch (5) + GitPanel (6) tests pass; 1 pre-existing test file fails on dev HEAD (`tauri-stubs/plugin-store.test.ts`, localStorage env) unrelated to this change
- [x] `cargo clippy --all-targets -- -D warnings` (in src-tauri) — clean for changed code; `lib.rs:643 unneeded return` is pre-existing on dev HEAD `6390a07` (verified via `git stash`)
- [x] `cargo test` (in src-tauri) — 69 `git_tracker` tests pass (incl. 4 new); 2 pre-existing failures on dev HEAD unrelated to this change (`cwd_tracker::test_detect_cwd_unix` macOS env, `mcp_probe::expands_bare_and_braced_references` — both fail identically via `git stash`)
- [x] Manual verification completed — see below.

### Manual repro (macOS)

1. `bun run tauri dev`, open a project with a multi-hunk modification in one file.
2. In the Git panel, select the file (working-tree side).
3. Click **Stage hunk** on one `@@` header in the diff view.
4. Confirm: only that hunk moves to staged; other hunks remain in the working tree.
5. Select the staged side, click **Unstage hunk** — hunk returns to the working tree.
6. Status + diff refresh correctly after each operation.

### Automated coverage

- **Rust**: `it_stage_hunk_stages_only_that_hunk_leaving_others_unstaged` (two-hunk file, partial stage proof), `it_unstage_hunk_reverses_a_previously_staged_hunk`, `it_stage_hunk_rejects_patch_whose_header_targets_a_different_path` (guard), `it_stage_hunk_rejects_unsafe_expected_path` (guard).
- **TS**: `buildHunkPatches` covers single-hunk, multi-hunk, meta-line preservation, multi-file guard, trailing newline.

## Notes for reviewers

- **Path-traversal hardening**: the renderer cannot stage arbitrary paths. `validate_hunk_patch_paths` runs server-side and rejects any patch whose header path ≠ expected. The frontend also filters multi-file diffs to the requested file, but the backend guard is the security boundary.
- **Binary files**: skipped implicitly — a binary diff has no `@@` hunks, so `buildHunkPatches` returns `[]` and no action is rendered.
- **Patch precision**: `--recount` tolerates a line-count mismatch in the `@@` header, which the renderer's patch builder can produce when it strips surrounding context. Line numbers in the header are derived from the original diff, not recomputed.
- Phase 2 (per-line selection within a hunk) will be a follow-up PR.

## CI & Review Gate

- [ ] All CI checks pass (PR Validation, Rust Checks, Build Verification, Security Scans)
- [ ] Code review comments from CodeRabbit / Claude have been addressed or resolved
- [ ] No unresolved review findings remain

## Checklist

- [x] My PR title follows the conventional commit format used by this repo
- [x] I linked the related issue or explained why none exists
- [x] I updated docs when needed (N/A)
- [x] I added or updated tests when needed (4 Rust + 5 TS new)
- [x] I verified the change does not introduce unrelated modifications (9 files, all in-scope)
- [x] I read AGENTS.md and followed the contributor guidelines
- [x] A human reviewed the complete diff before submission

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added per-hunk staging and unstaging actions in inline and split Git diff views.
  * Automatically refreshes Git status and diffs after each action.
  * Added error notifications when hunk operations fail.

* **Bug Fixes**
  * Prevents applying patches to unintended or unsafe file paths.
  * Added safeguards for stalled Git operations.
  * Improved handling of multi-file and malformed diff patches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->