### PR TITLE
feat(web-parity): add web entry resilience + facade web branches for CAP-3

### DIFF
--- a/src/renderer/App.test.tsx
+++ b/src/renderer/App.test.tsx
@@ -26,6 +26,68 @@ vi.mock('./hooks/use-visibility-state', () => ({
   useVisibilityState: mockUseVisibilityState
 }))
 
+// CAP-3: resilience hooks + ErrorBoundary/WhatsNewModal wiring assertions.
+const {
+  mockUseCrashRecovery,
+  mockUseTerminalExitNotification,
+  mockUseRemoteProjects,
+  mockUseWhatsNew,
+  mockInitNotificationPermissions
+} = vi.hoisted(() => ({
+  mockUseCrashRecovery: vi.fn(() => undefined),
+  mockUseTerminalExitNotification: vi.fn(() => undefined),
+  mockUseRemoteProjects: vi.fn(() => undefined),
+  mockUseWhatsNew: vi.fn(() => ({
+    isOpen: false,
+    version: '',
+    notes: null,
+    htmlUrl: null,
+    close: vi.fn()
+  })),
+  mockInitNotificationPermissions: vi.fn(() => Promise.resolve())
+}))
+
+vi.mock('./hooks/use-crash-recovery', () => ({
+  useCrashRecovery: mockUseCrashRecovery
+}))
+
+vi.mock('./hooks/use-terminal-exit-notification', () => ({
+  useTerminalExitNotification: mockUseTerminalExitNotification
+}))
+
+vi.mock('./hooks/use-remote-projects', () => ({
+  useRemoteProjects: mockUseRemoteProjects
+}))
+
+vi.mock('./hooks/use-whats-new', () => ({
+  useWhatsNew: mockUseWhatsNew
+}))
+
+vi.mock('./lib/tauri-notification-api', () => ({
+  initNotificationPermissions: mockInitNotificationPermissions
+}))
+
+// Render-through mock so the test can assert the wrap is present without
+// intercepting the child tree. The real ErrorBoundary is a class component
+// whose componentDidCatch side effects are irrelevant to wiring assertions.
+vi.mock('@/components/ErrorBoundary', () => ({
+  ErrorBoundary: ({ children, context }: { children: React.ReactNode; context?: string }) => (
+    <div data-testid="error-boundary" data-context={context}>
+      {children}
+    </div>
+  )
+}))
+
+vi.mock('./components/WhatsNewModal', () => ({
+  WhatsNewModal: (props: { isOpen: boolean; version: string }) => (
+    <div
+      data-testid="whats-new-modal"
+      data-open={String(props.isOpen)}
+      data-version={props.version}
+    />
+  )
+}))
+
 const mockCheckForUpdates = vi.fn(async () => {})
 const mockInitializeUpdater = vi.fn(async () => {})
 const mockStopPeriodicChecks = vi.fn(() => {})
@@ -188,5 +250,75 @@ describe('App Updater Integration', () => {
     unmount()
 
     expect(mockStopPeriodicChecks).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('App CAP-3 resilience wiring (web entry)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('wraps the tree in <ErrorBoundary context="App Root">', () => {
+    render(<App />)
+
+    const boundary = document.body.querySelector('[data-testid="error-boundary"]')
+    expect(boundary).not.toBeNull()
+    expect(boundary?.getAttribute('data-context')).toBe('App Root')
+  })
+
+  it('mounts <WhatsNewModal> as a sibling of <RouterProvider>', () => {
+    render(<App />)
+
+    const modal = document.body.querySelector('[data-testid="whats-new-modal"]')
+    expect(modal).not.toBeNull()
+    expect(modal?.getAttribute('data-open')).toBe('false')
+  })
+
+  it('forwards the hook open state and version to <WhatsNewModal>', () => {
+    mockUseWhatsNew.mockReturnValue({
+      isOpen: true,
+      version: '0.4.8',
+      notes: 'Release notes',
+      htmlUrl: 'https://github.com/gnoviawan/termul/releases/tag/v0.4.8',
+      close: vi.fn()
+    })
+
+    render(<App />)
+
+    const modal = document.body.querySelector('[data-testid="whats-new-modal"]')
+    expect(modal?.getAttribute('data-open')).toBe('true')
+    expect(modal?.getAttribute('data-version')).toBe('0.4.8')
+  })
+
+  it('calls useWhatsNew in the App body', () => {
+    render(<App />)
+
+    expect(mockUseWhatsNew).toHaveBeenCalledTimes(1)
+  })
+
+  it('mounts useCrashRecovery in AppEffects', () => {
+    render(<App />)
+
+    expect(mockUseCrashRecovery).toHaveBeenCalledTimes(1)
+  })
+
+  it('mounts useTerminalExitNotification in AppEffects', () => {
+    render(<App />)
+
+    expect(mockUseTerminalExitNotification).toHaveBeenCalledTimes(1)
+  })
+
+  it('mounts useRemoteProjects in AppEffects', () => {
+    render(<App />)
+
+    expect(mockUseRemoteProjects).toHaveBeenCalledTimes(1)
+  })
+
+  it('calls initNotificationPermissions on mount (useEffect [])', async () => {
+    render(<App />)
+
+    await waitFor(() => {
+      expect(mockInitNotificationPermissions).toHaveBeenCalledTimes(1)
+    })
   })
 })

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -2,20 +2,27 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { useEffect } from 'react'
 import { createHashRouter, RouterProvider } from 'react-router-dom'
 import { DirectoryPicker } from '@/components/DirectoryPicker'
+import { ErrorBoundary } from '@/components/ErrorBoundary'
 import { Toaster as Sonner } from '@/components/ui/sonner'
 import { Toaster } from '@/components/ui/toaster'
 import { TooltipProvider } from '@/components/ui/tooltip'
+import { WhatsNewModal } from './components/WhatsNewModal'
 import { useAppSettingsLoader } from './hooks/use-app-settings'
 import { useAppliedColorThemeSync } from './hooks/use-color-theme'
 import { useContextBarSettings } from './hooks/use-context-bar-settings'
+import { useCrashRecovery } from './hooks/use-crash-recovery'
 import { useCwd } from './hooks/use-cwd'
 import { useExitCode } from './hooks/use-exit-code'
 import { useGitBranch } from './hooks/use-git-branch'
 import { useGitStatus } from './hooks/use-git-status'
+import { useRemoteProjects } from './hooks/use-remote-projects'
 import { useTerminalDetachedOutput } from './hooks/use-terminal-detached-output'
+import { useTerminalExitNotification } from './hooks/use-terminal-exit-notification'
 import { useTerminalRestore } from './hooks/use-terminal-restore'
+import { useWhatsNew } from './hooks/use-whats-new'
 import { useTerminalAutoSave } from './hooks/useTerminalAutoSave'
 import WorkspaceLayout from './layouts/WorkspaceLayout'
+import { initNotificationPermissions } from './lib/tauri-notification-api'
 import AppPreferences from './pages/AppPreferences'
 import NotFound from './pages/NotFound'
 import ProjectSettings from './pages/ProjectSettings'
@@ -84,11 +91,16 @@ const queryClient = new QueryClient()
 // installed @xterm/xterm version is on the expected 6.1 line.
 // initialization or a check-renderer-whitelist CI job). Do not rely on comments alone.
 
-// Component to handle app-level effects like auto-save
+// Component to handle app-level effects like auto-save.
+// Mirrors TauriApp.tsx AppEffects mount order (lines 63-100) for the portable
+// subset. Native-only effects (usePreventDefaultContextMenu, showWindow,
+// useWindowState) are intentionally NOT ported — they would break the browser
+// (right-click dev menu, no native window). usePreventAltMenu stays (web-only).
 function AppEffects(): null {
   usePreventAltMenu()
   useTerminalAutoSave()
   useTerminalRestore()
+  useCrashRecovery()
   useTerminalDetachedOutput()
   useCwd()
   useGitBranch()
@@ -102,15 +114,27 @@ function AppEffects(): null {
   useProjectsLoader()
   useProjectsAutoSave()
   useMenuUpdaterListener()
+  useUpdateCheck()
+  useUpdateToast()
+  useVisibilityState()
+  useTerminalExitNotification()
+  useRemoteProjects()
   useAcpListeners()
   useAcpAgents()
   useAcpHistory()
   useAcpSessionResume()
   useAcpMcp()
-  useUpdateCheck()
-  useUpdateToast()
-  useVisibilityState()
   usePreventFileDropNavigation()
+
+  // Initialize notification permissions once at app startup so the OS (or
+  // browser) permission prompt appears early, not on first terminal exit. On
+  // web this calls the Web Notifications API (`Notification.requestPermission`);
+  // on desktop, the Tauri notification plugin. No-op in SSR/test (no
+  // `Notification` global).
+  useEffect(() => {
+    initNotificationPermissions()
+  }, [])
+
   return null
 }
 
@@ -135,20 +159,32 @@ const router = createHashRouter(
   }
 )
 
-const App = () => (
-  <QueryClientProvider client={queryClient}>
-    <TooltipProvider delayDuration={80} skipDelayDuration={300}>
-      <AppEffects />
-      <Toaster />
-      <Sonner />
-      {/* Web/remote mode only: in-app directory picker registered with
-          dialogApi so NewProjectModal's Browse button works without a native
-          dialog.open (Story: Web/remote project creation). Desktop never
-          mounts it. */}
-      {!isTauriContext() && <DirectoryPicker />}
-      <RouterProvider router={router} future={{ v7_startTransition: true }} />
-    </TooltipProvider>
-  </QueryClientProvider>
-)
+const App = () => {
+  const whatsNew = useWhatsNew()
+  return (
+    <QueryClientProvider client={queryClient}>
+      <TooltipProvider delayDuration={80} skipDelayDuration={300}>
+        <ErrorBoundary context="App Root">
+          <AppEffects />
+          <Toaster />
+          <Sonner />
+          {/* Web/remote mode only: in-app directory picker registered with
+              dialogApi so NewProjectModal's Browse button works without a native
+              dialog.open (Story: Web/remote project creation). Desktop never
+              mounts it. */}
+          {!isTauriContext() && <DirectoryPicker />}
+          <RouterProvider router={router} future={{ v7_startTransition: true }} />
+          <WhatsNewModal
+            isOpen={whatsNew.isOpen}
+            version={whatsNew.version}
+            notes={whatsNew.notes}
+            htmlUrl={whatsNew.htmlUrl}
+            onClose={whatsNew.close}
+          />
+        </ErrorBoundary>
+      </TooltipProvider>
+    </QueryClientProvider>
+  )
+}
 
 export default App

