### PR TITLE
fix(acp): stop leaking [blocked] type names into chat tool call rendering

### DIFF
--- a/src/renderer/components/chat/ToolCallCard.test.tsx
+++ b/src/renderer/components/chat/ToolCallCard.test.tsx
@@ -127,4 +127,56 @@ describe('ToolCallCard', () => {
     expect(document.querySelector('audio')).not.toBeInTheDocument()
     expect(screen.getByTitle('audio.mp3')).toBeInTheDocument()
   })
+
+  it('renders text from an unknown content type instead of a bracketed label', () => {
+    render(
+      <ToolCallCard
+        toolCall={toolCall('completed', [{ type: 'blocked', text: 'untracked/modified' }])}
+      />
+    )
+
+    fireEvent.click(screen.getByRole('button'))
+
+    expect(screen.getByText('untracked/modified')).toBeInTheDocument()
+    expect(screen.queryByText('[blocked]')).not.toBeInTheDocument()
+  })
+
+  it('renders text from a nested object in an unknown content type', () => {
+    render(
+      <ToolCallCard
+        toolCall={toolCall('completed', [{ type: 'blocked', output: { text: 'result' } }])}
+      />
+    )
+
+    fireEvent.click(screen.getByRole('button'))
+
+    expect(screen.getByText('result')).toBeInTheDocument()
+    expect(screen.queryByText('[blocked]')).not.toBeInTheDocument()
+  })
+
+  it('renders nothing for an unknown content type with no text-like fields', () => {
+    const { container } = render(
+      <ToolCallCard toolCall={toolCall('completed', [{ type: 'blocked' }])} />
+    )
+
+    fireEvent.click(screen.getByRole('button'))
+
+    expect(screen.queryByText('[blocked]')).not.toBeInTheDocument()
+    expect(screen.queryByText('blocked')).not.toBeInTheDocument()
+    const detail = container.querySelector('[class*="border-l"]')
+    expect(detail).toBeEmptyDOMElement()
+  })
+
+  it('renders nothing for a content item with a missing content field', () => {
+    const { container } = render(
+      <ToolCallCard toolCall={toolCall('completed', [{ type: 'content' }])} />
+    )
+
+    fireEvent.click(screen.getByRole('button'))
+
+    expect(screen.queryByText('[content]')).not.toBeInTheDocument()
+    expect(screen.queryByText('content')).not.toBeInTheDocument()
+    const detail = container.querySelector('[class*="border-l"]')
+    expect(detail).toBeEmptyDOMElement()
+  })
 })

--- a/src/renderer/components/chat/ToolCallCard.tsx
+++ b/src/renderer/components/chat/ToolCallCard.tsx
@@ -22,7 +22,12 @@ import { MediaBlocks } from './ChatMessage'
 import { bubbleEnter, CHAT_SPRING } from './chat-motion'
 import { DiffPreview } from './DiffPreview'
 import { type ToolIconName, toolIconName } from './tool-call-format'
-import { describeToolCall, readableOutput } from './tool-call-summary'
+import {
+  describeToolCall,
+  firstString,
+  READABLE_TEXT_KEYS,
+  readableOutput
+} from './tool-call-summary'
 
 /** Common prop shape shared by lucide icons and the bundled RobotIcon. */
 type ToolIconComponent = React.ComponentType<{ size?: number | string; className?: string }>
@@ -78,7 +83,29 @@ function renderContentBlock(block: ContentBlock, key: number): React.JSX.Element
   return <MediaBlocks key={key} blocks={[block]} />
 }
 
