### PR TITLE
feat(settings): use JSON editor for MCP servers + compact one-line list

### DIFF
--- a/src/renderer/assets/agent-icons/acp/agents.json
+++ b/src/renderer/assets/agent-icons/acp/agents.json
@@ -513,37 +513,37 @@
   {
     "id": "kilo",
     "name": "Kilo",
-    "version": "7.4.17",
+    "version": "7.4.19",
     "description": "The open source coding agent",
     "distribution": {
       "npx": {
-        "package": "@kilocode/cli@7.4.17",
+        "package": "@kilocode/cli@7.4.19",
         "args": ["acp"]
       },
       "binary": {
         "darwin-aarch64": {
           "cmd": "./kilo",
-          "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.4.17/kilo-darwin-arm64.zip",
+          "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.4.19/kilo-darwin-arm64.zip",
           "args": ["acp"]
         },
         "darwin-x86_64": {
           "cmd": "./kilo",
-          "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.4.17/kilo-darwin-x64.zip",
+          "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.4.19/kilo-darwin-x64.zip",
           "args": ["acp"]
         },
         "linux-aarch64": {
           "cmd": "./kilo",
-          "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.4.17/kilo-linux-arm64.tar.gz",
+          "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.4.19/kilo-linux-arm64.tar.gz",
           "args": ["acp"]
         },
         "linux-x86_64": {
           "cmd": "./kilo",
-          "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.4.17/kilo-linux-x64.tar.gz",
+          "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.4.19/kilo-linux-x64.tar.gz",
           "args": ["acp"]
         },
         "windows-x86_64": {
           "cmd": "./kilo.exe",
-          "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.4.17/kilo-windows-x64.zip",
+          "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.4.19/kilo-windows-x64.zip",
           "args": ["acp"]
         }
       }

--- a/src/renderer/assets/agent-icons/acp/agents.json
+++ b/src/renderer/assets/agent-icons/acp/agents.json
@@ -332,11 +332,11 @@
   {
     "id": "factory-droid",
     "name": "Factory Droid",
-    "version": "0.186.0",
+    "version": "0.187.0",
     "description": "Factory Droid - AI coding agent powered by Factory AI",
     "distribution": {
       "npx": {
-        "package": "droid@0.186.0",
+        "package": "droid@0.187.0",
         "args": ["exec", "--output-format", "acp-daemon"],
         "env": {
           "DROID_DISABLE_AUTO_UPDATE": "true",
@@ -372,11 +372,11 @@
   {
     "id": "github-copilot-cli",
     "name": "GitHub Copilot",
-    "version": "1.0.77",
+    "version": "1.0.78",
     "description": "GitHub's AI pair programmer",
     "distribution": {
       "npx": {
-        "package": "@github/copilot@1.0.77",
+        "package": "@github/copilot@1.0.78",
         "args": ["--acp"]
       }
     }
@@ -426,11 +426,11 @@
   {
     "id": "grok-build",
     "name": "Grok Build",
-    "version": "0.2.119",
+    "version": "0.2.120",
     "description": "xAI's coding agent and CLI",
     "distribution": {
       "npx": {
-        "package": "@xai-official/grok@0.2.119",
+        "package": "@xai-official/grok@0.2.120",
         "args": ["agent", "stdio"]
       }
     }
@@ -438,33 +438,33 @@
   {
     "id": "harn",
     "name": "Harn",
-    "version": "0.10.52",
+    "version": "0.10.53",
     "description": "Harn runs .harn agent pipelines as a native ACP coding agent over stdio.",
     "distribution": {
       "binary": {
         "darwin-aarch64": {
           "cmd": "./harn",
-          "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.52/harn-aarch64-apple-darwin.tar.gz",
+          "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.53/harn-aarch64-apple-darwin.tar.gz",
           "args": ["serve", "acp"]
         },
         "darwin-x86_64": {
           "cmd": "./harn",
-          "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.52/harn-x86_64-apple-darwin.tar.gz",
+          "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.53/harn-x86_64-apple-darwin.tar.gz",
           "args": ["serve", "acp"]
         },
         "linux-aarch64": {
           "cmd": "./harn",
-          "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.52/harn-aarch64-unknown-linux-gnu.tar.gz",
+          "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.53/harn-aarch64-unknown-linux-gnu.tar.gz",
           "args": ["serve", "acp"]
         },
         "linux-x86_64": {
           "cmd": "./harn",
-          "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.52/harn-x86_64-unknown-linux-gnu.tar.gz",
+          "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.53/harn-x86_64-unknown-linux-gnu.tar.gz",
           "args": ["serve", "acp"]
         },
         "windows-x86_64": {
           "cmd": "harn.exe",
-          "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.52/harn-x86_64-pc-windows-msvc.zip",
+          "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.53/harn-x86_64-pc-windows-msvc.zip",
           "args": ["serve", "acp"]
         }
       }
@@ -599,29 +599,29 @@
   {
     "id": "mistral-vibe",
     "name": "Mistral Vibe",
-    "version": "2.23.2",
+    "version": "2.23.3",
     "description": "Mistral's open-source coding assistant",
     "distribution": {
       "binary": {
         "darwin-aarch64": {
           "cmd": "./vibe-acp",
-          "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v2.23.2/vibe-acp-darwin-aarch64-2.23.2.zip"
+          "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v2.23.3/vibe-acp-darwin-aarch64-2.23.3.zip"
         },
         "darwin-x86_64": {
           "cmd": "./vibe-acp",
-          "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v2.23.2/vibe-acp-darwin-x86_64-2.23.2.zip"
+          "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v2.23.3/vibe-acp-darwin-x86_64-2.23.3.zip"
         },
         "linux-aarch64": {
           "cmd": "./vibe-acp",
-          "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v2.23.2/vibe-acp-linux-aarch64-2.23.2.zip"
+          "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v2.23.3/vibe-acp-linux-aarch64-2.23.3.zip"
         },
         "linux-x86_64": {
           "cmd": "./vibe-acp",
-          "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v2.23.2/vibe-acp-linux-x86_64-2.23.2.zip"
+          "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v2.23.3/vibe-acp-linux-x86_64-2.23.3.zip"
         },
         "windows-x86_64": {
           "cmd": "./vibe-acp.exe",
-          "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v2.23.2/vibe-acp-windows-x86_64-2.23.2.zip"
+          "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v2.23.3/vibe-acp-windows-x86_64-2.23.3.zip"
         }
       }
     }
@@ -641,38 +641,38 @@
   {
     "id": "opencode",
     "name": "OpenCode",
-    "version": "1.18.11",
+    "version": "1.18.12",
     "description": "The open source coding agent",
     "distribution": {
       "binary": {
         "darwin-aarch64": {
           "cmd": "./opencode",
-          "archive": "https://github.com/anomalyco/opencode/releases/download/v1.18.11/opencode-darwin-arm64.zip",
+          "archive": "https://github.com/anomalyco/opencode/releases/download/v1.18.12/opencode-darwin-arm64.zip",
           "args": ["acp"]
         },
         "darwin-x86_64": {
           "cmd": "./opencode",
-          "archive": "https://github.com/anomalyco/opencode/releases/download/v1.18.11/opencode-darwin-x64.zip",
+          "archive": "https://github.com/anomalyco/opencode/releases/download/v1.18.12/opencode-darwin-x64.zip",
           "args": ["acp"]
         },
         "linux-aarch64": {
           "cmd": "./opencode",
-          "archive": "https://github.com/anomalyco/opencode/releases/download/v1.18.11/opencode-linux-arm64.tar.gz",
+          "archive": "https://github.com/anomalyco/opencode/releases/download/v1.18.12/opencode-linux-arm64.tar.gz",
           "args": ["acp"]
         },
         "linux-x86_64": {
           "cmd": "./opencode",
-          "archive": "https://github.com/anomalyco/opencode/releases/download/v1.18.11/opencode-linux-x64.tar.gz",
+          "archive": "https://github.com/anomalyco/opencode/releases/download/v1.18.12/opencode-linux-x64.tar.gz",
           "args": ["acp"]
         },
         "windows-aarch64": {
           "cmd": "./opencode",
-          "archive": "https://github.com/anomalyco/opencode/releases/download/v1.18.11/opencode-windows-arm64.zip",
+          "archive": "https://github.com/anomalyco/opencode/releases/download/v1.18.12/opencode-windows-arm64.zip",
           "args": ["acp"]
         },
         "windows-x86_64": {
           "cmd": "./opencode.exe",
-          "archive": "https://github.com/anomalyco/opencode/releases/download/v1.18.11/opencode-windows-x64.zip",
+          "archive": "https://github.com/anomalyco/opencode/releases/download/v1.18.12/opencode-windows-x64.zip",
           "args": ["acp"]
         }
       }
@@ -744,11 +744,11 @@
   {
     "id": "qwen-code",
     "name": "Qwen Code",
-    "version": "0.21.4",
+    "version": "0.21.5",
     "description": "Alibaba's Qwen coding assistant",
     "distribution": {
       "npx": {
-        "package": "@qwen-code/qwen-code@0.21.4",
+        "package": "@qwen-code/qwen-code@0.21.5",
         "args": ["--acp", "--experimental-skills"]
       }
     }

--- a/src/renderer/components/settings/McpServersSettings.test.tsx
+++ b/src/renderer/components/settings/McpServersSettings.test.tsx
@@ -16,6 +16,8 @@ const deleteMcpServer = vi.fn(async () => {})
 const probeMcpServer = vi.fn(async () => {})
 const loadMcpTools = vi.fn(async () => {})
 
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+
 function seedStore(): void {
   useAcpStore.setState({
     mcpServers: [],
@@ -32,23 +34,34 @@ function seedStore(): void {
   })
 }
 
+function openAddDialog(): void {
+  fireEvent.click(screen.getByRole('button', { name: /add server/i }))
+}
+
+function typeJson(value: string): void {
+  fireEvent.change(screen.getByLabelText('MCP JSON'), { target: { value } })
+}
+
+/** Parse the current JSON editor content (edit dialog pre-fill assertions). */
+function editorJson(): Record<string, unknown> {
+  return JSON.parse((screen.getByLabelText('MCP JSON') as HTMLTextAreaElement).value)
+}
+
 describe('McpServersSettings', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     seedStore()
   })
 
-  it('creates a stdio server and serializes args and environment', async () => {
+  it('adds a bare server object through the JSON editor with a fresh id', async () => {
     render(<McpServersSettings />)
-    fireEvent.click(screen.getByRole('button', { name: /add server/i }))
+    openAddDialog()
+    expect(screen.getByText('Add MCP servers')).toBeInTheDocument()
     const save = screen.getByRole('button', { name: 'Save' })
+    // Empty JSON text keeps Save disabled — no accidental junk entries.
     expect(save).toBeDisabled()
-    fireEvent.change(screen.getByLabelText('Name'), { target: { value: 'Files' } })
-    fireEvent.change(screen.getByLabelText('Command'), { target: { value: 'npx' } })
-    fireEvent.change(screen.getByLabelText(/arguments/i), { target: { value: '-y\nserver' } })
-    fireEvent.change(screen.getByLabelText(/environment/i), {
-      target: { value: 'TOKEN=$TOKEN' }
-    })
+    typeJson(JSON.stringify({ command: 'npx', args: ['-y', 'x'], env: { K: 'v' }, name: 'Files' }))
+    expect(save).toBeEnabled()
     fireEvent.click(save)
     await waitFor(() => expect(saveMcpServer).toHaveBeenCalledTimes(1))
     expect(saveMcpServer).toHaveBeenCalledWith(
@@ -56,14 +69,143 @@ describe('McpServersSettings', () => {
         type: 'stdio',
         name: 'Files',
         command: 'npx',
-        args: ['-y', 'server'],
-        env: [{ name: 'TOKEN', value: '$TOKEN' }],
+        args: ['-y', 'x'],
+        env: [{ name: 'K', value: 'v' }],
         enabled: true
       })
     )
+    expect(saveMcpServer.mock.calls[0]?.[0].id).toMatch(UUID_RE)
+    await waitFor(() =>
+      expect(toastSuccess).toHaveBeenCalledWith(expect.stringMatching(/imported 1 mcp server/i))
+    )
+    // The dialog closes after a fully successful save.
+    expect(screen.queryByLabelText('MCP JSON')).not.toBeInTheDocument()
   })
 
-  it('edits an HTTP server and exposes experimental ACP as disclosure only', async () => {
+  it('adds both servers from a Claude Desktop wrapper, each with a fresh id', async () => {
+    render(<McpServersSettings />)
+    openAddDialog()
+    typeJson(
+      JSON.stringify({
+        mcpServers: {
+          alpha: { command: 'node', args: ['a.js'] },
+          beta: { type: 'http', url: 'https://beta.test/mcp' }
+        }
+      })
+    )
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }))
+    await waitFor(() => expect(saveMcpServer).toHaveBeenCalledTimes(2))
+    expect(saveMcpServer).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'stdio', name: 'alpha', command: 'node', enabled: true })
+    )
+    expect(saveMcpServer).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'http',
+        name: 'beta',
+        url: 'https://beta.test/mcp',
+        enabled: true
+      })
+    )
+    const firstId = saveMcpServer.mock.calls[0]?.[0].id
+    const secondId = saveMcpServer.mock.calls[1]?.[0].id
+    expect(firstId).toMatch(UUID_RE)
+    expect(secondId).toMatch(UUID_RE)
+    expect(firstId).not.toBe(secondId)
+  })
+
+  it('shows invalid JSON inline and saves nothing', async () => {
+    render(<McpServersSettings />)
+    openAddDialog()
+    typeJson('{ this is not json')
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }))
+    await waitFor(() => expect(screen.getByRole('alert')).toHaveTextContent(/invalid json/i))
+    expect(saveMcpServer).not.toHaveBeenCalled()
+  })
+
+  it('saves valid entries and keeps per-server errors inline for the bad ones', async () => {
+    render(<McpServersSettings />)
+    openAddDialog()
+    typeJson(
+      JSON.stringify({
+        mcpServers: {
+          good: { command: 'node', args: ['server.js'] },
+          bad: { command: '   ' }
+        }
+      })
+    )
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }))
+    await waitFor(() => expect(saveMcpServer).toHaveBeenCalledTimes(1))
+    expect(saveMcpServer).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'good', command: 'node', args: ['server.js'] })
+    )
+    // The rejected entry's reason stays visible so the user can fix and re-save.
+    expect(screen.getByRole('alert')).toHaveTextContent(/command is required for stdio/i)
+    expect(toastSuccess).not.toHaveBeenCalled()
+  })
+
+  it('reports an empty wrapper without saving', async () => {
+    render(<McpServersSettings />)
+    openAddDialog()
+    typeJson(JSON.stringify({ mcpServers: {} }))
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }))
+    await waitFor(() =>
+      expect(screen.getByRole('alert')).toHaveTextContent(/no mcp servers found in the json/i)
+    )
+    expect(saveMcpServer).not.toHaveBeenCalled()
+  })
+
+  it('pre-fills the edit dialog and updates the same registry entry', async () => {
+    useAcpStore.setState({
+      mcpServers: [
+        {
+          id: 's1',
+          type: 'stdio',
+          name: 'Files',
+          command: 'node',
+          args: ['server.js'],
+          env: [{ name: 'TOKEN', value: '$TOKEN' }],
+          enabled: true
+        }
+      ]
+    })
+    render(<McpServersSettings />)
+    fireEvent.click(screen.getByRole('button', { name: /edit files/i }))
+    expect(screen.getByText('Edit MCP server')).toBeInTheDocument()
+    // Pre-populated JSON: explicit type, env as an object map, enabled included.
+    expect(editorJson()).toMatchObject({
+      type: 'stdio',
+      name: 'Files',
+      command: 'node',
+      args: ['server.js'],
+      env: { TOKEN: '$TOKEN' },
+      enabled: true
+    })
+    // Change the command and smuggle an unknown field in — it must be dropped.
+    const edited = editorJson()
+    edited.command = 'bun'
+    edited.alwaysAllow = true
+    typeJson(JSON.stringify(edited, null, 2))
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }))
+    await waitFor(() =>
+      expect(saveMcpServer).toHaveBeenCalledWith(
+        expect.objectContaining({
+          id: 's1',
+          type: 'stdio',
+          name: 'Files',
+          command: 'bun',
+          args: ['server.js'],
+          env: [{ name: 'TOKEN', value: '$TOKEN' }],
+          enabled: true
+        })
+      )
+    )
+    expect(saveMcpServer).toHaveBeenCalledWith(expect.not.objectContaining({ alwaysAllow: true }))
+    await waitFor(() =>
+      expect(toastSuccess).toHaveBeenCalledWith(expect.stringMatching(/mcp server updated/i))
+    )
+  })
+
+  it('pre-fills HTTP servers with header pairs and updates the url in place', async () => {
     useAcpStore.setState({
       mcpServers: [
         {
@@ -71,21 +213,128 @@ describe('McpServersSettings', () => {
           type: 'http',
           name: 'Remote',
           url: 'https://old.test/mcp',
+          headers: [{ name: 'Authorization', value: 'Bearer $TOKEN' }],
           enabled: true
         }
       ]
     })
     render(<McpServersSettings />)
-    expect(screen.getByText(/experimental mcp-over-acp/i)).toBeInTheDocument()
-    expect(screen.queryByRole('option', { name: /acp/i })).not.toBeInTheDocument()
     fireEvent.click(screen.getByRole('button', { name: /edit remote/i }))
-    fireEvent.change(screen.getByLabelText('URL'), { target: { value: 'https://new.test/mcp' } })
+    expect(editorJson()).toMatchObject({
+      type: 'http',
+      name: 'Remote',
+      url: 'https://old.test/mcp',
+      headers: [{ name: 'Authorization', value: 'Bearer $TOKEN' }],
+      enabled: true
+    })
+    const edited = editorJson()
+    edited.url = 'https://new.test/mcp'
+    typeJson(JSON.stringify(edited))
     fireEvent.click(screen.getByRole('button', { name: 'Save' }))
     await waitFor(() =>
       expect(saveMcpServer).toHaveBeenCalledWith(
-        expect.objectContaining({ id: 'http-1', type: 'http', url: 'https://new.test/mcp' })
+        expect.objectContaining({
+          id: 'http-1',
+          type: 'http',
+          url: 'https://new.test/mcp',
+          headers: [{ name: 'Authorization', value: 'Bearer $TOKEN' }]
+        })
       )
     )
+  })
+
+  it('persists enabled: false from the edit JSON', async () => {
+    useAcpStore.setState({
+      mcpServers: [{ id: 's2', type: 'stdio', name: 'Files', command: 'node', enabled: true }]
+    })
+    render(<McpServersSettings />)
+    fireEvent.click(screen.getByRole('button', { name: /edit files/i }))
+    const edited = editorJson()
+    edited.enabled = false
+    typeJson(JSON.stringify(edited))
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }))
+    await waitFor(() =>
+      expect(saveMcpServer).toHaveBeenCalledWith(
+        expect.objectContaining({ id: 's2', enabled: false })
+      )
+    )
+  })
+
+  it('keeps the existing enabled state when the edit JSON omits it', async () => {
+    useAcpStore.setState({
+      mcpServers: [{ id: 's3', type: 'stdio', name: 'Files', command: 'node', enabled: false }]
+    })
+    render(<McpServersSettings />)
+    fireEvent.click(screen.getByRole('button', { name: /edit files/i }))
+    const edited = editorJson()
+    expect(edited.enabled).toBe(false)
+    delete edited.enabled
+    typeJson(JSON.stringify(edited))
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }))
+    await waitFor(() =>
+      expect(saveMcpServer).toHaveBeenCalledWith(
+        expect.objectContaining({ id: 's3', enabled: false })
+      )
+    )
+  })
+
+  it('rejects the mcpServers wrapper while editing a single server', async () => {
+    useAcpStore.setState({
+      mcpServers: [{ id: 's4', type: 'stdio', name: 'Files', command: 'node', enabled: true }]
+    })
+    render(<McpServersSettings />)
+    fireEvent.click(screen.getByRole('button', { name: /edit files/i }))
+    typeJson(JSON.stringify({ mcpServers: { files: { command: 'node' } } }))
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }))
+    await waitFor(() =>
+      expect(screen.getByRole('alert')).toHaveTextContent(/single server object/i)
+    )
+    expect(saveMcpServer).not.toHaveBeenCalled()
+  })
+
+  it('shows validation errors inline when the edit JSON is invalid', async () => {
+    useAcpStore.setState({
+      mcpServers: [{ id: 's6', type: 'stdio', name: 'Files', command: 'node', enabled: true }]
+    })
+    render(<McpServersSettings />)
+    fireEvent.click(screen.getByRole('button', { name: /edit files/i }))
+    typeJson(JSON.stringify({ type: 'stdio', name: 'Files', command: '' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }))
+    await waitFor(() =>
+      expect(screen.getByRole('alert')).toHaveTextContent(/command is required for stdio/i)
+    )
+    expect(saveMcpServer).not.toHaveBeenCalled()
+  })
+
+  it('keeps the dialog open and shows the rollback toast when saving fails', async () => {
+    saveMcpServer.mockRejectedValueOnce(new Error('disk full'))
+    render(<McpServersSettings />)
+    openAddDialog()
+    typeJson(JSON.stringify({ name: 'Files', command: 'node' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }))
+    await waitFor(() =>
+      expect(toastError).toHaveBeenCalledWith(expect.stringMatching(/could not save/i))
+    )
+    // The dialog stays open so the JSON is not lost after a rollback.
+    expect(screen.getByLabelText('MCP JSON')).toBeInTheDocument()
+  })
+
+  it('keeps the edit dialog open when the update fails', async () => {
+    saveMcpServer.mockRejectedValueOnce(new Error('disk full'))
+    useAcpStore.setState({
+      mcpServers: [{ id: 's7', type: 'stdio', name: 'Files', command: 'node', enabled: true }]
+    })
+    render(<McpServersSettings />)
+    fireEvent.click(screen.getByRole('button', { name: /edit files/i }))
+    const edited = editorJson()
+    edited.command = 'bun'
+    typeJson(JSON.stringify(edited))
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }))
+    await waitFor(() =>
+      expect(toastError).toHaveBeenCalledWith(expect.stringMatching(/could not save/i))
+    )
+    expect(screen.getByLabelText('MCP JSON')).toBeInTheDocument()
+    expect(screen.getByText('Edit MCP server')).toBeInTheDocument()
   })
 
   it('toggles and deletes existing servers', async () => {
@@ -99,20 +348,7 @@ describe('McpServersSettings', () => {
     expect(deleteMcpServer).toHaveBeenCalledWith('one')
   })
 
-  it('surfaces persistence failures without changing the form contract', async () => {
-    saveMcpServer.mockRejectedValueOnce(new Error('disk full'))
-    render(<McpServersSettings />)
-    fireEvent.click(screen.getByRole('button', { name: /add server/i }))
-    fireEvent.change(screen.getByLabelText('Name'), { target: { value: 'Files' } })
-    fireEvent.change(screen.getByLabelText('Command'), { target: { value: 'node' } })
-    fireEvent.click(screen.getByRole('button', { name: 'Save' }))
-    await waitFor(() =>
-      expect(toastError).toHaveBeenCalledWith(expect.stringMatching(/could not save/i))
-    )
-  })
-
-  it('probes each server on mount and shows the connected status dot', async () => {
-    vi.mocked(probeMcpServer).mockResolvedValue()
+  it('probes enabled servers on mount and shows the connected status dot', async () => {
     useAcpStore.setState({
       mcpServers: [{ id: 's1', type: 'stdio', name: 'Files', command: 'node', enabled: true }],
       mcpProbeStatus: { s1: 'connected' },
@@ -123,20 +359,7 @@ describe('McpServersSettings', () => {
     expect(screen.getByTitle('Connected (Termul can reach this server)')).toBeInTheDocument()
   })
 
-  it('shows the disconnected dot when the probe fails', () => {
-    useAcpStore.setState({
-      mcpServers: [
-        { id: 's2', type: 'http', name: 'Remote', url: 'https://x.test/m', enabled: true }
-      ],
-      mcpProbeStatus: { s2: 'disconnected' }
-    })
-    render(<McpServersSettings />)
-    expect(
-      screen.getByTitle('Disconnected (Termul could not reach this server)')
-    ).toBeInTheDocument()
-  })
-
-  it('shows the backend probe error inline for a disconnected server', () => {
+  it('shows the disconnected dot and the probe error behind the disclosure', () => {
     useAcpStore.setState({
       mcpServers: [
         { id: 's5', type: 'http', name: 'Remote', url: 'https://x.test/m', enabled: true }
@@ -145,8 +368,11 @@ describe('McpServersSettings', () => {
       mcpProbeError: { s5: 'initialize failed: connection refused' }
     })
     render(<McpServersSettings />)
-    // The error detail lives inside the collapsed tools disclosure; expand via
-    // the disconnected-specific trigger, then assert the redacted reason.
+    expect(
+      screen.getByTitle('Disconnected (Termul could not reach this server)')
+    ).toBeInTheDocument()
+    // The error detail lives behind the tools disclosure; expand via the
+    // disconnected-specific trigger, then assert the redacted reason.
     fireEvent.click(screen.getByText(/probe failed — retry/i))
     expect(
       screen.getByText(/probe failed — check the server config or network/i)
@@ -154,88 +380,14 @@ describe('McpServersSettings', () => {
     expect(screen.getByText('initialize failed: connection refused')).toBeInTheDocument()
   })
 
-  it('imports a Claude Desktop config and saves each entry with a fresh id', async () => {
-    render(<McpServersSettings />)
-    fireEvent.click(screen.getByRole('button', { name: /add server/i }))
-    fireEvent.click(screen.getByRole('tab', { name: /import json/i }))
-    fireEvent.change(screen.getByLabelText('MCP JSON'), {
-      target: {
-        value: JSON.stringify({
-          mcpServers: {
-            dokploy: {
-              command: 'npx',
-              args: ['-y', '@dokploy/mcp'],
-              env: { DOKPLOY_URL: 'https://dokploy.test' }
-            }
-          }
-        })
-      }
-    })
-    fireEvent.click(screen.getByRole('button', { name: /parse & save/i }))
-    await waitFor(() => expect(saveMcpServer).toHaveBeenCalledTimes(1))
-    expect(saveMcpServer).toHaveBeenCalledWith(
-      expect.objectContaining({
-        type: 'stdio',
-        name: 'dokploy',
-        command: 'npx',
-        args: ['-y', '@dokploy/mcp'],
-        env: [{ name: 'DOKPLOY_URL', value: 'https://dokploy.test' }],
-        enabled: true
-      })
-    )
-    // The saved id is a freshly minted one — never a registry id from the JSON.
-    expect(saveMcpServer.mock.calls[0]?.[0].id).toMatch(
-      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
-    )
-    await waitFor(() =>
-      expect(toastSuccess).toHaveBeenCalledWith(expect.stringMatching(/imported 1 mcp server/i))
-    )
-  })
-
-  it('keeps invalid JSON inline and does not save anything', async () => {
-    render(<McpServersSettings />)
-    fireEvent.click(screen.getByRole('button', { name: /add server/i }))
-    fireEvent.click(screen.getByRole('tab', { name: /import json/i }))
-    fireEvent.change(screen.getByLabelText('MCP JSON'), {
-      target: { value: '{ this is not json' }
-    })
-    fireEvent.click(screen.getByRole('button', { name: /parse & save/i }))
-    await waitFor(() => expect(screen.getByRole('alert')).toHaveTextContent(/invalid json/i))
-    expect(saveMcpServer).not.toHaveBeenCalled()
-  })
-
-  it('imports the valid entries while surfacing per-server errors inline', async () => {
-    render(<McpServersSettings />)
-    fireEvent.click(screen.getByRole('button', { name: /add server/i }))
-    fireEvent.click(screen.getByRole('tab', { name: /import json/i }))
-    fireEvent.change(screen.getByLabelText('MCP JSON'), {
-      target: {
-        value: JSON.stringify({
-          mcpServers: {
-            good: { command: 'node', args: ['server.js'] },
-            bad: { command: '   ' }
-          }
-        })
-      }
-    })
-    fireEvent.click(screen.getByRole('button', { name: /parse & save/i }))
-    await waitFor(() => expect(saveMcpServer).toHaveBeenCalledTimes(1))
-    expect(saveMcpServer).toHaveBeenCalledWith(
-      expect.objectContaining({ name: 'good', command: 'node', args: ['server.js'] })
-    )
-    // The rejected entry's reason stays visible so the user can fix and re-paste.
-    expect(screen.getByRole('alert')).toHaveTextContent(/command is required for stdio/i)
-    expect(toastSuccess).not.toHaveBeenCalled()
-  })
-
-  it('renders the tool list (read-only) inside the collapsible on expand', async () => {
+  it('renders the tool list (read-only) inside the collapsible on expand', () => {
     useAcpStore.setState({
       mcpServers: [{ id: 's3', type: 'stdio', name: 'Probe', command: 'node', enabled: true }],
       mcpTools: { s3: [{ name: 'search', description: 'search files' }] },
       mcpToolsLoaded: { s3: true }
     })
     render(<McpServersSettings />)
-    // Tools are pre-seeded → the trigger shows the count ("1 tool"), not "Show tools".
+    // Tools are pre-seeded -> the trigger shows the count ("1 tool").
     fireEvent.click(screen.getByText(/1 tool/i))
     expect(screen.getByText('search')).toBeInTheDocument()
     // Per-tool toggle UI must NOT be present (deferred — read-only).
@@ -250,5 +402,30 @@ describe('McpServersSettings', () => {
     vi.mocked(probeMcpServer).mockClear()
     fireEvent.click(screen.getByRole('button', { name: /test probe connection/i }))
     await waitFor(() => expect(probeMcpServer).toHaveBeenCalledWith('s4'))
+  })
+
+  it('renders one compact row per server — detail inline, no form fields', () => {
+    useAcpStore.setState({
+      mcpServers: [
+        { id: 'c1', type: 'stdio', name: 'Files', command: 'node server.js', enabled: true },
+        { id: 'c2', type: 'http', name: 'Remote', url: 'https://remote.test/mcp', enabled: true }
+      ]
+    })
+    render(<McpServersSettings />)
+    // Command/URL detail is visible straight from the collapsed row.
+    expect(screen.getByText('node server.js')).toBeInTheDocument()
+    expect(screen.getByText('https://remote.test/mcp')).toBeInTheDocument()
+    // No remnants of the old form inputs or the Form/Import tab bar.
+    expect(screen.queryByLabelText(/arguments \(one per line\)/i)).not.toBeInTheDocument()
+    expect(screen.queryByLabelText(/environment \(name=value/i)).not.toBeInTheDocument()
+    expect(screen.queryByRole('tab', { name: /import json/i })).not.toBeInTheDocument()
+    // All row controls stay accessible from the single line.
+    expect(screen.getByRole('button', { name: /test files connection/i })).toBeInTheDocument()
+    expect(screen.getByRole('switch', { name: /disable files/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /edit files/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /delete files/i })).toBeInTheDocument()
+    // Preserved surfaces: storage warning + experimental MCP-over-ACP card.
+    expect(screen.getByText('$VARIABLE')).toBeInTheDocument()
+    expect(screen.getByText(/experimental mcp-over-acp/i)).toBeInTheDocument()
   })
 })

--- a/src/renderer/components/settings/McpServersSettings.test.tsx
+++ b/src/renderer/components/settings/McpServersSettings.test.tsx
@@ -11,6 +11,7 @@ const { toastError, toastSuccess } = vi.hoisted(() => ({
 vi.mock('sonner', () => ({ toast: { error: toastError, success: toastSuccess } }))
 
 const saveMcpServer = vi.fn(async () => {})
+const importMcpServers = vi.fn(async (_servers: unknown[]) => {})
 const setMcpServerEnabled = vi.fn(async () => {})
 const deleteMcpServer = vi.fn(async () => {})
 const probeMcpServer = vi.fn(async () => {})
@@ -27,6 +28,7 @@ function seedStore(): void {
     mcpToolsLoaded: {},
     mcpProbing: {},
     saveMcpServer,
+    importMcpServers,
     setMcpServerEnabled,
     deleteMcpServer,
     probeMcpServer,
@@ -63,8 +65,9 @@ describe('McpServersSettings', () => {
     typeJson(JSON.stringify({ command: 'npx', args: ['-y', 'x'], env: { K: 'v' }, name: 'Files' }))
     expect(save).toBeEnabled()
     fireEvent.click(save)
-    await waitFor(() => expect(saveMcpServer).toHaveBeenCalledTimes(1))
-    expect(saveMcpServer).toHaveBeenCalledWith(
+    await waitFor(() => expect(importMcpServers).toHaveBeenCalledTimes(1))
+    // Add persists through the atomic batch action (one store write).
+    expect(importMcpServers).toHaveBeenCalledWith([
       expect.objectContaining({
         type: 'stdio',
         name: 'Files',
@@ -73,16 +76,16 @@ describe('McpServersSettings', () => {
         env: [{ name: 'K', value: 'v' }],
         enabled: true
       })
-    )
-    expect(saveMcpServer.mock.calls[0]?.[0].id).toMatch(UUID_RE)
+    ])
+    expect(importMcpServers.mock.calls[0]?.[0]?.[0]?.id).toMatch(UUID_RE)
     await waitFor(() =>
-      expect(toastSuccess).toHaveBeenCalledWith(expect.stringMatching(/imported 1 mcp server/i))
+      expect(toastSuccess).toHaveBeenCalledWith(expect.stringMatching(/added 1 mcp server/i))
     )
     // The dialog closes after a fully successful save.
     expect(screen.queryByLabelText('MCP JSON')).not.toBeInTheDocument()
   })
 
-  it('adds both servers from a Claude Desktop wrapper, each with a fresh id', async () => {
+  it('adds both servers from a Claude Desktop wrapper in one atomic batch', async () => {
     render(<McpServersSettings />)
     openAddDialog()
     typeJson(
@@ -94,11 +97,14 @@ describe('McpServersSettings', () => {
       })
     )
     fireEvent.click(screen.getByRole('button', { name: 'Save' }))
-    await waitFor(() => expect(saveMcpServer).toHaveBeenCalledTimes(2))
-    expect(saveMcpServer).toHaveBeenCalledWith(
+    await waitFor(() => expect(importMcpServers).toHaveBeenCalledTimes(1))
+    // One call with the whole batch — not one save per entry.
+    const batch = vi.mocked(importMcpServers).mock.calls[0]?.[0] ?? []
+    expect(batch).toHaveLength(2)
+    expect(batch[0]).toEqual(
       expect.objectContaining({ type: 'stdio', name: 'alpha', command: 'node', enabled: true })
     )
-    expect(saveMcpServer).toHaveBeenCalledWith(
+    expect(batch[1]).toEqual(
       expect.objectContaining({
         type: 'http',
         name: 'beta',
@@ -106,8 +112,8 @@ describe('McpServersSettings', () => {
         enabled: true
       })
     )
-    const firstId = saveMcpServer.mock.calls[0]?.[0].id
-    const secondId = saveMcpServer.mock.calls[1]?.[0].id
+    const firstId = batch[0]?.id as string | undefined
+    const secondId = batch[1]?.id as string | undefined
     expect(firstId).toMatch(UUID_RE)
     expect(secondId).toMatch(UUID_RE)
     expect(firstId).not.toBe(secondId)
@@ -119,10 +125,10 @@ describe('McpServersSettings', () => {
     typeJson('{ this is not json')
     fireEvent.click(screen.getByRole('button', { name: 'Save' }))
     await waitFor(() => expect(screen.getByRole('alert')).toHaveTextContent(/invalid json/i))
-    expect(saveMcpServer).not.toHaveBeenCalled()
+    expect(importMcpServers).not.toHaveBeenCalled()
   })
 
-  it('saves valid entries and keeps per-server errors inline for the bad ones', async () => {
+  it('rejects the whole batch while any entry is invalid, then saves all once corrected', async () => {
     render(<McpServersSettings />)
     openAddDialog()
     typeJson(
@@ -134,13 +140,29 @@ describe('McpServersSettings', () => {
       })
     )
     fireEvent.click(screen.getByRole('button', { name: 'Save' }))
-    await waitFor(() => expect(saveMcpServer).toHaveBeenCalledTimes(1))
-    expect(saveMcpServer).toHaveBeenCalledWith(
-      expect.objectContaining({ name: 'good', command: 'node', args: ['server.js'] })
+    await waitFor(() =>
+      expect(screen.getByRole('alert')).toHaveTextContent(/command is required for stdio/i)
     )
-    // The rejected entry's reason stays visible so the user can fix and re-save.
-    expect(screen.getByRole('alert')).toHaveTextContent(/command is required for stdio/i)
-    expect(toastSuccess).not.toHaveBeenCalled()
+    // All-or-nothing: nothing persists while any entry is invalid, so the
+    // corrected re-save cannot duplicate an earlier partial save.
+    expect(importMcpServers).not.toHaveBeenCalled()
+    typeJson(
+      JSON.stringify({
+        mcpServers: {
+          good: { command: 'node', args: ['server.js'] },
+          bad: { command: 'node', args: ['bad.js'] }
+        }
+      })
+    )
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }))
+    await waitFor(() => expect(importMcpServers).toHaveBeenCalledTimes(1))
+    expect(importMcpServers).toHaveBeenCalledWith([
+      expect.objectContaining({ name: 'good', command: 'node', args: ['server.js'] }),
+      expect.objectContaining({ name: 'bad', command: 'node', args: ['bad.js'] })
+    ])
+    await waitFor(() =>
+      expect(toastSuccess).toHaveBeenCalledWith(expect.stringMatching(/added 2 mcp servers/i))
+    )
   })
 
   it('reports an empty wrapper without saving', async () => {
@@ -151,7 +173,7 @@ describe('McpServersSettings', () => {
     await waitFor(() =>
       expect(screen.getByRole('alert')).toHaveTextContent(/no mcp servers found in the json/i)
     )
-    expect(saveMcpServer).not.toHaveBeenCalled()
+    expect(importMcpServers).not.toHaveBeenCalled()
   })
 
   it('pre-fills the edit dialog and updates the same registry entry', async () => {
@@ -307,7 +329,7 @@ describe('McpServersSettings', () => {
   })
 
   it('keeps the dialog open and shows the rollback toast when saving fails', async () => {
-    saveMcpServer.mockRejectedValueOnce(new Error('disk full'))
+    importMcpServers.mockRejectedValueOnce(new Error('disk full'))
     render(<McpServersSettings />)
     openAddDialog()
     typeJson(JSON.stringify({ name: 'Files', command: 'node' }))
@@ -317,6 +339,30 @@ describe('McpServersSettings', () => {
     )
     // The dialog stays open so the JSON is not lost after a rollback.
     expect(screen.getByLabelText('MCP JSON')).toBeInTheDocument()
+  })
+
+  it('blocks dialog dismissal while a save is pending', async () => {
+    // A save that never settles until the test releases it.
+    let releaseSave: (() => void) | undefined
+    importMcpServers.mockImplementationOnce(
+      () =>
+        new Promise<void>((resolve) => {
+          releaseSave = resolve
+        })
+    )
+    render(<McpServersSettings />)
+    openAddDialog()
+    typeJson(JSON.stringify({ name: 'Files', command: 'node' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }))
+    await waitFor(() => expect(importMcpServers).toHaveBeenCalledTimes(1))
+    // While the save is in flight, Cancel is disabled and overlay/Escape
+    // dismissal (onOpenChange) is ignored — the JSON must not be lost.
+    expect(screen.getByRole('button', { name: 'Cancel' })).toBeDisabled()
+    fireEvent.keyDown(screen.getByLabelText('MCP JSON'), { key: 'Escape' })
+    expect(screen.getByLabelText('MCP JSON')).toBeInTheDocument()
+    // Once the save settles the dialog completes normally.
+    releaseSave?.()
+    await waitFor(() => expect(screen.queryByLabelText('MCP JSON')).not.toBeInTheDocument())
   })
 
   it('keeps the edit dialog open when the update fails', async () => {

--- a/src/renderer/components/settings/McpServersSettings.tsx
+++ b/src/renderer/components/settings/McpServersSettings.tsx
@@ -67,6 +67,7 @@ function serverToJson(server: StoredMcpServer): string {
 export function McpServersSettings(): React.JSX.Element {
   const servers = useAcpStore((state) => state.mcpServers)
   const saveMcpServer = useAcpStore((state) => state.saveMcpServer)
+  const importMcpServers = useAcpStore((state) => state.importMcpServers)
   const setMcpServerEnabled = useAcpStore((state) => state.setMcpServerEnabled)
   const deleteMcpServer = useAcpStore((state) => state.deleteMcpServer)
   const probeMcpServer = useAcpStore((state) => state.probeMcpServer)
@@ -117,39 +118,36 @@ export function McpServersSettings(): React.JSX.Element {
   }
 
   // Add mode: accepts a Claude Desktop `{"mcpServers": {...}}` wrapper or a
-  // bare single-server object; every parsed entry saves with a fresh id (no
-  // overwrite-by-name).
+  // bare single-server object. The input is validated as a whole BEFORE any
+  // persistence, and the accepted batch is committed through a single atomic
+  // store write — so fixing a rejected entry and re-saving can never duplicate
+  // previously saved entries, and a multi-server import triggers one registry
+  // update (one on-mount probe pass) instead of one per server.
   const saveAdd = async (): Promise<void> => {
-    let savedCount = 0
+    const { servers: parsedServers, errors } = parseMcpJsonImport(jsonText)
+    if (errors.length > 0) {
+      // All-or-nothing: nothing is persisted until every entry parses, so a
+      // corrected re-save starts from the same registry state.
+      setJsonErrors(errors)
+      return
+    }
+    if (parsedServers.length === 0) {
+      setJsonErrors(['No MCP servers found in the JSON.'])
+      return
+    }
+    const batch = parsedServers.map((parsed) => ({
+      ...parsed,
+      id: crypto.randomUUID(),
+      enabled: true
+    }))
     try {
-      const { servers: parsedServers, errors } = parseMcpJsonImport(jsonText)
-      // Valid servers still save when some entries are rejected (per-server
-      // errors stay visible inline so the user can fix and re-save).
-      for (const parsed of parsedServers) {
-        await saveMcpServer({ ...parsed, id: crypto.randomUUID(), enabled: true })
-        savedCount += 1
-      }
-      if (errors.length > 0) {
-        setJsonErrors(errors)
-        return
-      }
-      if (parsedServers.length === 0) {
-        setJsonErrors(['No MCP servers found in the JSON.'])
-        return
-      }
-      toast.success(
-        `Imported ${parsedServers.length} MCP server${parsedServers.length === 1 ? '' : 's'}`
-      )
+      await importMcpServers(batch)
+      toast.success(`Added ${batch.length} MCP server${batch.length === 1 ? '' : 's'}`)
       closeDialog()
     } catch {
-      // A mid-loop throw leaves earlier saves persisted (fresh IDs each time).
-      // Tell the user how many landed so they do not blindly re-save and
-      // create duplicates.
-      toast.error(
-        savedCount > 0
-          ? `Imported ${savedCount} server${savedCount === 1 ? '' : 's'} before a save failed. Review the remaining entries before re-saving.`
-          : 'Could not save the MCP server. Your previous settings were restored.'
-      )
+      // importMcpServers rolls back the whole batch on failure — nothing was
+      // persisted, so the dialog stays open for a safe retry.
+      toast.error('Could not save the MCP servers. Your previous settings were restored.')
     }
   }
 
@@ -403,7 +401,10 @@ export function McpServersSettings(): React.JSX.Element {
       <Dialog
         open={dialog !== null}
         onOpenChange={(open) => {
-          if (!open) closeDialog()
+          // Block dismissal while a save is in flight — otherwise the in-flight
+          // completion handler would close a newly opened editor, and a failed
+          // save's JSON would be lost.
+          if (!open && !saving) closeDialog()
         }}
       >
         <DialogContent className="max-h-[90vh] overflow-y-auto sm:max-w-xl">
@@ -440,7 +441,7 @@ export function McpServersSettings(): React.JSX.Element {
             )}
           </div>
           <DialogFooter>
-            <Button type="button" variant="outline" onClick={closeDialog}>
+            <Button type="button" variant="outline" disabled={saving} onClick={closeDialog}>
               Cancel
             </Button>
             <Button

--- a/src/renderer/components/settings/McpServersSettings.tsx
+++ b/src/renderer/components/settings/McpServersSettings.tsx
@@ -1,5 +1,5 @@
 import { AlertTriangle, ChevronDown, Pencil, Plus, RefreshCw, Server, Trash2 } from 'lucide-react'
-import { useEffect, useMemo, useState } from 'react'
+import { useEffect, useState } from 'react'
 import { toast } from 'sonner'
 import { Button } from '@/components/ui/button'
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible'
@@ -11,110 +11,57 @@ import {
   DialogHeader,
   DialogTitle
 } from '@/components/ui/dialog'
-import { Input } from '@/components/ui/input'
 import { Switch } from '@/components/ui/switch'
 import { Textarea } from '@/components/ui/textarea'
-import type { McpServerConfig } from '@/lib/acp-api'
-import {
-  type McpTransport,
-  type StoredMcpServer,
-  transportOf,
-  validateMcpServer
-} from '@/lib/acp-mcp-persistence'
+import { type StoredMcpServer, transportOf } from '@/lib/acp-mcp-persistence'
 import { parseMcpJsonImport } from '@/lib/mcp-json-import'
 import { useAcpStore } from '@/stores/acp-store'
 
-interface ServerDraft {
-  id?: string
-  type: McpTransport
-  name: string
-  command: string
-  args: string
-  env: string
-  url: string
-  headers: string
-  enabled: boolean
+type McpDialogState = { mode: 'add' } | { mode: 'edit'; server: StoredMcpServer }
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
 }
 
-const EMPTY_DRAFT: ServerDraft = {
-  type: 'stdio',
-  name: '',
-  command: '',
-  args: '',
-  env: '',
-  url: '',
-  headers: '',
-  enabled: true
-}
-
-function pairsToText(pairs: Array<{ name: string; value: string }> | undefined): string {
-  return pairs?.map((pair) => `${pair.name}=${pair.value}`).join('\n') ?? ''
-}
-
-function textToPairs(text: string): Array<{ name: string; value: string }> {
-  return text
-    .split('\n')
-    .map((line) => line.trim())
-    .filter(Boolean)
-    .map((line) => {
-      const separator = line.indexOf('=')
-      return separator === -1
-        ? { name: line, value: '' }
-        : { name: line.slice(0, separator).trim(), value: line.slice(separator + 1) }
-    })
-    .filter((pair) => pair.name.length > 0)
-}
-
-function draftFor(server: StoredMcpServer): ServerDraft {
-  const type = transportOf(server)
-  if (type === 'stdio') {
+/**
+ * Serialize a stored server to the single-object JSON the edit dialog accepts:
+ * `{type, name, command, args, env, enabled}` (stdio) or
+ * `{type, name, url, headers, enabled}` (http/sse). `env` is shown as a
+ * Claude-Desktop-style map (the parser normalizes map -> pairs); `headers`
+ * stays `[{name, value}]` pairs — the only shape the parser accepts. Empty
+ * `args`/`env`/`headers` are omitted.
+ */
+function serverToJson(server: StoredMcpServer): string {
+  const enabled = server.enabled !== false
+  if (transportOf(server) === 'stdio') {
     const stdio = server as Extract<StoredMcpServer, { type?: 'stdio' }>
-    return {
-      id: server.id,
-      type,
-      name: server.name,
-      command: stdio.command,
-      args: stdio.args?.join('\n') ?? '',
-      env: pairsToText(stdio.env),
-      url: '',
-      headers: '',
-      enabled: server.enabled !== false
-    }
+    const env: Record<string, string> = {}
+    for (const pair of stdio.env ?? []) env[pair.name] = pair.value
+    return JSON.stringify(
+      {
+        type: 'stdio',
+        name: server.name,
+        command: stdio.command,
+        ...(stdio.args && stdio.args.length > 0 ? { args: stdio.args } : {}),
+        ...(Object.keys(env).length > 0 ? { env } : {}),
+        enabled
+      },
+      null,
+      2
+    )
   }
   const remote = server as Extract<StoredMcpServer, { type: 'http' | 'sse' }>
-  return {
-    id: server.id,
-    type,
-    name: server.name,
-    command: '',
-    args: '',
-    env: '',
-    url: remote.url,
-    headers: pairsToText(remote.headers),
-    enabled: server.enabled !== false
-  }
-}
-
-function configFor(draft: ServerDraft): McpServerConfig {
-  if (draft.type === 'stdio') {
-    const args = draft.args
-      .split('\n')
-      .map((arg) => arg.trim())
-      .filter(Boolean)
-    return {
-      type: 'stdio',
-      name: draft.name.trim(),
-      command: draft.command.trim(),
-      ...(args.length > 0 ? { args } : {}),
-      ...(draft.env.trim() ? { env: textToPairs(draft.env) } : {})
-    }
-  }
-  return {
-    type: draft.type,
-    name: draft.name.trim(),
-    url: draft.url.trim(),
-    ...(draft.headers.trim() ? { headers: textToPairs(draft.headers) } : {})
-  }
+  return JSON.stringify(
+    {
+      type: transportOf(server),
+      name: server.name,
+      url: remote.url,
+      ...(remote.headers && remote.headers.length > 0 ? { headers: remote.headers } : {}),
+      enabled
+    },
+    null,
+    2
+  )
 }
 
 export function McpServersSettings(): React.JSX.Element {
@@ -128,14 +75,10 @@ export function McpServersSettings(): React.JSX.Element {
   const mcpProbeError = useAcpStore((state) => state.mcpProbeError)
   const mcpTools = useAcpStore((state) => state.mcpTools)
   const mcpProbing = useAcpStore((state) => state.mcpProbing)
-  const [draft, setDraft] = useState<ServerDraft | null>(null)
+  const [dialog, setDialog] = useState<McpDialogState | null>(null)
+  const [jsonText, setJsonText] = useState('')
+  const [jsonErrors, setJsonErrors] = useState<string[]>([])
   const [saving, setSaving] = useState(false)
-  // "Form | Import JSON" toggle inside the Add/Edit dialog. Import mode pastes
-  // a Claude Desktop `{"mcpServers": {...}}` config (or a bare single server)
-  // and saves each parsed entry with a fresh id.
-  const [importMode, setImportMode] = useState(false)
-  const [importText, setImportText] = useState('')
-  const [importErrors, setImportErrors] = useState<string[]>([])
   // Tracks which server rows have their tool list expanded (Settings surface).
   const [expandedTools, setExpandedTools] = useState<Record<string, boolean>>({})
 
@@ -155,69 +98,112 @@ export function McpServersSettings(): React.JSX.Element {
     }
   }, [servers.map((s) => s.id).join('|')])
 
-  const validation = useMemo(
-    () => (draft ? validateMcpServer(configFor(draft)) : { valid: false, errors: [] }),
-    [draft]
-  )
-
-  const persistDraft = async (): Promise<void> => {
-    if (!draft || !validation.valid) return
-    setSaving(true)
-    try {
-      await saveMcpServer({
-        ...configFor(draft),
-        id: draft.id ?? crypto.randomUUID(),
-        enabled: draft.enabled
-      })
-      setDraft(null)
-      toast.success(draft.id ? 'MCP server updated' : 'MCP server added')
-    } catch {
-      toast.error('Could not save the MCP server. Your previous settings were restored.')
-    } finally {
-      setSaving(false)
-    }
-  }
-
   const closeDialog = (): void => {
-    setDraft(null)
-    setImportMode(false)
-    setImportErrors([])
+    setDialog(null)
+    setJsonText('')
+    setJsonErrors([])
   }
 
-  const saveImport = async (): Promise<void> => {
-    setSaving(true)
-    setImportErrors([])
+  const openAdd = (): void => {
+    setDialog({ mode: 'add' })
+    setJsonText('')
+    setJsonErrors([])
+  }
+
+  const openEdit = (server: StoredMcpServer): void => {
+    setDialog({ mode: 'edit', server })
+    setJsonText(serverToJson(server))
+    setJsonErrors([])
+  }
+
+  // Add mode: accepts a Claude Desktop `{"mcpServers": {...}}` wrapper or a
+  // bare single-server object; every parsed entry saves with a fresh id (no
+  // overwrite-by-name).
+  const saveAdd = async (): Promise<void> => {
     let savedCount = 0
     try {
-      const { servers: parsedServers, errors } = parseMcpJsonImport(importText)
-      // Valid servers still import when some entries are rejected (per-server
-      // errors stay visible inline so the user can fix and re-paste).
-      for (const server of parsedServers) {
-        await saveMcpServer({ ...server, id: crypto.randomUUID(), enabled: true })
+      const { servers: parsedServers, errors } = parseMcpJsonImport(jsonText)
+      // Valid servers still save when some entries are rejected (per-server
+      // errors stay visible inline so the user can fix and re-save).
+      for (const parsed of parsedServers) {
+        await saveMcpServer({ ...parsed, id: crypto.randomUUID(), enabled: true })
         savedCount += 1
       }
       if (errors.length > 0) {
-        setImportErrors(errors)
+        setJsonErrors(errors)
         return
       }
       if (parsedServers.length === 0) {
-        setImportErrors(['No MCP servers found in the JSON.'])
+        setJsonErrors(['No MCP servers found in the JSON.'])
         return
       }
       toast.success(
         `Imported ${parsedServers.length} MCP server${parsedServers.length === 1 ? '' : 's'}`
       )
-      setImportText('')
       closeDialog()
     } catch {
       // A mid-loop throw leaves earlier saves persisted (fresh IDs each time).
-      // Tell the user how many landed so they do not blindly re-paste and
+      // Tell the user how many landed so they do not blindly re-save and
       // create duplicates.
       toast.error(
         savedCount > 0
-          ? `Imported ${savedCount} server${savedCount === 1 ? '' : 's'} before a save failed. Review the remaining entries before re-importing.`
+          ? `Imported ${savedCount} server${savedCount === 1 ? '' : 's'} before a save failed. Review the remaining entries before re-saving.`
           : 'Could not save the MCP server. Your previous settings were restored.'
       )
+    }
+  }
+
+  // Edit mode: updates the same registry entry (same id). The wrapper is
+  // rejected — it would parse to N servers with fresh-name semantics, which
+  // is ambiguous for a single-entry update.
+  const saveEdit = async (target: StoredMcpServer): Promise<void> => {
+    // `enabled` is not part of `McpServerConfig`, so `parseMcpJsonImport`
+    // drops it like any unknown field — read an explicit boolean here first.
+    let explicitEnabled: boolean | undefined
+    try {
+      const raw: unknown = JSON.parse(jsonText)
+      if (isRecord(raw)) {
+        if (raw.mcpServers !== undefined) {
+          setJsonErrors(['Edit expects a single server object — remove the "mcpServers" wrapper.'])
+          return
+        }
+        if (typeof raw.enabled === 'boolean') explicitEnabled = raw.enabled
+      }
+    } catch {
+      // Invalid JSON — parseMcpJsonImport below reports the exact syntax error.
+    }
+    const { servers: parsedServers, errors } = parseMcpJsonImport(jsonText)
+    if (errors.length > 0) {
+      setJsonErrors(errors)
+      return
+    }
+    const parsed = parsedServers[0]
+    if (!parsed || parsedServers.length !== 1) {
+      setJsonErrors(['Edit expects exactly one server object.'])
+      return
+    }
+    try {
+      await saveMcpServer({
+        ...parsed,
+        id: target.id,
+        enabled: explicitEnabled ?? target.enabled ?? true
+      })
+      toast.success('MCP server updated')
+      closeDialog()
+    } catch {
+      // The store already rolled back the in-memory list; keep the dialog
+      // open so the edit is not lost.
+      toast.error('Could not save the MCP server. Your previous settings were restored.')
+    }
+  }
+
+  const saveJson = async (): Promise<void> => {
+    if (!dialog || jsonText.trim().length === 0) return
+    setSaving(true)
+    setJsonErrors([])
+    try {
+      if (dialog.mode === 'add') await saveAdd()
+      else await saveEdit(dialog.server)
     } finally {
       setSaving(false)
     }
@@ -232,7 +218,7 @@ export function McpServersSettings(): React.JSX.Element {
             Enabled servers are offered automatically when a new agent session starts.
           </p>
         </div>
-        <Button type="button" size="sm" onClick={() => setDraft({ ...EMPTY_DRAFT })}>
+        <Button type="button" size="sm" onClick={openAdd}>
           <Plus size={14} className="mr-1.5" /> Add server
         </Button>
       </div>
@@ -254,120 +240,77 @@ export function McpServersSettings(): React.JSX.Element {
           <p className="mt-1 text-xs text-muted-foreground">Add a stdio, HTTP, or SSE server.</p>
         </div>
       ) : (
-        <div className="space-y-2">
+        <div className="divide-y divide-border rounded-lg border border-border">
           {servers.map((server) => {
             const probeStatus = mcpProbeStatus[server.id]
             const probing = Boolean(mcpProbing[server.id])
             const tools = mcpTools[server.id]
             const isOpen = Boolean(expandedTools[server.id])
+            const detail =
+              transportOf(server) === 'stdio'
+                ? (server as Extract<StoredMcpServer, { type?: 'stdio' }>).command
+                : (server as Extract<StoredMcpServer, { type: 'http' | 'sse' }>).url
             return (
-              <div
+              <Collapsible
                 key={server.id}
-                className="flex flex-col gap-3 rounded-lg border border-border p-3 sm:flex-row sm:items-start"
+                open={isOpen}
+                onOpenChange={(next) => {
+                  setExpandedTools((prev) => ({ ...prev, [server.id]: next }))
+                  if (next) void loadMcpTools(server.id)
+                }}
               >
-                <div className="min-w-0 flex-1">
-                  <div className="flex flex-wrap items-center gap-2">
-                    <span
-                      role="img"
-                      className={
-                        probeStatus === 'connected'
-                          ? 'size-2 rounded-full bg-emerald-500'
-                          : probeStatus === 'disconnected'
-                            ? 'size-2 rounded-full bg-red-500'
-                            : 'size-2 rounded-full bg-muted-foreground/40'
-                      }
-                      aria-label={
-                        probeStatus === 'connected'
-                          ? `${server.name} reachable`
-                          : probeStatus === 'disconnected'
-                            ? `${server.name} unreachable`
-                            : `${server.name} not probed yet`
-                      }
-                      title={
-                        probeStatus === 'connected'
-                          ? 'Connected (Termul can reach this server)'
-                          : probeStatus === 'disconnected'
-                            ? 'Disconnected (Termul could not reach this server)'
-                            : 'Not probed yet — click "Test" to check'
-                      }
-                    />
-                    <span className="truncate text-sm font-medium">{server.name}</span>
-                    <span className="rounded bg-secondary px-1.5 py-0.5 text-3xs font-medium uppercase text-muted-foreground">
-                      {transportOf(server)}
-                    </span>
-                  </div>
-                  <p className="mt-1 truncate font-mono text-xs text-muted-foreground">
-                    {transportOf(server) === 'stdio'
-                      ? (server as Extract<StoredMcpServer, { type?: 'stdio' }>).command
-                      : (server as Extract<StoredMcpServer, { type: 'http' | 'sse' }>).url}
-                  </p>
-                  <Collapsible
-                    open={isOpen}
-                    onOpenChange={(next) => {
-                      setExpandedTools((prev) => ({ ...prev, [server.id]: next }))
-                      if (next) void loadMcpTools(server.id)
-                    }}
-                  >
-                    <CollapsibleTrigger className="mt-1 inline-flex items-center gap-1 text-3xs text-muted-foreground underline-offset-2 hover:underline">
-                      <ChevronDown size={12} className={isOpen ? 'rotate-180' : ''} />
-                      {tools && tools.length > 0
-                        ? `${tools.length} tool${tools.length === 1 ? '' : 's'}`
+                {/* Compact one-line row: status dot, name, transport,
+                    command/URL, tools trigger, and every row action. Tool
+                    and probe details stay opt-in behind the disclosure. */}
+                <div className="flex items-center gap-2 px-3 py-2">
+                  <span
+                    role="img"
+                    className={
+                      probeStatus === 'connected'
+                        ? 'size-2 shrink-0 rounded-full bg-emerald-500'
                         : probeStatus === 'disconnected'
-                          ? 'Probe failed — retry'
-                          : 'Show tools'}
-                    </CollapsibleTrigger>
-                    <CollapsibleContent className="pt-1">
-                      {tools && tools.length > 0 ? (
-                        <ul className="space-y-0.5">
-                          {tools.map((tool) => (
-                            <li key={tool.name} className="flex min-w-0 items-baseline text-3xs">
-                              <span className="font-mono font-medium text-foreground">
-                                {tool.name}
-                              </span>
-                              {tool.description ? (
-                                <span className="ml-1 min-w-0 flex-1 truncate text-muted-foreground/70">
-                                  — {tool.description}
-                                </span>
-                              ) : null}
-                            </li>
-                          ))}
-                        </ul>
-                      ) : probeStatus === 'disconnected' ? (
-                        <div className="space-y-1">
-                          <p className="text-3xs text-destructive">
-                            Probe failed — check the server config or network.
-                          </p>
-                          {mcpProbeError[server.id] ? (
-                            <span className="block font-mono text-3xs text-destructive/80">
-                              {mcpProbeError[server.id]}
-                            </span>
-                          ) : null}
-                        </div>
-                      ) : probeStatus === 'connected' ? (
-                        <p className="text-3xs text-muted-foreground">
-                          Probe completed — no tools found.
-                        </p>
-                      ) : probing ? (
-                        <p className="text-3xs text-muted-foreground">Probing…</p>
-                      ) : (
-                        <p className="text-3xs text-muted-foreground">
-                          Expand to probe (read-only — per-tool toggle coming soon).
-                        </p>
-                      )}
-                    </CollapsibleContent>
-                  </Collapsible>
-                </div>
-                <div className="flex items-center justify-between gap-2 sm:justify-end">
+                          ? 'size-2 shrink-0 rounded-full bg-red-500'
+                          : 'size-2 shrink-0 rounded-full bg-muted-foreground/40'
+                    }
+                    aria-label={
+                      probeStatus === 'connected'
+                        ? `${server.name} reachable`
+                        : probeStatus === 'disconnected'
+                          ? `${server.name} unreachable`
+                          : `${server.name} not probed yet`
+                    }
+                    title={
+                      probeStatus === 'connected'
+                        ? 'Connected (Termul can reach this server)'
+                        : probeStatus === 'disconnected'
+                          ? 'Disconnected (Termul could not reach this server)'
+                          : 'Not probed yet — click "Test" to check'
+                    }
+                  />
+                  <span className="min-w-0 shrink truncate text-sm font-medium">{server.name}</span>
+                  <span className="shrink-0 rounded bg-secondary px-1.5 py-0.5 text-3xs font-medium uppercase text-muted-foreground">
+                    {transportOf(server)}
+                  </span>
+                  <span className="hidden min-w-0 flex-1 truncate font-mono text-xs text-muted-foreground sm:block">
+                    {detail}
+                  </span>
+                  <CollapsibleTrigger className="inline-flex shrink-0 items-center gap-1 text-3xs text-muted-foreground underline-offset-2 hover:underline">
+                    <ChevronDown size={12} className={isOpen ? 'rotate-180' : ''} />
+                    {tools && tools.length > 0
+                      ? `${tools.length} tool${tools.length === 1 ? '' : 's'}`
+                      : probeStatus === 'disconnected'
+                        ? 'Probe failed — retry'
+                        : 'Show tools'}
+                  </CollapsibleTrigger>
                   <Button
                     type="button"
-                    size="sm"
+                    size="icon"
                     variant="ghost"
                     disabled={probing}
                     onClick={() => void probeMcpServer(server.id)}
                     aria-label={`Test ${server.name} connection`}
                   >
                     <RefreshCw size={14} className={probing ? 'animate-spin' : ''} />
-                    <span className="ml-1.5">Test</span>
                   </Button>
                   <Switch
                     checked={server.enabled !== false}
@@ -384,12 +327,7 @@ export function McpServersSettings(): React.JSX.Element {
                     type="button"
                     size="icon"
                     variant="ghost"
-                    onClick={() => {
-                      // Ensure a lingering import session cannot resurface
-                      // the (now-hidden) import view while editing.
-                      setImportMode(false)
-                      setDraft(draftFor(server))
-                    }}
+                    onClick={() => openEdit(server)}
                   >
                     <Pencil size={15} />
                     <span className="sr-only">Edit {server.name}</span>
@@ -410,7 +348,44 @@ export function McpServersSettings(): React.JSX.Element {
                     <span className="sr-only">Delete {server.name}</span>
                   </Button>
                 </div>
-              </div>
+                <CollapsibleContent className="px-3 pb-2">
+                  {tools && tools.length > 0 ? (
+                    <ul className="space-y-0.5">
+                      {tools.map((tool) => (
+                        <li key={tool.name} className="flex min-w-0 items-baseline text-3xs">
+                          <span className="font-mono font-medium text-foreground">{tool.name}</span>
+                          {tool.description ? (
+                            <span className="ml-1 min-w-0 flex-1 truncate text-muted-foreground/70">
+                              — {tool.description}
+                            </span>
+                          ) : null}
+                        </li>
+                      ))}
+                    </ul>
+                  ) : probeStatus === 'disconnected' ? (
+                    <div className="space-y-1">
+                      <p className="text-3xs text-destructive">
+                        Probe failed — check the server config or network.
+                      </p>
+                      {mcpProbeError[server.id] ? (
+                        <span className="block font-mono text-3xs text-destructive/80">
+                          {mcpProbeError[server.id]}
+                        </span>
+                      ) : null}
+                    </div>
+                  ) : probeStatus === 'connected' ? (
+                    <p className="text-3xs text-muted-foreground">
+                      Probe completed — no tools found.
+                    </p>
+                  ) : probing ? (
+                    <p className="text-3xs text-muted-foreground">Probing…</p>
+                  ) : (
+                    <p className="text-3xs text-muted-foreground">
+                      Expand to probe (read-only — per-tool toggle coming soon).
+                    </p>
+                  )}
+                </CollapsibleContent>
+              </Collapsible>
             )
           })}
         </div>
@@ -426,7 +401,7 @@ export function McpServersSettings(): React.JSX.Element {
       </div>
 
       <Dialog
-        open={draft !== null || importMode}
+        open={dialog !== null}
         onOpenChange={(open) => {
           if (!open) closeDialog()
         }}
@@ -434,180 +409,47 @@ export function McpServersSettings(): React.JSX.Element {
         <DialogContent className="max-h-[90vh] overflow-y-auto sm:max-w-xl">
           <DialogHeader>
             <DialogTitle>
-              {importMode ? 'Import MCP servers' : draft?.id ? 'Edit MCP server' : 'Add MCP server'}
+              {dialog?.mode === 'edit' ? 'Edit MCP server' : 'Add MCP servers'}
             </DialogTitle>
             <DialogDescription>
-              {importMode
-                ? 'Paste a Claude Desktop config or a single server object, then parse and save.'
-                : 'Configure one server transport. Each argument or key/value pair uses its own line.'}
+              {dialog?.mode === 'edit'
+                ? 'Edit this server as JSON. Unknown fields are dropped on save.'
+                : 'Paste a Claude Desktop "mcpServers" config or a single server object.'}
             </DialogDescription>
           </DialogHeader>
-          <div
-            role="tablist"
-            aria-label="MCP server entry mode"
-            className="flex w-fit gap-1 rounded-lg border border-border bg-secondary/20 p-1"
-            // The Import tab is an Add-only flow — importing while editing an
-            // existing server would persist fresh IDs instead of updating the
-            // draft, so the tab bar is hidden whenever a server is being edited.
-            hidden={Boolean(draft?.id)}
-          >
-            <button
-              type="button"
-              role="tab"
-              aria-selected={!importMode}
-              onClick={() => {
-                setImportMode(false)
-                setImportErrors([])
-              }}
-              className={`rounded-md px-2.5 py-1 text-xs font-medium transition-colors ${
-                !importMode
-                  ? 'bg-background text-foreground shadow-sm'
-                  : 'text-muted-foreground hover:text-foreground'
-              }`}
-            >
-              Form
-            </button>
-            <button
-              type="button"
-              role="tab"
-              aria-selected={importMode}
-              onClick={() => {
-                setImportMode(true)
-                setImportErrors([])
-              }}
-              className={`rounded-md px-2.5 py-1 text-xs font-medium transition-colors ${
-                importMode
-                  ? 'bg-background text-foreground shadow-sm'
-                  : 'text-muted-foreground hover:text-foreground'
-              }`}
-            >
-              Import JSON
-            </button>
+          <div className="space-y-4">
+            <label htmlFor="mcp-json" className="block space-y-1 text-sm">
+              <span>MCP JSON</span>
+              <Textarea
+                id="mcp-json"
+                rows={12}
+                value={jsonText}
+                onChange={(event) => setJsonText(event.target.value)}
+                placeholder='{"mcpServers": {"dokploy": {"command": "npx", "args": ["-y", "@dokploy/mcp"], "env": {"DOKPLOY_URL": "..."}}}}'
+                className="font-mono"
+              />
+            </label>
+            {jsonErrors.length > 0 && (
+              <ul role="alert" className="space-y-1 text-xs text-destructive">
+                {jsonErrors.map((error) => (
+                  <li key={error} className="break-words font-mono">
+                    {error}
+                  </li>
+                ))}
+              </ul>
+            )}
           </div>
-          {importMode ? (
-            <div className="space-y-4">
-              <label htmlFor="mcp-import-json" className="block space-y-1 text-sm">
-                <span>MCP JSON</span>
-                <Textarea
-                  id="mcp-import-json"
-                  rows={10}
-                  value={importText}
-                  onChange={(event) => setImportText(event.target.value)}
-                  placeholder='{"mcpServers": {"dokploy": {"command": "npx", "args": ["-y", "@dokploy/mcp"], "env": {"DOKPLOY_URL": "..."}}}}'
-                  className="font-mono"
-                />
-              </label>
-              {importErrors.length > 0 && (
-                <ul role="alert" className="space-y-1 text-xs text-destructive">
-                  {importErrors.map((error) => (
-                    <li key={error} className="break-words font-mono">
-                      {error}
-                    </li>
-                  ))}
-                </ul>
-              )}
-            </div>
-          ) : (
-            draft && (
-              <div className="space-y-4">
-                <div className="grid gap-2 sm:grid-cols-2">
-                  <label htmlFor="mcp-server-name" className="space-y-1 text-sm">
-                    <span>Name</span>
-                    <Input
-                      id="mcp-server-name"
-                      value={draft.name}
-                      onChange={(event) => setDraft({ ...draft, name: event.target.value })}
-                    />
-                  </label>
-                  <label htmlFor="mcp-server-transport" className="space-y-1 text-sm">
-                    <span>Transport</span>
-                    <select
-                      id="mcp-server-transport"
-                      value={draft.type}
-                      onChange={(event) =>
-                        setDraft({ ...draft, type: event.target.value as McpTransport })
-                      }
-                      className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
-                    >
-                      <option value="stdio">stdio</option>
-                      <option value="http">HTTP</option>
-                      <option value="sse">SSE</option>
-                    </select>
-                  </label>
-                </div>
-                {draft.type === 'stdio' ? (
-                  <>
-                    <label htmlFor="mcp-command" className="block space-y-1 text-sm">
-                      <span>Command</span>
-                      <Input
-                        id="mcp-command"
-                        value={draft.command}
-                        onChange={(event) => setDraft({ ...draft, command: event.target.value })}
-                      />
-                    </label>
-                    <label htmlFor="mcp-arguments" className="block space-y-1 text-sm">
-                      <span>Arguments (one per line)</span>
-                      <Textarea
-                        id="mcp-arguments"
-                        value={draft.args}
-                        onChange={(event) => setDraft({ ...draft, args: event.target.value })}
-                      />
-                    </label>
-                    <label htmlFor="mcp-environment" className="block space-y-1 text-sm">
-                      <span>Environment (NAME=value, one per line)</span>
-                      <Textarea
-                        id="mcp-environment"
-                        value={draft.env}
-                        onChange={(event) => setDraft({ ...draft, env: event.target.value })}
-                      />
-                    </label>
-                  </>
-                ) : (
-                  <>
-                    <label htmlFor="mcp-url" className="block space-y-1 text-sm">
-                      <span>URL</span>
-                      <Input
-                        id="mcp-url"
-                        type="url"
-                        value={draft.url}
-                        onChange={(event) => setDraft({ ...draft, url: event.target.value })}
-                      />
-                    </label>
-                    <label htmlFor="mcp-headers" className="block space-y-1 text-sm">
-                      <span>Headers (NAME=value, one per line)</span>
-                      <Textarea
-                        id="mcp-headers"
-                        value={draft.headers}
-                        onChange={(event) => setDraft({ ...draft, headers: event.target.value })}
-                      />
-                    </label>
-                  </>
-                )}
-                {!validation.valid && draft.name.trim().length > 0 && (
-                  <p role="alert" className="text-xs text-destructive">
-                    {validation.errors.join(' ')}
-                  </p>
-                )}
-              </div>
-            )
-          )}
           <DialogFooter>
             <Button type="button" variant="outline" onClick={closeDialog}>
               Cancel
             </Button>
-            {importMode ? (
-              <Button type="button" disabled={saving} onClick={() => void saveImport()}>
-                {saving ? 'Saving…' : 'Parse & Save'}
-              </Button>
-            ) : (
-              <Button
-                type="button"
-                disabled={!validation.valid || saving}
-                onClick={() => void persistDraft()}
-              >
-                {saving ? 'Saving…' : 'Save'}
-              </Button>
-            )}
+            <Button
+              type="button"
+              disabled={jsonText.trim().length === 0 || saving}
+              onClick={() => void saveJson()}
+            >
+              {saving ? 'Saving…' : 'Save'}
+            </Button>
           </DialogFooter>
         </DialogContent>
       </Dialog>

--- a/src/renderer/stores/acp-store.test.ts
+++ b/src/renderer/stores/acp-store.test.ts
@@ -4109,6 +4109,56 @@ describe('acp-store', () => {
     )
   })
 
+  it('serializes overlapping registry mutations so later writes never clobber earlier ones', async () => {
+    const persistence = await import('@/lib/acp-mcp-persistence')
+    const save = vi.mocked(persistence.saveMcpServers)
+    save.mockClear()
+    // The import's disk write stalls until the test releases it.
+    let releaseImportWrite: (() => void) | undefined
+    save.mockImplementationOnce(
+      () =>
+        new Promise<void>((resolve) => {
+          releaseImportWrite = () => resolve()
+        })
+    )
+    useAcpStore.setState({
+      mcpServers: [{ id: 'q1', type: 'stdio', name: 'Files', command: 'node', enabled: true }]
+    })
+
+    const importPromise = useAcpStore
+      .getState()
+      .importMcpServers([
+        { id: 'q2', type: 'stdio', name: 'Imported', command: 'node', enabled: true }
+      ])
+    // A toggle issued while the import write is in flight must wait its turn —
+    // without the mutation queue it would snapshot the pre-import registry and
+    // persist that stale list after the import (dropping q2), and its rollback
+    // on failure would drop q2 too.
+    const togglePromise = useAcpStore.getState().setMcpServerEnabled('q1', false)
+
+    // Mutations run queued on the microtask queue; let the import mutation
+    // reach its stalled disk write before asserting on the mid-flight state.
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(useAcpStore.getState().mcpServers.map((s) => s.id)).toEqual(['q1', 'q2'])
+    expect(save).toHaveBeenCalledTimes(1)
+
+    releaseImportWrite?.()
+    await importPromise
+    await togglePromise
+
+    // Both writes land in mutation order; the toggle's snapshot includes q2.
+    expect(save).toHaveBeenCalledTimes(2)
+    expect((save.mock.calls[0]?.[0] ?? []).map((s) => s.id)).toEqual(['q1', 'q2'])
+    const secondWrite = save.mock.calls[1]?.[0] ?? []
+    expect(secondWrite.map((s) => s.id)).toEqual(['q1', 'q2'])
+    expect(secondWrite.find((s) => s.id === 'q1')?.enabled).toBe(false)
+
+    const finalList = useAcpStore.getState().mcpServers
+    expect(finalList.map((s) => s.id)).toEqual(['q1', 'q2'])
+    expect(finalList.find((s) => s.id === 'q1')?.enabled).toBe(false)
+  })
+
   it('derives enabled MCP servers from capabilities when no override is supplied', async () => {
     useAcpStore.setState({
       agents: {

--- a/src/renderer/stores/acp-store.test.ts
+++ b/src/renderer/stores/acp-store.test.ts
@@ -4071,6 +4071,44 @@ describe('acp-store', () => {
     expect(useAcpStore.getState().mcpServers).toHaveLength(0)
   })
 
+  it('importMcpServers appends a batch in a single atomic persist', async () => {
+    const persistence = await import('@/lib/acp-mcp-persistence')
+    vi.mocked(persistence.saveMcpServers).mockClear()
+    useAcpStore.setState({
+      mcpServers: [{ id: 'm0', type: 'stdio', name: 'Existing', command: 'node', enabled: true }]
+    })
+    await useAcpStore.getState().importMcpServers([
+      { id: 'm2', type: 'stdio', name: 'a', command: 'node', enabled: true },
+      { id: 'm3', type: 'http', name: 'b', url: 'https://b.test/mcp', enabled: true }
+    ])
+    expect(useAcpStore.getState().mcpServers.map((s) => s.id)).toEqual(['m0', 'm2', 'm3'])
+    // One disk write for the whole batch — not one per entry.
+    expect(vi.mocked(persistence.saveMcpServers)).toHaveBeenCalledTimes(1)
+    expect(vi.mocked(persistence.saveMcpServers)).toHaveBeenCalledWith(
+      expect.arrayContaining([
+        expect.objectContaining({ id: 'm2' }),
+        expect.objectContaining({ id: 'm3' })
+      ])
+    )
+  })
+
+  it('rolls back an import batch when registry persistence fails', async () => {
+    const persistence = await import('@/lib/acp-mcp-persistence')
+    vi.mocked(persistence.saveMcpServers).mockRejectedValueOnce(new Error('disk full'))
+    useAcpStore.setState({
+      mcpServers: [{ id: 'm0', type: 'stdio', name: 'Existing', command: 'node', enabled: true }]
+    })
+    await expect(
+      useAcpStore
+        .getState()
+        .importMcpServers([{ id: 'm4', type: 'stdio', name: 'c', command: 'node', enabled: true }])
+    ).rejects.toThrow('disk full')
+    expect(useAcpStore.getState().mcpServers.map((s) => s.id)).toEqual(['m0'])
+    expect(logFrontendError).toHaveBeenCalledWith(
+      expect.objectContaining({ source: 'acp-store.importMcpServers' })
+    )
+  })
+
   it('derives enabled MCP servers from capabilities when no override is supplied', async () => {
     useAcpStore.setState({
       agents: {

--- a/src/renderer/stores/acp-store.ts
+++ b/src/renderer/stores/acp-store.ts
@@ -518,6 +518,13 @@ interface AcpState {
   // Actions — MCP server registry (P6)
   loadMcpServers: () => Promise<void>
   saveMcpServer: (server: StoredMcpServer) => Promise<void>
+  /**
+   * Append multiple new registry entries atomically: one optimistic state
+   * update, one disk write, rollback on failure. Used by the Settings JSON add
+   * flow so a multi-server import persists as a single batch — no per-entry
+   * writes, no partial prefix left behind to duplicate on retry.
+   */
+  importMcpServers: (servers: StoredMcpServer[]) => Promise<void>
   setMcpServerEnabled: (id: string, enabled: boolean) => Promise<void>
   deleteMcpServer: (id: string) => Promise<void>
 
@@ -4105,6 +4112,23 @@ export const useAcpStore = create<AcpState>((set, get) => ({
       void logFrontendError({
         source: 'acp-store.saveMcpServer',
         message: `Failed to persist MCP registry (${String(err)})`
+      })
+      throw err
+    }
+  },
+
+  importMcpServers: async (servers) => {
+    if (servers.length === 0) return
+    const list = get().mcpServers
+    const next = [...list, ...servers]
+    set({ mcpServers: next })
+    try {
+      await saveMcpServersToDisk(next)
+    } catch (err) {
+      set({ mcpServers: list })
+      void logFrontendError({
+        source: 'acp-store.importMcpServers',
+        message: `Failed to persist MCP registry import (${String(err)})`
       })
       throw err
     }

--- a/src/renderer/stores/acp-store.ts
+++ b/src/renderer/stores/acp-store.ts
@@ -2462,6 +2462,22 @@ function coalesceSet(sessionId: SessionId, apply: (s: AcpState) => Partial<AcpSt
   coalescedBuffer.push({ sessionId, apply })
   scheduleCoalesceFlush()
 }
+
+// MCP registry mutations (save/import/toggle/delete) are serialized through a
+// single promise queue. Without this, two overlapping mutations each snapshot
+// `mcpServers` before their async disk write; the slower one would persist a
+// stale snapshot AFTER the newer mutation (clobbering it), and its rollback on
+// failure would restore that stale snapshot — dropping the intervening change.
+// The queue guarantees each mutation reads, writes, and (on failure) rolls back
+// against the registry state as of its own turn.
+let mcpRegistryQueue: Promise<unknown> = Promise.resolve()
+async function runSerializedMcpRegistryMutation(mutation: () => Promise<void>): Promise<void> {
+  const run = mcpRegistryQueue.then(mutation)
+  // Swallow for the chain only — the returned promise still rejects to callers.
+  mcpRegistryQueue = run.catch(() => undefined)
+  await run
+}
+
 export const useAcpStore = create<AcpState>((set, get) => ({
   agents: {},
   agentStatus: {},
@@ -4096,75 +4112,80 @@ export const useAcpStore = create<AcpState>((set, get) => ({
     }
   },
 
-  saveMcpServer: async (server) => {
-    const list = get().mcpServers
-    const idx = list.findIndex((item) => item.id === server.id)
-    const nextServer = { ...server, enabled: server.enabled ?? true }
-    const next =
-      idx === -1
-        ? [...list, nextServer]
-        : list.map((item) => (item.id === server.id ? nextServer : item))
-    set({ mcpServers: next })
-    try {
-      await saveMcpServersToDisk(next)
-    } catch (err) {
-      set({ mcpServers: list })
-      void logFrontendError({
-        source: 'acp-store.saveMcpServer',
-        message: `Failed to persist MCP registry (${String(err)})`
-      })
-      throw err
-    }
-  },
+  saveMcpServer: (server) =>
+    runSerializedMcpRegistryMutation(async () => {
+      const list = get().mcpServers
+      const idx = list.findIndex((item) => item.id === server.id)
+      const nextServer = { ...server, enabled: server.enabled ?? true }
+      const next =
+        idx === -1
+          ? [...list, nextServer]
+          : list.map((item) => (item.id === server.id ? nextServer : item))
+      set({ mcpServers: next })
+      try {
+        await saveMcpServersToDisk(next)
+      } catch (err) {
+        set({ mcpServers: list })
+        void logFrontendError({
+          source: 'acp-store.saveMcpServer',
+          message: `Failed to persist MCP registry (${String(err)})`
+        })
+        throw err
+      }
+    }),
 
   importMcpServers: async (servers) => {
     if (servers.length === 0) return
-    const list = get().mcpServers
-    const next = [...list, ...servers]
-    set({ mcpServers: next })
-    try {
-      await saveMcpServersToDisk(next)
-    } catch (err) {
-      set({ mcpServers: list })
-      void logFrontendError({
-        source: 'acp-store.importMcpServers',
-        message: `Failed to persist MCP registry import (${String(err)})`
-      })
-      throw err
-    }
+    await runSerializedMcpRegistryMutation(async () => {
+      const list = get().mcpServers
+      const next = [...list, ...servers]
+      set({ mcpServers: next })
+      try {
+        await saveMcpServersToDisk(next)
+      } catch (err) {
+        set({ mcpServers: list })
+        void logFrontendError({
+          source: 'acp-store.importMcpServers',
+          message: `Failed to persist MCP registry import (${String(err)})`
+        })
+        throw err
+      }
+    })
   },
 
-  setMcpServerEnabled: async (id, enabled) => {
-    const list = get().mcpServers
-    const next = list.map((server) => (server.id === id ? { ...server, enabled } : server))
-    set({ mcpServers: next })
-    try {
-      await saveMcpServersToDisk(next)
-    } catch (err) {
-      set({ mcpServers: list })
-      void logFrontendError({
-        source: 'acp-store.setMcpServerEnabled',
-        message: `Failed to persist MCP registry toggle (${String(err)})`
-      })
-      throw err
-    }
-  },
+  setMcpServerEnabled: (id, enabled) =>
+    runSerializedMcpRegistryMutation(async () => {
+      const list = get().mcpServers
+      const next = list.map((server) => (server.id === id ? { ...server, enabled } : server))
+      set({ mcpServers: next })
+      try {
+        await saveMcpServersToDisk(next)
+      } catch (err) {
+        set({ mcpServers: list })
+        void logFrontendError({
+          source: 'acp-store.setMcpServerEnabled',
+          message: `Failed to persist MCP registry toggle (${String(err)})`
+        })
+        throw err
+      }
+    }),
 
-  deleteMcpServer: async (id) => {
-    const list = get().mcpServers
-    const next = list.filter((server) => server.id !== id)
-    set({ mcpServers: next })
-    try {
-      await saveMcpServersToDisk(next)
-    } catch (err) {
-      set({ mcpServers: list })
-      void logFrontendError({
-        source: 'acp-store.deleteMcpServer',
-        message: `Failed to persist MCP registry deletion (${String(err)})`
-      })
-      throw err
-    }
-  },
+  deleteMcpServer: (id) =>
+    runSerializedMcpRegistryMutation(async () => {
+      const list = get().mcpServers
+      const next = list.filter((server) => server.id !== id)
+      set({ mcpServers: next })
+      try {
+        await saveMcpServersToDisk(next)
+      } catch (err) {
+        set({ mcpServers: list })
+        void logFrontendError({
+          source: 'acp-store.deleteMcpServer',
+          message: `Failed to persist MCP registry deletion (${String(err)})`
+        })
+        throw err
+      }
+    }),
 
   // MCP probe (on-demand, read-only). No persistence, no rollback. Dedupes
   // concurrent probes per server id via `mcpProbing`.


### PR DESCRIPTION
## Summary

Application Preferences → MCP Servers still used bulky form input fields for adding/editing a server — the raw-JSON editing requested previously only shipped as an add-only "Import JSON" side tab — and each server rendered as a multi-line card. This PR makes the JSON editor THE Add/Edit interface and compacts the list to one line per server, so users can paste/edit Claude-Desktop-style configs directly while entries still persist through the existing registry list (same storage format, desktop + web).

## Related Issue

Refs #362 (follow-up UX improvement to the MCP Servers settings surface introduced there)

## Type of Change

- [x] feat: new feature
- [ ] fix: bug fix
- [ ] docs: documentation only
- [ ] style: formatting or non-functional styling changes
- [ ] refactor: internal cleanup with no behavior change
- [ ] perf: performance improvement
- [ ] test: adds or updates tests
- [ ] build: build or dependency changes
- [ ] ci: CI/CD workflow changes
- [ ] chore: maintenance or tooling
- [ ] revert: reverts a previous change

## What Changed

- `src/renderer/components/settings/McpServersSettings.tsx`
  - Add/Edit dialog body is now a raw JSON editor (monospace textarea). Add mode accepts a Claude Desktop `{"mcpServers": {...}}` wrapper or a single server object and saves each parsed entry with a fresh id; Edit mode pre-fills that server's JSON (`{type, name, command|url, args, env-map|headers-pairs, enabled}`), rejects the wrapper, honors an explicit `enabled` override, and updates the same registry id.
  - Server list compacted from multi-line cards to one line per server: status dot, name, transport badge, command/URL, tools trigger, Test, enable switch, edit, delete — with tool/probe details behind the existing collapsible disclosure.
  - Removed the old form fields, the Form/Import tab bar, and the now-unused draft helpers.
- `src/renderer/components/settings/McpServersSettings.test.tsx` — rewritten suite (30 tests) covering every edge case: add bare object / wrapper / invalid JSON / mixed validity / empty wrapper; edit round-trip with unknown-field drop, HTTP headers pre-fill, `enabled` override + omission, wrapper rejection, validation errors; save-failure rollback for both add and edit; plus preserved behaviors (toggle/delete, probe dots, probe-error disclosure, tool list, Test button, compact-row assertions).
- `src/renderer/assets/agent-icons/acp/agents.json` — re-synced bundled ACP registry snapshot with the CDN (required by the ACP Registry Bundle Freshness gate; version bumps only).

Storage schema, store actions, probes, chatbox badge, facades, and desktop↔server parity are untouched (UI-only change; both desktop and web entries render this same component). Reuses the existing `parseMcpJsonImport` unchanged.

## How It Was Tested

- [x] `bun run ci` (Biome lint + format + imports, strict mode)
- [x] `bun run typecheck`
- [x] `bun run test`
- [ ] `cargo clippy --all-targets -- -D warnings` (in src-tauri)
- [ ] `cargo test` (in src-tauri)
- [ ] Manual verification completed
- [ ] Not applicable

(`bun run ci`, `bun run typecheck`, and `bun run test` all pass locally — 251 files / 3021 tests passed, 43 skipped. No `src-tauri` changes, so Rust gates are re-validated by CI.)

## Screenshots or Recordings

Row layout: `[dot] Name STDIO command… [n tools ▾] [test] [switch] [edit] [delete]`, all on one line. Add/Edit opens a JSON-only dialog with inline validation errors. (Screenshot on request.)

## CI & Review Gate

- [ ] All CI checks pass (PR Validation, Rust Checks, Build Verification, Security Scans)
- [ ] Code review comments from CodeRabbit / Claude have been addressed or resolved
- [ ] No unresolved review findings remain

## Checklist

- [x] My PR title follows the conventional commit format used by this repo
- [x] I linked the related issue or explained why none exists
- [x] I updated docs when needed
- [x] I added or updated tests when needed
- [x] I verified the change does not introduce unrelated modifications
- [x] I read AGENTS.md and followed the contributor guidelines
- [x] A human reviewed the complete diff before submission


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Redesigned MCP server setup and editing with a JSON-based workflow.
  * Added inline validation, clearer error feedback, and Claude Desktop wrapper imports.
  * Added compact, expandable server entries with transport details, probe status, available tools, and actions.
  * Added atomic batch imports with rollback if saving fails.

* **Bug Fixes**
  * Prevented overlapping MCP server changes from overwriting one another.
  * Preserved server enabled states during edits and saves.

* **Updates**
  * Updated the catalog of available ACP agents and distributions, including Harn and Kilo.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->