### PR TITLE
fix(acp): restore persisted tool calls when resuming chat history

### DIFF
--- a/docs/api-contracts.md
+++ b/docs/api-contracts.md
@@ -174,7 +174,14 @@ Runs rollback logic for a migration.
 
 Desktop renderer chat history is stored under the Tauri app-data directory by a
 Rust-owned, versioned file store. The commands preserve the existing renderer
-`SessionIndexEntry` / `SessionPayload` JSON shape:
+`SessionIndexEntry` / `SessionPayload` JSON shape. `SessionPayload` carries
+`{ metadata, messages, toolCalls? }`: `toolCalls` is an optional mirror of the
+session's ACP tool calls so history reopens and post-reload resumes restore the
+tool cards in the timeline. Persisted tool calls drop `rawOutput` and unknown
+fields, normalize mid-flight statuses to `failed`, keep only the most recent
+calls, and are bounded per call by a serialized byte budget
+(`sanitizeToolCallsForPersistence`); payloads written before the field existed
+omit it.
 
 - `acp_history_list` returns `{ sessions, legacyImportComplete }`.
 - `acp_history_get` returns one full payload or `null` when absent.

--- a/src/renderer/assets/agent-icons/acp/agents.json
+++ b/src/renderer/assets/agent-icons/acp/agents.json
@@ -513,37 +513,37 @@
   {
     "id": "kilo",
     "name": "Kilo",
-    "version": "7.4.17",
+    "version": "7.4.19",
     "description": "The open source coding agent",
     "distribution": {
       "npx": {
-        "package": "@kilocode/cli@7.4.17",
+        "package": "@kilocode/cli@7.4.19",
         "args": ["acp"]
       },
       "binary": {
         "darwin-aarch64": {
           "cmd": "./kilo",
-          "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.4.17/kilo-darwin-arm64.zip",
+          "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.4.19/kilo-darwin-arm64.zip",
           "args": ["acp"]
         },
         "darwin-x86_64": {
           "cmd": "./kilo",
-          "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.4.17/kilo-darwin-x64.zip",
+          "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.4.19/kilo-darwin-x64.zip",
           "args": ["acp"]
         },
         "linux-aarch64": {
           "cmd": "./kilo",
-          "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.4.17/kilo-linux-arm64.tar.gz",
+          "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.4.19/kilo-linux-arm64.tar.gz",
           "args": ["acp"]
         },
         "linux-x86_64": {
           "cmd": "./kilo",
-          "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.4.17/kilo-linux-x64.tar.gz",
+          "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.4.19/kilo-linux-x64.tar.gz",
           "args": ["acp"]
         },
         "windows-x86_64": {
           "cmd": "./kilo.exe",
-          "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.4.17/kilo-windows-x64.zip",
+          "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.4.19/kilo-windows-x64.zip",
           "args": ["acp"]
         }
       }

--- a/src/renderer/assets/agent-icons/acp/agents.json
+++ b/src/renderer/assets/agent-icons/acp/agents.json
@@ -332,11 +332,11 @@
   {
     "id": "factory-droid",
     "name": "Factory Droid",
-    "version": "0.186.0",
+    "version": "0.187.0",
     "description": "Factory Droid - AI coding agent powered by Factory AI",
     "distribution": {
       "npx": {
-        "package": "droid@0.186.0",
+        "package": "droid@0.187.0",
         "args": ["exec", "--output-format", "acp-daemon"],
         "env": {
           "DROID_DISABLE_AUTO_UPDATE": "true",
@@ -372,11 +372,11 @@
   {
     "id": "github-copilot-cli",
     "name": "GitHub Copilot",
-    "version": "1.0.77",
+    "version": "1.0.78",
     "description": "GitHub's AI pair programmer",
     "distribution": {
       "npx": {
-        "package": "@github/copilot@1.0.77",
+        "package": "@github/copilot@1.0.78",
         "args": ["--acp"]
       }
     }
@@ -426,11 +426,11 @@
   {
     "id": "grok-build",
     "name": "Grok Build",
-    "version": "0.2.119",
+    "version": "0.2.120",
     "description": "xAI's coding agent and CLI",
     "distribution": {
       "npx": {
-        "package": "@xai-official/grok@0.2.119",
+        "package": "@xai-official/grok@0.2.120",
         "args": ["agent", "stdio"]
       }
     }
@@ -438,33 +438,33 @@
   {
     "id": "harn",
     "name": "Harn",
-    "version": "0.10.52",
+    "version": "0.10.53",
     "description": "Harn runs .harn agent pipelines as a native ACP coding agent over stdio.",
     "distribution": {
       "binary": {
         "darwin-aarch64": {
           "cmd": "./harn",
-          "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.52/harn-aarch64-apple-darwin.tar.gz",
+          "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.53/harn-aarch64-apple-darwin.tar.gz",
           "args": ["serve", "acp"]
         },
         "darwin-x86_64": {
           "cmd": "./harn",
-          "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.52/harn-x86_64-apple-darwin.tar.gz",
+          "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.53/harn-x86_64-apple-darwin.tar.gz",
           "args": ["serve", "acp"]
         },
         "linux-aarch64": {
           "cmd": "./harn",
-          "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.52/harn-aarch64-unknown-linux-gnu.tar.gz",
+          "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.53/harn-aarch64-unknown-linux-gnu.tar.gz",
           "args": ["serve", "acp"]
         },
         "linux-x86_64": {
           "cmd": "./harn",
-          "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.52/harn-x86_64-unknown-linux-gnu.tar.gz",
+          "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.53/harn-x86_64-unknown-linux-gnu.tar.gz",
           "args": ["serve", "acp"]
         },
         "windows-x86_64": {
           "cmd": "harn.exe",
-          "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.52/harn-x86_64-pc-windows-msvc.zip",
+          "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.53/harn-x86_64-pc-windows-msvc.zip",
           "args": ["serve", "acp"]
         }
       }
@@ -599,29 +599,29 @@
   {
     "id": "mistral-vibe",
     "name": "Mistral Vibe",
-    "version": "2.23.2",
+    "version": "2.23.3",
     "description": "Mistral's open-source coding assistant",
     "distribution": {
       "binary": {
         "darwin-aarch64": {
           "cmd": "./vibe-acp",
-          "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v2.23.2/vibe-acp-darwin-aarch64-2.23.2.zip"
+          "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v2.23.3/vibe-acp-darwin-aarch64-2.23.3.zip"
         },
         "darwin-x86_64": {
           "cmd": "./vibe-acp",
-          "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v2.23.2/vibe-acp-darwin-x86_64-2.23.2.zip"
+          "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v2.23.3/vibe-acp-darwin-x86_64-2.23.3.zip"
         },
         "linux-aarch64": {
           "cmd": "./vibe-acp",
-          "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v2.23.2/vibe-acp-linux-aarch64-2.23.2.zip"
+          "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v2.23.3/vibe-acp-linux-aarch64-2.23.3.zip"
         },
         "linux-x86_64": {
           "cmd": "./vibe-acp",
-          "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v2.23.2/vibe-acp-linux-x86_64-2.23.2.zip"
+          "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v2.23.3/vibe-acp-linux-x86_64-2.23.3.zip"
         },
         "windows-x86_64": {
           "cmd": "./vibe-acp.exe",
-          "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v2.23.2/vibe-acp-windows-x86_64-2.23.2.zip"
+          "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v2.23.3/vibe-acp-windows-x86_64-2.23.3.zip"
         }
       }
     }
@@ -641,38 +641,38 @@
   {
     "id": "opencode",
     "name": "OpenCode",
-    "version": "1.18.11",
+    "version": "1.18.12",
     "description": "The open source coding agent",
     "distribution": {
       "binary": {
         "darwin-aarch64": {
           "cmd": "./opencode",
-          "archive": "https://github.com/anomalyco/opencode/releases/download/v1.18.11/opencode-darwin-arm64.zip",
+          "archive": "https://github.com/anomalyco/opencode/releases/download/v1.18.12/opencode-darwin-arm64.zip",
           "args": ["acp"]
         },
         "darwin-x86_64": {
           "cmd": "./opencode",
-          "archive": "https://github.com/anomalyco/opencode/releases/download/v1.18.11/opencode-darwin-x64.zip",
+          "archive": "https://github.com/anomalyco/opencode/releases/download/v1.18.12/opencode-darwin-x64.zip",
           "args": ["acp"]
         },
         "linux-aarch64": {
           "cmd": "./opencode",
-          "archive": "https://github.com/anomalyco/opencode/releases/download/v1.18.11/opencode-linux-arm64.tar.gz",
+          "archive": "https://github.com/anomalyco/opencode/releases/download/v1.18.12/opencode-linux-arm64.tar.gz",
           "args": ["acp"]
         },
         "linux-x86_64": {
           "cmd": "./opencode",
-          "archive": "https://github.com/anomalyco/opencode/releases/download/v1.18.11/opencode-linux-x64.tar.gz",
+          "archive": "https://github.com/anomalyco/opencode/releases/download/v1.18.12/opencode-linux-x64.tar.gz",
           "args": ["acp"]
         },
         "windows-aarch64": {
           "cmd": "./opencode",
-          "archive": "https://github.com/anomalyco/opencode/releases/download/v1.18.11/opencode-windows-arm64.zip",
+          "archive": "https://github.com/anomalyco/opencode/releases/download/v1.18.12/opencode-windows-arm64.zip",
           "args": ["acp"]
         },
         "windows-x86_64": {
           "cmd": "./opencode.exe",
-          "archive": "https://github.com/anomalyco/opencode/releases/download/v1.18.11/opencode-windows-x64.zip",
+          "archive": "https://github.com/anomalyco/opencode/releases/download/v1.18.12/opencode-windows-x64.zip",
           "args": ["acp"]
         }
       }
@@ -744,11 +744,11 @@
   {
     "id": "qwen-code",
     "name": "Qwen Code",
-    "version": "0.21.4",
+    "version": "0.21.5",
     "description": "Alibaba's Qwen coding assistant",
     "distribution": {
       "npx": {
-        "package": "@qwen-code/qwen-code@0.21.4",
+        "package": "@qwen-code/qwen-code@0.21.5",
         "args": ["--acp", "--experimental-skills"]
       }
     }

--- a/src/renderer/lib/acp-history-persistence.test.ts
+++ b/src/renderer/lib/acp-history-persistence.test.ts
@@ -19,6 +19,7 @@ const { mockTransport, mockHistoryApi } = vi.hoisted(() => ({
 
 vi.mock('@/lib/acp-transport', () => ({ getAcpTransport: () => mockTransport }))
 vi.mock('@/lib/acp-history-api', () => ({ acpHistoryApi: mockHistoryApi }))
+vi.mock('@/lib/log-api', () => ({ logFrontendError: vi.fn() }))
 vi.mock('@/lib/api', () => ({
   persistenceApi: {
     read: vi.fn(),
@@ -28,6 +29,7 @@ vi.mock('@/lib/api', () => ({
   }
 }))
 
+import type { ToolCall } from '@/lib/acp-api'
 import { persistenceApi } from '@/lib/api'
 import type { ChatMessage } from '@/stores/acp-store'
 import {
@@ -41,12 +43,17 @@ import {
   loadSessionIndex,
   loadSessionPayload,
   markSessionPayloadPinned,
+  maxPayloadSeq,
+  PERSISTED_TOOL_CALL_BYTE_BUDGET,
+  PERSISTED_TOOL_CALLS_LIMIT,
   queueSessionPayloadDelete,
   queueSessionPayloadSave,
+  restoredToolCalls,
   runHistoryWipeMigration,
   SESSION_INDEX_KEY,
   type SessionIndexEntry,
   type SessionPayload,
+  sanitizeToolCallsForPersistence,
   saveSessionPayload,
   scopeSessionIndex,
   sessionPayloadKey,
@@ -158,6 +165,137 @@ describe('pure history helpers', () => {
   })
 })
 
+describe('durable tool-call sanitization', () => {
+  function toolCall(overrides: Partial<ToolCall> = {}): ToolCall {
+    return {
+      toolCallId: 'tc-1',
+      title: 'Read file',
+      kind: 'read',
+      status: 'completed',
+      timestamp: 100,
+      seq: 5,
+      rawInput: { path: '/a.ts' },
+      rawOutput: 'huge output',
+      ...overrides
+    }
+  }
+
+  it('returns undefined for absent or empty lists so the field is omitted', () => {
+    expect(sanitizeToolCallsForPersistence(undefined)).toBeUndefined()
+    expect(sanitizeToolCallsForPersistence([])).toBeUndefined()
+  })
+
+  it('strips rawOutput but keeps summary fields and timeline stamps', () => {
+    const [clean] = sanitizeToolCallsForPersistence([toolCall()])!
+    expect(clean.rawOutput).toBeUndefined()
+    expect(clean).toMatchObject({
+      toolCallId: 'tc-1',
+      title: 'Read file',
+      kind: 'read',
+      status: 'completed',
+      timestamp: 100,
+      seq: 5,
+      rawInput: { path: '/a.ts' }
+    })
+  })
+
+  it('keeps structured content and rawInput within the byte budget', () => {
+    const [clean] = sanitizeToolCallsForPersistence([
+      toolCall({
+        content: [{ type: 'text', text: 'short' }],
+        rawInput: { command: 'ls' }
+      })
+    ])!
+    expect(clean.content).toEqual([{ type: 'text', text: 'short' }])
+    expect(clean.rawInput).toEqual({ command: 'ls' })
+  })
+
+  it('degrades over-budget calls to the structural subset', () => {
+    const huge = 'x'.repeat(PERSISTED_TOOL_CALL_BYTE_BUDGET + 1)
+    const [clean] = sanitizeToolCallsForPersistence([
+      toolCall({ rawInput: { path: '/big.ts', blob: huge } })
+    ])!
+    expect(clean.rawInput).toBeUndefined()
+    expect(clean.content).toBeUndefined()
+    expect(clean).toMatchObject({ toolCallId: 'tc-1', title: 'Read file', kind: 'read', seq: 5 })
+  })
+
+  it('falls back to the structural subset for non-serializable fields', () => {
+    const circular: Record<string, unknown> = {}
+    circular.self = circular
+    const [clean] = sanitizeToolCallsForPersistence([toolCall({ rawInput: circular })])!
+    expect(clean.rawInput).toBeUndefined()
+    expect(clean).toMatchObject({ toolCallId: 'tc-1', status: 'completed', seq: 5 })
+  })
+
+  it('persists mid-flight statuses as failed so restored cards do not spin forever', () => {
+    const pending = sanitizeToolCallsForPersistence([toolCall({ status: 'pending' })])!
+    const inProgress = sanitizeToolCallsForPersistence([toolCall({ status: 'in_progress' })])!
+    expect(pending[0].status).toBe('failed')
+    expect(inProgress[0].status).toBe('failed')
+    const completed = sanitizeToolCallsForPersistence([toolCall({ status: 'completed' })])!
+    expect(completed[0].status).toBe('completed')
+  })
+
+  it('bounds agent-controlled titles so the degraded subset stays bounded', () => {
+    const hugeTitle = 't'.repeat(5000)
+    const [clean] = sanitizeToolCallsForPersistence([
+      toolCall({
+        title: hugeTitle,
+        rawInput: { blob: 'x'.repeat(PERSISTED_TOOL_CALL_BYTE_BUDGET) }
+      })
+    ])!
+    expect(clean.title!.length).toBeLessThanOrEqual(201)
+  })
+
+  it('drops unknown agent fields at the persistence boundary', () => {
+    const [clean] = sanitizeToolCallsForPersistence([
+      toolCall({ vendorBlob: 'should not survive' })
+    ])!
+    expect(clean.vendorBlob).toBeUndefined()
+    expect(clean.rawOutput).toBeUndefined()
+  })
+
+  it('keeps only the most recent calls per session (recency bound)', () => {
+    const calls = Array.from({ length: PERSISTED_TOOL_CALLS_LIMIT + 10 }, (_, index) => ({
+      toolCallId: `tc-${index}`,
+      seq: index + 1
+    }))
+    const clean = sanitizeToolCallsForPersistence(calls)!
+    expect(clean).toHaveLength(PERSISTED_TOOL_CALLS_LIMIT)
+    expect(clean[0].toolCallId).toBe('tc-10')
+    expect(clean[clean.length - 1].toolCallId).toBe(`tc-${PERSISTED_TOOL_CALLS_LIMIT + 9}`)
+  })
+
+  it('tolerates non-array input without throwing', () => {
+    expect(sanitizeToolCallsForPersistence('corrupt' as unknown as ToolCall[])).toBeUndefined()
+  })
+})
+
+describe('payload restore helpers', () => {
+  it('maxPayloadSeq folds message and tool-call seqs', () => {
+    expect(
+      maxPayloadSeq({
+        messages: [{ id: 'm', role: 'user', blocks: [], streaming: false, timestamp: 0, seq: 3 }],
+        toolCalls: [{ toolCallId: 'tc', seq: 7 }]
+      })
+    ).toBe(7)
+    expect(
+      maxPayloadSeq({
+        messages: [{ id: 'm', role: 'user', blocks: [], streaming: false, timestamp: 0, seq: 9 }],
+        toolCalls: [{ toolCallId: 'tc', seq: 2 }]
+      })
+    ).toBe(9)
+  })
+
+  it('restore helpers degrade corrupt toolCalls shapes instead of throwing', () => {
+    const corrupt = { toolCalls: 'not-an-array' as unknown as ToolCall[] }
+    expect(maxPayloadSeq({ messages: [], ...corrupt })).toBe(0)
+    expect(restoredToolCalls(corrupt)).toEqual([])
+    expect(restoredToolCalls({})).toEqual([])
+  })
+})
+
 describe('provider routing', () => {
   it('loads desktop index from the Rust facade, including fresh empty state', async () => {
     mockHistoryApi.list.mockResolvedValueOnce({ sessions: [], legacyImportComplete: false })
@@ -259,6 +397,48 @@ describe('bounded full-payload cache', () => {
       expect.objectContaining({ messages: [old, retained, latest] })
     )
     expect(getCachedSessionPayload('merge')?.messages).toEqual([old, retained, latest])
+  })
+
+  it('keeps live tool calls when merging a durable message prefix', async () => {
+    const old = msg('user', 'old')
+    const retained = msg('agent', 'retained')
+    const latest = msg('agent', 'latest')
+    const durableTool: ToolCall = { toolCallId: 'durable' }
+    const liveTool: ToolCall = { toolCallId: 'live' }
+    mockHistoryApi.get.mockResolvedValueOnce({
+      ...payload('merge-tools', [old, retained]),
+      toolCalls: [durableTool]
+    })
+
+    await saveSessionPayload('merge-tools', {
+      ...payload('merge-tools', [retained, latest]),
+      toolCalls: [liveTool]
+    })
+
+    expect(mockHistoryApi.save).toHaveBeenCalledWith(
+      'merge-tools',
+      expect.objectContaining({
+        messages: [old, retained, latest],
+        toolCalls: [liveTool]
+      })
+    )
+  })
+
+  it('falls back to durable tool calls when the live payload carries none', async () => {
+    const old = msg('user', 'old')
+    const retained = msg('agent', 'retained')
+    const durableTool: ToolCall = { toolCallId: 'durable' }
+    mockHistoryApi.get.mockResolvedValueOnce({
+      ...payload('fallback-tools', [old, retained]),
+      toolCalls: [durableTool]
+    })
+
+    await saveSessionPayload('fallback-tools', payload('fallback-tools', [retained]))
+
+    expect(mockHistoryApi.save).toHaveBeenCalledWith(
+      'fallback-tools',
+      expect.objectContaining({ toolCalls: [durableTool] })
+    )
   })
 })
 

--- a/src/renderer/lib/acp-history-persistence.test.ts
+++ b/src/renderer/lib/acp-history-persistence.test.ts
@@ -270,6 +270,21 @@ describe('durable tool-call sanitization', () => {
   it('tolerates non-array input without throwing', () => {
     expect(sanitizeToolCallsForPersistence('corrupt' as unknown as ToolCall[])).toBeUndefined()
   })
+
+  it('drops calls whose structural subset still exceeds the budget (oversized id)', () => {
+    const oversizedId = 'tc-'.concat('x'.repeat(PERSISTED_TOOL_CALL_BYTE_BUDGET + 1))
+    const clean = sanitizeToolCallsForPersistence([
+      toolCall({ toolCallId: oversizedId }),
+      toolCall({ toolCallId: 'tc-ok' })
+    ])!
+    expect(clean).toHaveLength(1)
+    expect(clean[0].toolCallId).toBe('tc-ok')
+  })
+
+  it('returns undefined when every call is dropped for exceeding the budget', () => {
+    const oversizedId = 'tc-'.concat('x'.repeat(PERSISTED_TOOL_CALL_BYTE_BUDGET + 1))
+    expect(sanitizeToolCallsForPersistence([toolCall({ toolCallId: oversizedId })])).toBeUndefined()
+  })
 })
 
 describe('payload restore helpers', () => {
@@ -293,6 +308,27 @@ describe('payload restore helpers', () => {
     expect(maxPayloadSeq({ messages: [], ...corrupt })).toBe(0)
     expect(restoredToolCalls(corrupt)).toEqual([])
     expect(restoredToolCalls({})).toEqual([])
+  })
+
+  it('restore helpers skip null and malformed entries inside the array', () => {
+    const valid = { toolCallId: 'tc-valid', seq: 4 }
+    const junk = [
+      null,
+      42,
+      'tc-string',
+      { seq: 3 },
+      { toolCallId: '' },
+      valid
+    ] as unknown as ToolCall[]
+    expect(maxPayloadSeq({ messages: [], toolCalls: junk })).toBe(4)
+    expect(restoredToolCalls({ toolCalls: junk })).toEqual([valid])
+  })
+
+  it('maxPayloadSeq ignores non-finite seqs instead of poisoning the rebase', () => {
+    const corrupt = {
+      toolCalls: [{ toolCallId: 'tc-nan', seq: Number.NaN }] as unknown as ToolCall[]
+    }
+    expect(maxPayloadSeq({ messages: [], ...corrupt })).toBe(0)
   })
 })
 

--- a/src/renderer/lib/acp-history-persistence.ts
+++ b/src/renderer/lib/acp-history-persistence.ts
@@ -1,9 +1,11 @@
 /** Desktop ACP history persistence boundary. */
 
 import type { PersistedSessionSummary } from '@shared/types/web-protocol.types'
+import type { ToolCall } from '@/lib/acp-api'
 import { acpHistoryApi } from '@/lib/acp-history-api'
 import { getAcpTransport } from '@/lib/acp-transport'
 import { persistenceApi } from '@/lib/api'
+import { logFrontendError } from '@/lib/log-api'
 import type { ChatMessage, SessionStatus } from '@/stores/acp-store'
 
 export const SESSION_INDEX_KEY = 'acp/sessions/index'
@@ -37,6 +39,117 @@ export interface SessionIndexEntry {
 export interface SessionPayload {
   metadata: SessionIndexEntry
   messages: ChatMessage[]
+  /**
+   * Durable tool calls mirrored alongside the transcript so history reopens
+   * and post-reload resumes restore the tool cards in the timeline. Written
+   * through `sanitizeToolCallsForPersistence` (no `rawOutput`, per-call size
+   * bound). Absent on payloads persisted before this field existed.
+   */
+  toolCalls?: ToolCall[]
+}
+
+/**
+ * Maximum serialized UTF-8 size of a single durable tool call. Calls exceeding
+ * the budget degrade to the structural subset so a giant diff or tool input
+ * cannot balloon the on-disk payload.
+ */
+export const PERSISTED_TOOL_CALL_BYTE_BUDGET = 32 * 1024
+
+/**
+ * Maximum number of tool calls persisted per session. Tool calls are never
+ * trimmed in the live window (messages have `MAX_LIVE_WINDOW_MESSAGES`), so the
+ * durable mirror keeps only the most recent calls — the same recency window a
+ * reader browses — bounding payload growth on very long sessions.
+ */
+export const PERSISTED_TOOL_CALLS_LIMIT = 500
+
+/** Agent-controlled titles are bounded so the degraded subset stays bounded. */
+const PERSISTED_TOOL_CALL_TITLE_LIMIT = 200
+
+const persistedTextEncoder = new TextEncoder()
+
+function boundedTitle(title: unknown): string | undefined {
+  if (typeof title !== 'string' || title.length === 0) return undefined
+  return title.length > PERSISTED_TOOL_CALL_TITLE_LIMIT
+    ? `${title.slice(0, PERSISTED_TOOL_CALL_TITLE_LIMIT)}…`
+    : title
+}
+
+/**
+ * Structural subset of a durable tool call: routing/status fields + timeline
+ * stamps only. Mid-flight statuses are persisted as `failed` — the turn that
+ * owned them has ended, and restoring `pending`/`in_progress` would reopen the
+ * card spinning forever.
+ */
+function structuralToolCall(toolCall: ToolCall): ToolCall {
+  const reduced: ToolCall = { toolCallId: toolCall.toolCallId }
+  const title = boundedTitle(toolCall.title)
+  if (title !== undefined) reduced.title = title
+  if (toolCall.kind !== undefined) reduced.kind = toolCall.kind
+  const status =
+    toolCall.status === 'pending' || toolCall.status === 'in_progress' ? 'failed' : toolCall.status
+  if (status !== undefined) reduced.status = status
+  if (typeof toolCall.timestamp === 'number') reduced.timestamp = toolCall.timestamp
+  if (typeof toolCall.seq === 'number') reduced.seq = toolCall.seq
+  return reduced
+}
+
+/**
+ * Mirror-ready tool calls for durable history. `rawOutput` (unbounded tool
+ * results) is never persisted, and only the known summary/render fields
+ * (`rawInput`, structured `content`) ride along — unknown agent fields are
+ * dropped at the boundary. Over-budget calls degrade to the structural subset
+ * instead of ballooning the payload; non-serializable calls degrade the same
+ * way (and the degradation is logged, never silent).
+ */
+export function sanitizeToolCallsForPersistence(
+  toolCalls: ToolCall[] | undefined
+): ToolCall[] | undefined {
+  if (!Array.isArray(toolCalls) || toolCalls.length === 0) return undefined
+  const degraded: string[] = []
+  const sanitized = toolCalls.slice(-PERSISTED_TOOL_CALLS_LIMIT).map((toolCall) => {
+    const candidate = structuralToolCall(toolCall)
+    if (toolCall.rawInput !== undefined) candidate.rawInput = toolCall.rawInput
+    if (toolCall.content !== undefined) candidate.content = toolCall.content
+    try {
+      const bytes = persistedTextEncoder.encode(JSON.stringify(candidate)).byteLength
+      if (bytes <= PERSISTED_TOOL_CALL_BYTE_BUDGET) return candidate
+    } catch {
+      // Non-serializable fields: fall through to the structural subset.
+    }
+    degraded.push(toolCall.toolCallId)
+    return structuralToolCall(toolCall)
+  })
+  if (degraded.length > 0) {
+    void logFrontendError({
+      level: 'warn',
+      source: 'acp.historyPersistence',
+      message: `Persisted ${degraded.length} tool call(s) in degraded structural form (over budget or non-serializable): ${degraded.slice(0, 3).join(', ')}`
+    })
+  }
+  return sanitized
+}
+
+/**
+ * Highest `seq` across a payload's messages and tool calls (they share one
+ * timeline counter). Corrupt/partial payloads degrade to the fields present —
+ * a non-array `toolCalls` never throws on the reopen hot path.
+ */
+export function maxPayloadSeq(payload: Pick<SessionPayload, 'messages' | 'toolCalls'>): number {
+  let maxSeq = 0
+  for (const message of payload.messages) {
+    if (typeof message.seq === 'number' && message.seq > maxSeq) maxSeq = message.seq
+  }
+  const toolCalls = Array.isArray(payload.toolCalls) ? payload.toolCalls : []
+  for (const toolCall of toolCalls) {
+    if (typeof toolCall.seq === 'number' && toolCall.seq > maxSeq) maxSeq = toolCall.seq
+  }
+  return maxSeq
+}
+
+/** Restored tool calls for a payload, tolerant of legacy/corrupt shapes. */
+export function restoredToolCalls(payload: Pick<SessionPayload, 'toolCalls'>): ToolCall[] {
+  return Array.isArray(payload.toolCalls) ? payload.toolCalls : []
 }
 
 function stablePayload(payload: SessionPayload): string {
@@ -322,7 +435,10 @@ export async function saveSessionPayload(id: string, payload: SessionPayload): P
       if (durablePrefix.length > 0) {
         nextPayload = {
           metadata: { ...payload.metadata },
-          messages: [...durablePrefix, ...payload.messages]
+          messages: [...durablePrefix, ...payload.messages],
+          // The live store owns the full (never-trimmed) tool-call list; only
+          // fall back to disk when the incoming payload carries none.
+          toolCalls: payload.toolCalls ?? durable.toolCalls
         }
         nextPayload.metadata.messageCount = nextPayload.messages.length
       }

--- a/src/renderer/lib/acp-history-persistence.ts
+++ b/src/renderer/lib/acp-history-persistence.ts
@@ -107,49 +107,93 @@ export function sanitizeToolCallsForPersistence(
 ): ToolCall[] | undefined {
   if (!Array.isArray(toolCalls) || toolCalls.length === 0) return undefined
   const degraded: string[] = []
-  const sanitized = toolCalls.slice(-PERSISTED_TOOL_CALLS_LIMIT).map((toolCall) => {
+  const dropped: string[] = []
+  const sanitized: ToolCall[] = []
+  for (const toolCall of toolCalls.slice(-PERSISTED_TOOL_CALLS_LIMIT)) {
     const candidate = structuralToolCall(toolCall)
     if (toolCall.rawInput !== undefined) candidate.rawInput = toolCall.rawInput
     if (toolCall.content !== undefined) candidate.content = toolCall.content
+    let persisted: ToolCall | undefined
     try {
       const bytes = persistedTextEncoder.encode(JSON.stringify(candidate)).byteLength
-      if (bytes <= PERSISTED_TOOL_CALL_BYTE_BUDGET) return candidate
+      if (bytes <= PERSISTED_TOOL_CALL_BYTE_BUDGET) persisted = candidate
     } catch {
       // Non-serializable fields: fall through to the structural subset.
     }
-    degraded.push(toolCall.toolCallId)
-    return structuralToolCall(toolCall)
-  })
-  if (degraded.length > 0) {
+    if (!persisted) {
+      // Over budget or non-serializable: degrade to the structural subset, then
+      // re-measure it. `toolCallId` is agent-sourced and unbounded, so even the
+      // subset can exceed the cap — omit the call entirely in that case so the
+      // per-call budget actually holds.
+      const structural = structuralToolCall(toolCall)
+      const structuralBytes = persistedTextEncoder.encode(JSON.stringify(structural)).byteLength
+      if (structuralBytes <= PERSISTED_TOOL_CALL_BYTE_BUDGET) {
+        degraded.push(toolCall.toolCallId)
+        persisted = structural
+      } else {
+        dropped.push(toolCall.toolCallId)
+      }
+    }
+    if (persisted) sanitized.push(persisted)
+  }
+  if (degraded.length > 0 || dropped.length > 0) {
+    const parts: string[] = []
+    if (degraded.length > 0) {
+      parts.push(`degraded ${degraded.length}: ${degraded.slice(0, 3).join(', ')}`)
+    }
+    if (dropped.length > 0) {
+      parts.push(`dropped ${dropped.length} over-size: ${dropped.slice(0, 3).join(', ')}`)
+    }
     void logFrontendError({
       level: 'warn',
       source: 'acp.historyPersistence',
-      message: `Persisted ${degraded.length} tool call(s) in degraded structural form (over budget or non-serializable): ${degraded.slice(0, 3).join(', ')}`
+      message: `Tool-call persistence budget enforced — ${parts.join('; ')}`
     })
   }
-  return sanitized
+  return sanitized.length > 0 ? sanitized : undefined
+}
+
+/** True for a restorable tool-call record: a non-null object with a string id. */
+function isRestorableToolCall(value: unknown): value is ToolCall {
+  if (typeof value !== 'object' || value === null) return false
+  const candidate = value as ToolCall
+  return typeof candidate.toolCallId === 'string' && candidate.toolCallId.length > 0
+}
+
+/** Filter a raw payload array down to restorable tool-call records. */
+function normalizedToolCalls(toolCalls: unknown): ToolCall[] {
+  if (!Array.isArray(toolCalls)) return []
+  return toolCalls.filter(isRestorableToolCall)
 }
 
 /**
  * Highest `seq` across a payload's messages and tool calls (they share one
  * timeline counter). Corrupt/partial payloads degrade to the fields present —
- * a non-array `toolCalls` never throws on the reopen hot path.
+ * a non-array `toolCalls`, or one containing non-record entries (`null`,
+ * scalar, missing id), never throws on the reopen hot path.
  */
 export function maxPayloadSeq(payload: Pick<SessionPayload, 'messages' | 'toolCalls'>): number {
   let maxSeq = 0
   for (const message of payload.messages) {
-    if (typeof message.seq === 'number' && message.seq > maxSeq) maxSeq = message.seq
+    if (typeof message.seq === 'number' && Number.isFinite(message.seq) && message.seq > maxSeq) {
+      maxSeq = message.seq
+    }
   }
-  const toolCalls = Array.isArray(payload.toolCalls) ? payload.toolCalls : []
-  for (const toolCall of toolCalls) {
-    if (typeof toolCall.seq === 'number' && toolCall.seq > maxSeq) maxSeq = toolCall.seq
+  for (const toolCall of normalizedToolCalls(payload.toolCalls)) {
+    if (
+      typeof toolCall.seq === 'number' &&
+      Number.isFinite(toolCall.seq) &&
+      toolCall.seq > maxSeq
+    ) {
+      maxSeq = toolCall.seq
+    }
   }
   return maxSeq
 }
 
 /** Restored tool calls for a payload, tolerant of legacy/corrupt shapes. */
 export function restoredToolCalls(payload: Pick<SessionPayload, 'toolCalls'>): ToolCall[] {
-  return Array.isArray(payload.toolCalls) ? payload.toolCalls : []
+  return normalizedToolCalls(payload.toolCalls)
 }
 
 function stablePayload(payload: SessionPayload): string {

--- a/src/renderer/stores/acp-store.test.ts
+++ b/src/renderer/stores/acp-store.test.ts
@@ -1284,6 +1284,114 @@ describe('acp-store', () => {
     )
   })
 
+  it('prompt_complete mirrors tool calls to disk so history reopens restore them', async () => {
+    seedSession('s1', 'agent-1')
+    useAcpStore.setState({
+      sessionIndex: [
+        {
+          id: 's1',
+          agentId: 'agent-1',
+          title: 'T',
+          cwd: '/work',
+          projectId: 'p1',
+          createdAt: 0,
+          lastActivityAt: 0,
+          messageCount: 1,
+          status: 'active'
+        }
+      ],
+      toolCalls: {
+        s1: [
+          {
+            toolCallId: 'tc-1',
+            title: 'Read file',
+            kind: 'read',
+            status: 'completed',
+            timestamp: 10,
+            seq: 3,
+            rawInput: { path: '/a.ts' },
+            rawOutput: 'secret output'
+          }
+        ]
+      }
+    })
+    const { queueSessionPayloadSave } = await import('@/lib/acp-history-persistence')
+    ;(queueSessionPayloadSave as ReturnType<typeof vi.fn>).mockClear()
+    useAcpStore.getState()._onPromptComplete({
+      agentId: 'agent-1',
+      sessionId: 's1',
+      stopReason: 'end_turn'
+    })
+    await flushTurnEnd()
+    const payload = (queueSessionPayloadSave as ReturnType<typeof vi.fn>).mock.calls[0]?.[1]
+    expect(payload.toolCalls).toEqual([
+      expect.objectContaining({ toolCallId: 'tc-1', kind: 'read', seq: 3 })
+    ])
+    // rawOutput must never reach disk.
+    expect(payload.toolCalls[0].rawOutput).toBeUndefined()
+  })
+
+  it('prompt_complete keeps the durable tool-call mirror when the live map key is absent', async () => {
+    // Transcript eviction / lazy backfill can leave `messages` present without
+    // the `toolCalls` key; the persist must then keep the cached mirror
+    // instead of blanking it.
+    seedSession('s1', 'agent-1')
+    useAcpStore.setState({
+      sessionIndex: [
+        {
+          id: 's1',
+          agentId: 'agent-1',
+          title: 'T',
+          cwd: '/work',
+          projectId: 'p1',
+          createdAt: 0,
+          lastActivityAt: 0,
+          messageCount: 1,
+          status: 'active'
+        }
+      ],
+      messages: {
+        s1: [
+          {
+            id: 'm1',
+            role: 'user',
+            blocks: [{ type: 'text', text: 'hi' }],
+            streaming: false,
+            timestamp: 0,
+            seq: 1
+          }
+        ]
+      }
+      // No `toolCalls['s1']` key — the live map lost it.
+    })
+    setCachedSessionPayload('s1', {
+      metadata: {
+        id: 's1',
+        agentId: 'agent-1',
+        agentConfigId: 'cfg-1',
+        title: 'T',
+        cwd: '/work',
+        projectId: 'p1',
+        createdAt: 0,
+        lastActivityAt: 0,
+        messageCount: 1,
+        status: 'active'
+      },
+      messages: [],
+      toolCalls: [{ toolCallId: 'durable', kind: 'read', seq: 2 }]
+    })
+    const { queueSessionPayloadSave } = await import('@/lib/acp-history-persistence')
+    ;(queueSessionPayloadSave as ReturnType<typeof vi.fn>).mockClear()
+    useAcpStore.getState()._onPromptComplete({
+      agentId: 'agent-1',
+      sessionId: 's1',
+      stopReason: 'end_turn'
+    })
+    await flushTurnEnd()
+    const saved = (queueSessionPayloadSave as ReturnType<typeof vi.fn>).mock.calls[0]?.[1]
+    expect(saved.toolCalls).toEqual([{ toolCallId: 'durable', kind: 'read', seq: 2 }])
+  })
+
   it('prompt_complete does not resurrect a chat deleted while the turn was in flight', async () => {
     // deleteHistorySession removed the index entry mid-turn; the turn-end
     // persist must not write it back.
@@ -2758,6 +2866,165 @@ describe('acp-store', () => {
     expect(invoke).not.toHaveBeenCalled()
     expect(useAcpStore.getState().messages['s-old']).toHaveLength(1)
     expect(useAcpStore.getState().sessions['s-old'].status).toBe('closed')
+    // Legacy payloads carry no toolCalls: degrade to an empty list, not a crash.
+    expect(useAcpStore.getState().toolCalls['s-old']).toEqual([])
+  })
+
+  it('openHistorySession restores persisted tool calls alongside the transcript', async () => {
+    const { loadSessionPayload } = await import('@/lib/acp-history-persistence')
+    ;(loadSessionPayload as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      metadata: {
+        id: 's-tools',
+        agentId: 'agent-x',
+        title: 'Tool chat',
+        cwd: '/w',
+        createdAt: 1,
+        lastActivityAt: 2,
+        messageCount: 1,
+        status: 'closed'
+      },
+      messages: [
+        {
+          id: 'm1',
+          role: 'user',
+          blocks: [{ type: 'text', text: 'do it' }],
+          streaming: false,
+          timestamp: 0,
+          seq: 1
+        }
+      ],
+      toolCalls: [
+        {
+          toolCallId: 'tc-1',
+          title: 'Read file',
+          kind: 'read',
+          status: 'completed',
+          timestamp: 10,
+          seq: 2,
+          rawInput: { path: '/a.ts' }
+        }
+      ]
+    })
+    await useAcpStore.getState().openHistorySession('s-tools')
+    // 'local' strategy: the mirrored tool calls are restored for the timeline.
+    expect(useAcpStore.getState().toolCalls['s-tools']).toEqual([
+      expect.objectContaining({ toolCallId: 'tc-1', kind: 'read', seq: 2 })
+    ])
+  })
+
+  it('openHistorySession degrades a corrupt toolCalls shape instead of throwing', async () => {
+    const { loadSessionPayload } = await import('@/lib/acp-history-persistence')
+    ;(loadSessionPayload as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      metadata: {
+        id: 's-corrupt',
+        agentId: 'agent-x',
+        title: 'Corrupt chat',
+        cwd: '/w',
+        createdAt: 1,
+        lastActivityAt: 2,
+        messageCount: 1,
+        status: 'closed'
+      },
+      messages: [
+        {
+          id: 'm1',
+          role: 'user',
+          blocks: [{ type: 'text', text: 'hello' }],
+          streaming: false,
+          timestamp: 0,
+          seq: 1
+        }
+      ],
+      toolCalls: 'not-an-array'
+    })
+    await expect(useAcpStore.getState().openHistorySession('s-corrupt')).resolves.toBeUndefined()
+    expect(useAcpStore.getState().toolCalls['s-corrupt']).toEqual([])
+    expect(useAcpStore.getState().messages['s-corrupt']).toHaveLength(1)
+  })
+
+  it('resumeLiveSession restores persisted tool calls with the transcript', async () => {
+    setCachedSessionPayload('s-resume', {
+      metadata: {
+        id: 's-resume',
+        agentId: 'agent-r',
+        title: 'Resume chat',
+        cwd: '/w',
+        projectId: 'p1',
+        createdAt: 1,
+        lastActivityAt: 2,
+        messageCount: 1,
+        status: 'active'
+      },
+      messages: [
+        {
+          id: 'm1',
+          role: 'user',
+          blocks: [{ type: 'text', text: 'hi' }],
+          streaming: false,
+          timestamp: 0,
+          seq: 1
+        }
+      ],
+      toolCalls: [{ toolCallId: 'tc-9', kind: 'read', status: 'completed', timestamp: 5, seq: 2 }]
+    })
+    ;(invoke as ReturnType<typeof vi.fn>).mockResolvedValueOnce({})
+    await useAcpStore.getState().resumeLiveSession('s-resume', 'agent-r', '/w')
+    expect(invoke).toHaveBeenCalledWith('acp_resume_session', {
+      agentId: 'agent-r',
+      sessionId: 's-resume',
+      cwd: '/w'
+    })
+    expect(useAcpStore.getState().toolCalls['s-resume']).toEqual([
+      expect.objectContaining({ toolCallId: 'tc-9', seq: 2 })
+    ])
+    expect(useAcpStore.getState().sessions['s-resume'].status).toBe('active')
+    // The seq rebase must fold in tool-call seqs (the messages carried only
+    // seq 1): the next live event must sort AFTER the restored tool card, or
+    // buildTimeline would render fresh content ahead of older history.
+    useAcpStore.getState()._onToolCall({
+      agentId: 'agent-r',
+      sessionId: 's-resume',
+      toolCall: { toolCallId: 'tc-live', kind: 'read', status: 'pending' }
+    })
+    _flushCoalescedForTesting()
+    const restored = useAcpStore.getState().toolCalls['s-resume']
+    const liveCall = restored.find((t) => t.toolCallId === 'tc-live')!
+    expect(liveCall.seq!).toBeGreaterThan(2)
+  })
+
+  it('resumeLiveSession keeps the restored transcript and tool calls when resume fails', async () => {
+    setCachedSessionPayload('s-resume-fail', {
+      metadata: {
+        id: 's-resume-fail',
+        agentId: 'agent-r',
+        title: 'Resume chat',
+        cwd: '/w',
+        projectId: 'p1',
+        createdAt: 1,
+        lastActivityAt: 2,
+        messageCount: 1,
+        status: 'active'
+      },
+      messages: [
+        {
+          id: 'm1',
+          role: 'user',
+          blocks: [{ type: 'text', text: 'hi' }],
+          streaming: false,
+          timestamp: 0,
+          seq: 1
+        }
+      ],
+      toolCalls: [{ toolCallId: 'tc-f', kind: 'edit', status: 'completed', timestamp: 5, seq: 2 }]
+    })
+    ;(invoke as ReturnType<typeof vi.fn>).mockRejectedValueOnce(new Error('agent gone'))
+    await expect(
+      useAcpStore.getState().resumeLiveSession('s-resume-fail', 'agent-r', '/w')
+    ).rejects.toBeDefined()
+    expect(useAcpStore.getState().messages['s-resume-fail']).toHaveLength(1)
+    expect(useAcpStore.getState().toolCalls['s-resume-fail']).toEqual([
+      expect.objectContaining({ toolCallId: 'tc-f', seq: 2 })
+    ])
   })
 
   it('openHistorySession keeps the restore preload visible for a perceptible minimum', async () => {

--- a/src/renderer/stores/acp-store.ts
+++ b/src/renderer/stores/acp-store.ts
@@ -89,10 +89,13 @@ import {
   loadSessionIndex as loadSessionIndexFromDisk,
   loadSessionPayload,
   markSessionPayloadPinned,
+  maxPayloadSeq,
   queueSessionPayloadDelete,
   queueSessionPayloadSave,
+  restoredToolCalls,
   type SessionIndexEntry,
   type SessionPayload,
+  sanitizeToolCallsForPersistence,
   saveSessionIndex as saveSessionIndexToDisk,
   unpinSessionPayload
 } from '@/lib/acp-history-persistence'
@@ -1110,6 +1113,7 @@ function persistSession(
   state: {
     sessions: Record<SessionId, AcpSession>
     messages: Record<SessionId, ChatMessage[]>
+    toolCalls: Record<SessionId, ToolCall[]>
     sessionIndex: SessionIndexEntry[]
     configToLiveAgent: Record<string, AgentId>
   },
@@ -1168,7 +1172,16 @@ function persistSession(
   }
   const nextIndex = [entry, ...state.sessionIndex.filter((e) => e.id !== sessionId)]
   setIndex(nextIndex)
-  const payload: SessionPayload = { metadata: entry, messages }
+  // Mirror the tool calls with the transcript so a history reopen / resume
+  // restores the tool cards (otherwise only thoughts + replies survive). When
+  // the live map key is absent (transcript eviction) fall back to the cached
+  // mirror so the durable copy is never blanked by an absent-key persist.
+  const liveToolCalls = state.toolCalls[sessionId]
+  const toolCalls =
+    liveToolCalls === undefined
+      ? cachedPayload?.toolCalls
+      : sanitizeToolCallsForPersistence(liveToolCalls)
+  const payload: SessionPayload = { metadata: entry, messages, toolCalls }
   // Rust owns the durable index and updates it with the payload in the queued
   // save. saveSessionIndexToDisk remains a compatibility no-op for non-desktop
   // callers while queueSessionPayloadSave owns the serialized durable write.
@@ -1962,11 +1975,7 @@ async function openHistorySessionInner(
 
   // Rebase the process-wide seq counter so live events appended after the
   // restored transcript sort after it (nextSeq() returns > max restored seq).
-  let maxRestoredSeq = 0
-  for (const m of payload.messages) {
-    if (typeof m.seq === 'number' && m.seq > maxRestoredSeq) maxRestoredSeq = m.seq
-  }
-  rebaseSeqCounter(maxRestoredSeq)
+  rebaseSeqCounter(maxPayloadSeq(payload))
 
   // Preserve controls already held by a cached closed session. Persisted
   // history does not contain them, and optional reopen fields may be omitted.
@@ -1996,7 +2005,10 @@ async function openHistorySessionInner(
         replaying: null
       }
     },
-    messages: { ...s.messages, [id]: trimLiveWindow(payload.messages, id) }
+    messages: { ...s.messages, [id]: trimLiveWindow(payload.messages, id) },
+    // Restore the mirrored tool calls so the timeline shows the tool cards
+    // again — without this only thoughts + replies survive a reopen.
+    toolCalls: { ...s.toolCalls, [id]: restoredToolCalls(payload) }
   }))
   onTranscriptInstalled()
 
@@ -2126,6 +2138,7 @@ async function openHistorySessionInner(
       // history (a partial replay may have replaced it).
       set((s) => ({
         messages: { ...s.messages, [id]: trimLiveWindow(payload.messages, id) },
+        toolCalls: { ...s.toolCalls, [id]: restoredToolCalls(payload) },
         sessions: withSessionResumeError(s.sessions, id, err)
       }))
       throw err
@@ -3623,11 +3636,7 @@ export const useAcpStore = create<AcpState>((set, get) => ({
     const payload = await loadSessionPayload(id)
     if (!payload) throw new Error(`no persisted history for ${id}`)
     const meta = payload.metadata
-    let maxRestoredSeq = 0
-    for (const m of payload.messages) {
-      if (typeof m.seq === 'number' && m.seq > maxRestoredSeq) maxRestoredSeq = m.seq
-    }
-    rebaseSeqCounter(maxRestoredSeq)
+    rebaseSeqCounter(maxPayloadSeq(payload))
     set((s) => ({
       sessions: {
         ...s.sessions,
@@ -3655,7 +3664,10 @@ export const useAcpStore = create<AcpState>((set, get) => ({
           replaying: 'streaming'
         }
       },
-      messages: { ...s.messages, [id]: trimLiveWindow(payload.messages, id) }
+      messages: { ...s.messages, [id]: trimLiveWindow(payload.messages, id) },
+      // Restore the mirrored tool calls alongside the transcript so the
+      // resumed session's timeline keeps its tool cards.
+      toolCalls: { ...s.toolCalls, [id]: restoredToolCalls(payload) }
     }))
     try {
       // `acpApi.resumeSession` routes to `acp_resume_session` (desktop) or the
@@ -3677,6 +3689,7 @@ export const useAcpStore = create<AcpState>((set, get) => ({
       // throws on the bootstrap path.
       set((s) => ({
         messages: { ...s.messages, [id]: trimLiveWindow(payload.messages, id) },
+        toolCalls: { ...s.toolCalls, [id]: restoredToolCalls(payload) },
         sessions: withSessionResumeError(s.sessions, id, err)
       }))
       throw err


### PR DESCRIPTION
## Summary

- Resuming a chat from the history sidebar (and the post-reload auto-resume) restored only the persisted `messages` — thoughts and agent replies — while the session's ACP tool calls vanished. Root cause: tool calls live in the store's separate `toolCalls` map, which the persistence boundary (`persistSession` → `SessionPayload`) never wrote and neither reopen path (`openHistorySession`, `resumeLiveSession`) restored, so `buildTimeline(messages, toolCalls)` had no tool items to interleave after a resume.
- This PR mirrors a sanitized tool-call list into the persisted payload and restores it in both resume paths, so reopened/resumed "worked" sessions show their tool cards again. Sanitization keeps the fields the cards render (summary inputs, structured content) while dropping unbounded/sensitive data and bounding disk growth.

## Related Issue

No related issue — the bug was reported directly during a development session; searched open issues for matching reports (resume/history/tool-call related) and found none covering this transcript-fidelity problem.

## Type of Change

- [ ] feat: new feature
- [x] fix: bug fix
- [ ] docs: documentation only
- [ ] style: formatting or non-functional styling changes
- [ ] refactor: internal cleanup with no behavior change
- [ ] perf: performance improvement
- [ ] test: adds or updates tests
- [ ] build: build or dependency changes
- [ ] ci: CI/CD workflow changes
- [ ] chore: maintenance or tooling
- [ ] revert: reverts a previous change

## What Changed

- `src/renderer/lib/acp-history-persistence.ts`: `SessionPayload` gains optional `toolCalls`; `sanitizeToolCallsForPersistence` (drops `rawOutput` + unknown agent fields, normalizes mid-flight `pending`/`in_progress` to `failed` so restored cards don't spin forever, caps titles, 32 KiB UTF-8 per-call budget with structural-subset fallback, 500-call recency bound, logged degradation); `maxPayloadSeq` / `restoredToolCalls` helpers tolerant of legacy/corrupt payloads; evicted-cache save keeps the live tool-call list (falls back to durable when the live key is absent).
- `src/renderer/stores/acp-store.ts`: `persistSession` mirrors sanitized tool calls (cached-mirror fallback so an absent live key never blanks the durable copy); `openHistorySessionInner` and `resumeLiveSession` restore the mirror and rebase the shared seq counter over tool-call seqs so fresh events sort after restored tool cards; both failure-restore paths restore tool calls alongside messages.
- `docs/api-contracts.md`: documents the new optional payload field and its sanitization contract.
- Tests: sanitization unit coverage (budget, caps, status normalization, corrupt/non-serializable input, unknown fields), merge preservation/fallback, persist-mirror + cached fallback, reopen/resume restore, legacy-payload degrade, corrupt-shape degrade, and a post-restore seq-ordering regression test.

## How It Was Tested

- [x] `bun run ci` (Biome lint + format + imports, strict mode)
- [x] `bun run typecheck`
- [x] `bun run test`
- [x] `cargo clippy --all-targets -- -D warnings` (in src-tauri)
- [ ] `cargo test` (in src-tauri)
- [ ] Manual verification completed
- [ ] Not applicable

Note: no Rust code is changed in this PR. Local `cargo test` on this Windows machine fails with `STATUS_ENTRYPOINT_NOT_FOUND` identically at the `dev` base commit (reproduced on the base with a clean target dir — a local native-dependency/toolchain environment issue, not this change); CI Rust tests run the same base green.

## Screenshots or Recordings

Not a visual change — restored tool cards use the existing `ToolCallCard` rendering; behavior is covered by store-level tests (restore + timeline-ordering).

## CI & Review Gate

- [x] All CI checks pass (PR Validation, Rust Checks, Build Verification, Security Scans)
- [x] Code review comments from CodeRabbit / Claude have been addressed or resolved
- [x] No unresolved review findings remain

## Checklist

- [x] My PR title follows the conventional commit format used by this repo
- [x] I linked the related issue or explained why none exists
- [x] I updated docs when needed
- [x] I added or updated tests when needed
- [x] I verified the change does not introduce unrelated modifications
- [x] I read AGENTS.md and followed the contributor guidelines
- [ ] A human reviewed the complete diff before submission


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tool-call history is now saved alongside chat messages and restored when reopening or resuming sessions.
  * Recent tool-call details remain available after replay or resume failures.
  * Added Harn to the available ACP agent catalog and refreshed several agent versions and downloads.
  * Persisted data is safely sanitized, size-limited, and compatible with older session histories.

* **Bug Fixes**
  * Improved recovery from malformed or incomplete saved tool-call data.
  * Prevented in-progress tool calls from remaining stuck after persistence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