-function renderContentItem(item: ToolCallContent, key: number): React.JSX.Element {
+/**
+ * Best-effort extraction of a readable string from an unrecognized
+ * ToolCallContent item. Tries common text keys directly, then one level of
+ * nesting (e.g. { output: { text: '...' } }). Returns null when nothing is
+ * found so the caller can render nothing instead of a bracketed type label.
+ * Shares `READABLE_TEXT_KEYS` + `firstString` with `readableOutput` to prevent
+ * drift between the structured-content and raw-output extraction paths.
+ */
+function extractItemText(item: ToolCallContent): string | null {
+  const record = item as Record<string, unknown>
+  const direct = firstString(record, READABLE_TEXT_KEYS)
+  if (direct) return direct
+  for (const k of READABLE_TEXT_KEYS) {
+    const v = record[k]
+    if (v && typeof v === 'object') {
+      const nested = firstString(v as Record<string, unknown>, READABLE_TEXT_KEYS)
+      if (nested) return nested
+    }
+  }
+  return null
+}
+
+function renderContentItem(item: ToolCallContent, key: number): React.JSX.Element | null {
   if (item.type === 'diff') {
     const d = item as { path: string; oldText?: string | null; newText: string }
     return (
@@ -90,13 +117,7 @@ function renderContentItem(item: ToolCallContent, key: number): React.JSX.Elemen
   }
   if (item.type === 'content') {
     const c = item as { content?: ContentBlock }
-    return c.content ? (
-      renderContentBlock(c.content, key)
-    ) : (
-      <div key={key} className="text-xs italic text-muted-foreground">
-        [content]
-      </div>
-    )
+    return c.content ? renderContentBlock(c.content, key) : null
   }
   if (item.type === 'terminal') {
     // The ACP `terminal` content variant only references a terminal by id; its
@@ -112,11 +133,18 @@ function renderContentItem(item: ToolCallContent, key: number): React.JSX.Elemen
       </div>
     )
   }
-  return (
-    <div key={key} className="text-xs italic text-muted-foreground">
-      [{item.type}]
-    </div>
-  )
+  // Unrecognized content type: try to surface any readable text the item
+  // carries before giving up. Never render the raw type name as a bracketed
+  // label — that leaks internal names into the chat UI.
+  const text = extractItemText(item)
+  if (text) {
+    return (
+      <div key={key} className="whitespace-pre-wrap break-words text-xs text-foreground/90">
+        {text}
+      </div>
+    )
+  }
+  return null
 }
 
 /** Human-friendly elapsed time for a settled tool call. */

--- a/src/renderer/components/chat/tool-call-summary.ts
+++ b/src/renderer/components/chat/tool-call-summary.ts
@@ -28,7 +28,10 @@ function asRecord(value: unknown): Record<string, unknown> | null {
   return value && typeof value === 'object' ? (value as Record<string, unknown>) : null
 }
 
-function firstString(obj: Record<string, unknown> | null, keys: string[]): string | undefined {
+export function firstString(
+  obj: Record<string, unknown> | null,
+  keys: string[]
+): string | undefined {
   if (!obj) return undefined
   for (const k of keys) {
     const v = obj[k]
@@ -62,6 +65,13 @@ const COMMAND_KEYS = ['command', 'cmd', 'script', 'commandLine']
 const QUERY_KEYS = ['query', 'pattern', 'q', 'search', 'searchTerm', 'regex']
 const URL_KEYS = ['url', 'uri', 'href', 'link']
 const TASK_NAME_KEYS = ['description', 'task', 'name', 'title']
+
+/**
+ * Keys that commonly carry readable text in a tool-call content item or raw
+ * output. Shared between `readableOutput` and `ToolCallCard`'s fallback
+ * extraction so the two paths never drift.
+ */
+export const READABLE_TEXT_KEYS = ['output', 'stdout', 'result', 'text', 'content', 'message']
 
 /**
  * Detect a subagent/Task dispatch. ACP gives no dedicated kind for these and
@@ -132,7 +142,7 @@ export function readableOutput(value: unknown): string {
   if (typeof value === 'string') return value.trim()
   const obj = asRecord(value)
   if (!obj) return ''
-  const direct = firstString(obj, ['output', 'stdout', 'result', 'text', 'content', 'message'])
+  const direct = firstString(obj, READABLE_TEXT_KEYS)
   if (direct) return direct
   const meta = asRecord(obj.metadata)
   const metaDiff = firstString(meta, ['diff'])


### PR DESCRIPTION
## Summary

The ACP chat UI rendered raw internal content-type names as bracketed text (e.g. `[blocked]`) inside tool call cards when a `ToolCallContent` item arrived with an unrecognized `type` value. Users saw confusing artifacts like `untracked/modified [blocked]` in the chat instead of clean output. This replaces the `[{item.type}]` fallback with a graceful text-extraction handler that surfaces readable text or renders nothing.

## Related Issue

No related issue — this is a renderer-level defensive fix for a chat rendering artifact reported during live use.

## Type of Change

- [ ] feat: new feature
- [x] fix: bug fix
- [ ] docs: documentation only
- [ ] style: formatting or non-functional styling changes
- [ ] refactor: internal cleanup with no behavior change
- [ ] perf: performance improvement
- [ ] test: adds or updates tests
- [ ] build: build or dependency changes
- [ ] ci: CI/CD workflow changes
- [ ] chore: maintenance or tooling
- [ ] revert: reverts a previous change

## What Changed

- `src/renderer/components/chat/ToolCallCard.tsx` — replaced the `[{item.type}]` fallback in `renderContentItem` with `extractItemText`, a graceful handler that tries common text keys (`output`, `stdout`, `result`, `text`, `content`, `message`) and renders the text if found, or returns `null` (renders nothing) if not. Changed the `[content]` fallback for missing `content` fields to also return `null`. Return type updated to `React.JSX.Element | null`.
- `src/renderer/components/chat/tool-call-summary.ts` — exported `firstString` and `READABLE_TEXT_KEYS` so the fallback extraction shares the same key list as `readableOutput`, preventing drift between the two text-extraction paths. Updated `readableOutput` to use the shared constant.
- `src/renderer/components/chat/ToolCallCard.test.tsx` — 4 new tests: unknown type with text renders the text; unknown type with nested object renders nested text; unknown type with no text renders nothing (asserts empty DOM); `type: content` with missing `content` field renders nothing (asserts empty DOM).

## How It Was Tested

- [x] `bun run ci` (Biome lint + format + imports, strict mode)
- [x] `bun run typecheck`
- [x] `bun run test`
- [ ] `cargo clippy --all-targets -- -D warnings` (in src-tauri)
- [ ] `cargo test` (in src-tauri)
- [x] Manual verification completed
- [ ] Not applicable

## Screenshots or Recordings

Not applicable — no visible UI change beyond removing confusing bracketed type-name text from tool call cards.

## CI & Review Gate

- [x] All CI checks pass (PR Validation, Rust Checks, Build Verification, Security Scans)
- [ ] Code review comments from CodeRabbit / Claude have been addressed or resolved
- [ ] No unresolved review findings remain

## Checklist

- [x] My PR title follows the conventional commit format used by this repo
- [x] I linked the related issue or explained why none exists
- [x] I updated docs when needed
- [x] I added or updated tests when needed
- [x] I verified the change does not introduce unrelated modifications
- [x] I read AGENTS.md and followed the contributor guidelines
- [ ] A human reviewed the complete diff before submission