### PR TITLE
fix(acp): slow streamed text fade with per-word stagger for smooth word reveal

### DIFF
--- a/src/renderer/components/chat/ChatMessage.test.tsx
+++ b/src/renderer/components/chat/ChatMessage.test.tsx
@@ -60,6 +60,7 @@ vi.mock('streamdown', async () => {
     const animatedName =
       animated === false ? 'false' : animated === true ? 'true' : (animatedConfig?.animation ?? '')
     const animatedDuration = animatedConfig ? String(animatedConfig.duration ?? '') : ''
+    const animatedStagger = animatedConfig ? String(animatedConfig.stagger ?? '') : ''
     const animatedEasing = animatedConfig?.easing ?? ''
 
     return (
@@ -68,6 +69,7 @@ vi.mock('streamdown', async () => {
         data-animating={isAnimating}
         data-animated={animatedName}
         data-animated-duration={animatedDuration}
+        data-animated-stagger={animatedStagger}
         data-animated-easing={animatedEasing}
         data-caret={caret}
         data-custom-table={Boolean(CustomTable)}
@@ -182,13 +184,14 @@ describe('ChatMessage', () => {
     expect(screen.getByTestId('streamdown')).toHaveAttribute('data-animated', 'false')
   })
 
-  it('passes the fadeIn animation config (duration/easing) under default motion', () => {
+  it('passes the fadeIn animation config (duration/easing/stagger) under default motion', () => {
     useReducedMotionMock.mockReturnValue(false)
     render(<ChatMessage message={agentMessage(true)} isLast />)
 
     const streamdown = screen.getByTestId('streamdown')
     expect(streamdown).toHaveAttribute('data-animated', 'fadeIn')
-    expect(streamdown).toHaveAttribute('data-animated-duration', '200')
+    expect(streamdown).toHaveAttribute('data-animated-duration', '500')
+    expect(streamdown).toHaveAttribute('data-animated-stagger', '150')
     expect(streamdown).toHaveAttribute('data-animated-easing', 'cubic-bezier(0.22, 1, 0.36, 1)')
   })
 

--- a/src/renderer/components/chat/ChatMessage.tsx
+++ b/src/renderer/components/chat/ChatMessage.tsx
@@ -252,15 +252,16 @@ const STREAMDOWN_COMPONENTS = {
   table: ChatMarkdownTable
 } as const
 
-// Opacity-only fade so streamed words reveal smoothly without the blur-filter
-// jank of sd-blurIn. `animated` uses the styles.css keyframes imported in
-// main.tsx; already-visible words get duration 0 (no re-animation).
+// Slow opacity fade + per-word stagger so 3-4 words are mid-fade at once
+// (a smooth transparent→solid wave) instead of all words snapping in.
+// `animated` uses the styles.css keyframes imported in main.tsx; already-
+// visible words get duration 0 (no re-animation).
 const STREAMDOWN_ANIMATED = {
   animation: 'fadeIn',
   sep: 'word',
-  duration: 200,
+  duration: 500,
   easing: 'cubic-bezier(0.22, 1, 0.36, 1)',
-  stagger: 8
+  stagger: 150
 } as const
 
 /**

--- a/src/renderer/layouts/WorkspaceLayout.test.tsx
+++ b/src/renderer/layouts/WorkspaceLayout.test.tsx
@@ -848,7 +848,7 @@ describe('WorkspaceLayout - Empty States', () => {
 
       renderWithRouter()
 
-      expect(backendShortcut).toBeDefined()
+      await waitFor(() => expect(backendShortcut).toBeDefined())
       act(() => backendShortcut?.('colorThemePicker'))
       expect(await screen.findByRole('dialog', { name: 'Color theme picker' })).toBeInTheDocument()
     })


### PR DESCRIPTION
## Summary

Streamed ACP agent replies fade in too fast. The prior change (#518) replaced `sd-blurIn` with opacity-only `sd-fadeIn` to kill blur-filter jank, but tuned it to `duration: 200ms, stagger: 8ms`. With an 8ms stagger all words in a render start their 200ms fade within a few ms of each other, so the live stream snaps in rather than revealing smoothly — the fade feels instant instead of gradual.

This PR slows the per-word fade and raises the per-word stagger so 3-4 words are simultaneously mid-fade at any moment, producing a smooth transparent→solid wave instead of a snap-in. Still pure opacity (`sd-fadeIn`), still Streamdown's officially-supported `AnimateOptions` config; no new animation system, no store/data-flow/caret changes, reduced-motion gate unchanged.

A small CI-stabilization rider is bundled (commit 2): the pre-existing fragile theme-picker test in `WorkspaceLayout.test.tsx` was racing its own `useEffect` and failed non-deterministically on CI, blocking this otherwise-green PR. Fixed with a `waitFor` wrapper, matching the `aa4740f4` precedent ("stabilize theme-picker test on CI"). See `## What Changed` below.

## Related Issue

No related issue — follow-up tuning to the opacity-fade change in #518 (PR #518 replaced `blurIn` with `fadeIn`; the resulting fade felt too fast and needs a slower duration + a visible per-word stagger for a smooth wave). No separate issue was filed for this tuning.

## Type of Change

- [x] fix: bug fix

## What Changed

- `src/renderer/components/chat/ChatMessage.tsx` — `STREAMDOWN_ANIMATED` const: `duration: 200 → 500` (2.5× slower per-word fade) and `stagger: 8 → 150` (creates a duration/stagger ratio of ~3.3, so 3-4 words overlap mid-fade at any moment — a smooth transparent→solid wave). Kept `animation: 'fadeIn'`, `sep: 'word'`, `easing: 'cubic-bezier(0.22, 1, 0.36, 1)'`, `as const`, and the `animated={reduced ? false : STREAMDOWN_ANIMATED}` reduced-motion gate. Updated the comment above the const to describe the new behavior.
- `src/renderer/components/chat/ChatMessage.test.tsx` — `MockStreamdown` extended to render `data-animated-stagger` (mirroring the existing `data-animated-duration`/`easing` pattern). Default-motion test renamed to `'passes the fadeIn animation config (duration/easing/stagger) under default motion'` and now asserts `data-animated-duration='500'` + `data-animated-stagger='150'` (keeps the existing `data-animated='fadeIn'` and easing assertions). Reduced-motion test unchanged (still asserts `data-animated='false'`).
- `src/renderer/layouts/WorkspaceLayout.test.tsx` *(CI-stabilization rider, commit 2)* — wrapped the sync `expect(backendShortcut).toBeDefined()` in `await waitFor(...)` so the `useEffect` that registers `onShortcut` (`WorkspaceLayout.tsx:1273`) has time to flush on CI. The sync assertion raced the effect and failed non-deterministically on CI (Linux + Node 24) while passing locally. Mirrors the stabilization pattern `aa4740f4` applied to the sibling assertion. Unrelated to the animation change; bundled as a rider because it blocked this PR's CI and has direct repo precedent.

## How It Was Tested

- [x] `bun run ci` (Biome lint + format + imports, strict mode)
- [x] `bun run typecheck`
- [x] `bun run test`
- [x] `cargo clippy --all-targets -- -D warnings` (in src-tauri) — verified by CI (Rust Checks job, SUCCESS)
- [x] `cargo test` (in src-tauri) — verified by CI (Rust Checks job, SUCCESS)
- [x] Manual verification completed — streamed a live agent turn in `bun run dev:web` and confirmed words reveal as a smooth wave (3-4 words visible at distinct opacities at any moment) instead of snapping in; caret still shows while streaming and hides on finalize.

## Screenshots or Recordings

Not included — the change is a timing tuning of an existing opacity animation (no visual layout change). Best verified by streaming a live agent turn in `bun run dev:web` or `bun run dev` and watching the trailing message reveal.

## CI & Review Gate

- [x] All CI checks pass (PR Validation, Rust Checks, Build Verification, Security Scans)
- [x] Code review comments from CodeRabbit / Claude have been addressed or resolved (CodeRabbit posted a summary walkthrough with no actionable findings; no inline comments)
- [x] No unresolved review findings remain

## Checklist

- [x] My PR title follows the conventional commit format used by this repo
- [x] I linked the related issue or explained why none exists
- [x] I updated docs when needed (no docs update needed for a tuning change)
- [x] I added or updated tests when needed (extended `MockStreamdown` + updated the default-motion regression test; added `waitFor` to the fragile theme-picker test)
- [x] I verified the change does not introduce unrelated modifications (the only rider is the documented `WorkspaceLayout.test.tsx` CI-stabilization, with `aa4740f4` precedent)
- [x] I read AGENTS.md and followed the contributor guidelines
- [x] A human reviewed the complete diff before submission
