### PR TITLE
feat(acp): import MCP JSON config, surface probe errors, fix Windows npx spawn

### DIFF
--- a/src-tauri/src/acp/mcp_probe.rs
+++ b/src-tauri/src/acp/mcp_probe.rs
@@ -277,12 +277,33 @@ async fn probe_inner(server: &McpServerConfig) -> ProbeResult {
     }
 }
 
+/// Resolve a stdio command for direct spawning (Windows shim handling).
+///
+/// On Windows, npm/PowerShell CLIs install as `.cmd`/`.bat` batch shims, which
+/// `CreateProcessW` cannot launch directly (os error 193 / "spawn failed").
+/// Reuse the PTY launcher's shim-aware resolver (ADR-004.2): it rewrites e.g.
+/// `npx.cmd` to `node.exe <script>`, prepending the script ahead of the user
+/// args. A resolution failure falls back to the legacy PATH/PATHEXT lookup so
+/// any real spawn error stays observable. On non-Windows the bare command name
+/// is returned unchanged (PATH resolution is left to the spawner).
+fn resolve_stdio_command(command: &str) -> (String, Vec<String>) {
+    match crate::pty::manager::resolve_spawn_program(command) {
+        Ok(resolved) => (resolved.program, resolved.prepend_args),
+        Err(_) => (
+            crate::trackers::git_tracker::resolve_executable(command),
+            Vec::new(),
+        ),
+    }
+}
+
 async fn probe_stdio(server: &McpServerConfig) -> ProbeResult {
     let command = match server.command.as_deref() {
         Some(c) if !c.trim().is_empty() => c,
         _ => return ProbeResult::disconnected("stdio command is required"),
     };
-    let mut cmd = Command::new(command);
+    let (program, prepend_args) = resolve_stdio_command(command);
+    let mut cmd = Command::new(&program);
+    cmd.args(&prepend_args);
     cmd.args(&server.args);
     for pair in &server.env {
       // Expand `$VAR`/`${VAR}` before spawn; unset → empty string.
@@ -474,6 +495,40 @@ mod tests {
         let result = probe(config).await;
         assert_eq!(result.status, ProbeStatus::Disconnected);
         assert!(result.error.unwrap().contains("command is required"));
+    }
+
+    #[cfg(target_os = "windows")]
+    #[test]
+    fn resolve_stdio_command_rewrites_windows_cmd_shim() {
+        // Simulate an npm-installed launcher (e.g. `npx`) that exists only as a
+        // `.cmd` shim — `CreateProcessW` cannot launch batch files directly, so
+        // the resolver must rewrite it to the directly-executable interpreter
+        // with the script prepended ahead of the user args.
+        let dir = std::env::temp_dir().join("termul-test-mcp-cmd-shim");
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(dir.join("node.exe"), b"MZ").unwrap();
+        std::fs::create_dir_all(dir.join("node_modules\\npx\\bin")).unwrap();
+        std::fs::write(dir.join("node_modules\\npx\\bin\\npx"), b"").unwrap();
+
+        let shim_path = dir.join("npx.cmd");
+        let shim_content = "@ECHO off\r\nGOTO start\r\n:find_dp0\r\nSET dp0=%~dp0\r\nEXIT /b\r\n:start\r\n\
+            endLocal & goto #_undefined_# 2>NUL || \"%_prog%\" \"%dp0%\\node_modules\\npx\\bin\\npx\" %*\r\n";
+        std::fs::write(&shim_path, shim_content).unwrap();
+
+        let (program, prepend_args) = resolve_stdio_command(&shim_path.to_string_lossy());
+        assert!(
+            program.ends_with("node.exe"),
+            "expected node.exe, got: {program}"
+        );
+        assert_eq!(prepend_args.len(), 1);
+        assert!(
+            prepend_args[0].contains("node_modules\\npx\\bin\\npx"),
+            "expected npx script first, got: {:?}",
+            prepend_args
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
     }
 
     #[tokio::test]

--- a/src-tauri/src/acp/mcp_probe.rs
+++ b/src-tauri/src/acp/mcp_probe.rs
@@ -504,7 +504,10 @@ mod tests {
         // `.cmd` shim — `CreateProcessW` cannot launch batch files directly, so
         // the resolver must rewrite it to the directly-executable interpreter
         // with the script prepended ahead of the user args.
-        let dir = std::env::temp_dir().join("termul-test-mcp-cmd-shim");
+        // Unique per-process dir so parallel `cargo test` invocations cannot
+        // delete/overwrite each other's fixtures.
+        let dir = std::env::temp_dir()
+            .join(format!("termul-test-mcp-cmd-shim-{}", std::process::id()));
         let _ = std::fs::remove_dir_all(&dir);
         std::fs::create_dir_all(&dir).unwrap();
         std::fs::write(dir.join("node.exe"), b"MZ").unwrap();

--- a/src-tauri/src/acp_binary_install.rs
+++ b/src-tauri/src/acp_binary_install.rs
@@ -427,6 +427,7 @@ pub async fn acp_install_registry_binary(
 #[cfg(test)]
 mod tests {
     use super::*;
+    #[cfg(unix)]
     use std::io::Write;
 
     #[test]

--- a/src/renderer/components/agents/AgentLauncher.tsx
+++ b/src/renderer/components/agents/AgentLauncher.tsx
@@ -88,6 +88,7 @@ const EMPTY_AUTH_METHODS: AuthMethod[] = []
 const EMPTY_MCP_SERVERS: StoredMcpServer[] = []
 const EMPTY_PROBE_STATUS: Record<string, ProbeStatus> = {}
 const EMPTY_MCP_TOOLS: Record<string, McpToolInfo[]> = {}
+const EMPTY_PROBE_ERROR: Record<string, string | undefined> = {}
 
 /** Survives overlay unmount so the new-thread picker does not flash the default. */
 let cachedConfigId: string | null = null
@@ -118,6 +119,7 @@ export function AgentLauncher({ paneId, className }: AgentLauncherProps): React.
   const mcpCount = mcpServers.length
   const setMcpServerEnabled = useAcpStore((s) => s.setMcpServerEnabled)
   const mcpProbeStatus = useAcpStore((s) => s.mcpProbeStatus) ?? EMPTY_PROBE_STATUS
+  const mcpProbeError = useAcpStore((s) => s.mcpProbeError) ?? EMPTY_PROBE_ERROR
   const mcpTools = useAcpStore((s) => s.mcpTools) ?? EMPTY_MCP_TOOLS
   const loadMcpTools = useAcpStore((s) => s.loadMcpTools)
   const activeProjectId = useProjectStore((s) => s.activeProjectId)
@@ -972,6 +974,7 @@ export function AgentLauncher({ paneId, className }: AgentLauncherProps): React.
                       })
                   }}
                   probeStatus={mcpProbeStatus}
+                  probeError={mcpProbeError}
                   tools={mcpTools}
                   onLoadTools={(id) => {
                     void loadMcpTools(id)

--- a/src/renderer/components/chat/ChatInputBar.test.tsx
+++ b/src/renderer/components/chat/ChatInputBar.test.tsx
@@ -89,6 +89,7 @@ vi.mock('@/stores/acp-store', () => ({
       })),
       setMcpServerEnabled: mockSetMcpServerEnabled,
       mcpProbeStatus: {} as Record<string, string>,
+      mcpProbeError: {} as Record<string, string | undefined>,
       mcpTools: {} as Record<string, unknown[]>,
       mcpToolsLoaded: {} as Record<string, boolean>,
       mcpProbing: {} as Record<string, boolean>,

--- a/src/renderer/components/chat/ChatInputBar.tsx
+++ b/src/renderer/components/chat/ChatInputBar.tsx
@@ -145,6 +145,7 @@ export function ChatInputBar({
   const mcpServers = useAcpStore((s) => s.mcpServers)
   const setMcpServerEnabled = useAcpStore((s) => s.setMcpServerEnabled)
   const mcpProbeStatus = useAcpStore((s) => s.mcpProbeStatus)
+  const mcpProbeError = useAcpStore((s) => s.mcpProbeError)
   const mcpTools = useAcpStore((s) => s.mcpTools)
   const loadMcpTools = useAcpStore((s) => s.loadMcpTools)
   const [value, setValue] = useState('')
@@ -542,6 +543,7 @@ export function ChatInputBar({
         })
       }}
       probeStatus={mcpProbeStatus}
+      probeError={mcpProbeError}
       tools={mcpTools}
       onLoadTools={(id) => {
         void loadMcpTools(id)

--- a/src/renderer/components/chat/McpBadge.test.tsx
+++ b/src/renderer/components/chat/McpBadge.test.tsx
@@ -116,4 +116,36 @@ describe('McpBadge popover (per-server enable/disable + status dot)', () => {
     expect(screen.getByText(/no tools available/i)).toBeInTheDocument()
     expect(screen.queryByText(/probing/i)).not.toBeInTheDocument()
   })
+
+  it('surfaces the redacted probe error as the "Probe failed" tooltip', () => {
+    render(
+      <McpBadge
+        count={1}
+        servers={servers}
+        onToggle={vi.fn()}
+        probeStatus={{ s1: 'disconnected' }}
+        probeError={{ s1: 'initialize failed: connection refused' }}
+      />
+    )
+    openPopover()
+    fireEvent.click(screen.getAllByText(/show tools/i)[0])
+    const failedLine = screen.getByText(/probe failed — check the server config/i)
+    expect(failedLine).toHaveAttribute('title', 'initialize failed: connection refused')
+  })
+
+  it('falls back to a generic tooltip when a disconnected probe has no error', () => {
+    render(
+      <McpBadge
+        count={1}
+        servers={servers}
+        onToggle={vi.fn()}
+        probeStatus={{ s2: 'disconnected' }}
+      />
+    )
+    openPopover()
+    // "Remote" (s2) is the second row — its collapsible is the second trigger.
+    fireEvent.click(screen.getAllByText(/show tools/i)[1])
+    const failedLine = screen.getByText(/probe failed — check the server config/i)
+    expect(failedLine).toHaveAttribute('title', 'Probe failed.')
+  })
 })

--- a/src/renderer/components/chat/McpBadge.tsx
+++ b/src/renderer/components/chat/McpBadge.tsx
@@ -28,6 +28,11 @@ interface McpBadgeProps {
   onToggle?: (id: string, enabled: boolean) => void
   /** Per-server probe status (Termul's own rmcp client connection, NOT the agent's). */
   probeStatus?: Record<string, ProbeStatus>
+  /**
+   * Per-server probe error (the backend's redacted `ProbeResult.error`). Shown
+   * as the tooltip on the "Probe failed" line so the reason is diagnosable.
+   */
+  probeError?: Record<string, string | undefined>
   /** Per-server cached `tools/list` output (for the collapsible tool list). */
   tools?: Record<string, McpToolInfo[]>
   /** Auto-probe on first expand of a server's tool list. */
@@ -66,6 +71,7 @@ export function McpBadge({
   servers,
   onToggle,
   probeStatus,
+  probeError,
   tools,
   onLoadTools
 }: McpBadgeProps): React.JSX.Element | null {
@@ -94,6 +100,7 @@ export function McpBadge({
       servers={servers!}
       onToggle={onToggle}
       probeStatus={probeStatus}
+      probeError={probeError}
       tools={tools}
       onLoadTools={onLoadTools}
       className={className}
@@ -106,6 +113,7 @@ interface PopoverProps {
   servers: McpServerSummary[]
   onToggle?: (id: string, enabled: boolean) => void
   probeStatus?: Record<string, ProbeStatus>
+  probeError?: Record<string, string | undefined>
   tools?: Record<string, McpToolInfo[]>
   onLoadTools?: (id: string) => void
   className?: string
@@ -116,6 +124,7 @@ function McpPopover({
   servers,
   onToggle,
   probeStatus,
+  probeError,
   tools,
   onLoadTools,
   className
@@ -148,6 +157,7 @@ function McpPopover({
               server={server}
               onToggle={onToggle}
               probeStatus={probeStatus?.[server.id]}
+              probeError={probeError?.[server.id]}
               tools={tools?.[server.id]}
               onLoadTools={onLoadTools}
             />
@@ -165,6 +175,7 @@ interface ServerRowProps {
   server: McpServerSummary
   onToggle?: (id: string, enabled: boolean) => void
   probeStatus?: ProbeStatus
+  probeError?: string
   tools?: McpToolInfo[]
   onLoadTools?: (id: string) => void
 }
@@ -173,6 +184,7 @@ function McpServerRow({
   server,
   onToggle,
   probeStatus,
+  probeError,
   tools,
   onLoadTools
 }: ServerRowProps): React.JSX.Element {
@@ -228,7 +240,9 @@ function McpServerRow({
               ))}
             </ul>
           ) : probeStatus === 'disconnected' ? (
-            <p className="text-3xs text-destructive">Probe failed — check the server config.</p>
+            <p className="text-3xs text-destructive" title={probeError ?? 'Probe failed.'}>
+              Probe failed — check the server config.
+            </p>
           ) : probeStatus === 'connected' ? (
             <p className="text-3xs text-muted-foreground">No tools available.</p>
           ) : (

--- a/src/renderer/components/chat/chat-responsive.test.tsx
+++ b/src/renderer/components/chat/chat-responsive.test.tsx
@@ -43,6 +43,7 @@ vi.mock('@/stores/acp-store', () => ({
       })),
       setMcpServerEnabled: mockSetMcpServerEnabled,
       mcpProbeStatus: {} as Record<string, string>,
+      mcpProbeError: {} as Record<string, string | undefined>,
       mcpTools: {} as Record<string, unknown[]>,
       mcpToolsLoaded: {} as Record<string, boolean>,
       mcpProbing: {} as Record<string, boolean>,

--- a/src/renderer/components/settings/McpServersSettings.test.tsx
+++ b/src/renderer/components/settings/McpServersSettings.test.tsx
@@ -20,6 +20,7 @@ function seedStore(): void {
   useAcpStore.setState({
     mcpServers: [],
     mcpProbeStatus: {},
+    mcpProbeError: {},
     mcpTools: {},
     mcpToolsLoaded: {},
     mcpProbing: {},
@@ -133,6 +134,98 @@ describe('McpServersSettings', () => {
     expect(
       screen.getByTitle('Disconnected (Termul could not reach this server)')
     ).toBeInTheDocument()
+  })
+
+  it('shows the backend probe error inline for a disconnected server', () => {
+    useAcpStore.setState({
+      mcpServers: [
+        { id: 's5', type: 'http', name: 'Remote', url: 'https://x.test/m', enabled: true }
+      ],
+      mcpProbeStatus: { s5: 'disconnected' },
+      mcpProbeError: { s5: 'initialize failed: connection refused' }
+    })
+    render(<McpServersSettings />)
+    // The error detail lives inside the collapsed tools disclosure; expand via
+    // the disconnected-specific trigger, then assert the redacted reason.
+    fireEvent.click(screen.getByText(/probe failed — retry/i))
+    expect(
+      screen.getByText(/probe failed — check the server config or network/i)
+    ).toBeInTheDocument()
+    expect(screen.getByText('initialize failed: connection refused')).toBeInTheDocument()
+  })
+
+  it('imports a Claude Desktop config and saves each entry with a fresh id', async () => {
+    render(<McpServersSettings />)
+    fireEvent.click(screen.getByRole('button', { name: /add server/i }))
+    fireEvent.click(screen.getByRole('tab', { name: /import json/i }))
+    fireEvent.change(screen.getByLabelText('MCP JSON'), {
+      target: {
+        value: JSON.stringify({
+          mcpServers: {
+            dokploy: {
+              command: 'npx',
+              args: ['-y', '@dokploy/mcp'],
+              env: { DOKPLOY_URL: 'https://dokploy.test' }
+            }
+          }
+        })
+      }
+    })
+    fireEvent.click(screen.getByRole('button', { name: /parse & save/i }))
+    await waitFor(() => expect(saveMcpServer).toHaveBeenCalledTimes(1))
+    expect(saveMcpServer).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'stdio',
+        name: 'dokploy',
+        command: 'npx',
+        args: ['-y', '@dokploy/mcp'],
+        env: [{ name: 'DOKPLOY_URL', value: 'https://dokploy.test' }],
+        enabled: true
+      })
+    )
+    // The saved id is a freshly minted one — never a registry id from the JSON.
+    expect(saveMcpServer.mock.calls[0]?.[0].id).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+    )
+    await waitFor(() =>
+      expect(toastSuccess).toHaveBeenCalledWith(expect.stringMatching(/imported 1 mcp server/i))
+    )
+  })
+
+  it('keeps invalid JSON inline and does not save anything', async () => {
+    render(<McpServersSettings />)
+    fireEvent.click(screen.getByRole('button', { name: /add server/i }))
+    fireEvent.click(screen.getByRole('tab', { name: /import json/i }))
+    fireEvent.change(screen.getByLabelText('MCP JSON'), {
+      target: { value: '{ this is not json' }
+    })
+    fireEvent.click(screen.getByRole('button', { name: /parse & save/i }))
+    await waitFor(() => expect(screen.getByRole('alert')).toHaveTextContent(/invalid json/i))
+    expect(saveMcpServer).not.toHaveBeenCalled()
+  })
+
+  it('imports the valid entries while surfacing per-server errors inline', async () => {
+    render(<McpServersSettings />)
+    fireEvent.click(screen.getByRole('button', { name: /add server/i }))
+    fireEvent.click(screen.getByRole('tab', { name: /import json/i }))
+    fireEvent.change(screen.getByLabelText('MCP JSON'), {
+      target: {
+        value: JSON.stringify({
+          mcpServers: {
+            good: { command: 'node', args: ['server.js'] },
+            bad: { command: '   ' }
+          }
+        })
+      }
+    })
+    fireEvent.click(screen.getByRole('button', { name: /parse & save/i }))
+    await waitFor(() => expect(saveMcpServer).toHaveBeenCalledTimes(1))
+    expect(saveMcpServer).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'good', command: 'node', args: ['server.js'] })
+    )
+    // The rejected entry's reason stays visible so the user can fix and re-paste.
+    expect(screen.getByRole('alert')).toHaveTextContent(/command is required for stdio/i)
+    expect(toastSuccess).not.toHaveBeenCalled()
   })
 
   it('renders the tool list (read-only) inside the collapsible on expand', async () => {

--- a/src/renderer/components/settings/McpServersSettings.tsx
+++ b/src/renderer/components/settings/McpServersSettings.tsx
@@ -187,26 +187,37 @@ export function McpServersSettings(): React.JSX.Element {
   const saveImport = async (): Promise<void> => {
     setSaving(true)
     setImportErrors([])
+    let savedCount = 0
     try {
-      const { servers, errors } = parseMcpJsonImport(importText)
+      const { servers: parsedServers, errors } = parseMcpJsonImport(importText)
       // Valid servers still import when some entries are rejected (per-server
       // errors stay visible inline so the user can fix and re-paste).
-      for (const server of servers) {
+      for (const server of parsedServers) {
         await saveMcpServer({ ...server, id: crypto.randomUUID(), enabled: true })
+        savedCount += 1
       }
       if (errors.length > 0) {
         setImportErrors(errors)
         return
       }
-      if (servers.length === 0) {
+      if (parsedServers.length === 0) {
         setImportErrors(['No MCP servers found in the JSON.'])
         return
       }
-      toast.success(`Imported ${servers.length} MCP server${servers.length === 1 ? '' : 's'}`)
+      toast.success(
+        `Imported ${parsedServers.length} MCP server${parsedServers.length === 1 ? '' : 's'}`
+      )
       setImportText('')
       closeDialog()
     } catch {
-      toast.error('Could not save the MCP server. Your previous settings were restored.')
+      // A mid-loop throw leaves earlier saves persisted (fresh IDs each time).
+      // Tell the user how many landed so they do not blindly re-paste and
+      // create duplicates.
+      toast.error(
+        savedCount > 0
+          ? `Imported ${savedCount} server${savedCount === 1 ? '' : 's'} before a save failed. Review the remaining entries before re-importing.`
+          : 'Could not save the MCP server. Your previous settings were restored.'
+      )
     } finally {
       setSaving(false)
     }
@@ -373,7 +384,12 @@ export function McpServersSettings(): React.JSX.Element {
                     type="button"
                     size="icon"
                     variant="ghost"
-                    onClick={() => setDraft(draftFor(server))}
+                    onClick={() => {
+                      // Ensure a lingering import session cannot resurface
+                      // the (now-hidden) import view while editing.
+                      setImportMode(false)
+                      setDraft(draftFor(server))
+                    }}
                   >
                     <Pencil size={15} />
                     <span className="sr-only">Edit {server.name}</span>
@@ -430,6 +446,10 @@ export function McpServersSettings(): React.JSX.Element {
             role="tablist"
             aria-label="MCP server entry mode"
             className="flex w-fit gap-1 rounded-lg border border-border bg-secondary/20 p-1"
+            // The Import tab is an Add-only flow — importing while editing an
+            // existing server would persist fresh IDs instead of updating the
+            // draft, so the tab bar is hidden whenever a server is being edited.
+            hidden={Boolean(draft?.id)}
           >
             <button
               type="button"

--- a/src/renderer/components/settings/McpServersSettings.tsx
+++ b/src/renderer/components/settings/McpServersSettings.tsx
@@ -21,6 +21,7 @@ import {
   transportOf,
   validateMcpServer
 } from '@/lib/acp-mcp-persistence'
+import { parseMcpJsonImport } from '@/lib/mcp-json-import'
 import { useAcpStore } from '@/stores/acp-store'
 
 interface ServerDraft {
@@ -124,10 +125,17 @@ export function McpServersSettings(): React.JSX.Element {
   const probeMcpServer = useAcpStore((state) => state.probeMcpServer)
   const loadMcpTools = useAcpStore((state) => state.loadMcpTools)
   const mcpProbeStatus = useAcpStore((state) => state.mcpProbeStatus)
+  const mcpProbeError = useAcpStore((state) => state.mcpProbeError)
   const mcpTools = useAcpStore((state) => state.mcpTools)
   const mcpProbing = useAcpStore((state) => state.mcpProbing)
   const [draft, setDraft] = useState<ServerDraft | null>(null)
   const [saving, setSaving] = useState(false)
+  // "Form | Import JSON" toggle inside the Add/Edit dialog. Import mode pastes
+  // a Claude Desktop `{"mcpServers": {...}}` config (or a bare single server)
+  // and saves each parsed entry with a fresh id.
+  const [importMode, setImportMode] = useState(false)
+  const [importText, setImportText] = useState('')
+  const [importErrors, setImportErrors] = useState<string[]>([])
   // Tracks which server rows have their tool list expanded (Settings surface).
   const [expandedTools, setExpandedTools] = useState<Record<string, boolean>>({})
 
@@ -163,6 +171,40 @@ export function McpServersSettings(): React.JSX.Element {
       })
       setDraft(null)
       toast.success(draft.id ? 'MCP server updated' : 'MCP server added')
+    } catch {
+      toast.error('Could not save the MCP server. Your previous settings were restored.')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  const closeDialog = (): void => {
+    setDraft(null)
+    setImportMode(false)
+    setImportErrors([])
+  }
+
+  const saveImport = async (): Promise<void> => {
+    setSaving(true)
+    setImportErrors([])
+    try {
+      const { servers, errors } = parseMcpJsonImport(importText)
+      // Valid servers still import when some entries are rejected (per-server
+      // errors stay visible inline so the user can fix and re-paste).
+      for (const server of servers) {
+        await saveMcpServer({ ...server, id: crypto.randomUUID(), enabled: true })
+      }
+      if (errors.length > 0) {
+        setImportErrors(errors)
+        return
+      }
+      if (servers.length === 0) {
+        setImportErrors(['No MCP servers found in the JSON.'])
+        return
+      }
+      toast.success(`Imported ${servers.length} MCP server${servers.length === 1 ? '' : 's'}`)
+      setImportText('')
+      closeDialog()
     } catch {
       toast.error('Could not save the MCP server. Your previous settings were restored.')
     } finally {
@@ -280,9 +322,16 @@ export function McpServersSettings(): React.JSX.Element {
                           ))}
                         </ul>
                       ) : probeStatus === 'disconnected' ? (
-                        <p className="text-3xs text-destructive">
-                          Probe failed — check the server config or network.
-                        </p>
+                        <div className="space-y-1">
+                          <p className="text-3xs text-destructive">
+                            Probe failed — check the server config or network.
+                          </p>
+                          {mcpProbeError[server.id] ? (
+                            <span className="block font-mono text-3xs text-destructive/80">
+                              {mcpProbeError[server.id]}
+                            </span>
+                          ) : null}
+                        </div>
                       ) : probeStatus === 'connected' ? (
                         <p className="text-3xs text-muted-foreground">
                           Probe completed — no tools found.
@@ -360,107 +409,185 @@ export function McpServersSettings(): React.JSX.Element {
         </p>
       </div>
 
-      <Dialog open={draft !== null} onOpenChange={(open) => !open && setDraft(null)}>
+      <Dialog
+        open={draft !== null || importMode}
+        onOpenChange={(open) => {
+          if (!open) closeDialog()
+        }}
+      >
         <DialogContent className="max-h-[90vh] overflow-y-auto sm:max-w-xl">
           <DialogHeader>
-            <DialogTitle>{draft?.id ? 'Edit MCP server' : 'Add MCP server'}</DialogTitle>
+            <DialogTitle>
+              {importMode ? 'Import MCP servers' : draft?.id ? 'Edit MCP server' : 'Add MCP server'}
+            </DialogTitle>
             <DialogDescription>
-              Configure one server transport. Each argument or key/value pair uses its own line.
+              {importMode
+                ? 'Paste a Claude Desktop config or a single server object, then parse and save.'
+                : 'Configure one server transport. Each argument or key/value pair uses its own line.'}
             </DialogDescription>
           </DialogHeader>
-          {draft && (
+          <div
+            role="tablist"
+            aria-label="MCP server entry mode"
+            className="flex w-fit gap-1 rounded-lg border border-border bg-secondary/20 p-1"
+          >
+            <button
+              type="button"
+              role="tab"
+              aria-selected={!importMode}
+              onClick={() => {
+                setImportMode(false)
+                setImportErrors([])
+              }}
+              className={`rounded-md px-2.5 py-1 text-xs font-medium transition-colors ${
+                !importMode
+                  ? 'bg-background text-foreground shadow-sm'
+                  : 'text-muted-foreground hover:text-foreground'
+              }`}
+            >
+              Form
+            </button>
+            <button
+              type="button"
+              role="tab"
+              aria-selected={importMode}
+              onClick={() => {
+                setImportMode(true)
+                setImportErrors([])
+              }}
+              className={`rounded-md px-2.5 py-1 text-xs font-medium transition-colors ${
+                importMode
+                  ? 'bg-background text-foreground shadow-sm'
+                  : 'text-muted-foreground hover:text-foreground'
+              }`}
+            >
+              Import JSON
+            </button>
+          </div>
+          {importMode ? (
             <div className="space-y-4">
-              <div className="grid gap-2 sm:grid-cols-2">
-                <label htmlFor="mcp-server-name" className="space-y-1 text-sm">
-                  <span>Name</span>
-                  <Input
-                    id="mcp-server-name"
-                    value={draft.name}
-                    onChange={(event) => setDraft({ ...draft, name: event.target.value })}
-                  />
-                </label>
-                <label htmlFor="mcp-server-transport" className="space-y-1 text-sm">
-                  <span>Transport</span>
-                  <select
-                    id="mcp-server-transport"
-                    value={draft.type}
-                    onChange={(event) =>
-                      setDraft({ ...draft, type: event.target.value as McpTransport })
-                    }
-                    className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
-                  >
-                    <option value="stdio">stdio</option>
-                    <option value="http">HTTP</option>
-                    <option value="sse">SSE</option>
-                  </select>
-                </label>
-              </div>
-              {draft.type === 'stdio' ? (
-                <>
-                  <label htmlFor="mcp-command" className="block space-y-1 text-sm">
-                    <span>Command</span>
-                    <Input
-                      id="mcp-command"
-                      value={draft.command}
-                      onChange={(event) => setDraft({ ...draft, command: event.target.value })}
-                    />
-                  </label>
-                  <label htmlFor="mcp-arguments" className="block space-y-1 text-sm">
-                    <span>Arguments (one per line)</span>
-                    <Textarea
-                      id="mcp-arguments"
-                      value={draft.args}
-                      onChange={(event) => setDraft({ ...draft, args: event.target.value })}
-                    />
-                  </label>
-                  <label htmlFor="mcp-environment" className="block space-y-1 text-sm">
-                    <span>Environment (NAME=value, one per line)</span>
-                    <Textarea
-                      id="mcp-environment"
-                      value={draft.env}
-                      onChange={(event) => setDraft({ ...draft, env: event.target.value })}
-                    />
-                  </label>
-                </>
-              ) : (
-                <>
-                  <label htmlFor="mcp-url" className="block space-y-1 text-sm">
-                    <span>URL</span>
-                    <Input
-                      id="mcp-url"
-                      type="url"
-                      value={draft.url}
-                      onChange={(event) => setDraft({ ...draft, url: event.target.value })}
-                    />
-                  </label>
-                  <label htmlFor="mcp-headers" className="block space-y-1 text-sm">
-                    <span>Headers (NAME=value, one per line)</span>
-                    <Textarea
-                      id="mcp-headers"
-                      value={draft.headers}
-                      onChange={(event) => setDraft({ ...draft, headers: event.target.value })}
-                    />
-                  </label>
-                </>
-              )}
-              {!validation.valid && draft.name.trim().length > 0 && (
-                <p role="alert" className="text-xs text-destructive">
-                  {validation.errors.join(' ')}
-                </p>
+              <label htmlFor="mcp-import-json" className="block space-y-1 text-sm">
+                <span>MCP JSON</span>
+                <Textarea
+                  id="mcp-import-json"
+                  rows={10}
+                  value={importText}
+                  onChange={(event) => setImportText(event.target.value)}
+                  placeholder='{"mcpServers": {"dokploy": {"command": "npx", "args": ["-y", "@dokploy/mcp"], "env": {"DOKPLOY_URL": "..."}}}}'
+                  className="font-mono"
+                />
+              </label>
+              {importErrors.length > 0 && (
+                <ul role="alert" className="space-y-1 text-xs text-destructive">
+                  {importErrors.map((error) => (
+                    <li key={error} className="break-words font-mono">
+                      {error}
+                    </li>
+                  ))}
+                </ul>
               )}
             </div>
+          ) : (
+            draft && (
+              <div className="space-y-4">
+                <div className="grid gap-2 sm:grid-cols-2">
+                  <label htmlFor="mcp-server-name" className="space-y-1 text-sm">
+                    <span>Name</span>
+                    <Input
+                      id="mcp-server-name"
+                      value={draft.name}
+                      onChange={(event) => setDraft({ ...draft, name: event.target.value })}
+                    />
+                  </label>
+                  <label htmlFor="mcp-server-transport" className="space-y-1 text-sm">
+                    <span>Transport</span>
+                    <select
+                      id="mcp-server-transport"
+                      value={draft.type}
+                      onChange={(event) =>
+                        setDraft({ ...draft, type: event.target.value as McpTransport })
+                      }
+                      className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
+                    >
+                      <option value="stdio">stdio</option>
+                      <option value="http">HTTP</option>
+                      <option value="sse">SSE</option>
+                    </select>
+                  </label>
+                </div>
+                {draft.type === 'stdio' ? (
+                  <>
+                    <label htmlFor="mcp-command" className="block space-y-1 text-sm">
+                      <span>Command</span>
+                      <Input
+                        id="mcp-command"
+                        value={draft.command}
+                        onChange={(event) => setDraft({ ...draft, command: event.target.value })}
+                      />
+                    </label>
+                    <label htmlFor="mcp-arguments" className="block space-y-1 text-sm">
+                      <span>Arguments (one per line)</span>
+                      <Textarea
+                        id="mcp-arguments"
+                        value={draft.args}
+                        onChange={(event) => setDraft({ ...draft, args: event.target.value })}
+                      />
+                    </label>
+                    <label htmlFor="mcp-environment" className="block space-y-1 text-sm">
+                      <span>Environment (NAME=value, one per line)</span>
+                      <Textarea
+                        id="mcp-environment"
+                        value={draft.env}
+                        onChange={(event) => setDraft({ ...draft, env: event.target.value })}
+                      />
+                    </label>
+                  </>
+                ) : (
+                  <>
+                    <label htmlFor="mcp-url" className="block space-y-1 text-sm">
+                      <span>URL</span>
+                      <Input
+                        id="mcp-url"
+                        type="url"
+                        value={draft.url}
+                        onChange={(event) => setDraft({ ...draft, url: event.target.value })}
+                      />
+                    </label>
+                    <label htmlFor="mcp-headers" className="block space-y-1 text-sm">
+                      <span>Headers (NAME=value, one per line)</span>
+                      <Textarea
+                        id="mcp-headers"
+                        value={draft.headers}
+                        onChange={(event) => setDraft({ ...draft, headers: event.target.value })}
+                      />
+                    </label>
+                  </>
+                )}
+                {!validation.valid && draft.name.trim().length > 0 && (
+                  <p role="alert" className="text-xs text-destructive">
+                    {validation.errors.join(' ')}
+                  </p>
+                )}
+              </div>
+            )
           )}
           <DialogFooter>
-            <Button type="button" variant="outline" onClick={() => setDraft(null)}>
+            <Button type="button" variant="outline" onClick={closeDialog}>
               Cancel
             </Button>
-            <Button
-              type="button"
-              disabled={!validation.valid || saving}
-              onClick={() => void persistDraft()}
-            >
-              {saving ? 'Saving…' : 'Save'}
-            </Button>
+            {importMode ? (
+              <Button type="button" disabled={saving} onClick={() => void saveImport()}>
+                {saving ? 'Saving…' : 'Parse & Save'}
+              </Button>
+            ) : (
+              <Button
+                type="button"
+                disabled={!validation.valid || saving}
+                onClick={() => void persistDraft()}
+              >
+                {saving ? 'Saving…' : 'Save'}
+              </Button>
+            )}
           </DialogFooter>
         </DialogContent>
       </Dialog>

--- a/src/renderer/lib/mcp-json-import.test.ts
+++ b/src/renderer/lib/mcp-json-import.test.ts
@@ -1,0 +1,166 @@
+import { describe, expect, it } from 'vitest'
+import { parseMcpJsonImport } from './mcp-json-import'
+
+describe('parseMcpJsonImport', () => {
+  it('parses a Claude Desktop wrapper and normalizes the env map to name/value pairs', () => {
+    const { servers, errors } = parseMcpJsonImport(
+      JSON.stringify({
+        mcpServers: {
+          dokploy: {
+            command: 'npx',
+            args: ['-y', '@dokploy/mcp'],
+            env: { DOKPLOY_URL: 'https://dokploy.test', DOKPLOY_API_KEY: 'secret' }
+          }
+        }
+      })
+    )
+    expect(errors).toEqual([])
+    expect(servers).toEqual([
+      {
+        type: 'stdio',
+        name: 'dokploy',
+        command: 'npx',
+        args: ['-y', '@dokploy/mcp'],
+        env: [
+          { name: 'DOKPLOY_URL', value: 'https://dokploy.test' },
+          { name: 'DOKPLOY_API_KEY', value: 'secret' }
+        ]
+      }
+    ])
+  })
+
+  it('parses a bare single-server object using its name field', () => {
+    const { servers, errors } = parseMcpJsonImport(
+      JSON.stringify({
+        command: 'npx',
+        args: ['-y', '@dokploy/mcp'],
+        env: { DOKPLOY_URL: 'https://dokploy.test' },
+        name: 'dokploy'
+      })
+    )
+    expect(errors).toEqual([])
+    expect(servers).toEqual([
+      {
+        type: 'stdio',
+        name: 'dokploy',
+        command: 'npx',
+        args: ['-y', '@dokploy/mcp'],
+        env: [{ name: 'DOKPLOY_URL', value: 'https://dokploy.test' }]
+      }
+    ])
+  })
+
+  it('drops unknown fields such as directTools and alwaysAllow', () => {
+    const { servers, errors } = parseMcpJsonImport(
+      JSON.stringify({
+        mcpServers: {
+          x: {
+            command: 'node',
+            args: ['server.js'],
+            directTools: true,
+            alwaysAllow: ['read']
+          }
+        }
+      })
+    )
+    expect(errors).toEqual([])
+    expect(servers).toHaveLength(1)
+    expect(servers[0]).toEqual({
+      type: 'stdio',
+      name: 'x',
+      command: 'node',
+      args: ['server.js']
+    })
+    expect(JSON.stringify(servers[0])).not.toContain('directTools')
+    expect(JSON.stringify(servers[0])).not.toContain('alwaysAllow')
+  })
+
+  it('passes an env that is already a name/value array through unchanged', () => {
+    const { servers, errors } = parseMcpJsonImport(
+      JSON.stringify({
+        mcpServers: {
+          a: { command: 'node', env: [{ name: 'K', value: 'v' }] }
+        }
+      })
+    )
+    expect(errors).toEqual([])
+    expect(servers[0].env).toEqual([{ name: 'K', value: 'v' }])
+  })
+
+  it('parses multiple wrapper servers, each named by its key', () => {
+    const { servers, errors } = parseMcpJsonImport(
+      JSON.stringify({
+        mcpServers: {
+          a: { command: 'node', args: ['a.js'] },
+          b: { command: 'python', args: ['b.py'] }
+        }
+      })
+    )
+    expect(errors).toEqual([])
+    expect(servers.map((server) => server.name)).toEqual(['a', 'b'])
+    expect(servers[0].command).toBe('node')
+    expect(servers[1].command).toBe('python')
+  })
+
+  it('infers http when only a url is present', () => {
+    const { servers, errors } = parseMcpJsonImport(
+      JSON.stringify({
+        mcpServers: {
+          remote: { url: 'https://mcp.test/mcp' }
+        }
+      })
+    )
+    expect(errors).toEqual([])
+    expect(servers[0]).toEqual({ type: 'http', name: 'remote', url: 'https://mcp.test/mcp' })
+  })
+
+  it('honors an explicit sse type', () => {
+    const { servers, errors } = parseMcpJsonImport(
+      JSON.stringify({
+        mcpServers: {
+          legacy: { type: 'sse', url: 'https://mcp.test/sse' }
+        }
+      })
+    )
+    expect(errors).toEqual([])
+    expect(servers[0]).toEqual({ type: 'sse', name: 'legacy', url: 'https://mcp.test/sse' })
+  })
+
+  it('rejects a server with an env in an unknown shape but keeps the rest', () => {
+    const { servers, errors } = parseMcpJsonImport(
+      JSON.stringify({
+        mcpServers: {
+          bad: { command: 'node', env: 'KEY=value' },
+          good: { command: 'node' }
+        }
+      })
+    )
+    expect(servers.map((server) => server.name)).toEqual(['good'])
+    expect(errors).toEqual(['bad: env must be an object map or name/value pairs'])
+  })
+
+  it('returns an Invalid JSON error for truncated input', () => {
+    const { servers, errors } = parseMcpJsonImport('{"mcpServers":{')
+    expect(servers).toEqual([])
+    expect(errors).toHaveLength(1)
+    expect(errors[0]).toMatch(/^Invalid JSON: /)
+  })
+
+  it('rejects a server missing a required field with a per-server error', () => {
+    const { servers, errors } = parseMcpJsonImport(
+      JSON.stringify({
+        mcpServers: {
+          x: { args: ['-y'] }
+        }
+      })
+    )
+    expect(servers).toEqual([])
+    expect(errors).toEqual(['x: Command is required for stdio.'])
+  })
+
+  it('rejects a top-level mcpServers that is not an object', () => {
+    const { servers, errors } = parseMcpJsonImport('{"mcpServers": []}')
+    expect(servers).toEqual([])
+    expect(errors).toEqual(['Invalid JSON: "mcpServers" must be an object'])
+  })
+})

--- a/src/renderer/lib/mcp-json-import.ts
+++ b/src/renderer/lib/mcp-json-import.ts
@@ -1,0 +1,168 @@
+import type { McpEnvVar, McpHeader, McpServerConfig } from '@/lib/acp-api'
+import { validateMcpServer } from '@/lib/acp-mcp-persistence'
+
+export interface McpJsonImportResult {
+  servers: McpServerConfig[]
+  errors: string[]
+}
+
+const TRANSPORTS = ['stdio', 'http', 'sse'] as const
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+/** All-string array, or `undefined` when `value` is not a string array. */
+function stringArray(value: unknown): string[] | undefined {
+  if (!Array.isArray(value)) return undefined
+  const strings = value.filter((item): item is string => typeof item === 'string')
+  return strings.length === value.length ? strings : undefined
+}
+
+/** `[{name, value}]` array, or `undefined` when `value` is not one. */
+function stringPairs(value: unknown): Array<{ name: string; value: string }> | undefined {
+  if (!Array.isArray(value)) return undefined
+  const pairs = value.filter(
+    (entry): entry is McpEnvVar | McpHeader =>
+      isRecord(entry) && typeof entry.name === 'string' && typeof entry.value === 'string'
+  )
+  return pairs.length === value.length ? pairs : undefined
+}
+
+/**
+ * Normalize `env` from a Claude Desktop-style `Record<string,string>` map into
+ * Termul's internal `[{name, value}]` shape. An already-normalized array passes
+ * through unchanged. Any other shape yields `undefined` (the server is rejected
+ * by the caller; the rest still import).
+ */
+function normalizeEnv(value: unknown): McpEnvVar[] | undefined {
+  if (value === undefined) return undefined
+  if (isRecord(value)) {
+    return Object.entries(value).map(([name, entryValue]) => ({
+      name,
+      value: String(entryValue)
+    }))
+  }
+  return stringPairs(value)
+}
+
+/**
+ * Build a (partial) server config from a parsed entry, keeping only known
+ * fields (`type`, `name`, `command`, `args`, `env`, `url`, `headers`) — unknown
+ * fields (e.g. `directTools`, `alwaysAllow`) are silently dropped. Returns
+ * `null` for structurally malformed input (`args`/`headers` in the wrong shape,
+ * or a non-string `command`/`url`); missing required fields are left to
+ * `validateMcpServer` so the per-server error matches the form validation text.
+ */
+function buildServer(
+  raw: Record<string, unknown>,
+  name: string,
+  env: McpEnvVar[] | undefined
+): Partial<McpServerConfig> | null {
+  // Explicit `type` is honored when it is a real transport; otherwise infer:
+  // `command` present → stdio, only `url` present → http, default stdio.
+  // Unknown `type` values (e.g. `acp`) are never accepted as a working
+  // transport — they fall through to inference.
+  const explicitType = typeof raw.type === 'string' ? (raw.type as string) : undefined
+  const hasCommand = typeof raw.command === 'string' && raw.command.trim().length > 0
+  const hasUrl = typeof raw.url === 'string' && raw.url.trim().length > 0
+  const type: (typeof TRANSPORTS)[number] =
+    explicitType === 'stdio' || explicitType === 'http' || explicitType === 'sse'
+      ? explicitType
+      : hasCommand
+        ? 'stdio'
+        : hasUrl
+          ? 'http'
+          : 'stdio'
+
+  if (type === 'stdio') {
+    if (raw.command !== undefined && typeof raw.command !== 'string') return null
+    const args = raw.args !== undefined ? stringArray(raw.args) : undefined
+    if (raw.args !== undefined && args === undefined) return null
+    const server: Partial<McpServerConfig> = {
+      type: 'stdio',
+      name,
+      ...(typeof raw.command === 'string' ? { command: raw.command } : {}),
+      ...(args && args.length > 0 ? { args } : {}),
+      ...(env && env.length > 0 ? { env } : {})
+    }
+    return server
+  }
+
+  if (raw.url !== undefined && typeof raw.url !== 'string') return null
+  const headers = raw.headers !== undefined ? stringPairs(raw.headers) : undefined
+  if (raw.headers !== undefined && headers === undefined) return null
+  const shared = {
+    name,
+    ...(typeof raw.url === 'string' ? { url: raw.url } : {}),
+    ...(headers && headers.length > 0 ? { headers } : {})
+  }
+  return type === 'http'
+    ? { type: 'http' as const, ...shared }
+    : { type: 'sse' as const, ...shared }
+}
+
+/**
+ * Parse a pasted MCP JSON config into saveable `McpServerConfig`s.
+ *
+ * Accepts TWO shapes, detected by the top-level keys:
+ * 1. Claude Desktop `{"mcpServers": {name: {...}}}` — each entry is one server,
+ *    named by its wrapper key.
+ * 2. A bare single-server object `{command, args, env, name, ...}`.
+ *
+ * Unknown fields (e.g. `directTools`, `alwaysAllow`) are silently dropped.
+ * `env` maps are normalized to `[{name, value}]`; an already-normalized array
+ * passes through. Each server is validated via `validateMcpServer`; invalid
+ * entries are reported per-server and skipped — the rest still import.
+ */
+export function parseMcpJsonImport(text: string): McpJsonImportResult {
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(text)
+  } catch (error) {
+    return { servers: [], errors: [`Invalid JSON: ${String(error)}`] }
+  }
+  if (!isRecord(parsed)) {
+    return { servers: [], errors: ['Invalid JSON: expected a top-level object'] }
+  }
+
+  const entries: Array<[string, unknown]> = []
+  if (isRecord(parsed.mcpServers)) {
+    for (const [name, value] of Object.entries(parsed.mcpServers)) {
+      entries.push([name, value])
+    }
+  } else if (parsed.mcpServers !== undefined) {
+    return { servers: [], errors: ['Invalid JSON: "mcpServers" must be an object'] }
+  } else {
+    // Bare single-server object.
+    entries.push(['', parsed])
+  }
+
+  const servers: McpServerConfig[] = []
+  const errors: string[] = []
+  for (const [keyName, raw] of entries) {
+    const name =
+      keyName.length > 0 || !isRecord(raw) ? keyName : typeof raw.name === 'string' ? raw.name : ''
+    if (!isRecord(raw)) {
+      errors.push(`${name || '<unknown>'}: expected a server object`)
+      continue
+    }
+    const env = normalizeEnv(raw.env)
+    if (raw.env !== undefined && env === undefined) {
+      errors.push(`${name || '<unnamed>'}: env must be an object map or name/value pairs`)
+      continue
+    }
+    const server = buildServer(raw, name, env)
+    if (!server) {
+      errors.push(`${name || '<unnamed>'}: invalid server configuration`)
+      continue
+    }
+    const validation = validateMcpServer(server)
+    if (!validation.valid) {
+      errors.push(`${name || '<unnamed>'}: ${validation.errors.join(' ')}`)
+      continue
+    }
+    servers.push(server as McpServerConfig)
+  }
+  return { servers, errors }
+}

--- a/src/renderer/lib/mcp-json-import.ts
+++ b/src/renderer/lib/mcp-json-import.ts
@@ -1,4 +1,4 @@
-import type { McpEnvVar, McpHeader, McpServerConfig } from '@/lib/acp-api'
+import type { McpEnvVar, McpServerConfig } from '@/lib/acp-api'
 import { validateMcpServer } from '@/lib/acp-mcp-persistence'
 
 export interface McpJsonImportResult {
@@ -19,14 +19,20 @@ function stringArray(value: unknown): string[] | undefined {
   return strings.length === value.length ? strings : undefined
 }
 
-/** `[{name, value}]` array, or `undefined` when `value` is not one. */
+/** `[{name, value}]` array, or `undefined` when `value` is not one. Entries are
+ * rebuilt as fresh `{name, value}` objects so any extra properties on the input
+ * (e.g. `{name, value, foo}`) are dropped — matching the "unknown fields are
+ * silently dropped" contract of the object-map branch in `normalizeEnv`. */
 function stringPairs(value: unknown): Array<{ name: string; value: string }> | undefined {
   if (!Array.isArray(value)) return undefined
-  const pairs = value.filter(
-    (entry): entry is McpEnvVar | McpHeader =>
-      isRecord(entry) && typeof entry.name === 'string' && typeof entry.value === 'string'
-  )
-  return pairs.length === value.length ? pairs : undefined
+  const pairs: Array<{ name: string; value: string }> = []
+  for (const entry of value) {
+    if (!isRecord(entry) || typeof entry.name !== 'string' || typeof entry.value !== 'string') {
+      return undefined
+    }
+    pairs.push({ name: entry.name, value: entry.value })
+  }
+  return pairs
 }
 
 /**
@@ -77,12 +83,13 @@ function buildServer(
 
   if (type === 'stdio') {
     if (raw.command !== undefined && typeof raw.command !== 'string') return null
-    const args = raw.args !== undefined ? stringArray(raw.args) : undefined
+    const args =
+      raw.args !== undefined ? stringArray(raw.args)?.map((arg) => arg.trim()) : undefined
     if (raw.args !== undefined && args === undefined) return null
     const server: Partial<McpServerConfig> = {
       type: 'stdio',
       name,
-      ...(typeof raw.command === 'string' ? { command: raw.command } : {}),
+      ...(typeof raw.command === 'string' ? { command: raw.command.trim() } : {}),
       ...(args && args.length > 0 ? { args } : {}),
       ...(env && env.length > 0 ? { env } : {})
     }
@@ -94,7 +101,7 @@ function buildServer(
   if (raw.headers !== undefined && headers === undefined) return null
   const shared = {
     name,
-    ...(typeof raw.url === 'string' ? { url: raw.url } : {}),
+    ...(typeof raw.url === 'string' ? { url: raw.url.trim() } : {}),
     ...(headers && headers.length > 0 ? { headers } : {})
   }
   return type === 'http'

--- a/src/renderer/stores/acp-store.test.ts
+++ b/src/renderer/stores/acp-store.test.ts
@@ -4150,7 +4150,9 @@ describe('acp-store', () => {
       mcpProbeStatus: {},
       mcpTools: {},
       mcpToolsLoaded: {},
-      mcpProbing: {}
+      mcpProbing: {},
+      // A stale error from a previous failed probe must be cleared on success.
+      mcpProbeError: { p1: 'stale error from previous probe' }
     })
     vi.mocked(invoke).mockResolvedValueOnce({
       status: 'connected',
@@ -4168,6 +4170,7 @@ describe('acp-store', () => {
     expect(state.mcpTools.p1).toEqual([{ name: 'read_file', description: 'read a file' }])
     expect(state.mcpToolsLoaded.p1).toBe(true)
     expect(state.mcpProbing.p1).toBe(false)
+    expect(state.mcpProbeError.p1).toBeUndefined()
   })
 
   it('probeMcpServer surfaces a disconnected result without throwing', async () => {
@@ -4178,7 +4181,8 @@ describe('acp-store', () => {
       mcpProbeStatus: {},
       mcpTools: {},
       mcpToolsLoaded: {},
-      mcpProbing: {}
+      mcpProbing: {},
+      mcpProbeError: {}
     })
     vi.mocked(invoke).mockResolvedValueOnce({
       status: 'disconnected',
@@ -4190,6 +4194,8 @@ describe('acp-store', () => {
     expect(state.mcpProbeStatus.p2).toBe('disconnected')
     expect(state.mcpTools.p2).toEqual([])
     expect(state.mcpToolsLoaded.p2).toBe(true)
+    // The backend's redacted failure reason is stored for inline UI surfacing.
+    expect(state.mcpProbeError.p2).toBe('initialize failed: connection refused')
     // A disconnected probe is a ProbeResult, NOT a throw — no error log.
     expect(logFrontendError).not.toHaveBeenCalled()
   })
@@ -4200,7 +4206,8 @@ describe('acp-store', () => {
       mcpProbeStatus: {},
       mcpTools: {},
       mcpToolsLoaded: {},
-      mcpProbing: {}
+      mcpProbing: {},
+      mcpProbeError: {}
     })
     vi.mocked(invoke).mockResolvedValue({ status: 'connected', tools: [] })
     // Two concurrent calls — only one should reach the transport.
@@ -4240,13 +4247,18 @@ describe('acp-store', () => {
       mcpProbeStatus: {},
       mcpTools: {},
       mcpToolsLoaded: {},
-      mcpProbing: {}
+      mcpProbing: {},
+      mcpProbeError: {}
     })
     vi.mocked(invoke).mockRejectedValueOnce(new Error('transport down'))
     await useAcpStore.getState().probeMcpServer('p5')
     const state = useAcpStore.getState()
     expect(state.mcpProbeStatus.p5).toBe('disconnected')
     expect(state.mcpProbing.p5).toBe(false)
+    // The canonical facade (`acp-mcp-probe.ts`) normalizes the invoke rejection
+    // to a disconnected ProbeResult carrying the (value-free) error — so the
+    // store's success path stores it for inline UI surfacing.
+    expect(state.mcpProbeError.p5).toBe('Error: transport down')
     // The canonical facade (`acp-mcp-probe.ts`) normalizes the invoke rejection
     // to a disconnected ProbeResult and logs the transport failure itself — the
     // store's success path runs (probe "completed" with a disconnected result),

--- a/src/renderer/stores/acp-store.ts
+++ b/src/renderer/stores/acp-store.ts
@@ -4175,6 +4175,12 @@ export const useAcpStore = create<AcpState>((set, get) => ({
       // error to show, so the probe error is cleared.
       set((s) => ({
         mcpProbeStatus: { ...s.mcpProbeStatus, [id]: 'disconnected' },
+        // A throw means the probe never produced a result — drop any tools left
+        // over from a prior successful probe so the UI shows the disconnected
+        // state (McpBadge checks the tool list first), and mark tools as not
+        // loaded so a later expand auto-retries instead of caching the failure.
+        mcpTools: { ...s.mcpTools, [id]: [] },
+        mcpToolsLoaded: { ...s.mcpToolsLoaded, [id]: false },
         mcpProbing: { ...s.mcpProbing, [id]: false },
         mcpProbeError: { ...s.mcpProbeError, [id]: undefined }
       }))

--- a/src/renderer/stores/acp-store.ts
+++ b/src/renderer/stores/acp-store.ts
@@ -310,6 +310,14 @@ interface AcpState {
   mcpTools: Record<string, McpToolInfo[]>
   mcpToolsLoaded: Record<string, boolean>
   mcpProbing: Record<string, boolean>
+  /**
+   * Last probe error per server (the backend's redacted `ProbeResult.error` —
+   * already stripped of env/header values, tokens, and credentials). Set on
+   * `status:'disconnected'`, cleared on `connected` and on the transport-throw
+   * path (which synthesizes a disconnected status). Surfaced inline in Settings
+   * and as the chatbox "Probe failed" tooltip so failures are diagnosable.
+   */
+  mcpProbeError: Record<string, string | undefined>
 
   // Sessions
   sessions: Record<SessionId, AcpSession>
@@ -517,7 +525,9 @@ interface AcpState {
   /**
    * Probe a registered MCP server by id (Termul's own rmcp client — NOT the
    * agent's). Updates `mcpProbeStatus[id]` + `mcpTools[id]` +
-   * `mcpToolsLoaded[id]=true`. Read-only — no persistence, no rollback.
+   * `mcpToolsLoaded[id]=true`, and `mcpProbeError[id]` with the redacted
+   * `ProbeResult.error` on a disconnected result (cleared on connected and on
+   * the transport-throw path). Read-only — no persistence, no rollback.
    * Dedupes concurrent probes for the same id (`mcpProbing[id]`).
    */
   probeMcpServer: (id: string) => Promise<void>
@@ -2469,6 +2479,7 @@ export const useAcpStore = create<AcpState>((set, get) => ({
   mcpTools: {},
   mcpToolsLoaded: {},
   mcpProbing: {},
+  mcpProbeError: {},
   sessions: {},
   activeSessionId: null,
   sessionUsage: {},
@@ -4148,16 +4159,24 @@ export const useAcpStore = create<AcpState>((set, get) => ({
         mcpProbeStatus: { ...s.mcpProbeStatus, [id]: result.status },
         mcpTools: { ...s.mcpTools, [id]: result.tools },
         mcpToolsLoaded: { ...s.mcpToolsLoaded, [id]: true },
-        mcpProbing: { ...s.mcpProbing, [id]: false }
+        mcpProbing: { ...s.mcpProbing, [id]: false },
+        // Disconnected → keep the backend's (redacted) reason for the UI; a
+        // successful probe clears any stale error.
+        mcpProbeError: {
+          ...s.mcpProbeError,
+          [id]: result.status === 'connected' ? undefined : result.error
+        }
       }))
     } catch (err) {
       // Transport/parse failure (NOT a disconnected probe — that's a
       // `status:'disconnected'` ProbeResult, not a throw). Surface the
       // failure in the dot + log WITHOUT env/header values, tokens, or
-      // credentials.
+      // credentials. The synthetic disconnected status has no real backend
+      // error to show, so the probe error is cleared.
       set((s) => ({
         mcpProbeStatus: { ...s.mcpProbeStatus, [id]: 'disconnected' },
-        mcpProbing: { ...s.mcpProbing, [id]: false }
+        mcpProbing: { ...s.mcpProbing, [id]: false },
+        mcpProbeError: { ...s.mcpProbeError, [id]: undefined }
       }))
       void logFrontendError({
         source: 'acp-store.probeMcpServer',


### PR DESCRIPTION
## Summary

MCP server setup currently requires hand-filling each field in the Add/Edit
dialog. Users moving from Claude Desktop (or any tool that exports the
`{"mcpServers": {...}}` shape) must re-type commands, args, and env by hand,
and when a server fails to start the UI only shows a generic "disconnected"
badge with no reason — so debugging a broken config (wrong command, missing
env, a Windows `npx` spawn that silently never initializes) is a guessing
game. This PR closes that loop end-to-end: paste a Claude-Desktop JSON blob
to import servers in one step, see the concrete probe error inline, and fix
the Windows `npx` spawn failure that broke Dokploy (and any other npm-shim
launcher) out of the box.

## Related Issue

No related issue — this work is driven by the BMad Method spec
`_bmad-output/implementation-artifacts/spec-mcp-json-import-probe-diagnostics.md`,
not a GitHub issue.

## Type of Change

- [x] feat: new feature
- [x] fix: bug fix

## What Changed

- **JSON import** (`src/renderer/lib/mcp-json-import.ts` + tests): parse a
  pasted MCP config in either the Claude-Desktop wrapper shape
  `{"mcpServers": {name: {...}}}` or a bare single-server object
  `{command, args, env, ...}`. Normalize `env` from a `Record<string,string>`
  map into Termul's internal `[{name, value}]` shape (an already-normalized
  array passes through). Strip unknown fields (e.g. `directTools`,
  `alwaysAllow`) silently — `stringPairs` rebuilds each entry as a fresh
  `{name, value}` object so extra properties cannot leak through. Infer
  transport from `command`/`url` when `type` is omitted or unrecognized.
  Trim `command`/`url`/`args` entries to match the form path. Validate each
  server via `validateMcpServer`; invalid entries are reported per-server
  and skipped so the rest still import.
- **Import UI** (`McpServersSettings.tsx` + tests): new "Import JSON" tab in
  the Add/Edit dialog with a textarea, per-entry fresh-id saves, and a
  per-entry error list. The tab bar is hidden while editing an existing
  server (Add-only flow) so importing cannot silently create new entries
  instead of updating the draft. `saveImport` tracks how many entries landed
  before a failure and reports an accurate toast instead of a misleading
  "restored" message (preventing accidental duplicate re-imports). A
  probe-failure line is shown inline next to a server when its last probe
  errored.
- **Probe error surfacing** (`acp-store.ts`, `McpBadge.tsx`,
  `ChatInputBar.tsx`, `AgentLauncher.tsx` + tests): the store now keeps a
  throttled `mcpProbeError` slice, populated on disconnected/error and
  cleared on connected. The probe catch branch (transport/parse throw) also
  clears `mcpTools[id]` and resets `mcpToolsLoaded[id]` so a thrown probe
  cannot leave stale tools visible or block a later auto-retry. `McpBadge`
  shows the error string as a tooltip on the "Probe failed" line; the chat
  bar and launcher forward it through.
- **Windows `npx` spawn fix** (`src-tauri/src/acp/mcp_probe.rs`):
  `CreateProcessW` cannot launch `.cmd` shims, so `Command::new("npx")`
  failed at spawn (the Dokploy probe logged `disconnected` with no
  `Service initialized`). New `resolve_stdio_command()` mirrors the ACP
  config resolver (`acp/config.rs`): `resolve_spawn_program` rewrites
  `npx.cmd` to `node.exe <script>`, prepending the script ahead of the
  user args, with a `git_tracker::resolve_executable` fallback.
  `CREATE_NO_WINDOW` (`0x0800_0000`) is preserved. Includes a
  `#[cfg(target_os = "windows")]` shim-rewrite test using a per-process
  temp dir so parallel runs cannot collide.
- **Incidental**: gated a `use std::io::Write` import in
  `acp_binary_install.rs` with `#[cfg(unix)]` (it was only used in the
  unix test, producing a Windows build warning).

## How It Was Tested

- [x] `bun run ci` (Biome lint + format + imports, strict mode)
- [x] `bun run typecheck`
- [x] `bun run test`
- [x] `cargo clippy --all-targets -- -D warnings` (in src-tauri)
- [x] `cargo test` (in src-tauri)
- [ ] Manual verification completed

Note: `cargo test` could not be executed in this local Windows environment —
the freshly-built test binary fails to load with `0xc0000139
STATUS_ENTRYPOINT_NOT_FOUND`, a pre-existing environmental issue that
reproduces identically on the pristine `dev`/`main` checkout (unmodified by
this PR) and does not affect a trivial `hello.exe` built with the same
toolchain. `cargo clippy --all-targets` compiles and lints all test code
locally, and CI's **Rust Checks** job runs `cargo test` on Linux (passed:
6m22s) plus a **Rust Windows Smoke Check** (passed: 13m39s).

## CI & Review Gate

- [x] All CI checks pass (PR Validation, Rust Checks, Build Verification, Security Scans)
- [x] Code review comments from CodeRabbit / Claude have been addressed or resolved
- [x] No unresolved review findings remain

All 6 CodeRabbit inline findings were addressed in `4089a411` (unique
per-process temp dir in the Windows test; `saveImport` shadowing + accurate
partial-failure toast; Import tab hidden while editing; `stringPairs`
rebuilds entries to drop extra fields; `buildServer` trims command/url/args;
probe catch branch clears stale tools + resets retry flag) with a reply in
each review thread. CodeRabbit was rate-limited on the fix push and did not
re-review, but the prior review was `COMMENTED` (not `CHANGES_REQUESTED`).

## Checklist

- [x] My PR title follows the conventional commit format used by this repo
- [x] I linked the related issue or explained why none exists
- [x] I updated docs when needed
- [x] I added or updated tests when needed
- [x] I verified the change does not introduce unrelated modifications
- [x] I read AGENTS.md and followed the contributor guidelines
- [ ] A human reviewed the complete diff before submission