--- a/src/renderer/lib/__tests__/tauri-notification-api.web.test.ts
+++ b/src/renderer/lib/__tests__/tauri-notification-api.web.test.ts
@@ -1,0 +1,270 @@
+/**
+ * Web-branch tests for tauri-notification-api.ts (CAP-3: Web UI entry parity).
+ *
+ * `initNotificationPermissions` and `sendDesktopNotification` branch on
+ * `isTauriContext()`: desktop calls `@tauri-apps/plugin-notification`
+ * (`isPermissionGranted`/`requestPermission`/`sendNotification`); web calls
+ * the Web Notifications API (`Notification.requestPermission()` +
+ * `new Notification(title, { body })`). This file asserts, per the
+ * `log-api.test.ts` dual-branch pattern, that:
+ * - the WEB branch calls the Web Notifications API and NOT the Tauri plugin
+ * - the DESKTOP branch calls the Tauri plugin and NOT the Web Notifications API
+ * - `typeof Notification === 'undefined'` (SSR/test) degrades to a no-op
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const {
+  mockIsPermissionGranted,
+  mockRequestPermission,
+  mockSendNotification,
+  mockIsTauriContext,
+  mockNotificationConstructor,
+  mockNotificationRequestPermission
+} = vi.hoisted(() => ({
+  mockIsPermissionGranted: vi.fn(),
+  mockRequestPermission: vi.fn(),
+  mockSendNotification: vi.fn(),
+  mockIsTauriContext: vi.fn(),
+  mockNotificationConstructor: vi.fn(),
+  mockNotificationRequestPermission: vi.fn()
+}))
+
+vi.mock('@tauri-apps/plugin-notification', () => ({
+  isPermissionGranted: mockIsPermissionGranted,
+  requestPermission: mockRequestPermission,
+  sendNotification: mockSendNotification
+}))
+
+vi.mock('../tauri-runtime', () => ({
+  isTauriContext: mockIsTauriContext
+}))
+
+// Stub the global `Notification` constructor + static `requestPermission`.
+// `permission` is read by `initNotificationPermissions` to short-circuit when
+// already granted. We default it to 'default' so each test exercises the
+// request path unless it overrides.
+const NotificationStub = vi.fn().mockImplementation(mockNotificationConstructor) as unknown as {
+  new (title: string, options?: NotificationOptions): Notification
+  requestPermission: () => Promise<NotificationPermission>
+  permission: NotificationPermission
+}
+;(NotificationStub as unknown as { requestPermission: typeof vi.fn }).requestPermission =
+  mockNotificationRequestPermission
+;(NotificationStub as unknown as { permission: NotificationPermission }).permission = 'default'
+
+import {
+  _resetNotificationPermissionForTesting,
+  initNotificationPermissions,
+  sendDesktopNotification
+} from '../tauri-notification-api'
+
+describe('tauri-notification-api (web vs desktop branch)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    _resetNotificationPermissionForTesting()
+    mockNotificationRequestPermission.mockResolvedValue('default')
+    ;(NotificationStub as unknown as { permission: NotificationPermission }).permission = 'default'
+    vi.stubGlobal('Notification', NotificationStub)
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  describe('initNotificationPermissions', () => {
+    it('web: calls Notification.requestPermission() and maps granted → true', async () => {
+      mockIsTauriContext.mockReturnValue(false)
+      mockNotificationRequestPermission.mockResolvedValue('granted')
+
+      await initNotificationPermissions()
+
+      expect(mockNotificationRequestPermission).toHaveBeenCalledTimes(1)
+      expect(mockIsPermissionGranted).not.toHaveBeenCalled()
+      expect(mockRequestPermission).not.toHaveBeenCalled()
+    })
+
+    it('web: maps denied → false', async () => {
+      mockIsTauriContext.mockReturnValue(false)
+      mockNotificationRequestPermission.mockResolvedValue('denied')
+
+      await initNotificationPermissions()
+
+      expect(mockNotificationRequestPermission).toHaveBeenCalledTimes(1)
+    })
+
+    it('web: short-circuits when Notification.permission === "granted" (no prompt)', async () => {
+      mockIsTauriContext.mockReturnValue(false)
+      ;(NotificationStub as unknown as { permission: NotificationPermission }).permission =
+        'granted'
+
+      await initNotificationPermissions()
+
+      // Already granted — must not re-prompt.
+      expect(mockNotificationRequestPermission).not.toHaveBeenCalled()
+    })
+
+    it('web: no-op when typeof Notification === "undefined" (SSR/test)', async () => {
+      mockIsTauriContext.mockReturnValue(false)
+      vi.unstubAllGlobals() // remove the `Notification` global
+
+      await initNotificationPermissions()
+
+      expect(mockNotificationRequestPermission).not.toHaveBeenCalled()
+      expect(mockIsPermissionGranted).not.toHaveBeenCalled()
+    })
+
+    it('web: swallows when Notification.requestPermission() throws', async () => {
+      mockIsTauriContext.mockReturnValue(false)
+      mockNotificationRequestPermission.mockRejectedValue(new Error('blocked'))
+
+      await expect(initNotificationPermissions()).resolves.toBeUndefined()
+      expect(mockNotificationRequestPermission).toHaveBeenCalledTimes(1)
+    })
+
+    it('web: concurrent calls share one in-flight request (no double prompt)', async () => {
+      mockIsTauriContext.mockReturnValue(false)
+      let resolveRequest: (value: NotificationPermission) => void = () => {}
+      mockNotificationRequestPermission.mockImplementation(
+        () =>
+          new Promise<NotificationPermission>((resolve) => {
+            resolveRequest = resolve
+          })
+      )
+
+      const first = initNotificationPermissions()
+      const second = initNotificationPermissions()
+
+      resolveRequest('granted')
+      await Promise.all([first, second])
+
+      expect(mockNotificationRequestPermission).toHaveBeenCalledTimes(1)
+    })
+
+    it('desktop: calls isPermissionGranted + requestPermission, maps granted → true', async () => {
+      mockIsTauriContext.mockReturnValue(true)
+      mockIsPermissionGranted.mockResolvedValue(false)
+      mockRequestPermission.mockResolvedValue('granted')
+
+      await initNotificationPermissions()
+
+      expect(mockIsPermissionGranted).toHaveBeenCalledTimes(1)
+      expect(mockRequestPermission).toHaveBeenCalledTimes(1)
+      expect(mockNotificationRequestPermission).not.toHaveBeenCalled()
+    })
+
+    it('desktop: skips request when already granted', async () => {
+      mockIsTauriContext.mockReturnValue(true)
+      mockIsPermissionGranted.mockResolvedValue(true)
+
+      await initNotificationPermissions()
+
+      expect(mockIsPermissionGranted).toHaveBeenCalledTimes(1)
+      expect(mockRequestPermission).not.toHaveBeenCalled()
+    })
+
+    it('desktop: never calls the Web Notifications API', async () => {
+      mockIsTauriContext.mockReturnValue(true)
+      mockIsPermissionGranted.mockResolvedValue(true)
+
+      await initNotificationPermissions()
+
+      expect(mockNotificationRequestPermission).not.toHaveBeenCalled()
+      expect(mockNotificationConstructor).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('sendDesktopNotification', () => {
+    it('web: calls new Notification(title, { body }) when permissionGranted', async () => {
+      mockIsTauriContext.mockReturnValue(false)
+      mockNotificationRequestPermission.mockResolvedValue('granted')
+      await initNotificationPermissions()
+
+      await sendDesktopNotification('Project', 'term — DONE')
+
+      expect(mockNotificationConstructor).toHaveBeenCalledTimes(1)
+      expect(mockNotificationConstructor).toHaveBeenCalledWith('Project', { body: 'term — DONE' })
+      expect(mockSendNotification).not.toHaveBeenCalled()
+    })
+
+    it('web: no-op when permission denied (no new Notification)', async () => {
+      mockIsTauriContext.mockReturnValue(false)
+      mockNotificationRequestPermission.mockResolvedValue('denied')
+      await initNotificationPermissions()
+
+      await sendDesktopNotification('Project', 'term — DONE')
+
+      expect(mockNotificationConstructor).not.toHaveBeenCalled()
+      expect(mockSendNotification).not.toHaveBeenCalled()
+    })
+
+    it('web: lazy-inits permission on first sendDesktopNotification call', async () => {
+      mockIsTauriContext.mockReturnValue(false)
+      // Do NOT call initNotificationPermissions first — permissionGranted is null.
+      mockNotificationRequestPermission.mockResolvedValue('granted')
+
+      await sendDesktopNotification('Project', 'term — DONE')
+
+      expect(mockNotificationRequestPermission).toHaveBeenCalledTimes(1)
+      expect(mockNotificationConstructor).toHaveBeenCalledWith('Project', { body: 'term — DONE' })
+    })
+
+    it('web: no-op when typeof Notification === "undefined" (SSR/test)', async () => {
+      mockIsTauriContext.mockReturnValue(false)
+      vi.unstubAllGlobals() // remove the `Notification` global
+
+      await sendDesktopNotification('Project', 'term — DONE')
+
+      expect(mockNotificationConstructor).not.toHaveBeenCalled()
+      expect(mockSendNotification).not.toHaveBeenCalled()
+    })
+
+    it('web: swallows when new Notification() throws', async () => {
+      mockIsTauriContext.mockReturnValue(false)
+      mockNotificationRequestPermission.mockResolvedValue('granted')
+      await initNotificationPermissions()
+      mockNotificationConstructor.mockImplementation(() => {
+        throw new Error('notification disabled')
+      })
+
+      await expect(sendDesktopNotification('Project', 'term — DONE')).resolves.toBeUndefined()
+    })
+
+    it('desktop: calls sendNotification({ title, body }) when permissionGranted', async () => {
+      mockIsTauriContext.mockReturnValue(true)
+      mockIsPermissionGranted.mockResolvedValue(true)
+      await initNotificationPermissions()
+
+      await sendDesktopNotification('Project', 'term — DONE')
+
+      expect(mockSendNotification).toHaveBeenCalledTimes(1)
+      expect(mockSendNotification).toHaveBeenCalledWith({
+        title: 'Project',
+        body: 'term — DONE'
+      })
+      expect(mockNotificationConstructor).not.toHaveBeenCalled()
+    })
+
+    it('desktop: never calls the Web Notifications API', async () => {
+      mockIsTauriContext.mockReturnValue(true)
+      mockIsPermissionGranted.mockResolvedValue(true)
+      await initNotificationPermissions()
+
+      await sendDesktopNotification('Project', 'term — DONE')
+
+      expect(mockNotificationConstructor).not.toHaveBeenCalled()
+      expect(mockNotificationRequestPermission).not.toHaveBeenCalled()
+    })
+
+    it('desktop: no-op when permission denied', async () => {
+      mockIsTauriContext.mockReturnValue(true)
+      mockIsPermissionGranted.mockResolvedValue(false)
+      mockRequestPermission.mockResolvedValue('denied')
+      await initNotificationPermissions()
+
+      await sendDesktopNotification('Project', 'term — DONE')
+
+      expect(mockSendNotification).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/src/renderer/lib/__tests__/tauri-notification-api.web.test.ts
+++ b/src/renderer/lib/__tests__/tauri-notification-api.web.test.ts
@@ -84,13 +84,31 @@ describe('tauri-notification-api (web vs desktop branch)', () => {
       expect(mockRequestPermission).not.toHaveBeenCalled()
     })
 
-    it('web: maps denied → false', async () => {
+    it('web: does not cache a denial (leaves re-checkable so a later grant via settings is picked up)', async () => {
       mockIsTauriContext.mockReturnValue(false)
       mockNotificationRequestPermission.mockResolvedValue('denied')
 
       await initNotificationPermissions()
 
+      // Denial is not cached as `false` — a later send re-checks.
       expect(mockNotificationRequestPermission).toHaveBeenCalledTimes(1)
+    })
+
+    it('web: sendDesktopNotification re-checks after a denial and picks up a later grant', async () => {
+      mockIsTauriContext.mockReturnValue(false)
+      // First init: denied.
+      mockNotificationRequestPermission.mockResolvedValue('denied')
+      await initNotificationPermissions()
+
+      // Send while denied — no notification, and permission was re-checked.
+      mockNotificationConstructor.mockClear()
+      await sendDesktopNotification('Project', 'term — DONE')
+      expect(mockNotificationConstructor).not.toHaveBeenCalled()
+
+      // User grants via browser settings → next send picks it up.
+      mockNotificationRequestPermission.mockResolvedValue('granted')
+      await sendDesktopNotification('Project', 'term — DONE')
+      expect(mockNotificationConstructor).toHaveBeenCalledTimes(1)
     })
 
     it('web: short-circuits when Notification.permission === "granted" (no prompt)', async () => {

--- a/src/renderer/lib/__tests__/tauri-opener-api.web.test.ts
+++ b/src/renderer/lib/__tests__/tauri-opener-api.web.test.ts
@@ -1,0 +1,194 @@
+/**
+ * Web-branch tests for tauri-opener-api.ts (CAP-3: Web UI entry parity).
+ *
+ * `openUrlWithSystemBrowser` branches on `isTauriContext()`: desktop calls
+ * `@tauri-apps/plugin-opener`'s `openUrl(url)`; web/remote calls
+ * `window.open(url, '_blank', 'noopener')`. The other two methods
+ * (`openWithExternalApp`, `revealInFileManager`) have no browser equivalent
+ * and stay desktop-only — they call the Tauri plugin in both modes (the web
+ * build's stubbed plugin throws `tauriUnavailable`, which the methods wrap
+ * into an `IpcResult` error).
+ *
+ * This file asserts, per the `log-api.test.ts` dual-branch pattern, that:
+ * - the WEB branch of `openUrlWithSystemBrowser` calls `window.open` and NOT `openUrl`
+ * - the DESKTOP branch calls `openUrl` and NOT `window.open`
+ * - `openWithExternalApp`/`revealInFileManager` call the Tauri plugin in both modes
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { mockOpenPath, mockOpenUrl, mockRevealItemInDir, mockIsTauriContext, mockWindowOpen } =
+  vi.hoisted(() => ({
+    mockOpenPath: vi.fn(),
+    mockOpenUrl: vi.fn(),
+    mockRevealItemInDir: vi.fn(),
+    mockIsTauriContext: vi.fn(),
+    mockWindowOpen: vi.fn()
+  }))
+
+vi.mock('@tauri-apps/plugin-opener', () => ({
+  openPath: mockOpenPath,
+  openUrl: mockOpenUrl,
+  revealItemInDir: mockRevealItemInDir
+}))
+
+vi.mock('../tauri-runtime', () => ({
+  isTauriContext: mockIsTauriContext
+}))
+
+import { openerApi } from '../tauri-opener-api'
+
+const URL = 'https://github.com/gnoviawan/termul/releases/tag/v0.4.8'
+const PATH = '/some/path/file.txt'
+
+describe('openerApi.openUrlWithSystemBrowser (web vs desktop branch)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockWindowOpen.mockReset()
+    vi.stubGlobal('open', mockWindowOpen)
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('web: calls window.open(url, "_blank", "noopener")', async () => {
+    mockIsTauriContext.mockReturnValue(false)
+    mockWindowOpen.mockReturnValue(null)
+
+    const result = await openerApi.openUrlWithSystemBrowser(URL)
+
+    expect(result).toEqual({ success: true, data: undefined })
+    expect(mockWindowOpen).toHaveBeenCalledWith(URL, '_blank', 'noopener')
+    expect(mockOpenUrl).not.toHaveBeenCalled()
+  })
+
+  it('web: returns success even when popup blocker returns null (best-effort)', async () => {
+    mockIsTauriContext.mockReturnValue(false)
+    mockWindowOpen.mockReturnValue(null)
+
+    const result = await openerApi.openUrlWithSystemBrowser(URL)
+
+    expect(result.success).toBe(true)
+  })
+
+  it('web: swallows SecurityError from window.open (best-effort)', async () => {
+    mockIsTauriContext.mockReturnValue(false)
+    mockWindowOpen.mockImplementation(() => {
+      throw new Error('SecurityError: blocked')
+    })
+
+    const result = await openerApi.openUrlWithSystemBrowser(URL)
+
+    expect(result).toEqual({ success: true, data: undefined })
+    expect(mockWindowOpen).toHaveBeenCalledWith(URL, '_blank', 'noopener')
+  })
+
+  it('web: no-ops for non-http(s)/mailto schemes (javascript:/data:) — no window.open', async () => {
+    mockIsTauriContext.mockReturnValue(false)
+
+    for (const dangerous of ['javascript:alert(1)', 'data:text/html,<script>alert(1)</script>']) {
+      const result = await openerApi.openUrlWithSystemBrowser(dangerous)
+
+      expect(result).toEqual({ success: true, data: undefined })
+    }
+    expect(mockWindowOpen).not.toHaveBeenCalled()
+  })
+
+  it('desktop: calls openUrl(url) and NOT window.open', async () => {
+    mockIsTauriContext.mockReturnValue(true)
+    mockOpenUrl.mockResolvedValue(undefined)
+
+    const result = await openerApi.openUrlWithSystemBrowser(URL)
+
+    expect(result).toEqual({ success: true, data: undefined })
+    expect(mockOpenUrl).toHaveBeenCalledWith(URL)
+    expect(mockWindowOpen).not.toHaveBeenCalled()
+  })
+
+  it('desktop: returns error result when openUrl rejects', async () => {
+    mockIsTauriContext.mockReturnValue(true)
+    mockOpenUrl.mockRejectedValue(new Error('native opener failed'))
+
+    const result = await openerApi.openUrlWithSystemBrowser(URL)
+
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.code).toBe('OPEN_URL_ERROR')
+      expect(result.error).toBe('native opener failed')
+    }
+  })
+})
+
+describe('openWithExternalApp (no web branch — desktop-only)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockWindowOpen.mockReset()
+    vi.stubGlobal('open', mockWindowOpen)
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('web: still calls the Tauri plugin (no web branch)', async () => {
+    mockIsTauriContext.mockReturnValue(false)
+    mockOpenPath.mockRejectedValue(new Error('unavailable in web build'))
+
+    const result = await openerApi.openWithExternalApp(PATH)
+
+    expect(mockOpenPath).toHaveBeenCalledWith(PATH)
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.code).toBe('OPEN_ERROR')
+    }
+    // Must NOT use window.open — no browser equivalent for "open with external app".
+    expect(mockWindowOpen).not.toHaveBeenCalled()
+  })
+
+  it('desktop: calls openPath(path)', async () => {
+    mockIsTauriContext.mockReturnValue(true)
+    mockOpenPath.mockResolvedValue(undefined)
+
+    const result = await openerApi.openWithExternalApp(PATH)
+
+    expect(result).toEqual({ success: true, data: undefined })
+    expect(mockOpenPath).toHaveBeenCalledWith(PATH)
+  })
+})
+
+describe('revealInFileManager (no web branch — desktop-only)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockWindowOpen.mockReset()
+    vi.stubGlobal('open', mockWindowOpen)
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('web: still calls the Tauri plugin (no web branch)', async () => {
+    mockIsTauriContext.mockReturnValue(false)
+    mockRevealItemInDir.mockRejectedValue(new Error('unavailable in web build'))
+
+    const result = await openerApi.revealInFileManager(PATH)
+
+    expect(mockRevealItemInDir).toHaveBeenCalledWith(PATH)
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.code).toBe('REVEAL_ERROR')
+    }
+    expect(mockWindowOpen).not.toHaveBeenCalled()
+  })
+
+  it('desktop: calls revealItemInDir(path)', async () => {
+    mockIsTauriContext.mockReturnValue(true)
+    mockRevealItemInDir.mockResolvedValue(undefined)
+
+    const result = await openerApi.revealInFileManager(PATH)
+
+    expect(result).toEqual({ success: true, data: undefined })
+    expect(mockRevealItemInDir).toHaveBeenCalledWith(PATH)
+  })
+})

--- a/src/renderer/lib/__tests__/tauri-release-notes.test.ts
+++ b/src/renderer/lib/__tests__/tauri-release-notes.test.ts
@@ -10,6 +10,13 @@ vi.mock('@tauri-apps/plugin-store', () => ({
   }
 }))
 
+// Desktop branch: these tests exercise the Tauri code path. Without this stub,
+// `isTauriContext()` is false under Vitest and the facades take the web branch
+// (covered separately by `tauri-release-notes.web.test.ts`).
+vi.mock('../tauri-runtime', () => ({
+  isTauriContext: vi.fn(() => true)
+}))
+
 import { getVersion } from '@tauri-apps/api/app'
 import { Store } from '@tauri-apps/plugin-store'
 import {

--- a/src/renderer/lib/__tests__/tauri-release-notes.web.test.ts
+++ b/src/renderer/lib/__tests__/tauri-release-notes.web.test.ts
@@ -1,0 +1,213 @@
+/**
+ * Web-branch tests for tauri-release-notes.ts (CAP-3: Web UI entry parity).
+ *
+ * `getCurrentAppVersion`, `getLastSeenVersion`, and `setLastSeenVersion`
+ * branch on `isTauriContext()`: desktop calls Tauri's `getVersion()` +
+ * `@tauri-apps/plugin-store`; web reads the build-time `VITE_APP_VERSION`
+ * define (fallback `'0.0.0'`) + a localStorage-backed adapter. This file
+ * asserts, per the `log-api.test.ts` dual-branch pattern, that:
+ * - the WEB branch uses `import.meta.env.VITE_APP_VERSION` + localStorage
+ * - the DESKTOP branch uses `getVersion()` + the Tauri `Store`
+ * - `_resetReleaseNotesStoreForTesting` clears the shared singleton so each
+ *   test re-creates the adapter for the current branch.
+ *
+ * `fetchReleaseNotes` is already web-safe (browser-native `fetch`) and is
+ * covered by the existing `tauri-release-notes.test.ts`; this file does not
+ * re-test it.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { mockGetVersion, mockStoreLoad, mockIsTauriContext } = vi.hoisted(() => ({
+  mockGetVersion: vi.fn(),
+  mockStoreLoad: vi.fn(),
+  mockIsTauriContext: vi.fn()
+}))
+
+vi.mock('@tauri-apps/api/app', () => ({
+  getVersion: mockGetVersion
+}))
+
+vi.mock('@tauri-apps/plugin-store', () => ({
+  Store: {
+    load: mockStoreLoad
+  }
+}))
+
+vi.mock('../tauri-runtime', () => ({
+  isTauriContext: mockIsTauriContext
+}))
+
+import {
+  _resetReleaseNotesStoreForTesting,
+  getCurrentAppVersion,
+  getLastSeenVersion,
+  setLastSeenVersion
+} from '../tauri-release-notes'
+
+const STORE_FILE = 'whats-new.json'
+const LAST_SEEN_VERSION_KEY = 'whatsNew.lastSeenVersion'
+
+describe('tauri-release-notes (web vs desktop branch)', () => {
+  const mockTauriStore = {
+    get: vi.fn(),
+    set: vi.fn(),
+    delete: vi.fn(),
+    save: vi.fn()
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    _resetReleaseNotesStoreForTesting()
+    localStorage.clear()
+
+    mockStoreLoad.mockResolvedValue(mockTauriStore)
+    mockTauriStore.get.mockResolvedValue(null)
+    mockTauriStore.set.mockResolvedValue(undefined)
+    mockTauriStore.save.mockResolvedValue(undefined)
+
+    // `VITE_APP_VERSION` is undefined under Vitest (the `define` only applies
+    // in the web Vite build). Tests that want the env-constant path stub it
+    // explicitly with `vi.stubEnv`.
+    vi.stubEnv('VITE_APP_VERSION', '')
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  describe('getCurrentAppVersion', () => {
+    it('web: returns import.meta.env.VITE_APP_VERSION when defined', async () => {
+      mockIsTauriContext.mockReturnValue(false)
+      vi.stubEnv('VITE_APP_VERSION', '0.4.8')
+
+      await expect(getCurrentAppVersion()).resolves.toBe('0.4.8')
+      expect(mockGetVersion).not.toHaveBeenCalled()
+    })
+
+    it('web: falls back to "0.0.0" when VITE_APP_VERSION is undefined (test/SSR)', async () => {
+      mockIsTauriContext.mockReturnValue(false)
+      vi.stubEnv('VITE_APP_VERSION', '')
+
+      await expect(getCurrentAppVersion()).resolves.toBe('0.0.0')
+      expect(mockGetVersion).not.toHaveBeenCalled()
+    })
+
+    it('desktop: calls Tauri getVersion()', async () => {
+      mockIsTauriContext.mockReturnValue(true)
+      mockGetVersion.mockResolvedValue('0.4.8')
+
+      await expect(getCurrentAppVersion()).resolves.toBe('0.4.8')
+      expect(mockGetVersion).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('getLastSeenVersion (web branch: localStorage)', () => {
+    it('web: returns null when localStorage is empty (fresh install)', async () => {
+      mockIsTauriContext.mockReturnValue(false)
+
+      await expect(getLastSeenVersion()).resolves.toBeNull()
+      expect(mockStoreLoad).not.toHaveBeenCalled()
+    })
+
+    it('web: reads the stored value from the localStorage adapter', async () => {
+      mockIsTauriContext.mockReturnValue(false)
+      localStorage.setItem(`${STORE_FILE}::${LAST_SEEN_VERSION_KEY}`, JSON.stringify('0.4.7'))
+
+      await expect(getLastSeenVersion()).resolves.toBe('0.4.7')
+      expect(mockTauriStore.get).not.toHaveBeenCalled()
+    })
+
+    it('web: returns null when the stored JSON is corrupt', async () => {
+      mockIsTauriContext.mockReturnValue(false)
+      localStorage.setItem(`${STORE_FILE}::${LAST_SEEN_VERSION_KEY}`, '{not-json')
+
+      await expect(getLastSeenVersion()).resolves.toBeNull()
+    })
+
+    it('web: returns null when the stored value is absent (key missing)', async () => {
+      mockIsTauriContext.mockReturnValue(false)
+      localStorage.setItem(`${STORE_FILE}::other`, JSON.stringify('value'))
+
+      await expect(getLastSeenVersion()).resolves.toBeNull()
+    })
+  })
+
+  describe('setLastSeenVersion (web branch: localStorage)', () => {
+    it('web: writes the value to localStorage and is readable back', async () => {
+      mockIsTauriContext.mockReturnValue(false)
+
+      await setLastSeenVersion('0.4.8')
+
+      const raw = localStorage.getItem(`${STORE_FILE}::${LAST_SEEN_VERSION_KEY}`)
+      expect(raw).not.toBeNull()
+      expect(JSON.parse(raw!)).toBe('0.4.8')
+
+      // Round-trip: getLastSeenVersion reads what setLastSeenVersion wrote.
+      await expect(getLastSeenVersion()).resolves.toBe('0.4.8')
+      expect(mockTauriStore.set).not.toHaveBeenCalled()
+    })
+
+    it('web: preserves other keys when writing', async () => {
+      mockIsTauriContext.mockReturnValue(false)
+      localStorage.setItem(`${STORE_FILE}::other`, JSON.stringify('preserved'))
+      localStorage.setItem(`${STORE_FILE}::${LAST_SEEN_VERSION_KEY}`, JSON.stringify('0.4.6'))
+
+      await setLastSeenVersion('0.4.8')
+
+      expect(JSON.parse(localStorage.getItem(`${STORE_FILE}::${LAST_SEEN_VERSION_KEY}`)!)).toBe(
+        '0.4.8'
+      )
+      expect(JSON.parse(localStorage.getItem(`${STORE_FILE}::other`)!)).toBe('preserved')
+    })
+  })
+
+  describe('getLastSeenVersion / setLastSeenVersion (desktop branch: Tauri Store)', () => {
+    it('desktop: getLastSeenVersion reads from the Tauri Store', async () => {
+      mockIsTauriContext.mockReturnValue(true)
+      mockTauriStore.get.mockResolvedValue('0.4.6')
+
+      await expect(getLastSeenVersion()).resolves.toBe('0.4.6')
+      expect(mockStoreLoad).toHaveBeenCalledTimes(1)
+      expect(mockTauriStore.get).toHaveBeenCalledWith(LAST_SEEN_VERSION_KEY)
+    })
+
+    it('desktop: setLastSeenVersion writes + saves via the Tauri Store', async () => {
+      mockIsTauriContext.mockReturnValue(true)
+
+      await setLastSeenVersion('0.4.8')
+
+      expect(mockTauriStore.set).toHaveBeenCalledWith(LAST_SEEN_VERSION_KEY, '0.4.8')
+      expect(mockTauriStore.save).toHaveBeenCalledTimes(1)
+    })
+
+    it('desktop: reuses the loaded Store instance between calls', async () => {
+      mockIsTauriContext.mockReturnValue(true)
+      mockTauriStore.get.mockResolvedValue('0.4.6')
+
+      await getLastSeenVersion()
+      await getLastSeenVersion()
+
+      expect(mockStoreLoad).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('_resetReleaseNotesStoreForTesting', () => {
+    it('clears the shared singleton so the next getStore() re-creates the adapter', async () => {
+      // Desktop branch — creates a Tauri Store adapter.
+      mockIsTauriContext.mockReturnValue(true)
+      mockTauriStore.get.mockResolvedValue('0.4.6')
+      await getLastSeenVersion()
+      expect(mockStoreLoad).toHaveBeenCalledTimes(1)
+
+      // Reset + flip to web — the next call must NOT reuse the Tauri adapter.
+      _resetReleaseNotesStoreForTesting()
+      mockIsTauriContext.mockReturnValue(false)
+      localStorage.setItem(`${STORE_FILE}::${LAST_SEEN_VERSION_KEY}`, JSON.stringify('0.4.7'))
+      await getLastSeenVersion()
+
+      // No additional Tauri Store.load call (web uses localStorage).
+      expect(mockStoreLoad).toHaveBeenCalledTimes(1)
+    })
+  })
+})

--- a/src/renderer/lib/__tests__/tauri-session-api.test.ts
+++ b/src/renderer/lib/__tests__/tauri-session-api.test.ts
@@ -36,6 +36,13 @@ vi.mock('@tauri-apps/plugin-store', () => {
   }
 })
 
+// Desktop branch: these tests exercise the Tauri code path. Without this stub,
+// `isTauriContext()` is false under Vitest and the facades take the web branch
+// (covered separately by `tauri-session-api.web.test.ts`).
+vi.mock('../tauri-runtime', () => ({
+  isTauriContext: vi.fn(() => true)
+}))
+
 import type { SessionData } from '@shared/types/ipc.types'
 import { Store } from '@tauri-apps/plugin-store'
 import {
@@ -426,6 +433,23 @@ describe('tauriSessionApi', () => {
       }
 
       currentMockStore.get.mockResolvedValue(invalidData)
+
+      const result = await tauriSessionApi.hasSession()
+
+      expect(result.success).toBe(true)
+      if (result.success) {
+        expect(result.data).toBe(false)
+      }
+    })
+
+    it('should return false for a valid session with no terminals', async () => {
+      const sessionData = createValidSessionData()
+      const persisted = {
+        _version: 1,
+        data: { ...sessionData, terminals: [] }
+      }
+
+      currentMockStore.get.mockResolvedValue(persisted)
 
       const result = await tauriSessionApi.hasSession()
 

--- a/src/renderer/lib/__tests__/tauri-session-api.web.test.ts
+++ b/src/renderer/lib/__tests__/tauri-session-api.web.test.ts
@@ -1,0 +1,291 @@
+/**
+ * Web-branch tests for tauri-session-api.ts (CAP-3: Web UI entry parity).
+ *
+ * `getStore` branches on `isTauriContext()`: desktop calls
+ * `Store.load(STORE_FILE, ...)`; web constructs a `WebSessionStore` backed by
+ * flat composite localStorage keys (`${STORE_FILE}::${key}`, e.g.
+ * `termul-sessions.json::sessions/auto-save`), matching the spec's I/O
+ * matrix. All session methods (`save`/`restore`/`clear`/`flush`/`hasSession`)
+ * go through `getStore`, so branching in `getStore` makes them all web-aware.
+ *
+ * This file asserts, per the `log-api.test.ts` dual-branch pattern, that:
+ * - the WEB branch reads/writes localStorage and does NOT touch `Store.load`
+ * - the DESKTOP branch uses `Store.load` and does NOT touch localStorage
+ * - corrupted localStorage (schema mismatch) makes `hasSession` return false
+ *
+ * The existing `tauri-session-api.test.ts` covers the desktop branch's
+ * validation/error paths in depth; this file focuses on the web branch +
+ * the branch boundary.
+ */
+
+import type { SessionData } from '@shared/types/ipc.types'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { mockStoreLoad, mockIsTauriContext } = vi.hoisted(() => ({
+  mockStoreLoad: vi.fn(),
+  mockIsTauriContext: vi.fn()
+}))
+
+vi.mock('@tauri-apps/plugin-store', () => ({
+  Store: {
+    load: mockStoreLoad
+  }
+}))
+
+vi.mock('../tauri-runtime', () => ({
+  isTauriContext: mockIsTauriContext
+}))
+
+import { _resetStoreInstanceForTesting, tauriSessionApi } from '../tauri-session-api'
+
+const STORE_FILE = 'termul-sessions.json'
+const SESSION_KEY = 'sessions/auto-save'
+
+function validSessionData(): SessionData {
+  return {
+    timestamp: new Date().toISOString(),
+    terminals: [
+      {
+        id: 'term-1',
+        shell: 'bash',
+        cwd: '/home/user',
+        history: ['ls', 'cd /tmp']
+      }
+    ],
+    workspaces: [
+      {
+        projectId: 'proj-1',
+        activeTerminalId: 'term-1',
+        terminals: [{ id: 'term-1', shell: 'bash', cwd: '/home/user', history: [] }]
+      }
+    ]
+  }
+}
+
+describe('tauriSessionApi (web vs desktop branch)', () => {
+  const mockTauriStore = {
+    get: vi.fn(),
+    set: vi.fn(),
+    delete: vi.fn(),
+    save: vi.fn()
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    _resetStoreInstanceForTesting()
+    localStorage.clear()
+
+    mockStoreLoad.mockResolvedValue(mockTauriStore)
+    mockTauriStore.get.mockResolvedValue(undefined)
+    mockTauriStore.set.mockResolvedValue(undefined)
+    mockTauriStore.delete.mockResolvedValue(undefined)
+    mockTauriStore.save.mockResolvedValue(undefined)
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  describe('hasSession (web branch: localStorage)', () => {
+    it('web: returns false when localStorage is empty', async () => {
+      mockIsTauriContext.mockReturnValue(false)
+
+      const result = await tauriSessionApi.hasSession()
+
+      expect(result).toEqual({ success: true, data: false })
+      expect(mockStoreLoad).not.toHaveBeenCalled()
+    })
+
+    it('web: returns true when a valid session is persisted', async () => {
+      mockIsTauriContext.mockReturnValue(false)
+      const data = validSessionData()
+      const persisted = { _version: 1, data }
+      localStorage.setItem(`${STORE_FILE}::${SESSION_KEY}`, JSON.stringify(persisted))
+
+      const result = await tauriSessionApi.hasSession()
+
+      expect(result).toEqual({ success: true, data: true })
+      expect(mockTauriStore.get).not.toHaveBeenCalled()
+    })
+
+    it('web: returns false when the persisted session has no terminals', async () => {
+      mockIsTauriContext.mockReturnValue(false)
+      const data = validSessionData()
+      const persisted = { _version: 1, data: { ...data, terminals: [] } }
+      localStorage.setItem(`${STORE_FILE}::${SESSION_KEY}`, JSON.stringify(persisted))
+
+      const result = await tauriSessionApi.hasSession()
+
+      expect(result).toEqual({ success: true, data: false })
+    })
+
+    it('web: returns false when localStorage holds corrupted (schema-mismatch) data', async () => {
+      mockIsTauriContext.mockReturnValue(false)
+      const corrupted = {
+        _version: 1,
+        data: {
+          timestamp: 'bad',
+          terminals: 'not-an-array',
+          workspaces: []
+        }
+      }
+      localStorage.setItem(`${STORE_FILE}::${SESSION_KEY}`, JSON.stringify(corrupted))
+
+      const result = await tauriSessionApi.hasSession()
+
+      expect(result).toEqual({ success: true, data: false })
+    })
+
+    it('web: returns false when the stored JSON is unparseable', async () => {
+      mockIsTauriContext.mockReturnValue(false)
+      localStorage.setItem(`${STORE_FILE}::${SESSION_KEY}`, '{not-json')
+
+      const result = await tauriSessionApi.hasSession()
+
+      expect(result).toEqual({ success: true, data: false })
+    })
+  })
+
+  describe('save + restore (web branch: localStorage round-trip)', () => {
+    it('web: save writes to localStorage; restore reads it back', async () => {
+      mockIsTauriContext.mockReturnValue(false)
+      const data = validSessionData()
+
+      const saveResult = await tauriSessionApi.save(data)
+      expect(saveResult).toEqual({ success: true, data: undefined })
+      expect(mockTauriStore.set).not.toHaveBeenCalled()
+
+      const restoreResult = await tauriSessionApi.restore()
+      expect(restoreResult.success).toBe(true)
+      if (restoreResult.success) {
+        expect(restoreResult.data.terminals).toEqual(data.terminals)
+        expect(restoreResult.data.workspaces).toEqual(data.workspaces)
+      }
+    })
+
+    it('web: restore returns SESSION_NOT_FOUND when nothing saved', async () => {
+      mockIsTauriContext.mockReturnValue(false)
+
+      const result = await tauriSessionApi.restore()
+
+      expect(result.success).toBe(false)
+      if (!result.success) {
+        expect(result.code).toBe('SESSION_NOT_FOUND')
+      }
+    })
+
+    it('web: save rejects invalid session data with SESSION_INVALID', async () => {
+      mockIsTauriContext.mockReturnValue(false)
+      const invalid = {
+        timestamp: 'x',
+        terminals: 'not-array',
+        workspaces: []
+      } as unknown as SessionData
+
+      const result = await tauriSessionApi.save(invalid)
+
+      expect(result.success).toBe(false)
+      if (!result.success) {
+        expect(result.code).toBe('SESSION_INVALID')
+      }
+    })
+
+    it('web: save returns SESSION_STORE_ERROR when the localStorage write fails (quota)', async () => {
+      mockIsTauriContext.mockReturnValue(false)
+      const data = validSessionData()
+      const spy = vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+        throw new Error('QuotaExceededError')
+      })
+
+      try {
+        const result = await tauriSessionApi.save(data)
+
+        expect(result.success).toBe(false)
+        if (!result.success) {
+          expect(result.code).toBe('SESSION_STORE_ERROR')
+        }
+      } finally {
+        spy.mockRestore()
+      }
+    })
+  })
+
+  describe('clear (web branch: localStorage)', () => {
+    it('web: clear removes the session key from localStorage', async () => {
+      mockIsTauriContext.mockReturnValue(false)
+      const data = validSessionData()
+      await tauriSessionApi.save(data)
+
+      const result = await tauriSessionApi.clear()
+
+      expect(result).toEqual({ success: true, data: undefined })
+      expect(localStorage.getItem(`${STORE_FILE}::${SESSION_KEY}`)).toBeNull()
+      expect(mockTauriStore.delete).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('flush (web branch: localStorage)', () => {
+    it('web: flush succeeds with no pending data (localStorage is sync, save is no-op)', async () => {
+      mockIsTauriContext.mockReturnValue(false)
+
+      const result = await tauriSessionApi.flush()
+
+      expect(result).toEqual({ success: true, data: undefined })
+    })
+  })
+
+  describe('desktop branch: Tauri Store', () => {
+    it('desktop: hasSession reads from the Tauri Store (not localStorage)', async () => {
+      mockIsTauriContext.mockReturnValue(true)
+      mockTauriStore.get.mockResolvedValue(undefined)
+
+      await tauriSessionApi.hasSession()
+
+      expect(mockStoreLoad).toHaveBeenCalledTimes(1)
+      expect(mockTauriStore.get).toHaveBeenCalledWith(SESSION_KEY)
+      // localStorage must not be touched on the desktop branch.
+      expect(localStorage.getItem(STORE_FILE)).toBeNull()
+    })
+
+    it('desktop: save writes via the Tauri Store', async () => {
+      mockIsTauriContext.mockReturnValue(true)
+      const data = validSessionData()
+
+      await tauriSessionApi.save(data)
+
+      expect(mockTauriStore.set).toHaveBeenCalledWith(
+        SESSION_KEY,
+        expect.objectContaining({ _version: 1, data: expect.objectContaining({}) })
+      )
+      expect(mockTauriStore.save).toHaveBeenCalled()
+      expect(localStorage.getItem(STORE_FILE)).toBeNull()
+    })
+
+    it('desktop: clear deletes via the Tauri Store', async () => {
+      mockIsTauriContext.mockReturnValue(true)
+
+      await tauriSessionApi.clear()
+
+      expect(mockTauriStore.delete).toHaveBeenCalledWith(SESSION_KEY)
+      expect(mockTauriStore.save).toHaveBeenCalled()
+    })
+  })
+
+  describe('_resetStoreInstanceForTesting (branch flip)', () => {
+    it('clears the shared singleton so the next call re-creates the adapter for the new branch', async () => {
+      // Desktop branch — creates a Tauri Store adapter.
+      mockIsTauriContext.mockReturnValue(true)
+      mockTauriStore.get.mockResolvedValue(undefined)
+      await tauriSessionApi.hasSession()
+      expect(mockStoreLoad).toHaveBeenCalledTimes(1)
+
+      // Reset + flip to web — must NOT reuse the Tauri adapter.
+      _resetStoreInstanceForTesting()
+      mockIsTauriContext.mockReturnValue(false)
+      await tauriSessionApi.hasSession()
+
+      // No additional Store.load call (web uses localStorage).
+      expect(mockStoreLoad).toHaveBeenCalledTimes(1)
+    })
+  })
+})

--- a/src/renderer/lib/__tests__/tauri-session-api.web.test.ts
+++ b/src/renderer/lib/__tests__/tauri-session-api.web.test.ts
@@ -222,6 +222,26 @@ describe('tauriSessionApi (web vs desktop branch)', () => {
       expect(localStorage.getItem(`${STORE_FILE}::${SESSION_KEY}`)).toBeNull()
       expect(mockTauriStore.delete).not.toHaveBeenCalled()
     })
+
+    it('web: clear returns SESSION_STORE_ERROR when localStorage.removeItem fails', async () => {
+      mockIsTauriContext.mockReturnValue(false)
+      const data = validSessionData()
+      await tauriSessionApi.save(data)
+      const spy = vi.spyOn(Storage.prototype, 'removeItem').mockImplementation(() => {
+        throw new Error('SecurityError')
+      })
+
+      try {
+        const result = await tauriSessionApi.clear()
+
+        expect(result.success).toBe(false)
+        if (!result.success) {
+          expect(result.code).toBe('SESSION_STORE_ERROR')
+        }
+      } finally {
+        spy.mockRestore()
+      }
+    })
   })
 
   describe('flush (web branch: localStorage)', () => {

--- a/src/renderer/lib/tauri-notification-api.ts
+++ b/src/renderer/lib/tauri-notification-api.ts
@@ -77,7 +77,13 @@ async function performInitNotificationPermissions(): Promise<void> {
     }
 
     const result = await Notification.requestPermission()
-    permissionGranted = result === 'granted'
+    // Cache grants, not denials: `Notification.permission` can change via
+    // browser settings, and a stale `false` would suppress a later grant.
+    // Leaving `null` lets `sendDesktopNotification` re-check on the next send
+    // (`requestPermission` is a no-op-prompt once the user has decided).
+    if (result === 'granted') {
+      permissionGranted = true
+    }
   } catch (error) {
     // Swallow — best-effort facade; never throw to the UI on permission failure.
     console.error('[Notification] Failed to request web notification permission:', error)

--- a/src/renderer/lib/tauri-notification-api.ts
+++ b/src/renderer/lib/tauri-notification-api.ts
@@ -1,11 +1,14 @@
 /**
  * Tauri Notification API adapter
  *
- * Provides desktop notification capabilities through the Tauri notification plugin.
- * Falls back gracefully outside Tauri runtime (tests, browser context).
+ * Provides desktop notification capabilities. Branches on `isTauriContext()`:
+ * - Desktop: `@tauri-apps/plugin-notification` (OS notification).
+ * - Web/remote: the Web Notifications API (`Notification.requestPermission()`
+ *   + `new Notification(title, { body })`).
  *
- * Permission is requested eagerly at import time (when the app loads).
- * If the user denies permission, the denial is cached so we don't re-prompt.
+ * Permission is requested eagerly at app startup (`initNotificationPermissions`
+ * is called from `AppEffects` / `TauriApp`'s `AppEffects`). If the user denies
+ * permission, the denial is cached so we don't re-prompt.
  */
 import {
   isPermissionGranted,
@@ -18,30 +21,66 @@ import { isTauriContext } from './tauri-runtime'
 let permissionGranted: boolean | null = null
 
 /**
+ * In-flight initialization promise. The startup effect and a lazy init from
+ * `sendDesktopNotification` may race while the first permission request is
+ * pending; deduping to a single promise avoids a second OS/browser prompt.
+ */
+let permissionInitPromise: Promise<void> | null = null
+
+/**
  * Initialize notification permissions.
  * Call this once during app startup to request permission early.
  * This avoids surprising the user with a permission prompt when a terminal exits.
  */
-export async function initNotificationPermissions(): Promise<void> {
-  if (!isTauriContext()) {
+export function initNotificationPermissions(): Promise<void> {
+  if (!permissionInitPromise) {
+    permissionInitPromise = performInitNotificationPermissions().finally(() => {
+      permissionInitPromise = null
+    })
+  }
+  return permissionInitPromise
+}
+
+async function performInitNotificationPermissions(): Promise<void> {
+  if (isTauriContext()) {
+    try {
+      const granted = await isPermissionGranted()
+
+      if (granted) {
+        permissionGranted = true
+        return
+      }
+
+      // Permission is denied (not "not determined" on some platforms) or default
+      // Try requesting once. If denied, cache it so we don't re-prompt.
+      const result = await requestPermission()
+      permissionGranted = result === 'granted'
+    } catch (error) {
+      console.error('[Notification] Failed to initialize notification permissions:', error)
+      permissionGranted = false
+    }
+    return
+  }
+
+  // Web/remote: Web Notifications API. Guard `typeof Notification` for SSR /
+  // test environments (jsdom does not expose `Notification`).
+  if (typeof Notification === 'undefined') {
     permissionGranted = false
     return
   }
 
   try {
-    const granted = await isPermissionGranted()
-
-    if (granted) {
+    // `Notification.permission` may already be 'granted' (no prompt needed).
+    if (Notification.permission === 'granted') {
       permissionGranted = true
       return
     }
 
-    // Permission is denied (not "not determined" on some platforms) or default
-    // Try requesting once. If denied, cache it so we don't re-prompt.
-    const result = await requestPermission()
+    const result = await Notification.requestPermission()
     permissionGranted = result === 'granted'
   } catch (error) {
-    console.error('[Notification] Failed to initialize notification permissions:', error)
+    // Swallow — best-effort facade; never throw to the UI on permission failure.
+    console.error('[Notification] Failed to request web notification permission:', error)
     permissionGranted = false
   }
 }
@@ -54,13 +93,6 @@ export async function initNotificationPermissions(): Promise<void> {
  * @param body - Notification body text (e.g., terminal name)
  */
 export async function sendDesktopNotification(title: string, body: string): Promise<void> {
-  if (!isTauriContext()) {
-    if (import.meta.env.DEV) {
-      console.log('[Notification] Skipping notification outside Tauri runtime:', { title, body })
-    }
-    return
-  }
-
   if (permissionGranted === null) {
     // Permission not yet initialized — try to init now
     await initNotificationPermissions()
@@ -73,9 +105,32 @@ export async function sendDesktopNotification(title: string, body: string): Prom
     return
   }
 
-  try {
-    sendNotification({ title, body })
-  } catch (error) {
-    console.error('[Notification] Failed to send notification:', error)
+  if (isTauriContext()) {
+    try {
+      sendNotification({ title, body })
+    } catch (error) {
+      console.error('[Notification] Failed to send notification:', error)
+    }
+    return
   }
+
+  // Web/remote: Web Notifications API. Guard `typeof Notification` again for
+  // SSR/test safety even though `initNotificationPermissions` already checked.
+  if (typeof Notification === 'undefined') return
+
+  try {
+    new Notification(title, { body })
+  } catch (error) {
+    // Swallow — best-effort facade. A notification failure must never throw.
+    console.error('[Notification] Failed to send web notification:', error)
+  }
+}
+
+/**
+ * @internal Testing only — reset the cached permission state so each test can
+ * re-exercise the `isTauriContext()` branch from a clean slate.
+ */
+export function _resetNotificationPermissionForTesting(): void {
+  permissionGranted = null
+  permissionInitPromise = null
 }

--- a/src/renderer/lib/tauri-opener-api.ts
+++ b/src/renderer/lib/tauri-opener-api.ts
@@ -4,11 +4,19 @@
  * Provides functions for opening files with external applications
  * and revealing items in the system file manager.
  *
- * Uses @tauri-apps/plugin-opener for cross-platform file operations.
+ * Uses @tauri-apps/plugin-opener for cross-platform file operations on the
+ * desktop. On web/remote, `openUrlWithSystemBrowser` branches to
+ * `window.open(url, '_blank', 'noopener')` so the "View on GitHub" button in
+ * `WhatsNewModal` works in a browser. The other two methods
+ * (`openWithExternalApp`, `revealInFileManager`) have no browser equivalent
+ * and stay desktop-only — they reject when called on web (the stubbed plugin
+ * throws `tauriUnavailable`).
  */
 
 import type { IpcResult } from '@shared/types/ipc.types'
 import { openPath, openUrl, revealItemInDir } from '@tauri-apps/plugin-opener'
+
+import { isTauriContext } from './tauri-runtime'
 
 export interface OpenerApi {
   openWithExternalApp: (path: string) => Promise<IpcResult<void>>
@@ -32,6 +40,26 @@ function createTauriOpenerApi(): OpenerApi {
     },
 
     async openUrlWithSystemBrowser(url: string): Promise<IpcResult<void>> {
+      if (!isTauriContext()) {
+        // Web/remote: open a new tab. A popup blocker may return null; that is
+        // not an error worth surfacing (best-effort facade). Swallow and report
+        // success so the caller (e.g. WhatsNewModal) doesn't show a broken UX.
+        //
+        // Scheme guard: only hand `http(s):`/`mailto:` URLs to `window.open`.
+        // `javascript:`/`data:`/`file:` would execute script or navigate the
+        // current browsing context — a code-execution vector the desktop path
+        // (OS handler) does not have. Non-conforming schemes no-op silently.
+        if (!/^(https?:|mailto:)/i.test(url)) {
+          return { success: true, data: undefined }
+        }
+        try {
+          window.open(url, '_blank', 'noopener')
+        } catch {
+          // Swallow — SecurityError or popup blocker. Best-effort.
+        }
+        return { success: true, data: undefined }
+      }
+
       try {
         await openUrl(url)
         return { success: true, data: undefined }

--- a/src/renderer/lib/tauri-release-notes.ts
+++ b/src/renderer/lib/tauri-release-notes.ts
@@ -1,21 +1,89 @@
 import { getVersion } from '@tauri-apps/api/app'
 import { Store } from '@tauri-apps/plugin-store'
 
+import { isTauriContext } from './tauri-runtime'
+
 const STORE_FILE = 'whats-new.json'
 const LAST_SEEN_VERSION_KEY = 'whatsNew.lastSeenVersion'
 
 const GITHUB_RELEASE_BY_TAG_URL = 'https://api.github.com/repos/gnoviawan/termul/releases/tags'
 const RELEASE_FETCH_TIMEOUT_MS = 8000
 
-let storeInstance: Store | null = null
+/**
+ * Adapter shape shared by the Tauri `Store` and the web localStorage-backed
+ * store. Both expose `get`/`set`/`save` so the facade methods can branch in
+ * `getStore` and the rest of the call site is transport-agnostic.
+ */
+interface ReleaseNotesStore {
+  get<T>(key: string): Promise<T | undefined>
+  set(key: string, value: unknown): Promise<void>
+  save(): Promise<void>
+}
 
-async function getStore(): Promise<Store> {
+/**
+ * Web-only localStorage-backed store adapter (CAP-3). Mirrors the Tauri
+ * `Store` shape over flat composite localStorage keys shaped
+ * `${STORE_FILE}::${key}` (e.g. `whats-new.json::whatsNew.lastSeenVersion`),
+ * matching the spec's I/O matrix. Each logical key is its own localStorage
+ * entry; there is no shared envelope object.
+ *
+ * `save()` is a no-op — localStorage writes are synchronous, so `set`
+ * already persists. All ops swallow `QuotaExceededError`/`SecurityError`/JSON
+ * parse failures and degrade silently (the facade is best-effort: the
+ * "what's new" popup must never throw on persistence failure).
+ */
+class WebReleaseNotesStore implements ReleaseNotesStore {
+  private readonly storageKey: string
+
+  constructor(storageKey: string) {
+    this.storageKey = storageKey
+  }
+
+  private compositeKey(key: string): string {
+    return `${this.storageKey}::${key}`
+  }
+
+  async get<T>(key: string): Promise<T | undefined> {
+    if (typeof localStorage === 'undefined') return undefined
+    try {
+      const raw = localStorage.getItem(this.compositeKey(key))
+      if (raw === null) return undefined
+      return JSON.parse(raw) as T
+    } catch {
+      // Corrupt JSON / SecurityError (private mode) — degrade silently.
+      return undefined
+    }
+  }
+
+  async set(key: string, value: unknown): Promise<void> {
+    if (typeof localStorage === 'undefined') return
+    try {
+      localStorage.setItem(this.compositeKey(key), JSON.stringify(value))
+    } catch {
+      // QuotaExceededError / SecurityError — drop the write silently. The UI
+      // must never throw on persistence; reads return last-good or empty.
+    }
+  }
+
+  async save(): Promise<void> {
+    // no-op — localStorage is synchronous; `set` already persisted.
+  }
+}
+
+let storeInstance: ReleaseNotesStore | null = null
+
+async function getStore(): Promise<ReleaseNotesStore> {
   if (storeInstance) return storeInstance
 
-  storeInstance = await Store.load(STORE_FILE, {
-    autoSave: false,
-    defaults: {}
-  })
+  // Ternary (rather than if/else) so TypeScript's control-flow analysis sees
+  // exactly one branch assigns `storeInstance` — the post-block type narrows
+  // to `ReleaseNotesStore` (not `| null`).
+  storeInstance = isTauriContext()
+    ? await Store.load(STORE_FILE, {
+        autoSave: false,
+        defaults: {}
+      })
+    : new WebReleaseNotesStore(STORE_FILE)
 
   return storeInstance
 }
@@ -68,9 +136,19 @@ export function compareVersions(a: string, b: string): number {
 
 /**
  * Get the running application version.
+ *
+ * Branches on `isTauriContext()`: desktop reads via Tauri's `getVersion()`;
+ * web reads the build-time `import.meta.env.VITE_APP_VERSION` define injected
+ * by `vite.config.web.ts`. Falls back to `'0.0.0'` when the define is absent
+ * (e.g. under Vitest, or a misconfigured build) so `compareVersions` treats it
+ * as same/downgrade and never pops "what's new" on a stale value.
  */
 export async function getCurrentAppVersion(): Promise<string> {
-  return getVersion()
+  if (isTauriContext()) {
+    return getVersion()
+  }
+  const v = import.meta.env.VITE_APP_VERSION
+  return typeof v === 'string' && v.length > 0 ? v : '0.0.0'
 }
 
 /**
@@ -137,5 +215,8 @@ export async function fetchReleaseNotes(version: string): Promise<ReleaseNotes |
 }
 
 export function _resetReleaseNotesStoreForTesting(): void {
+  // Nils the shared singleton so the next `getStore()` call re-creates the
+  // adapter for the current `isTauriContext()` branch. Covers both the Tauri
+  // `Store` and the web `WebReleaseNotesStore` since they share this variable.
   storeInstance = null
 }

--- a/src/renderer/lib/tauri-session-api.ts
+++ b/src/renderer/lib/tauri-session-api.ts
@@ -1,7 +1,12 @@
 /**
  * Tauri Session API Adapter
  *
- * Provides session persistence functionality using Tauri's plugin-store.
+ * Provides session persistence functionality. Branches on `isTauriContext()`:
+ * - Desktop: `@tauri-apps/plugin-store` (`Store.load(STORE_FILE, ...)`).
+ * - Web/remote: a localStorage-backed adapter over flat composite keys
+ *   shaped `${STORE_FILE}::${key}` (e.g. `termul-sessions.json::sessions/auto-save`),
+ *   matching the spec's I/O matrix.
+ *
  * Follows the same pattern as tauri-persistence-api.ts for consistency.
  *
  * Features:
@@ -14,6 +19,8 @@
 import type { IpcResult, SessionApi, SessionData } from '@shared/types/ipc.types'
 import { IpcErrorCodes } from '@shared/types/ipc.types'
 import { Store } from '@tauri-apps/plugin-store'
+
+import { isTauriContext } from './tauri-runtime'
 
 // ============================================================================
 // Constants
@@ -33,11 +40,87 @@ interface PersistedSession {
   data: SessionData
 }
 
+/**
+ * Adapter shape shared by the Tauri `Store` and the web localStorage-backed
+ * store. Both expose `get`/`set`/`delete`/`save` so the session methods can
+ * branch in `getStore` and stay transport-agnostic. Signatures mirror the
+ * real Tauri `Store` (`delete` returns `Promise<boolean>` — whether the key
+ * was present) so `Store` is structurally assignable to this interface.
+ */
+interface SessionStoreAdapter {
+  get<T>(key: string): Promise<T | undefined>
+  set(key: string, value: unknown): Promise<void>
+  delete(key: string): Promise<boolean>
+  save(): Promise<void>
+}
+
+/**
+ * Web-only localStorage-backed session store adapter (CAP-3). Mirrors the
+ * Tauri `Store` shape over flat composite localStorage keys shaped
+ * `${STORE_FILE}::${key}` (e.g. `termul-sessions.json::sessions/auto-save`),
+ * matching the spec's I/O matrix. Each logical key is its own localStorage
+ * entry; there is no shared envelope object.
+ *
+ * `save()` is a no-op — localStorage writes are synchronous, so `set`
+ * already persists. Reads swallow `QuotaExceededError`/`SecurityError`/JSON
+ * parse failures and degrade to `undefined` (best-effort on read). Writes do
+ * NOT swallow — a `QuotaExceededError` on `set` propagates so `save` can
+ * surface a `SESSION_STORE_ERROR` (the session store is not best-effort: a
+ * silent write failure would make crash-recovery believe a session persisted
+ * that did not).
+ */
+class WebSessionStore implements SessionStoreAdapter {
+  private readonly storageKey: string
+
+  constructor(storageKey: string) {
+    this.storageKey = storageKey
+  }
+
+  private compositeKey(key: string): string {
+    return `${this.storageKey}::${key}`
+  }
+
+  async get<T>(key: string): Promise<T | undefined> {
+    if (typeof localStorage === 'undefined') return undefined
+    try {
+      const raw = localStorage.getItem(this.compositeKey(key))
+      if (raw === null) return undefined
+      return JSON.parse(raw) as T
+    } catch {
+      // Corrupt JSON / SecurityError (private mode) — degrade silently.
+      return undefined
+    }
+  }
+
+  async set(key: string, value: unknown): Promise<void> {
+    if (typeof localStorage === 'undefined') return
+    // Propagate QuotaExceededError/SecurityError so `save` reports a
+    // SESSION_STORE_ERROR instead of a false success.
+    localStorage.setItem(this.compositeKey(key), JSON.stringify(value))
+  }
+
+  async delete(key: string): Promise<boolean> {
+    if (typeof localStorage === 'undefined') return false
+    const composite = this.compositeKey(key)
+    const had = localStorage.getItem(composite) !== null
+    try {
+      localStorage.removeItem(composite)
+    } catch {
+      // SecurityError (private mode) — degrade silently.
+    }
+    return had
+  }
+
+  async save(): Promise<void> {
+    // no-op — localStorage is synchronous; `set` already persisted.
+  }
+}
+
 // ============================================================================
 // State
 // ============================================================================
 
-let storeInstance: Store | null = null
+let storeInstance: SessionStoreAdapter | null = null
 let autoSaveTimeout: ReturnType<typeof setTimeout> | null = null
 let pendingAutoSaveData: SessionData | null = null
 
@@ -45,10 +128,16 @@ let pendingAutoSaveData: SessionData | null = null
 // Store Management
 // ============================================================================
 
-async function getStore(): Promise<Store> {
-  if (!storeInstance) {
-    storeInstance = await Store.load(STORE_FILE, { autoSave: false, defaults: {} })
-  }
+async function getStore(): Promise<SessionStoreAdapter> {
+  if (storeInstance) return storeInstance
+
+  // Ternary (rather than if/else) so TypeScript's control-flow analysis sees
+  // exactly one branch assigns `storeInstance` — the post-block type narrows
+  // to `SessionStoreAdapter` (not `| null`).
+  storeInstance = isTauriContext()
+    ? await Store.load(STORE_FILE, { autoSave: false, defaults: {} })
+    : new WebSessionStore(STORE_FILE)
+
   return storeInstance
 }
 
@@ -262,6 +351,11 @@ async function hasSession(): Promise<IpcResult<boolean>> {
 
       // Return false if data is invalid
       if (!validateSessionData(sessionData)) {
+        return { success: true, data: false }
+      }
+
+      // A session with no terminals has nothing to restore — return false.
+      if (sessionData.terminals.length === 0) {
         return { success: true, data: false }
       }
     }

--- a/src/renderer/lib/tauri-session-api.ts
+++ b/src/renderer/lib/tauri-session-api.ts
@@ -102,12 +102,17 @@ class WebSessionStore implements SessionStoreAdapter {
   async delete(key: string): Promise<boolean> {
     if (typeof localStorage === 'undefined') return false
     const composite = this.compositeKey(key)
-    const had = localStorage.getItem(composite) !== null
+    let had: boolean
     try {
-      localStorage.removeItem(composite)
+      had = localStorage.getItem(composite) !== null
     } catch {
-      // SecurityError (private mode) — degrade silently.
+      // Corrupt access / SecurityError on read — degrade silently, matching `get()`.
+      return false
     }
+    // Propagate removeItem failures so `clear()` can surface a
+    // SESSION_STORE_ERROR instead of reporting a false success (the same
+    // no-silent-write-failure contract `set()` upholds).
+    localStorage.removeItem(composite)
     return had
   }
 

--- a/src/renderer/main.tsx
+++ b/src/renderer/main.tsx
@@ -52,11 +52,15 @@ const root = createRoot(document.getElementById('root')!)
 // runs in parallel with React bootstrap (issue #378). Does not pull Tauri.
 preloadCommonLanguages()
 
+// Forward uncaught renderer errors + unhandled rejections to the backend log
+// file so production crashes are diagnosable (issue #244). Runs in BOTH modes:
+// - Tauri: invokes the `log_frontend_error` command (desktop log file).
+// - Web: POSTs to `/log/frontend-error` (the web branch in `logFrontendError`
+//   was added in Phase 2.3; the server reuses the same sanitization + tracing).
+// `installGlobalErrorForwarding` is idempotent and a no-op outside a browser.
+installGlobalErrorForwarding()
+
 if (isTauriContext()) {
-  // Forward uncaught renderer errors + unhandled rejections to the backend log
-  // file so production crashes are diagnosable (issue #244). Tauri-only: the
-  // browser/web path has no backend command to call.
-  installGlobalErrorForwarding()
   void import('./TauriApp')
     .then(({ default: TauriApp }) => {
       root.render(<TauriApp />)

--- a/src/renderer/vite-env.d.ts
+++ b/src/renderer/vite-env.d.ts
@@ -5,6 +5,14 @@ interface ImportMetaEnv {
   readonly VITE_TERMUL_UPDATE_MODE?: 'tauri' | 'aur'
   /** Set `true` by `vite.config.web.ts` for the browser/headless client build. */
   readonly TERMUL_WEB?: boolean
+  /**
+   * Build-time app version (CAP-3). Injected by `vite.config.web.ts`
+   * `define` from `package.json#version` so `getCurrentAppVersion()` can
+   * return the running version on the web client (desktop uses Tauri's
+   * `getVersion`). Falls back to `'0.0.0'` at runtime when undefined
+   * (e.g. under Vitest, where the define is not applied).
+   */
+  readonly VITE_APP_VERSION?: string
 }
 
 interface ImportMeta {

--- a/vite.config.web.ts
+++ b/vite.config.web.ts
@@ -104,7 +104,13 @@ export default defineConfig({
   define: {
     'import.meta.env.PACKAGE_VERSION': JSON.stringify(pkg.version),
     // Feature-gate signal for Story 1.5+ (desktop-only path exclusion).
-    'import.meta.env.TERMUL_WEB': JSON.stringify(true)
+    'import.meta.env.TERMUL_WEB': JSON.stringify(true),
+    // CAP-3: build-time app version for `getCurrentAppVersion()` web branch
+    // (tauri-release-notes.ts). Desktop reads version via Tauri `getVersion`;
+    // the web client has no Tauri runtime, so inject the package version as a
+    // string literal here. Tests run under Vitest (not this config) and read
+    // `undefined`, which the facade downgrades to `'0.0.0'`.
+    'import.meta.env.VITE_APP_VERSION': JSON.stringify(pkg.version)
   },
 
   build: {


### PR DESCRIPTION
## Summary

The web entry (`src/renderer/App.tsx`) lacks the resilience features the desktop entry (`TauriApp.tsx`) mounts — no `ErrorBoundary`, no `WhatsNewModal`, no crash-recovery/terminal-exit-notification, and no eager notification-permission init. Web users get uncaught render errors tearing down the app, no "what's new" popup, no crash-recovery, and no terminal-exit notifications. The four facades these features depend on (`tauri-notification-api`, `tauri-release-notes`, `tauri-opener-api`, `tauri-session-api`) no-op on `!isTauriContext()`, so even mounting the hooks would be inert.

This PR converts `App.tsx` to a block body mirroring `TauriApp.tsx`'s resilience surface (ErrorBoundary wrap + WhatsNewModal + the portable hook subset + `initNotificationPermissions`), and adds `isTauriContext()` web branches to the four facades using browser-native APIs (Web Notifications API, localStorage composite-key adapters, `window.open`, `import.meta.env`). It also moves `installGlobalErrorForwarding()` out of the Tauri-only branch in `main.tsx` so the web client forwards `window.onerror`/`unhandledrejection` to the server log.

## Related Issue

Refs #432 — Web ACP Agent: headless server + mobile-responsive browser client. CAP-3 is the web UI entry parity phase of this epic; the epic also covers the SSH bridge, mobile shell entry points, and streaming search, which remain separate follow-up iterations.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## What Changed

- `src/renderer/App.tsx`: converted arrow-expression body to a block body; wrapped children in `<ErrorBoundary context="App Root">`; mounted `<WhatsNewModal>` as a sibling of `<RouterProvider>`; added `useCrashRecovery`, `useTerminalExitNotification`, `useRemoteProjects`, and an `initNotificationPermissions()` `useEffect` to `AppEffects`.
- `src/renderer/main.tsx`: moved `installGlobalErrorForwarding()` out of the Tauri-only branch so it runs in both desktop and web modes; updated the stale comment.
- `src/renderer/lib/tauri-notification-api.ts`: replaced the no-op `!isTauriContext()` branches with the Web Notifications API (`Notification.requestPermission()` + `new Notification(...)`); added a single-flight in-flight promise dedupe so concurrent `initNotificationPermissions()` calls (startup effect vs. lazy init in `sendDesktopNotification`) don't double-prompt; a web denial is not cached so a later grant via browser settings is picked up.
- `src/renderer/lib/tauri-release-notes.ts`: added web branches for `getCurrentAppVersion` (`import.meta.env.VITE_APP_VERSION` with `'0.0.0'` fallback) and a localStorage-backed adapter over flat composite keys (`whats-new.json::whatsNew.lastSeenVersion`); `fetchReleaseNotes` is already web-safe.
- `src/renderer/lib/tauri-opener-api.ts`: added a web branch to `openUrlWithSystemBrowser` (`window.open(url, '_blank', 'noopener')`) with an `http(s)`/`mailto` scheme guard (refuses `javascript:`/`data:`/`file:`); the other two methods stay desktop-only.
- `src/renderer/lib/tauri-session-api.ts`: added a web branch using a localStorage-backed adapter over flat composite keys (`termul-sessions.json::sessions/auto-save`); `hasSession` returns false for sessions with empty `terminals[]`; `save`/`clear` propagate `QuotaExceededError`/`SecurityError` as `SESSION_STORE_ERROR` instead of false success.
- `vite.config.web.ts`: added `define: { 'import.meta.env.VITE_APP_VERSION': JSON.stringify(pkg.version) }`.
- `src/renderer/vite-env.d.ts`: added `VITE_APP_VERSION` env typing.
- New dual-branch tests: `tauri-notification-api.web.test.ts`, `tauri-release-notes.web.test.ts`, `tauri-opener-api.web.test.ts`, `tauri-session-api.web.test.ts` — toggle `isTauriContext`, assert each branch calls the right API.
- Extended `App.test.tsx` with CAP-3 assertions (ErrorBoundary wrap, WhatsNewModal mount, AppEffects hooks) and an open-state wiring test (`useWhatsNew` `isOpen:true` → `data-open="true"` + `data-version` passthrough).

## How It Was Tested

- [x] Unit tests — `bun run test` (Vitest): 248 files / 2980 tests passed, 42 skipped.
- [x] Lint — `bun run ci` (Biome, `--diagnostic-level=error`): green, 0 errors on changed files.
- [x] Typecheck — `bun run typecheck` (node + web + test configs): pass.
- [x] Web build — `bun run build:web`: succeeds, `dist-web/index.html` produced.
- [x] Rust checks (`cargo clippy --all-targets -- -D warnings` + `cargo test`): passed on CI (Linux); no Rust changes in this PR.

## CI & Review Gate

- [x] All CI checks pass
- [x] Claude code review resolved (Claude workflow disabled_manually; CodeRabbit review addressed — no CHANGES_REQUESTED, all inline threads replied)

## Checklist

- [x] Code follows the project's style guide (Biome, 2-space, no semicolons, single quotes)
- [x] Self-reviewed the diff
- [x] Added tests for new behavior
- [x] No `@tauri-apps/**` imports outside `src/renderer/lib/`
- [x] Every new web branch has a matching `.web.test.ts`
