### PR TITLE
feat(acp): add MCP tools to launcher and refine tool list styling

### DIFF
--- a/src/renderer/components/agents/AgentLauncher.test.tsx
+++ b/src/renderer/components/agents/AgentLauncher.test.tsx
@@ -52,6 +52,8 @@ const {
   mockNavigate,
   mockRetargetWarmPool,
   mockSetSelectedAgentConfigId,
+  mockSetMcpServerEnabled,
+  mockLoadMcpTools,
   acpStateRef
 } = vi.hoisted(() => ({
   mockStartChat: vi.fn(),
@@ -79,6 +81,8 @@ const {
   mockNavigate: vi.fn(),
   mockRetargetWarmPool: vi.fn(),
   mockSetSelectedAgentConfigId: vi.fn(),
+  mockSetMcpServerEnabled: vi.fn(),
+  mockLoadMcpTools: vi.fn(),
   acpStateRef: {
     current: {
       agentConfigs: [] as StoredAgentConfig[],
@@ -98,7 +102,10 @@ const {
       sessions: {} as Record<string, AcpSession>,
       commands: {},
       configToLiveAgent: {} as Record<string, string>,
-      agents: {} as Record<string, { id: string; capabilities: unknown; authMethods?: unknown[] }>
+      agents: {} as Record<string, { id: string; capabilities: unknown; authMethods?: unknown[] }>,
+      mcpServers: [] as Array<{ id: string; name: string; enabled?: boolean }>,
+      mcpProbeStatus: {} as Record<string, string>,
+      mcpTools: {} as Record<string, unknown[]>
     }
   }
 }))
@@ -221,6 +228,8 @@ vi.mock('@/stores/acp-store', () => {
     saveAgentConfig: typeof mockSaveAgentConfig
     retargetWarmPool: typeof mockRetargetWarmPool
     setSelectedAgentConfigId: typeof mockSetSelectedAgentConfigId
+    setMcpServerEnabled: typeof mockSetMcpServerEnabled
+    loadMcpTools: typeof mockLoadMcpTools
   }
   const useAcpStore = (sel?: (s: MockAcpState) => unknown) =>
     sel
@@ -228,7 +237,9 @@ vi.mock('@/stores/acp-store', () => {
           ...acpStateRef.current,
           saveAgentConfig: mockSaveAgentConfig,
           retargetWarmPool: mockRetargetWarmPool,
-          setSelectedAgentConfigId: mockSetSelectedAgentConfigId
+          setSelectedAgentConfigId: mockSetSelectedAgentConfigId,
+          setMcpServerEnabled: mockSetMcpServerEnabled,
+          loadMcpTools: mockLoadMcpTools
         })
       : getState()
   useAcpStore.getState = getState
@@ -369,9 +380,13 @@ beforeEach(() => {
     sessions: {},
     commands: {},
     configToLiveAgent: {},
-    agents: {}
+    agents: {},
+    mcpServers: [],
+    mcpProbeStatus: {},
+    mcpTools: {}
   }
   mockAuthenticateAgent.mockResolvedValue(undefined)
+  mockSetMcpServerEnabled.mockResolvedValue(undefined)
   mockPersistRead.mockResolvedValue({ success: true, data: undefined })
   mockPersistWrite.mockResolvedValue({ success: true })
   mockStartChat.mockResolvedValue('session-1')
@@ -617,6 +632,30 @@ describe('AgentLauncher ACP new thread', () => {
     // launcher must NOT cancel the warm session (it stays ready for the next
     // chat / a project switch-back).
     expect(mockCancelPreparedChat).not.toHaveBeenCalled()
+  })
+
+  it('invalidates + re-prepares the warm session when an MCP server is toggled', async () => {
+    const defaultAgent = defaultReadyAgent()
+    acpStateRef.current.mcpServers = [{ id: 's1', name: 'Files', enabled: true }]
+    renderLauncher()
+
+    // Wait for the warm pool to retarget (prepares the session).
+    await waitFor(() =>
+      expect(mockRetargetWarmPool).toHaveBeenCalledWith(defaultAgent.configId, '/work', 'p1')
+    )
+
+    // Open the MCP servers popover and toggle the "Files" server off.
+    fireEvent.click(screen.getByRole('button', { name: /mcp servers/i }))
+    const filesSwitch = await screen.findByRole('switch', { name: /Disable Files/i })
+    fireEvent.click(filesSwitch)
+
+    // The toggle persists to the registry, then cancels + re-prepares so the
+    // next launch resolves MCP from the updated registry instead of the stale
+    // pre-warmed session.
+    await waitFor(() => expect(mockSetMcpServerEnabled).toHaveBeenCalledWith('s1', false))
+    const key = `${defaultAgent.configId}\0${'/work'}\0`
+    expect(mockCancelPreparedChat).toHaveBeenCalledWith(key)
+    expect(mockPrepareChat).toHaveBeenCalledWith(defaultAgent.configId, '/work', undefined, 'p1')
   })
 
   it('restores a persisted ACP selection', async () => {

--- a/src/renderer/components/agents/AgentLauncher.tsx
+++ b/src/renderer/components/agents/AgentLauncher.tsx
@@ -21,6 +21,7 @@ import {
   resolveModelOption
 } from '@/components/chat/chat-input-bar-config'
 import { FileMentionMenu } from '@/components/chat/FileMentionMenu'
+import { McpBadge } from '@/components/chat/McpBadge'
 import { SkillComposerOverlay } from '@/components/chat/SkillComposerOverlay'
 import { SlashCommandMenu, type SlashMenuHandle } from '@/components/chat/SlashCommandMenu'
 import { isSlashTriggerAny } from '@/components/chat/slash-menu-model'
@@ -38,7 +39,14 @@ import { useAcpRuntimeProbe } from '@/hooks/use-acp-runtime-probe'
 import { useAgentSkills } from '@/hooks/use-agent-skills'
 import { useMentionRecents } from '@/hooks/use-mention-recents'
 import type { StoredAgentConfig } from '@/lib/acp-agents-persistence'
-import { type AuthMethod, acpApi, type ContentBlock } from '@/lib/acp-api'
+import {
+  type AuthMethod,
+  acpApi,
+  type ContentBlock,
+  type McpToolInfo,
+  type ProbeStatus
+} from '@/lib/acp-api'
+import type { StoredMcpServer } from '@/lib/acp-mcp-persistence'
 import { currentPlatformArch } from '@/lib/agents/acp-registry'
 import type { PrepareChatError } from '@/lib/agents/acp-spawn-errors'
 import { findBundledIconByKey } from '@/lib/agents/agent-icon-catalog'
@@ -75,6 +83,9 @@ interface AgentLauncherProps {
 
 const EMPTY_COMMANDS: [] = []
 const EMPTY_AUTH_METHODS: AuthMethod[] = []
+const EMPTY_MCP_SERVERS: StoredMcpServer[] = []
+const EMPTY_PROBE_STATUS: Record<string, ProbeStatus> = {}
+const EMPTY_MCP_TOOLS: Record<string, McpToolInfo[]> = {}
 
 /** Survives overlay unmount so the new-thread picker does not flash the default. */
 let cachedConfigId: string | null = null
@@ -101,6 +112,12 @@ export function AgentLauncher({ paneId, className }: AgentLauncherProps): React.
 
   const acpConfigs = useAcpStore((s) => s.agentConfigs)
   const saveAgentConfig = useAcpStore((s) => s.saveAgentConfig)
+  const mcpServers = useAcpStore((s) => s.mcpServers) ?? EMPTY_MCP_SERVERS
+  const mcpCount = mcpServers.length
+  const setMcpServerEnabled = useAcpStore((s) => s.setMcpServerEnabled)
+  const mcpProbeStatus = useAcpStore((s) => s.mcpProbeStatus) ?? EMPTY_PROBE_STATUS
+  const mcpTools = useAcpStore((s) => s.mcpTools) ?? EMPTY_MCP_TOOLS
+  const loadMcpTools = useAcpStore((s) => s.loadMcpTools)
   const activeProjectId = useProjectStore((s) => s.activeProjectId)
   const activeProject = useActiveProject()
   const projectLabel = activeProject?.name ?? 'this folder'
@@ -924,7 +941,25 @@ export function AgentLauncher({ paneId, className }: AgentLauncherProps): React.
               </div>
             </div>
             <div className="flex items-center justify-between gap-3 px-3 pb-3">
-              <AttachFilesButton onClick={() => void pickFiles()} disabled={!canPick} />
+              <div className="flex min-w-0 items-center gap-2">
+                <AttachFilesButton onClick={() => void pickFiles()} disabled={!canPick} />
+                <McpBadge
+                  count={mcpCount}
+                  servers={mcpServers}
+                  onToggle={(id, enabled) => {
+                    void setMcpServerEnabled(id, enabled).catch(() => {
+                      toast.error(
+                        'Could not update the MCP server. Your previous setting was restored.'
+                      )
+                    })
+                  }}
+                  probeStatus={mcpProbeStatus}
+                  tools={mcpTools}
+                  onLoadTools={(id) => {
+                    void loadMcpTools(id)
+                  }}
+                />
+              </div>
               <div className="flex min-w-0 flex-wrap items-center justify-end gap-2.5">
                 <AcpAgentPicker
                   agents={supportedAgents}

--- a/src/renderer/components/agents/AgentLauncher.tsx
+++ b/src/renderer/components/agents/AgentLauncher.tsx
@@ -947,11 +947,24 @@ export function AgentLauncher({ paneId, className }: AgentLauncherProps): React.
                   count={mcpCount}
                   servers={mcpServers}
                   onToggle={(id, enabled) => {
-                    void setMcpServerEnabled(id, enabled).catch(() => {
-                      toast.error(
-                        'Could not update the MCP server. Your previous setting was restored.'
-                      )
-                    })
+                    void setMcpServerEnabled(id, enabled)
+                      .then(() => {
+                        // The launcher pre-warms a `session/new` keyed without
+                        // MCP servers; createSession resolved the MCP set from
+                        // the registry AT pre-warm time. A toggle changes that
+                        // registry, so the warm session now holds a stale MCP
+                        // selection. Cancel + re-prepare so the next launch
+                        // resolves MCP from the updated registry.
+                        if (!preparedKey || !activeConfigId || !projectRoot) return
+                        const store = useAcpStore.getState()
+                        store.cancelPreparedChat(preparedKey)
+                        store.prepareChat(activeConfigId, projectRoot, undefined, activeProjectId)
+                      })
+                      .catch(() => {
+                        toast.error(
+                          'Could not update the MCP server. Your previous setting was restored.'
+                        )
+                      })
                   }}
                   probeStatus={mcpProbeStatus}
                   tools={mcpTools}

--- a/src/renderer/components/chat/McpBadge.test.tsx
+++ b/src/renderer/components/chat/McpBadge.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, within } from '@testing-library/react'
+import { fireEvent, render, screen } from '@testing-library/react'
 import { describe, expect, it, vi } from 'vitest'
 import { McpBadge } from './McpBadge'
 
@@ -59,10 +59,10 @@ describe('McpBadge popover (per-server enable/disable + status dot)', () => {
     const onToggle = vi.fn()
     render(<McpBadge count={1} servers={servers} onToggle={onToggle} />)
     openPopover()
-    // "Files" (s1) is enabled → its "Off" radio switches it off. Each row's
-    // radios are scoped by their RadioGroup; click the "Off" radio input by id.
-    const offRadio = document.getElementById('mcp-s1-off') as HTMLInputElement
-    fireEvent.click(offRadio)
+    // "Files" (s1) is enabled → its Switch turns it off. Each row's Switch is
+    // labelled with the server name + Disable/Enable prefix.
+    const filesSwitch = screen.getByRole('switch', { name: /Disable Files/i }) as HTMLInputElement
+    fireEvent.click(filesSwitch)
     expect(onToggle).toHaveBeenCalledWith('s1', false)
   })
 
@@ -70,8 +70,8 @@ describe('McpBadge popover (per-server enable/disable + status dot)', () => {
     const onToggle = vi.fn()
     render(<McpBadge count={1} servers={servers} onToggle={onToggle} />)
     openPopover()
-    const onRadio = document.getElementById('mcp-s2-on') as HTMLInputElement
-    fireEvent.click(onRadio)
+    const remoteSwitch = screen.getByRole('switch', { name: /Enable Remote/i }) as HTMLInputElement
+    fireEvent.click(remoteSwitch)
     expect(onToggle).toHaveBeenCalledWith('s2', true)
   })
 

--- a/src/renderer/components/chat/McpBadge.tsx
+++ b/src/renderer/components/chat/McpBadge.tsx
@@ -207,10 +207,10 @@ function McpServerRow({
           {tools && tools.length > 0 ? (
             <ul className="space-y-0.5">
               {tools.map((tool) => (
-                <li key={tool.name} className="text-3xs">
+                <li key={tool.name} className="flex min-w-0 items-baseline text-3xs">
                   <span className="font-mono font-medium text-foreground">{tool.name}</span>
                   {tool.description ? (
-                    <span className="ml-1 truncate text-muted-foreground/70">
+                    <span className="ml-1 min-w-0 flex-1 truncate text-muted-foreground/70">
                       — {tool.description}
                     </span>
                   ) : null}

--- a/src/renderer/components/chat/McpBadge.tsx
+++ b/src/renderer/components/chat/McpBadge.tsx
@@ -2,9 +2,8 @@ import { Plug, PlugZap } from 'lucide-react'
 import { useState } from 'react'
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible'
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
-import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group'
+import { Switch } from '@/components/ui/switch'
 import type { McpToolInfo, ProbeStatus } from '@/lib/acp-api'
-import type { StoredMcpServer } from '@/lib/acp-mcp-persistence'
 import { cn } from '@/lib/utils'
 
 interface McpServerSummary {
@@ -171,7 +170,6 @@ function McpServerRow({
   onLoadTools
 }: ServerRowProps): React.JSX.Element {
   const enabled = server.enabled !== false
-  const radioValue = enabled ? 'on' : 'off'
   return (
     <li className="space-y-1.5 rounded-md border border-border/50 p-2">
       <div className="flex items-center justify-between gap-2">
@@ -185,28 +183,14 @@ function McpServerRow({
           <span className="truncate text-sm font-medium">{server.name}</span>
         </div>
         {onToggle && (
-          <RadioGroup
-            value={radioValue}
-            aria-label={`${server.name} enabled state`}
-            className="flex gap-2"
-            onValueChange={(value) => {
-              if (value === radioValue) return
-              onToggle(server.id, value === 'on')
+          <Switch
+            checked={enabled}
+            aria-label={`${enabled ? 'Disable' : 'Enable'} ${server.name}`}
+            onCheckedChange={(checked) => {
+              if (checked === enabled) return
+              onToggle(server.id, checked)
             }}
-          >
-            <span className="flex items-center gap-1">
-              <RadioGroupItem value="on" id={`mcp-${server.id}-on`} />
-              <label htmlFor={`mcp-${server.id}-on`} className="text-muted-foreground">
-                On
-              </label>
-            </span>
-            <span className="flex items-center gap-1">
-              <RadioGroupItem value="off" id={`mcp-${server.id}-off`} />
-              <label htmlFor={`mcp-${server.id}-off`} className="text-muted-foreground">
-                Off
-              </label>
-            </span>
-          </RadioGroup>
+          />
         )}
       </div>
       <Collapsible
@@ -223,10 +207,12 @@ function McpServerRow({
           {tools && tools.length > 0 ? (
             <ul className="space-y-0.5">
               {tools.map((tool) => (
-                <li key={tool.name} className="text-3xs text-muted-foreground">
-                  <span className="font-mono">{tool.name}</span>
+                <li key={tool.name} className="text-3xs">
+                  <span className="font-mono font-medium text-foreground">{tool.name}</span>
                   {tool.description ? (
-                    <span className="ml-1 truncate">— {tool.description}</span>
+                    <span className="ml-1 truncate text-muted-foreground/70">
+                      — {tool.description}
+                    </span>
                   ) : null}
                 </li>
               ))}

--- a/src/renderer/components/settings/McpServersSettings.tsx
+++ b/src/renderer/components/settings/McpServersSettings.tsx
@@ -267,10 +267,14 @@ export function McpServersSettings(): React.JSX.Element {
                       {tools && tools.length > 0 ? (
                         <ul className="space-y-0.5">
                           {tools.map((tool) => (
-                            <li key={tool.name} className="text-3xs text-muted-foreground">
-                              <span className="font-mono">{tool.name}</span>
+                            <li key={tool.name} className="text-3xs">
+                              <span className="font-mono font-medium text-foreground">
+                                {tool.name}
+                              </span>
                               {tool.description ? (
-                                <span className="ml-1 truncate">— {tool.description}</span>
+                                <span className="ml-1 truncate text-muted-foreground/70">
+                                  — {tool.description}
+                                </span>
                               ) : null}
                             </li>
                           ))}

--- a/src/renderer/components/settings/McpServersSettings.tsx
+++ b/src/renderer/components/settings/McpServersSettings.tsx
@@ -267,12 +267,12 @@ export function McpServersSettings(): React.JSX.Element {
                       {tools && tools.length > 0 ? (
                         <ul className="space-y-0.5">
                           {tools.map((tool) => (
-                            <li key={tool.name} className="text-3xs">
+                            <li key={tool.name} className="flex min-w-0 items-baseline text-3xs">
                               <span className="font-mono font-medium text-foreground">
                                 {tool.name}
                               </span>
                               {tool.description ? (
-                                <span className="ml-1 truncate text-muted-foreground/70">
+                                <span className="ml-1 min-w-0 flex-1 truncate text-muted-foreground/70">
                                   — {tool.description}
                                 </span>
                               ) : null}


### PR DESCRIPTION
## Summary

The MCP tool list UI was visually flat and inconsistent across surfaces: the per-server enable/disable control in the chatbox used an On/Off radio group (out of step with the settings page's Switch), the tool name and description shared the same muted color so the eye couldn't tell them apart, and the Ctrl+T agent launcher had no MCP tool visibility at all even though it launches chats that consume MCP servers. This PR unifies the three surfaces and gives each tool entry a clear name-vs-description hierarchy.

## Related Issue

No related issue — this is a UI polish follow-up to the MCP server/tool UI shipped in #525. No tracking issue exists for this styling/parity refinement.

## Type of Change

- [x] feat: new feature
- [ ] fix: bug fix
- [ ] docs: documentation only
- [ ] style: formatting or non-functional styling changes
- [ ] refactor: internal cleanup with no behavior change
- [ ] perf: performance improvement
- [ ] test: adds or updates tests
- [ ] build: build or dependency changes
- [ ] ci: CI/CD workflow changes
- [ ] chore: maintenance or tooling
- [ ] revert: reverts a previous change

## What Changed

- Surface the `McpBadge` (per-server enable/disable + collapsible tool list) in the Ctrl+T agent launcher composer row, wired to the same `setMcpServerEnabled` / `loadMcpTools` store actions as the chatbox. Defaults to an empty server list so the badge stays hidden when no servers are configured.
- Replace the chatbox per-server On/Off `RadioGroup` with a single `Switch` toggle for parity with the settings page.
- Give each tool entry a distinct visual hierarchy in both the settings panel and the chatbox popover: tool name in bold foreground (`font-mono font-medium text-foreground`), description in dimmed muted-foreground (`text-muted-foreground/70`).
- Make the tool description truncatable in both surfaces: each `<li>` is a constrained flex row (`flex min-w-0 items-baseline`) and the description span is `ml-1 min-w-0 flex-1 truncate` so the ellipsis renders on long descriptions.
- Invalidate + re-prepare the launcher's warm session when an MCP server is toggled, so the next launch resolves MCP from the updated registry instead of claiming a stale pre-warmed session (the prepared session is keyed without MCP servers; `createSession` resolves MCP from the live registry at creation time).
- Update `McpBadge` tests to query the `switch` role with `Disable/Enable <name>` labels instead of the removed radio ids, and add a launcher regression test for toggle-after-prewarm.

## How It Was Tested

- [x] `bun run ci` (Biome lint + format + imports, strict mode)
- [x] `bun run typecheck`
- [x] `bun run test`
- [ ] `cargo clippy --all-targets -- -D warnings` (in src-tauri)
- [ ] `cargo test` (in src-tauri)
- [x] Manual verification completed
- [ ] Not applicable

## Screenshots or Recordings

N/A — small structural/styling change to existing components; verified via the affected unit tests (McpBadge, ChatInputBar, chat-responsive, AgentLauncher, McpServersSettings all green).

## CI & Review Gate

- [x] All CI checks pass (PR Validation, Rust Checks, Build Verification, Security Scans)
- [x] Code review comments from CodeRabbit / Claude have been addressed or resolved
- [x] No unresolved review findings remain

## Checklist

- [x] My PR title follows the conventional commit format used by this repo
- [x] I linked the related issue or explained why none exists
- [x] I updated docs when needed
- [x] I added or updated tests when needed
- [x] I verified the change does not introduce unrelated modifications
- [x] I read AGENTS.md and followed the contributor guidelines
- [ ] A human reviewed the complete diff before submission
