### PR TITLE
fix(acp): humanize stream and rate-limit agent errors

### DIFF
--- a/src/renderer/components/chat/AgentChatPanel.tsx
+++ b/src/renderer/components/chat/AgentChatPanel.tsx
@@ -8,6 +8,7 @@ import { buildPromptWithLoadedSkills, useAgentSkills } from '@/hooks/use-agent-s
 import { useMobileWebShell } from '@/hooks/use-mobile-web-shell'
 import { useOskViewport } from '@/hooks/use-osk-viewport'
 import type { AvailableCommand, ContentBlock, PlanEntry, SessionId, ToolCall } from '@/lib/acp-api'
+import { formatAcpAgentError } from '@/lib/agents/acp-spawn-errors'
 import { extractSkillNames } from '@/lib/skill-tokens'
 import { isTauriContext } from '@/lib/tauri-runtime'
 import { getDefaultCwdForProject } from '@/lib/worktree-context'
@@ -390,7 +391,9 @@ export function AgentChatPanel({
       }
     : undefined
   const activeError =
-    session.lastError && session.lastError !== dismissedError ? session.lastError : null
+    session.lastError && session.lastError !== dismissedError
+      ? formatAcpAgentError(session.lastError)
+      : null
 
   return (
     <div

--- a/src/renderer/lib/agents/acp-spawn-errors.test.ts
+++ b/src/renderer/lib/agents/acp-spawn-errors.test.ts
@@ -1,12 +1,40 @@
 import { describe, expect, it } from 'vitest'
 import type { AuthMethod } from '@/lib/acp-api'
 import {
+  ACP_RATE_LIMIT_MESSAGE,
+  ACP_STREAM_INTERRUPT_MESSAGE,
   AmbiguousAuthError,
   classifySetupError,
+  formatAcpAgentError,
   formatAcpSpawnError,
   isAmbiguousAuthError,
   SETUP_ERROR_LABELS
 } from './acp-spawn-errors'
+
+describe('formatAcpAgentError', () => {
+  it('rewrites NGHTTP2_ENHANCE_YOUR_CALM / RetriableError stream closes as rate-limit', () => {
+    expect(
+      formatAcpAgentError(
+        'Error: RetriableError: [internal] Stream closed with error code NGHTTP2_ENHANCE_YOUR_CALM'
+      )
+    ).toBe(ACP_RATE_LIMIT_MESSAGE)
+    expect(formatAcpAgentError('rate limit exceeded')).toBe(ACP_RATE_LIMIT_MESSAGE)
+    expect(formatAcpAgentError('HTTP 429 Too Many Requests')).toBe(ACP_RATE_LIMIT_MESSAGE)
+  })
+
+  it('rewrites generic stream/connection drops as interrupted', () => {
+    expect(formatAcpAgentError('RetriableError: [internal] Stream closed')).toBe(
+      ACP_STREAM_INTERRUPT_MESSAGE
+    )
+    expect(formatAcpAgentError('ECONNRESET')).toBe(ACP_STREAM_INTERRUPT_MESSAGE)
+    expect(formatAcpAgentError('the stream was destroyed')).toBe(ACP_STREAM_INTERRUPT_MESSAGE)
+  })
+
+  it('passes unrelated diagnostics through verbatim', () => {
+    expect(formatAcpAgentError('credit limit exceeded')).toBe('credit limit exceeded')
+    expect(formatAcpAgentError(new Error('insufficient credit'))).toBe('insufficient credit')
+  })
+})
 
 describe('formatAcpSpawnError', () => {
   it('passes non-ENOENT messages through verbatim', () => {
@@ -73,6 +101,15 @@ describe('classifySetupError order and categories (P4)', () => {
     expect(classifySetupError('connection refused').category).toBe('transport')
     expect(classifySetupError('ECONNRESET').category).toBe('transport')
     expect(classifySetupError('agent thread is no longer running').category).toBe('transport')
+  })
+
+  it('rewrites transport/rate-limit detail into friendly copy', () => {
+    expect(classifySetupError('the stream was destroyed').detail).toBe(ACP_STREAM_INTERRUPT_MESSAGE)
+    expect(
+      classifySetupError(
+        'Error: RetriableError: [internal] Stream closed with error code NGHTTP2_ENHANCE_YOUR_CALM'
+      ).detail
+    ).toBe(ACP_RATE_LIMIT_MESSAGE)
   })
 
   it('treats "connection timed out" as transport, not timeout (evicts the process)', () => {

--- a/src/renderer/lib/agents/acp-spawn-errors.ts
+++ b/src/renderer/lib/agents/acp-spawn-errors.ts
@@ -7,6 +7,35 @@ import type { AgentConfig, AuthMethod } from '@/lib/acp-api'
 const ENOENT_PATTERN =
   /enoent|no such file|program not found|command not found|spawn.*fail|failed to spawn/i
 
+/** Server/client rate-limit or HTTP/2 "slow down" (e.g. NGHTTP2_ENHANCE_YOUR_CALM). */
+const RATE_LIMIT_PATTERN =
+  /ENHANCE_YOUR_CALM|enhance[\s_-]?your[\s_-]?calm|rate[\s_-]?limit|too many requests|\b429\b/i
+
+/**
+ * Mid-turn stream / connection drops. Checked after rate-limit so
+ * `Stream closed … NGHTTP2_ENHANCE_YOUR_CALM` maps to the rate-limit copy.
+ */
+const STREAM_INTERRUPT_PATTERN =
+  /RetriableError|NGHTTP2_|destroyed|stream (?:closed|ended|destroyed|error)|broken pipe|e?pipe\b|econnreset|econnrefused|disconnected|connection (?:closed|lost|reset|refused|aborted)|connection.*timed out|agent thread (?:is no longer running|dropped)/i
+
+export const ACP_RATE_LIMIT_MESSAGE =
+  'Connection was rate-limited by the agent service. Wait a moment, then retry.'
+
+export const ACP_STREAM_INTERRUPT_MESSAGE =
+  'Agent connection was interrupted. Wait a moment, then retry.'
+
+/**
+ * Turn a raw agent turn/setup error into a user-facing message. Known
+ * rate-limit and stream/connection failures are rewritten into short
+ * actionable copy; everything else is passed through verbatim.
+ */
+export function formatAcpAgentError(raw: unknown): string {
+  const message = raw instanceof Error ? raw.message : String(raw)
+  if (RATE_LIMIT_PATTERN.test(message)) return ACP_RATE_LIMIT_MESSAGE
+  if (STREAM_INTERRUPT_PATTERN.test(message)) return ACP_STREAM_INTERRUPT_MESSAGE
+  return message
+}
+
 /**
  * Turn a raw spawn/setup error into a user-facing message. Only ENOENT-style
  * failures (a missing/unresolvable command) are rewritten into actionable
@@ -133,10 +162,9 @@ const TIMEOUT_PATTERN = /timed out|timeout/i
  *
  * Transport is checked before auth (so connection/stream wording wins when both
  * are present) and before timeout (so "connection timed out" evicts rather than
- * being treated as a benign slow setup). The category is always derived from the
- * RAW error message; only the `spawn` category rewrites `detail` into friendly
- * ENOENT guidance so the user-facing text stays actionable without losing the
- * diagnostic for other categories.
+ * The category is always derived from the RAW error message; `spawn` rewrites
+ * `detail` via {@link formatAcpSpawnError}, and `transport` / `unknown` run
+ * {@link formatAcpAgentError} so rate-limit and stream drops stay actionable.
  */
 export function classifySetupError(
   raw: unknown,
@@ -155,7 +183,11 @@ export function classifySetupError(
     }
   }
   if (TRANSPORT_PATTERN.test(message)) {
-    return { category: 'transport', label: SETUP_ERROR_LABELS.transport, detail: message }
+    return {
+      category: 'transport',
+      label: SETUP_ERROR_LABELS.transport,
+      detail: formatAcpAgentError(raw)
+    }
   }
   if (AUTH_PATTERN.test(message)) {
     return { category: 'auth', label: SETUP_ERROR_LABELS.auth, detail: message }
@@ -163,5 +195,9 @@ export function classifySetupError(
   if (TIMEOUT_PATTERN.test(message)) {
     return { category: 'timeout', label: SETUP_ERROR_LABELS.timeout, detail: message }
   }
-  return { category: 'unknown', label: SETUP_ERROR_LABELS.unknown, detail: message }
+  return {
+    category: 'unknown',
+    label: SETUP_ERROR_LABELS.unknown,
+    detail: formatAcpAgentError(raw)
+  }
 }


### PR DESCRIPTION
## Summary
- Add `formatAcpAgentError` to rewrite opaque stream/rate-limit diagnostics (e.g. `NGHTTP2_ENHANCE_YOUR_CALM`, `RetriableError`, `429`) into short actionable copy
- Show the friendly message in chat error notices and setup transport/unknown failures
- Leave unrelated agent diagnostics unchanged

## Test plan
- [ ] Trigger or simulate a Cursor agent `NGHTTP2_ENHANCE_YOUR_CALM` / stream-closed error and confirm chat shows: "Connection was rate-limited by the agent service. Wait a moment, then retry."
- [ ] Simulate a generic connection drop (`ECONNRESET` / stream destroyed) and confirm: "Agent connection was interrupted. Wait a moment, then retry."
- [ ] Confirm unrelated errors (e.g. credit limit) still show the original message
- [ ] `npx vitest run src/renderer/lib/agents/acp-spawn-errors.test.ts`


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved agent error messages in chat by replacing technical rate-limit and connection interruption details with clearer explanations.
  * Preserved relevant diagnostic messages when no known error pattern is detected.
  * Enhanced setup error classification for transport and rate-limit failures.

* **Tests**
  * Added coverage for formatted agent errors and friendly error classification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->