### PR TITLE
feat(file-explorer): add vscode-style header toolbar actions (new file, new folder, refresh)

### DIFF
--- a/src/renderer/components/file-explorer/FileExplorer.test.tsx
+++ b/src/renderer/components/file-explorer/FileExplorer.test.tsx
@@ -33,6 +33,11 @@ const mockUpdateCursorPosition = vi.fn()
 const mockAddEditorTab = vi.fn()
 const mockRemoveTab = vi.fn()
 
+const mockCreateFile = vi.fn()
+const mockCreateDirectory = vi.fn()
+const mockRenameFile = vi.fn()
+const mockRefreshTree = vi.fn().mockResolvedValue(undefined)
+
 const mockExplorerState = {
   rootPath: null as string | null,
   directoryContents: new Map<
@@ -57,10 +62,20 @@ const mockExplorerState = {
   searchLastCompletedQuery: ''
 }
 
+/** Live object returned by the mocked useFileExplorerStore.getState(). */
+const mockStoreGetState = {
+  expandedDirs: new Set<string>(),
+  selectedPaths: new Set<string>(),
+  loadingDirs: new Set<string>(),
+  lastClickedPath: null as string | null,
+  rootPath: null as string | null,
+  clearSelection: mockClearSelection
+}
+
 vi.mock('@/stores/file-explorer-store', () => ({
   useFileExplorer: () => mockExplorerState,
   useFileExplorerActions: () => ({
-    toggleDirectory: mockToggleDirectory,
+    toggleDirectory: (...args: unknown[]) => mockToggleDirectory(...args),
     selectPath: mockSelectPath,
     togglePathSelection: mockTogglePathSelection,
     selectPathRange: mockSelectPathRange,
@@ -72,19 +87,14 @@ vi.mock('@/stores/file-explorer-store', () => ({
     duplicateSelected: mockDuplicateSelected,
     collapseAll: mockCollapseAll,
     refreshDirectory: mockRefreshDirectory,
+    refreshTree: mockRefreshTree,
     setRootLoadError: mockSetRootLoadError,
     setSearchQuery: mockSetSearchQuery,
     searchInRoot: mockSearchInRoot,
     resetSearch: mockResetSearch
   }),
   useFileExplorerStore: {
-    getState: vi.fn(() => ({
-      expandedDirs: new Set<string>(),
-      selectedPaths: new Set<string>(),
-      loadingDirs: new Set<string>(),
-      lastClickedPath: null,
-      clearSelection: mockClearSelection
-    })),
+    getState: vi.fn(() => mockStoreGetState),
     setState: vi.fn()
   }
 }))
@@ -92,7 +102,10 @@ vi.mock('@/stores/file-explorer-store', () => ({
 vi.mock('@/lib/api', () => ({
   filesystemApi: {
     searchFileNamesStreamCancel: (...args: unknown[]) => mockSearchFileNamesStreamCancel(...args),
-    searchContentStreamCancel: (...args: unknown[]) => mockSearchContentStreamCancel(...args)
+    searchContentStreamCancel: (...args: unknown[]) => mockSearchContentStreamCancel(...args),
+    createFile: (...args: unknown[]) => mockCreateFile(...args),
+    createDirectory: (...args: unknown[]) => mockCreateDirectory(...args),
+    renameFile: (...args: unknown[]) => mockRenameFile(...args)
   }
 }))
 
@@ -131,7 +144,24 @@ vi.mock('./FileTreeContextMenu', () => ({
 
 beforeEach(() => {
   vi.clearAllMocks()
+  // clearAllMocks keeps per-test mockReturnValue overrides; restore the
+  // default store-state implementation for every test.
+  vi.mocked(useFileExplorerStore.getState).mockImplementation(() => mockStoreGetState)
   mockOpenFile.mockResolvedValue(undefined)
+  mockCreateFile.mockResolvedValue({ success: true, data: undefined })
+  mockCreateDirectory.mockResolvedValue({ success: true, data: undefined })
+  mockRenameFile.mockResolvedValue({ success: true, data: undefined })
+  mockRefreshTree.mockResolvedValue(undefined)
+  // Expanding a directory marks it expanded in the mocked store state so
+  // expand-chain guards (GH-540) observe the toggle's effect.
+  mockToggleDirectory.mockImplementation(async (dirPath: string) => {
+    mockStoreGetState.expandedDirs.add(dirPath)
+  })
+  mockStoreGetState.expandedDirs = new Set<string>()
+  mockStoreGetState.selectedPaths = new Set<string>()
+  mockStoreGetState.loadingDirs = new Set<string>()
+  mockStoreGetState.lastClickedPath = null
+  mockStoreGetState.rootPath = null
   mockExplorerState.rootPath = null
   mockExplorerState.directoryContents = new Map()
   mockExplorerState.isVisible = true
@@ -557,5 +587,182 @@ describe('FileExplorer', () => {
 
     expect(mockSearchFileNamesStreamCancel).not.toHaveBeenCalled()
     expect(mockSearchContentStreamCancel).not.toHaveBeenCalled()
+  })
+})
+
+describe('FileExplorer header toolbar (GH-540)', () => {
+  function setExpandedDirs(expandedDirs: Set<string>): void {
+    mockStoreGetState.expandedDirs = expandedDirs
+  }
+
+  function setProjectRoot(rootPath: string | null): void {
+    mockExplorerState.rootPath = rootPath
+    mockStoreGetState.rootPath = rootPath
+  }
+
+  function openProjectWithRootEntries(
+    entries: Array<{ path: string; name: string; type: 'file' | 'directory' }>
+  ): void {
+    setProjectRoot('/project')
+    mockExplorerState.directoryContents = new Map([['/project', entries]])
+  }
+
+  beforeEach(() => {
+    setExpandedDirs(new Set(['/project']))
+  })
+
+  it('renders all four actions with tooltips and accessible labels', () => {
+    openProjectWithRootEntries([])
+
+    render(<FileExplorer />)
+
+    for (const name of ['New File', 'New Folder', 'Refresh', 'Collapse All']) {
+      const button = screen.getByRole('button', { name })
+      expect(button).toBeEnabled()
+      expect(button).toHaveAttribute('title', name)
+    }
+  })
+
+  it('disables every action when no project is open', () => {
+    setProjectRoot(null)
+
+    render(<FileExplorer />)
+
+    for (const name of ['New File', 'New Folder', 'Refresh', 'Collapse All']) {
+      expect(screen.getByRole('button', { name })).toBeDisabled()
+    }
+  })
+
+  it('starts creation in the project root when nothing is selected', async () => {
+    openProjectWithRootEntries([])
+
+    render(<FileExplorer />)
+    fireEvent.click(screen.getByRole('button', { name: 'New File' }))
+
+    const input = await screen.findByPlaceholderText('File name...')
+    fireEvent.change(input, { target: { value: 'notes.txt' } })
+    fireEvent.keyDown(input, { key: 'Enter' })
+
+    await waitFor(() => expect(mockCreateFile).toHaveBeenCalledWith('/project/notes.txt'))
+  })
+
+  it('creates a folder in the project root when nothing is selected', async () => {
+    openProjectWithRootEntries([])
+
+    render(<FileExplorer />)
+    fireEvent.click(screen.getByRole('button', { name: 'New Folder' }))
+
+    const input = await screen.findByPlaceholderText('Folder name...')
+    fireEvent.change(input, { target: { value: 'docs' } })
+    fireEvent.keyDown(input, { key: 'Enter' })
+
+    await waitFor(() => expect(mockCreateDirectory).toHaveBeenCalledWith('/project/docs'))
+  })
+
+  it('targets the selected directory', async () => {
+    openProjectWithRootEntries([{ path: '/project/src', name: 'src', type: 'directory' }])
+    mockExplorerState.selectedPaths = new Set(['/project/src'])
+
+    render(<FileExplorer />)
+    fireEvent.click(screen.getByRole('button', { name: 'New File' }))
+
+    const input = await screen.findByPlaceholderText('File name...')
+    fireEvent.change(input, { target: { value: 'main.ts' } })
+    fireEvent.keyDown(input, { key: 'Enter' })
+
+    await waitFor(() => expect(mockCreateFile).toHaveBeenCalledWith('/project/src/main.ts'))
+  })
+
+  it('targets the parent directory of the selected file', async () => {
+    setProjectRoot('/project')
+    mockExplorerState.directoryContents = new Map([
+      ['/project', []],
+      ['/project/src', [{ path: '/project/src/app.ts', name: 'app.ts', type: 'file' as const }]]
+    ])
+    mockExplorerState.selectedPaths = new Set(['/project/src/app.ts'])
+
+    render(<FileExplorer />)
+    fireEvent.click(screen.getByRole('button', { name: 'New File' }))
+
+    const input = await screen.findByPlaceholderText('File name...')
+    fireEvent.change(input, { target: { value: 'util.ts' } })
+    fireEvent.keyDown(input, { key: 'Enter' })
+
+    await waitFor(() => expect(mockCreateFile).toHaveBeenCalledWith('/project/src/util.ts'))
+  })
+
+  it('falls back to the project root when multiple entries are selected', async () => {
+    openProjectWithRootEntries([{ path: '/project/src', name: 'src', type: 'directory' }])
+    mockExplorerState.selectedPaths = new Set(['/project/src', '/project/README.md'])
+
+    render(<FileExplorer />)
+    fireEvent.click(screen.getByRole('button', { name: 'New File' }))
+
+    const input = await screen.findByPlaceholderText('File name...')
+    fireEvent.change(input, { target: { value: 'top.md' } })
+    fireEvent.keyDown(input, { key: 'Enter' })
+
+    await waitFor(() => expect(mockCreateFile).toHaveBeenCalledWith('/project/top.md'))
+  })
+
+  it('auto-expands unexpanded ancestor directories of the target before creating', async () => {
+    setProjectRoot('/project')
+    mockExplorerState.directoryContents = new Map([
+      ['/project', [{ path: '/project/src', name: 'src', type: 'directory' as const }]],
+      ['/project/src', [{ path: '/project/src/deep', name: 'deep', type: 'directory' as const }]]
+    ])
+    mockExplorerState.selectedPaths = new Set(['/project/src/deep'])
+    setExpandedDirs(new Set(['/project']))
+
+    render(<FileExplorer />)
+    fireEvent.click(screen.getByRole('button', { name: 'New File' }))
+
+    const input = await screen.findByPlaceholderText('File name...')
+    expect(mockToggleDirectory).toHaveBeenCalledWith('/project/src')
+    expect(mockToggleDirectory).toHaveBeenCalledWith('/project/src/deep')
+    expect(mockToggleDirectory).not.toHaveBeenCalledWith('/project')
+
+    fireEvent.change(input, { target: { value: 'leaf.ts' } })
+    fireEvent.keyDown(input, { key: 'Enter' })
+
+    await waitFor(() => expect(mockCreateFile).toHaveBeenCalledWith('/project/src/deep/leaf.ts'))
+  })
+
+  it('aborts creation when the target directory cannot be expanded', async () => {
+    openProjectWithRootEntries([{ path: '/project/src', name: 'src', type: 'directory' }])
+    mockExplorerState.selectedPaths = new Set(['/project/src'])
+    // Expansion fails (e.g. load error): the toggle never marks the dir expanded.
+    mockToggleDirectory.mockImplementationOnce(async () => {})
+
+    render(<FileExplorer />)
+    fireEvent.click(screen.getByRole('button', { name: 'New File' }))
+
+    await waitFor(() => expect(mockToggleDirectory).toHaveBeenCalledWith('/project/src'))
+    expect(screen.queryByPlaceholderText('File name...')).not.toBeInTheDocument()
+    expect(mockCreateFile).not.toHaveBeenCalled()
+    expect(mockCreateDirectory).not.toHaveBeenCalled()
+  })
+
+  it('refresh re-reads the tree without touching inline state', async () => {
+    openProjectWithRootEntries([{ path: '/project/src', name: 'src', type: 'directory' }])
+
+    render(<FileExplorer />)
+    fireEvent.click(screen.getByRole('button', { name: 'Refresh' }))
+
+    await waitFor(() => expect(mockRefreshTree).toHaveBeenCalledTimes(1))
+    expect(screen.queryByPlaceholderText('File name...')).not.toBeInTheDocument()
+  })
+
+  it('does not start a collapse or create action when disabled without a project', () => {
+    setProjectRoot(null)
+
+    render(<FileExplorer />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'New File' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Collapse All' }))
+
+    expect(mockCollapseAll).not.toHaveBeenCalled()
+    expect(mockToggleDirectory).not.toHaveBeenCalled()
+    expect(screen.queryByPlaceholderText('File name...')).not.toBeInTheDocument()
   })
 })

--- a/src/renderer/components/file-explorer/FileExplorer.tsx
+++ b/src/renderer/components/file-explorer/FileExplorer.tsx
@@ -1,5 +1,13 @@
 import type { DirectoryEntry } from '@shared/types/filesystem.types'
-import { ChevronsDownUp, LoaderCircle, Search, X } from 'lucide-react'
+import {
+  ChevronsDownUp,
+  FilePlus,
+  FolderPlus,
+  LoaderCircle,
+  RefreshCw,
+  Search,
+  X
+} from 'lucide-react'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { toast } from 'sonner'
 import { clipboardApi, filesystemApi, openerApi } from '@/lib/api'
@@ -64,6 +72,7 @@ export function FileExplorer({ side = 'right' }: FileExplorerProps): React.JSX.E
     duplicateSelected,
     collapseAll,
     refreshDirectory,
+    refreshTree,
     setRootLoadError,
     setSearchQuery,
     searchInRoot,
@@ -94,6 +103,10 @@ export function FileExplorer({ side = 'right' }: FileExplorerProps): React.JSX.E
   const resizeStateRef = useRef<{ startX: number; startWidth: number } | null>(null)
   const resizeCleanupRef = useRef<(() => void) | null>(null)
   const userSelectedTabRef = useRef(false)
+  // Mirror of inlineInput so async handlers can re-check the latest value
+  // after awaiting directory expansion (GH-540 re-entrancy guard).
+  const inlineInputRef = useRef<InlineInputState | null>(null)
+  inlineInputRef.current = inlineInput
 
   const rootEntries = rootPath ? directoryContents.get(rootPath) : undefined
   const normalizedSearchQuery = searchQuery ?? ''
@@ -520,6 +533,122 @@ export function FileExplorer({ side = 'right' }: FileExplorerProps): React.JSX.E
     setInputValue('')
   }, [])
 
+  /** Find a directory entry by absolute path across all loaded directories. */
+  const findEntryByPath = useCallback(
+    (path: string): DirectoryEntry | undefined => {
+      for (const entries of directoryContents.values()) {
+        const found = entries.find((entry) => entry.path === path)
+        if (found) return found
+      }
+      return undefined
+    },
+    [directoryContents]
+  )
+
+  /**
+   * VSCode-style target resolution for header creation actions (GH-540):
+   * selected directory > parent of selected file > project root.
+   * Multi-selection or unresolvable selections fall back to the root.
+   */
+  const getCreateTargetDir = useCallback((): string => {
+    if (!rootPath) return ''
+    if (selectedPaths.size === 1) {
+      const selectedPath = Array.from(selectedPaths)[0]
+      const selectedEntry = findEntryByPath(selectedPath)
+      if (selectedEntry?.type === 'directory') return selectedEntry.path.replace(/\\/g, '/')
+      if (selectedEntry?.type === 'file') {
+        const normalized = selectedEntry.path.replace(/\\/g, '/')
+        const lastSlash = normalized.lastIndexOf('/')
+        return lastSlash > 0 ? normalized.slice(0, lastSlash) : lastSlash === 0 ? '/' : rootPath
+      }
+    }
+    return rootPath
+  }, [rootPath, selectedPaths, findEntryByPath])
+
+  /** Expand every directory from the project root down to (and including) the target. */
+  const expandDirectoryChain = useCallback(
+    async (targetDir: string): Promise<'expanded' | 'load-failed' | 'root-changed'> => {
+      if (!rootPath) return 'load-failed'
+      const normalizedRoot = rootPath.replace(/\\/g, '/')
+      let normalizedTarget = targetDir.replace(/\\/g, '/')
+      if (
+        normalizedTarget !== normalizedRoot &&
+        !normalizedTarget.startsWith(`${normalizedRoot}/`)
+      ) {
+        normalizedTarget = normalizedRoot
+      }
+
+      const chain: string[] = []
+      let current = normalizedTarget
+      while (
+        current !== normalizedRoot &&
+        current.length > normalizedRoot.length &&
+        current.startsWith(`${normalizedRoot}/`)
+      ) {
+        chain.push(current)
+        const lastSlash = current.lastIndexOf('/')
+        if (lastSlash <= 0) break
+        current = current.slice(0, lastSlash)
+      }
+      chain.push(normalizedRoot)
+      chain.reverse()
+
+      for (const dir of chain) {
+        if (!useFileExplorerStore.getState().expandedDirs.has(dir)) {
+          await toggleDirectory(dir)
+        }
+        // Abort if the directory could not be expanded (load failure) or the
+        // project changed mid-chain.
+        const state = useFileExplorerStore.getState()
+        if (state.rootPath !== rootPath) return 'root-changed'
+        if (!state.expandedDirs.has(dir)) return 'load-failed'
+      }
+      return 'expanded'
+    },
+    [rootPath, toggleDirectory]
+  )
+
+  /** Best-effort scroll of a tree row (by entry path) into view. */
+  const revealTreePath = useCallback((path: string) => {
+    window.requestAnimationFrame(() => {
+      const row = containerRef.current?.querySelector(`[data-path="${CSS.escape(path)}"]`)
+      row?.scrollIntoView({ block: 'nearest' })
+    })
+  }, [])
+
+  /**
+   * Header New File / New Folder (GH-540): resolve + expand + reveal the
+   * target directory, then start the existing inline create flow.
+   */
+  const startHeaderCreate = useCallback(
+    async (type: 'file' | 'folder') => {
+      if (inlineInputRef.current) return
+      const targetDir = getCreateTargetDir()
+      if (!targetDir) return
+      const expandResult = await expandDirectoryChain(targetDir)
+      // Re-check after the awaits: another flow may have opened an input or
+      // switched projects while the chain was expanding.
+      if (expandResult !== 'expanded' || inlineInputRef.current) {
+        if (expandResult === 'load-failed') {
+          toast.error('Could not open the target directory', {
+            description: 'The folder could not be expanded. Try again once the tree is loaded.'
+          })
+        }
+        return
+      }
+      revealTreePath(targetDir)
+      setContextMenu(null)
+      setInlineInput({ parentPath: targetDir, type, mode: 'create' })
+      setInputValue('')
+    },
+    [getCreateTargetDir, expandDirectoryChain, revealTreePath]
+  )
+
+  /** Header Refresh (GH-540): re-read root + expanded dirs, keeping state. */
+  const handleHeaderRefresh = useCallback(() => {
+    void refreshTree()
+  }, [refreshTree])
+
   const handleRename = useCallback((entry: DirectoryEntry) => {
     setContextMenu(null)
     const normalizedPath = entry.path.replace(/\\/g, '/')
@@ -858,13 +987,48 @@ export function FileExplorer({ side = 'right' }: FileExplorerProps): React.JSX.E
       {/* Header */}
       <div className="flex items-center justify-between px-3 h-10 border-b border-border flex-shrink-0 rounded-t-xl">
         <span className="text-xs tracking-wider text-sidebar-foreground uppercase">Explorer</span>
-        <button
-          onClick={collapseAll}
-          className="text-muted-foreground hover:text-foreground transition-colors p-0.5"
-          title="Collapse All"
-        >
-          <ChevronsDownUp size={14} />
-        </button>
+        <div className="flex items-center gap-1">
+          <button
+            type="button"
+            onClick={() => void startHeaderCreate('file')}
+            disabled={!rootPath}
+            className="text-muted-foreground hover:text-foreground transition-colors p-0.5 rounded-sm focus:outline-none focus-visible:ring-1 focus-visible:ring-primary disabled:opacity-40 disabled:cursor-not-allowed"
+            title="New File"
+            aria-label="New File"
+          >
+            <FilePlus size={14} />
+          </button>
+          <button
+            type="button"
+            onClick={() => void startHeaderCreate('folder')}
+            disabled={!rootPath}
+            className="text-muted-foreground hover:text-foreground transition-colors p-0.5 rounded-sm focus:outline-none focus-visible:ring-1 focus-visible:ring-primary disabled:opacity-40 disabled:cursor-not-allowed"
+            title="New Folder"
+            aria-label="New Folder"
+          >
+            <FolderPlus size={14} />
+          </button>
+          <button
+            type="button"
+            onClick={handleHeaderRefresh}
+            disabled={!rootPath}
+            className="text-muted-foreground hover:text-foreground transition-colors p-0.5 rounded-sm focus:outline-none focus-visible:ring-1 focus-visible:ring-primary disabled:opacity-40 disabled:cursor-not-allowed"
+            title="Refresh"
+            aria-label="Refresh"
+          >
+            <RefreshCw size={14} />
+          </button>
+          <button
+            type="button"
+            onClick={collapseAll}
+            disabled={!rootPath}
+            className="text-muted-foreground hover:text-foreground transition-colors p-0.5 rounded-sm focus:outline-none focus-visible:ring-1 focus-visible:ring-primary disabled:opacity-40 disabled:cursor-not-allowed"
+            title="Collapse All"
+            aria-label="Collapse All"
+          >
+            <ChevronsDownUp size={14} />
+          </button>
+        </div>
       </div>
 
       <div className="px-3 py-1.5 border-b border-border">

--- a/src/renderer/components/file-explorer/FileTreeNode.test.tsx
+++ b/src/renderer/components/file-explorer/FileTreeNode.test.tsx
@@ -42,4 +42,30 @@ describe('FileTreeNode', () => {
     expect(nameEl).toHaveClass('min-w-0', 'flex-1', 'truncate')
     expect(nameEl.parentElement).toHaveClass('min-w-0', 'overflow-hidden')
   })
+
+  it('exposes the entry path via data-path for header-action reveal (GH-540)', () => {
+    render(
+      <FileTreeNode
+        entry={{
+          path: '/project/src/deep',
+          name: 'deep',
+          type: 'directory',
+          extension: null,
+          size: 0,
+          modifiedAt: Date.UTC(2026, 5, 10)
+        }}
+        depth={1}
+        isExpanded={false}
+        isSelected={false}
+        isLoading={false}
+        onToggle={vi.fn()}
+        onSelect={vi.fn()}
+        onContextMenu={vi.fn()}
+      />
+    )
+
+    const row = document.querySelector('[data-path="/project/src/deep"]')
+    expect(row).not.toBeNull()
+    expect(row).toHaveTextContent('deep')
+  })
 })

--- a/src/renderer/components/file-explorer/FileTreeNode.tsx
+++ b/src/renderer/components/file-explorer/FileTreeNode.tsx
@@ -91,6 +91,7 @@ export function FileTreeNode({
   return (
     <>
       <div
+        data-path={entry.path}
         className={cn(
           'group relative flex min-w-0 items-center h-7 cursor-pointer text-sm hover:bg-secondary/50 transition-colors select-none',
           isIgnored && 'opacity-50',

--- a/src/renderer/stores/file-explorer-store.test.ts
+++ b/src/renderer/stores/file-explorer-store.test.ts
@@ -318,6 +318,134 @@ describe('file-explorer-store', () => {
     })
   })
 
+  describe('refreshTree (GH-540)', () => {
+    it('re-reads the root and every expanded directory', async () => {
+      useFileExplorerStore.setState({
+        rootPath: '/project',
+        directoryContents: new Map<string, DirectoryEntry[]>([
+          ['/project', mockEntries],
+          ['/project/src', mockEntries],
+          ['/project/docs', mockEntries]
+        ]),
+        expandedDirs: new Set(['/project/src', '/project/docs'])
+      })
+
+      await useFileExplorerStore.getState().refreshTree()
+
+      expect(mockApi.filesystem.readDirectory).toHaveBeenCalledWith('/project')
+      expect(mockApi.filesystem.readDirectory).toHaveBeenCalledWith('/project/src')
+      expect(mockApi.filesystem.readDirectory).toHaveBeenCalledWith('/project/docs')
+      expect(mockApi.filesystem.readDirectory).toHaveBeenCalledTimes(3)
+    })
+
+    it('preserves expanded state and selection', async () => {
+      useFileExplorerStore.setState({
+        rootPath: '/project',
+        directoryContents: new Map<string, DirectoryEntry[]>([['/project', mockEntries]]),
+        expandedDirs: new Set(['/project/src']),
+        selectedPaths: new Set(['/project/index.ts']),
+        lastClickedPath: '/project/index.ts'
+      })
+
+      await useFileExplorerStore.getState().refreshTree()
+
+      const state = useFileExplorerStore.getState()
+      expect(state.expandedDirs).toEqual(new Set(['/project/src']))
+      expect(state.selectedPaths).toEqual(new Set(['/project/index.ts']))
+      expect(state.lastClickedPath).toBe('/project/index.ts')
+    })
+
+    it('refreshes only the root when nothing else is expanded (no duplicates)', async () => {
+      useFileExplorerStore.setState({
+        rootPath: '/project',
+        directoryContents: new Map<string, DirectoryEntry[]>([['/project', mockEntries]]),
+        expandedDirs: new Set(['/project'])
+      })
+
+      await useFileExplorerStore.getState().refreshTree()
+
+      expect(mockApi.filesystem.readDirectory).toHaveBeenCalledTimes(1)
+      expect(mockApi.filesystem.readDirectory).toHaveBeenCalledWith('/project')
+    })
+
+    it('is a no-op when no project root is set', async () => {
+      await useFileExplorerStore.getState().refreshTree()
+
+      expect(mockApi.filesystem.readDirectory).not.toHaveBeenCalled()
+    })
+
+    it('skips directories that were collapsed while the refresh is running', async () => {
+      useFileExplorerStore.setState({
+        rootPath: '/project',
+        directoryContents: new Map<string, DirectoryEntry[]>([
+          ['/project', mockEntries],
+          ['/project/src', mockEntries],
+          ['/project/docs', mockEntries]
+        ]),
+        expandedDirs: new Set(['/project/src', '/project/docs'])
+      })
+
+      mockApi.filesystem.readDirectory.mockImplementation(async (path: string) => {
+        if (path === '/project') {
+          // User collapses /project/src while the refresh is in flight.
+          useFileExplorerStore.setState({ expandedDirs: new Set(['/project/docs']) })
+        }
+        return { success: true, data: mockEntries }
+      })
+
+      await useFileExplorerStore.getState().refreshTree()
+
+      expect(mockApi.filesystem.readDirectory).toHaveBeenCalledWith('/project')
+      expect(mockApi.filesystem.readDirectory).toHaveBeenCalledWith('/project/docs')
+      expect(mockApi.filesystem.readDirectory).not.toHaveBeenCalledWith('/project/src')
+    })
+
+    it('stops refreshing when the project root changes mid-refresh', async () => {
+      useFileExplorerStore.setState({
+        rootPath: '/project',
+        directoryContents: new Map<string, DirectoryEntry[]>([['/project', mockEntries]]),
+        expandedDirs: new Set(['/project/src', '/project/docs'])
+      })
+
+      mockApi.filesystem.readDirectory.mockImplementation(async (path: string) => {
+        if (path === '/project') {
+          useFileExplorerStore.setState({ rootPath: '/other-project' })
+        }
+        return { success: true, data: mockEntries }
+      })
+
+      await useFileExplorerStore.getState().refreshTree()
+
+      expect(mockApi.filesystem.readDirectory).toHaveBeenCalledTimes(1)
+      expect(mockApi.filesystem.readDirectory).toHaveBeenCalledWith('/project')
+    })
+
+    it('ignores concurrent refreshTree calls while one is in flight', async () => {
+      useFileExplorerStore.setState({
+        rootPath: '/project',
+        directoryContents: new Map<string, DirectoryEntry[]>([['/project', mockEntries]]),
+        expandedDirs: new Set<string>()
+      })
+
+      let releaseRead: ((value: { success: boolean; data: DirectoryEntry[] }) => void) | undefined
+      const firstRead = new Promise<{ success: boolean; data: DirectoryEntry[] }>((resolve) => {
+        releaseRead = resolve
+      })
+      mockApi.filesystem.readDirectory.mockReturnValueOnce(firstRead)
+
+      const first = useFileExplorerStore.getState().refreshTree()
+      expect(useFileExplorerStore.getState().refreshingTree).toBe(true)
+
+      // Second call while the first is still awaiting must be a no-op.
+      await useFileExplorerStore.getState().refreshTree()
+      expect(mockApi.filesystem.readDirectory).toHaveBeenCalledTimes(1)
+
+      releaseRead?.({ success: true, data: mockEntries })
+      await first
+      expect(useFileExplorerStore.getState().refreshingTree).toBe(false)
+    })
+  })
+
   describe('restoreExpandedDirs', () => {
     it('should restore only directories within root and skip missing paths', async () => {
       useFileExplorerStore.getState().setRootPath('/project')

--- a/src/renderer/stores/file-explorer-store.ts
+++ b/src/renderer/stores/file-explorer-store.ts
@@ -86,12 +86,16 @@ export interface FileExplorerState {
   pendingCollapses: Map<string, PendingDirectoryCollapse>
   /** Skip tree motion (e.g. collapse all) */
   suppressTreeAnimations: boolean
+  /** True while a header-initiated refreshTree pass is in flight (GH-540). */
+  refreshingTree: boolean
 
   setRootPath: (path: string | null) => void
   setWorktreeRoot: (path: string | null) => void
   toggleDirectory: (path: string) => Promise<void>
   finalizeDirectoryCollapse: (path: string) => void
   refreshDirectory: (path: string) => Promise<void>
+  /** Re-read the root and every expanded directory (GH-540 header Refresh). */
+  refreshTree: () => Promise<void>
   selectPath: (path: string | null) => void
   togglePathSelection: (path: string) => void
   selectPathRange: (fromPath: string, toPath: string) => void
@@ -238,6 +242,7 @@ export const useFileExplorerStore = create<FileExplorerState>((set, get) => ({
   searchLastCompletedQuery: '',
   pendingCollapses: new Map<string, PendingDirectoryCollapse>(),
   suppressTreeAnimations: false,
+  refreshingTree: false,
 
   setRootPath: (path: string | null): void => {
     // Unwatch all previously expanded directories
@@ -412,6 +417,34 @@ export const useFileExplorerStore = create<FileExplorerState>((set, get) => ({
       }
     } catch {
       // Silently fail on refresh
+    }
+  },
+
+  refreshTree: async (): Promise<void> => {
+    const { rootPath } = get()
+    if (!rootPath || get().refreshingTree) return
+
+    set({ refreshingTree: true })
+    try {
+      const capturedRoot = rootPath
+      // Only re-read directories that belong to the current root; stale
+      // expanded dirs from a previous worktree override must not be fetched.
+      const dirsToRefresh = new Set<string>([
+        rootPath,
+        ...Array.from(get().expandedDirs).filter((dir) => isPathWithinRoot(dir, rootPath))
+      ])
+
+      // Sequential on purpose: re-check live state before each read so a
+      // collapse or project switch that lands mid-refresh is honored instead
+      // of being overwritten by stale in-flight results.
+      for (const dir of dirsToRefresh) {
+        const state = get()
+        if (state.rootPath !== capturedRoot) return
+        if (dir !== capturedRoot && !state.expandedDirs.has(dir)) continue
+        await state.refreshDirectory(dir)
+      }
+    } finally {
+      set({ refreshingTree: false })
     }
   },
 
@@ -953,6 +986,7 @@ export function useFileExplorerActions(): Pick<
   | 'toggleDirectory'
   | 'finalizeDirectoryCollapse'
   | 'refreshDirectory'
+  | 'refreshTree'
   | 'selectPath'
   | 'togglePathSelection'
   | 'selectPathRange'
@@ -979,6 +1013,7 @@ export function useFileExplorerActions(): Pick<
       toggleDirectory: state.toggleDirectory,
       finalizeDirectoryCollapse: state.finalizeDirectoryCollapse,
       refreshDirectory: state.refreshDirectory,
+      refreshTree: state.refreshTree,
       selectPath: state.selectPath,
       togglePathSelection: state.togglePathSelection,
       selectPathRange: state.selectPathRange,


### PR DESCRIPTION
## Summary

- The file explorer exposes **New File** and **New Folder** only through the right-click context menu on a directory, and the header shows a single **Collapse All** button — file/folder creation and tree refresh are hidden affordances new users have to discover by right-clicking.
- Standard editors (VSCode) surface these as small icon buttons in the explorer header, grouped with refresh. This PR adds that toolbar and a proper tree refresh that preserves state.

What it does:

1. Header toolbar group: **New File** (`FilePlus`), **New Folder** (`FolderPlus`), **Refresh** (`RefreshCw`), **Collapse All** (existing) — muted by default, hover highlight, tooltips + `aria-label`s, keyboard focusable, disabled/no-op when no project is open.
2. New File / New Folder reuse the existing inline creation flow with VSCode target-directory resolution: selected directory > parent of selected file > project root (multi/unresolvable selection → root). The target's ancestor chain is auto-expanded and scrolled into view before the input opens; load-failure and project-switch aborts are handled with user feedback on failures.
3. Refresh is a new store action (`refreshTree`) that sequentially re-reads the root + every expanded directory behind an in-flight guard, re-checking live state per read — expanded state and selection are preserved by construction, and collapse/project-switch races mid-refresh are honored.

## Related Issue

Closes #540

## Type of Change

- [x] feat: new feature
- [ ] fix: bug fix
- [ ] docs: documentation only
- [ ] style: formatting or non-functional styling changes
- [ ] refactor: internal cleanup with no behavior change
- [ ] perf: performance improvement
- [ ] test: adds or updates tests
- [ ] build: build or dependency changes
- [ ] ci: CI/CD workflow changes
- [ ] chore: maintenance or tooling
- [ ] revert: reverts a previous commit

## What Changed

- `src/renderer/components/file-explorer/FileExplorer.tsx` — header toolbar group, target resolution (`getCreateTargetDir`), expand chain with abort reasons (`expanded` / `load-failed` / `root-changed`), target reveal via `data-path` + `scrollIntoView`, refresh wiring
- `src/renderer/components/file-explorer/FileTreeNode.tsx` — `data-path` row attribute for reveal lookups
- `src/renderer/stores/file-explorer-store.ts` — `refreshTree` action + `refreshingTree` flag, exposed via `useFileExplorerActions`
- Tests: `FileExplorer.test.tsx` toolbar suite (resolution rules, auto-expand, abort-on-load-failure, refresh, disabled states), `file-explorer-store.test.ts` refreshTree suite (state preservation, collapse-mid-refresh skip, root-switch bail, concurrent-call guard), `FileTreeNode.test.tsx` data-path test

Note: overlaps with the companion PR for #539 in the `FileExplorer.tsx` header area; whichever lands second will need a small conflict resolution there.

## How It Was Tested

- [x] `bun run ci` (Biome lint + format + imports, strict mode)
- [x] `bun run typecheck`
- [x] `bun run test`
- [ ] `cargo clippy --all-targets -- -D warnings` (in src-tauri)
- [ ] `cargo test` (in src-tauri)
- [ ] Manual verification completed
- [ ] Not applicable

Renderer-only change: no Rust code modified (`git diff origin/dev -- src-tauri` is empty), so cargo gates are unaffected. Full Vitest suite green (3033 tests).

## Screenshots or Recordings

Automated test coverage only (headless environment); the toolbar matches the styling of the existing Collapse All button.

## CI & Review Gate

- [ ] All CI checks pass (PR Validation, Rust Checks, Build Verification, Security Scans)
- [ ] Code review comments from CodeRabbit / Claude have been addressed or resolved
- [ ] No unresolved review findings remain

## Checklist

- [x] My PR title follows the conventional commit format used by this repo
- [x] I linked the related issue or explained why none exists
- [ ] I updated docs when needed
- [x] I added or updated tests when needed
- [x] I verified the change does not introduce unrelated modifications
- [x] I read AGENTS.md and followed the contributor guidelines
- [ ] A human reviewed the complete diff before submission
