### PR TITLE
feat(acp): default turn + idle timeouts to unlimited

### DIFF
--- a/src-tauri/src/acp/commands.rs
+++ b/src-tauri/src/acp/commands.rs
@@ -279,8 +279,8 @@ pub async fn acp_probe_mcp_server(
 }
 
 /// Set the in-process ACP turn (hard-cap) timeout override, in seconds, or
-/// `None` to clear it (fall back to the env var / 3h default). Pushed from the
-/// App Preferences UI so the turn timeout is editable without a restart or
+/// `None` to clear it (fall back to the env var / unlimited default). Pushed from
+/// the App Preferences UI so the turn timeout is editable without a restart or
 /// env var. Desktop-only: the standalone `termul-server` has no settings
 /// surface and configures via `TERMUL_ACP_TURN_TIMEOUT_SECS`. The env var
 /// remains top-precedence (operator/diagnostic override).
@@ -291,7 +291,7 @@ pub fn acp_set_turn_timeout(secs: Option<u64>) -> Result<(), String> {
 }
 
 /// Set the in-process ACP turn *idle* timeout override, in seconds, or `None`
-/// to clear it (fall back to the env var / 15min default). Pushed from the
+/// to clear it (fall back to the env var / unlimited default). Pushed from the
 /// App Preferences UI. Desktop-only parity with `acp_set_turn_timeout`: the
 /// standalone `termul-server` configures via `TERMUL_ACP_TURN_IDLE_TIMEOUT_SECS`.
 /// The env var remains top-precedence (operator/diagnostic override).

--- a/src-tauri/src/acp/manager.rs
+++ b/src-tauri/src/acp/manager.rs
@@ -386,8 +386,12 @@ where
             }
             None => {
                 // No deadlines (fully unlimited): only completion or cancel can
-                // end the turn. `idle_rx.changed()` is still polled so activity
-                // stays drained, but it no longer resets any deadline.
+                // end the turn. The `idle_rx` arm is intentionally absent —
+                // there is no deadline to reset, and a closed watch channel
+                // would otherwise return `Err` ready on every poll and busy-loop
+                // (starving the runtime). If a deadline is later configured it
+                // routes through the `Some` branch above, where the idle arm
+                // resets the idle deadline.
                 tokio::select! {
                     biased;
                     result = &mut prompt => return result,
@@ -397,7 +401,6 @@ where
                             Err(_) => Ok(StopReason::Cancelled),
                         };
                     }
-                    _ = idle_rx.changed() => {}
                 }
             }
         }

--- a/src-tauri/src/acp/manager.rs
+++ b/src-tauri/src/acp/manager.rs
@@ -91,23 +91,27 @@ const FIRST_PROMPT_WARMUP_TIMEOUT: Duration = Duration::from_secs(45);
 /// Upper bound on joining a driver thread during `kill`/`kill_all`, so app exit
 /// can never hang on a wedged agent.
 const JOIN_TIMEOUT: Duration = Duration::from_secs(5);
-/// Idle timeout for an agent turn: if the agent produces NO activity (no
-/// `session/update`/`tool_call` notification) for this long, the turn is
-/// considered wedged and is cancelled. 900s gives breathing room above the
-/// longest expected silent sub-tool (a ~600s shell command) so legitimate
-/// long-running tool calls don't race the idle deadline, while a truly wedged
-/// (silent) turn fails in ~15min instead of hours. Reset on every inbound
-/// notification via `DriverState::signal_idle`. Overridable via
-/// `TERMUL_ACP_TURN_IDLE_TIMEOUT_SECS`.
-const TURN_IDLE_TIMEOUT: Duration = Duration::from_secs(900);
-/// Hard wall-clock cap for a single agent turn — the last-resort backstop so
-/// a chatty-but-non-completing agent (streaming forever) is still bounded. 3h
-/// accommodates very long agentic turns that stay active (the idle timer keeps
-/// resetting, so this only fires for an agent that never stops). On either idle
-/// or hard timeout → cancel + `CANCEL_GRACE` → `status: 'error'`. Distinct from
-/// 1.7's 60s permission sub-timeout (`permissions.rs:47`). Overridable via
-/// `TERMUL_ACP_TURN_TIMEOUT_SECS`.
-const TURN_TIMEOUT: Duration = Duration::from_secs(10800);
+// Idle timeout for an agent turn: if the agent produces NO activity (no
+// `session/update`/`tool_call` notification) for this long, the turn is
+// considered wedged and is cancelled. The default is **unlimited** (`None` —
+// see `turn_idle_timeout`): a silent/wedged turn is NOT killed by default;
+// only an explicit `TERMUL_ACP_TURN_IDLE_TIMEOUT_SECS` env var or an App
+// Preferences value imposes an idle bound. Reset on every inbound notification
+// via `DriverState::signal_idle`.
+//
+// The historical 900s (15min) default was retired in favour of unlimited — a
+// legitimate long-running silent sub-tool (a ~600s shell command) no longer
+// races an arbitrary idle deadline, and a truly wedged turn is left to the
+// operator/user to cancel (or to bound explicitly via the env var).
+// The default hard wall-clock cap for a single agent turn is **unlimited**
+// (`None` — see `resolved_turn_timeout`): no last-resort backstop is imposed
+// unless the operator sets `TERMUL_ACP_TURN_TIMEOUT_SECS` or the user picks a
+// bounded value in App Preferences. The per-turn *idle* timeout
+// (`turn_idle_timeout`) is also unlimited by default, so neither a chatty
+// nor a silent agent is killed by default — the hard cap is an opt-in
+// diagnostic backstop. On either idle or hard timeout → cancel +
+// `CANCEL_GRACE` → `status: 'error'`. Distinct from 1.7's 60s permission
+// sub-timeout (`permissions.rs:47`).
 
 /// `session/new` timeout. Precedence: `TERMUL_ACP_SESSION_NEW_TIMEOUT_SECS`
 /// (env, operator/diagnostic; seconds, must be > 0) → in-process UI override
@@ -179,9 +183,12 @@ fn session_reopen_timeout() -> Duration {
 
 /// Per-turn idle timeout. Precedence: `TERMUL_ACP_TURN_IDLE_TIMEOUT_SECS`
 /// (env, operator/diagnostic; seconds, must be > 0) → in-process UI override
-/// ([`set_turn_idle_timeout_override`]) → [`TURN_IDLE_TIMEOUT`]. The window
-/// with no agent activity after which a turn is considered wedged.
-pub fn turn_idle_timeout() -> Duration {
+/// ([`set_turn_idle_timeout_override`]) → `None` (**unlimited** default). `None`
+/// means a silent/wedged turn is NOT killed by the idle timer — only completion,
+/// cancel, or an explicitly configured idle/hard bound ends it. The window, when
+/// set, is the duration with no agent activity after which a turn is considered
+/// wedged.
+pub fn turn_idle_timeout() -> Option<Duration> {
     std::env::var("TERMUL_ACP_TURN_IDLE_TIMEOUT_SECS")
         .ok()
         .and_then(|v| v.parse().ok())
@@ -192,7 +199,6 @@ pub fn turn_idle_timeout() -> Duration {
                 .filter(|secs| *secs > 0)
                 .map(Duration::from_secs)
         })
-        .unwrap_or(TURN_IDLE_TIMEOUT)
 }
 
 /// In-process override for the hard wall-clock cap, set by the
@@ -287,69 +293,113 @@ fn first_prompt_warmup_timeout_override() -> Option<u64> {
 }
 
 /// Hard wall-clock cap per turn. Precedence: `TERMUL_ACP_TURN_TIMEOUT_SECS`
-/// (env, operator/diagnostic) → in-process UI override → [`TURN_TIMEOUT`]
-/// (3h default). The last-resort backstop so a streaming-but-non-completing
-/// agent is still bounded.
-pub fn resolved_turn_timeout() -> Duration {
+/// (env, operator/diagnostic; seconds, must be > 0) → in-process UI override
+/// ([`set_turn_timeout_override`]) → `None` (**unlimited** default). `None`
+/// means no hard backstop is imposed — the per-turn *idle* timeout
+/// ([`turn_idle_timeout`]) still bounds silent/wedged turns, so a chatty agent
+/// that stays active is not killed by default. An operator who wants a bounded
+/// hard cap sets the env var, or the user picks a value in App Preferences.
+pub fn resolved_turn_timeout() -> Option<Duration> {
     std::env::var("TERMUL_ACP_TURN_TIMEOUT_SECS")
         .ok()
         .and_then(|v| v.parse().ok())
         .filter(|secs: &u64| *secs > 0)
         .map(Duration::from_secs)
-        .or_else(|| turn_timeout_override().map(Duration::from_secs))
-        .unwrap_or(TURN_TIMEOUT)
+        .or_else(|| {
+            turn_timeout_override()
+                .filter(|secs| *secs > 0)
+                .map(Duration::from_secs)
+        })
 }
 
 /// Race an in-flight ACP prompt turn against completion, a cancel signal, an
-/// idle deadline (reset on agent activity via `idle_rx`), and a hard wall-clock
-/// cap. On idle/hard timeout, invoke `on_timeout_cancel` (the caller's cancel
-/// hook — updates DriverState cancel/timeout state so the in-flight turn winds
-/// down), await `CANCEL_GRACE`, then return a typed timeout error. Extracted
-/// so the deadline loop is unit-testable with mock futures. A pre-iteration
-/// deadline check bounds a continuously-ready activity arm (under `biased`) so
-/// a streaming-but-non-completing agent can't slip past the hard cap.
+/// optional idle deadline (reset on agent activity via `idle_rx`), and an
+/// optional hard wall-clock cap. On idle/hard timeout, invoke `on_timeout_cancel`
+/// (the caller's cancel hook — updates DriverState cancel/timeout state so the
+/// in-flight turn winds down), await `CANCEL_GRACE`, then return a typed timeout
+/// error. Extracted so the deadline loop is unit-testable with mock futures. A
+/// pre-iteration deadline check bounds a continuously-ready activity arm (under
+/// `biased`) so a streaming-but-non-completing agent can't slip past a cap. When
+/// a deadline is `None` (the unlimited default for idle and/or hard), it imposes
+/// no bound — a fully-unlimited turn (both `None`) is ended only by completion or
+/// cancel, so a wedged agent is NOT killed by default.
 async fn race_turn<P>(
     prompt: P,
     mut cancel_rx: oneshot::Receiver<()>,
     idle_rx: &mut watch::Receiver<()>,
     on_timeout_cancel: impl Fn(),
-    idle: Duration,
-    hard: Duration,
+    idle: Option<Duration>,
+    hard: Option<Duration>,
 ) -> Result<StopReason, String>
 where
     P: std::future::Future<Output = Result<StopReason, String>>,
 {
     tokio::pin!(prompt);
-    let hard_deadline = tokio::time::Instant::now() + hard;
-    let mut idle_deadline = tokio::time::Instant::now() + idle;
+    let hard_deadline = hard.map(|d| tokio::time::Instant::now() + d);
+    let mut idle_deadline = idle.map(|d| tokio::time::Instant::now() + d);
     loop {
-        let next_deadline = idle_deadline.min(hard_deadline);
+        // Next deadline: the earliest of the configured (Some) deadlines; `None`
+        // when neither idle nor hard is configured (fully unlimited).
+        let next_deadline = match (idle_deadline, hard_deadline) {
+            (Some(i), Some(h)) => Some(i.min(h)),
+            (Some(i), None) => Some(i),
+            (None, Some(h)) => Some(h),
+            (None, None) => None,
+        };
         // Pre-select check: under `biased`, a continuously-ready activity arm
         // would win every poll and `sleep_until` would never fire — silently
-        // defeating the hard cap for a streaming-but-non-completing agent.
-        if tokio::time::Instant::now() >= next_deadline {
-            on_timeout_cancel();
-            return match tokio::time::timeout(CANCEL_GRACE, &mut prompt).await {
-                Ok(result) => result,
-                Err(_) if next_deadline == idle_deadline => {
-                    Err(format!("turn idle timeout: no agent activity for {idle:?}"))
-                }
-                Err(_) => Err(format!("turn hard timeout: exceeded {hard:?}")),
-            };
-        }
-        tokio::select! {
-            biased;
-            result = &mut prompt => return result,
-            _ = &mut cancel_rx => {
+        // defeating the cap(s) for a streaming-but-non-completing agent.
+        if let Some(nd) = next_deadline {
+            if tokio::time::Instant::now() >= nd {
+                on_timeout_cancel();
                 return match tokio::time::timeout(CANCEL_GRACE, &mut prompt).await {
                     Ok(result) => result,
-                    Err(_) => Ok(StopReason::Cancelled),
+                    Err(_) if idle_deadline == Some(nd) => {
+                        let idle_dur = idle.unwrap_or(Duration::ZERO);
+                        Err(format!("turn idle timeout: no agent activity for {idle_dur:?}"))
+                    }
+                    Err(_) => {
+                        let hard_dur = hard.unwrap_or(Duration::ZERO);
+                        Err(format!("turn hard timeout: exceeded {hard_dur:?}"))
+                    }
                 };
             }
-            _ = idle_rx.changed() => {
-                idle_deadline = tokio::time::Instant::now() + idle;
+        }
+        match next_deadline {
+            Some(nd) => {
+                tokio::select! {
+                    biased;
+                    result = &mut prompt => return result,
+                    _ = &mut cancel_rx => {
+                        return match tokio::time::timeout(CANCEL_GRACE, &mut prompt).await {
+                            Ok(result) => result,
+                            Err(_) => Ok(StopReason::Cancelled),
+                        };
+                    }
+                    _ = idle_rx.changed() => {
+                        if let Some(d) = idle {
+                            idle_deadline = Some(tokio::time::Instant::now() + d);
+                        }
+                    }
+                    _ = tokio::time::sleep_until(nd) => {}
+                }
             }
-            _ = tokio::time::sleep_until(next_deadline) => {}
+            None => {
+                // No deadlines (fully unlimited): only completion or cancel can
+                // end the turn. `idle_rx.changed()` is still polled so activity
+                // stays drained, but it no longer resets any deadline.
+                tokio::select! {
+                    biased;
+                    result = &mut prompt => return result,
+                    _ = &mut cancel_rx => {
+                        return match tokio::time::timeout(CANCEL_GRACE, &mut prompt).await {
+                            Ok(result) => result,
+                            Err(_) => Ok(StopReason::Cancelled),
+                        };
+                    }
+                    _ = idle_rx.changed() => {}
+                }
+            }
         }
     }
 }
@@ -2463,11 +2513,13 @@ async fn run_command_loop(
                 let turn_turn_id = turn_id.clone();
                 let spawn_result = cx.spawn(async move {
                     // Race the turn against completion, a cancel signal, an
-                    // idle deadline (reset by agent `session/update` activity
-                    // via `DriverState::signal_idle`), and a hard wall-clock
-                    // cap. On idle/hard timeout → signal cancel + `CANCEL_GRACE`
-                    // + a typed error (`acp-store` sets `status: 'error'`). See
-                    // [`race_turn`].
+                    // optional idle deadline (reset by agent `session/update`
+                    // activity via `DriverState::signal_idle`), and an optional
+                    // hard wall-clock cap. Both default to `None` (unlimited):
+                    // a turn is bounded only if the operator/user configured a
+                    // value. On idle/hard timeout → signal cancel +
+                    // `CANCEL_GRACE` + a typed error (`acp-store` sets
+                    // `status: 'error'`). See [`race_turn`].
                     let idle = turn_idle_timeout();
                     let hard = resolved_turn_timeout();
                     let cancel_state = turn_state.clone();
@@ -3349,8 +3401,8 @@ mod tests {
             move || {
                 on_timeout_clone.fetch_add(1, Ordering::SeqCst);
             },
-            Duration::from_millis(50),
-            Duration::from_secs(10),
+            Some(Duration::from_millis(50)),
+            Some(Duration::from_secs(10)),
         )
         .await;
         let _ = activity.await;
@@ -3377,8 +3429,8 @@ mod tests {
             move || {
                 on_timeout_clone.fetch_add(1, Ordering::SeqCst);
             },
-            Duration::from_millis(100),
-            Duration::from_secs(10),
+            Some(Duration::from_millis(100)),
+            Some(Duration::from_secs(10)),
         )
         .await;
         let err = result.unwrap_err();
@@ -3408,8 +3460,8 @@ mod tests {
             move || {
                 on_timeout_clone.fetch_add(1, Ordering::SeqCst);
             },
-            Duration::from_millis(50),
-            Duration::from_millis(200),
+            Some(Duration::from_millis(50)),
+            Some(Duration::from_millis(200)),
         )
         .await;
         activity.abort();
@@ -3439,8 +3491,8 @@ mod tests {
             move || {
                 on_timeout_clone.fetch_add(1, Ordering::SeqCst);
             },
-            Duration::from_millis(100),
-            Duration::from_secs(10),
+            Some(Duration::from_millis(100)),
+            Some(Duration::from_secs(10)),
         )
         .await;
         let _ = canceller.await;
@@ -3451,8 +3503,92 @@ mod tests {
         assert_eq!(on_timeout.load(Ordering::SeqCst), 0);
     }
 
+    /// Fully-unlimited default (`idle = None`, `hard = None`): a silent,
+    /// never-completing turn is bounded ONLY by an explicit cancel — no
+    /// timeout fires. This is the new default contract.
+    #[tokio::test(start_paused = true)]
+    async fn race_turn_unlimited_silent_turn_only_ends_on_cancel() {
+        let (_idle_tx, mut idle_rx) = watch::channel(()); // no activity
+        let (cancel_tx, cancel_rx) = oneshot::channel::<()>();
+        let on_timeout = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let on_timeout_clone = on_timeout.clone();
+        let canceller = tokio::spawn(async move {
+            tokio::time::sleep(Duration::from_millis(50)).await;
+            let _ = cancel_tx.send(());
+        });
+        let result = race_turn(
+            std::future::pending::<Result<StopReason, String>>(),
+            cancel_rx,
+            &mut idle_rx,
+            move || {
+                on_timeout_clone.fetch_add(1, Ordering::SeqCst);
+            },
+            None,
+            None,
+        )
+        .await;
+        let _ = canceller.await;
+        assert!(
+            matches!(result, Ok(StopReason::Cancelled)),
+            "got {result:?}"
+        );
+        assert_eq!(
+            on_timeout.load(Ordering::SeqCst),
+            0,
+            "unlimited turn must not invoke on_timeout_cancel"
+        );
+    }
+
+    /// Unlimited hard cap (`hard = None`) with a bounded idle: a streaming,
+    /// never-completing turn that keeps activity alive never hits the idle
+    /// deadline and is bounded ONLY by cancel — the absent hard cap imposes no
+    /// bound, matching "unlimited hard cap".
+    #[tokio::test(start_paused = true)]
+    async fn race_turn_unlimited_hard_cap_active_turn_only_ends_on_cancel() {
+        let (idle_tx, mut idle_rx) = watch::channel(());
+        let (cancel_tx, cancel_rx) = oneshot::channel::<()>();
+        let activity = tokio::spawn(async move {
+            loop {
+                tokio::time::sleep(Duration::from_millis(10)).await;
+                let _ = idle_tx.send(());
+            }
+        });
+        let on_timeout = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let on_timeout_clone = on_timeout.clone();
+        let canceller = tokio::spawn(async move {
+            tokio::time::sleep(Duration::from_millis(60)).await;
+            let _ = cancel_tx.send(());
+        });
+        // idle 50ms (kept reset by activity), hard None (unlimited): an active
+        // turn never hits either, so only cancel ends it.
+        let result = race_turn(
+            std::future::pending::<Result<StopReason, String>>(),
+            cancel_rx,
+            &mut idle_rx,
+            move || {
+                on_timeout_clone.fetch_add(1, Ordering::SeqCst);
+            },
+            Some(Duration::from_millis(50)),
+            None,
+        )
+        .await;
+        activity.abort();
+        let _ = activity.await;
+        let _ = canceller.await;
+        assert!(
+            matches!(result, Ok(StopReason::Cancelled)),
+            "got {result:?}"
+        );
+        assert_eq!(
+            on_timeout.load(Ordering::SeqCst),
+            0,
+            "unlimited hard cap must not invoke on_timeout_cancel for an active turn"
+        );
+    }
+
     /// `resolved_turn_timeout` precedence: env var > UI override > default.
-    /// The override replaces the default when no env var is set.
+    /// The override replaces the default when no env var is set; the default is
+    /// now `None` (unlimited).
     #[test]
     fn turn_timeout_override_takes_effect_when_no_env_var() {
         // The env var is usually absent in the test runner; when it IS set
@@ -3461,31 +3597,31 @@ mod tests {
             return;
         }
         set_turn_timeout_override(Some(42));
-        assert_eq!(resolved_turn_timeout(), Duration::from_secs(42));
+        assert_eq!(resolved_turn_timeout(), Some(Duration::from_secs(42)));
         set_turn_timeout_override(None);
-        assert_eq!(resolved_turn_timeout(), TURN_TIMEOUT);
+        assert_eq!(resolved_turn_timeout(), None);
     }
 
     /// `turn_idle_timeout` full precedence ladder, in ONE test so the shared
     /// override static and env var are never touched by concurrent tests:
-    /// env var absent → override wins over default; cleared → default; env
-    /// var present → env beats a simultaneous UI override (the operator
-    /// precedence the settings UI documents). When the env var is ALREADY
-    /// set on the host (operator machine), only the env-wins phase runs and
-    /// its original value is restored afterwards.
+    /// env var absent → override wins over default; cleared → default (`None`
+    /// / unlimited); env var present → env beats a simultaneous UI override
+    /// (the operator precedence the settings UI documents). When the env var is
+    /// ALREADY set on the host (operator machine), only the env-wins phase runs
+    /// and its original value is restored afterwards.
     #[test]
     fn turn_idle_timeout_precedence_env_beats_override_beats_default() {
         let preexisting = std::env::var("TERMUL_ACP_TURN_IDLE_TIMEOUT_SECS").ok();
         if preexisting.is_none() {
             set_turn_idle_timeout_override(Some(42));
-            assert_eq!(turn_idle_timeout(), Duration::from_secs(42));
+            assert_eq!(turn_idle_timeout(), Some(Duration::from_secs(42)));
             set_turn_idle_timeout_override(None);
-            assert_eq!(turn_idle_timeout(), TURN_IDLE_TIMEOUT);
+            assert_eq!(turn_idle_timeout(), None);
         }
 
         std::env::set_var("TERMUL_ACP_TURN_IDLE_TIMEOUT_SECS", "60");
         set_turn_idle_timeout_override(Some(1800));
-        assert_eq!(turn_idle_timeout(), Duration::from_secs(60));
+        assert_eq!(turn_idle_timeout(), Some(Duration::from_secs(60)));
 
         match preexisting {
             Some(v) => std::env::set_var("TERMUL_ACP_TURN_IDLE_TIMEOUT_SECS", v),

--- a/src-tauri/src/web/ws.rs
+++ b/src-tauri/src/web/ws.rs
@@ -317,7 +317,14 @@ pub enum HistoryMode {
 #[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct RuntimePolicy {
+    /// Authoritative absolute server turn ceiling, in ms. `0` is the
+    /// **unlimited** sentinel — no hard cap is imposed (the default). A
+    /// non-zero value is the bounded hard-cap deadline the client should not
+    /// let its inactivity refresh extend past.
     pub turn_timeout_ms: u64,
+    /// Inactivity budget, in ms, refreshed on matching-session activity. `0`
+    /// is the **unlimited** sentinel — the client imposes no inactivity timer
+    /// (the default). A non-zero value is the bounded inactivity window.
     pub prompt_inactivity_timeout_ms: u64,
     pub permission_reconnect_grace_ms: u64,
     pub ping_interval_ms: u64,
@@ -327,14 +334,25 @@ pub struct RuntimePolicy {
 impl RuntimePolicy {
     #[must_use]
     pub fn resolved(permission_reconnect_grace: Duration) -> Self {
-        let turn_timeout = crate::acp::manager::resolved_turn_timeout();
+        let turn_timeout = crate::acp::manager::resolved_turn_timeout(); // Option
+        let turn_idle = crate::acp::manager::turn_idle_timeout();         // Option
+        // `turn_timeout_ms`: 0 = unlimited (no hard cap) sentinel; otherwise
+        // the bounded hard cap in ms.
+        let turn_timeout_ms = turn_timeout.map(|d| d.as_millis() as u64).unwrap_or(0);
+        // Inactivity budget published to the client. Preserve the original
+        // `hard/2` derivation when a hard cap is configured (bounded, strictly
+        // shorter than the ceiling); otherwise use the idle timeout when it is
+        // configured (bounded); otherwise 0 (unlimited — no client-side
+        // inactivity timer). 0 keeps the client's `setTimeout` well under the
+        // browser 32-bit ceiling and defers entirely to the server.
+        let prompt_inactivity_timeout_ms = match (turn_timeout, turn_idle) {
+            (Some(hard), _) => (hard.as_millis() as u64 / 2).max(1),
+            (None, Some(idle)) => idle.as_millis() as u64,
+            (None, None) => 0,
+        };
         Self {
-            turn_timeout_ms: turn_timeout.as_millis() as u64,
-            // The inactivity budget — refreshed on matching-session activity but
-            // strictly shorter than the absolute turn ceiling so a stalled turn
-            // still times out even with intermittent activity. Half the turn
-            // timeout keeps the inactivity budget proportional to the ceiling.
-            prompt_inactivity_timeout_ms: (turn_timeout.as_millis() as u64 / 2).max(1),
+            turn_timeout_ms,
+            prompt_inactivity_timeout_ms,
             permission_reconnect_grace_ms: permission_reconnect_grace.as_millis() as u64,
             ping_interval_ms: PING_INTERVAL.as_millis() as u64,
             pong_timeout_ms: PONG_TIMEOUT.as_millis() as u64,

--- a/src/renderer/lib/acp-transport.ts
+++ b/src/renderer/lib/acp-transport.ts
@@ -304,17 +304,17 @@ const REQUEST_TIMEOUT_MS = 60_000
 const SEND_PROMPT_GRACE_MS = 10_000
 /**
  * Fallback only until the authenticate reply publishes the authoritative policy.
- * Timeout for `send_prompt`, which awaits the full agent turn on the server.
- * Stays slightly above Rust `TURN_TIMEOUT` (600s / `TERMUL_ACP_TURN_TIMEOUT_SECS`)
- * plus {@link SEND_PROMPT_GRACE_MS} so the server's specific `turn timeout`
- * error reaches the client before this generic timeout fires. A 60s client
- * budget caused `AcpTransportError: Request send_prompt timed out` on
- * mobile/ngrok whenever a turn (tools, thinking, slow models) exceeded a
- * minute — even while streaming events were still arriving.
+ * Timeout for `send_prompt`, which awaits the full agent turn on the server. The
+ * server's default turn (hard-cap + idle) timeout is **unlimited** (the
+ * published `turnTimeoutMs` / `promptInactivityTimeoutMs` are `0` to signal
+ * unlimited), so once authenticated the client imposes no client-side timer.
+ * This fallback only covers the brief pre-auth window (send_prompt requires a
+ * session, so it normally never fires pre-auth) with a bounded, setTimeout-safe
+ * 1h budget.
  *
- * NOTE: if a deployment raises `TERMUL_ACP_TURN_TIMEOUT_SECS` above 600s,
- * this constant must be raised to match (ideally the server would publish its
- * turn budget to the client — tracked separately).
+ * NOTE: a deployment that sets `TERMUL_ACP_TURN_TIMEOUT_SECS` /
+ * `TERMUL_ACP_TURN_IDLE_TIMEOUT_SECS` publishes those bounded values, which the
+ * client honours instead of this fallback.
  */
 const FALLBACK_SEND_PROMPT_INACTIVITY_MS = 3_600_000
 const RECONNECT_BASE_MS = 500
@@ -354,11 +354,14 @@ const HEARTBEAT_FAILURE_THRESHOLD = 2
 type Pending = {
   resolve: (value: unknown) => void
   reject: (err: unknown) => void
-  timer: ReturnType<typeof setTimeout>
+  /** Inactivity timer; `null` when the server policy is unlimited (no
+   * client-side inactivity timer is imposed). */
+  timer: ReturnType<typeof setTimeout> | null
   type: WsRequestType
   sessionId?: string
   /** Absolute deadline (epoch-ms) for send_prompt — the inactivity timer never
-   * extends past it. `undefined` for non-send_prompt requests. */
+   * extends past it. `undefined` when the server imposes no hard cap
+   * (unlimited) or for non-send_prompt requests. */
   deadline?: number
 }
 
@@ -486,7 +489,7 @@ export class WsAcpTransport implements AcpTransport {
       this.reconnectTimer = null
     }
     for (const [, p] of this.pending) {
-      clearTimeout(p.timer)
+      if (p.timer) clearTimeout(p.timer)
       p.reject(new AcpTransportError('closed', 'transport disposed'))
     }
     this.pending.clear()
@@ -869,7 +872,7 @@ export class WsAcpTransport implements AcpTransport {
 
   private rejectAllPending(code: string, message: string): void {
     for (const [, p] of this.pending) {
-      clearTimeout(p.timer)
+      if (p.timer) clearTimeout(p.timer)
       p.reject(new AcpTransportError(code, message))
     }
     this.pending.clear()
@@ -1092,7 +1095,7 @@ export class WsAcpTransport implements AcpTransport {
   private handleReply(reply: WsReply): void {
     const pending = this.pending.get(reply.id)
     if (!pending) return
-    clearTimeout(pending.timer)
+    if (pending.timer) clearTimeout(pending.timer)
     this.pending.delete(reply.id)
     if (reply.ok) {
       pending.resolve(reply.payload)
@@ -1200,21 +1203,38 @@ export class WsAcpTransport implements AcpTransport {
   }
 
   private refreshPromptActivity(sessionId: string): void {
-    const inactivityMs =
-      (this.runtimePolicy?.promptInactivityTimeoutMs ?? FALLBACK_SEND_PROMPT_INACTIVITY_MS) +
-      SEND_PROMPT_GRACE_MS
-    const now = Date.now()
+    const serverInactivityMs =
+      this.runtimePolicy?.promptInactivityTimeoutMs ?? FALLBACK_SEND_PROMPT_INACTIVITY_MS
+    // 0 = server-imposed unlimited inactivity: no inactivity budget is imposed.
+    const inactivityMs = serverInactivityMs > 0 ? serverInactivityMs + SEND_PROMPT_GRACE_MS : 0
     for (const [id, pending] of this.pending) {
       if (pending.type !== 'send_prompt' || pending.sessionId !== sessionId) continue
       // Reset the inactivity timer but never extend past the absolute deadline.
-      const remaining = pending.deadline != null ? pending.deadline - now : inactivityMs
-      const timerMs = Math.min(inactivityMs, Math.max(0, remaining))
-      clearTimeout(pending.timer)
-      pending.timer = setTimeout(() => {
-        this.pending.delete(id)
-        pending.reject(new AcpTransportError('timeout', 'Request send_prompt timed out'))
-      }, timerMs)
+      const timerMs = this.computeSendPromptTimerMs(inactivityMs, pending.deadline)
+      if (pending.timer) clearTimeout(pending.timer)
+      pending.timer =
+        timerMs > 0
+          ? setTimeout(() => {
+              this.pending.delete(id)
+              pending.reject(new AcpTransportError('timeout', 'Request send_prompt timed out'))
+            }, timerMs)
+          : null
     }
+  }
+
+  /**
+   * Compute the send_prompt inactivity timer, in ms, honouring the server's
+   * unlimited (0) sentinels. Returns 0 when both the inactivity budget and the
+   * hard-cap deadline are unlimited — the caller then sets no client-side
+   * timer (the request waits for a reply / cancel / socket close only).
+   */
+  private computeSendPromptTimerMs(inactivityMs: number, deadline: number | undefined): number {
+    if (inactivityMs > 0) {
+      const remaining = deadline != null ? deadline - Date.now() : inactivityMs
+      return Math.min(inactivityMs, Math.max(0, remaining))
+    }
+    if (deadline != null) return Math.max(0, deadline - Date.now())
+    return 0
   }
 
   private request<T = unknown>(type: WsRequestType, payload: unknown): Promise<T> {
@@ -1237,22 +1257,30 @@ export class WsAcpTransport implements AcpTransport {
           ? payloadRecord.sessionId
           : undefined
       const isSendPrompt = type === 'send_prompt'
-      const inactivityMs = isSendPrompt
-        ? (this.runtimePolicy?.promptInactivityTimeoutMs ?? FALLBACK_SEND_PROMPT_INACTIVITY_MS) +
-          SEND_PROMPT_GRACE_MS
-        : REQUEST_TIMEOUT_MS
+      const serverInactivityMs = isSendPrompt
+        ? (this.runtimePolicy?.promptInactivityTimeoutMs ?? FALLBACK_SEND_PROMPT_INACTIVITY_MS)
+        : 0
+      const serverHardCapMs = isSendPrompt
+        ? (this.runtimePolicy?.turnTimeoutMs ?? FALLBACK_SEND_PROMPT_INACTIVITY_MS)
+        : 0
+      // 0 = server-imposed unlimited; a non-zero value is the bounded budget
+      // plus the grace margin so the server's typed timeout wins the race.
+      const inactivityMs = serverInactivityMs > 0 ? serverInactivityMs + SEND_PROMPT_GRACE_MS : 0
       // Absolute ceiling: the inactivity refresh never extends past this
       // deadline so a long-stalled turn still times out despite intermittent
-      // activity.
-      const deadline = isSendPrompt
-        ? Date.now() +
-          (this.runtimePolicy?.turnTimeoutMs ?? FALLBACK_SEND_PROMPT_INACTIVITY_MS) +
-          SEND_PROMPT_GRACE_MS
-        : undefined
-      const timer = setTimeout(() => {
-        this.pending.delete(id)
-        reject(new AcpTransportError('timeout', `Request ${type} timed out`))
-      }, inactivityMs)
+      // activity. `0` (unlimited hard cap) → no absolute deadline.
+      const deadline =
+        serverHardCapMs > 0 ? Date.now() + serverHardCapMs + SEND_PROMPT_GRACE_MS : undefined
+      const timerMs = isSendPrompt
+        ? this.computeSendPromptTimerMs(inactivityMs, deadline)
+        : REQUEST_TIMEOUT_MS
+      const timer =
+        timerMs > 0
+          ? setTimeout(() => {
+              this.pending.delete(id)
+              reject(new AcpTransportError('timeout', `Request ${type} timed out`))
+            }, timerMs)
+          : null
       this.pending.set(id, {
         resolve: (v) => resolve(v as T),
         reject,
@@ -1262,7 +1290,7 @@ export class WsAcpTransport implements AcpTransport {
         deadline
       })
       if (!this.socket || this.socket.readyState !== WebSocket.OPEN) {
-        clearTimeout(timer)
+        if (timer) clearTimeout(timer)
         this.pending.delete(id)
         reject(new AcpTransportError('closed', 'WebSocket not open'))
         return

--- a/src/renderer/types/settings.ts
+++ b/src/renderer/types/settings.ts
@@ -65,14 +65,15 @@ export interface AppSettings {
   /** Whole-UI zoom factor (1.0 = 100%). Scales the entire window like VS Code's window zoom. */
   uiZoomLevel: number
   /** ACP turn hard-cap timeout in seconds, or null = use the Rust default
-   * (3h). Set via App Preferences; pushed to the Rust core. */
+   * (unlimited by default). Set via App Preferences; pushed to the Rust core. */
   acpTurnTimeoutSecs: number | null
   /** Automatically save dirty editor files after edits pause (GH-539). */
   editorAutoSave: boolean
   /** Idle delay in ms before a dirty editor file is auto-saved (GH-539). */
   editorAutoSaveDelayMs: number
   /** ACP per-turn idle timeout in seconds, or null = use the env var / Rust
-   * default (15min). Set via App Preferences; pushed to the Rust core. */
+   * default (unlimited by default). Set via App Preferences; pushed to the
+   * Rust core. */
   acpTurnIdleTimeoutSecs: number | null
   /** ACP session/new timeout in seconds, or null = use the env var / Rust
    * default (60s). Set via App Preferences; pushed to the Rust core. */
@@ -180,12 +181,13 @@ export const REMOTE_BIND_MODE_OPTIONS: Array<{
 ]
 
 // ACP turn (hard-cap) timeout options for the App Preferences UI. `null` =
-// follow the env var / Rust default (3h); a number is the override in seconds.
+// follow the env var / Rust default (unlimited); a number is the override in
+// seconds.
 export const ACP_TURN_TIMEOUT_OPTIONS: Array<{
   value: number | null
   label: string
 }> = [
-  { value: null, label: 'Environment/default (3 hours)' },
+  { value: null, label: 'Environment/default (unlimited)' },
   { value: 3600, label: '1 hour' },
   { value: 7200, label: '2 hours' },
   { value: 21600, label: '6 hours' },
@@ -194,12 +196,12 @@ export const ACP_TURN_TIMEOUT_OPTIONS: Array<{
 ]
 
 // ACP turn idle-timeout options (the silent-turn window). `null` = follow the
-// env var / Rust default (15 minutes); a number is the override in seconds.
+// env var / Rust default (unlimited); a number is the override in seconds.
 export const ACP_TURN_IDLE_TIMEOUT_OPTIONS: Array<{
   value: number | null
   label: string
 }> = [
-  { value: null, label: 'Environment/default (15 minutes)' },
+  { value: null, label: 'Environment/default (unlimited)' },
   { value: 300, label: '5 minutes' },
   { value: 600, label: '10 minutes' },
   { value: 900, label: '15 minutes' },

--- a/src/renderer/types/settings.ts
+++ b/src/renderer/types/settings.ts
@@ -64,8 +64,9 @@ export interface AppSettings {
   appearanceMode: 'light' | 'dark'
   /** Whole-UI zoom factor (1.0 = 100%). Scales the entire window like VS Code's window zoom. */
   uiZoomLevel: number
-  /** ACP turn hard-cap timeout in seconds, or null = use the Rust default
-   * (unlimited by default). Set via App Preferences; pushed to the Rust core. */
+  /** ACP turn hard-cap timeout in seconds, or null = use the env var / Rust
+   * default (unlimited by default). Set via App Preferences; pushed to the
+   * Rust core. */
   acpTurnTimeoutSecs: number | null
   /** Automatically save dirty editor files after edits pause (GH-539). */
   editorAutoSave: boolean

--- a/src/shared/types/web-protocol.types.ts
+++ b/src/shared/types/web-protocol.types.ts
@@ -224,9 +224,12 @@ export type HistoryMode = 'server' | 'live_only'
 
 /** Additive policy negotiated during the relay authenticate handshake. */
 export interface AcpRuntimePolicy {
-  /** Authoritative absolute server turn ceiling. */
+  /** Authoritative absolute server turn ceiling, in ms. `0` is the
+   *  unlimited sentinel — no hard cap is imposed (the default). */
   turnTimeoutMs: number
-  /** Matching session activity refreshes the renderer timer to this budget. */
+  /** Matching session activity refreshes the renderer timer to this budget,
+   *  in ms. `0` is the unlimited sentinel — no inactivity timer is imposed
+   *  (the default). */
   promptInactivityTimeoutMs: number
   /** Grace before a last-subscriber disconnect denies pending permissions. */
   permissionReconnectGraceMs: number


### PR DESCRIPTION
## Summary

Change the ACP per-turn **hard-cap timeout** and the **per-turn idle timeout** defaults from bounded (3h / 15min) to **unlimited** ("infinite"). A turn is now bounded only when the operator sets `TERMUL_ACP_TURN_TIMEOUT_SECS` / `TERMUL_ACP_TURN_IDLE_TIMEOUT_SECS`, or the user picks a value in App Preferences; otherwise only completion or cancel ends a turn.

Requested: both the turn timeout and the turn idle timeout should default to unlimited/infinite (not "1 year" pseudo-unlimited).

## Related Issue

No related issue exists — this is a direct intent request to default both ACP turn timeouts (hard-cap + idle) to unlimited/infinite. No prior PR addresses this.

## Type of Change

- [x] feat: new feature

## What Changed

**Rust (`src-tauri`)**
- `manager.rs`: `resolved_turn_timeout()` / `turn_idle_timeout()` now return `Option<Duration>` (`None` = unlimited). Removed the `TURN_TIMEOUT` (3h) and `TURN_IDLE_TIMEOUT` (15min) consts. `race_turn` takes `idle`/`hard` as `Option<Duration>`; when both `None`, only completion/cancel ends the turn (the idle-activity arm still drains the watch channel). Added `race_turn_unlimited_*` tests and updated the precedence tests to assert `None` defaults.
- `web/ws.rs`: `RuntimePolicy` publishes `0` as the **unlimited sentinel** for `turn_timeout_ms` / `prompt_inactivity_timeout_ms`. Inactivity budget keeps `hard/2` when a hard cap is set, else the idle timeout, else `0` — keeping the client's `setTimeout` well under the browser 32-bit ceiling.
- `commands.rs`: doc-comment updates (3h / 15min → unlimited default).

**Renderer (`src/renderer`) + shared**
- `acp-transport.ts`: `Pending.timer` is now nullable. When the server policy is unlimited (`0`), **no client-side inactivity timer or absolute deadline** is imposed. New `computeSendPromptTimerMs` helper centralises the bounded/unlimited logic. All `clearTimeout` sites guard on null. Pre-auth fallback (`FALLBACK_SEND_PROMPT_INACTIVITY_MS`, 1h) is retained but only covers the brief pre-auth window (send_prompt requires a session, so it normally never fires pre-auth); the stale "600s" comment is corrected.
- `settings.ts`: App Preferences option labels/comments updated `3 hours` / `15 minutes` → `unlimited`.
- `web-protocol.types.ts`: `AcpRuntimePolicy` field docs note the `0` = unlimited sentinel.

## How It Was Tested

- [x] `bun run ci` (Biome lint + format + imports, strict mode)
- [x] `bun run typecheck`
- [x] `bun run test`
- [x] `cargo clippy --all-targets -- -D warnings` (in src-tauri)
- [x] `cargo test` (in src-tauri)
- [ ] Manual verification completed

Notes:
- `cargo clippy --all-targets -- -D warnings` clean.
- `cargo test --lib --no-run` compiles; the test binary cannot start in this Windows env due to a missing runtime DLL (STATUS_DLL_NOT_FOUND) — CI runs it on a proper host.
- `bun run ci` and `bun run typecheck` pass.
- `bun run test`: all 284 directly-affected tests pass (`acp-transport`, `use-app-settings`, `acp-store`, `prompt-queue-orchestration`). One unrelated flaky test (`WorkspaceLayout.test.tsx` color-theme-picker shortcut) failed under full parallel load but passes in isolation.

## Screenshots or Recordings

N/A — no UI layout change; only timeout semantics + App Preferences option labels (`3 hours`/`15 minutes` → `unlimited`).

## CI & Review Gate

- [ ] All CI checks pass (PR Validation, Rust Checks, Build Verification, Security Scans)
- [ ] Code review comments from CodeRabbit / Claude have been addressed or resolved
- [ ] No unresolved review findings remain

## Checklist

- [x] My PR title follows the conventional commit format used by this repo
- [x] I linked the related issue or explained why none exists
- [x] I updated docs when needed
- [x] I added or updated tests when needed
- [x] I verified the change does not introduce unrelated modifications
- [x] I read AGENTS.md and followed the contributor guidelines
- [ ] A human reviewed the complete diff before submission

## Risk / notes

- A truly wedged (silent, never-completing) agent is no longer killed by default — it is left to the operator/user to cancel, or to bound explicitly via the env vars / App Preferences. This matches the requested "unlimited" semantic. Operators who relied on the 15min idle safety net should set `TERMUL_ACP_TURN_IDLE_TIMEOUT_SECS`.
- Desktop (in-process `race_turn`) and the standalone `termul-server` / web client (`RuntimePolicy` over WS) both honour the unlimited default. The kill-all split (`serve_router` vs `serve`) is untouched.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Turn and inactivity timeouts now default to unlimited when no limit is configured.
  * Clearing timeout overrides correctly restores the unlimited default.
  * Timeout handling now supports unlimited, partial, and bounded configurations while preserving cancellation and grace periods.

* **Documentation**
  * Updated settings and protocol descriptions to clarify timeout behavior and unlimited-value options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->