### PR TITLE
feat(acp): host ACP catalog and verified atomic installation (CAP-6)

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -5927,6 +5927,7 @@ dependencies = [
  "agent-client-protocol",
  "anyhow",
  "async-process",
+ "async-trait",
  "axum",
  "chrono",
  "flate2",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -139,6 +139,11 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 futures-util = { version = "0.3", default-features = false }
 
+# async trait support (CAP-6 / Story 9: install service Downloader/Extractor
+# injection seams). Already in the dep tree transitively; declared here so
+# the install service can use the macro directly.
+async-trait = "0.1"
+
 # Embed the Vite web bundle (dist-web/) into the binary so the standalone
 # termul-server AND the desktop's in-process shared-live server serve the web
 # client without dist-web/ on disk. #[allow_missing] keeps dev/CI-compile

--- a/src-tauri/src/acp/archive.rs
+++ b/src-tauri/src/acp/archive.rs
@@ -1,0 +1,405 @@
+//! Shared ACP archive download + extract + permission helpers (CAP-6 / Story 9).
+//!
+//! Extracted from the legacy desktop-only `acp_binary_install.rs` so both the
+//! legacy desktop command (kept for back-compat) and the new host-owned
+//! [`crate::acp::install::AcpInstallService`] share ONE implementation. All
+//! helpers are `pub(crate)` and take explicit args (no `AppHandle`) so the
+//! install service can call them with its own resolved paths.
+//!
+//! # Protections (mirrors the legacy command)
+//!
+//! - Streaming download cap: `MAX_ARCHIVE_BYTES` (256 MiB), enforced
+//!   incrementally during `stage_archive` so a hostile server can't force an
+//!   unbounded buffer.
+//! - Decompressed-output quotas: `MAX_EXTRACTED_BYTES` (1 GiB) +
+//!   `MAX_EXTRACTED_FILES` (50_000), to bound zip/tar bombs.
+//! - Path-traversal rejection: zip `enclosed_name`, tar rejects
+//!   `ParentDir`/`RootDir`/`Prefix`.
+//! - `resolve_cmd_in_root` re-validates the resolved `cmd` stays inside the
+//!   install root post-extract.
+//! - `mark_spawnables_in_tree` restores the executable bit by magic-number
+//!   sniff (zip extracts often land as `0644`).
+//! - Archive-format allowlist: `.zip` / `.tar.gz` / `.tgz` only.
+
+use std::io::{Read, Write};
+use std::path::{Component, Path, PathBuf};
+use std::time::Duration;
+
+use futures_util::StreamExt;
+
+/// Fetch timeout for the archive download (mirrors the legacy command).
+pub(crate) const FETCH_TIMEOUT_SECS: u64 = 120;
+/// Streaming-download cap: a hostile server can't force an unbounded buffer.
+pub(crate) const MAX_ARCHIVE_BYTES: u64 = 256 * 1024 * 1024;
+/// Decompressed-output quotas, to bound zip/tar bombs.
+pub(crate) const MAX_EXTRACTED_BYTES: u64 = 1024 * 1024 * 1024;
+pub(crate) const MAX_EXTRACTED_FILES: usize = 50_000;
+
+/// Strip a leading `./` / `.\` and trim so a catalog `cmd` like
+/// `./dist-package/cursor-agent` resolves relative to the install root.
+pub(crate) fn normalize_cmd_path(cmd: &str) -> PathBuf {
+    let trimmed = cmd.trim();
+    let stripped = trimmed
+        .strip_prefix("./")
+        .or_else(|| trimmed.strip_prefix(".\\"))
+        .unwrap_or(trimmed);
+    Path::new(stripped).to_path_buf()
+}
+
+/// Validate that `cmd` resolves to a regular file inside `root` after
+/// extraction. Canonicalizes ONLY to validate the path cannot escape the
+/// install root — returns the plain (non-canonicalized) joined path so Windows
+/// downstream consumers don't choke on the `\\?\` extended-length prefix.
+pub(crate) fn resolve_cmd_in_root(root: &Path, cmd: &str) -> Result<PathBuf, String> {
+    let rel = normalize_cmd_path(cmd);
+    for comp in rel.components() {
+        match comp {
+            Component::ParentDir | Component::RootDir | Component::Prefix(_) => {
+                return Err("invalid cmd path".to_string());
+            }
+            _ => {}
+        }
+    }
+    let candidate = root.join(&rel);
+    let canon_root = root
+        .canonicalize()
+        .map_err(|e| format!("install dir missing: {e}"))?;
+    let canon_cmd = candidate
+        .canonicalize()
+        .map_err(|e| format!("installed binary not found ({cmd}): {e}"))?;
+    if !canon_cmd.starts_with(&canon_root) {
+        return Err("cmd escapes install directory".to_string());
+    }
+    if !canon_cmd
+        .metadata()
+        .map_err(|e| format!("installed binary stat failed: {e}"))?
+        .is_file()
+    {
+        return Err("installed binary is a directory".to_string());
+    }
+    Ok(candidate)
+}
+
+/// Stream-copy a reader to disk while enforcing the global extracted-bytes
+/// quota. `written` tracks the running total across all entries.
+fn copy_bounded(
+    mut reader: impl Read,
+    out: &mut std::fs::File,
+    written: &mut u64,
+) -> Result<(), String> {
+    let mut buf = [0u8; 64 * 1024];
+    loop {
+        let n = reader.read(&mut buf).map_err(|e| e.to_string())?;
+        if n == 0 {
+            break;
+        }
+        *written += n as u64;
+        if *written > MAX_EXTRACTED_BYTES {
+            return Err("archive expands beyond size limit".to_string());
+        }
+        out.write_all(&buf[..n]).map_err(|e| e.to_string())?;
+    }
+    Ok(())
+}
+
+fn extract_zip(archive_path: &Path, dest: &Path) -> Result<(), String> {
+    let file = std::fs::File::open(archive_path).map_err(|e| e.to_string())?;
+    let mut archive = zip::ZipArchive::new(file).map_err(|e| format!("zip: {e}"))?;
+    let mut written: u64 = 0;
+    let mut files: usize = 0;
+    for i in 0..archive.len() {
+        let mut entry = archive.by_index(i).map_err(|e| e.to_string())?;
+        // enclosed_name() rejects path traversal (absolute / `..`) entries.
+        let Some(name) = entry.enclosed_name().map(|p| p.to_owned()) else {
+            continue;
+        };
+        let out_path = dest.join(name);
+        if entry.is_dir() {
+            std::fs::create_dir_all(&out_path).map_err(|e| e.to_string())?;
+        } else {
+            files += 1;
+            if files > MAX_EXTRACTED_FILES {
+                return Err("archive contains too many files".to_string());
+            }
+            if let Some(parent) = out_path.parent() {
+                std::fs::create_dir_all(parent).map_err(|e| e.to_string())?;
+            }
+            let unix_mode = entry.unix_mode();
+            let mut out = std::fs::File::create(&out_path).map_err(|e| e.to_string())?;
+            copy_bounded(&mut entry, &mut out, &mut written)?;
+            drop(out);
+            if let Some(mode) = unix_mode {
+                apply_permission_bits(&out_path, mode);
+            }
+        }
+    }
+    Ok(())
+}
+
+fn extract_tar_gz(archive_path: &Path, dest: &Path) -> Result<(), String> {
+    let file = std::fs::File::open(archive_path).map_err(|e| e.to_string())?;
+    let gz = flate2::read::GzDecoder::new(file);
+    let mut archive = tar::Archive::new(gz);
+    let canon_dest = dest
+        .canonicalize()
+        .map_err(|e| format!("extract dir missing: {e}"))?;
+    let mut written: u64 = 0;
+    let mut files: usize = 0;
+    for entry in archive.entries().map_err(|e| format!("tar: {e}"))? {
+        let mut entry = entry.map_err(|e| format!("tar: {e}"))?;
+        let path = entry.path().map_err(|e| format!("tar: {e}"))?.into_owned();
+        // Reject absolute paths and parent-dir traversal.
+        if path
+            .components()
+            .any(|c| matches!(c, Component::ParentDir | Component::RootDir | Component::Prefix(_)))
+        {
+            return Err("tar entry has unsafe path".to_string());
+        }
+        let out_path = canon_dest.join(&path);
+        if entry.header().entry_type().is_dir() {
+            std::fs::create_dir_all(&out_path).map_err(|e| e.to_string())?;
+        } else {
+            files += 1;
+            if files > MAX_EXTRACTED_FILES {
+                return Err("archive contains too many files".to_string());
+            }
+            if let Some(parent) = out_path.parent() {
+                std::fs::create_dir_all(parent).map_err(|e| e.to_string())?;
+            }
+            let mode = entry.header().mode().ok();
+            let mut out = std::fs::File::create(&out_path).map_err(|e| e.to_string())?;
+            copy_bounded(&mut entry, &mut out, &mut written)?;
+            drop(out);
+            if let Some(mode) = mode {
+                apply_permission_bits(&out_path, mode);
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Dispatch extraction by archive extension. Allowlist: `.zip` /
+/// `.tar.gz` / `.tgz` only.
+pub(crate) fn extract_archive(archive_path: &Path, dest: &Path) -> Result<(), String> {
+    let name = archive_path
+        .file_name()
+        .and_then(|s| s.to_str())
+        .unwrap_or("")
+        .to_ascii_lowercase();
+    if name.ends_with(".zip") {
+        extract_zip(archive_path, dest)
+    } else if name.ends_with(".tar.gz") || name.ends_with(".tgz") {
+        extract_tar_gz(archive_path, dest)
+    } else {
+        Err("unsupported archive type (expected .zip or .tar.gz)".to_string())
+    }
+}
+
+#[cfg(unix)]
+pub(crate) fn apply_permission_bits(path: &Path, mode: u32) {
+    use std::os::unix::fs::PermissionsExt;
+    // Drop setuid/setgid/sticky from untrusted archives; keep rwx only.
+    let mode = mode & 0o777;
+    let _ = std::fs::set_permissions(path, std::fs::Permissions::from_mode(mode));
+}
+
+#[cfg(not(unix))]
+pub(crate) fn apply_permission_bits(_path: &Path, _mode: u32) {}
+
+#[cfg(unix)]
+pub(crate) fn mark_executable(path: &Path) {
+    use std::os::unix::fs::PermissionsExt;
+    if let Ok(meta) = std::fs::metadata(path) {
+        let mut perms = meta.permissions();
+        perms.set_mode(perms.mode() | 0o111);
+        let _ = std::fs::set_permissions(path, perms);
+    }
+}
+
+#[cfg(not(unix))]
+pub(crate) fn mark_executable(_path: &Path) {}
+
+/// True when `head` looks like a script or native executable that must be
+/// runnable after extract. Zip extracts often land as `0644` even when the
+/// archive carried unix modes (or omitted them entirely).
+pub(crate) fn looks_like_spawnable(head: &[u8]) -> bool {
+    if head.len() >= 2 && head[0] == b'#' && head[1] == b'!' {
+        return true;
+    }
+    if head.len() >= 4 && head.starts_with(b"\x7fELF") {
+        return true;
+    }
+    // Mach-O (32/64, LE/BE) and fat/universal.
+    const MACHO: &[[u8; 4]] = &[
+        [0xcf, 0xfa, 0xed, 0xfe], // MH_MAGIC_64
+        [0xce, 0xfa, 0xed, 0xfe], // MH_MAGIC
+        [0xfe, 0xed, 0xfa, 0xcf], // MH_CIGAM_64
+        [0xfe, 0xed, 0xfa, 0xce], // MH_CIGAM
+        [0xca, 0xfe, 0xba, 0xbe], // FAT_MAGIC
+        [0xbe, 0xba, 0xfe, 0xca], // FAT_CIGAM
+    ];
+    if head.len() >= 4 {
+        let magic = [head[0], head[1], head[2], head[3]];
+        if MACHO.contains(&magic) {
+            return true;
+        }
+    }
+    false
+}
+
+/// Walk `root` and `+x` any shebang / ELF / Mach-O file. Complements archive
+/// mode restoration when the zip omitted unix permissions.
+pub(crate) fn mark_spawnables_in_tree(root: &Path) {
+    let Ok(entries) = std::fs::read_dir(root) else {
+        return;
+    };
+    let mut stack: Vec<PathBuf> = entries.filter_map(|e| e.ok().map(|e| e.path())).collect();
+    while let Some(path) = stack.pop() {
+        let Ok(meta) = path.symlink_metadata() else {
+            continue;
+        };
+        if meta.file_type().is_symlink() {
+            continue;
+        }
+        if meta.is_dir() {
+            if let Ok(children) = std::fs::read_dir(&path) {
+                stack.extend(children.filter_map(|e| e.ok().map(|e| e.path())));
+            }
+            continue;
+        }
+        if !meta.is_file() {
+            continue;
+        }
+        let Ok(mut file) = std::fs::File::open(&path) else {
+            continue;
+        };
+        let mut head = [0u8; 4];
+        let Ok(n) = file.read(&mut head) else {
+            continue;
+        };
+        if looks_like_spawnable(&head[..n]) {
+            mark_executable(&path);
+        }
+    }
+}
+
+/// Download the archive into `tmp_dir`, extract it into `staging`, and validate
+/// that `cmd` resolves to a regular file inside `staging`. Kept separate from
+/// the swap logic so the caller can clean up staging on any failure.
+///
+/// Used by the legacy desktop `install_registry_binary` command. The new
+/// `AcpInstallService` uses injected `Downloader`/`Extractor` traits for
+/// testability; its production `Downloader` impl reuses this function's
+/// streaming + cap logic.
+pub(crate) async fn stage_archive(
+    archive_url: &str,
+    cmd: &str,
+    tmp_dir: &Path,
+    staging: &Path,
+) -> Result<PathBuf, String> {
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(FETCH_TIMEOUT_SECS))
+        .build()
+        .map_err(|e| format!("http client: {e}"))?;
+
+    let response = client
+        .get(archive_url)
+        .send()
+        .await
+        .map_err(|e| format!("download failed: {e}"))?;
+    if !response.status().is_success() {
+        return Err(format!("download returned HTTP {}", response.status()));
+    }
+
+    // Stream the body to disk, enforcing the download cap incrementally.
+    let archive_name = archive_url
+        .rsplit('/')
+        .next()
+        .filter(|s| !s.is_empty())
+        .unwrap_or("archive.bin");
+    let archive_path = tmp_dir.join(archive_name);
+    let mut file = std::fs::File::create(&archive_path).map_err(|e| e.to_string())?;
+    let mut downloaded: u64 = 0;
+    let mut stream = response.bytes_stream();
+    while let Some(chunk) = stream.next().await {
+        let chunk = chunk.map_err(|e| format!("download stream: {e}"))?;
+        downloaded += chunk.len() as u64;
+        if downloaded > MAX_ARCHIVE_BYTES {
+            return Err("archive too large".to_string());
+        }
+        file.write_all(&chunk).map_err(|e| e.to_string())?;
+    }
+    file.flush().map_err(|e| e.to_string())?;
+    drop(file);
+
+    extract_archive(&archive_path, staging)?;
+    // Validate the cmd resolves to a regular file inside the staging dir.
+    let staged_program = resolve_cmd_in_root(staging, cmd)?;
+    mark_executable(&staged_program);
+    mark_spawnables_in_tree(staging);
+    Ok(staged_program)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn looks_like_spawnable_detects_shebang_elf_macho() {
+        assert!(looks_like_spawnable(b"#!/bin/bash\n"));
+        assert!(looks_like_spawnable(b"\x7fELF\x02\x01"));
+        assert!(looks_like_spawnable(&[0xcf, 0xfa, 0xed, 0xfe, 0, 0]));
+        assert!(!looks_like_spawnable(b"{\"ok\":true}"));
+        assert!(!looks_like_spawnable(b""));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn mark_spawnables_makes_companion_node_executable() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = std::env::temp_dir().join(format!("termul-acp-exec-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let node = dir.join("node");
+        let script = dir.join("cursor-agent");
+        let text = dir.join("readme.txt");
+
+        {
+            let mut f = std::fs::File::create(&node).unwrap();
+            f.write_all(&[0xcf, 0xfa, 0xed, 0xfe, 0, 0, 0, 0]).unwrap();
+        }
+        {
+            let mut f = std::fs::File::create(&script).unwrap();
+            f.write_all(b"#!/usr/bin/env bash\necho hi\n").unwrap();
+        }
+        std::fs::write(&text, b"hello").unwrap();
+
+        for p in [&node, &script, &text] {
+            std::fs::set_permissions(p, std::fs::Permissions::from_mode(0o644)).unwrap();
+        }
+
+        mark_spawnables_in_tree(&dir);
+
+        let node_mode = std::fs::metadata(&node).unwrap().permissions().mode() & 0o111;
+        let script_mode = std::fs::metadata(&script).unwrap().permissions().mode() & 0o111;
+        let text_mode = std::fs::metadata(&text).unwrap().permissions().mode() & 0o111;
+        let _ = std::fs::remove_dir_all(&dir);
+
+        assert_eq!(node_mode, 0o111);
+        assert_eq!(script_mode, 0o111);
+        assert_eq!(text_mode, 0);
+    }
+
+    #[test]
+    fn extract_archive_rejects_unknown_extension() {
+        let dir = std::env::temp_dir().join(format!("termul-acp-rej-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let archive = dir.join("evil.7z");
+        std::fs::write(&archive, b"").unwrap();
+        let dest = dir.join("dest");
+        std::fs::create_dir_all(&dest).unwrap();
+        let result = extract_archive(&archive, &dest);
+        assert!(result.is_err());
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+}

--- a/src-tauri/src/acp/catalog.rs
+++ b/src-tauri/src/acp/catalog.rs
@@ -1,0 +1,1178 @@
+//! Host-owned ACP catalog service (CAP-6 / Story 8).
+//!
+//! Moves catalog loading, host capability resolution (OS/arch/runtime), and
+//! per-agent installability computation from the renderer to the host. The host
+//! embeds the trusted `agents.json` at build time (`include_str!`), optionally
+//! augments with the explicitly-approved CDN registry snapshot (reusing
+//! `acp_registry_snapshot`), probes real runtime availability, computes the
+//! 5-state `SupportedAcpAgentStatus` per agent, and serves the resolved catalog
+//! via a single `list_catalog()` operation exposed across all three transports
+//! (Tauri command `acp_list_catalog`, HTTP `GET /acp/catalog`, WS
+//! `list_acp_catalog`).
+//!
+//! # Storage layout
+//!
+//! The service root is `<app_data_dir>/acp-catalog` (desktop) or
+//! `<service_account_state_dir>/acp-catalog` (standalone). The opt-in config
+//! file lives at `root/acp-catalog-config.json`, written via
+//! [`crate::acp::atomic_file::replace`]. The CDN snapshot cache lives at
+//! `root/acp-registry-snapshot-cache.json` (reuses the
+//! `acp_registry_snapshot` cache format so a desktop that already fetched the
+//! snapshot under `app_cache_dir` does not collide — the catalog root's cache
+//! is independent).
+//!
+//! # Concurrency
+//!
+//! `AcpCatalogService::open` returns an `Arc<Self>` shared by the host runtime
+//! (desktop OR standalone, never both). The probe cache is an `RwLock<Option<…>>`
+//! so concurrent `list_catalog` callers share the cached probes within the TTL;
+//! a `refresh=true` force-refresh invalidates the cache and re-probes.
+//!
+//! # What the catalog NEVER carries
+//!
+//! `AgentConfig.env` (carries API keys), resolved absolute executable paths
+//! (leaks host filesystem layout), or non-HTTPS download URLs. The catalog is
+//! credential-free, path-free, read-only host introspection.
+
+use std::fs;
+use std::io;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+
+use parking_lot::RwLock;
+use serde::{Deserialize, Serialize};
+
+use crate::acp::atomic_file;
+use crate::acp_registry_snapshot;
+
+// ---------------------------------------------------------------------------
+// Wire types (camelCase serde, byte-identical to the TS shapes)
+// ---------------------------------------------------------------------------
+
+/// The 5-state per-agent installability status. Mirrors the existing renderer
+/// `SupportedAcpAgentStatus` (`supported-acp-agents.ts:70-80`). Serialized as
+/// kebab-case to match the TS union
+/// `'ready' | 'install-required' | 'needs-runtime' | 'manual-install' |
+/// 'unavailable'`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum SupportedAcpAgentStatus {
+    Ready,
+    InstallRequired,
+    NeedsRuntime,
+    ManualInstall,
+    Unavailable,
+}
+
+/// Runtime availability on the host. Extends the existing `AcpRuntimeProbe`
+/// (`config.rs:141-154`) to cover `node`/`bun`/`python3` + named binary probes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CatalogRuntimeAvailability {
+    pub npx: bool,
+    pub uvx: bool,
+    pub node: bool,
+    pub bun: bool,
+    pub python3: bool,
+}
+
+/// Host capability block: OS + arch + runtime availability. The host is the
+/// single source of truth — web clients never probe `@tauri-apps/plugin-os` or
+/// PATH locally.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct HostCapability {
+    pub os: String,
+    pub arch: String,
+    pub runtimes: CatalogRuntimeAvailability,
+}
+
+/// A platform target pair (e.g. `{ os: "linux", arch: "x86_64" }`).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PlatformTarget {
+    pub os: String,
+    pub arch: String,
+}
+
+/// Whether a catalog entry came from the trusted bundled baseline or the
+/// explicitly-approved CDN registry augmentation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum CatalogSource {
+    Bundled,
+    Registry,
+}
+
+/// One resolved catalog entry. Carries identity + distribution metadata +
+/// computed `status` + `runtimeRequirements` + `platformTargets`. Never
+/// carries `AgentConfig.env` (API keys) or resolved absolute executable paths.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CatalogAgent {
+    pub id: String,
+    pub name: String,
+    pub version: String,
+    pub description: String,
+    pub source: CatalogSource,
+    pub distribution: serde_json::Value,
+    pub runtime_requirements: Vec<String>,
+    pub status: SupportedAcpAgentStatus,
+    pub platform_targets: Vec<PlatformTarget>,
+}
+
+/// The resolved catalog payload served across all three transports.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AcpCatalog {
+    pub host: HostCapability,
+    pub agents: Vec<CatalogAgent>,
+}
+
+/// `POST /acp/catalog/opt-in` + WS `set_catalog_opt_in` request body.
+/// `deny_unknown_fields` rejects an over-serialized payload (e.g.
+/// `{ enabled: true, extra: "junk" }`) loudly at the host boundary — maps to
+/// `VALIDATION_ERROR`.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct SetCatalogOptInRequest {
+    pub enabled: bool,
+}
+
+// ---------------------------------------------------------------------------
+// Opt-in config persistence
+// ---------------------------------------------------------------------------
+
+/// Current on-disk opt-in config schema version.
+const CATALOG_CONFIG_SCHEMA_VERSION: u32 = 1;
+
+/// Schema-versioned envelope for the opt-in config file. Mirrors the
+/// `WorkspaceManifestFile` pattern so future migrations route through a
+/// `migrate` hook. A corrupt file is backed up via
+/// [`atomic_file::backup_corrupt`] then treated as fresh (opt-in = false).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct CatalogConfigFile {
+    pub schema_version: u32,
+    pub opt_in_cdn: bool,
+}
+
+const CONFIG_FILENAME: &str = "acp-catalog-config.json";
+const SNAPSHOT_CACHE_FILENAME: &str = "acp-registry-snapshot-cache.json";
+
+// ---------------------------------------------------------------------------
+// Bundled catalog (trusted baseline, embedded at build time)
+// ---------------------------------------------------------------------------
+
+/// The trusted baseline catalog, embedded at build time via `include_str!`.
+/// The path is relative to this file and resolves to
+/// `src/renderer/assets/agent-icons/acp/agents.json` within the workspace.
+/// Cannot be tampered without rebuilding the host binary.
+const BUNDLED_CATALOG_JSON: &str =
+    include_str!("../../../src/renderer/assets/agent-icons/acp/agents.json");
+
+/// A raw bundled agent entry (the shape of `agents.json`).
+#[derive(Debug, Clone, Deserialize)]
+struct BundledAgent {
+    id: String,
+    name: String,
+    #[serde(default)]
+    version: String,
+    #[serde(default)]
+    description: String,
+    distribution: serde_json::Value,
+}
+
+// ---------------------------------------------------------------------------
+// Probe cache
+// ---------------------------------------------------------------------------
+
+/// Cached probe results + the resolved catalog. Held under an `RwLock` so
+/// concurrent `list_catalog` callers share the cached probes within the TTL.
+struct CachedCatalog {
+    catalog: AcpCatalog,
+    computed_at: Instant,
+}
+
+/// Probe cache TTL — 60s. Avoids re-probing PATH on every catalog request; a
+/// `refresh=true` force-refresh invalidates the cache and re-probes.
+const PROBE_TTL: Duration = Duration::from_secs(60);
+
+// ---------------------------------------------------------------------------
+// Service
+// ---------------------------------------------------------------------------
+
+/// Host-owned ACP catalog service. One instance per host runtime (desktop OR
+/// standalone `termul-server`, never shared across processes). Constructed via
+/// [`AcpCatalogService::open`], which creates the root directory + idempotent
+/// re-open (mirrors `WorkspaceManifestService::open`).
+///
+/// The service:
+/// 1. Parses the bundled `agents.json` (embedded via `include_str!`) at
+///    construction — a parse failure is fatal (should not happen with a
+///    build-time-embedded file) and surfaces as `CATALOG_LOAD_FAILED`.
+/// 2. Optionally augments with the CDN registry snapshot (gated on the
+///    host-persisted opt-in flag) via
+///    `acp_registry_snapshot::fetch_acp_registry_snapshot_with_cache_path`.
+/// 3. Probes real runtime availability (`npx`/`uvx`/`node`/`bun`/`python3`) +
+///    named binary probes (PATH-only — never executes untrusted code).
+/// 4. Computes the 5-state `SupportedAcpAgentStatus` per agent.
+/// 5. Caches the resolved catalog in-process for 60s; `refresh=true`
+///    force-refreshes.
+pub struct AcpCatalogService {
+    root: PathBuf,
+    cache: RwLock<Option<CachedCatalog>>,
+}
+
+impl AcpCatalogService {
+    /// Open (or re-open) an acp-catalog root. Creates the directory if
+    /// missing; idempotent re-open returns a fresh `Arc<Self>` over the same
+    /// root. Mirrors `WorkspaceManifestService::open`: Unix 0700 root, create
+    /// the dir, return an `Arc<Self>`. A non-directory root is an error so a
+    /// misconfigured host fails loudly at startup.
+    pub async fn open(root: PathBuf) -> io::Result<Arc<Self>> {
+        if root.exists() && !root.is_dir() {
+            return Err(io::Error::other(format!(
+                "acp-catalog root '{}' is not a directory",
+                root.display()
+            )));
+        }
+        #[cfg(unix)]
+        {
+            std::os::unix::fs::DirBuilder::new()
+                .mode(0o700)
+                .recursive(true)
+                .create(&root)?;
+        }
+        #[cfg(not(unix))]
+        {
+            fs::create_dir_all(&root)?;
+        }
+        // Eagerly parse the bundled catalog at startup so a malformed
+        // `include_str!` (should not happen — it is build-time-trusted) is
+        // logged immediately. The parse still re-runs per `list_catalog` call,
+        // so a failure also surfaces as `CatalogError::BundledParse` to the
+        // first caller; this log only advances the visibility to startup.
+        if let Err(error) = parse_bundled_catalog() {
+            log::error!(
+                "[acp-catalog] bundled catalog parse failed (should not happen with include_str!): {error}"
+            );
+        }
+        log::info!("[acp-catalog] service ready root={}", root.display());
+        Ok(Arc::new(Self {
+            root,
+            cache: RwLock::new(None),
+        }))
+    }
+
+    /// The catalog root directory.
+    #[must_use]
+    pub fn root(&self) -> &Path {
+        &self.root
+    }
+
+    /// Path to the opt-in config file.
+    fn config_path(&self) -> PathBuf {
+        self.root.join(CONFIG_FILENAME)
+    }
+
+    /// Path to the CDN snapshot cache file (reuses the
+    /// `acp_registry_snapshot` cache format).
+    fn snapshot_cache_path(&self) -> PathBuf {
+        self.root.join(SNAPSHOT_CACHE_FILENAME)
+    }
+
+    /// Resolve the catalog. Returns the cached catalog if fresh (within TTL);
+    /// otherwise re-probes + re-computes + re-caches. `refresh=true`
+    /// force-refreshes (invalidates the cache + re-probes).
+    pub async fn list_catalog(
+        self: &Arc<Self>,
+        refresh: bool,
+    ) -> Result<AcpCatalog, CatalogError> {
+        // Fast path: return the cached catalog if fresh.
+        if !refresh {
+            let cache = self.cache.read();
+            if let Some(cached) = cache.as_ref() {
+                if cached.computed_at.elapsed() < PROBE_TTL {
+                    return Ok(cached.catalog.clone());
+                }
+            }
+        }
+        // Slow path: re-probe + re-compute + re-cache.
+        let catalog = self.resolve_catalog().await?;
+        let mut cache = self.cache.write();
+        *cache = Some(CachedCatalog {
+            catalog: catalog.clone(),
+            computed_at: Instant::now(),
+        });
+        Ok(catalog)
+    }
+
+    /// Read the opt-in flag. Returns `false` when the file is missing (the
+    /// default — CDN augmentation is off) or when the file is corrupt (backed
+    /// up + treated as fresh, mirroring `WorkspaceManifestService`).
+    pub fn is_opt_in(&self) -> bool {
+        match self.read_opt_in_blocking() {
+            Ok(enabled) => enabled,
+            Err(error) => {
+                log::warn!(
+                    "[acp-catalog] opt-in read failed (defaulting to false): {error}"
+                );
+                false
+            }
+        }
+    }
+
+    /// Set the opt-in flag. Persists to `root/acp-catalog-config.json` via
+    /// `atomic_file::replace` (crash-consistent). A corrupt file on the
+    /// read-back is backed up + treated as fresh.
+    pub fn set_opt_in(&self, enabled: bool) -> Result<(), CatalogError> {
+        let path = self.config_path();
+        let envelope = CatalogConfigFile {
+            schema_version: CATALOG_CONFIG_SCHEMA_VERSION,
+            opt_in_cdn: enabled,
+        };
+        let serialized = serde_json::to_vec_pretty(&envelope)?;
+        atomic_file::replace(&path, &serialized)?;
+        // Invalidate the probe cache so the next `list_catalog` re-evaluates
+        // the CDN augmentation (the opt-in change flips whether CDN entries
+        // are included).
+        let mut cache = self.cache.write();
+        *cache = None;
+        log::info!("[acp-catalog] opt-in set enabled={enabled}");
+        Ok(())
+    }
+
+    // --- Internals -----------------------------------------------------------
+
+    /// Read the opt-in flag (blocking — the file is tiny JSON, sub-ms).
+    fn read_opt_in_blocking(&self) -> Result<bool, CatalogError> {
+        let path = self.config_path();
+        let bytes = match fs::read(&path) {
+            Ok(bytes) => bytes,
+            Err(error) if error.kind() == io::ErrorKind::NotFound => {
+                // Missing file = opt-in is off (the default).
+                return Ok(false);
+            }
+            Err(error) => return Err(error.into()),
+        };
+        match serde_json::from_slice::<CatalogConfigFile>(&bytes) {
+            Ok(file) if file.schema_version == CATALOG_CONFIG_SCHEMA_VERSION => Ok(file.opt_in_cdn),
+            Ok(file) => {
+                log::warn!(
+                    "[acp-catalog] opt-in bad schema_version expected={} found={} — backing up + fresh start",
+                    CATALOG_CONFIG_SCHEMA_VERSION,
+                    file.schema_version
+                );
+                let _ = atomic_file::backup_corrupt(&path, &bytes);
+                Ok(false)
+            }
+            Err(error) => {
+                log::warn!(
+                    "[acp-catalog] opt-in file corrupt error={error} — backing up + fresh start"
+                );
+                let _ = atomic_file::backup_corrupt(&path, &bytes);
+                Ok(false)
+            }
+        }
+    }
+
+    /// Resolve the full catalog: probe runtimes + parse bundled + optional CDN
+    /// augmentation + per-agent status computation.
+    async fn resolve_catalog(&self) -> Result<AcpCatalog, CatalogError> {
+        let runtimes = probe_runtimes();
+        let host = HostCapability {
+            os: host_os().to_string(),
+            arch: std::env::consts::ARCH.to_string(),
+            runtimes,
+        };
+        let platform_arch = host_platform_arch();
+
+        // Parse the bundled catalog (trusted baseline).
+        let bundled = parse_bundled_catalog()?;
+
+        // Optional CDN augmentation (gated on the host-persisted opt-in).
+        let mut agents: Vec<CatalogAgent> = bundled
+            .iter()
+            .map(|agent| compute_catalog_agent(agent, &host, &platform_arch, CatalogSource::Bundled))
+            .collect();
+
+        let bundled_count = agents.len();
+        if self.is_opt_in() {
+            match acp_registry_snapshot::fetch_acp_registry_snapshot_with_cache_path(
+                &self.snapshot_cache_path(),
+                false,
+            )
+            .await
+            {
+                Ok(snapshot) => {
+                    // Collect bundled ids into an owned set so we can mutate
+                    // `agents` (push CDN entries) without holding an immutable
+                    // borrow of `agents` (borrow checker: `seen` borrows from
+                    // `agents` via `iter()`, which conflicts with `push`).
+                    let seen: std::collections::HashSet<String> =
+                        agents.iter().map(|a| a.id.clone()).collect();
+                    let mut cdn_count = 0;
+                    for snapshot_agent in &snapshot.agents {
+                        if seen.contains(&snapshot_agent.id) {
+                            continue; // bundled entry wins on id collision.
+                        }
+                        // Validate the CDN entry (reuse the snapshot's
+                        // `is_safe_agent_id` + `sanitize_distribution`).
+                        if !acp_registry_snapshot::is_safe_agent_id(&snapshot_agent.id) {
+                            continue;
+                        }
+                        let Some(distribution) =
+                            acp_registry_snapshot::sanitize_distribution(&snapshot_agent.distribution)
+                        else {
+                            continue;
+                        };
+                        let entry = BundledAgent {
+                            id: snapshot_agent.id.clone(),
+                            name: snapshot_agent.name.clone(),
+                            version: snapshot_agent.version.clone(),
+                            description: snapshot_agent.description.clone(),
+                            distribution,
+                        };
+                        agents.push(compute_catalog_agent(
+                            &entry,
+                            &host,
+                            &platform_arch,
+                            CatalogSource::Registry,
+                        ));
+                        cdn_count += 1;
+                    }
+                    log::info!(
+                        "[acp-catalog] resolved bundled={} cdn={} total={}",
+                        bundled_count,
+                        cdn_count,
+                        agents.len()
+                    );
+                }
+                Err(error) => {
+                    // CDN fetch failed — degrade gracefully to bundled-only.
+                    // The client receives success (no error); a warn log
+                    // records the CDN failure.
+                    log::warn!(
+                        "[acp-catalog] CDN fetch failed (degrading to bundled-only): {error}"
+                    );
+                }
+            }
+        } else {
+            log::debug!(
+                "[acp-catalog] opt-in off — serving bundled-only ({} agents)",
+                bundled_count
+            );
+        }
+
+        // Sort by name for stable display order (mirrors the renderer's
+        // `buildSupportedAcpAgents` sort).
+        agents.sort_by(|a, b| a.name.cmp(&b.name));
+
+        Ok(AcpCatalog { host, agents })
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Errors
+// ---------------------------------------------------------------------------
+
+/// Catalog load / persistence failure.
+#[derive(Debug)]
+pub enum CatalogError {
+    /// The bundled `agents.json` failed to parse (should not happen with
+    /// `include_str!`).
+    BundledParse(serde_json::Error),
+    /// Filesystem read/write failure (permission, disk full, …).
+    Io(io::Error),
+}
+
+impl std::fmt::Display for CatalogError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::BundledParse(error) => {
+                write!(f, "bundled catalog parse failed: {error}")
+            }
+            Self::Io(error) => write!(f, "acp-catalog io error: {error}"),
+        }
+    }
+}
+
+impl std::error::Error for CatalogError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::BundledParse(error) => Some(error),
+            Self::Io(error) => Some(error),
+        }
+    }
+}
+
+impl From<io::Error> for CatalogError {
+    fn from(value: io::Error) -> Self {
+        Self::Io(value)
+    }
+}
+
+impl From<serde_json::Error> for CatalogError {
+    fn from(value: serde_json::Error) -> Self {
+        Self::BundledParse(value)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Host capability + probe helpers
+// ---------------------------------------------------------------------------
+
+/// The host OS string. `std::env::consts::OS` returns `"linux"` / `"macos"` /
+/// `"windows"`. The bundled catalog's binary map keys use `"darwin"` for macOS
+/// (mirrors `currentPlatformArch()` in `acp-registry.ts:127-131`), so the
+/// `host_platform_arch()` helper maps `"macos"` → `"darwin"` for the binary
+/// map lookup. The `host.os` field in the catalog response keeps the
+/// `std::env::consts::OS` value (the raw OS string the web client can display).
+fn host_os() -> &'static str {
+    std::env::consts::OS
+}
+
+/// The platform-arch key for the bundled catalog's binary map lookup.
+/// Mirrors `currentPlatformArch()` in `acp-registry.ts:127-131`: maps
+/// `"macos"` → `"darwin"` and returns `"{os}-{arch}"`.
+fn host_platform_arch() -> String {
+    let os = if std::env::consts::OS == "macos" {
+        "darwin"
+    } else {
+        std::env::consts::OS
+    };
+    format!("{}-{}", os, std::env::consts::ARCH)
+}
+
+/// Probe runtime availability. PATH-only probes — never executes untrusted
+/// code (no `npx --version` subprocess that could hang or prompt). Reuses
+/// `crate::acp::config::is_registry_launcher_on_path` which delegates to
+/// `pty::manager::resolve_spawn_program` (Windows) +
+/// `resolve_executable_in_path` (non-Windows).
+fn probe_runtimes() -> CatalogRuntimeAvailability {
+    CatalogRuntimeAvailability {
+        npx: crate::acp::config::is_registry_launcher_on_path("npx"),
+        uvx: crate::acp::config::is_registry_launcher_on_path("uvx"),
+        node: crate::acp::config::is_registry_launcher_on_path("node"),
+        bun: crate::acp::config::is_registry_launcher_on_path("bun"),
+        python3: crate::acp::config::is_registry_launcher_on_path("python3"),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Bundled catalog parsing
+// ---------------------------------------------------------------------------
+
+/// Parse the embedded `agents.json` into typed entries. Called at construction
+/// (eager parse so a malformed file surfaces at startup) and on each catalog
+/// resolution (cheap — the file is small, ~10KB).
+fn parse_bundled_catalog() -> Result<Vec<BundledAgent>, serde_json::Error> {
+    let agents: Vec<BundledAgent> = serde_json::from_str(BUNDLED_CATALOG_JSON)?;
+    Ok(agents)
+}
+
+// ---------------------------------------------------------------------------
+// Per-agent status computation
+// ---------------------------------------------------------------------------
+
+/// Compute the `CatalogAgent` for a bundled or CDN-sourced agent entry.
+/// Determines the preferred distribution (npx > uvx > binary), probes runtime
+/// availability + binary-on-PATH, and computes the 5-state
+/// `SupportedAcpAgentStatus`.
+fn compute_catalog_agent(
+    agent: &BundledAgent,
+    host: &HostCapability,
+    platform_arch: &str,
+    source: CatalogSource,
+) -> CatalogAgent {
+    let dist = &agent.distribution;
+    let dist_obj = dist.as_object();
+
+    // Determine the preferred distribution + runtime requirements.
+    let has_npx = dist_obj.is_some_and(|o| o.contains_key("npx"));
+    let has_uvx = dist_obj.is_some_and(|o| o.contains_key("uvx"));
+    let has_binary = dist_obj.is_some_and(|o| o.contains_key("binary"));
+
+    let (runtime_reqs, status) = if has_npx {
+        // npx is the preferred distribution.
+        (vec!["npx".to_string()], if host.runtimes.npx {
+            SupportedAcpAgentStatus::Ready
+        } else {
+            SupportedAcpAgentStatus::NeedsRuntime
+        })
+    } else if has_uvx {
+        (vec!["uvx".to_string()], if host.runtimes.uvx {
+            SupportedAcpAgentStatus::Ready
+        } else {
+            SupportedAcpAgentStatus::NeedsRuntime
+        })
+    } else if has_binary {
+        // Binary-only distribution. Look up the platform target.
+        let target = dist_obj
+            .and_then(|o| o.get("binary"))
+            .and_then(|b| b.as_object())
+            .and_then(|b| b.get(platform_arch))
+            .and_then(|t| t.as_object());
+
+        let status =
+            compute_binary_status(target, crate::acp::config::is_registry_launcher_on_path);
+        (Vec::new(), status)
+    } else {
+        // No recognized distribution kind.
+        (Vec::new(), SupportedAcpAgentStatus::Unavailable)
+    };
+
+    // Platform targets: empty for npx/uvx (works on any platform where the
+    // runtime exists); parsed binary keys for binary distributions.
+    let platform_targets = if has_binary && !has_npx && !has_uvx {
+        parse_binary_platform_targets(dist)
+    } else {
+        Vec::new()
+    };
+
+    CatalogAgent {
+        id: agent.id.clone(),
+        name: agent.name.clone(),
+        version: agent.version.clone(),
+        description: agent.description.clone(),
+        source,
+        distribution: dist.clone(),
+        runtime_requirements: runtime_reqs,
+        status,
+        platform_targets,
+    }
+}
+
+/// Parse the binary distribution map keys into `PlatformTarget` pairs.
+/// Keys are `"{os}-{arch}"` (e.g. `"darwin-aarch64"`, `"linux-x86_64"`).
+fn parse_binary_platform_targets(dist: &serde_json::Value) -> Vec<PlatformTarget> {
+    let Some(binary) = dist.get("binary").and_then(|b| b.as_object()) else {
+        return Vec::new();
+    };
+    let mut targets = Vec::new();
+    for key in binary.keys() {
+        if let Some((os, arch)) = key.split_once('-') {
+            targets.push(PlatformTarget {
+                os: os.to_string(),
+                arch: arch.to_string(),
+            });
+        }
+    }
+    targets
+}
+
+/// Compute the status for a binary-distributed agent.
+/// - Binary on PATH (bare name) → `ready`
+/// - Binary not on PATH + HTTPS archive → `install-required`
+/// - Binary not on PATH + no archive → `manual-install`
+/// - No platform target → `unavailable`
+///
+/// The PATH probe is injected so the "binary on PATH → ready" branch (matrix
+/// row 7) is unit-testable without a real binary on PATH.
+fn compute_binary_status(
+    target: Option<&serde_json::Map<String, serde_json::Value>>,
+    probe: impl Fn(&str) -> bool,
+) -> SupportedAcpAgentStatus {
+    let Some(target) = target else {
+        return SupportedAcpAgentStatus::Unavailable;
+    };
+    let cmd = target.get("cmd").and_then(|c| c.as_str()).unwrap_or("");
+    let archive = target.get("archive").and_then(|a| a.as_str());
+
+    // If the command is a bare name (not a relative path), probe it on PATH.
+    let is_relative = cmd.starts_with("./") || cmd.starts_with(".\\");
+    if !is_relative && !cmd.is_empty() && probe(cmd) {
+        return SupportedAcpAgentStatus::Ready;
+    }
+
+    // Binary not on PATH. Check for an installable archive (HTTPS + allowed
+    // format). This is Story 9's install path concern; the catalog only
+    // reports the status, it does not perform the install.
+    if let Some(url) = archive {
+        if is_https_archive_url(url) {
+            return SupportedAcpAgentStatus::InstallRequired;
+        }
+    }
+    SupportedAcpAgentStatus::ManualInstall
+}
+
+/// Check if a URL is HTTPS + an allowed archive format (zip / tar.gz / tgz).
+/// Mirrors `supportedArchiveUrl` in `acp-registry.ts:148-154`.
+fn is_https_archive_url(url: &str) -> bool {
+    if !url.starts_with("https://") {
+        return false;
+    }
+    let path = url.split(['?', '#']).next().unwrap_or(url).to_lowercase();
+    path.ends_with(".zip") || path.ends_with(".tar.gz") || path.ends_with(".tgz")
+}
+
+/// Epoch-millis timestamp (mirrors `workspace_manifest::now_millis`).
+#[allow(dead_code)]
+fn now_millis() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0)
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn temp_dir(label: &str) -> PathBuf {
+        let path = std::env::temp_dir().join(format!(
+            "termul-acp-catalog-{label}-{}-{}",
+            std::process::id(),
+            now_millis()
+        ));
+        fs::create_dir_all(&path).unwrap();
+        path
+    }
+
+    fn sample_agent(id: &str, distribution: serde_json::Value) -> BundledAgent {
+        BundledAgent {
+            id: id.to_string(),
+            name: id.to_string(),
+            version: "1.0.0".to_string(),
+            description: "test".to_string(),
+            distribution,
+        }
+    }
+
+    fn host_with_runtimes(npx: bool, uvx: bool) -> HostCapability {
+        HostCapability {
+            os: "linux".to_string(),
+            arch: "x86_64".to_string(),
+            runtimes: CatalogRuntimeAvailability {
+                npx,
+                uvx,
+                node: true,
+                bun: false,
+                python3: true,
+            },
+        }
+    }
+
+    // ---- Bundled catalog parse ----
+
+    #[test]
+    fn bundled_catalog_parses_successfully() {
+        let agents = parse_bundled_catalog().unwrap();
+        assert!(!agents.is_empty(), "bundled catalog should not be empty");
+        // Every entry must have an id + name + distribution.
+        for agent in &agents {
+            assert!(!agent.id.is_empty(), "agent id must not be empty");
+            assert!(!agent.name.is_empty(), "agent name must not be empty");
+            assert!(
+                agent.distribution.is_object(),
+                "agent distribution must be an object"
+            );
+        }
+    }
+
+    #[test]
+    fn bundled_catalog_includes_known_agents() {
+        let agents = parse_bundled_catalog().unwrap();
+        let ids: Vec<&str> = agents.iter().map(|a| a.id.as_str()).collect();
+        assert!(ids.contains(&"claude-acp"), "claude-acp must be in the bundled catalog");
+        assert!(ids.contains(&"gemini"), "gemini must be in the bundled catalog");
+    }
+
+    // ---- I/O matrix: npx on PATH → ready ----
+
+    #[test]
+    fn npx_agent_with_npx_on_path_is_ready() {
+        let agent = sample_agent(
+            "test-npx",
+            serde_json::json!({ "npx": { "package": "test@1.0.0" } }),
+        );
+        let host = host_with_runtimes(true, false);
+        let catalog_agent = compute_catalog_agent(&agent, &host, "linux-x86_64", CatalogSource::Bundled);
+        assert_eq!(catalog_agent.status, SupportedAcpAgentStatus::Ready);
+        assert_eq!(catalog_agent.runtime_requirements, vec!["npx".to_string()]);
+        assert_eq!(catalog_agent.source, CatalogSource::Bundled);
+    }
+
+    // ---- I/O matrix: npx missing → needs-runtime ----
+
+    #[test]
+    fn npx_agent_without_npx_is_needs_runtime() {
+        let agent = sample_agent(
+            "test-npx",
+            serde_json::json!({ "npx": { "package": "test@1.0.0" } }),
+        );
+        let host = host_with_runtimes(false, false);
+        let catalog_agent = compute_catalog_agent(&agent, &host, "linux-x86_64", CatalogSource::Bundled);
+        assert_eq!(catalog_agent.status, SupportedAcpAgentStatus::NeedsRuntime);
+    }
+
+    // ---- I/O matrix: uvx on PATH → ready ----
+
+    #[test]
+    fn uvx_agent_with_uvx_on_path_is_ready() {
+        let agent = sample_agent(
+            "test-uvx",
+            serde_json::json!({ "uvx": { "package": "test==1.0.0" } }),
+        );
+        let host = host_with_runtimes(false, true);
+        let catalog_agent = compute_catalog_agent(&agent, &host, "linux-x86_64", CatalogSource::Bundled);
+        assert_eq!(catalog_agent.status, SupportedAcpAgentStatus::Ready);
+        assert_eq!(catalog_agent.runtime_requirements, vec!["uvx".to_string()]);
+    }
+
+    // ---- I/O matrix: uvx missing → needs-runtime ----
+
+    #[test]
+    fn uvx_agent_without_uvx_is_needs_runtime() {
+        let agent = sample_agent(
+            "test-uvx",
+            serde_json::json!({ "uvx": { "package": "test==1.0.0" } }),
+        );
+        let host = host_with_runtimes(false, false);
+        let catalog_agent = compute_catalog_agent(&agent, &host, "linux-x86_64", CatalogSource::Bundled);
+        assert_eq!(catalog_agent.status, SupportedAcpAgentStatus::NeedsRuntime);
+    }
+
+    // ---- I/O matrix: binary with archive → install-required ----
+
+    #[test]
+    fn binary_agent_with_https_archive_is_install_required() {
+        let agent = sample_agent(
+            "test-binary",
+            serde_json::json!({
+                "binary": {
+                    "linux-x86_64": {
+                        "cmd": "./test-agent",
+                        "archive": "https://example.com/test-agent-linux-x86_64.tar.gz"
+                    }
+                }
+            }),
+        );
+        let host = host_with_runtimes(false, false);
+        let catalog_agent = compute_catalog_agent(&agent, &host, "linux-x86_64", CatalogSource::Bundled);
+        assert_eq!(catalog_agent.status, SupportedAcpAgentStatus::InstallRequired);
+        assert!(!catalog_agent.platform_targets.is_empty());
+    }
+
+    // ---- I/O matrix: binary without archive → manual-install ----
+
+    #[test]
+    fn binary_agent_without_archive_is_manual_install() {
+        let agent = sample_agent(
+            "test-binary",
+            serde_json::json!({
+                "binary": {
+                    "linux-x86_64": {
+                        "cmd": "./test-agent"
+                    }
+                }
+            }),
+        );
+        let host = host_with_runtimes(false, false);
+        let catalog_agent = compute_catalog_agent(&agent, &host, "linux-x86_64", CatalogSource::Bundled);
+        assert_eq!(catalog_agent.status, SupportedAcpAgentStatus::ManualInstall);
+    }
+
+    // ---- I/O matrix: no platform target → unavailable ----
+
+    #[test]
+    fn binary_agent_no_matching_platform_is_unavailable() {
+        let agent = sample_agent(
+            "test-binary",
+            serde_json::json!({
+                "binary": {
+                    "darwin-aarch64": {
+                        "cmd": "./test-agent",
+                        "archive": "https://example.com/test-agent-darwin.tar.gz"
+                    }
+                }
+            }),
+        );
+        let host = host_with_runtimes(false, false);
+        let catalog_agent = compute_catalog_agent(&agent, &host, "linux-x86_64", CatalogSource::Bundled);
+        assert_eq!(catalog_agent.status, SupportedAcpAgentStatus::Unavailable);
+    }
+
+    // ---- I/O matrix: binary bare-name on PATH → ready (probe-injected) ----
+
+    #[test]
+    fn binary_agent_bare_name_on_path_is_ready() {
+        // A bare-name (non-relative) cmd with an installable archive. When the
+        // injected probe reports the binary is on PATH, the status is `ready`
+        // (the archive is not used). When the probe reports it is NOT on PATH,
+        // the status falls through to `install-required` (HTTPS archive).
+        let target: serde_json::Map<String, serde_json::Value> = serde_json::json!({
+            "cmd": "test-agent",
+            "archive": "https://example.com/test-agent.zip"
+        })
+        .as_object()
+        .unwrap()
+        .clone();
+
+        assert_eq!(
+            compute_binary_status(Some(&target), |_| true),
+            SupportedAcpAgentStatus::Ready
+        );
+
+        // When the probe reports it is NOT on PATH, the status falls through
+        // to `install-required` (HTTPS archive).
+        assert_eq!(
+            compute_binary_status(Some(&target), |_| false),
+            SupportedAcpAgentStatus::InstallRequired
+        );
+    }
+
+    // ---- I/O matrix: opt-in path succeeds (degrades gracefully if CDN fails) ----
+
+    // ---- I/O matrix: opt-in persistence + corrupt-file backup ----
+
+    #[tokio::test]
+    async fn opt_in_persistence_round_trip() {
+        let root = temp_dir("opt-in-round-trip");
+        let service = AcpCatalogService::open(root.join("catalog"))
+            .await
+            .unwrap();
+        assert!(!service.is_opt_in(), "default opt-in should be false");
+        service.set_opt_in(true).unwrap();
+        assert!(service.is_opt_in(), "opt-in should be true after set");
+        service.set_opt_in(false).unwrap();
+        assert!(!service.is_opt_in(), "opt-in should be false after unset");
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[tokio::test]
+    async fn opt_in_corrupt_file_backed_up_and_defaults_false() {
+        let root = temp_dir("opt-in-corrupt");
+        let catalog_dir = root.join("catalog");
+        fs::create_dir_all(&catalog_dir).unwrap();
+        let config_path = catalog_dir.join(CONFIG_FILENAME);
+        fs::write(&config_path, b"{ not valid json").unwrap();
+
+        let service = AcpCatalogService::open(catalog_dir).await.unwrap();
+        assert!(!service.is_opt_in(), "corrupt opt-in defaults to false");
+
+        // Backup exists alongside the bad file.
+        let backups: Vec<_> = fs::read_dir(service.root())
+            .unwrap()
+            .flatten()
+            .filter(|entry| {
+                entry
+                    .file_name()
+                    .to_str()
+                    .map(|n| n.contains("corrupt-"))
+                    .unwrap_or(false)
+            })
+            .collect();
+        assert_eq!(backups.len(), 1, "exactly one corrupt backup");
+        let _ = fs::remove_dir_all(root);
+    }
+
+    // ---- I/O matrix: deny_unknown_fields on opt-in request ----
+
+    #[test]
+    fn set_catalog_opt_in_request_rejects_unknown_fields() {
+        let payload = serde_json::json!({ "enabled": true, "extra": "junk" });
+        let result: Result<SetCatalogOptInRequest, _> = serde_json::from_value(payload);
+        assert!(result.is_err(), "deny_unknown_fields must reject extra fields");
+    }
+
+    #[test]
+    fn set_catalog_opt_in_request_accepts_enabled_only() {
+        let payload = serde_json::json!({ "enabled": true });
+        let request: SetCatalogOptInRequest = serde_json::from_value(payload).unwrap();
+        assert!(request.enabled);
+    }
+
+    // ---- I/O matrix: catalog cache TTL ----
+
+    #[tokio::test]
+    async fn list_catalog_caches_within_ttl() {
+        let root = temp_dir("cache-ttl");
+        let service = AcpCatalogService::open(root.join("catalog"))
+            .await
+            .unwrap();
+        let catalog1 = service.list_catalog(false).await.unwrap();
+        let catalog2 = service.list_catalog(false).await.unwrap();
+        // Both calls return the same agents (within the TTL the cache is
+        // not invalidated). The exact probe results may differ on a CI runner
+        // but the cached call must return the same data.
+        assert_eq!(catalog1.agents.len(), catalog2.agents.len());
+        assert_eq!(catalog1.host.os, catalog2.host.os);
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[tokio::test]
+    async fn list_catalog_refresh_invalidates_cache() {
+        let root = temp_dir("cache-refresh");
+        let service = AcpCatalogService::open(root.join("catalog"))
+            .await
+            .unwrap();
+        let catalog1 = service.list_catalog(false).await.unwrap();
+        // Force refresh — must not error and must return the same agent count
+        // (probes re-run but the bundled catalog is the same).
+        let catalog2 = service.list_catalog(true).await.unwrap();
+        assert_eq!(catalog1.agents.len(), catalog2.agents.len());
+        let _ = fs::remove_dir_all(root);
+    }
+
+    // ---- I/O matrix: CDN degradation fallback ----
+
+    #[tokio::test]
+    async fn list_catalog_without_opt_in_serves_bundled_only() {
+        let root = temp_dir("no-opt-in");
+        let service = AcpCatalogService::open(root.join("catalog"))
+            .await
+            .unwrap();
+        let catalog = service.list_catalog(false).await.unwrap();
+        // Every agent is bundled (no CDN entries without opt-in).
+        for agent in &catalog.agents {
+            assert_eq!(agent.source, CatalogSource::Bundled);
+        }
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[tokio::test]
+    async fn list_catalog_with_opt_in_succeeds_and_serves_catalog() {
+        let root = temp_dir("opt-in-success");
+        let service = AcpCatalogService::open(root.join("catalog"))
+            .await
+            .unwrap();
+        service.set_opt_in(true).unwrap();
+        // With opt-in on, the catalog resolves successfully whether the CDN
+        // fetch succeeds (registry entries added, tagged `source: 'registry'`)
+        // or fails (degrade to bundled-only with a warn log). The client always
+        // receives `success: true` (no error) — the degrade-gracefully contract.
+        let catalog = service.list_catalog(false).await.unwrap();
+        assert!(!catalog.agents.is_empty(), "catalog must serve agents");
+        for agent in &catalog.agents {
+            assert!(
+                matches!(
+                    agent.source,
+                    CatalogSource::Bundled | CatalogSource::Registry
+                ),
+                "agent source must be bundled or registry"
+            );
+        }
+        let _ = fs::remove_dir_all(root);
+    }
+
+    // ---- Serde shape tests ----
+
+    #[test]
+    fn acp_catalog_serializes_camel_case() {
+        let catalog = AcpCatalog {
+            host: HostCapability {
+                os: "linux".to_string(),
+                arch: "x86_64".to_string(),
+                runtimes: CatalogRuntimeAvailability {
+                    npx: true,
+                    uvx: false,
+                    node: true,
+                    bun: false,
+                    python3: true,
+                },
+            },
+            agents: vec![CatalogAgent {
+                id: "test".to_string(),
+                name: "Test".to_string(),
+                version: "1.0.0".to_string(),
+                description: "test agent".to_string(),
+                source: CatalogSource::Bundled,
+                distribution: serde_json::json!({ "npx": { "package": "test@1.0.0" } }),
+                runtime_requirements: vec!["npx".to_string()],
+                status: SupportedAcpAgentStatus::Ready,
+                platform_targets: vec![],
+            }],
+        };
+        let value = serde_json::to_value(&catalog).unwrap();
+        assert!(value.get("host").is_some());
+        assert!(value["host"].get("os").is_some());
+        assert!(value["host"].get("arch").is_some());
+        assert!(value["host"]["runtimes"].get("npx").is_some());
+        assert!(value["host"]["runtimes"].get("uvx").is_some());
+        assert!(value["host"]["runtimes"].get("node").is_some());
+        assert!(value["host"]["runtimes"].get("bun").is_some());
+        assert!(value["host"]["runtimes"].get("python3").is_some());
+        assert!(value["agents"][0].get("id").is_some());
+        assert!(value["agents"][0].get("name").is_some());
+        assert!(value["agents"][0].get("version").is_some());
+        assert!(value["agents"][0].get("description").is_some());
+        assert!(value["agents"][0].get("source").is_some());
+        assert!(value["agents"][0].get("distribution").is_some());
+        assert!(value["agents"][0].get("runtimeRequirements").is_some());
+        assert!(value["agents"][0].get("status").is_some());
+        assert!(value["agents"][0].get("platformTargets").is_some());
+        // Status serializes as kebab-case.
+        assert_eq!(value["agents"][0]["status"], "ready");
+        assert_eq!(value["agents"][0]["source"], "bundled");
+    }
+
+    #[test]
+    fn supported_acp_agent_status_serializes_kebab_case() {
+        let statuses = [
+            (SupportedAcpAgentStatus::Ready, "ready"),
+            (SupportedAcpAgentStatus::InstallRequired, "install-required"),
+            (SupportedAcpAgentStatus::NeedsRuntime, "needs-runtime"),
+            (SupportedAcpAgentStatus::ManualInstall, "manual-install"),
+            (SupportedAcpAgentStatus::Unavailable, "unavailable"),
+        ];
+        for (status, expected) in statuses {
+            let value = serde_json::to_value(status).unwrap();
+            assert_eq!(value, expected);
+        }
+    }
+
+    #[test]
+    fn catalog_source_serializes_lowercase() {
+        assert_eq!(
+            serde_json::to_value(CatalogSource::Bundled).unwrap(),
+            "bundled"
+        );
+        assert_eq!(
+            serde_json::to_value(CatalogSource::Registry).unwrap(),
+            "registry"
+        );
+    }
+
+    #[test]
+    fn is_https_archive_url_validates_scheme_and_format() {
+        assert!(is_https_archive_url("https://example.com/agent.zip"));
+        assert!(is_https_archive_url("https://example.com/agent.tar.gz"));
+        assert!(is_https_archive_url("https://example.com/agent.tgz"));
+        assert!(!is_https_archive_url("http://example.com/agent.zip"));
+        assert!(!is_https_archive_url("https://example.com/agent.exe"));
+        assert!(!is_https_archive_url("ftp://example.com/agent.zip"));
+    }
+
+    #[test]
+    fn parse_binary_platform_targets_extracts_os_arch_pairs() {
+        let dist = serde_json::json!({
+            "binary": {
+                "darwin-aarch64": { "cmd": "./agent" },
+                "linux-x86_64": { "cmd": "./agent" },
+                "windows-x86_64": { "cmd": "agent.exe" }
+            }
+        });
+        let targets = parse_binary_platform_targets(&dist);
+        assert_eq!(targets.len(), 3);
+        let oses: Vec<&str> = targets.iter().map(|t| t.os.as_str()).collect();
+        assert!(oses.contains(&"darwin"));
+        assert!(oses.contains(&"linux"));
+        assert!(oses.contains(&"windows"));
+    }
+
+    #[test]
+    fn host_platform_arch_maps_macos_to_darwin() {
+        // The function uses std::env::consts::OS which is compile-time; on a
+        // non-macOS runner the result is the raw OS. The test just verifies the
+        // format is "{os}-{arch}" and the macOS→darwin mapping is documented.
+        let pa = host_platform_arch();
+        assert!(pa.contains('-'), "platform-arch must contain a dash");
+    }
+}

--- a/src-tauri/src/acp/catalog.rs
+++ b/src-tauri/src/acp/catalog.rs
@@ -665,7 +665,11 @@ fn parse_binary_platform_targets(dist: &serde_json::Value) -> Vec<PlatformTarget
 
 /// Compute the status for a binary-distributed agent.
 /// - Binary on PATH (bare name) → `ready`
-/// - Binary not on PATH + HTTPS archive → `install-required`
+/// - Binary not on PATH + HTTPS archive + `sha256` present → `install-required`
+/// - Binary not on PATH + HTTPS archive but NO `sha256` → `manual-install`
+///   (Story 9 tightening: the catalog does not promise an install the host
+///   must reject — `INTEGRITY_METADATA_MISSING`. The launcher shows
+///   manual-install until the maintainer publishes a digest.)
 /// - Binary not on PATH + no archive → `manual-install`
 /// - No platform target → `unavailable`
 ///
@@ -680,6 +684,15 @@ fn compute_binary_status(
     };
     let cmd = target.get("cmd").and_then(|c| c.as_str()).unwrap_or("");
     let archive = target.get("archive").and_then(|a| a.as_str());
+    // Treat an empty-string sha256 as absent (Story 9 tightening): the host
+    // cannot verify integrity against an empty digest, so the catalog must
+    // not offer the install. `sha256.map(|s| !s.is_empty())` collapses `""`
+    // and missing both to `false`.
+    let has_sha256 = target
+        .get("sha256")
+        .and_then(|s| s.as_str())
+        .map(|s| !s.is_empty())
+        .unwrap_or(false);
 
     // If the command is a bare name (not a relative path), probe it on PATH.
     let is_relative = cmd.starts_with("./") || cmd.starts_with(".\\");
@@ -688,11 +701,16 @@ fn compute_binary_status(
     }
 
     // Binary not on PATH. Check for an installable archive (HTTPS + allowed
-    // format). This is Story 9's install path concern; the catalog only
-    // reports the status, it does not perform the install.
+    // format). Story 9 tightening: an archive without a non-empty `sha256`
+    // digest is `manual-install` (not `install-required`) — the host cannot
+    // verify integrity without the catalog digest, so it must not offer the
+    // install.
     if let Some(url) = archive {
         if is_https_archive_url(url) {
-            return SupportedAcpAgentStatus::InstallRequired;
+            if has_sha256 {
+                return SupportedAcpAgentStatus::InstallRequired;
+            }
+            return SupportedAcpAgentStatus::ManualInstall;
         }
     }
     SupportedAcpAgentStatus::ManualInstall
@@ -839,10 +857,39 @@ mod tests {
         assert_eq!(catalog_agent.status, SupportedAcpAgentStatus::NeedsRuntime);
     }
 
-    // ---- I/O matrix: binary with archive → install-required ----
+    // ---- I/O matrix: binary with archive + sha256 → install-required ----
 
     #[test]
-    fn binary_agent_with_https_archive_is_install_required() {
+    fn binary_agent_with_https_archive_and_sha256_is_install_required() {
+        // Story 9 tightening: `install-required` only when the catalog target
+        // carries BOTH an HTTPS archive AND a `sha256` digest. Without the
+        // digest, the host cannot verify integrity, so the status is
+        // `manual-install` (a separate test pins that).
+        let agent = sample_agent(
+            "test-binary",
+            serde_json::json!({
+                "binary": {
+                    "linux-x86_64": {
+                        "cmd": "./test-agent",
+                        "archive": "https://example.com/test-agent-linux-x86_64.tar.gz",
+                        "sha256": "abcdef0123456789"
+                    }
+                }
+            }),
+        );
+        let host = host_with_runtimes(false, false);
+        let catalog_agent = compute_catalog_agent(&agent, &host, "linux-x86_64", CatalogSource::Bundled);
+        assert_eq!(catalog_agent.status, SupportedAcpAgentStatus::InstallRequired);
+        assert!(!catalog_agent.platform_targets.is_empty());
+    }
+
+    // ---- I/O matrix: binary with archive but NO sha256 → manual-install (Story 9) ----
+
+    #[test]
+    fn binary_agent_with_archive_but_no_sha256_is_manual_install() {
+        // Story 9 tightening: an HTTPS archive without a `sha256` digest is
+        // `manual-install` (not `install-required`) — the host cannot verify
+        // integrity, so the catalog must not promise an install it must reject.
         let agent = sample_agent(
             "test-binary",
             serde_json::json!({
@@ -856,8 +903,31 @@ mod tests {
         );
         let host = host_with_runtimes(false, false);
         let catalog_agent = compute_catalog_agent(&agent, &host, "linux-x86_64", CatalogSource::Bundled);
-        assert_eq!(catalog_agent.status, SupportedAcpAgentStatus::InstallRequired);
-        assert!(!catalog_agent.platform_targets.is_empty());
+        assert_eq!(catalog_agent.status, SupportedAcpAgentStatus::ManualInstall);
+    }
+
+    // ---- I/O matrix: binary with archive + EMPTY-string sha256 → manual-install ----
+
+    #[test]
+    fn binary_agent_with_archive_but_empty_sha256_is_manual_install() {
+        // Story 9 tightening (patch): an empty-string `sha256` is treated as
+        // absent — the host cannot verify integrity against an empty digest,
+        // so the catalog must not offer the install.
+        let agent = sample_agent(
+            "test-binary",
+            serde_json::json!({
+                "binary": {
+                    "linux-x86_64": {
+                        "cmd": "./test-agent",
+                        "archive": "https://example.com/test-agent-linux-x86_64.tar.gz",
+                        "sha256": ""
+                    }
+                }
+            }),
+        );
+        let host = host_with_runtimes(false, false);
+        let catalog_agent = compute_catalog_agent(&agent, &host, "linux-x86_64", CatalogSource::Bundled);
+        assert_eq!(catalog_agent.status, SupportedAcpAgentStatus::ManualInstall);
     }
 
     // ---- I/O matrix: binary without archive → manual-install ----
@@ -903,13 +973,15 @@ mod tests {
 
     #[test]
     fn binary_agent_bare_name_on_path_is_ready() {
-        // A bare-name (non-relative) cmd with an installable archive. When the
-        // injected probe reports the binary is on PATH, the status is `ready`
-        // (the archive is not used). When the probe reports it is NOT on PATH,
-        // the status falls through to `install-required` (HTTPS archive).
+        // A bare-name (non-relative) cmd with an installable archive + sha256.
+        // When the injected probe reports the binary is on PATH, the status is
+        // `ready` (the archive is not used). When the probe reports it is NOT
+        // on PATH, the status falls through to `install-required` (HTTPS
+        // archive + sha256 present — Story 9 tightening).
         let target: serde_json::Map<String, serde_json::Value> = serde_json::json!({
             "cmd": "test-agent",
-            "archive": "https://example.com/test-agent.zip"
+            "archive": "https://example.com/test-agent.zip",
+            "sha256": "abcdef"
         })
         .as_object()
         .unwrap()
@@ -921,7 +993,7 @@ mod tests {
         );
 
         // When the probe reports it is NOT on PATH, the status falls through
-        // to `install-required` (HTTPS archive).
+        // to `install-required` (HTTPS archive + sha256 present).
         assert_eq!(
             compute_binary_status(Some(&target), |_| false),
             SupportedAcpAgentStatus::InstallRequired

--- a/src-tauri/src/acp/catalog.rs
+++ b/src-tauri/src/acp/catalog.rs
@@ -240,7 +240,8 @@ impl AcpCatalogService {
         }
         #[cfg(unix)]
         {
-            std::os::unix::fs::DirBuilder::new()
+            use std::os::unix::fs::DirBuilderExt;
+            std::fs::DirBuilder::new()
                 .mode(0o700)
                 .recursive(true)
                 .create(&root)?;

--- a/src-tauri/src/acp/commands.rs
+++ b/src-tauri/src/acp/commands.rs
@@ -344,6 +344,80 @@ pub async fn acp_set_catalog_opt_in(
     }
 }
 
+/// `acp_install_agent(agentId)` — host-owned verified-atomic ACP install
+/// (CAP-6 / Story 9). Resolves the agent by id from the catalog, downloads the
+/// catalog-resolved HTTPS archive, verifies `sha256` (from the catalog's
+/// `binary.{os-arch}.sha256` field), extracts safely, atomically activates,
+/// serializes per-agent, records an installed-agents manifest, and returns
+/// `{ command: absolute_path, args }`. The request is `{ agentId }` only; the
+/// host resolves everything from the trusted catalog — never accepts
+/// browser-supplied URLs, commands, executable paths, or args.
+/// Mirrors `POST /acp/install` + WS `install_acp_agent` byte-for-byte.
+///
+/// The `request` arg is accepted as a raw `serde_json::Value` and manually
+/// deserialized with `deny_unknown_fields` so an extra-field rejection
+/// surfaces as `IpcResult::error(..., VALIDATION_ERROR)` — NOT a Tauri serde
+/// rejection (which the renderer would map to `INVOKE_ERROR`, breaking the
+/// transport parity with HTTP/WS where `deny_unknown_fields` →
+/// `VALIDATION_ERROR`). Mirrors `install_api.rs::install` + the WS
+/// `handle_install_acp_agent`.
+#[tauri::command]
+pub async fn acp_install_agent(
+    request: serde_json::Value,
+    store: State<'_, crate::commands::HostAcpInstallStore>,
+) -> Result<crate::commands::IpcResult<crate::acp::install::InstallOutcome>, String> {
+    let request: crate::acp::install::InstallRequest = match serde_json::from_value(request) {
+        Ok(req) => req,
+        Err(error) => {
+            log::warn!(
+                "[acp-install] {} install_agent validation failed: {error}",
+                crate::logging::session_id()
+            );
+            return Ok(crate::commands::IpcResult::error(
+                format!("payload validation failed: {error}"),
+                crate::acp::install::code::VALIDATION_ERROR,
+            ));
+        }
+    };
+    let agent_id_log = request.agent_id.clone();
+    log::info!(
+        "[acp-install] {} install_agent start agent={}",
+        crate::logging::session_id(),
+        agent_id_log
+    );
+    let Some(service) = store.store().map(std::sync::Arc::clone) else {
+        log::warn!(
+            "[acp-install] {} install_agent unavailable (no host store)",
+            crate::logging::session_id()
+        );
+        return Ok(crate::commands::IpcResult::error(
+            "acp install store is unavailable",
+            crate::acp::install::code::ACP_INSTALL_UNAVAILABLE,
+        ));
+    };
+    match service.install_by_id(&request.agent_id).await {
+        Ok(outcome) => {
+            log::info!(
+                "[acp-install] {} install_agent success agent={}",
+                crate::logging::session_id(),
+                agent_id_log
+            );
+            Ok(crate::commands::IpcResult::success(outcome))
+        }
+        Err(error) => {
+            let code = error.code();
+            log::error!(
+                "[acp-install] {} install_agent failure agent={} code={} msg={}",
+                crate::logging::session_id(),
+                agent_id_log,
+                code,
+                error.message
+            );
+            Ok(crate::commands::IpcResult::error(error.message, code))
+        }
+    }
+}
+
 /// On-demand MCP client probe. Takes a renderer-supplied `McpServerConfig`
 /// (stateless — no registry-store coupling), opens a fresh rmcp client
 /// connection, calls `initialize` + `tools/list`, then closes, and returns

--- a/src-tauri/src/acp/commands.rs
+++ b/src-tauri/src/acp/commands.rs
@@ -272,6 +272,78 @@ pub fn acp_probe_runtime() -> crate::acp::config::AcpRuntimeProbe {
     crate::acp::config::probe_registry_runtime()
 }
 
+/// `acp_list_catalog(refresh?: bool)` — resolve the host-owned ACP catalog
+/// (CAP-6 / Story 8). Returns the host's OS/arch/runtime availability + the
+/// per-agent resolved `SupportedAcpAgentStatus` (ready / install-required /
+/// needs-runtime / manual-install / unavailable). The catalog is
+/// credential-free, path-free, read-only host introspection — never carries
+/// `AgentConfig.env` (API keys) or resolved absolute executable paths.
+/// Mirrors `GET /acp/catalog` + WS `list_acp_catalog` byte-for-byte.
+#[tauri::command]
+pub async fn acp_list_catalog(
+    refresh: Option<bool>,
+    store: State<'_, crate::commands::HostAcpCatalogStore>,
+) -> Result<crate::commands::IpcResult<crate::acp::AcpCatalog>, String> {
+    let refresh = refresh.unwrap_or(false);
+    log::info!("[acp-catalog] list start refresh={refresh}");
+    let Some(service) = store.store().map(std::sync::Arc::clone) else {
+        log::warn!("[acp-catalog] list unavailable (no host store)");
+        return Ok(crate::commands::IpcResult::error(
+            "acp catalog store is unavailable",
+            "ACP_CATALOG_UNAVAILABLE",
+        ));
+    };
+    match service.list_catalog(refresh).await {
+        Ok(catalog) => {
+            log::info!(
+                "[acp-catalog] list success agents={}",
+                catalog.agents.len()
+            );
+            Ok(crate::commands::IpcResult::success(catalog))
+        }
+        Err(error) => {
+            log::error!("[acp-catalog] list failure error={error}");
+            Ok(crate::commands::IpcResult::error(
+                error.to_string(),
+                "CATALOG_LOAD_FAILED",
+            ))
+        }
+    }
+}
+
+/// `acp_set_catalog_opt_in(enabled: bool)` — persist the host opt-in flag that
+/// gates the CDN registry augmentation (CAP-6 / Story 8). When enabled, the
+/// next `list_catalog` includes CDN entries tagged `source: 'registry'` (if
+/// the fetch succeeds); when disabled, only bundled entries are served.
+/// Mirrors `POST /acp/catalog/opt-in` + WS `set_catalog_opt_in` byte-for-byte.
+#[tauri::command]
+pub async fn acp_set_catalog_opt_in(
+    enabled: bool,
+    store: State<'_, crate::commands::HostAcpCatalogStore>,
+) -> Result<crate::commands::IpcResult<()>, String> {
+    log::info!("[acp-catalog] set_opt_in start enabled={enabled}");
+    let Some(service) = store.store().map(std::sync::Arc::clone) else {
+        log::warn!("[acp-catalog] set_opt_in unavailable (no host store)");
+        return Ok(crate::commands::IpcResult::error(
+            "acp catalog store is unavailable",
+            "ACP_CATALOG_UNAVAILABLE",
+        ));
+    };
+    match service.set_opt_in(enabled) {
+        Ok(()) => {
+            log::info!("[acp-catalog] set_opt_in success enabled={enabled}");
+            Ok(crate::commands::IpcResult::success(()))
+        }
+        Err(error) => {
+            log::error!("[acp-catalog] set_opt_in failure error={error}");
+            Ok(crate::commands::IpcResult::error(
+                error.to_string(),
+                "ACP_CATALOG_OPT_IN_FAILED",
+            ))
+        }
+    }
+}
+
 /// On-demand MCP client probe. Takes a renderer-supplied `McpServerConfig`
 /// (stateless — no registry-store coupling), opens a fresh rmcp client
 /// connection, calls `initialize` + `tools/list`, then closes, and returns

--- a/src-tauri/src/acp/config.rs
+++ b/src-tauri/src/acp/config.rs
@@ -119,7 +119,7 @@ fn resolve_executable_in_path(command: &str, path: &str) -> Option<String> {
     None
 }
 
-fn is_registry_launcher_on_path(command: &str) -> bool {
+pub(crate) fn is_registry_launcher_on_path(command: &str) -> bool {
     let mut env_map = HashMap::new();
     crate::pty::env_refresh::apply_fresh_path(&mut env_map);
 

--- a/src-tauri/src/acp/install.rs
+++ b/src-tauri/src/acp/install.rs
@@ -1333,6 +1333,288 @@ mod tests {
         let _ = std::fs::remove_dir_all(root);
     }
 
+    // ---- real-archive traversal + quota (Category D) ----
+    //
+    // The existing `extraction_failure_propagates_code` mocks the extractor
+    // returning a string. These tests feed REAL hostile zip/tar archives
+    // (crafted with the `zip`/`tar`/`flate2` crates already in Cargo.toml)
+    // through the production `ArchiveExtractor` — proving the traversal/quota
+    // guards fire on real archive contents, not just mocked error returns.
+
+    /// Craft a zip containing a single `../evil` traversal entry. The `zip`
+    /// crate accepts the raw name on WRITE (`start_file`); the production
+    /// `extract_zip` guard rejects it on READ via `enclosed_name()` (returns
+    /// `None` → the entry is skipped, so no file is written outside the
+    /// extraction dir). Returns the archive bytes + their sha256 hex.
+    fn slip_zip() -> (Vec<u8>, String) {
+        use std::io::Write;
+        let tmp = std::env::temp_dir()
+            .join(format!("termul-acp-install-slip-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&tmp).unwrap();
+        let zip_path = tmp.join("evil.zip");
+        {
+            let file = std::fs::File::create(&zip_path).unwrap();
+            let mut zip = zip::ZipWriter::new(file);
+            let opts = zip::write::SimpleFileOptions::default();
+            zip.start_file("../evil", opts)
+                .expect("zip start_file accepts a traversal name on write");
+            zip.write_all(b"pwned").unwrap();
+            zip.finish().unwrap();
+        }
+        let bytes = std::fs::read(&zip_path).unwrap();
+        let mut hasher = Sha256::new();
+        hasher.update(&bytes);
+        let hex = hex_encode(&hasher.finalize());
+        let _ = std::fs::remove_dir_all(&tmp);
+        (bytes, hex)
+    }
+
+    /// Craft a tar.gz containing a single `../../evil` traversal entry. The
+    /// `tar` crate's `Header::set_path` rejects `..` on WRITE, so a hostile
+    /// tar (the kind a non-Rust packager or attacker produces — the tar format
+    /// stores the name verbatim) must be crafted by writing the raw header
+    /// name bytes directly + recomputing the checksum. The production
+    /// `extract_tar_gz` guard then rejects it on READ (`entry.path()` returns
+    /// the raw `..` components → "tar entry has unsafe path"). Returns the
+    /// archive bytes + their sha256 hex.
+    fn slip_tar_gz() -> (Vec<u8>, String) {
+        use std::io::Write;
+        let tmp = std::env::temp_dir()
+            .join(format!("termul-acp-install-tarslip-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&tmp).unwrap();
+        let tar_gz_path = tmp.join("evil.tar.gz");
+        {
+            let file = std::fs::File::create(&tar_gz_path).unwrap();
+            let gz = flate2::write::GzEncoder::new(file, flate2::Compression::default());
+            let mut tar = tar::Builder::new(gz);
+            // Build a regular-file header with a benign name (sets size/mode/
+            // magic), then overwrite the name field with the traversal path +
+            // set the typeflag + recompute the checksum. `Builder::append` takes
+            // `&Header` (immutable) so it cannot re-validate or re-set the path —
+            // the raw bytes are written verbatim.
+            let mut header = tar::Header::new_gnu();
+            header.set_path("evil").unwrap();
+            header.set_size(5);
+            header.set_mode(0o644);
+            let name = b"../../evil";
+            let bytes = header.as_mut_bytes();
+            bytes[..name.len()].copy_from_slice(name);
+            for slot in &mut bytes[name.len()..100] {
+                *slot = 0;
+            }
+            bytes[156] = b'0'; // typeflag = regular file
+            header.set_cksum();
+            tar.append(&header, &b"pwned"[..]).unwrap();
+            tar.finish().unwrap();
+            let gz = tar.into_inner().unwrap();
+            let mut file = gz.finish().unwrap();
+            file.flush().unwrap();
+        }
+        let bytes = std::fs::read(&tar_gz_path).unwrap();
+        let mut hasher = Sha256::new();
+        hasher.update(&bytes);
+        let hex = hex_encode(&hasher.finalize());
+        let _ = std::fs::remove_dir_all(&tmp);
+        (bytes, hex)
+    }
+
+    /// Craft a zip with `n` single-byte file entries (used to exceed
+    /// `MAX_EXTRACTED_FILES`). Each entry is a flat, traversal-safe name so
+    /// the production `extract_zip` file counter (not `enclosed_name`) is what
+    /// trips. Returns the archive bytes + their sha256 hex.
+    fn overfull_zip(n: usize) -> (Vec<u8>, String) {
+        use std::io::Write;
+        let tmp = std::env::temp_dir()
+            .join(format!("termul-acp-install-overfull-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&tmp).unwrap();
+        let zip_path = tmp.join("overfull.zip");
+        {
+            let file = std::fs::File::create(&zip_path).unwrap();
+            let mut zip = zip::ZipWriter::new(file);
+            let opts = zip::write::SimpleFileOptions::default();
+            for i in 0..n {
+                zip.start_file(format!("f{i}"), opts)
+                    .expect("start_file for overfull entry");
+                zip.write_all(b"x").unwrap();
+            }
+            zip.finish().unwrap();
+        }
+        let bytes = std::fs::read(&zip_path).unwrap();
+        let mut hasher = Sha256::new();
+        hasher.update(&bytes);
+        let hex = hex_encode(&hasher.finalize());
+        let _ = std::fs::remove_dir_all(&tmp);
+        (bytes, hex)
+    }
+
+    #[tokio::test]
+    async fn real_zip_slip_entry_rejected_before_extraction() {
+        let root = temp_dir("zip-slip");
+        let (bytes, sha) = slip_zip();
+        let pa = platform_arch_for(&host());
+
+        // Phase 1: the REAL `ArchiveExtractor` (not the `FailingExtractor`
+        // mock) on the hostile zip in isolation. `enclosed_name()` skips the
+        // `../evil` entry → extraction Ok, dest left empty, and NO file
+        // escapes the dest dir (the slip target `dest/../evil` = `root/evil`
+        // does not exist). Proves the production `enclosed_name` guard fires
+        // on a real hostile archive.
+        {
+            let dest = root.join("direct");
+            std::fs::create_dir_all(&dest).unwrap();
+            let archive_path = root.join("evil.zip");
+            std::fs::write(&archive_path, &bytes).unwrap();
+            let extractor = ArchiveExtractor;
+            let result = extractor.extract(&archive_path, &dest).await;
+            assert!(
+                result.is_ok(),
+                "enclosed_name skips the slip entry (Ok, no write): {:?}",
+                result.err()
+            );
+            assert!(!root.join("evil").exists(), "no file escaped the dest dir");
+            assert!(
+                std::fs::read_dir(&dest).unwrap().next().is_none(),
+                "dest empty — the slip entry was skipped"
+            );
+        }
+
+        // Phase 2: the full install flow with `CannedDownloader` + the REAL
+        // `ArchiveExtractor`. The catalog `cmd` is the slip path so the
+        // production `resolve_cmd_in_root` ALSO fires (the install returns
+        // `PATH_TRAVERSAL_DETECTED` from cmd resolution — proving extraction
+        // succeeded, i.e. `enclosed_name` skipped the entry, then the cmd
+        // guard rejected it). No staging dir lingers + no activation.
+        let service = open_service(root.clone()).await;
+        let agent = sample_binary_agent(
+            "slip-agent",
+            &pa,
+            Some(&sha),
+            "../evil",
+            "https://example.com/evil.zip",
+        );
+        let downloader: Arc<dyn Downloader> = Arc::new(CannedDownloader {
+            bytes: bytes.clone(),
+            filename: "archive.zip".to_string(),
+            fail: false,
+        });
+        let err = service
+            .install(&agent, &host(), Some(downloader), None)
+            .await
+            .expect_err("zip slip must be rejected before extraction");
+        assert_eq!(err.code(), code::PATH_TRAVERSAL_DETECTED);
+        assert!(
+            err.message.contains("cmd"),
+            "rejection must come from resolve_cmd_in_root: {}",
+            err.message
+        );
+        assert!(!service.root().join("evil").exists());
+        assert!(
+            !service.root().join("slip-agent").exists(),
+            "no activation on rejection"
+        );
+        for entry in std::fs::read_dir(service.root()).unwrap().flatten() {
+            let name = entry.file_name();
+            assert!(
+                !name.to_string_lossy().contains(".staging-"),
+                "staging dir must be cleaned up: {}",
+                name.to_string_lossy()
+            );
+        }
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[tokio::test]
+    async fn real_tar_traversal_rejected_before_extraction() {
+        let root = temp_dir("tar-slip");
+        let (bytes, sha) = slip_tar_gz();
+        let pa = platform_arch_for(&host());
+        let service = open_service(root.clone()).await;
+        // `cmd` is benign here — the production `extract_tar_gz` guard rejects
+        // the `../../evil` entry DURING extraction (before cmd resolution), so
+        // the install returns `PATH_TRAVERSAL_DETECTED` from the extractor
+        // itself (mapped from "tar entry has unsafe path").
+        let agent = sample_binary_agent(
+            "tar-slip-agent",
+            &pa,
+            Some(&sha),
+            "./acp",
+            "https://example.com/evil.tar.gz",
+        );
+        let downloader: Arc<dyn Downloader> = Arc::new(CannedDownloader {
+            bytes,
+            filename: "evil.tar.gz".to_string(),
+            fail: false,
+        });
+        let err = service
+            .install(&agent, &host(), Some(downloader), None)
+            .await
+            .expect_err("tar traversal must be rejected before extraction");
+        assert_eq!(err.code(), code::PATH_TRAVERSAL_DETECTED);
+        assert!(
+            err.message.contains("unsafe path"),
+            "rejection must come from the tar traversal guard: {}",
+            err.message
+        );
+        assert!(
+            !service.root().join("tar-slip-agent").exists(),
+            "no activation on rejection"
+        );
+        for entry in std::fs::read_dir(service.root()).unwrap().flatten() {
+            let name = entry.file_name();
+            assert!(
+                !name.to_string_lossy().contains(".staging-"),
+                "staging dir must be cleaned up: {}",
+                name.to_string_lossy()
+            );
+        }
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[tokio::test]
+    async fn extracted_file_count_quota_enforced_on_real_archive() {
+        // Craft a zip with one more entry than `MAX_EXTRACTED_FILES`. The
+        // production `extract_zip` counter trips on the (N+1)th non-dir entry
+        // → `EXTRACTION_QUOTA_EXCEEDED` + the staging dir is cleaned up.
+        // NOTE: this writes MAX_EXTRACTED_FILES files to disk during extraction
+        // before tripping (the production guard checks AFTER incrementing) —
+        // correct per the spec, but the slowest test in the module.
+        let n = crate::acp::archive::MAX_EXTRACTED_FILES + 1;
+        let (bytes, sha) = overfull_zip(n);
+        let root = temp_dir("quota");
+        let pa = platform_arch_for(&host());
+        let service = open_service(root.clone()).await;
+        let agent = sample_binary_agent(
+            "quota-agent",
+            &pa,
+            Some(&sha),
+            "./acp",
+            "https://example.com/overfull.zip",
+        );
+        let downloader: Arc<dyn Downloader> = Arc::new(CannedDownloader {
+            bytes,
+            filename: "archive.zip".to_string(),
+            fail: false,
+        });
+        let err = service
+            .install(&agent, &host(), Some(downloader), None)
+            .await
+            .expect_err("file-count quota must be exceeded");
+        assert_eq!(err.code(), code::EXTRACTION_QUOTA_EXCEEDED);
+        assert!(
+            !service.root().join("quota-agent").exists(),
+            "no activation on quota failure"
+        );
+        for entry in std::fs::read_dir(service.root()).unwrap().flatten() {
+            let name = entry.file_name();
+            assert!(
+                !name.to_string_lossy().contains(".staging-"),
+                "staging dir must be cleaned up: {}",
+                name.to_string_lossy()
+            );
+        }
+        let _ = std::fs::remove_dir_all(root);
+    }
+
     // ---- download failure ----
 
     #[tokio::test]

--- a/src-tauri/src/acp/install.rs
+++ b/src-tauri/src/acp/install.rs
@@ -417,7 +417,8 @@ impl AcpInstallService {
         }
         #[cfg(unix)]
         {
-            std::os::unix::fs::DirBuilder::new()
+            use std::os::unix::fs::DirBuilderExt;
+            std::fs::DirBuilder::new()
                 .mode(0o700)
                 .recursive(true)
                 .create(&root)?;

--- a/src-tauri/src/acp/install.rs
+++ b/src-tauri/src/acp/install.rs
@@ -1,0 +1,1618 @@
+//! Host-owned verified-atomic ACP install service (CAP-6 / Story 9).
+//!
+//! Builds the host-owned install flow on top of the catalog (Story 8's
+//! `AcpCatalogService`): downloads the catalog-resolved HTTPS archive, verifies
+//! `sha256` (read from the catalog's `binary.{os-arch}.sha256` field),
+//! extracts safely, atomically activates, serializes per-agent, records an
+//! installed-agents manifest, and exposes `install_agent(agentId)` across all
+//! three transports (Tauri `acp_install_agent`, HTTP `POST /acp/install`, WS
+//! `install_acp_agent`).
+//!
+//! # Integrity source
+//!
+//! The trusted catalog metadata is the single source of both the archive URL
+//! and its expected digest. The install service reads an optional `sha256`
+//! (hex string) from the `binary.{os-arch}` target of the catalog's
+//! `distribution` (opaque JSON — additive, no schema break). Present → verify
+//! the downloaded archive's sha256 **before extraction**; mismatch → abort,
+//! leave the previous install intact, return `INTEGRITY_MISMATCH`. Absent →
+//! reject with `INTEGRITY_METADATA_MISSING` (do NOT relax the contract; do NOT
+//! fall back to "HTTPS-only"). The catalog's `compute_binary_status` is
+//! tightened (Story 9) so a binary target without `sha256` returns
+//! `ManualInstall` (not `InstallRequired`), so the launcher does not offer an
+//! install the host must reject.
+//!
+//! # Per-agent serialization
+//!
+//! An `Arc<TokioMutex<()>>` map keyed by `agent_id` (mirrors
+//! `WorkspaceManifestService::project_lock`), held under a parking_lot
+//! `Mutex`, evicted on successful uninstall, so concurrent installs of the
+//! *same* agent serialize while *different* agents install in parallel.
+//!
+//! # Atomic activation
+//!
+//! Download + verify + extract into a temp staging dir under the install root;
+//! `backup old (rename to .old) → rename(staging, root) → drop backup` with
+//! restore-on-failure (the existing `install_registry_binary` swap pattern). A
+//! tampered/failed install leaves the previous installation (if any) intact.
+//!
+//! # Installed-agents manifest
+//!
+//! A schema-versioned envelope `{ schema_version, agents: HashMap<agent_id,
+//! InstalledAgent> }` at `<install_root>/installed.json`, written via
+//! `atomic_file::replace`, corrupt-file backup via
+//! `atomic_file::backup_corrupt` then treated as empty. Updated **after**
+//! successful activation. The manifest IS the audit record (no separate audit
+//! log concept exists).
+//!
+//! # Testability
+//!
+//! `Downloader` + `Extractor` traits injected into `install` mirror Story 8's
+//! `compute_binary_status(target, probe)` probe-injection, so the I/O matrix
+//! rows (sha256-mismatch / quota / traversal / download-failure) are
+//! unit-testable without network.
+
+use std::collections::HashMap;
+use std::fs;
+use std::io;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::time::{Instant, SystemTime, UNIX_EPOCH};
+
+use parking_lot::Mutex;
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use tokio::sync::Mutex as TokioMutex;
+
+use crate::acp::archive::{
+    extract_archive, mark_executable, mark_spawnables_in_tree, normalize_cmd_path,
+    resolve_cmd_in_root, MAX_ARCHIVE_BYTES,
+};
+use crate::acp::atomic_file;
+use crate::acp::catalog::{CatalogAgent, HostCapability, SupportedAcpAgentStatus};
+use crate::acp::AcpCatalogService;
+use crate::acp_registry_snapshot::is_safe_agent_id;
+
+// ---------------------------------------------------------------------------
+// Wire types (camelCase serde, byte-identical to the TS shapes)
+// ---------------------------------------------------------------------------
+
+/// `POST /acp/install` + WS `install_acp_agent` + Tauri `acp_install_agent`
+/// request body. `deny_unknown_fields` rejects an over-serialized payload
+/// loudly at the host boundary — maps to `VALIDATION_ERROR`. The request
+/// carries ONLY `{ agentId }`; the host resolves everything (archive URL, cmd,
+/// args, env, sha256) from the trusted catalog — never accepts browser-supplied
+/// URLs, commands, executable paths, or args.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct InstallRequest {
+    pub agent_id: String,
+}
+
+/// The install outcome (the existing contract the renderer wraps into
+/// `AgentConfig` via `installedBinaryConfig`). `command` is the absolute path
+/// to the resolved executable under the install root; `args` is the catalog
+/// target's `args` (or empty).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct InstallOutcome {
+    pub command: String,
+    pub args: Vec<String>,
+}
+
+// ---------------------------------------------------------------------------
+// Error codes
+// ---------------------------------------------------------------------------
+
+/// Install failure. Carries a stable SCREAMING_SNAKE_CASE `code` string
+/// byte-identical across all three transports (Tauri `IpcResult.code`, HTTP
+/// `IpcBody.code`, WS `WsReply.err.code`). The WS path uses
+/// `WsReply::err_with_code` (a raw-string constructor) so the install-specific
+/// codes are not collapsed into the protocol-level `WsErrorCode` enum.
+#[derive(Debug, Clone)]
+pub struct InstallError {
+    pub code: &'static str,
+    pub message: String,
+}
+
+impl InstallError {
+    fn new(code: &'static str, message: impl Into<String>) -> Self {
+        Self {
+            code,
+            message: message.into(),
+        }
+    }
+
+    /// The stable SCREAMING_SNAKE_CASE machine code.
+    #[must_use]
+    pub fn code(&self) -> &'static str {
+        self.code
+    }
+}
+
+impl std::fmt::Display for InstallError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}: {}", self.code, self.message)
+    }
+}
+
+impl std::error::Error for InstallError {}
+
+// Stable error codes (mirrors the spec's I/O & Edge-Case Matrix). The
+// `InstallError` constructors use these; the degrade-mode handlers
+// (`commands.rs` + `install_api.rs` + `ws.rs`) ALSO reference these constants
+// (not literal strings) so a rename in this mod cannot silently drift from
+// the wire bytes.
+#[allow(dead_code)]
+pub(crate) mod code {
+    pub const INTEGRITY_MISMATCH: &str = "INTEGRITY_MISMATCH";
+    pub const INTEGRITY_METADATA_MISSING: &str = "INTEGRITY_METADATA_MISSING";
+    pub const UNSUPPORTED_PLATFORM: &str = "UNSUPPORTED_PLATFORM";
+    pub const ARCHIVE_TOO_LARGE: &str = "ARCHIVE_TOO_LARGE";
+    pub const EXTRACTION_QUOTA_EXCEEDED: &str = "EXTRACTION_QUOTA_EXCEEDED";
+    pub const PATH_TRAVERSAL_DETECTED: &str = "PATH_TRAVERSAL_DETECTED";
+    pub const DOWNLOAD_FAILED: &str = "DOWNLOAD_FAILED";
+    pub const CATALOG_AGENT_NOT_FOUND: &str = "CATALOG_AGENT_NOT_FOUND";
+    pub const NOT_INSTALLABLE: &str = "NOT_INSTALLABLE";
+    pub const ACP_INSTALL_UNAVAILABLE: &str = "ACP_INSTALL_UNAVAILABLE";
+    pub const VALIDATION_ERROR: &str = "VALIDATION_ERROR";
+    pub const INSTALL_FAILED: &str = "INSTALL_FAILED";
+}
+
+// ---------------------------------------------------------------------------
+// Downloader / Extractor traits (injected for testability)
+// ---------------------------------------------------------------------------
+
+/// Downloaded archive descriptor. The production downloader streams the body
+/// to a temp file under `target_dir` (never holding the full archive in RAM
+/// — the 256 MiB cap bounds memory to the streaming buffer); tests inject a
+/// canned-bytes impl that writes the bytes to a temp file.
+pub struct DownloadedArchive {
+    /// The temp file holding the downloaded archive bytes.
+    pub path: PathBuf,
+    /// The archive filename (last path segment of the URL, query stripped),
+    /// used to dispatch `.zip` vs `.tar.gz`/`.tgz` extraction.
+    pub filename: String,
+    /// Downloaded byte count (for logging).
+    pub size: u64,
+}
+
+/// Async download seam. The production impl streams the HTTPS archive to a
+/// temp file with an incremental size cap (never holding the full archive in
+/// RAM — a 256 MiB × N parallel installs OOM hazard); tests inject a
+/// canned-bytes impl to drive the sha256-mismatch / archive-too-large /
+/// download-failure matrix rows without network.
+#[async_trait::async_trait]
+pub trait Downloader: Send + Sync {
+    /// Download the archive into `target_dir` (a private staging dir the
+    /// caller manages + cleans up). Enforce `MAX_ARCHIVE_BYTES`
+    /// incrementally. The returned `path` lives under `target_dir`.
+    async fn download(
+        &self,
+        url: &str,
+        target_dir: &Path,
+    ) -> Result<DownloadedArchive, InstallError>;
+}
+
+/// Async extract seam. The production impl calls `archive::extract_archive`
+/// with the traversal/quota protections; tests inject a failing impl to drive
+/// the path-traversal / quota matrix rows without touching the filesystem.
+#[async_trait::async_trait]
+pub trait Extractor: Send + Sync {
+    /// Extract `archive_path` into `dest`. Enforce path-traversal rejection +
+    /// `MAX_EXTRACTED_BYTES` / `MAX_EXTRACTED_FILES` quotas.
+    async fn extract(&self, archive_path: &Path, dest: &Path) -> Result<(), InstallError>;
+}
+
+/// Production downloader: streams the HTTPS archive to a temp file under
+/// `target_dir` with an incremental size cap (never holds the full archive in
+/// RAM — the legacy `stage_archive` pattern). Used by the default `install`
+/// path.
+struct HttpDownloader;
+
+#[async_trait::async_trait]
+impl Downloader for HttpDownloader {
+    async fn download(
+        &self,
+        url: &str,
+        target_dir: &Path,
+    ) -> Result<DownloadedArchive, InstallError> {
+        use futures_util::StreamExt;
+        use std::io::Write;
+        use std::time::Duration;
+
+        if !url.starts_with("https://") {
+            return Err(InstallError::new(
+                code::DOWNLOAD_FAILED,
+                "archive URL must be https",
+            ));
+        }
+        // Redirects: archives are direct download URLs. Reject ANY redirect
+        // (a 302 → `http://` would download over plaintext, leaking the URL
+        // path/query). `Policy::none()` makes reqwest surface a 3xx as an
+        // error → DOWNLOAD_FAILED.
+        let client = reqwest::Client::builder()
+            .timeout(Duration::from_secs(crate::acp::archive::FETCH_TIMEOUT_SECS))
+            .redirect(reqwest::redirect::Policy::none())
+            .build()
+            .map_err(|e| InstallError::new(code::DOWNLOAD_FAILED, format!("http client: {e}")))?;
+        let response = client
+            .get(url)
+            .send()
+            .await
+            .map_err(|e| InstallError::new(code::DOWNLOAD_FAILED, format!("download failed: {e}")))?;
+        if response.status().is_redirection() {
+            // Belt-and-suspenders: `Policy::none()` already turned the 3xx
+            // into an error above, but defend against a future policy change.
+            return Err(InstallError::new(
+                code::DOWNLOAD_FAILED,
+                format!("download redirected (HTTP {}) — refused", response.status()),
+            ));
+        }
+        if !response.status().is_success() {
+            return Err(InstallError::new(
+                code::DOWNLOAD_FAILED,
+                format!("download returned HTTP {}", response.status()),
+            ));
+        }
+
+        // Derive the archive filename from the URL, stripping the query
+        // string + fragment so `https://x/y.zip?id=1` → `y.zip` (not
+        // `y.zip?id=1`, which would break extension dispatch).
+        let path_part = url.split(['?', '#']).next().unwrap_or(url);
+        let filename = path_part
+            .rsplit('/')
+            .next()
+            .filter(|s| !s.is_empty())
+            .unwrap_or("archive.bin")
+            .to_string();
+        let archive_path = target_dir.join(&filename);
+        let mut file = std::fs::File::create(&archive_path)
+            .map_err(|e| InstallError::new(code::DOWNLOAD_FAILED, format!("create temp: {e}")))?;
+        let mut downloaded: u64 = 0;
+        let mut stream = response.bytes_stream();
+        while let Some(chunk) = stream.next().await {
+            let chunk = chunk
+                .map_err(|e| InstallError::new(code::DOWNLOAD_FAILED, format!("stream: {e}")))?;
+            downloaded += chunk.len() as u64;
+            if downloaded > MAX_ARCHIVE_BYTES {
+                return Err(InstallError::new(
+                    code::ARCHIVE_TOO_LARGE,
+                    "archive exceeds download cap",
+                ));
+            }
+            file.write_all(&chunk)
+                .map_err(|e| InstallError::new(code::DOWNLOAD_FAILED, format!("write: {e}")))?;
+        }
+        file.flush()
+            .map_err(|e| InstallError::new(code::DOWNLOAD_FAILED, format!("flush: {e}")))?;
+        Ok(DownloadedArchive {
+            path: archive_path,
+            filename,
+            size: downloaded,
+        })
+    }
+}
+
+/// Production extractor: delegates to `archive::extract_archive`.
+struct ArchiveExtractor;
+
+#[async_trait::async_trait]
+impl Extractor for ArchiveExtractor {
+    async fn extract(&self, archive_path: &Path, dest: &Path) -> Result<(), InstallError> {
+        tokio::task::spawn_blocking({
+            let archive_path = archive_path.to_path_buf();
+            let dest = dest.to_path_buf();
+            move || extract_archive(&archive_path, &dest)
+        })
+        .await
+        .map_err(|e| InstallError::new(code::INSTALL_FAILED, format!("extract task: {e}")))?
+        .map_err(|e| {
+            // Map the archive helpers' coarse strings to install codes.
+            if e.contains("too many files") || e.contains("size limit") {
+                InstallError::new(code::EXTRACTION_QUOTA_EXCEEDED, e)
+            } else if e.contains("unsafe path") || e.contains("escapes") || e.contains("invalid cmd")
+            {
+                InstallError::new(code::PATH_TRAVERSAL_DETECTED, e)
+            } else {
+                InstallError::new(code::INSTALL_FAILED, e)
+            }
+        })
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Installed-agents manifest
+// ---------------------------------------------------------------------------
+
+/// Current on-disk installed-agents manifest schema version.
+const INSTALLED_MANIFEST_SCHEMA_VERSION: u32 = 1;
+const INSTALLED_MANIFEST_FILENAME: &str = "installed.json";
+
+/// One installed-agent record. The manifest IS the audit record (no separate
+/// audit log concept exists).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct InstalledAgent {
+    pub agent_id: String,
+    pub version: String,
+    /// The `{os}-{arch}` platform target key this install resolved.
+    pub platform_target: String,
+    /// The verified sha256 hex digest of the downloaded archive.
+    pub sha256: String,
+    /// The absolute resolved executable path under the install root.
+    pub command: String,
+    /// The catalog target's args (or empty).
+    pub args: Vec<String>,
+    /// Epoch-millis install timestamp.
+    pub installed_at: u64,
+}
+
+/// Schema-versioned envelope for `installed.json`. Mirrors the
+/// `WorkspaceManifestFile` pattern so future migrations route through a
+/// `migrate` hook. A corrupt file is backed up via `backup_corrupt` then
+/// treated as empty (fresh install proceeds).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct InstalledManifestFile {
+    pub schema_version: u32,
+    pub agents: HashMap<String, InstalledAgent>,
+}
+
+impl Default for InstalledManifestFile {
+    fn default() -> Self {
+        Self {
+            schema_version: INSTALLED_MANIFEST_SCHEMA_VERSION,
+            agents: HashMap::new(),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Per-agent lock map (mirrors WorkspaceManifestService::ProjectLockMap)
+// ---------------------------------------------------------------------------
+
+type AgentLockMap = HashMap<String, Arc<TokioMutex<()>>>;
+
+// ---------------------------------------------------------------------------
+// Service
+// ---------------------------------------------------------------------------
+
+/// Host-owned verified-atomic ACP install service. One instance per host
+/// runtime (desktop OR standalone `termul-server`, never shared across
+/// processes). Constructed via [`AcpInstallService::open`], which creates the
+/// root directory + idempotent re-open (mirrors `WorkspaceManifestService::open`
+/// + `AcpCatalogService::open`).
+///
+/// The service holds an `Arc<AcpCatalogService>` for the convenience
+/// `install_by_id` path only; the catalog-agnostic `install(agent, host)`
+/// method takes a `&CatalogAgent` + `&HostCapability` + injected
+/// `Downloader`/`Extractor` so the I/O matrix rows are unit-testable without a
+/// real catalog service.
+pub struct AcpInstallService {
+    root: PathBuf,
+    catalog: Arc<AcpCatalogService>,
+    /// Per-`agent_id` write mutex. Grows on first install; evicted on
+    /// successful uninstall. Bounded by the number of distinct agents.
+    locks: Mutex<AgentLockMap>,
+    /// In-memory cache of the on-disk manifest. Held under a `Mutex` (not
+    /// `RwLock`) because every install both reads + writes; the per-agent
+    /// `TokioMutex` serializes the long install, this only guards the manifest
+    /// read/update which is sub-ms.
+    manifest: Mutex<InstalledManifestFile>,
+}
+
+impl AcpInstallService {
+    /// Open (or re-open) an install root. Creates the directory if missing;
+    /// idempotent re-open returns a fresh `Arc<Self>` over the same root.
+    /// Mirrors `WorkspaceManifestService::open` + `AcpCatalogService::open`:
+    /// Unix `0700` root, create the dir, load the manifest with corrupt-backup,
+    /// return an `Arc<Self>`. A non-directory root is an error.
+    pub async fn open(root: PathBuf, catalog: Arc<AcpCatalogService>) -> io::Result<Arc<Self>> {
+        if root.exists() && !root.is_dir() {
+            return Err(io::Error::other(format!(
+                "acp-install root '{}' is not a directory",
+                root.display()
+            )));
+        }
+        #[cfg(unix)]
+        {
+            std::os::unix::fs::DirBuilder::new()
+                .mode(0o700)
+                .recursive(true)
+                .create(&root)?;
+        }
+        #[cfg(not(unix))]
+        {
+            fs::create_dir_all(&root)?;
+        }
+        let manifest = Self::load_manifest_blocking(&root.join(INSTALLED_MANIFEST_FILENAME))
+            .unwrap_or_else(|error| {
+                log::warn!(
+                    "[acp-install] manifest load failed (defaulting to empty): {error}"
+                );
+                InstalledManifestFile::default()
+            });
+        log::info!("[acp-install] service ready root={}", root.display());
+        Ok(Arc::new(Self {
+            root,
+            catalog,
+            locks: Mutex::new(HashMap::new()),
+            manifest: Mutex::new(manifest),
+        }))
+    }
+
+    /// The install root directory.
+    #[must_use]
+    pub fn root(&self) -> &Path {
+        &self.root
+    }
+
+    /// Per-`agent_id` lock — get-or-insert (mirrors `project_lock`). The lock
+    /// entry persists until `uninstall` evicts it; an invalid agent_id never
+    /// reaches here (the caller validates first).
+    fn agent_lock(self: &Arc<Self>, agent_id: &str) -> Arc<TokioMutex<()>> {
+        let mut locks = self.locks.lock();
+        if let Some(lock) = locks.get(agent_id) {
+            return Arc::clone(lock);
+        }
+        let lock = Arc::new(TokioMutex::new(()));
+        locks.insert(agent_id.to_string(), Arc::clone(&lock));
+        lock
+    }
+
+    /// Load the on-disk manifest (blocking). A missing file = empty (fresh
+    /// start). A corrupt file is backed up via `backup_corrupt` then treated as
+    /// empty. A wrong schema version is backed up + empty.
+    fn load_manifest_blocking(path: &Path) -> io::Result<InstalledManifestFile> {
+        let bytes = match fs::read(path) {
+            Ok(bytes) => bytes,
+            Err(error) if error.kind() == io::ErrorKind::NotFound => {
+                return Ok(InstalledManifestFile::default());
+            }
+            Err(error) => return Err(error),
+        };
+        match serde_json::from_slice::<InstalledManifestFile>(&bytes) {
+            Ok(file) if file.schema_version == INSTALLED_MANIFEST_SCHEMA_VERSION => Ok(file),
+            Ok(file) => {
+                log::warn!(
+                    "[acp-install] manifest bad schema_version expected={} found={} — backing up + fresh start",
+                    INSTALLED_MANIFEST_SCHEMA_VERSION,
+                    file.schema_version
+                );
+                let _ = atomic_file::backup_corrupt(path, &bytes);
+                Ok(InstalledManifestFile::default())
+            }
+            Err(error) => {
+                log::warn!(
+                    "[acp-install] manifest corrupt error={error} — backing up + fresh start"
+                );
+                let _ = atomic_file::backup_corrupt(path, &bytes);
+                Ok(InstalledManifestFile::default())
+            }
+        }
+    }
+
+    /// Persist the manifest atomically (mirrors `WorkspaceManifestService::write`'s
+    /// `spawn_blocking` + `atomic_file::replace`).
+    fn persist_manifest_blocking(
+        root: &Path,
+        manifest: &InstalledManifestFile,
+    ) -> io::Result<()> {
+        let path = root.join(INSTALLED_MANIFEST_FILENAME);
+        let serialized = serde_json::to_vec_pretty(manifest).map_err(io::Error::other)?;
+        atomic_file::replace(&path, &serialized)
+    }
+
+    /// `install_by_id(agent_id)` — resolve the agent via the catalog, then
+    /// delegate to the catalog-agnostic `install`. The convenience path for
+    /// the three transports; the handler could also resolve the catalog entry
+    /// itself and call `install` directly.
+    pub async fn install_by_id(
+        self: &Arc<Self>,
+        agent_id: &str,
+    ) -> Result<InstallOutcome, InstallError> {
+        if !is_safe_agent_id(agent_id) {
+            return Err(InstallError::new(
+                code::VALIDATION_ERROR,
+                "invalid agent id",
+            ));
+        }
+        let catalog = self.catalog.list_catalog(false).await.map_err(|error| {
+            InstallError::new(code::INSTALL_FAILED, format!("catalog resolve failed: {error}"))
+        })?;
+        let agent = catalog
+            .agents
+            .iter()
+            .find(|a| a.id == agent_id)
+            .ok_or_else(|| {
+                InstallError::new(code::CATALOG_AGENT_NOT_FOUND, format!("agent '{agent_id}' not in catalog"))
+            })?;
+        self.install(agent, &catalog.host, None, None).await
+    }
+
+    /// Catalog-agnostic install. Takes a resolved `&CatalogAgent` + the host
+    /// capability + OPTIONAL injected `Downloader`/`Extractor` (production
+    /// uses `HttpDownloader`/`ArchiveExtractor` when `None`; tests inject
+    /// canned-bytes/failing impls to drive the I/O matrix without network).
+    ///
+    /// This is the core of the install flow:
+    /// 1. Validate the catalog status is `install-required`.
+    /// 2. Resolve the host's `binary.{os-arch}` target.
+    /// 3. Reject if no `sha256` (`INTEGRITY_METADATA_MISSING`) or no archive
+    ///    (`UNSUPPORTED_PLATFORM`).
+    /// 4. Acquire the per-`agent_id` mutex (serialize same-agent installs).
+    /// 5. Download → verify sha256 → extract into staging → atomic swap.
+    /// 6. Update the manifest.
+    pub async fn install(
+        self: &Arc<Self>,
+        agent: &CatalogAgent,
+        host: &HostCapability,
+        downloader: Option<Arc<dyn Downloader>>,
+        extractor: Option<Arc<dyn Extractor>>,
+    ) -> Result<InstallOutcome, InstallError> {
+        // 0. Defense-in-depth: validate the agent_id even though the catalog
+        // already validated it. `install()` is catalog-agnostic (takes a
+        // `&CatalogAgent`) and a synthetic/dotted id could escape the install
+        // root via `root.join(&agent.id)`. Mirrors `install_by_id`'s gate.
+        if !is_safe_agent_id(&agent.id) {
+            return Err(InstallError::new(
+                code::VALIDATION_ERROR,
+                "invalid agent id",
+            ));
+        }
+        // 1. Status gate.
+        if agent.status != SupportedAcpAgentStatus::InstallRequired {
+            return Err(InstallError::new(
+                code::NOT_INSTALLABLE,
+                format!(
+                    "agent '{}' status is {:?} (not install-required)",
+                    agent.id, agent.status
+                ),
+            ));
+        }
+
+        // 2. Resolve the host's binary target.
+        let platform_arch = host_platform_arch(host);
+        let target = agent
+            .distribution
+            .get("binary")
+            .and_then(|b| b.as_object())
+            .and_then(|b| b.get(&platform_arch))
+            .and_then(|t| t.as_object())
+            .ok_or_else(|| {
+                InstallError::new(
+                    code::UNSUPPORTED_PLATFORM,
+                    format!("no binary target for {platform_arch}"),
+                )
+            })?;
+
+        let cmd = target
+            .get("cmd")
+            .and_then(|c| c.as_str())
+            .ok_or_else(|| {
+                InstallError::new(code::INSTALL_FAILED, "catalog binary target missing 'cmd'")
+            })?;
+        let archive_url = target
+            .get("archive")
+            .and_then(|a| a.as_str())
+            .ok_or_else(|| {
+                InstallError::new(code::UNSUPPORTED_PLATFORM, "catalog binary target missing 'archive'")
+            })?;
+        let sha256_hex = target
+            .get("sha256")
+            .and_then(|s| s.as_str())
+            .ok_or_else(|| {
+                InstallError::new(
+                    code::INTEGRITY_METADATA_MISSING,
+                    "catalog binary target missing 'sha256' — cannot verify integrity",
+                )
+            })?;
+        let args: Vec<String> = target
+            .get("args")
+            .and_then(|a| a.as_array())
+            .map(|a| {
+                a.iter()
+                    .filter_map(|v| v.as_str().map(String::from))
+                    .collect()
+            })
+            .unwrap_or_default();
+
+        // 4. Per-agent serialization.
+        let lock = self.agent_lock(&agent.id);
+        let _guard = lock.lock().await;
+
+        let agent_id_log = sanitize_agent_id_log(&agent.id);
+        let archive_host = archive_host_for_log(archive_url);
+        log::info!(
+            "[acp-install] {} install start agent={} target={} archive_host={}",
+            crate::logging::session_id(),
+            agent_id_log,
+            platform_arch,
+            archive_host
+        );
+        let started = Instant::now();
+
+        // 5. Download → verify → extract → swap.
+        let downloader = downloader.unwrap_or_else(|| Arc::new(HttpDownloader));
+        let extractor = extractor.unwrap_or_else(|| Arc::new(ArchiveExtractor));
+
+        // Staging dir under the install root. Owns BOTH the downloaded
+        // archive temp file AND the extracted tree — a single
+        // `remove_dir_all` cleans up on any failure path.
+        let tmp_dir = self
+            .root
+            .join(format!(".staging-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&tmp_dir).map_err(|e| {
+            InstallError::new(code::INSTALL_FAILED, format!("create staging: {e}"))
+        })?;
+        let staging = tmp_dir.join("stage");
+        std::fs::create_dir_all(&staging).map_err(|e| {
+            let _ = std::fs::remove_dir_all(&tmp_dir);
+            InstallError::new(code::INSTALL_FAILED, format!("create staging stage: {e}"))
+        })?;
+
+        // Download streams the archive body to a temp file under `tmp_dir`
+        // (never held in RAM — the 256 MiB cap bounds memory to the streaming
+        // buffer). The archive temp file lives inside `tmp_dir` so a failure
+        // path's `remove_dir_all(&tmp_dir)` reclaims it too.
+        let downloaded = match downloader.download(archive_url, &tmp_dir).await {
+            Ok(d) => d,
+            Err(e) => {
+                let _ = std::fs::remove_dir_all(&tmp_dir);
+                log::error!(
+                    "[acp-install] {} install failure agent={} code={} msg={}",
+                    crate::logging::session_id(),
+                    agent_id_log,
+                    e.code,
+                    e.message
+                );
+                return Err(e);
+            }
+        };
+        let bytes_len = downloaded.size;
+        let archive_path = downloaded.path;
+
+        // sha256 verify BEFORE extraction. Read the temp file in chunks so a
+        // 256 MiB archive never materializes in RAM for the hash either.
+        let actual_hex = match sha256_file(&archive_path) {
+            Ok(hex) => hex,
+            Err(e) => {
+                let _ = std::fs::remove_dir_all(&tmp_dir);
+                log::error!(
+                    "[acp-install] {} sha256 read failure agent={} msg={}",
+                    crate::logging::session_id(),
+                    agent_id_log,
+                    e
+                );
+                return Err(InstallError::new(
+                    code::INSTALL_FAILED,
+                    format!("sha256 read failed: {e}"),
+                ));
+            }
+        };
+        if !actual_hex.eq_ignore_ascii_case(sha256_hex) {
+            let _ = std::fs::remove_dir_all(&tmp_dir);
+            log::error!(
+                "[acp-install] {} integrity mismatch agent={} — aborting before extraction",
+                crate::logging::session_id(),
+                agent_id_log
+            );
+            return Err(InstallError::new(
+                code::INTEGRITY_MISMATCH,
+                "downloaded archive sha256 does not match the catalog digest",
+            ));
+        }
+
+        if let Err(e) = extractor.extract(&archive_path, &staging).await {
+            let _ = std::fs::remove_dir_all(&tmp_dir);
+            log::error!(
+                "[acp-install] {} extract failure agent={} code={} msg={}",
+                crate::logging::session_id(),
+                agent_id_log,
+                e.code,
+                e.message
+            );
+            return Err(e);
+        }
+
+        // Validate the cmd resolves to a regular file inside staging.
+        if let Err(e) = resolve_cmd_in_root(&staging, cmd) {
+            let _ = std::fs::remove_dir_all(&tmp_dir);
+            log::error!(
+                "[acp-install] {} cmd resolution failure agent={} msg={}",
+                crate::logging::session_id(),
+                agent_id_log,
+                e
+            );
+            return Err(InstallError::new(code::PATH_TRAVERSAL_DETECTED, e));
+        }
+        // Mark spawnables (zip extracts often land as 0644).
+        mark_spawnables_in_tree(&staging);
+        let staged_program = staging.join(normalize_cmd_path(cmd));
+        mark_executable(&staged_program);
+
+        // Atomic-ish swap: backup old → rename(staging, root) → drop backup.
+        // Use `with_file_name(format!("{id}.old"))` (NOT `with_extension`) so a
+        // dotted agent_id like `com.foo.agent` survives (with_extension would
+        // mangle it to `com.foo.old`, colliding/destroying unrelated paths
+        // and breaking restore-on-failure).
+        let install_root_for_agent = self.root.join(&agent.id);
+        let backup = install_root_for_agent.with_file_name(format!("{}.old", agent.id));
+        let _ = std::fs::remove_dir_all(&backup);
+        if install_root_for_agent.exists() {
+            if let Err(e) = std::fs::rename(&install_root_for_agent, &backup) {
+                let _ = std::fs::remove_dir_all(&tmp_dir);
+                return Err(InstallError::new(
+                    code::INSTALL_FAILED,
+                    format!("backup old install: {e}"),
+                ));
+            }
+        }
+        if let Err(e) = std::fs::rename(&staging, &install_root_for_agent) {
+            // Restore the previous install on swap failure.
+            if backup.exists() {
+                let _ = std::fs::rename(&backup, &install_root_for_agent);
+            }
+            let _ = std::fs::remove_dir_all(&tmp_dir);
+            return Err(InstallError::new(
+                code::INSTALL_FAILED,
+                format!("promote install: {e}"),
+            ));
+        }
+        let _ = std::fs::remove_dir_all(&backup);
+        let _ = std::fs::remove_dir_all(&tmp_dir);
+
+        // Recompute the program path under the final root (plain, non-canonical).
+        let program = install_root_for_agent.join(normalize_cmd_path(cmd));
+
+        // 6. Update the manifest. Clone the updated state under the guard,
+        // then drop the guard before `spawn_blocking` so the `parking_lot`
+        // MutexGuard (which is `!Send`) is not held across the `.await`.
+        let installed_at = now_millis();
+        let record = InstalledAgent {
+            agent_id: agent.id.clone(),
+            version: agent.version.clone(),
+            platform_target: platform_arch,
+            sha256: actual_hex,
+            command: program.to_string_lossy().to_string(),
+            args: args.clone(),
+            installed_at,
+        };
+        let manifest_clone = {
+            let mut manifest = self.manifest.lock();
+            manifest.agents.insert(agent.id.clone(), record.clone());
+            manifest.clone()
+        };
+        let root = self.root.clone();
+        if let Err(e) =
+            tokio::task::spawn_blocking(move || Self::persist_manifest_blocking(&root, &manifest_clone))
+                .await
+        {
+            log::error!("[acp-install] {} manifest persist task failed: {e}", crate::logging::session_id());
+        }
+
+        let elapsed = started.elapsed();
+        log::info!(
+            "[acp-install] {} install success agent={} bytes={} duration_ms={}",
+            crate::logging::session_id(),
+            agent_id_log,
+            bytes_len,
+            elapsed.as_millis()
+        );
+
+        Ok(InstallOutcome {
+            command: program.to_string_lossy().to_string(),
+            args,
+        })
+    }
+
+    /// Remove an installed agent: delete the install dir + remove the manifest
+    /// entry. Idempotent (no error if not installed).
+    ///
+    /// The per-agent lock-map entry is NOT evicted — a concurrent caller that
+    /// called `agent_lock` between guard-acquire and eviction would hold a
+    /// clone of the OLD `Arc<TokioMutex>`, while a new caller arriving after
+    /// eviction gets a FRESH `Arc`, so two same-agent operations would run in
+    /// parallel (breaking the serialization invariant). The map is naturally
+    /// bounded by the number of distinct catalog agents (small); letting the
+    /// entry linger is the safe choice (mirrors the conservative path).
+    pub async fn uninstall(self: &Arc<Self>, agent_id: &str) -> Result<(), InstallError> {
+        if !is_safe_agent_id(agent_id) {
+            return Err(InstallError::new(code::VALIDATION_ERROR, "invalid agent id"));
+        }
+        let lock = self.agent_lock(agent_id);
+        let _guard = lock.lock().await;
+
+        let install_dir = self.root.join(agent_id);
+        let _ = std::fs::remove_dir_all(&install_dir);
+        // `with_file_name(format!("{id}.old"))` (NOT `with_extension`) so a
+        // dotted agent_id survives — mirrors `install`'s backup path.
+        let backup = install_dir.with_file_name(format!("{}.old", agent_id));
+        let _ = std::fs::remove_dir_all(&backup);
+
+        // Clone the updated manifest + drop the guard before spawn_blocking
+        // (parking_lot MutexGuard is `!Send`).
+        let (manifest_clone, removed) = {
+            let mut manifest = self.manifest.lock();
+            let removed = manifest.agents.remove(agent_id).is_some();
+            (manifest.clone(), removed)
+        };
+        if removed {
+            let root = self.root.clone();
+            let _ = tokio::task::spawn_blocking(move || {
+                Self::persist_manifest_blocking(&root, &manifest_clone)
+            })
+            .await;
+        }
+        // NOTE: the per-agent lock-map entry is intentionally NOT evicted
+        // (see the doc comment above).
+        log::info!(
+            "[acp-install] {} uninstall agent={}",
+            crate::logging::session_id(),
+            sanitize_agent_id_log(agent_id)
+        );
+        Ok(())
+    }
+
+    /// Read-only snapshot of the installed-agents manifest (for the catalog's
+    /// deferred "ready for already-installed agents" refresh — story 9 only
+    /// writes the manifest; the catalog-status refresh is a deferred parity
+    /// item).
+    pub fn installed_agents(&self) -> Vec<InstalledAgent> {
+        self.manifest
+            .lock()
+            .agents
+            .values()
+            .cloned()
+            .collect()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// The platform-arch key for the catalog's binary map lookup. Mirrors
+/// `catalog::host_platform_arch` but takes the host capability (testable with
+/// synthetic input) instead of `std::env::consts::OS`.
+fn host_platform_arch(host: &HostCapability) -> String {
+    let os = if host.os == "macos" { "darwin" } else { &host.os };
+    format!("{}-{}", os, host.arch)
+}
+
+/// Epoch-millis timestamp (mirrors `workspace_manifest::now_millis`).
+fn now_millis() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0)
+}
+
+/// Hex-encode a byte slice (lowercase). Avoids pulling a `hex` crate dep.
+fn hex_encode(bytes: &[u8]) -> String {
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    let mut out = String::with_capacity(bytes.len() * 2);
+    for &b in bytes {
+        out.push(HEX[(b >> 4) as usize] as char);
+        out.push(HEX[(b & 0x0f) as usize] as char);
+    }
+    out
+}
+
+/// Sanitize an agent_id for logging (it's already safe per `is_safe_agent_id`,
+/// but this is a single chokepoint).
+fn sanitize_agent_id_log(id: &str) -> &str {
+    id
+}
+
+/// Extract the archive URL's host for logging — never the full URL with
+/// path/query (may carry tokens in some registries), never env/args. The
+/// `http://` branch is intentionally absent: the `HttpDownloader` rejects
+/// non-https URLs with `DOWNLOAD_FAILED`, so a plaintext URL never reaches
+/// logging.
+fn archive_host_for_log(url: &str) -> &str {
+    // `https://host/path...` → `host`.
+    url.strip_prefix("https://")
+        .unwrap_or(url)
+        .split(['/', '?', '#'])
+        .next()
+        .unwrap_or("")
+}
+
+/// Compute the sha256 hex digest of a file by streaming it in chunks (64 KiB
+/// buffer) so a 256 MiB archive never materializes in RAM for the hash.
+/// Mirrors the `copy_bounded` streaming pattern in `archive.rs`.
+fn sha256_file(path: &Path) -> io::Result<String> {
+    use std::io::{BufReader, Read};
+    let mut file = BufReader::with_capacity(64 * 1024, std::fs::File::open(path)?);
+    let mut hasher = Sha256::new();
+    let mut buf = [0u8; 64 * 1024];
+    loop {
+        let n = file.read(&mut buf)?;
+        if n == 0 {
+            break;
+        }
+        hasher.update(&buf[..n]);
+    }
+    Ok(hex_encode(&hasher.finalize_reset()))
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::acp::catalog::{CatalogSource, HostCapability, PlatformTarget};
+    use std::path::PathBuf;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    fn temp_dir(label: &str) -> PathBuf {
+        let path = std::env::temp_dir().join(format!(
+            "termul-acp-install-{label}-{}-{}",
+            std::process::id(),
+            now_millis()
+        ));
+        fs::create_dir_all(&path).unwrap();
+        path
+    }
+
+    fn host() -> HostCapability {
+        HostCapability {
+            os: std::env::consts::OS.to_string(),
+            arch: std::env::consts::ARCH.to_string(),
+            runtimes: crate::acp::catalog::CatalogRuntimeAvailability {
+                npx: false,
+                uvx: false,
+                node: false,
+                bun: false,
+                python3: false,
+            },
+        }
+    }
+
+    fn platform_arch_for(host: &HostCapability) -> String {
+        host_platform_arch(host)
+    }
+
+    fn sample_binary_agent(
+        id: &str,
+        platform_arch: &str,
+        sha256: Option<&str>,
+        cmd: &str,
+        archive: &str,
+    ) -> CatalogAgent {
+        let mut target = serde_json::json!({
+            "cmd": cmd,
+            "archive": archive,
+            "args": ["acp"],
+        });
+        if let Some(hex) = sha256 {
+            target["sha256"] = serde_json::json!(hex);
+        }
+        CatalogAgent {
+            id: id.to_string(),
+            name: id.to_string(),
+            version: "1.0.0".to_string(),
+            description: "test".to_string(),
+            source: CatalogSource::Bundled,
+            distribution: serde_json::json!({
+                "binary": { platform_arch: target }
+            }),
+            runtime_requirements: Vec::new(),
+            status: SupportedAcpAgentStatus::InstallRequired,
+            platform_targets: vec![PlatformTarget {
+                os: host().os,
+                arch: host().arch,
+            }],
+        }
+    }
+
+    /// Build a tiny valid zip archive in memory (a single `acp` text file) so
+    /// the production extractor can extract it. Returns the bytes + the
+    /// expected sha256 hex.
+    fn tiny_zip(payload: &str) -> (Vec<u8>, String) {
+        use std::io::Write;
+        let tmp = std::env::temp_dir()
+            .join(format!("termul-acp-install-zip-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&tmp).unwrap();
+        let payload_path = tmp.join("acp");
+        let mut f = std::fs::File::create(&payload_path).unwrap();
+        f.write_all(payload.as_bytes()).unwrap();
+        drop(f);
+
+        let zip_path = tmp.join("archive.zip");
+        {
+            let file = std::fs::File::create(&zip_path).unwrap();
+            let mut zip = zip::ZipWriter::new(file);
+            let opts = zip::write::SimpleFileOptions::default();
+            zip.start_file("acp", opts).unwrap();
+            let mut f = std::fs::File::open(&payload_path).unwrap();
+            std::io::copy(&mut f, &mut zip).unwrap();
+            zip.finish().unwrap();
+        }
+        let bytes = std::fs::read(&zip_path).unwrap();
+        let mut hasher = Sha256::new();
+        hasher.update(&bytes);
+        let hex = hex_encode(&hasher.finalize());
+        let _ = std::fs::remove_dir_all(&tmp);
+        (bytes, hex)
+    }
+
+    async fn open_service(root: PathBuf) -> Arc<AcpInstallService> {
+        let catalog = crate::acp::AcpCatalogService::open(root.join("catalog"))
+            .await
+            .unwrap();
+        AcpInstallService::open(root.join("installs"), catalog)
+            .await
+            .unwrap()
+    }
+
+    /// A downloader that writes canned bytes to a temp file under `target_dir`
+    /// (the production extractor will extract them). Used for happy-path +
+    /// sha256-mismatch.
+    struct CannedDownloader {
+        bytes: Vec<u8>,
+        filename: String,
+        fail: bool,
+    }
+
+    #[async_trait::async_trait]
+    impl Downloader for CannedDownloader {
+        async fn download(
+            &self,
+            _url: &str,
+            target_dir: &Path,
+        ) -> Result<DownloadedArchive, InstallError> {
+            if self.fail {
+                return Err(InstallError::new(code::DOWNLOAD_FAILED, "canned download failure"));
+            }
+            use std::io::Write;
+            let path = target_dir.join(&self.filename);
+            let mut f = std::fs::File::create(&path)
+                .map_err(|e| InstallError::new(code::INSTALL_FAILED, format!("canned create: {e}")))?;
+            f.write_all(&self.bytes)
+                .map_err(|e| InstallError::new(code::INSTALL_FAILED, format!("canned write: {e}")))?;
+            Ok(DownloadedArchive {
+                path,
+                filename: self.filename.clone(),
+                size: self.bytes.len() as u64,
+            })
+        }
+    }
+
+    /// A downloader that exceeds the size cap.
+    struct TooLargeDownloader;
+    #[async_trait::async_trait]
+    impl Downloader for TooLargeDownloader {
+        async fn download(
+            &self,
+            _url: &str,
+            _target_dir: &Path,
+        ) -> Result<DownloadedArchive, InstallError> {
+            Err(InstallError::new(
+                code::ARCHIVE_TOO_LARGE,
+                "canned too-large",
+            ))
+        }
+    }
+
+    /// An extractor that always fails with a traversal-style message.
+    struct FailingExtractor { message: String }
+    #[async_trait::async_trait]
+    impl Extractor for FailingExtractor {
+        async fn extract(&self, _archive_path: &Path, _dest: &Path) -> Result<(), InstallError> {
+            Err(InstallError::new(
+                code::PATH_TRAVERSAL_DETECTED,
+                self.message.clone(),
+            ))
+        }
+    }
+
+    // ---- Happy-path install ----
+
+    #[tokio::test]
+    async fn happy_path_install_verifies_sha256_and_activates() {
+        let root = temp_dir("happy");
+        let service = open_service(root.clone()).await;
+        let (bytes, sha) = tiny_zip("acp payload");
+        let pa = platform_arch_for(&host());
+        let agent = sample_binary_agent(
+            "test-agent",
+            &pa,
+            Some(&sha),
+            "./acp",
+            "https://example.com/test.zip",
+        );
+        let downloader: Arc<dyn Downloader> = Arc::new(CannedDownloader {
+            bytes: bytes.clone(),
+            filename: "archive.zip".to_string(),
+            fail: false,
+        });
+        let outcome = service
+            .install(&agent, &host(), Some(downloader), None)
+            .await
+            .expect("happy path install");
+        assert!(outcome.command.contains("test-agent"));
+        assert_eq!(outcome.args, vec!["acp".to_string()]);
+        // Manifest has the entry.
+        let installed = service.installed_agents();
+        assert_eq!(installed.len(), 1);
+        assert_eq!(installed[0].agent_id, "test-agent");
+        assert_eq!(installed[0].sha256, sha);
+        // On-disk manifest persisted.
+        let manifest_path = service.root().join(INSTALLED_MANIFEST_FILENAME);
+        let on_disk: InstalledManifestFile =
+            serde_json::from_slice(&fs::read(&manifest_path).unwrap()).unwrap();
+        assert_eq!(on_disk.agents.len(), 1);
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    // ---- sha256 mismatch (tampered) ----
+
+    #[tokio::test]
+    async fn sha256_mismatch_aborts_before_extraction() {
+        let root = temp_dir("mismatch");
+        let service = open_service(root.clone()).await;
+        let (bytes, _sha) = tiny_zip("real payload");
+        let host = host();
+        let pa = platform_arch_for(&host);
+        let tampered_sha = "deadbeef".repeat(8);
+        let agent = sample_binary_agent(
+            "tampered",
+            &pa,
+            Some(tampered_sha.as_str()),
+            "./acp",
+            "https://example.com/tampered.zip",
+        );
+        let downloader: Arc<dyn Downloader> = Arc::new(CannedDownloader {
+            bytes: bytes.clone(),
+            filename: "archive.zip".to_string(),
+            fail: false,
+        });
+        let extractor_calls = Arc::new(AtomicUsize::new(0));
+        let counting_extractor: Arc<dyn Extractor> =
+            Arc::new(CountingExtractor::new(extractor_calls.clone()));
+        let err = service
+            .install(&agent, &host, Some(downloader), Some(counting_extractor))
+            .await
+            .expect_err("mismatch must error");
+        assert_eq!(err.code(), code::INTEGRITY_MISMATCH);
+        // Extraction must NOT have run.
+        assert_eq!(extractor_calls.load(Ordering::SeqCst), 0);
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    /// Wraps ArchiveExtractor to count calls (for the mismatch assertion).
+    struct CountingExtractor {
+        calls: Arc<AtomicUsize>,
+        inner: ArchiveExtractor,
+    }
+    impl CountingExtractor {
+        fn new(calls: Arc<AtomicUsize>) -> Self {
+            Self {
+                calls,
+                inner: ArchiveExtractor,
+            }
+        }
+    }
+    #[async_trait::async_trait]
+    impl Extractor for CountingExtractor {
+        async fn extract(&self, archive_path: &Path, dest: &Path) -> Result<(), InstallError> {
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            self.inner.extract(archive_path, dest).await
+        }
+    }
+
+    // ---- sha256 absent ----
+
+    #[tokio::test]
+    async fn sha256_absent_rejects_before_download() {
+        let root = temp_dir("no-sha");
+        let service = open_service(root.clone()).await;
+        let pa = platform_arch_for(&host());
+        let agent = sample_binary_agent(
+            "no-sha",
+            &pa,
+            None,
+            "./acp",
+            "https://example.com/no-sha.zip",
+        );
+        let downloader: Arc<dyn Downloader> = Arc::new(CannedDownloader {
+            bytes: vec![],
+            filename: "archive.zip".to_string(),
+            fail: false,
+        });
+        let err = service
+            .install(&agent, &host(), Some(downloader), None)
+            .await
+            .expect_err("no-sha must error");
+        assert_eq!(err.code(), code::INTEGRITY_METADATA_MISSING);
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    // ---- unsupported platform ----
+
+    #[tokio::test]
+    async fn unsupported_platform_rejects_before_download() {
+        let root = temp_dir("no-platform");
+        let service = open_service(root.clone()).await;
+        // Agent with a binary target for a DIFFERENT platform.
+        let agent = sample_binary_agent(
+            "no-platform",
+            "darwin-aarch64",
+            Some("abc"),
+            "./acp",
+            "https://example.com/no-platform.zip",
+        );
+        // Use the test host (linux/windows-x86_64) so the lookup misses.
+        let err = service
+            .install(&agent, &host(), None, None)
+            .await
+            .expect_err("no-platform must error");
+        assert_eq!(err.code(), code::UNSUPPORTED_PLATFORM);
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    // ---- not installable ----
+
+    #[tokio::test]
+    async fn not_installable_rejects_non_install_required_status() {
+        let root = temp_dir("not-installable");
+        let service = open_service(root.clone()).await;
+        let pa = platform_arch_for(&host());
+        let mut agent = sample_binary_agent(
+            "ready-agent",
+            &pa,
+            Some("abc"),
+            "./acp",
+            "https://example.com/ready.zip",
+        );
+        agent.status = SupportedAcpAgentStatus::Ready;
+        let err = service
+            .install(&agent, &host(), None, None)
+            .await
+            .expect_err("ready must error");
+        assert_eq!(err.code(), code::NOT_INSTALLABLE);
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    // ---- archive too large ----
+
+    #[tokio::test]
+    async fn archive_too_large_aborts_download() {
+        let root = temp_dir("too-large");
+        let service = open_service(root.clone()).await;
+        let pa = platform_arch_for(&host());
+        let agent = sample_binary_agent(
+            "big",
+            &pa,
+            Some("abc"),
+            "./acp",
+            "https://example.com/big.zip",
+        );
+        let downloader: Arc<dyn Downloader> = Arc::new(TooLargeDownloader);
+        let err = service
+            .install(&agent, &host(), Some(downloader), None)
+            .await
+            .expect_err("too-large must error");
+        assert_eq!(err.code(), code::ARCHIVE_TOO_LARGE);
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    // ---- extraction quota / path traversal ----
+
+    #[tokio::test]
+    async fn extraction_failure_propagates_code() {
+        let root = temp_dir("extract-fail");
+        let service = open_service(root.clone()).await;
+        let (bytes, sha) = tiny_zip("payload");
+        let pa = platform_arch_for(&host());
+        let agent = sample_binary_agent(
+            "traversal",
+            &pa,
+            Some(&sha),
+            "./acp",
+            "https://example.com/traversal.zip",
+        );
+        let downloader: Arc<dyn Downloader> = Arc::new(CannedDownloader {
+            bytes,
+            filename: "archive.zip".to_string(),
+            fail: false,
+        });
+        let extractor: Arc<dyn Extractor> = Arc::new(FailingExtractor {
+            message: "unsafe path detected".to_string(),
+        });
+        let err = service
+            .install(&agent, &host(), Some(downloader), Some(extractor))
+            .await
+            .expect_err("extract failure must error");
+        assert_eq!(err.code(), code::PATH_TRAVERSAL_DETECTED);
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    // ---- download failure ----
+
+    #[tokio::test]
+    async fn download_failure_propagates_code() {
+        let root = temp_dir("dl-fail");
+        let service = open_service(root.clone()).await;
+        let pa = platform_arch_for(&host());
+        let agent = sample_binary_agent(
+            "dl-fail",
+            &pa,
+            Some("abc"),
+            "./acp",
+            "https://example.com/dl-fail.zip",
+        );
+        let downloader: Arc<dyn Downloader> = Arc::new(CannedDownloader {
+            bytes: vec![],
+            filename: "archive.zip".to_string(),
+            fail: true,
+        });
+        let err = service
+            .install(&agent, &host(), Some(downloader), None)
+            .await
+            .expect_err("download failure must error");
+        assert_eq!(err.code(), code::DOWNLOAD_FAILED);
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    // ---- manifest corrupt backup ----
+
+    #[tokio::test]
+    async fn manifest_corrupt_file_backed_up_and_treated_as_empty() {
+        let root = temp_dir("manifest-corrupt");
+        let install_dir = root.join("installs");
+        fs::create_dir_all(&install_dir).unwrap();
+        let manifest_path = install_dir.join(INSTALLED_MANIFEST_FILENAME);
+        fs::write(&manifest_path, b"{ not valid json").unwrap();
+
+        let catalog = crate::acp::AcpCatalogService::open(root.join("catalog"))
+            .await
+            .unwrap();
+        let service = AcpInstallService::open(install_dir, catalog)
+            .await
+            .unwrap();
+        assert!(service.installed_agents().is_empty());
+
+        // Backup exists.
+        let backups: Vec<_> = fs::read_dir(service.root())
+            .unwrap()
+            .flatten()
+            .filter(|e| {
+                e.file_name()
+                    .to_str()
+                    .map(|n| n.contains("corrupt-"))
+                    .unwrap_or(false)
+            })
+            .collect();
+        assert_eq!(backups.len(), 1, "exactly one corrupt backup");
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    // ---- concurrent same-agent install serializes ----
+
+    #[tokio::test]
+    async fn concurrent_same_agent_install_serializes() {
+        let root = temp_dir("concurrent-same");
+        let service = open_service(root.clone()).await;
+        let (bytes, sha) = tiny_zip("payload");
+        let host = host();
+        let pa = platform_arch_for(&host);
+        let agent = sample_binary_agent(
+            "concurrent",
+            &pa,
+            Some(&sha),
+            "./acp",
+            "https://example.com/concurrent.zip",
+        );
+
+        // Two concurrent installs of the SAME agent. Both share the per-agent
+        // mutex; both should succeed (idempotent re-install). The manifest
+        // should have exactly one entry.
+        let svc = service.clone();
+        let agent1 = agent.clone();
+        let dl1: Arc<dyn Downloader> = Arc::new(CannedDownloader {
+            bytes: bytes.clone(),
+            filename: "archive.zip".to_string(),
+            fail: false,
+        });
+        let svc2 = service.clone();
+        let agent2 = agent.clone();
+        let dl2: Arc<dyn Downloader> = Arc::new(CannedDownloader {
+            bytes: bytes.clone(),
+            filename: "archive.zip".to_string(),
+            fail: false,
+        });
+        let (r1, r2) = tokio::join!(
+            svc.install(&agent1, &host, Some(dl1), None),
+            svc2.install(&agent2, &host, Some(dl2), None)
+        );
+        let o1 = r1.expect("first install ok");
+        let o2 = r2.expect("second install ok");
+        assert_eq!(o1.command, o2.command, "both return same command");
+        assert_eq!(service.installed_agents().len(), 1);
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    // ---- concurrent different-agent install runs in parallel ----
+
+    #[tokio::test]
+    async fn concurrent_different_agent_install_parallel() {
+        let root = temp_dir("concurrent-diff");
+        let service = open_service(root.clone()).await;
+        let (bytes, sha) = tiny_zip("payload");
+        let host = host();
+        let pa = platform_arch_for(&host);
+        let agent_a = sample_binary_agent(
+            "agent-a",
+            &pa,
+            Some(&sha),
+            "./acp",
+            "https://example.com/a.zip",
+        );
+        let agent_b = sample_binary_agent(
+            "agent-b",
+            &pa,
+            Some(&sha),
+            "./acp",
+            "https://example.com/b.zip",
+        );
+        let svc = service.clone();
+        let dl1: Arc<dyn Downloader> = Arc::new(CannedDownloader {
+            bytes: bytes.clone(),
+            filename: "archive.zip".to_string(),
+            fail: false,
+        });
+        let svc2 = service.clone();
+        let dl2: Arc<dyn Downloader> = Arc::new(CannedDownloader {
+            bytes: bytes.clone(),
+            filename: "archive.zip".to_string(),
+            fail: false,
+        });
+        let (r1, r2) = tokio::join!(
+            svc.install(&agent_a, &host, Some(dl1), None),
+            svc2.install(&agent_b, &host, Some(dl2), None)
+        );
+        r1.expect("a install ok");
+        r2.expect("b install ok");
+        assert_eq!(service.installed_agents().len(), 2);
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    // ---- idempotent re-install ----
+
+    #[tokio::test]
+    async fn idempotent_reinstall_overwrites() {
+        let root = temp_dir("idempotent");
+        let service = open_service(root.clone()).await;
+        let (bytes, sha) = tiny_zip("payload");
+        let pa = platform_arch_for(&host());
+        let agent = sample_binary_agent(
+            "idem",
+            &pa,
+            Some(&sha),
+            "./acp",
+            "https://example.com/idem.zip",
+        );
+        let dl: Arc<dyn Downloader> = Arc::new(CannedDownloader {
+            bytes: bytes.clone(),
+            filename: "archive.zip".to_string(),
+            fail: false,
+        });
+        let o1 = service
+            .install(&agent, &host(), Some(dl), None)
+            .await
+            .expect("first install");
+        let dl2: Arc<dyn Downloader> = Arc::new(CannedDownloader {
+            bytes: bytes.clone(),
+            filename: "archive.zip".to_string(),
+            fail: false,
+        });
+        let o2 = service
+            .install(&agent, &host(), Some(dl2), None)
+            .await
+            .expect("re-install");
+        assert_eq!(o1.command, o2.command);
+        assert_eq!(service.installed_agents().len(), 1);
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    // ---- validation: invalid agent id ----
+
+    #[tokio::test]
+    async fn install_by_id_rejects_invalid_agent_id() {
+        let root = temp_dir("bad-id");
+        let service = open_service(root.clone()).await;
+        let err = service.install_by_id("").await.expect_err("empty id errors");
+        assert_eq!(err.code(), code::VALIDATION_ERROR);
+        let err = service.install_by_id("../escape").await.expect_err("bad id errors");
+        assert_eq!(err.code(), code::VALIDATION_ERROR);
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    // ---- install_by_id: agent not in catalog ----
+
+    #[tokio::test]
+    async fn install_by_id_agent_not_in_catalog() {
+        let root = temp_dir("not-in-catalog");
+        let service = open_service(root.clone()).await;
+        let err = service
+            .install_by_id("nonexistent-agent")
+            .await
+            .expect_err("not in catalog errors");
+        assert_eq!(err.code(), code::CATALOG_AGENT_NOT_FOUND);
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    // ---- uninstall ----
+
+    #[tokio::test]
+    async fn uninstall_removes_dir_and_manifest_entry() {
+        let root = temp_dir("uninstall");
+        let service = open_service(root.clone()).await;
+        let (bytes, sha) = tiny_zip("payload");
+        let pa = platform_arch_for(&host());
+        let agent = sample_binary_agent(
+            "to-remove",
+            &pa,
+            Some(&sha),
+            "./acp",
+            "https://example.com/to-remove.zip",
+        );
+        let dl: Arc<dyn Downloader> = Arc::new(CannedDownloader {
+            bytes,
+            filename: "archive.zip".to_string(),
+            fail: false,
+        });
+        service
+            .install(&agent, &host(), Some(dl), None)
+            .await
+            .expect("install");
+        assert_eq!(service.installed_agents().len(), 1);
+        service.uninstall("to-remove").await.expect("uninstall");
+        assert!(service.installed_agents().is_empty());
+        assert!(!service.root().join("to-remove").exists());
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    // ---- serde shape tests ----
+
+    #[test]
+    fn install_request_rejects_unknown_fields() {
+        let payload = serde_json::json!({ "agentId": "opencode", "extra": "junk" });
+        let result: Result<InstallRequest, _> = serde_json::from_value(payload);
+        assert!(result.is_err(), "deny_unknown_fields must reject extra");
+    }
+
+    #[test]
+    fn install_request_accepts_agent_id_only() {
+        let payload = serde_json::json!({ "agentId": "opencode" });
+        let req: InstallRequest = serde_json::from_value(payload).unwrap();
+        assert_eq!(req.agent_id, "opencode");
+    }
+
+    #[test]
+    fn install_outcome_serializes_camel_case() {
+        let outcome = InstallOutcome {
+            command: "/path/to/opencode".to_string(),
+            args: vec!["acp".to_string()],
+        };
+        let value = serde_json::to_value(&outcome).unwrap();
+        assert_eq!(value["command"], "/path/to/opencode");
+        assert_eq!(value["args"][0], "acp");
+    }
+
+    #[test]
+    fn archive_host_for_log_extracts_host_only() {
+        assert_eq!(
+            archive_host_for_log("https://github.com/anomalyco/opencode/releases/download/v1/opencode.zip"),
+            "github.com"
+        );
+        assert_eq!(archive_host_for_log("https://example.com/path?query=1"), "example.com");
+        assert_eq!(archive_host_for_log("not-a-url"), "not-a-url");
+    }
+}

--- a/src-tauri/src/acp/manager.rs
+++ b/src-tauri/src/acp/manager.rs
@@ -1317,8 +1317,30 @@ impl AcpManager {
         let (command_tx, mut command_rx) = mpsc::unbounded_channel();
         tokio::spawn(async move {
             while let Some(command) = command_rx.recv().await {
-                if let AcpCommand::OwnsSession { session_id, reply } = command {
-                    let _ = reply.send(Ok(sessions.contains(&session_id.0)));
+                match command {
+                    AcpCommand::OwnsSession { session_id, reply } => {
+                        let _ = reply.send(Ok(sessions.contains(&session_id.0)));
+                    }
+                    // Story 10 (cross-client continuity): handle the prompt-flow
+                    // commands so `handle_send_prompt` reaches persistence
+                    // without a real agent binary. `IsEphemeralSession` → false
+                    // (so `persist_user_prompt` runs + the user prompt is the
+                    // durable transcript); `SendPrompt` → `EndTurn` (so the turn
+                    // completes + the watermark advances). No streaming events
+                    // are emitted — the persisted `user_prompt` IS the transcript
+                    // the cross-client restore test reads back via
+                    // `handle_get_session_payload`.
+                    AcpCommand::IsEphemeralSession { reply, .. } => {
+                        let _ = reply.send(Ok(false));
+                    }
+                    AcpCommand::SendPrompt { reply, .. } => {
+                        let _ = reply.send(Ok(StopReason::EndTurn));
+                    }
+                    // Unhandled commands are silently dropped (same behavior
+                    // as the prior `if let`). A reply-bearing variant dropped
+                    // here will cause the caller to hang — future tests that
+                    // add new commands should add a dedicated match arm.
+                    _ => {}
                 }
             }
         });

--- a/src-tauri/src/acp/mod.rs
+++ b/src-tauri/src/acp/mod.rs
@@ -9,6 +9,7 @@
 //! `_bmad-output/implementation-artifacts/spec-adr-003-p0-rust-acp-core.md`.
 
 pub mod atomic_file;
+pub mod catalog;
 pub mod chat_history_store;
 pub mod client;
 pub mod commands;
@@ -34,6 +35,12 @@ pub use chat_history_store::{
 };
 #[allow(unused_imports)]
 pub use config::{AgentConfig, AgentId, SessionId};
+#[allow(unused_imports)]
+pub use catalog::{
+    AcpCatalog, AcpCatalogService, CatalogAgent, CatalogConfigFile, CatalogError,
+    CatalogRuntimeAvailability, CatalogSource, HostCapability, PlatformTarget,
+    SetCatalogOptInRequest, SupportedAcpAgentStatus,
+};
 #[allow(unused_imports)]
 pub use history_import::import_chat_history;
 #[allow(unused_imports)]

--- a/src-tauri/src/acp/mod.rs
+++ b/src-tauri/src/acp/mod.rs
@@ -9,6 +9,7 @@
 //! `_bmad-output/implementation-artifacts/spec-adr-003-p0-rust-acp-core.md`.
 
 pub mod atomic_file;
+pub mod archive;
 pub mod catalog;
 pub mod chat_history_store;
 pub mod client;
@@ -16,6 +17,7 @@ pub mod commands;
 pub mod config;
 pub mod events;
 pub mod history_import;
+pub mod install;
 pub mod manager;
 pub mod mcp_probe;
 pub mod project_registry;
@@ -40,6 +42,11 @@ pub use catalog::{
     AcpCatalog, AcpCatalogService, CatalogAgent, CatalogConfigFile, CatalogError,
     CatalogRuntimeAvailability, CatalogSource, HostCapability, PlatformTarget,
     SetCatalogOptInRequest, SupportedAcpAgentStatus,
+};
+#[allow(unused_imports)]
+pub use install::{
+    AcpInstallService, DownloadedArchive, Downloader, Extractor, InstallError, InstallOutcome,
+    InstallRequest, InstalledAgent, InstalledManifestFile,
 };
 #[allow(unused_imports)]
 pub use history_import::import_chat_history;

--- a/src-tauri/src/acp_binary_install.rs
+++ b/src-tauri/src/acp_binary_install.rs
@@ -1,18 +1,22 @@
 //! Download and extract ACP registry release archives into app-local storage.
+//!
+//! Story 9 (CAP-6): the download/extract/permission helpers now live in
+//! `acp/archive.rs` (shared with the new `AcpInstallService`); this module is
+//! the legacy desktop-only `#[tauri::command]` kept for back-compat. The
+//! host-owned verified install path lives in `acp/install.rs` and is exposed
+//! across all three transports (Tauri `acp_install_agent`, HTTP
+//! `POST /acp/install`, WS `install_acp_agent`).
+//!
+//! `is_safe_agent_id` is consolidated onto `acp_registry_snapshot::is_safe_agent_id`
+//! (the pub version) — no duplicate here.
 
-use std::io::{Read, Write};
-use std::path::{Component, Path, PathBuf};
-use std::time::Duration;
+use std::path::PathBuf;
 
-use futures_util::StreamExt;
 use serde::{Deserialize, Serialize};
 use tauri::{AppHandle, Manager};
 
-const FETCH_TIMEOUT_SECS: u64 = 120;
-const MAX_ARCHIVE_BYTES: u64 = 256 * 1024 * 1024;
-/// Decompressed-output quotas, to bound zip/tar bombs.
-const MAX_EXTRACTED_BYTES: u64 = 1024 * 1024 * 1024;
-const MAX_EXTRACTED_FILES: usize = 50_000;
+use crate::acp::archive::{normalize_cmd_path, stage_archive};
+use crate::acp_registry_snapshot::is_safe_agent_id;
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -30,14 +34,6 @@ pub struct InstallAcpRegistryBinaryOutcome {
     pub args: Vec<String>,
 }
 
-fn is_safe_agent_id(id: &str) -> bool {
-    !id.is_empty()
-        && id.len() <= 128
-        && id
-            .chars()
-            .all(|c| c.is_ascii_alphanumeric() || c == '.' || c == '_' || c == '-')
-}
-
 fn is_allowed_archive_url(url: &str) -> bool {
     url.len() <= 2048 && url.starts_with("https://")
 }
@@ -50,312 +46,9 @@ fn install_root(app: &AppHandle, agent_id: &str) -> Result<PathBuf, String> {
     Ok(base.join("acp-registry-binaries").join(agent_id))
 }
 
-fn normalize_cmd_path(cmd: &str) -> PathBuf {
-    let trimmed = cmd.trim();
-    let stripped = trimmed
-        .strip_prefix("./")
-        .or_else(|| trimmed.strip_prefix(".\\"))
-        .unwrap_or(trimmed);
-    Path::new(stripped).to_path_buf()
-}
-
-fn resolve_cmd_in_root(root: &Path, cmd: &str) -> Result<PathBuf, String> {
-    let rel = normalize_cmd_path(cmd);
-    for comp in rel.components() {
-        match comp {
-            Component::ParentDir | Component::RootDir | Component::Prefix(_) => {
-                return Err("invalid cmd path".to_string());
-            }
-            _ => {}
-        }
-    }
-    let candidate = root.join(&rel);
-    // Canonicalize ONLY to validate the path cannot escape the install root.
-    // We must not return the canonicalized form: on Windows it carries the
-    // `\\?\` extended-length prefix, which breaks downstream consumers (e.g.
-    // the cursor PowerShell shim's `$scriptPath` math, leading node to receive
-    // a truncated `C:` script path). Return the plain joined path instead.
-    let canon_root = root
-        .canonicalize()
-        .map_err(|e| format!("install dir missing: {e}"))?;
-    let canon_cmd = candidate
-        .canonicalize()
-        .map_err(|e| format!("installed binary not found ({cmd}): {e}"))?;
-    if !canon_cmd.starts_with(&canon_root) {
-        return Err("cmd escapes install directory".to_string());
-    }
-    // Must be a regular file: a directory would later fail at spawn time.
-    if !canon_cmd
-        .metadata()
-        .map_err(|e| format!("installed binary stat failed: {e}"))?
-        .is_file()
-    {
-        return Err("installed binary is a directory".to_string());
-    }
-    Ok(candidate)
-}
-
-/// Stream-copy a reader to disk while enforcing the global extracted-bytes
-/// quota. `written` tracks the running total across all entries.
-fn copy_bounded(
-    mut reader: impl Read,
-    out: &mut std::fs::File,
-    written: &mut u64,
-) -> Result<(), String> {
-    let mut buf = [0u8; 64 * 1024];
-    loop {
-        let n = reader.read(&mut buf).map_err(|e| e.to_string())?;
-        if n == 0 {
-            break;
-        }
-        *written += n as u64;
-        if *written > MAX_EXTRACTED_BYTES {
-            return Err("archive expands beyond size limit".to_string());
-        }
-        out.write_all(&buf[..n]).map_err(|e| e.to_string())?;
-    }
-    Ok(())
-}
-
-fn extract_zip(archive_path: &Path, dest: &Path) -> Result<(), String> {
-    let file = std::fs::File::open(archive_path).map_err(|e| e.to_string())?;
-    let mut archive = zip::ZipArchive::new(file).map_err(|e| format!("zip: {e}"))?;
-    let mut written: u64 = 0;
-    let mut files: usize = 0;
-    for i in 0..archive.len() {
-        let mut entry = archive.by_index(i).map_err(|e| e.to_string())?;
-        // enclosed_name() rejects path traversal (absolute / `..`) entries.
-        let Some(name) = entry.enclosed_name().map(|p| p.to_owned()) else {
-            continue;
-        };
-        let out_path = dest.join(name);
-        if entry.is_dir() {
-            std::fs::create_dir_all(&out_path).map_err(|e| e.to_string())?;
-        } else {
-            files += 1;
-            if files > MAX_EXTRACTED_FILES {
-                return Err("archive contains too many files".to_string());
-            }
-            if let Some(parent) = out_path.parent() {
-                std::fs::create_dir_all(parent).map_err(|e| e.to_string())?;
-            }
-            // Capture mode before consuming the entry body.
-            let unix_mode = entry.unix_mode();
-            let mut out = std::fs::File::create(&out_path).map_err(|e| e.to_string())?;
-            copy_bounded(&mut entry, &mut out, &mut written)?;
-            drop(out);
-            if let Some(mode) = unix_mode {
-                apply_permission_bits(&out_path, mode);
-            }
-        }
-    }
-    Ok(())
-}
-
-fn extract_tar_gz(archive_path: &Path, dest: &Path) -> Result<(), String> {
-    let file = std::fs::File::open(archive_path).map_err(|e| e.to_string())?;
-    let gz = flate2::read::GzDecoder::new(file);
-    let mut archive = tar::Archive::new(gz);
-    let canon_dest = dest
-        .canonicalize()
-        .map_err(|e| format!("extract dir missing: {e}"))?;
-    let mut written: u64 = 0;
-    let mut files: usize = 0;
-    for entry in archive.entries().map_err(|e| format!("tar: {e}"))? {
-        let mut entry = entry.map_err(|e| format!("tar: {e}"))?;
-        let path = entry.path().map_err(|e| format!("tar: {e}"))?.into_owned();
-        // Reject absolute paths and parent-dir traversal.
-        if path.components().any(|c| {
-            matches!(
-                c,
-                Component::ParentDir | Component::RootDir | Component::Prefix(_)
-            )
-        }) {
-            return Err("tar entry has unsafe path".to_string());
-        }
-        let out_path = canon_dest.join(&path);
-        if entry.header().entry_type().is_dir() {
-            std::fs::create_dir_all(&out_path).map_err(|e| e.to_string())?;
-        } else {
-            files += 1;
-            if files > MAX_EXTRACTED_FILES {
-                return Err("archive contains too many files".to_string());
-            }
-            if let Some(parent) = out_path.parent() {
-                std::fs::create_dir_all(parent).map_err(|e| e.to_string())?;
-            }
-            let mode = entry.header().mode().ok();
-            let mut out = std::fs::File::create(&out_path).map_err(|e| e.to_string())?;
-            copy_bounded(&mut entry, &mut out, &mut written)?;
-            drop(out);
-            if let Some(mode) = mode {
-                apply_permission_bits(&out_path, mode);
-            }
-        }
-    }
-    Ok(())
-}
-
-fn extract_archive(archive_path: &Path, dest: &Path) -> Result<(), String> {
-    let name = archive_path
-        .file_name()
-        .and_then(|s| s.to_str())
-        .unwrap_or("")
-        .to_ascii_lowercase();
-    if name.ends_with(".zip") {
-        extract_zip(archive_path, dest)
-    } else if name.ends_with(".tar.gz") || name.ends_with(".tgz") {
-        extract_tar_gz(archive_path, dest)
-    } else {
-        Err("unsupported archive type (expected .zip or .tar.gz)".to_string())
-    }
-}
-
-#[cfg(unix)]
-fn apply_permission_bits(path: &Path, mode: u32) {
-    use std::os::unix::fs::PermissionsExt;
-    // Drop setuid/setgid/sticky from untrusted archives; keep rwx only.
-    let mode = mode & 0o777;
-    let _ = std::fs::set_permissions(path, std::fs::Permissions::from_mode(mode));
-}
-
-#[cfg(not(unix))]
-fn apply_permission_bits(_path: &Path, _mode: u32) {}
-
-#[cfg(unix)]
-fn mark_executable(path: &Path) {
-    use std::os::unix::fs::PermissionsExt;
-    if let Ok(meta) = std::fs::metadata(path) {
-        let mut perms = meta.permissions();
-        perms.set_mode(perms.mode() | 0o111);
-        let _ = std::fs::set_permissions(path, perms);
-    }
-}
-
-#[cfg(not(unix))]
-fn mark_executable(_path: &Path) {}
-
-/// True when `head` looks like a script or native executable that must be
-/// runnable after extract. Zip extracts often land as `0644` even when the
-/// archive carried unix modes (or omitted them entirely) — Cursor's bundled
-/// `node` / `rg` hit Permission denied without this.
-fn looks_like_spawnable(head: &[u8]) -> bool {
-    if head.len() >= 2 && head[0] == b'#' && head[1] == b'!' {
-        return true;
-    }
-    if head.len() >= 4 && head.starts_with(b"\x7fELF") {
-        return true;
-    }
-    // Mach-O (32/64, LE/BE) and fat/universal.
-    const MACHO: &[[u8; 4]] = &[
-        [0xcf, 0xfa, 0xed, 0xfe], // MH_MAGIC_64
-        [0xce, 0xfa, 0xed, 0xfe], // MH_MAGIC
-        [0xfe, 0xed, 0xfa, 0xcf], // MH_CIGAM_64
-        [0xfe, 0xed, 0xfa, 0xce], // MH_CIGAM
-        [0xca, 0xfe, 0xba, 0xbe], // FAT_MAGIC
-        [0xbe, 0xba, 0xfe, 0xca], // FAT_CIGAM
-    ];
-    if head.len() >= 4 {
-        let magic = [head[0], head[1], head[2], head[3]];
-        if MACHO.contains(&magic) {
-            return true;
-        }
-    }
-    false
-}
-
-/// Walk `root` and +x any shebang / ELF / Mach-O file. Complements archive mode
-/// restoration when the zip omitted unix permissions (common for registry
-/// packages that ship a launcher script + companion `node` binary).
-fn mark_spawnables_in_tree(root: &Path) {
-    let Ok(entries) = std::fs::read_dir(root) else {
-        return;
-    };
-    let mut stack: Vec<PathBuf> = entries.filter_map(|e| e.ok().map(|e| e.path())).collect();
-    while let Some(path) = stack.pop() {
-        let Ok(meta) = path.symlink_metadata() else {
-            continue;
-        };
-        if meta.file_type().is_symlink() {
-            continue;
-        }
-        if meta.is_dir() {
-            if let Ok(children) = std::fs::read_dir(&path) {
-                stack.extend(children.filter_map(|e| e.ok().map(|e| e.path())));
-            }
-            continue;
-        }
-        if !meta.is_file() {
-            continue;
-        }
-        let Ok(mut file) = std::fs::File::open(&path) else {
-            continue;
-        };
-        let mut head = [0u8; 4];
-        let Ok(n) = file.read(&mut head) else {
-            continue;
-        };
-        if looks_like_spawnable(&head[..n]) {
-            mark_executable(&path);
-        }
-    }
-}
-
-/// Download the archive into `tmp_dir`, extract it into `staging`, and validate
-/// that `cmd` resolves to a regular file inside `staging`. Kept separate from
-/// the swap logic so the caller can clean up staging on any failure.
-async fn stage_archive(
-    archive_url: &str,
-    cmd: &str,
-    tmp_dir: &Path,
-    staging: &Path,
-) -> Result<(), String> {
-    let client = reqwest::Client::builder()
-        .timeout(Duration::from_secs(FETCH_TIMEOUT_SECS))
-        .build()
-        .map_err(|e| format!("http client: {e}"))?;
-
-    let response = client
-        .get(archive_url)
-        .send()
-        .await
-        .map_err(|e| format!("download failed: {e}"))?;
-    if !response.status().is_success() {
-        return Err(format!("download returned HTTP {}", response.status()));
-    }
-
-    // Stream the body to disk, enforcing the download cap incrementally so a
-    // hostile server can't force us to buffer an unbounded response.
-    let archive_name = archive_url
-        .rsplit('/')
-        .next()
-        .filter(|s| !s.is_empty())
-        .unwrap_or("archive.bin");
-    let archive_path = tmp_dir.join(archive_name);
-    let mut file = std::fs::File::create(&archive_path).map_err(|e| e.to_string())?;
-    let mut downloaded: u64 = 0;
-    let mut stream = response.bytes_stream();
-    while let Some(chunk) = stream.next().await {
-        let chunk = chunk.map_err(|e| format!("download stream: {e}"))?;
-        downloaded += chunk.len() as u64;
-        if downloaded > MAX_ARCHIVE_BYTES {
-            return Err("archive too large".to_string());
-        }
-        file.write_all(&chunk).map_err(|e| e.to_string())?;
-    }
-    file.flush().map_err(|e| e.to_string())?;
-    drop(file);
-
-    extract_archive(&archive_path, staging)?;
-    // Validate the cmd resolves to a regular file inside the staging dir.
-    let staged_program = resolve_cmd_in_root(staging, cmd)?;
-    mark_executable(&staged_program);
-    // Registry packages (e.g. Cursor) ship a launcher that execs a sibling
-    // `node` / helper binary — those must be runnable too.
-    mark_spawnables_in_tree(staging);
-    Ok(())
-}
-
+/// Download + extract into a private staging directory; only swap it into the
+/// real install root once everything succeeds, so a failure never destroys a
+/// previously-working install.
 pub async fn install_registry_binary(
     app: &AppHandle,
     req: InstallAcpRegistryBinaryRequest,
@@ -376,9 +69,6 @@ pub async fn install_registry_binary(
         std::fs::create_dir_all(parent).map_err(|e| format!("create install parent: {e}"))?;
     }
 
-    // Download + extract into a private staging directory; only swap it into the
-    // real install root once everything succeeds, so a failure never destroys a
-    // previously-working install.
     let tmp_dir = std::env::temp_dir().join(format!("termul-acp-dl-{}", uuid::Uuid::new_v4()));
     std::fs::create_dir_all(&tmp_dir).map_err(|e| e.to_string())?;
     let staging = tmp_dir.join("stage");
@@ -422,58 +112,4 @@ pub async fn acp_install_registry_binary(
     request: InstallAcpRegistryBinaryRequest,
 ) -> Result<InstallAcpRegistryBinaryOutcome, String> {
     install_registry_binary(&app, request).await
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    #[cfg(unix)]
-    use std::io::Write;
-
-    #[test]
-    fn looks_like_spawnable_detects_shebang_elf_macho() {
-        assert!(looks_like_spawnable(b"#!/bin/bash\n"));
-        assert!(looks_like_spawnable(b"\x7fELF\x02\x01"));
-        assert!(looks_like_spawnable(&[0xcf, 0xfa, 0xed, 0xfe, 0, 0]));
-        assert!(!looks_like_spawnable(b"{\"ok\":true}"));
-        assert!(!looks_like_spawnable(b""));
-    }
-
-    #[cfg(unix)]
-    #[test]
-    fn mark_spawnables_makes_companion_node_executable() {
-        use std::os::unix::fs::PermissionsExt;
-
-        let dir = std::env::temp_dir().join(format!("termul-acp-exec-{}", uuid::Uuid::new_v4()));
-        std::fs::create_dir_all(&dir).unwrap();
-        let node = dir.join("node");
-        let script = dir.join("cursor-agent");
-        let text = dir.join("readme.txt");
-
-        {
-            let mut f = std::fs::File::create(&node).unwrap();
-            f.write_all(&[0xcf, 0xfa, 0xed, 0xfe, 0, 0, 0, 0]).unwrap();
-        }
-        {
-            let mut f = std::fs::File::create(&script).unwrap();
-            f.write_all(b"#!/usr/bin/env bash\necho hi\n").unwrap();
-        }
-        std::fs::write(&text, b"hello").unwrap();
-
-        // Simulate zip extract: plain 0644 files.
-        for p in [&node, &script, &text] {
-            std::fs::set_permissions(p, std::fs::Permissions::from_mode(0o644)).unwrap();
-        }
-
-        mark_spawnables_in_tree(&dir);
-
-        let node_mode = std::fs::metadata(&node).unwrap().permissions().mode() & 0o111;
-        let script_mode = std::fs::metadata(&script).unwrap().permissions().mode() & 0o111;
-        let text_mode = std::fs::metadata(&text).unwrap().permissions().mode() & 0o111;
-        let _ = std::fs::remove_dir_all(&dir);
-
-        assert_eq!(node_mode, 0o111);
-        assert_eq!(script_mode, 0o111);
-        assert_eq!(text_mode, 0);
-    }
 }

--- a/src-tauri/src/acp_registry_snapshot.rs
+++ b/src-tauri/src/acp_registry_snapshot.rs
@@ -59,7 +59,7 @@ struct CachedSnapshot {
     fetched_at: String,
 }
 
-fn is_safe_agent_id(id: &str) -> bool {
+pub fn is_safe_agent_id(id: &str) -> bool {
     !id.is_empty()
         && id.len() <= 128
         && id
@@ -67,7 +67,7 @@ fn is_safe_agent_id(id: &str) -> bool {
             .all(|c| c.is_ascii_alphanumeric() || c == '.' || c == '_' || c == '-')
 }
 
-fn sanitize_distribution(value: &serde_json::Value) -> Option<serde_json::Value> {
+pub fn sanitize_distribution(value: &serde_json::Value) -> Option<serde_json::Value> {
     value.as_object().cloned().map(serde_json::Value::Object)
 }
 
@@ -99,24 +99,12 @@ fn parse_snapshot(body: &str) -> Result<Vec<AcpRegistrySnapshotAgent>, String> {
     Ok(agents)
 }
 
-fn cache_path(app: &AppHandle) -> Result<std::path::PathBuf, String> {
-    let dir = app
-        .path()
-        .app_cache_dir()
-        .map_err(|e| format!("Failed to resolve cache dir: {}", e))?;
-    Ok(dir.join(CACHE_FILE))
-}
-
-fn read_cache(app: &AppHandle) -> Option<CachedSnapshot> {
-    let path = cache_path(app).ok()?;
+fn read_cache_at(path: &std::path::Path) -> Option<CachedSnapshot> {
     let contents = std::fs::read_to_string(path).ok()?;
     serde_json::from_str::<CachedSnapshot>(&contents).ok()
 }
 
-fn write_cache(app: &AppHandle, agents: &[AcpRegistrySnapshotAgent], fetched_at: &str) {
-    let Ok(path) = cache_path(app) else {
-        return;
-    };
+fn write_cache_at(path: &std::path::Path, agents: &[AcpRegistrySnapshotAgent], fetched_at: &str) {
     if let Some(parent) = path.parent() {
         let _ = std::fs::create_dir_all(parent);
     }
@@ -129,12 +117,16 @@ fn write_cache(app: &AppHandle, agents: &[AcpRegistrySnapshotAgent], fetched_at:
     }
 }
 
-pub async fn fetch_acp_registry_snapshot(
-    app: &AppHandle,
+/// Core fetch+parse+cache logic parameterized by an explicit cache file path.
+/// Both the desktop `AppHandle`-based entry point and the standalone
+/// `AcpCatalogService` path delegate here so the fetch logic is NOT duplicated
+/// (CAP-6 / Story 8 reuses this for the catalog's CDN augmentation).
+pub async fn fetch_acp_registry_snapshot_with_cache_path(
+    cache_path: &std::path::Path,
     force_refresh: bool,
 ) -> Result<AcpRegistrySnapshot, String> {
     if !force_refresh {
-        if let Some(cached) = read_cache(app) {
+        if let Some(cached) = read_cache_at(cache_path) {
             return Ok(AcpRegistrySnapshot {
                 agents: cached.agents,
                 source: "cache".to_string(),
@@ -168,7 +160,7 @@ pub async fn fetch_acp_registry_snapshot(
     match fetch_result {
         Ok(agents) => {
             let fetched_at = chrono::Utc::now().to_rfc3339();
-            write_cache(app, &agents, &fetched_at);
+            write_cache_at(cache_path, &agents, &fetched_at);
             Ok(AcpRegistrySnapshot {
                 agents,
                 source: "network".to_string(),
@@ -176,7 +168,7 @@ pub async fn fetch_acp_registry_snapshot(
             })
         }
         Err(network_err) => {
-            if let Some(cached) = read_cache(app) {
+            if let Some(cached) = read_cache_at(cache_path) {
                 log::warn!(
                     "ACP registry snapshot fetch failed ({}); serving cached snapshot",
                     network_err
@@ -190,6 +182,22 @@ pub async fn fetch_acp_registry_snapshot(
             Err(network_err)
         }
     }
+}
+
+fn cache_path(app: &AppHandle) -> Result<std::path::PathBuf, String> {
+    let dir = app
+        .path()
+        .app_cache_dir()
+        .map_err(|e| format!("Failed to resolve cache dir: {}", e))?;
+    Ok(dir.join(CACHE_FILE))
+}
+
+pub async fn fetch_acp_registry_snapshot(
+    app: &AppHandle,
+    force_refresh: bool,
+) -> Result<AcpRegistrySnapshot, String> {
+    let path = cache_path(app)?;
+    fetch_acp_registry_snapshot_with_cache_path(&path, force_refresh).await
 }
 
 #[tauri::command]

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -3241,6 +3241,7 @@ pub async fn sftp_create_file(
 /// param is accepted for API stability but ignored (the tunnel targets
 /// localhost). App auth / token-gating land in Epic 2.
 #[tauri::command]
+#[allow(clippy::too_many_arguments)]
 pub async fn remote_server_start(
     acp_manager: State<'_, Arc<crate::acp::AcpManager>>,
     pty_manager: State<'_, Arc<PtyManager>>,
@@ -3248,6 +3249,7 @@ pub async fn remote_server_start(
     remote_state: State<'_, Arc<remote::RemoteServerState>>,
     project_registry: State<'_, Arc<crate::web::ProjectRegistry>>,
     workspace_manifest_store: State<'_, HostWorkspaceManifestStore>,
+    acp_catalog_store: State<'_, HostAcpCatalogStore>,
     bind_mode: Option<String>,
 ) -> Result<IpcResult<remote::RemoteStatus>, String> {
     // Default to localhost only when the caller omits the bind mode; an
@@ -3265,6 +3267,11 @@ pub async fn remote_server_start(
     // manifest through the three `/workspace/*` routes. `None` degrades to
     // fresh-only mode (no host store attached).
     let workspace_manifest = workspace_manifest_store.store().map(Arc::clone);
+    // CAP-6 / Story 8: thread the desktop's `AcpCatalogService` (opened under
+    // `<app_data_dir>/acp-catalog` in `lib.rs`) through to `serve_router` so
+    // the web/remote client can resolve the catalog through `GET /acp/catalog`
+    // + WS `list_acp_catalog`. `None` degrades to `ACP_CATALOG_UNAVAILABLE`.
+    let acp_catalog = acp_catalog_store.store().map(Arc::clone);
     let started = remote_state
         .start(
             acp_manager.inner().clone(),
@@ -3273,6 +3280,7 @@ pub async fn remote_server_start(
             project_registry.inner().clone(),
             bind_mode,
             workspace_manifest,
+            acp_catalog,
         )
         .await;
     match started {
@@ -4210,6 +4218,30 @@ impl HostWorkspaceManifestStore {
     /// Callers that need to clone the `Arc` should `.as_ref().map(Arc::clone)`.
     #[must_use]
     pub(crate) fn store(&self) -> Option<&Arc<crate::acp::WorkspaceManifestService>> {
+        self.0.as_ref()
+    }
+}
+
+/// Tauri state wrapper for the host-owned `AcpCatalogService` (CAP-6 / Story
+/// 8). Mirrors `HostWorkspaceManifestStore`: `None` degrades to
+/// `ACP_CATALOG_UNAVAILABLE` (the desktop could not open the catalog root at
+/// startup). Held as `Option<Arc<…>>` so the desktop's degraded path is
+/// graceful, not a boot failure.
+#[derive(Default)]
+pub struct HostAcpCatalogStore(Option<Arc<crate::acp::AcpCatalogService>>);
+
+impl HostAcpCatalogStore {
+    /// Construct from an already-opened `AcpCatalogService` (`None` for
+    /// degraded mode — the desktop could not open the store at startup).
+    #[must_use]
+    pub fn new(service: Option<Arc<crate::acp::AcpCatalogService>>) -> Self {
+        Self(service)
+    }
+
+    /// Access the inner `AcpCatalogService` (`None` in degraded mode).
+    /// Callers that need to clone the `Arc` should `.as_ref().map(Arc::clone)`.
+    #[must_use]
+    pub(crate) fn store(&self) -> Option<&Arc<crate::acp::AcpCatalogService>> {
         self.0.as_ref()
     }
 }

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -3250,6 +3250,7 @@ pub async fn remote_server_start(
     project_registry: State<'_, Arc<crate::web::ProjectRegistry>>,
     workspace_manifest_store: State<'_, HostWorkspaceManifestStore>,
     acp_catalog_store: State<'_, HostAcpCatalogStore>,
+    acp_install_store: State<'_, HostAcpInstallStore>,
     bind_mode: Option<String>,
 ) -> Result<IpcResult<remote::RemoteStatus>, String> {
     // Default to localhost only when the caller omits the bind mode; an
@@ -3272,6 +3273,12 @@ pub async fn remote_server_start(
     // the web/remote client can resolve the catalog through `GET /acp/catalog`
     // + WS `list_acp_catalog`. `None` degrades to `ACP_CATALOG_UNAVAILABLE`.
     let acp_catalog = acp_catalog_store.store().map(Arc::clone);
+    // CAP-6 / Story 9: thread the desktop's `AcpInstallService` (opened under
+    // `<app_data_dir>/acp-registry-binaries` in `lib.rs`) through to
+    // `serve_router` so the web/remote client can install through
+    // `POST /acp/install` + WS `install_acp_agent`. `None` degrades to
+    // `ACP_INSTALL_UNAVAILABLE`.
+    let acp_install = acp_install_store.store().map(Arc::clone);
     let started = remote_state
         .start(
             acp_manager.inner().clone(),
@@ -3281,6 +3288,7 @@ pub async fn remote_server_start(
             bind_mode,
             workspace_manifest,
             acp_catalog,
+            acp_install,
         )
         .await;
     match started {
@@ -4242,6 +4250,30 @@ impl HostAcpCatalogStore {
     /// Callers that need to clone the `Arc` should `.as_ref().map(Arc::clone)`.
     #[must_use]
     pub(crate) fn store(&self) -> Option<&Arc<crate::acp::AcpCatalogService>> {
+        self.0.as_ref()
+    }
+}
+
+/// Tauri state wrapper for the host-owned `AcpInstallService` (CAP-6 / Story
+/// 9). Mirrors `HostAcpCatalogStore`: `None` degrades to
+/// `ACP_INSTALL_UNAVAILABLE` (the desktop could not open the install root at
+/// startup). Held as `Option<Arc<…>>` so the desktop's degraded path is
+/// graceful, not a boot failure.
+#[derive(Default)]
+pub struct HostAcpInstallStore(Option<Arc<crate::acp::install::AcpInstallService>>);
+
+impl HostAcpInstallStore {
+    /// Construct from an already-opened `AcpInstallService` (`None` for
+    /// degraded mode — the desktop could not open the store at startup).
+    #[must_use]
+    pub fn new(service: Option<Arc<crate::acp::install::AcpInstallService>>) -> Self {
+        Self(service)
+    }
+
+    /// Access the inner `AcpInstallService` (`None` in degraded mode).
+    /// Callers that need to clone the `Arc` should `.as_ref().map(Arc::clone)`.
+    #[must_use]
+    pub(crate) fn store(&self) -> Option<&Arc<crate::acp::install::AcpInstallService>> {
         self.0.as_ref()
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -123,8 +123,8 @@ fn resolve_executable_from_path(command: &str) -> Option<String> {
 
 // Re-exports for commands
 pub use acp::{
-    AcpManager, ChatHistoryStore, FileProjectRegistry, SessionPersistence,
-    WorkspaceManifestService,
+    AcpCatalogService, AcpInstallService, AcpManager, ChatHistoryStore, FileProjectRegistry,
+    SessionPersistence, WorkspaceManifestService,
 };
 pub use pty::PtyManager;
 pub use trackers::{CwdTracker, ExitCodeTracker, GitTracker, TerminalEventHub};

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1143,6 +1143,43 @@ pub fn run() {
                 workspace_manifest_service.clone(),
             ));
 
+            // CAP-6 / Story 8: open the host-owned ACP catalog root under
+            // `<app_data_dir>/acp-catalog`. The desktop owns its own root —
+            // NEVER shared with a standalone `termul-server` on the same
+            // machine. The catalog embeds the trusted `agents.json` at build
+            // time, optionally augments with the explicitly-approved CDN
+            // registry snapshot, probes real runtime availability, and
+            // computes the 5-state `SupportedAcpAgentStatus` per agent.
+            // `None` degrades to `ACP_CATALOG_UNAVAILABLE` (the catalog
+            // commands/routes return the error code; the app must still boot).
+            let acp_catalog_root = handle
+                .path()
+                .app_data_dir()
+                .map_err(|error| format!("failed to resolve app data directory: {error}"))?
+                .join("acp-catalog");
+            let acp_catalog_service =
+                match tauri::async_runtime::block_on(
+                    crate::acp::AcpCatalogService::open(acp_catalog_root.clone()),
+                ) {
+                    Ok(service) => {
+                        log::info!(
+                            "[acp-catalog] host service ready path={}",
+                            service.root().display()
+                        );
+                        Some(service)
+                    }
+                    Err(error) => {
+                        log::error!(
+                            "[acp-catalog] host service unavailable path={} error={error}",
+                            acp_catalog_root.display()
+                        );
+                        None
+                    }
+                };
+            app.manage(commands::HostAcpCatalogStore::new(
+                acp_catalog_service.clone(),
+            ));
+
             // Create ACP Manager — spawns/owns ACP agent subprocesses.
             //
             // Desktop mode fans ACP events out to TWO sinks: `TauriEventSink`
@@ -1513,6 +1550,9 @@ pub fn run() {
             acp::commands::acp_set_session_reopen_timeout,
             acp::commands::acp_set_first_prompt_warmup_timeout,
             acp::commands::acp_probe_mcp_server,
+            // CAP-6 / Story 8: ACP catalog (host-owned resolution).
+            acp::commands::acp_list_catalog,
+            acp::commands::acp_set_catalog_opt_in,
             acp_registry_snapshot::acp_fetch_registry_snapshot,
             acp_binary_install::acp_install_registry_binary,
             // Agent Skills (Zed-compatible SKILL.md packages)

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1180,6 +1180,56 @@ pub fn run() {
                 acp_catalog_service.clone(),
             ));
 
+            // CAP-6 / Story 9: open the host-owned verified-atomic ACP install
+            // root. The desktop owns its own root under
+            // `<app_data_dir>/acp-registry-binaries` (NEVER shared with a
+            // standalone `termul-server` on the same machine). The install
+            // service downloads + verifies (sha256) + extracts + atomically
+            // activates ACP agent archives resolved from the catalog, records
+            // an installed-agents manifest, and exposes `install_agent(agentId)`
+            // across all three transports. `None` degrades to
+            // `ACP_INSTALL_UNAVAILABLE`.
+            let acp_install_root = handle
+                .path()
+                .app_data_dir()
+                .map_err(|error| format!("failed to resolve app data directory: {error}"))?
+                .join("acp-registry-binaries");
+            let acp_install_service =
+                match acp_catalog_service.as_ref().zip(Some(acp_install_root.clone())) {
+                    Some((catalog, root)) => {
+                        match tauri::async_runtime::block_on(
+                            crate::acp::install::AcpInstallService::open(
+                                root.clone(),
+                                std::sync::Arc::clone(catalog),
+                            ),
+                        ) {
+                            Ok(service) => {
+                                log::info!(
+                                    "[acp-install] host service ready path={}",
+                                    service.root().display()
+                                );
+                                Some(service)
+                            }
+                            Err(error) => {
+                                log::error!(
+                                    "[acp-install] host service unavailable path={} error={error}",
+                                    root.display()
+                                );
+                                None
+                            }
+                        }
+                    }
+                    None => {
+                        log::warn!(
+                            "[acp-install] host service unavailable (catalog store is None)"
+                        );
+                        None
+                    }
+                };
+            app.manage(commands::HostAcpInstallStore::new(
+                acp_install_service.clone(),
+            ));
+
             // Create ACP Manager — spawns/owns ACP agent subprocesses.
             //
             // Desktop mode fans ACP events out to TWO sinks: `TauriEventSink`
@@ -1553,6 +1603,8 @@ pub fn run() {
             // CAP-6 / Story 8: ACP catalog (host-owned resolution).
             acp::commands::acp_list_catalog,
             acp::commands::acp_set_catalog_opt_in,
+            // CAP-6 / Story 9: ACP install (host-owned verified-atomic install).
+            acp::commands::acp_install_agent,
             acp_registry_snapshot::acp_fetch_registry_snapshot,
             acp_binary_install::acp_install_registry_binary,
             // Agent Skills (Zed-compatible SKILL.md packages)

--- a/src-tauri/src/remote/host.rs
+++ b/src-tauri/src/remote/host.rs
@@ -34,7 +34,7 @@ use tokio::process::Child;
 use tokio::sync::oneshot;
 use tracing::{info, warn};
 
-use crate::acp::{AcpCatalogService, AcpManager, WorkspaceManifestService};
+use crate::acp::{AcpCatalogService, AcpInstallService, AcpManager, WorkspaceManifestService};
 use crate::pty::PtyManager;
 use crate::web::sink::WsRelaySink;
 use crate::web::{serve_router, ProjectRegistry, ServerConfig};
@@ -234,6 +234,12 @@ impl RemoteServerState {
     /// `serve_router` so the web/remote client can resolve the catalog through
     /// `GET /acp/catalog` + WS `list_acp_catalog`. `None` degrades to
     /// `ACP_CATALOG_UNAVAILABLE`.
+    ///
+    /// `acp_install` is the desktop's own `AcpInstallService` (opened under
+    /// `<app_data_dir>/acp-registry-binaries` in `lib.rs`). Threaded through
+    /// to `serve_router` so the web/remote client can install through
+    /// `POST /acp/install` + WS `install_acp_agent`. `None` degrades to
+    /// `ACP_INSTALL_UNAVAILABLE`.
     #[allow(clippy::too_many_arguments)]
     pub async fn start(
         &self,
@@ -244,6 +250,7 @@ impl RemoteServerState {
         _bind_mode: RemoteBindMode,
         workspace_manifest: Option<Arc<WorkspaceManifestService>>,
         acp_catalog: Option<Arc<AcpCatalogService>>,
+        acp_install: Option<Arc<AcpInstallService>>,
     ) -> Result<RemoteStatus, String> {
         // The built-in cloudflared quick-tunnel forwards to localhost, so the
         // desktop-hosted server always binds localhost regardless of the
@@ -334,6 +341,7 @@ impl RemoteServerState {
             shutdown,
             workspace_manifest,
             acp_catalog,
+            acp_install,
         )
         .await
         .map_err(|e| format!("Failed to start remote server: {}", e))?;
@@ -627,6 +635,7 @@ mod tests {
                 RemoteBindMode::Localhost,
                 None,
                 None,
+                None,
                 )
             .await
             .expect("start on localhost binds an OS-assigned port");
@@ -659,6 +668,7 @@ mod tests {
                 RemoteBindMode::Localhost,
                 None,
                 None,
+                None,
                 )
             .await
             .expect("restart after stop succeeds");
@@ -682,6 +692,7 @@ mod tests {
                 RemoteBindMode::Localhost,
                 None,
                 None,
+                None,
                 )
             .await
             .expect("first start succeeds");
@@ -693,6 +704,7 @@ mod tests {
                 relay.clone(),
                 registry.clone(),
                 RemoteBindMode::Localhost,
+                None,
                 None,
                 None,
                 )
@@ -726,6 +738,7 @@ mod tests {
                 RemoteBindMode::Localhost,
                 None,
                 None,
+                None,
                 )
             .await
             .expect("start succeeds");
@@ -754,6 +767,7 @@ mod tests {
                 relay.clone(),
                 registry.clone(),
                 RemoteBindMode::Localhost,
+                None,
                 None,
                 None,
                 )

--- a/src-tauri/src/remote/host.rs
+++ b/src-tauri/src/remote/host.rs
@@ -34,7 +34,7 @@ use tokio::process::Child;
 use tokio::sync::oneshot;
 use tracing::{info, warn};
 
-use crate::acp::{AcpManager, WorkspaceManifestService};
+use crate::acp::{AcpCatalogService, AcpManager, WorkspaceManifestService};
 use crate::pty::PtyManager;
 use crate::web::sink::WsRelaySink;
 use crate::web::{serve_router, ProjectRegistry, ServerConfig};
@@ -228,6 +228,13 @@ impl RemoteServerState {
     /// Threaded through to `serve_router` so the web/remote client can
     /// read/write a project's manifest through `/workspace/*`. `None`
     /// degrades to fresh-only mode.
+    ///
+    /// `acp_catalog` is the desktop's own `AcpCatalogService` (opened under
+    /// `<app_data_dir>/acp-catalog` in `lib.rs`). Threaded through to
+    /// `serve_router` so the web/remote client can resolve the catalog through
+    /// `GET /acp/catalog` + WS `list_acp_catalog`. `None` degrades to
+    /// `ACP_CATALOG_UNAVAILABLE`.
+    #[allow(clippy::too_many_arguments)]
     pub async fn start(
         &self,
         acp: Arc<AcpManager>,
@@ -236,6 +243,7 @@ impl RemoteServerState {
         registry: Arc<ProjectRegistry>,
         _bind_mode: RemoteBindMode,
         workspace_manifest: Option<Arc<WorkspaceManifestService>>,
+        acp_catalog: Option<Arc<AcpCatalogService>>,
     ) -> Result<RemoteStatus, String> {
         // The built-in cloudflared quick-tunnel forwards to localhost, so the
         // desktop-hosted server always binds localhost regardless of the
@@ -302,6 +310,7 @@ impl RemoteServerState {
             // `workspace_manifest` argument below), so no path is resolved
             // from the config here — `None` degrades nothing on this path.
             workspace_manifests_dir: None,
+            acp_catalog_dir: None,
         };
 
         let (shutdown_tx, shutdown_rx) = oneshot::channel::<()>();
@@ -324,6 +333,7 @@ impl RemoteServerState {
             cfg,
             shutdown,
             workspace_manifest,
+            acp_catalog,
         )
         .await
         .map_err(|e| format!("Failed to start remote server: {}", e))?;
@@ -616,7 +626,8 @@ mod tests {
                 registry.clone(),
                 RemoteBindMode::Localhost,
                 None,
-            )
+                None,
+                )
             .await
             .expect("start on localhost binds an OS-assigned port");
         assert!(status.running, "start returns a running status");
@@ -647,7 +658,8 @@ mod tests {
                 registry.clone(),
                 RemoteBindMode::Localhost,
                 None,
-            )
+                None,
+                )
             .await
             .expect("restart after stop succeeds");
         assert!(again.running);
@@ -669,7 +681,8 @@ mod tests {
                 registry.clone(),
                 RemoteBindMode::Localhost,
                 None,
-            )
+                None,
+                )
             .await
             .expect("first start succeeds");
 
@@ -681,7 +694,8 @@ mod tests {
                 registry.clone(),
                 RemoteBindMode::Localhost,
                 None,
-            )
+                None,
+                )
             .await;
         assert!(
             second.is_err(),
@@ -711,7 +725,8 @@ mod tests {
                 registry.clone(),
                 RemoteBindMode::Localhost,
                 None,
-            )
+                None,
+                )
             .await
             .expect("start succeeds");
         // The serve task holds `Arc::clone(&acp)`; stop drains it. The desktop
@@ -740,7 +755,8 @@ mod tests {
                 registry.clone(),
                 RemoteBindMode::Localhost,
                 None,
-            )
+                None,
+                )
             .await
             .expect("start");
 

--- a/src-tauri/src/server_main.rs
+++ b/src-tauri/src/server_main.rs
@@ -92,6 +92,20 @@ fn main() -> ExitCode {
                 return ExitCode::from(1);
             }
         };
+        // CAP-6 / Story 8: open the host-owned ACP catalog root. The
+        // standalone binary owns its own root — NEVER shared with a desktop
+        // host on the same machine. Defaults to `<state dir>/acp-catalog`.
+        let acp_catalog_dir = cfg
+            .acp_catalog_dir
+            .clone()
+            .unwrap_or_else(|| cfg.service_account_state_dir().join("acp-catalog"));
+        let acp_catalog = match crate::acp::AcpCatalogService::open(acp_catalog_dir).await {
+            Ok(service) => Some(service),
+            Err(error) => {
+                eprintln!("termul-server: failed to open acp-catalog store: {error}");
+                return ExitCode::from(1);
+            }
+        };
         let ws_relay = Arc::new(WsRelaySink::with_persistence(
             cfg.event_log_capacity,
             Arc::clone(&persistence),
@@ -185,6 +199,7 @@ fn main() -> ExitCode {
             projects_file,
             cfg,
             workspace_manifest,
+            acp_catalog,
         )
         .await
         {
@@ -198,16 +213,17 @@ fn main() -> ExitCode {
 }
 
 fn usage() -> &'static str {
-    "Usage: termul-server [--host HOST] [--port PORT] [--event-log-capacity N] [--permission-timeout SECS] [--permission-reconnect-grace SECS] [--project-root PATH] [--projects-file PATH] [--sessions-dir PATH] [--workspace-manifests-dir PATH]\n\n\
+    "Usage: termul-server [--host HOST] [--port PORT] [--event-log-capacity N] [--permission-timeout SECS] [--permission-reconnect-grace SECS] [--project-root PATH] [--projects-file PATH] [--sessions-dir PATH] [--workspace-manifests-dir PATH] [--acp-catalog-dir PATH]\n\n\
      Options:\n\
-       --host HOST                 Bind host (default: 127.0.0.1; use 0.0.0.0 to expose)\n\
-       --port PORT                 Bind port (default: 8080)\n\
-       --event-log-capacity N      Per-session event-log ring capacity (default: 4096)\n\
-       --permission-timeout SECS   Permission rendezvous timeout in seconds (default: 60)\n\
-       --permission-reconnect-grace SECS  Last-subscriber reconnect grace (default: 15)\n\
-       --project-root PATH         Project-root boundary for /fs/* routes (default: $TERMUL_PROJECT_ROOT or $HOME)\n\
-       --projects-file PATH        VFS-roots registry file (default: $TERMUL_PROJECTS_FILE; missing = empty list)\n\
-       --sessions-dir PATH         Durable sessions root (default: $TERMUL_SESSIONS_DIR or service-account state dir)\n\
-       --workspace-manifests-dir PATH  Workspace manifests root (default: <state dir>/workspace-manifests)\n\
-       -h, --help                  Show this help"
+        --host HOST                 Bind host (default: 127.0.0.1; use 0.0.0.0 to expose)\n\
+        --port PORT                 Bind port (default: 8080)\n\
+        --event-log-capacity N      Per-session event-log ring capacity (default: 4096)\n\
+        --permission-timeout SECS   Permission rendezvous timeout in seconds (default: 60)\n\
+        --permission-reconnect-grace SECS  Last-subscriber reconnect grace (default: 15)\n\
+        --project-root PATH         Project-root boundary for /fs/* routes (default: $TERMUL_PROJECT_ROOT or $HOME)\n\
+        --projects-file PATH        VFS-roots registry file (default: $TERMUL_PROJECTS_FILE; missing = empty list)\n\
+        --sessions-dir PATH         Durable sessions root (default: $TERMUL_SESSIONS_DIR or service-account state dir)\n\
+        --workspace-manifests-dir PATH  Workspace manifests root (default: <state dir>/workspace-manifests)\n\
+        --acp-catalog-dir PATH      ACP catalog root (default: <state dir>/acp-catalog)\n\
+        -h, --help                  Show this help"
 }

--- a/src-tauri/src/server_main.rs
+++ b/src-tauri/src/server_main.rs
@@ -106,6 +106,26 @@ fn main() -> ExitCode {
                 return ExitCode::from(1);
             }
         };
+        // CAP-6 / Story 9: open the host-owned verified-atomic ACP install
+        // root. The standalone binary owns its own root — NEVER shared with a
+        // desktop host on the same machine. Defaults to
+        // `<state dir>/acp-registry-binaries`. The install service holds the
+        // catalog `Arc` for the convenience `install_by_id` path.
+        let acp_install_dir = cfg
+            .service_account_state_dir()
+            .join("acp-registry-binaries");
+        let acp_install = match crate::acp::install::AcpInstallService::open(
+            acp_install_dir,
+            std::sync::Arc::clone(acp_catalog.as_ref().expect("catalog opened above")),
+        )
+        .await
+        {
+            Ok(service) => Some(service),
+            Err(error) => {
+                eprintln!("termul-server: failed to open acp-install store: {error}");
+                return ExitCode::from(1);
+            }
+        };
         let ws_relay = Arc::new(WsRelaySink::with_persistence(
             cfg.event_log_capacity,
             Arc::clone(&persistence),
@@ -200,6 +220,7 @@ fn main() -> ExitCode {
             cfg,
             workspace_manifest,
             acp_catalog,
+            acp_install,
         )
         .await
         {

--- a/src-tauri/src/server_main.rs
+++ b/src-tauri/src/server_main.rs
@@ -21,8 +21,9 @@ use termul_manager_lib::web::{
     WsRelaySink,
 };
 use termul_manager_lib::{
-    AcpManager, CwdTracker, ExitCodeTracker, FileProjectRegistry, GitTracker, PtyManager,
-    SessionPersistence, TerminalEventHub, WorkspaceManifestService,
+    AcpCatalogService, AcpInstallService, AcpManager, CwdTracker, ExitCodeTracker,
+    FileProjectRegistry, GitTracker, PtyManager, SessionPersistence, TerminalEventHub,
+    WorkspaceManifestService,
 };
 use tracing::info;
 use tracing_subscriber::EnvFilter;
@@ -99,7 +100,7 @@ fn main() -> ExitCode {
             .acp_catalog_dir
             .clone()
             .unwrap_or_else(|| cfg.service_account_state_dir().join("acp-catalog"));
-        let acp_catalog = match crate::acp::AcpCatalogService::open(acp_catalog_dir).await {
+        let acp_catalog = match AcpCatalogService::open(acp_catalog_dir).await {
             Ok(service) => Some(service),
             Err(error) => {
                 eprintln!("termul-server: failed to open acp-catalog store: {error}");
@@ -114,7 +115,7 @@ fn main() -> ExitCode {
         let acp_install_dir = cfg
             .service_account_state_dir()
             .join("acp-registry-binaries");
-        let acp_install = match crate::acp::install::AcpInstallService::open(
+        let acp_install = match AcpInstallService::open(
             acp_install_dir,
             std::sync::Arc::clone(acp_catalog.as_ref().expect("catalog opened above")),
         )

--- a/src-tauri/src/web/catalog_api.rs
+++ b/src-tauri/src/web/catalog_api.rs
@@ -1,0 +1,464 @@
+//! HTTP handlers for the host-owned ACP catalog (CAP-6 / Story 8).
+//!
+//! Mirrors the desktop `#[tauri::command] acp_list_catalog` +
+//! `acp_set_catalog_opt_in` handlers over HTTP so the web/remote client can
+//! resolve the catalog through the same `IpcBody<T>` contract.
+//!
+//! - **`GET /acp/catalog`** — list the resolved catalog. Optional
+//!   `?refresh=true` query forces a fresh probe (bypassing the 60s TTL).
+//! - **`POST /acp/catalog/opt-in`** — set the host opt-in flag that gates the
+//!   CDN registry augmentation. Body: `{ enabled: boolean }`
+//!   (`deny_unknown_fields` rejects extra fields loudly).
+//!
+//! The read `GET` is open (no loopback guard — mirrors `GET /projects`:
+//! read-only host introspection). The opt-in `POST` mirrors the
+//! `set_default_project` posture (any connected client until Epic 2 wires auth).
+//!
+//! Degrade-mode (`acp_catalog: None`) returns `IpcBody::err(...,
+//! "ACP_CATALOG_UNAVAILABLE")`.
+
+use axum::{
+    body::Bytes,
+    extract::{Query, State},
+    http::StatusCode,
+    response::IntoResponse,
+    Json,
+};
+use serde::Deserialize;
+use tracing::{debug, info, warn};
+
+use crate::acp::{AcpCatalog, SetCatalogOptInRequest};
+use crate::web::fs_api::IpcBody;
+use crate::web::ws::AppState;
+
+/// `GET /acp/catalog?refresh=true` query params.
+#[derive(Debug, Deserialize)]
+pub struct CatalogQuery {
+    /// When `true`, force-refresh the probe cache (bypass the 60s TTL). When
+    /// absent / `false`, serve the cached catalog if fresh.
+    #[serde(default)]
+    pub refresh: Option<bool>,
+}
+
+/// `GET /acp/catalog` — list the resolved ACP catalog.
+///
+/// Returns the host's OS/arch/runtime availability + per-agent resolved
+/// `SupportedAcpAgentStatus`. The catalog is credential-free, path-free,
+/// read-only host introspection — never carries `AgentConfig.env` (API keys)
+/// or resolved absolute executable paths. The web client never probes
+/// `@tauri-apps/plugin-os` or PATH locally — the host is the single source of
+/// truth.
+///
+/// Degrade-mode (`acp_catalog: None`) returns
+/// `IpcBody::err(..., "ACP_CATALOG_UNAVAILABLE")`.
+pub async fn list(
+    State(state): State<AppState>,
+    Query(query): Query<CatalogQuery>,
+) -> impl IntoResponse {
+    let refresh = query.refresh.unwrap_or(false);
+    let Some(service) = state.acp_catalog.as_ref() else {
+        // Degraded mode — no host store attached.
+        return (
+            StatusCode::OK,
+            Json(IpcBody::<AcpCatalog>::err(
+                "acp catalog store is unavailable",
+                "ACP_CATALOG_UNAVAILABLE",
+            )),
+        );
+    };
+    match service.list_catalog(refresh).await {
+        Ok(catalog) => {
+            debug!(
+                target: "termul::web::catalog_api",
+                agents = catalog.agents.len(),
+                "get: resolved catalog"
+            );
+            (StatusCode::OK, Json(IpcBody::ok(catalog)))
+        }
+        Err(error) => {
+            warn!(
+                target: "termul::web::catalog_api",
+                error = %error,
+                "get: catalog resolution failed"
+            );
+            (
+                StatusCode::OK,
+                Json(IpcBody::<AcpCatalog>::err(
+                    error.to_string(),
+                    "CATALOG_LOAD_FAILED",
+                )),
+            )
+        }
+    }
+}
+
+/// `POST /acp/catalog/opt-in` — set the host opt-in flag.
+///
+/// Body: `SetCatalogOptInRequest { enabled: boolean }` with
+/// `deny_unknown_fields` so an over-serialized payload (`{ enabled: true,
+/// extra: "junk" }`) is rejected loudly as `VALIDATION_ERROR` (NOT silently
+/// dropped). The opt-in gates the CDN registry augmentation: when enabled,
+/// the next `GET /acp/catalog` includes CDN entries tagged
+/// `source: 'registry'` (if the fetch succeeds); when disabled, only bundled
+/// entries are served.
+///
+/// Degrade-mode (`acp_catalog: None`) returns
+/// `IpcBody::err(..., "ACP_CATALOG_UNAVAILABLE")`.
+///
+/// Manual body deserialization so a `deny_unknown_fields` rejection surfaces
+/// as 200 + `IpcBody::err(VALIDATION_ERROR)` — NOT a 4xx JsonRejection (which
+/// the renderer would map to `NETWORK_ERROR`, masking the validation failure).
+/// Mirrors the `workspace_api::write` handler pattern.
+pub async fn set_opt_in(
+    State(state): State<AppState>,
+    body: Bytes,
+) -> impl IntoResponse {
+    let req: SetCatalogOptInRequest = match serde_json::from_slice(&body) {
+        Ok(req) => req,
+        Err(error) => {
+            warn!(
+                target: "termul::web::catalog_api",
+                error = %error,
+                "set_opt_in: payload validation failed (deny_unknown_fields or malformed JSON)"
+            );
+            return (
+                StatusCode::OK,
+                Json(IpcBody::<()>::err(
+                    format!("payload validation failed: {error}"),
+                    "VALIDATION_ERROR",
+                )),
+            );
+        }
+    };
+    let Some(service) = state.acp_catalog.as_ref() else {
+        return (
+            StatusCode::OK,
+            Json(IpcBody::<()>::err(
+                "acp catalog store is unavailable",
+                "ACP_CATALOG_UNAVAILABLE",
+            )),
+        );
+    };
+    match service.set_opt_in(req.enabled) {
+        Ok(()) => {
+            info!(
+                target: "termul::web::catalog_api",
+                enabled = req.enabled,
+                "set_opt_in: persisted"
+            );
+            (StatusCode::OK, Json(IpcBody::<()>::ok(())))
+        }
+        Err(error) => {
+            warn!(
+                target: "termul::web::catalog_api",
+                error = %error,
+                "set_opt_in: persistence failed"
+            );
+            (
+                StatusCode::OK,
+                Json(IpcBody::<()>::err(
+                    error.to_string(),
+                    "ACP_CATALOG_OPT_IN_FAILED",
+                )),
+            )
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::acp::AcpCatalogService;
+    use crate::web::ws::HistoryMode;
+    use axum::body::Body;
+    use axum::http::{Request, StatusCode};
+    use axum::routing::{get, post};
+    use std::sync::Arc;
+    use tower::ServiceExt;
+
+    /// Temp directory removed on drop (including panic paths).
+    struct TempDir(std::path::PathBuf);
+    impl TempDir {
+        fn new(label: &str) -> Self {
+            let nanos = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_nanos())
+                .unwrap_or(0);
+            let path = std::env::temp_dir().join(format!(
+                "termul-catalog-api-{label}-{}-{nanos}",
+                std::process::id()
+            ));
+            std::fs::create_dir_all(&path).expect("create temp dir");
+            Self(path)
+        }
+        fn path(&self) -> &std::path::Path {
+            &self.0
+        }
+    }
+    impl Drop for TempDir {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_dir_all(&self.0);
+        }
+    }
+
+    async fn state_with_store(root: &std::path::Path) -> AppState {
+        let store = AcpCatalogService::open(root.join("catalog"))
+            .await
+            .expect("open store");
+        let pty = crate::web::test_pty_manager();
+        AppState {
+            acp: Arc::new(crate::acp::AcpManager::new(vec![])),
+            terminal_events: pty.terminal_events(),
+            cwd_tracker: pty.cwd_tracker(),
+            git_tracker: pty.git_tracker(),
+            exit_code_tracker: pty.exit_code_tracker(),
+            pty,
+            relay: Arc::new(crate::web::sink::WsRelaySink::new()),
+            registry: Arc::new(crate::web::project_registry::ProjectRegistry::new()),
+            registry_persistence: None,
+            projects_file: None,
+            history_mode: HistoryMode::LiveOnly,
+            project_root: Arc::new(std::env::temp_dir()),
+            workspace_manifest: None,
+            acp_catalog: Some(store),
+        }
+    }
+
+    async fn state_without_store() -> AppState {
+        let pty = crate::web::test_pty_manager();
+        AppState {
+            acp: Arc::new(crate::acp::AcpManager::new(vec![])),
+            terminal_events: pty.terminal_events(),
+            cwd_tracker: pty.cwd_tracker(),
+            git_tracker: pty.git_tracker(),
+            exit_code_tracker: pty.exit_code_tracker(),
+            pty,
+            relay: Arc::new(crate::web::sink::WsRelaySink::new()),
+            registry: Arc::new(crate::web::project_registry::ProjectRegistry::new()),
+            registry_persistence: None,
+            projects_file: None,
+            history_mode: HistoryMode::LiveOnly,
+            project_root: Arc::new(std::env::temp_dir()),
+            workspace_manifest: None,
+            acp_catalog: None,
+        }
+    }
+
+    fn test_router(state: AppState) -> axum::Router {
+        axum::Router::new()
+            .route("/acp/catalog", get(super::list))
+            .route("/acp/catalog/opt-in", post(set_opt_in))
+            .with_state(state)
+    }
+
+    async fn body_as_json<T: serde::de::DeserializeOwned>(body: Body) -> T {
+        let bytes = axum::body::to_bytes(body, usize::MAX)
+            .await
+            .expect("read body");
+        serde_json::from_slice(&bytes).expect("deserialize IpcBody")
+    }
+
+    // ---- Degraded mode (None store) ----
+
+    #[tokio::test]
+    async fn get_catalog_degraded_returns_unavailable() {
+        let state = state_without_store().await;
+        let resp = test_router(state)
+            .oneshot(
+                Request::builder()
+                    .method("GET")
+                    .uri("/acp/catalog")
+                    .body(Body::empty())
+                    .expect("build request"),
+            )
+            .await
+            .expect("router response");
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body: IpcBody<AcpCatalog> = body_as_json(resp.into_body()).await;
+        assert!(!body.success);
+        assert_eq!(body.code.as_deref(), Some("ACP_CATALOG_UNAVAILABLE"));
+    }
+
+    #[tokio::test]
+    async fn set_opt_in_degraded_returns_unavailable() {
+        let state = state_without_store().await;
+        let resp = test_router(state)
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/acp/catalog/opt-in")
+                    .header("content-type", "application/json")
+                    .body(Body::from(br#"{"enabled":true}"#.to_vec()))
+                    .expect("build request"),
+            )
+            .await
+            .expect("router response");
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body: IpcBody<()> = body_as_json(resp.into_body()).await;
+        assert!(!body.success);
+        assert_eq!(body.code.as_deref(), Some("ACP_CATALOG_UNAVAILABLE"));
+    }
+
+    // ---- Happy path ----
+
+    #[tokio::test]
+    async fn get_catalog_happy_path_returns_resolved_catalog() {
+        let dir = TempDir::new("get-happy");
+        let state = state_with_store(dir.path()).await;
+        let resp = test_router(state)
+            .oneshot(
+                Request::builder()
+                    .method("GET")
+                    .uri("/acp/catalog")
+                    .body(Body::empty())
+                    .expect("build request"),
+            )
+            .await
+            .expect("router response");
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body: IpcBody<AcpCatalog> = body_as_json(resp.into_body()).await;
+        assert!(body.success, "catalog get must succeed");
+        let catalog = body.data.unwrap();
+        assert!(!catalog.agents.is_empty(), "bundled catalog is not empty");
+        // Host capability present.
+        assert!(!catalog.host.os.is_empty());
+        assert!(!catalog.host.arch.is_empty());
+        // Runtimes present.
+        // Every agent has the expected fields.
+        for agent in &catalog.agents {
+            assert!(!agent.id.is_empty());
+            assert!(!agent.name.is_empty());
+            assert!(!agent.version.is_empty());
+        }
+    }
+
+    #[tokio::test]
+    async fn get_catalog_with_refresh_query_force_refreshes() {
+        let dir = TempDir::new("get-refresh");
+        let state = state_with_store(dir.path()).await;
+        let resp = test_router(state)
+            .oneshot(
+                Request::builder()
+                    .method("GET")
+                    .uri("/acp/catalog?refresh=true")
+                    .body(Body::empty())
+                    .expect("build request"),
+            )
+            .await
+            .expect("router response");
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body: IpcBody<AcpCatalog> = body_as_json(resp.into_body()).await;
+        assert!(body.success);
+    }
+
+    #[tokio::test]
+    async fn set_opt_in_happy_path_persists_flag() {
+        let dir = TempDir::new("set-opt-in");
+        let state = state_with_store(dir.path()).await;
+        let resp = test_router(state.clone())
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/acp/catalog/opt-in")
+                    .header("content-type", "application/json")
+                    .body(Body::from(br#"{"enabled":true}"#.to_vec()))
+                    .expect("build request"),
+            )
+            .await
+            .expect("router response");
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body: IpcBody<()> = body_as_json(resp.into_body()).await;
+        assert!(body.success, "set_opt_in must succeed");
+        // Verify the flag was persisted.
+        let service = state.acp_catalog.as_ref().unwrap();
+        assert!(service.is_opt_in(), "opt-in should be true after POST");
+    }
+
+    // ---- deny_unknown_fields rejection ----
+
+    #[tokio::test]
+    async fn set_opt_in_rejects_extra_field_as_validation_error() {
+        let dir = TempDir::new("set-opt-in-reject");
+        let state = state_with_store(dir.path()).await;
+        let resp = test_router(state)
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/acp/catalog/opt-in")
+                    .header("content-type", "application/json")
+                    .body(Body::from(br#"{"enabled":true,"extra":"junk"}"#.to_vec()))
+                    .expect("build request"),
+            )
+            .await
+            .expect("router response");
+        assert_eq!(
+            resp.status(),
+            StatusCode::OK,
+            "deny_unknown_fields rejection must surface as 200 + IpcBody::err (Patch 1)"
+        );
+        let body: IpcBody<()> = body_as_json(resp.into_body()).await;
+        assert!(!body.success);
+        assert_eq!(body.code.as_deref(), Some("VALIDATION_ERROR"));
+    }
+
+    #[tokio::test]
+    async fn set_opt_in_rejects_malformed_json() {
+        let dir = TempDir::new("set-opt-in-malformed");
+        let state = state_with_store(dir.path()).await;
+        let resp = test_router(state)
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/acp/catalog/opt-in")
+                    .header("content-type", "application/json")
+                    .body(Body::from(b"{ not valid json".to_vec()))
+                    .expect("build request"),
+            )
+            .await
+            .expect("router response");
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body: IpcBody<()> = body_as_json(resp.into_body()).await;
+        assert!(!body.success);
+        assert_eq!(body.code.as_deref(), Some("VALIDATION_ERROR"));
+    }
+
+    // ---- Serde shape tests ----
+
+    #[test]
+    fn acp_catalog_wire_shape_is_camel_case() {
+        let catalog = AcpCatalog {
+            host: crate::acp::HostCapability {
+                os: "linux".to_string(),
+                arch: "x86_64".to_string(),
+                runtimes: crate::acp::CatalogRuntimeAvailability {
+                    npx: true,
+                    uvx: false,
+                    node: true,
+                    bun: false,
+                    python3: true,
+                },
+            },
+            agents: vec![crate::acp::CatalogAgent {
+                id: "test".to_string(),
+                name: "Test".to_string(),
+                version: "1.0.0".to_string(),
+                description: "test".to_string(),
+                source: crate::acp::CatalogSource::Bundled,
+                distribution: serde_json::json!({ "npx": { "package": "test@1.0.0" } }),
+                runtime_requirements: vec!["npx".to_string()],
+                status: crate::acp::SupportedAcpAgentStatus::Ready,
+                platform_targets: vec![crate::acp::PlatformTarget {
+                    os: "linux".to_string(),
+                    arch: "x86_64".to_string(),
+                }],
+            }],
+        };
+        let value = serde_json::to_value(&catalog).unwrap();
+        // camelCase fields.
+        assert!(value["host"]["runtimes"]["npx"].is_boolean());
+        assert!(value["agents"][0]["runtimeRequirements"].is_array());
+        assert!(value["agents"][0]["platformTargets"].is_array());
+        assert_eq!(value["agents"][0]["status"], "ready");
+        assert_eq!(value["agents"][0]["source"], "bundled");
+    }
+}

--- a/src-tauri/src/web/catalog_api.rs
+++ b/src-tauri/src/web/catalog_api.rs
@@ -221,6 +221,7 @@ mod tests {
             project_root: Arc::new(std::env::temp_dir()),
             workspace_manifest: None,
             acp_catalog: Some(store),
+            acp_install: None,
         }
     }
 
@@ -241,6 +242,7 @@ mod tests {
             project_root: Arc::new(std::env::temp_dir()),
             workspace_manifest: None,
             acp_catalog: None,
+            acp_install: None,
         }
     }
 

--- a/src-tauri/src/web/config.rs
+++ b/src-tauri/src/web/config.rs
@@ -180,6 +180,12 @@ pub struct ServerConfig {
     /// it constructs its own `WorkspaceManifestService` under
     /// `<app_data_dir>/workspace-manifests`).
     pub workspace_manifests_dir: Option<PathBuf>,
+    /// CAP-6 / Story 8: acp-catalog root override. `None` means "use
+    /// `<service_account_state_dir>/acp-catalog`" — the standalone binary
+    /// resolves this in `server_main.rs`. The desktop shared-live path never
+    /// reads this field; it constructs its own `AcpCatalogService` under
+    /// `<app_data_dir>/acp-catalog`.
+    pub acp_catalog_dir: Option<PathBuf>,
 }
 
 impl ServerConfig {
@@ -277,6 +283,9 @@ impl ServerConfig {
         // here (the service creates the directory if missing; a present
         // non-directory fails loudly at `WorkspaceManifestService::open`).
         let mut workspace_manifests_dir: Option<PathBuf> = None;
+        // CAP-6 / Story 8: acp-catalog root override. Same pattern as
+        // `workspace_manifests_dir` — `None` means resolve at startup.
+        let mut acp_catalog_dir: Option<PathBuf> = None;
 
         let mut iter = args.into_iter().peekable();
         while let Some(arg) = iter.next() {
@@ -411,6 +420,20 @@ impl ServerConfig {
                     }
                     workspace_manifests_dir = Some(PathBuf::from(trimmed));
                 }
+                "--acp-catalog-dir" => {
+                    let value = iter.next().ok_or_else(|| {
+                        ParseCliError::Message(
+                            "missing value for --acp-catalog-dir".into(),
+                        )
+                    })?;
+                    let trimmed = value.as_ref().trim();
+                    if trimmed.is_empty() {
+                        return Err(ParseCliError::Message(
+                            "invalid --acp-catalog-dir '': must be a non-empty path".into(),
+                        ));
+                    }
+                    acp_catalog_dir = Some(PathBuf::from(trimmed));
+                }
                 "--projects-file" => {
                     let value = iter.next().ok_or_else(|| {
                         ParseCliError::Message("missing value for --projects-file".into())
@@ -494,6 +517,7 @@ impl ServerConfig {
             projects_file,
             sessions_dir: Some(sessions_dir),
             workspace_manifests_dir,
+            acp_catalog_dir,
         })
     }
 }
@@ -618,6 +642,7 @@ mod tests {
             projects_file: None,
             sessions_dir: None,
             workspace_manifests_dir: None,
+            acp_catalog_dir: None,
         };
         assert_eq!(
             cfg.bind_addr(),
@@ -634,6 +659,7 @@ mod tests {
             projects_file: None,
             sessions_dir: None,
             workspace_manifests_dir: None,
+            acp_catalog_dir: None,
         };
         assert_eq!(bad.bind_addr(), None);
     }
@@ -844,6 +870,7 @@ mod tests {
             projects_file: None,
             sessions_dir: None,
             workspace_manifests_dir: None,
+            acp_catalog_dir: None,
         };
         // We cannot safely mutate the real process env vars in a parallel
         // test runner, so we assert the contract indirectly: the resolved

--- a/src-tauri/src/web/fs_api.rs
+++ b/src-tauri/src/web/fs_api.rs
@@ -881,6 +881,7 @@ mod tests {
             history_mode: crate::web::ws::HistoryMode::LiveOnly,
             project_root: Arc::new(root.canonicalize().unwrap_or_else(|_| root.to_path_buf())),
             workspace_manifest: None,
+            acp_catalog: None,
         }
     }
 

--- a/src-tauri/src/web/fs_api.rs
+++ b/src-tauri/src/web/fs_api.rs
@@ -882,6 +882,7 @@ mod tests {
             project_root: Arc::new(root.canonicalize().unwrap_or_else(|_| root.to_path_buf())),
             workspace_manifest: None,
             acp_catalog: None,
+            acp_install: None,
         }
     }
 

--- a/src-tauri/src/web/git_api.rs
+++ b/src-tauri/src/web/git_api.rs
@@ -1029,6 +1029,7 @@ mod tests {
             history_mode: HistoryMode::LiveOnly,
             project_root: Arc::new(root.canonicalize().unwrap_or_else(|_| root.to_path_buf())),
             workspace_manifest: None,
+            acp_catalog: None,
         }
     }
 

--- a/src-tauri/src/web/git_api.rs
+++ b/src-tauri/src/web/git_api.rs
@@ -1030,6 +1030,7 @@ mod tests {
             project_root: Arc::new(root.canonicalize().unwrap_or_else(|_| root.to_path_buf())),
             workspace_manifest: None,
             acp_catalog: None,
+            acp_install: None,
         }
     }
 

--- a/src-tauri/src/web/install_api.rs
+++ b/src-tauri/src/web/install_api.rs
@@ -1,0 +1,338 @@
+//! HTTP handler for the host-owned verified-atomic ACP install (CAP-6 / Story 9).
+//!
+//! Mirrors the desktop `#[tauri::command] acp_install_agent` handler over HTTP
+//! so the web/remote client can install a catalog agent through the same
+//! `IpcBody<T>` contract.
+//!
+//! - **`POST /acp/install`** — install an agent. Body: `{ agentId: string }`
+//!   (`deny_unknown_fields` rejects extra fields loudly). The host resolves
+//!   the agent by id from the catalog, downloads the HTTPS archive, verifies
+//!   `sha256`, extracts safely, atomically activates, serializes per-agent,
+//!   records the installed-agents manifest, and returns
+//!   `{ command: absolute_path, args: string[] }`.
+//!
+//! The request carries ONLY `{ agentId }`; the host never accepts
+//! browser-supplied URLs, commands, executable paths, or args — the trusted
+//! catalog is the single source of both the archive URL and its expected
+//! digest.
+//!
+//! Degrade-mode (`acp_install: None`) returns
+//! `IpcBody::err(..., code::ACP_INSTALL_UNAVAILABLE)`. HTTP 200 for both success
+//! AND app-level failures (mirrors `catalog_api.rs`); only transport/parse
+//! failures become non-200 (renderer maps to `NETWORK_ERROR`).
+
+use axum::{
+    body::Bytes,
+    extract::State,
+    http::StatusCode,
+    response::IntoResponse,
+    Json,
+};
+use tracing::{info, warn};
+
+use crate::acp::install::{code, InstallOutcome, InstallRequest};
+use crate::web::fs_api::IpcBody;
+use crate::web::ws::AppState;
+
+/// `POST /acp/install` — install a catalog agent.
+///
+/// Manual body deserialization so a `deny_unknown_fields` rejection surfaces as
+/// 200 + `IpcBody::err(VALIDATION_ERROR)` — NOT a 4xx JsonRejection (which the
+/// renderer would map to `NETWORK_ERROR`, masking the validation failure).
+/// Mirrors the `catalog_api::set_opt_in` handler pattern.
+///
+/// Degrade-mode (`acp_install: None`) returns
+/// `IpcBody::err(..., code::ACP_INSTALL_UNAVAILABLE)`.
+pub async fn install(
+    State(state): State<AppState>,
+    body: Bytes,
+) -> impl IntoResponse {
+    let req: InstallRequest = match serde_json::from_slice(&body) {
+        Ok(req) => req,
+        Err(error) => {
+            warn!(
+                target: "termul::web::install_api",
+                session = crate::logging::session_id(),
+                error = %error,
+                "install: payload validation failed (deny_unknown_fields or malformed JSON)"
+            );
+            return (
+                StatusCode::OK,
+                Json(IpcBody::<InstallOutcome>::err(
+                    format!("payload validation failed: {error}"),
+                    code::VALIDATION_ERROR,
+                )),
+            );
+        }
+    };
+    let Some(service) = state.acp_install.as_ref() else {
+        return (
+            StatusCode::OK,
+            Json(IpcBody::<InstallOutcome>::err(
+                "acp install store is unavailable",
+                code::ACP_INSTALL_UNAVAILABLE,
+            )),
+        );
+    };
+    match service.install_by_id(&req.agent_id).await {
+        Ok(outcome) => {
+            info!(
+                target: "termul::web::install_api",
+                session = crate::logging::session_id(),
+                agent = %req.agent_id,
+                "install: success"
+            );
+            (StatusCode::OK, Json(IpcBody::ok(outcome)))
+        }
+        Err(error) => {
+            let code = error.code();
+            warn!(
+                target: "termul::web::install_api",
+                session = crate::logging::session_id(),
+                agent = %req.agent_id,
+                code,
+                msg = %error.message,
+                "install: failure"
+            );
+            (
+                StatusCode::OK,
+                Json(IpcBody::<InstallOutcome>::err(error.message, code)),
+            )
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::acp::AcpCatalogService;
+    use crate::acp::install::AcpInstallService;
+    use crate::web::ws::HistoryMode;
+    use axum::body::Body;
+    use axum::http::{Request, StatusCode};
+    use axum::routing::post;
+    use std::sync::Arc;
+    use tower::ServiceExt;
+
+    /// Temp directory removed on drop (including panic paths).
+    struct TempDir(std::path::PathBuf);
+    impl TempDir {
+        fn new(label: &str) -> Self {
+            let nanos = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_nanos())
+                .unwrap_or(0);
+            let path = std::env::temp_dir().join(format!(
+                "termul-install-api-{label}-{}-{nanos}",
+                std::process::id()
+            ));
+            std::fs::create_dir_all(&path).expect("create temp dir");
+            Self(path)
+        }
+        fn path(&self) -> &std::path::Path {
+            &self.0
+        }
+    }
+    impl Drop for TempDir {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_dir_all(&self.0);
+        }
+    }
+
+    async fn state_with_store(root: &std::path::Path) -> AppState {
+        let catalog = AcpCatalogService::open(root.join("catalog"))
+            .await
+            .expect("open catalog");
+        let store = AcpInstallService::open(root.join("installs"), catalog)
+            .await
+            .expect("open install store");
+        let pty = crate::web::test_pty_manager();
+        AppState {
+            acp: Arc::new(crate::acp::AcpManager::new(vec![])),
+            terminal_events: pty.terminal_events(),
+            cwd_tracker: pty.cwd_tracker(),
+            git_tracker: pty.git_tracker(),
+            exit_code_tracker: pty.exit_code_tracker(),
+            pty,
+            relay: Arc::new(crate::web::sink::WsRelaySink::new()),
+            registry: Arc::new(crate::web::project_registry::ProjectRegistry::new()),
+            registry_persistence: None,
+            projects_file: None,
+            history_mode: HistoryMode::LiveOnly,
+            project_root: Arc::new(std::env::temp_dir()),
+            workspace_manifest: None,
+            acp_catalog: None,
+            acp_install: Some(store),
+        }
+    }
+
+    async fn state_without_store() -> AppState {
+        let pty = crate::web::test_pty_manager();
+        AppState {
+            acp: Arc::new(crate::acp::AcpManager::new(vec![])),
+            terminal_events: pty.terminal_events(),
+            cwd_tracker: pty.cwd_tracker(),
+            git_tracker: pty.git_tracker(),
+            exit_code_tracker: pty.exit_code_tracker(),
+            pty,
+            relay: Arc::new(crate::web::sink::WsRelaySink::new()),
+            registry: Arc::new(crate::web::project_registry::ProjectRegistry::new()),
+            registry_persistence: None,
+            projects_file: None,
+            history_mode: HistoryMode::LiveOnly,
+            project_root: Arc::new(std::env::temp_dir()),
+            workspace_manifest: None,
+            acp_catalog: None,
+            acp_install: None,
+        }
+    }
+
+    fn test_router(state: AppState) -> axum::Router {
+        axum::Router::new()
+            .route("/acp/install", post(super::install))
+            .with_state(state)
+    }
+
+    async fn body_as_json<T: serde::de::DeserializeOwned>(body: Body) -> T {
+        let bytes = axum::body::to_bytes(body, usize::MAX)
+            .await
+            .expect("read body");
+        serde_json::from_slice(&bytes).expect("deserialize IpcBody")
+    }
+
+    // ---- Degraded mode (None store) ----
+
+    #[tokio::test]
+    async fn install_degraded_returns_unavailable() {
+        let state = state_without_store().await;
+        let resp = test_router(state)
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/acp/install")
+                    .header("content-type", "application/json")
+                    .body(Body::from(br#"{"agentId":"opencode"}"#.to_vec()))
+                    .expect("build request"),
+            )
+            .await
+            .expect("router response");
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body: IpcBody<InstallOutcome> = body_as_json(resp.into_body()).await;
+        assert!(!body.success);
+        assert_eq!(body.code.as_deref(), Some(code::ACP_INSTALL_UNAVAILABLE));
+    }
+
+    // ---- deny_unknown_fields rejection ----
+
+    #[tokio::test]
+    async fn install_rejects_extra_field_as_validation_error() {
+        let dir = TempDir::new("install-reject");
+        let state = state_with_store(dir.path()).await;
+        let resp = test_router(state)
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/acp/install")
+                    .header("content-type", "application/json")
+                    .body(Body::from(br#"{"agentId":"opencode","extra":"junk"}"#.to_vec()))
+                    .expect("build request"),
+            )
+            .await
+            .expect("router response");
+        assert_eq!(
+            resp.status(),
+            StatusCode::OK,
+            "deny_unknown_fields rejection must surface as 200 + IpcBody::err"
+        );
+        let body: IpcBody<InstallOutcome> = body_as_json(resp.into_body()).await;
+        assert!(!body.success);
+        assert_eq!(body.code.as_deref(), Some(code::VALIDATION_ERROR));
+    }
+
+    #[tokio::test]
+    async fn install_rejects_malformed_json() {
+        let dir = TempDir::new("install-malformed");
+        let state = state_with_store(dir.path()).await;
+        let resp = test_router(state)
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/acp/install")
+                    .header("content-type", "application/json")
+                    .body(Body::from(b"{ not valid json".to_vec()))
+                    .expect("build request"),
+            )
+            .await
+            .expect("router response");
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body: IpcBody<InstallOutcome> = body_as_json(resp.into_body()).await;
+        assert!(!body.success);
+        assert_eq!(body.code.as_deref(), Some(code::VALIDATION_ERROR));
+    }
+
+    // ---- Empty agentId → VALIDATION_ERROR (via is_safe_agent_id) ----
+
+    #[tokio::test]
+    async fn install_rejects_empty_agent_id_as_validation_error() {
+        let dir = TempDir::new("install-empty-id");
+        let state = state_with_store(dir.path()).await;
+        let resp = test_router(state)
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/acp/install")
+                    .header("content-type", "application/json")
+                    .body(Body::from(br#"{"agentId":""}"#.to_vec()))
+                    .expect("build request"),
+            )
+            .await
+            .expect("router response");
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body: IpcBody<InstallOutcome> = body_as_json(resp.into_body()).await;
+        assert!(!body.success);
+        assert_eq!(body.code.as_deref(), Some(code::VALIDATION_ERROR));
+    }
+
+    // ---- Agent not in catalog → CATALOG_AGENT_NOT_FOUND ----
+
+    #[tokio::test]
+    async fn install_unknown_agent_returns_catalog_agent_not_found() {
+        let dir = TempDir::new("install-unknown");
+        let state = state_with_store(dir.path()).await;
+        let resp = test_router(state)
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/acp/install")
+                    .header("content-type", "application/json")
+                    .body(Body::from(br#"{"agentId":"does-not-exist"}"#.to_vec()))
+                    .expect("build request"),
+            )
+            .await
+            .expect("router response");
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body: IpcBody<InstallOutcome> = body_as_json(resp.into_body()).await;
+        assert!(!body.success);
+        assert_eq!(body.code.as_deref(), Some("CATALOG_AGENT_NOT_FOUND"));
+    }
+
+    // ---- Serde shape tests ----
+
+    #[test]
+    fn install_request_rejects_unknown_fields_serde() {
+        let payload = serde_json::json!({ "agentId": "opencode", "extra": "junk" });
+        let result: Result<InstallRequest, _> = serde_json::from_value(payload);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn install_outcome_serializes_camel_case() {
+        let outcome = InstallOutcome {
+            command: "/path/to/opencode".to_string(),
+            args: vec!["acp".to_string()],
+        };
+        let value = serde_json::to_value(&outcome).unwrap();
+        assert_eq!(value["command"], "/path/to/opencode");
+        assert_eq!(value["args"][0], "acp");
+    }
+}

--- a/src-tauri/src/web/log_api.rs
+++ b/src-tauri/src/web/log_api.rs
@@ -110,6 +110,7 @@ mod tests {
             ),
             workspace_manifest: None,
             acp_catalog: None,
+            acp_install: None,
         }
     }
 

--- a/src-tauri/src/web/log_api.rs
+++ b/src-tauri/src/web/log_api.rs
@@ -109,6 +109,7 @@ mod tests {
                     .unwrap_or_else(|_| std::env::temp_dir()),
             ),
             workspace_manifest: None,
+            acp_catalog: None,
         }
     }
 

--- a/src-tauri/src/web/mcp_probe_api.rs
+++ b/src-tauri/src/web/mcp_probe_api.rs
@@ -71,6 +71,7 @@ mod tests {
             project_root: Arc::new(std::env::temp_dir()),
             workspace_manifest: None,
             acp_catalog: None,
+            acp_install: None,
         };
         axum::Router::new()
             .route("/mcp-servers/probe", post(super::probe))

--- a/src-tauri/src/web/mcp_probe_api.rs
+++ b/src-tauri/src/web/mcp_probe_api.rs
@@ -70,6 +70,7 @@ mod tests {
             history_mode: HistoryMode::LiveOnly,
             project_root: Arc::new(std::env::temp_dir()),
             workspace_manifest: None,
+            acp_catalog: None,
         };
         axum::Router::new()
             .route("/mcp-servers/probe", post(super::probe))

--- a/src-tauri/src/web/mcp_servers_api.rs
+++ b/src-tauri/src/web/mcp_servers_api.rs
@@ -130,6 +130,7 @@ mod tests {
             history_mode: HistoryMode::LiveOnly,
             project_root: Arc::new(dir),
             workspace_manifest: None,
+            acp_catalog: None,
         };
         axum::Router::new()
             .route("/mcp-servers", get(super::get).put(super::put))

--- a/src-tauri/src/web/mcp_servers_api.rs
+++ b/src-tauri/src/web/mcp_servers_api.rs
@@ -131,6 +131,7 @@ mod tests {
             project_root: Arc::new(dir),
             workspace_manifest: None,
             acp_catalog: None,
+            acp_install: None,
         };
         axum::Router::new()
             .route("/mcp-servers", get(super::get).put(super::put))

--- a/src-tauri/src/web/mod.rs
+++ b/src-tauri/src/web/mod.rs
@@ -19,6 +19,7 @@ pub mod catalog_api;
 pub mod config;
 pub mod fs_api;
 pub mod git_api;
+pub mod install_api;
 pub mod log_api;
 pub mod mcp_probe_api;
 pub mod mcp_servers_api;
@@ -95,6 +96,13 @@ pub(crate) fn test_pty_manager() -> Arc<PtyManager> {
 /// the desktop host opens its own under `<app_data_dir>/acp-catalog`. `None`
 /// degrades to `ACP_CATALOG_UNAVAILABLE`.
 ///
+/// `acp_install` is the host-owned [`AcpInstallService`] for CAP-6 / Story 9 —
+/// downloads + verifies (sha256) + extracts + atomically activates ACP agent
+/// archives resolved from the catalog. The standalone binary opens it under
+/// `<service_account_state_dir>/acp-registry-binaries`; the desktop host opens
+/// its own under `<app_data_dir>/acp-registry-binaries`. `None` degrades to
+/// `ACP_INSTALL_UNAVAILABLE`.
+///
 /// The standalone binary owns its agent lifetime end-to-end, so it kills agents
 /// on exit. The desktop-hosted shared-live path calls [`serve_router`] directly
 /// and must NOT kill the desktop's live agents — see [`serve_router`].
@@ -113,6 +121,7 @@ pub async fn serve(
     cfg: ServerConfig,
     workspace_manifest: Option<Arc<crate::acp::WorkspaceManifestService>>,
     acp_catalog: Option<Arc<crate::acp::AcpCatalogService>>,
+    acp_install: Option<Arc<crate::acp::install::AcpInstallService>>,
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let (_addr, handle) = serve_router(
         acp.clone(),
@@ -129,6 +138,7 @@ pub async fn serve(
         shutdown_signal_future(),
         workspace_manifest,
         acp_catalog,
+        acp_install,
     )
     .await?;
 
@@ -197,6 +207,7 @@ pub async fn serve_router(
     shutdown: impl Future<Output = ()> + Send + 'static,
     workspace_manifest: Option<Arc<crate::acp::WorkspaceManifestService>>,
     acp_catalog: Option<Arc<crate::acp::AcpCatalogService>>,
+    acp_install: Option<Arc<crate::acp::install::AcpInstallService>>,
 ) -> Result<(SocketAddr, JoinHandle<()>), Box<dyn std::error::Error + Send + Sync>> {
     let bind_addr = cfg.bind_addr().ok_or_else(|| {
         format!(
@@ -241,6 +252,7 @@ pub async fn serve_router(
         history_mode,
         workspace_manifest,
         acp_catalog,
+        acp_install,
     );
 
     let handle = tokio::spawn(async move {

--- a/src-tauri/src/web/mod.rs
+++ b/src-tauri/src/web/mod.rs
@@ -15,6 +15,7 @@
 //! event log, cursor, tiers) is [`ws`] (Story 1.4).
 
 pub mod assets;
+pub mod catalog_api;
 pub mod config;
 pub mod fs_api;
 pub mod git_api;
@@ -88,6 +89,12 @@ pub(crate) fn test_pty_manager() -> Arc<PtyManager> {
 /// its own under `<app_data_dir>/workspace-manifests` (never shared across
 /// processes — `Never`-clause). `None` degrades to fresh-only mode.
 ///
+/// `acp_catalog` is the host-owned [`AcpCatalogService`] for CAP-6 / Story 8 —
+/// resolves the trusted ACP catalog (OS/arch/runtime + per-agent status). The
+/// standalone binary opens it under `<service_account_state_dir>/acp-catalog`;
+/// the desktop host opens its own under `<app_data_dir>/acp-catalog`. `None`
+/// degrades to `ACP_CATALOG_UNAVAILABLE`.
+///
 /// The standalone binary owns its agent lifetime end-to-end, so it kills agents
 /// on exit. The desktop-hosted shared-live path calls [`serve_router`] directly
 /// and must NOT kill the desktop's live agents — see [`serve_router`].
@@ -105,6 +112,7 @@ pub async fn serve(
     projects_file: Option<PathBuf>,
     cfg: ServerConfig,
     workspace_manifest: Option<Arc<crate::acp::WorkspaceManifestService>>,
+    acp_catalog: Option<Arc<crate::acp::AcpCatalogService>>,
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let (_addr, handle) = serve_router(
         acp.clone(),
@@ -120,6 +128,7 @@ pub async fn serve(
         cfg,
         shutdown_signal_future(),
         workspace_manifest,
+        acp_catalog,
     )
     .await?;
 
@@ -187,6 +196,7 @@ pub async fn serve_router(
     cfg: ServerConfig,
     shutdown: impl Future<Output = ()> + Send + 'static,
     workspace_manifest: Option<Arc<crate::acp::WorkspaceManifestService>>,
+    acp_catalog: Option<Arc<crate::acp::AcpCatalogService>>,
 ) -> Result<(SocketAddr, JoinHandle<()>), Box<dyn std::error::Error + Send + Sync>> {
     let bind_addr = cfg.bind_addr().ok_or_else(|| {
         format!(
@@ -230,6 +240,7 @@ pub async fn serve_router(
         cfg.project_root.clone(),
         history_mode,
         workspace_manifest,
+        acp_catalog,
     );
 
     let handle = tokio::spawn(async move {

--- a/src-tauri/src/web/projects_api.rs
+++ b/src-tauri/src/web/projects_api.rs
@@ -232,6 +232,7 @@ mod tests {
             history_mode: crate::web::ws::HistoryMode::LiveOnly,
             project_root: Arc::new(std::path::PathBuf::new()),
             workspace_manifest: None,
+            acp_catalog: None,
         }
     }
 
@@ -258,6 +259,7 @@ mod tests {
             history_mode: crate::web::ws::HistoryMode::LiveOnly,
             project_root: Arc::new(std::path::PathBuf::new()),
             workspace_manifest: None,
+            acp_catalog: None,
         }
     }
 

--- a/src-tauri/src/web/projects_api.rs
+++ b/src-tauri/src/web/projects_api.rs
@@ -233,6 +233,7 @@ mod tests {
             project_root: Arc::new(std::path::PathBuf::new()),
             workspace_manifest: None,
             acp_catalog: None,
+            acp_install: None,
         }
     }
 
@@ -260,6 +261,7 @@ mod tests {
             project_root: Arc::new(std::path::PathBuf::new()),
             workspace_manifest: None,
             acp_catalog: None,
+            acp_install: None,
         }
     }
 

--- a/src-tauri/src/web/router.rs
+++ b/src-tauri/src/web/router.rs
@@ -16,9 +16,10 @@ use axum::{
     Router,
 };
 
-use crate::acp::{AcpManager, FileProjectRegistry, WorkspaceManifestService};
+use crate::acp::{AcpCatalogService, AcpManager, FileProjectRegistry, WorkspaceManifestService};
 use crate::pty::PtyManager;
 use crate::trackers::{CwdTracker, ExitCodeTracker, GitTracker, TerminalEventHub};
+use crate::web::catalog_api;
 use crate::web::fs_api;
 use crate::web::git_api;
 use crate::web::log_api;
@@ -63,6 +64,7 @@ pub fn router(
     project_root: PathBuf,
     history_mode: HistoryMode,
     workspace_manifest: Option<Arc<WorkspaceManifestService>>,
+    acp_catalog: Option<Arc<AcpCatalogService>>,
 ) -> Router {
     let mut r = Router::new()
         .route("/health", get(health_check))
@@ -138,7 +140,16 @@ pub fn router(
         // loopback-guarded inside the handler.
         .route("/workspace/{projectId}", get(workspace_api::get))
         .route("/workspace/{projectId}/write", post(workspace_api::write))
-        .route("/workspace/{projectId}/delete", post(workspace_api::delete));
+        .route("/workspace/{projectId}/delete", post(workspace_api::delete))
+        // ACP catalog web routes (CAP-6: Web & Mobile 1:1 Parity). Each
+        // mirrors a desktop `#[tauri::command] acp_*_catalog` handler; see
+        // `web/catalog_api.rs`. Registered AHEAD of the static fallback so
+        // the SPA mount cannot shadow them. The read `GET` is open (read-only
+        // host introspection, mirrors `GET /projects`); the `POST` opt-in
+        // mirrors `set_default_project` posture (any connected client until
+        // Epic 2).
+        .route("/acp/catalog", get(catalog_api::list))
+        .route("/acp/catalog/opt-in", post(catalog_api::set_opt_in));
     // Static fallback: disk ServeDir in dev (dist-web/ on disk) or the embedded
     // bundle in release. `/health` + `/ws` are registered above so the static
     // mount cannot shadow them (Story 1.3 AC1).
@@ -160,6 +171,7 @@ pub fn router(
         projects_file: projects_file.map(Arc::new),
         history_mode,
         workspace_manifest,
+        acp_catalog,
         project_root: Arc::new(project_root),
     })
 }
@@ -233,6 +245,8 @@ pub fn router_with_static(
         .route("/workspace/{projectId}", get(workspace_api::get))
         .route("/workspace/{projectId}/write", post(workspace_api::write))
         .route("/workspace/{projectId}/delete", post(workspace_api::delete))
+        .route("/acp/catalog", get(catalog_api::list))
+        .route("/acp/catalog/opt-in", post(catalog_api::set_opt_in))
         .fallback_service(assets::static_service_from(static_dir))
         .with_state(AppState {
             acp,
@@ -247,6 +261,7 @@ pub fn router_with_static(
             projects_file: None,
             history_mode: HistoryMode::LiveOnly,
             workspace_manifest: None,
+            acp_catalog: None,
             project_root: Arc::new(project_root),
         })
 }

--- a/src-tauri/src/web/router.rs
+++ b/src-tauri/src/web/router.rs
@@ -16,12 +16,13 @@ use axum::{
     Router,
 };
 
-use crate::acp::{AcpCatalogService, AcpManager, FileProjectRegistry, WorkspaceManifestService};
+use crate::acp::{AcpCatalogService, AcpInstallService, AcpManager, FileProjectRegistry, WorkspaceManifestService};
 use crate::pty::PtyManager;
 use crate::trackers::{CwdTracker, ExitCodeTracker, GitTracker, TerminalEventHub};
 use crate::web::catalog_api;
 use crate::web::fs_api;
 use crate::web::git_api;
+use crate::web::install_api;
 use crate::web::log_api;
 use crate::web::mcp_probe_api;
 use crate::web::mcp_servers_api;
@@ -65,6 +66,7 @@ pub fn router(
     history_mode: HistoryMode,
     workspace_manifest: Option<Arc<WorkspaceManifestService>>,
     acp_catalog: Option<Arc<AcpCatalogService>>,
+    acp_install: Option<Arc<AcpInstallService>>,
 ) -> Router {
     let mut r = Router::new()
         .route("/health", get(health_check))
@@ -149,7 +151,13 @@ pub fn router(
         // mirrors `set_default_project` posture (any connected client until
         // Epic 2).
         .route("/acp/catalog", get(catalog_api::list))
-        .route("/acp/catalog/opt-in", post(catalog_api::set_opt_in));
+        .route("/acp/catalog/opt-in", post(catalog_api::set_opt_in))
+        // ACP install web route (CAP-6 / Story 9: verified-atomic install).
+        // Mirrors the desktop `#[tauri::command] acp_install_agent` handler;
+        // see `web/install_api.rs`. Registered AHEAD of the static fallback so
+        // the SPA mount cannot shadow it. The request is `{ agentId }` only;
+        // the host resolves everything from the trusted catalog.
+        .route("/acp/install", post(install_api::install));
     // Static fallback: disk ServeDir in dev (dist-web/ on disk) or the embedded
     // bundle in release. `/health` + `/ws` are registered above so the static
     // mount cannot shadow them (Story 1.3 AC1).
@@ -172,6 +180,7 @@ pub fn router(
         history_mode,
         workspace_manifest,
         acp_catalog,
+        acp_install,
         project_root: Arc::new(project_root),
     })
 }
@@ -247,6 +256,7 @@ pub fn router_with_static(
         .route("/workspace/{projectId}/delete", post(workspace_api::delete))
         .route("/acp/catalog", get(catalog_api::list))
         .route("/acp/catalog/opt-in", post(catalog_api::set_opt_in))
+        .route("/acp/install", post(install_api::install))
         .fallback_service(assets::static_service_from(static_dir))
         .with_state(AppState {
             acp,
@@ -262,6 +272,7 @@ pub fn router_with_static(
             history_mode: HistoryMode::LiveOnly,
             workspace_manifest: None,
             acp_catalog: None,
+            acp_install: None,
             project_root: Arc::new(project_root),
         })
 }

--- a/src-tauri/src/web/search_api.rs
+++ b/src-tauri/src/web/search_api.rs
@@ -338,6 +338,7 @@ mod tests {
                     .unwrap_or_else(|_| std::env::temp_dir()),
             ),
             workspace_manifest: None,
+            acp_catalog: None,
         }
     }
 

--- a/src-tauri/src/web/search_api.rs
+++ b/src-tauri/src/web/search_api.rs
@@ -339,6 +339,7 @@ mod tests {
             ),
             workspace_manifest: None,
             acp_catalog: None,
+            acp_install: None,
         }
     }
 

--- a/src-tauri/src/web/skills_api.rs
+++ b/src-tauri/src/web/skills_api.rs
@@ -182,6 +182,7 @@ mod tests {
                     .unwrap_or_else(|_| std::env::temp_dir()),
             ),
             workspace_manifest: None,
+            acp_catalog: None,
         }
     }
 

--- a/src-tauri/src/web/skills_api.rs
+++ b/src-tauri/src/web/skills_api.rs
@@ -183,6 +183,7 @@ mod tests {
             ),
             workspace_manifest: None,
             acp_catalog: None,
+            acp_install: None,
         }
     }
 

--- a/src-tauri/src/web/workspace_api.rs
+++ b/src-tauri/src/web/workspace_api.rs
@@ -332,6 +332,7 @@ mod tests {
             history_mode: HistoryMode::LiveOnly,
             project_root: Arc::new(std::env::temp_dir()),
             workspace_manifest: Some(store),
+            acp_catalog: None,
         }
     }
 
@@ -355,6 +356,7 @@ mod tests {
             history_mode: HistoryMode::LiveOnly,
             project_root: Arc::new(std::env::temp_dir()),
             workspace_manifest: None,
+            acp_catalog: None,
         }
     }
 

--- a/src-tauri/src/web/workspace_api.rs
+++ b/src-tauri/src/web/workspace_api.rs
@@ -333,6 +333,7 @@ mod tests {
             project_root: Arc::new(std::env::temp_dir()),
             workspace_manifest: Some(store),
             acp_catalog: None,
+            acp_install: None,
         }
     }
 
@@ -357,6 +358,7 @@ mod tests {
             project_root: Arc::new(std::env::temp_dir()),
             workspace_manifest: None,
             acp_catalog: None,
+            acp_install: None,
         }
     }
 

--- a/src-tauri/src/web/ws.rs
+++ b/src-tauri/src/web/ws.rs
@@ -302,6 +302,14 @@ pub struct AppState {
     /// `workspace_api.rs`; the desktop renderer uses the `workspace_manifest_*`
     /// Tauri commands (same `IpcResult<T>` shape byte-for-byte).
     pub workspace_manifest: Option<Arc<crate::acp::WorkspaceManifestService>>,
+    /// Host-owned ACP catalog service (CAP-6 / Story 8). `None` when the
+    /// desktop could not open `AcpCatalogService` at startup (degraded mode —
+    /// routes return `ACP_CATALOG_UNAVAILABLE`). The web/remote client reads
+    /// the resolved catalog through `GET /acp/catalog` + WS
+    /// `list_acp_catalog`; the desktop renderer uses the `acp_list_catalog` +
+    /// `acp_set_catalog_opt_in` Tauri commands (same `IpcResult<T>` shape
+    /// byte-for-byte).
+    pub acp_catalog: Option<Arc<crate::acp::AcpCatalogService>>,
     /// PR-S4: the project-root boundary for the fs_api routes. Requests whose
     /// canonicalized target path resolves outside this root are refused with
     /// `code: "OUTSIDE_ROOT"` (or `PATH_TRAVERSAL` for explicit `..`
@@ -457,6 +465,9 @@ async fn run_relay(socket: WebSocket, state: AppState) {
     let registry_persistence = state.registry_persistence.clone();
     let projects_file = state.projects_file.clone();
     let history_mode = state.history_mode;
+    // CAP-6 / Story 8: the host-owned ACP catalog service for the
+    // `list_acp_catalog` + `set_catalog_opt_in` WS requests.
+    let acp_catalog = state.acp_catalog.clone();
     // Client ids registered via `subscribe` — unregistered on disconnect.
     let mut subscribed_clients: Vec<(String, ClientId)> = Vec::new();
     // Per-connection tracking for `switch_project` (Ask-First resolution): the
@@ -581,6 +592,7 @@ async fn run_relay(socket: WebSocket, state: AppState) {
                         &current_project,
                         &switch_queue,
                         history_mode,
+                        acp_catalog.as_ref(),
                     )
                     .await;
                     if write_tx.send(Outbound::Reply(handled)).is_err() {
@@ -698,6 +710,7 @@ async fn handle_request(
     current_project: &Arc<parking_lot::Mutex<Option<String>>>,
     switch_queue: &Arc<tokio::sync::Mutex<ProjectSwitchQueue>>,
     history_mode: HistoryMode,
+    acp_catalog: Option<&Arc<crate::acp::AcpCatalogService>>,
 ) -> WsReply {
     let req: WsRequest = match serde_json::from_str(text) {
         Ok(r) => r,
@@ -882,6 +895,17 @@ async fn handle_request(
             .await
         }
         "spawn_agent" => handle_spawn_agent(id, &req.payload, acp, current_agent).await,
+        // CAP-6 / Story 8: host-owned ACP catalog resolution. The catalog
+        // carries the host's OS/arch/runtime availability + per-agent
+        // resolved `SupportedAcpAgentStatus`. The web client never probes
+        // `@tauri-apps/plugin-os` or PATH locally — the host is the single
+        // source of truth.
+        "list_acp_catalog" => {
+            handle_list_acp_catalog(id, &req.payload, acp_catalog).await
+        }
+        "set_catalog_opt_in" => {
+            handle_set_catalog_opt_in(id, &req.payload, acp_catalog).await
+        }
         "kill_agent" => {
             handle_kill_agent(
                 id,
@@ -1328,6 +1352,88 @@ async fn handle_kill_agent(
 /// `list_agents` → `AcpManager::list_agents()`. Reply = `AgentId[]` (JSON array).
 fn handle_list_agents(id: String, acp: &Arc<AcpManager>) -> WsReply {
     ok_with_payload(id, &acp.list_agents())
+}
+
+// --- CAP-6 / Story 8: ACP catalog WS handlers ------------------------------
+
+/// `list_acp_catalog` WS request payload. `refresh` is optional (defaults to
+/// false — serve the cached catalog if fresh within the TTL).
+#[derive(Debug, Deserialize, Default)]
+#[serde(rename_all = "camelCase", default)]
+struct ListAcpCatalogPayload {
+    refresh: Option<bool>,
+}
+
+async fn handle_list_acp_catalog(
+    id: String,
+    payload: &Value,
+    acp_catalog: Option<&Arc<crate::acp::AcpCatalogService>>,
+) -> WsReply {
+    let parsed: ListAcpCatalogPayload = match serde_json::from_value(payload.clone()) {
+        Ok(p) => p,
+        Err(e) => {
+            return WsReply::err(
+                id,
+                WsErrorCode::Unsupported,
+                format!("malformed list_acp_catalog payload: {e}"),
+            )
+        }
+    };
+    let Some(service) = acp_catalog.cloned() else {
+        return WsReply::err(
+            id,
+            WsErrorCode::Unsupported,
+            "acp catalog store is unavailable",
+        );
+    };
+    match service.list_catalog(parsed.refresh.unwrap_or(false)).await {
+        Ok(catalog) => ok_with_payload(id, &catalog),
+        Err(error) => WsReply::err(
+            id,
+            WsErrorCode::Unsupported,
+            format!("catalog load failed: {error}"),
+        ),
+    }
+}
+
+/// `set_catalog_opt_in` WS request payload. `deny_unknown_fields` rejects an
+/// over-serialized payload loudly at the host boundary.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct SetCatalogOptInPayload {
+    enabled: bool,
+}
+
+async fn handle_set_catalog_opt_in(
+    id: String,
+    payload: &Value,
+    acp_catalog: Option<&Arc<crate::acp::AcpCatalogService>>,
+) -> WsReply {
+    let parsed: SetCatalogOptInPayload = match serde_json::from_value(payload.clone()) {
+        Ok(p) => p,
+        Err(e) => {
+            return WsReply::err(
+                id,
+                WsErrorCode::Unsupported,
+                format!("malformed set_catalog_opt_in payload (want enabled): {e}"),
+            )
+        }
+    };
+    let Some(service) = acp_catalog.cloned() else {
+        return WsReply::err(
+            id,
+            WsErrorCode::Unsupported,
+            "acp catalog store is unavailable",
+        );
+    };
+    match service.set_opt_in(parsed.enabled) {
+        Ok(()) => WsReply::ok(id, Some(json!({}))),
+        Err(error) => WsReply::err(
+            id,
+            WsErrorCode::Unsupported,
+            format!("opt-in persistence failed: {error}"),
+        ),
+    }
 }
 
 /// `create_session` → `AcpManager::new_session(agent_id, cwd, mcp_servers)`.
@@ -3142,6 +3248,7 @@ mod tests {
                 &current_project,
                 &switch_queue,
                 HistoryMode::LiveOnly,
+            None,
             ))
     }
 
@@ -3487,6 +3594,7 @@ mod tests {
                 &current_project,
                 &switch_queue,
                 HistoryMode::LiveOnly,
+            None,
             ));
         assert!(!reply.ok);
         assert_eq!(reply.err.unwrap().code, "unsupported");
@@ -3570,6 +3678,7 @@ mod tests {
             &current_project,
             &switch_queue,
             HistoryMode::LiveOnly,
+        None,
         ));
         assert!(!reply.ok);
         assert_eq!(reply.err.unwrap().code, "permission_denied");
@@ -3619,6 +3728,7 @@ mod tests {
             &current_project,
             &switch_queue,
             HistoryMode::LiveOnly,
+        None,
         ));
         assert!(!reply.ok);
         assert_eq!(reply.err.unwrap().code, "not_found");
@@ -3654,6 +3764,7 @@ mod tests {
             &current_project,
             &switch_queue,
             HistoryMode::LiveOnly,
+        None,
         ));
         assert!(ok_reply.ok, "first response wins: {:?}", ok_reply.err);
         // Second frame for the same requestId → stale (ticket evicted).
@@ -3672,6 +3783,7 @@ mod tests {
             &current_project,
             &switch_queue,
             HistoryMode::LiveOnly,
+        None,
         ));
         assert!(!stale_reply.ok);
         assert_eq!(stale_reply.err.unwrap().code, "stale");
@@ -3706,6 +3818,7 @@ mod tests {
             &current_project,
             &switch_queue,
             HistoryMode::LiveOnly,
+        None,
         ));
         assert!(!reply.ok);
         assert_eq!(reply.err.unwrap().code, "permission_denied");
@@ -3793,6 +3906,7 @@ mod tests {
             &current_project,
             &switch_queue,
             HistoryMode::LiveOnly,
+        None,
         ));
         assert!(!reply.ok);
         assert_eq!(reply.err.unwrap().code, "unsupported");
@@ -3826,6 +3940,7 @@ mod tests {
             &current_project,
             &switch_queue,
             HistoryMode::LiveOnly,
+        None,
         ));
         assert!(!reply.ok);
         assert_eq!(reply.err.unwrap().code, "permission_denied");
@@ -3873,6 +3988,7 @@ mod tests {
             &current_project,
             &switch_queue,
             HistoryMode::LiveOnly,
+        None,
         ));
         assert!(!reply.ok);
         assert_eq!(reply.err.unwrap().code, "not_found");
@@ -3907,6 +4023,7 @@ mod tests {
             &current_project,
             &switch_queue,
             HistoryMode::LiveOnly,
+        None,
         ));
         assert!(ok_reply.ok, "first answer wins: {:?}", ok_reply.err);
         let stale_reply = block_on(handle_request(
@@ -3924,6 +4041,7 @@ mod tests {
             &current_project,
             &switch_queue,
             HistoryMode::LiveOnly,
+        None,
         ));
         assert!(!stale_reply.ok);
         assert_eq!(stale_reply.err.unwrap().code, "stale");
@@ -3957,6 +4075,7 @@ mod tests {
             &current_project,
             &switch_queue,
             HistoryMode::LiveOnly,
+        None,
         ));
         assert!(!reply.ok);
         assert_eq!(reply.err.unwrap().code, "permission_denied");
@@ -4012,6 +4131,7 @@ mod tests {
                 &current_project,
                 &switch_queue,
                 HistoryMode::LiveOnly,
+            None,
             ));
         assert!(!reply.ok);
         assert_eq!(reply.err.unwrap().code, "stale");
@@ -4037,6 +4157,7 @@ mod tests {
                 &current_project,
                 &switch_queue,
                 HistoryMode::LiveOnly,
+            None,
             ));
         assert!(reply_ok.ok, "{:?}", reply_ok.err);
         assert_eq!(subs2.len(), 1);
@@ -4061,6 +4182,7 @@ mod tests {
                 &current_project,
                 &switch_queue,
                 HistoryMode::LiveOnly,
+            None,
             ));
         assert!(reply_resub.ok, "{:?}", reply_resub.err);
         assert_eq!(subs2.len(), 1);
@@ -4086,6 +4208,7 @@ mod tests {
                 &current_project,
                 &switch_queue,
                 HistoryMode::LiveOnly,
+            None,
             ));
         assert!(reply_live.ok, "{:?}", reply_live.err);
 
@@ -4138,6 +4261,7 @@ mod tests {
             &current_project,
             &switch_queue,
             HistoryMode::LiveOnly,
+        None,
         ));
         assert!(reply.ok, "{:?}", reply.err);
         let payload = reply.payload.expect("selected payload");
@@ -4195,6 +4319,7 @@ mod tests {
             &current_project,
             &switch_queue,
             HistoryMode::LiveOnly,
+        None,
         ));
         assert!(!reply.ok);
         assert_eq!(reply.err.unwrap().code, "not_found");
@@ -4309,6 +4434,7 @@ mod tests {
             &current_project,
             &switch_queue,
             HistoryMode::LiveOnly,
+        None,
         ));
         assert!(!reply.ok);
         assert_eq!(reply.err.unwrap().code, "not_found");
@@ -5016,6 +5142,7 @@ mod tests {
             &current_project_a,
             &switch_queue,
             HistoryMode::LiveOnly,
+            None,
         )
         .await;
         assert!(reply_a.ok, "client A switch succeeds: {:?}", reply_a.err);

--- a/src-tauri/src/web/ws.rs
+++ b/src-tauri/src/web/ws.rs
@@ -3107,6 +3107,199 @@ mod tests {
         let _ = std::fs::remove_dir_all(root);
     }
 
+    // ---- CAP-6 / Story 8 deferred 8.3: WS dispatch parity for the catalog ----
+    //
+    // No Rust test sent a `list_acp_catalog`/`set_catalog_opt_in` WS frame
+    // through `handle_request`. These prove the WS reply's success/data/code
+    // fields match the HTTP `GET /acp/catalog` / `POST /acp/catalog/opt-in`
+    // response, served through a REAL `AcpCatalogService` (the host authority).
+
+    /// Like `handle_sync` but with a real catalog store attached, so the
+    /// `list_acp_catalog` / `set_catalog_opt_in` WS frames dispatch to the real
+    /// `AcpCatalogService`. Post-auth (authed=true).
+    async fn handle_request_with_catalog(
+        text: &str,
+        catalog: &Arc<crate::acp::AcpCatalogService>,
+    ) -> WsReply {
+        let relay = Arc::new(WsRelaySink::new());
+        let acp = Arc::new(AcpManager::new(vec![]));
+        let (tx, _rx) = mpsc::unbounded_channel::<Outbound>();
+        let mut subs = Vec::new();
+        let registry = Arc::new(ProjectRegistry::new());
+        let mut current_agent: Option<AgentId> = None;
+        let current_session = Arc::new(parking_lot::Mutex::new(None::<SessionId>));
+        let current_project = Arc::new(parking_lot::Mutex::new(None::<String>));
+        let switch_queue = Arc::new(tokio::sync::Mutex::new(ProjectSwitchQueue::default()));
+        let mut authed = true;
+        handle_request(
+            text,
+            &mut authed,
+            &acp,
+            &relay,
+            &registry,
+            None,
+            None,
+            &tx,
+            &mut subs,
+            &mut current_agent,
+            &current_session,
+            &current_project,
+            &switch_queue,
+            HistoryMode::LiveOnly,
+            Some(catalog),
+            None,
+        )
+        .await
+    }
+
+    #[tokio::test]
+    async fn handle_list_acp_catalog_ws_dispatch_returns_payload() {
+        let root =
+            std::env::temp_dir().join(format!("termul-ws-cat-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&root).unwrap();
+        let catalog = crate::acp::AcpCatalogService::open(root.join("catalog"))
+            .await
+            .unwrap();
+
+        // WS: a `list_acp_catalog` frame through `handle_request` (post-auth).
+        let reply = handle_request_with_catalog(
+            r#"{"id":"r1","type":"list_acp_catalog","payload":{}}"#,
+            &catalog,
+        )
+        .await;
+
+        // HTTP `GET /acp/catalog` on the SAME store returns
+        // `IpcBody { success: true, data: catalog, code: None }`. The WS reply's
+        // success/data/code fields must match byte-for-byte (deferred 8.3).
+        let http_catalog = catalog.list_catalog(false).await.unwrap();
+        let http_data = serde_json::to_value(&http_catalog).unwrap();
+        assert!(reply.ok, "WS ok matches HTTP success (true)");
+        assert!(
+            reply.err.is_none(),
+            "no err code on success (matches HTTP code: None)"
+        );
+        assert_eq!(
+            reply.payload.as_ref(),
+            Some(&http_data),
+            "WS payload (catalog) byte-identical to HTTP data"
+        );
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[tokio::test]
+    async fn handle_set_catalog_opt_in_ws_dispatch_persists() {
+        let root =
+            std::env::temp_dir().join(format!("termul-ws-optin-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&root).unwrap();
+        let catalog = crate::acp::AcpCatalogService::open(root.join("catalog"))
+            .await
+            .unwrap();
+        assert!(!catalog.is_opt_in(), "opt-in starts false");
+
+        // WS: a `set_catalog_opt_in` frame through `handle_request` (post-auth).
+        let reply = handle_request_with_catalog(
+            r#"{"id":"r1","type":"set_catalog_opt_in","payload":{"enabled":true}}"#,
+            &catalog,
+        )
+        .await;
+
+        // The opt-in persists (the host is the authority) + the WS reply
+        // matches the HTTP `POST /acp/catalog/opt-in` response: both succeed
+        // (WS ok=true / HTTP success=true), no code. (The WS success payload is
+        // `{}` vs the HTTP data `null` — a known minor parity wrinkle; the
+        // binding criterion is "opt-in persists + both transports succeed".)
+        assert!(reply.ok, "WS ok matches HTTP success (true)");
+        assert!(reply.err.is_none(), "no err code on success");
+        assert!(catalog.is_opt_in(), "opt-in persisted (host authority)");
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    // ---- Cross-client host-authority (Category C / Recovery Matrix: Browser A → Browser B) ----
+
+    #[tokio::test]
+    async fn second_client_restores_session_created_by_first_client() {
+        let root =
+            std::env::temp_dir().join(format!("termul-ws-cross-{}", uuid::Uuid::new_v4()));
+        let cwd = root.join("cwd");
+        std::fs::create_dir_all(&cwd).unwrap();
+        let persistence =
+            crate::acp::SessionPersistence::open(root.join("sessions")).await.unwrap();
+        let relay = Arc::new(WsRelaySink::with_persistence(8, persistence.clone()));
+        let acp = Arc::new(AcpManager::with_persistence(vec![], persistence.clone()));
+        // The test agent owns the session + handles the prompt-flow commands
+        // (IsEphemeralSession→false, SendPrompt→EndTurn) so `handle_send_prompt`
+        // persists the user prompt without a real agent binary.
+        let mut sessions = HashSet::new();
+        sessions.insert("session-cross".to_string());
+        acp.install_test_agent_with_sessions(AgentId("agent-cross".to_string()), sessions);
+        persistence
+            .register_session(crate::acp::SessionRegistration {
+                session_id: "session-cross".to_string(),
+                stable_agent_namespace: None,
+                runtime_agent_id: Some("agent-cross".to_string()),
+                project_id: None,
+                cwd: cwd.clone(),
+            })
+            .await
+            .unwrap();
+
+        // Client A (browser A) sends a prompt → the host persists the
+        // `user_prompt` via SessionPersistence (the cross-client authority).
+        // No client-side storage is involved.
+        let reply_a = handle_send_prompt(
+            "req-a".to_string(),
+            &json!({
+                "agentId": "agent-cross",
+                "sessionId": "session-cross",
+                "text": "hello from client A",
+                "turnId": "turn-cross"
+            }),
+            &acp,
+            &relay,
+        )
+        .await;
+        assert!(reply_a.ok, "client A's send_prompt succeeds + persists");
+
+        // Client B (browser B) — a DIFFERENT client with no shared CLIENT-SIDE
+        // in-memory state (no browser localStorage/sessionStorage) — calls
+        // `handle_get_session_payload` for the SAME session id.
+        // The host materializes the transcript from its durable store (the
+        // authority), not from client A's browser.
+        let reply_b = handle_get_session_payload(
+            "req-b".to_string(),
+            &json!({ "sessionId": "session-cross" }),
+            &relay,
+            HistoryMode::Server,
+        )
+        .await;
+        assert!(reply_b.ok, "client B restores the session from the host");
+        assert!(reply_b.err.is_none());
+        let payload = reply_b.payload.expect("transcript payload");
+        let messages = payload["messages"]
+            .as_array()
+            .expect("transcript messages array");
+        assert!(!messages.is_empty(), "transcript has client A's prompt");
+        // The user prompt client A sent is in client B's transcript (role=user,
+        // id=turn:<turnId>, text present) — proving the host is the authority.
+        let user_msg = messages
+            .iter()
+            .find(|m| m["role"] == "user")
+            .expect("user message in transcript");
+        assert_eq!(user_msg["id"], "turn:turn-cross");
+        let blocks = user_msg["blocks"].as_array().expect("user message blocks");
+        let text = blocks
+            .iter()
+            .map(|b| b["text"].as_str().unwrap_or(""))
+            .collect::<String>();
+        assert!(
+            text.contains("hello from client A"),
+            "client B sees client A's prompt text: {text}"
+        );
+
+        persistence.shutdown().await.unwrap();
+        let _ = std::fs::remove_dir_all(root);
+    }
+
     #[test]
     fn tier_of_maps_lossy_events() {
         assert_eq!(tier_of("message_chunk"), ReliabilityTier::Lossy);

--- a/src-tauri/src/web/ws.rs
+++ b/src-tauri/src/web/ws.rs
@@ -174,6 +174,28 @@ impl WsReply {
             }),
         }
     }
+
+    /// Build a failure reply with a raw (SCREAMING_SNAKE_CASE) code string.
+    ///
+    /// CAP-6 / Story 9: the install handler carries transport-identical codes
+    /// (`INTEGRITY_MISMATCH`, `INTEGRITY_METADATA_MISSING`, …) matching the
+    /// Tauri `IpcResult.code` + HTTP `IpcBody.code` byte-for-byte. The
+    /// protocol-level `WsErrorCode` enum is snake_case (e.g. `unsupported`),
+    /// so the install codes cannot be expressed as enum variants without
+    /// breaking the wire contract. This constructor accepts a raw string so
+    /// the install handler's `err.code` is byte-identical across transports.
+    #[must_use]
+    pub fn err_with_code(id: impl Into<String>, code: impl Into<String>, message: impl Into<String>) -> Self {
+        Self {
+            id: id.into(),
+            ok: false,
+            payload: None,
+            err: Some(WsError {
+                code: code.into(),
+                message: message.into(),
+            }),
+        }
+    }
 }
 
 /// The `err` object inside a failing [`WsReply`].
@@ -310,6 +332,14 @@ pub struct AppState {
     /// `acp_set_catalog_opt_in` Tauri commands (same `IpcResult<T>` shape
     /// byte-for-byte).
     pub acp_catalog: Option<Arc<crate::acp::AcpCatalogService>>,
+    /// Host-owned verified-atomic ACP install service (CAP-6 / Story 9). `None`
+    /// when the desktop could not open `AcpInstallService` at startup (degraded
+    /// mode — the `install_acp_agent` handler returns
+    /// `ACP_INSTALL_UNAVAILABLE`). The web/remote client installs a catalog
+    /// agent through `POST /acp/install` (catalog_api sibling) + WS
+    /// `install_acp_agent`; the desktop renderer uses the `acp_install_agent`
+    /// Tauri command (same `IpcResult<T>` shape byte-for-byte).
+    pub acp_install: Option<Arc<crate::acp::install::AcpInstallService>>,
     /// PR-S4: the project-root boundary for the fs_api routes. Requests whose
     /// canonicalized target path resolves outside this root are refused with
     /// `code: "OUTSIDE_ROOT"` (or `PATH_TRAVERSAL` for explicit `..`
@@ -468,6 +498,9 @@ async fn run_relay(socket: WebSocket, state: AppState) {
     // CAP-6 / Story 8: the host-owned ACP catalog service for the
     // `list_acp_catalog` + `set_catalog_opt_in` WS requests.
     let acp_catalog = state.acp_catalog.clone();
+    // CAP-6 / Story 9: the host-owned verified-atomic ACP install service for
+    // the `install_acp_agent` WS request.
+    let acp_install = state.acp_install.clone();
     // Client ids registered via `subscribe` — unregistered on disconnect.
     let mut subscribed_clients: Vec<(String, ClientId)> = Vec::new();
     // Per-connection tracking for `switch_project` (Ask-First resolution): the
@@ -593,6 +626,7 @@ async fn run_relay(socket: WebSocket, state: AppState) {
                         &switch_queue,
                         history_mode,
                         acp_catalog.as_ref(),
+                        acp_install.as_ref(),
                     )
                     .await;
                     if write_tx.send(Outbound::Reply(handled)).is_err() {
@@ -711,6 +745,7 @@ async fn handle_request(
     switch_queue: &Arc<tokio::sync::Mutex<ProjectSwitchQueue>>,
     history_mode: HistoryMode,
     acp_catalog: Option<&Arc<crate::acp::AcpCatalogService>>,
+    acp_install: Option<&Arc<crate::acp::install::AcpInstallService>>,
 ) -> WsReply {
     let req: WsRequest = match serde_json::from_str(text) {
         Ok(r) => r,
@@ -905,6 +940,18 @@ async fn handle_request(
         }
         "set_catalog_opt_in" => {
             handle_set_catalog_opt_in(id, &req.payload, acp_catalog).await
+        }
+        // CAP-6 / Story 9: host-owned verified-atomic ACP install. The web
+        // client installs a catalog agent through `install_acp_agent`; the
+        // host resolves the agent by id from the catalog, downloads the HTTPS
+        // archive, verifies sha256, extracts safely, atomically activates,
+        // serializes per-agent, records the manifest, and returns
+        // `{ command, args }`. The request is `{ agentId }` only; the host
+        // never accepts browser-supplied URLs/commands/paths/args. Errors
+        // carry SCREAMING_SNAKE_CASE codes byte-identical to the Tauri +
+        // HTTP transports (via `WsReply::err_with_code`).
+        "install_acp_agent" => {
+            handle_install_acp_agent(id, &req.payload, acp_install).await
         }
         "kill_agent" => {
             handle_kill_agent(
@@ -1433,6 +1480,53 @@ async fn handle_set_catalog_opt_in(
             WsErrorCode::Unsupported,
             format!("opt-in persistence failed: {error}"),
         ),
+    }
+}
+
+// --- CAP-6 / Story 9: ACP install WS handler --------------------------------
+
+/// `install_acp_agent` WS request payload. `deny_unknown_fields` rejects an
+/// over-serialized payload loudly at the host boundary (the request is
+/// `{ agentId }` only — never carries archive URLs, commands, executable
+/// paths, or args; the host resolves everything from the trusted catalog).
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct InstallAcpAgentPayload {
+    agent_id: String,
+}
+
+/// `install_acp_agent` WS request handler. Mirrors the desktop
+/// `#[tauri::command] acp_install_agent` + HTTP `POST /acp/install` handlers.
+/// Degrade-mode (`acp_install: None`) returns `ACP_INSTALL_UNAVAILABLE`. All
+/// errors carry SCREAMING_SNAKE_CASE codes byte-identical to the other
+/// transports via `WsReply::err_with_code` (the protocol-level `WsErrorCode`
+/// enum is snake_case, so the install codes use the raw-string constructor).
+async fn handle_install_acp_agent(
+    id: String,
+    payload: &Value,
+    acp_install: Option<&Arc<crate::acp::install::AcpInstallService>>,
+) -> WsReply {
+    use crate::acp::install::code;
+    let parsed: InstallAcpAgentPayload = match serde_json::from_value(payload.clone()) {
+        Ok(p) => p,
+        Err(e) => {
+            return WsReply::err_with_code(
+                id,
+                code::VALIDATION_ERROR,
+                format!("malformed install_acp_agent payload (want agentId): {e}"),
+            )
+        }
+    };
+    let Some(service) = acp_install.cloned() else {
+        return WsReply::err_with_code(
+            id,
+            code::ACP_INSTALL_UNAVAILABLE,
+            "acp install store is unavailable",
+        );
+    };
+    match service.install_by_id(&parsed.agent_id).await {
+        Ok(outcome) => ok_with_payload(id, &outcome),
+        Err(error) => WsReply::err_with_code(id, error.code(), error.message),
     }
 }
 
@@ -3249,6 +3343,7 @@ mod tests {
                 &switch_queue,
                 HistoryMode::LiveOnly,
             None,
+            None,
             ))
     }
 
@@ -3414,6 +3509,104 @@ mod tests {
         );
         assert!(!reply.ok);
         assert_eq!(reply.err.unwrap().code, "unsupported");
+    }
+
+    // --- CAP-6 / Story 9: install_acp_agent WS handler tests ----------------
+    // Mirrors install_api.rs's set: degrade-mode → ACP_INSTALL_UNAVAILABLE,
+    // extra-field payload → VALIDATION_ERROR, unknown-agent (with a real
+    // store) → CATALOG_AGENT_NOT_FOUND. Threaded through the same
+    // `handle_request(...)` entry the other WS tests use.
+
+    #[test]
+    fn install_acp_agent_degraded_returns_unavailable() {
+        // handle_sync passes acp_install: None → degrade-mode.
+        let mut authed = true;
+        let reply = handle_sync(
+            r#"{"id":"r1","type":"install_acp_agent","payload":{"agentId":"opencode"}}"#,
+            &mut authed,
+        );
+        assert!(!reply.ok, "install_acp_agent degraded must fail");
+        assert_eq!(reply.err.unwrap().code, "ACP_INSTALL_UNAVAILABLE");
+    }
+
+    #[test]
+    fn install_acp_agent_rejects_extra_field_as_validation_error() {
+        // deny_unknown_fields on InstallAcpAgentPayload rejects extra fields
+        // loudly → VALIDATION_ERROR (NOT unsupported — the install handler
+        // parses the payload itself, not the envelope).
+        let mut authed = true;
+        let reply = handle_sync(
+            r#"{"id":"r1","type":"install_acp_agent","payload":{"agentId":"x","extra":"junk"}}"#,
+            &mut authed,
+        );
+        assert!(!reply.ok, "extra-field must fail");
+        assert_eq!(reply.err.unwrap().code, "VALIDATION_ERROR");
+    }
+
+    #[test]
+    fn install_acp_agent_rejects_missing_agent_id_as_validation_error() {
+        let mut authed = true;
+        let reply = handle_sync(
+            r#"{"id":"r1","type":"install_acp_agent","payload":{}}"#,
+            &mut authed,
+        );
+        assert!(!reply.ok, "missing agentId must fail");
+        assert_eq!(reply.err.unwrap().code, "VALIDATION_ERROR");
+    }
+
+    #[tokio::test]
+    async fn install_acp_agent_unknown_agent_returns_catalog_agent_not_found() {
+        // Open a real install store (with a fresh catalog — no agents wired
+        // to a sha256/digest) + call handle_request directly with
+        // acp_install: Some(...). An unknown agent id resolves to
+        // CATALOG_AGENT_NOT_FOUND (the catalog has no such agent).
+        let tmp = std::env::temp_dir().join(format!(
+            "termul-ws-install-unknown-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_nanos())
+                .unwrap_or(0)
+        ));
+        std::fs::create_dir_all(&tmp).unwrap();
+        let catalog = crate::acp::AcpCatalogService::open(tmp.join("catalog"))
+            .await
+            .unwrap();
+        let store = crate::acp::install::AcpInstallService::open(tmp.join("installs"), catalog)
+            .await
+            .unwrap();
+        let acp = Arc::new(AcpManager::new(vec![]));
+        let relay = Arc::new(WsRelaySink::new());
+        let registry = Arc::new(ProjectRegistry::new());
+        let (tx, _rx) = mpsc::unbounded_channel::<Outbound>();
+        let mut subs: Vec<(String, ClientId)> = Vec::new();
+        let mut current_agent: Option<AgentId> = None;
+        let current_session = Arc::new(parking_lot::Mutex::new(None::<SessionId>));
+        let current_project = Arc::new(parking_lot::Mutex::new(None::<String>));
+        let switch_queue = Arc::new(tokio::sync::Mutex::new(ProjectSwitchQueue::default()));
+        let mut authed = true;
+        let reply = handle_request(
+            r#"{"id":"r1","type":"install_acp_agent","payload":{"agentId":"does-not-exist"}}"#,
+            &mut authed,
+            &acp,
+            &relay,
+            &registry,
+            None,
+            None,
+            &tx,
+            &mut subs,
+            &mut current_agent,
+            &current_session,
+            &current_project,
+            &switch_queue,
+            HistoryMode::LiveOnly,
+            None,
+            Some(&store),
+        )
+        .await;
+        assert!(!reply.ok, "unknown agent must fail");
+        assert_eq!(reply.err.unwrap().code, "CATALOG_AGENT_NOT_FOUND");
+        let _ = std::fs::remove_dir_all(&tmp);
     }
 
     /// `spawn_agent` success path: `ok_with_payload` serializes the full
@@ -3595,6 +3788,7 @@ mod tests {
                 &switch_queue,
                 HistoryMode::LiveOnly,
             None,
+            None,
             ));
         assert!(!reply.ok);
         assert_eq!(reply.err.unwrap().code, "unsupported");
@@ -3679,6 +3873,7 @@ mod tests {
             &switch_queue,
             HistoryMode::LiveOnly,
         None,
+        None,
         ));
         assert!(!reply.ok);
         assert_eq!(reply.err.unwrap().code, "permission_denied");
@@ -3729,6 +3924,7 @@ mod tests {
             &switch_queue,
             HistoryMode::LiveOnly,
         None,
+        None,
         ));
         assert!(!reply.ok);
         assert_eq!(reply.err.unwrap().code, "not_found");
@@ -3765,6 +3961,7 @@ mod tests {
             &switch_queue,
             HistoryMode::LiveOnly,
         None,
+        None,
         ));
         assert!(ok_reply.ok, "first response wins: {:?}", ok_reply.err);
         // Second frame for the same requestId → stale (ticket evicted).
@@ -3783,6 +3980,7 @@ mod tests {
             &current_project,
             &switch_queue,
             HistoryMode::LiveOnly,
+        None,
         None,
         ));
         assert!(!stale_reply.ok);
@@ -3818,6 +4016,7 @@ mod tests {
             &current_project,
             &switch_queue,
             HistoryMode::LiveOnly,
+        None,
         None,
         ));
         assert!(!reply.ok);
@@ -3907,6 +4106,7 @@ mod tests {
             &switch_queue,
             HistoryMode::LiveOnly,
         None,
+        None,
         ));
         assert!(!reply.ok);
         assert_eq!(reply.err.unwrap().code, "unsupported");
@@ -3940,6 +4140,7 @@ mod tests {
             &current_project,
             &switch_queue,
             HistoryMode::LiveOnly,
+        None,
         None,
         ));
         assert!(!reply.ok);
@@ -3989,6 +4190,7 @@ mod tests {
             &switch_queue,
             HistoryMode::LiveOnly,
         None,
+        None,
         ));
         assert!(!reply.ok);
         assert_eq!(reply.err.unwrap().code, "not_found");
@@ -4024,6 +4226,7 @@ mod tests {
             &switch_queue,
             HistoryMode::LiveOnly,
         None,
+        None,
         ));
         assert!(ok_reply.ok, "first answer wins: {:?}", ok_reply.err);
         let stale_reply = block_on(handle_request(
@@ -4041,6 +4244,7 @@ mod tests {
             &current_project,
             &switch_queue,
             HistoryMode::LiveOnly,
+        None,
         None,
         ));
         assert!(!stale_reply.ok);
@@ -4075,6 +4279,7 @@ mod tests {
             &current_project,
             &switch_queue,
             HistoryMode::LiveOnly,
+        None,
         None,
         ));
         assert!(!reply.ok);
@@ -4132,6 +4337,7 @@ mod tests {
                 &switch_queue,
                 HistoryMode::LiveOnly,
             None,
+            None,
             ));
         assert!(!reply.ok);
         assert_eq!(reply.err.unwrap().code, "stale");
@@ -4158,6 +4364,7 @@ mod tests {
                 &switch_queue,
                 HistoryMode::LiveOnly,
             None,
+            None,
             ));
         assert!(reply_ok.ok, "{:?}", reply_ok.err);
         assert_eq!(subs2.len(), 1);
@@ -4182,6 +4389,7 @@ mod tests {
                 &current_project,
                 &switch_queue,
                 HistoryMode::LiveOnly,
+            None,
             None,
             ));
         assert!(reply_resub.ok, "{:?}", reply_resub.err);
@@ -4208,6 +4416,7 @@ mod tests {
                 &current_project,
                 &switch_queue,
                 HistoryMode::LiveOnly,
+            None,
             None,
             ));
         assert!(reply_live.ok, "{:?}", reply_live.err);
@@ -4261,6 +4470,7 @@ mod tests {
             &current_project,
             &switch_queue,
             HistoryMode::LiveOnly,
+        None,
         None,
         ));
         assert!(reply.ok, "{:?}", reply.err);
@@ -4319,6 +4529,7 @@ mod tests {
             &current_project,
             &switch_queue,
             HistoryMode::LiveOnly,
+        None,
         None,
         ));
         assert!(!reply.ok);
@@ -4434,6 +4645,7 @@ mod tests {
             &current_project,
             &switch_queue,
             HistoryMode::LiveOnly,
+        None,
         None,
         ));
         assert!(!reply.ok);
@@ -5142,6 +5354,7 @@ mod tests {
             &current_project_a,
             &switch_queue,
             HistoryMode::LiveOnly,
+            None,
             None,
         )
         .await;

--- a/src/renderer/assets/agent-icons/acp/agents.json
+++ b/src/renderer/assets/agent-icons/acp/agents.json
@@ -7,7 +7,9 @@
     "distribution": {
       "npx": {
         "package": "agoragentic-mcp@1.3.0",
-        "args": ["--acp"]
+        "args": [
+          "--acp"
+        ]
       }
     }
   },
@@ -49,7 +51,9 @@
     "distribution": {
       "npx": {
         "package": "@augmentcode/auggie@0.34.0",
-        "args": ["--acp"],
+        "args": [
+          "--acp"
+        ],
         "env": {
           "AUGMENT_DISABLE_AUTO_UPDATE": "1"
         }
@@ -86,7 +90,9 @@
     "distribution": {
       "npx": {
         "package": "cline@3.0.49",
-        "args": ["--acp"]
+        "args": [
+          "--acp"
+        ]
       }
     }
   },
@@ -98,7 +104,9 @@
     "distribution": {
       "npx": {
         "package": "@tencent-ai/codebuddy-code@2.106.7",
-        "args": ["--acp"]
+        "args": [
+          "--acp"
+        ]
       }
     }
   },
@@ -123,32 +131,50 @@
         "darwin-aarch64": {
           "cmd": "./coco-1.0.73+180523.e6179a031de9-darwin-arm64/cortex",
           "archive": "https://sfc-repo.snowflakecomputing.com/cortex-code-cli/a4643c4278/1.0.73%2B180523.e6179a031de9/coco-1.0.73%2B180523.e6179a031de9-darwin-arm64.tar.gz",
-          "args": ["acp", "serve"]
+          "args": [
+            "acp",
+            "serve"
+          ]
         },
         "darwin-x86_64": {
           "cmd": "./coco-1.0.73+180523.e6179a031de9-darwin-amd64/cortex",
           "archive": "https://sfc-repo.snowflakecomputing.com/cortex-code-cli/a4643c4278/1.0.73%2B180523.e6179a031de9/coco-1.0.73%2B180523.e6179a031de9-darwin-amd64.tar.gz",
-          "args": ["acp", "serve"]
+          "args": [
+            "acp",
+            "serve"
+          ]
         },
         "linux-x86_64": {
           "cmd": "./coco-1.0.73+180523.e6179a031de9-linux-amd64/cortex",
           "archive": "https://sfc-repo.snowflakecomputing.com/cortex-code-cli/a4643c4278/1.0.73%2B180523.e6179a031de9/coco-1.0.73%2B180523.e6179a031de9-linux-amd64.tar.gz",
-          "args": ["acp", "serve"]
+          "args": [
+            "acp",
+            "serve"
+          ]
         },
         "linux-aarch64": {
           "cmd": "./coco-1.0.73+180523.e6179a031de9-linux-arm64/cortex",
           "archive": "https://sfc-repo.snowflakecomputing.com/cortex-code-cli/a4643c4278/1.0.73%2B180523.e6179a031de9/coco-1.0.73%2B180523.e6179a031de9-linux-arm64.tar.gz",
-          "args": ["acp", "serve"]
+          "args": [
+            "acp",
+            "serve"
+          ]
         },
         "windows-x86_64": {
           "cmd": "./coco-1.0.73+180523.e6179a031de9-windows-amd64/cortex.exe",
           "archive": "https://sfc-repo.snowflakecomputing.com/cortex-code-cli/a4643c4278/1.0.73%2B180523.e6179a031de9/coco-1.0.73%2B180523.e6179a031de9-windows-amd64.tar.gz",
-          "args": ["acp", "serve"]
+          "args": [
+            "acp",
+            "serve"
+          ]
         },
         "windows-aarch64": {
           "cmd": "./coco-1.0.73+180523.e6179a031de9-windows-arm64/cortex.exe",
           "archive": "https://sfc-repo.snowflakecomputing.com/cortex-code-cli/a4643c4278/1.0.73%2B180523.e6179a031de9/coco-1.0.73%2B180523.e6179a031de9-windows-arm64.tar.gz",
-          "args": ["acp", "serve"]
+          "args": [
+            "acp",
+            "serve"
+          ]
         }
       }
     }
@@ -189,27 +215,37 @@
         "darwin-aarch64": {
           "cmd": "./crow-cli",
           "archive": "https://github.com/crow-cli/crow-cli/releases/download/v0.1.24/crow-cli-darwin-aarch64.tar.gz",
-          "args": ["acp"]
+          "args": [
+            "acp"
+          ]
         },
         "darwin-x86_64": {
           "cmd": "./crow-cli",
           "archive": "https://github.com/crow-cli/crow-cli/releases/download/v0.1.24/crow-cli-darwin-x86_64.tar.gz",
-          "args": ["acp"]
+          "args": [
+            "acp"
+          ]
         },
         "linux-aarch64": {
           "cmd": "./crow-cli",
           "archive": "https://github.com/crow-cli/crow-cli/releases/download/v0.1.24/crow-cli-linux-aarch64.tar.gz",
-          "args": ["acp"]
+          "args": [
+            "acp"
+          ]
         },
         "linux-x86_64": {
           "cmd": "./crow-cli",
           "archive": "https://github.com/crow-cli/crow-cli/releases/download/v0.1.24/crow-cli-linux-x86_64.tar.gz",
-          "args": ["acp"]
+          "args": [
+            "acp"
+          ]
         },
         "windows-x86_64": {
           "cmd": "./crow-cli.exe",
           "archive": "https://github.com/crow-cli/crow-cli/releases/download/v0.1.24/crow-cli-windows-x86_64.zip",
-          "args": ["acp"]
+          "args": [
+            "acp"
+          ]
         }
       }
     }
@@ -224,32 +260,44 @@
         "darwin-aarch64": {
           "cmd": "./dist-package/cursor-agent",
           "archive": "https://downloads.cursor.com/lab/2026.07.23-e383d2b/darwin/arm64/agent-cli-package.tar.gz",
-          "args": ["acp"]
+          "args": [
+            "acp"
+          ]
         },
         "darwin-x86_64": {
           "cmd": "./dist-package/cursor-agent",
           "archive": "https://downloads.cursor.com/lab/2026.07.23-e383d2b/darwin/x64/agent-cli-package.tar.gz",
-          "args": ["acp"]
+          "args": [
+            "acp"
+          ]
         },
         "linux-aarch64": {
           "cmd": "./dist-package/cursor-agent",
           "archive": "https://downloads.cursor.com/lab/2026.07.23-e383d2b/linux/arm64/agent-cli-package.tar.gz",
-          "args": ["acp"]
+          "args": [
+            "acp"
+          ]
         },
         "linux-x86_64": {
           "cmd": "./dist-package/cursor-agent",
           "archive": "https://downloads.cursor.com/lab/2026.07.23-e383d2b/linux/x64/agent-cli-package.tar.gz",
-          "args": ["acp"]
+          "args": [
+            "acp"
+          ]
         },
         "windows-aarch64": {
           "cmd": "./dist-package\\cursor-agent.cmd",
           "archive": "https://downloads.cursor.com/lab/2026.07.23-e383d2b/windows/arm64/agent-cli-package.zip",
-          "args": ["acp"]
+          "args": [
+            "acp"
+          ]
         },
         "windows-x86_64": {
           "cmd": "./dist-package\\cursor-agent.cmd",
           "archive": "https://downloads.cursor.com/lab/2026.07.23-e383d2b/windows/x64/agent-cli-package.zip",
-          "args": ["acp"]
+          "args": [
+            "acp"
+          ]
         }
       }
     }
@@ -275,32 +323,44 @@
         "darwin-aarch64": {
           "cmd": "./bin/devin",
           "archive": "https://static.devin.ai/cli/3000.3.27/devin-3000.3.27-aarch64-apple-darwin.tar.gz",
-          "args": ["acp"]
+          "args": [
+            "acp"
+          ]
         },
         "darwin-x86_64": {
           "cmd": "./bin/devin",
           "archive": "https://static.devin.ai/cli/3000.3.27/devin-3000.3.27-x86_64-apple-darwin.tar.gz",
-          "args": ["acp"]
+          "args": [
+            "acp"
+          ]
         },
         "linux-aarch64": {
           "cmd": "./bin/devin",
           "archive": "https://static.devin.ai/cli/3000.3.27/devin-3000.3.27-aarch64-unknown-linux.tar.gz",
-          "args": ["acp"]
+          "args": [
+            "acp"
+          ]
         },
         "linux-x86_64": {
           "cmd": "./bin/devin",
           "archive": "https://static.devin.ai/cli/3000.3.27/devin-3000.3.27-x86_64-unknown-linux.tar.gz",
-          "args": ["acp"]
+          "args": [
+            "acp"
+          ]
         },
         "windows-aarch64": {
           "cmd": "./bin\\devin.exe",
           "archive": "https://static.devin.ai/cli/3000.3.27/devin-3000.3.27-aarch64-pc-windows.zip",
-          "args": ["acp"]
+          "args": [
+            "acp"
+          ]
         },
         "windows-x86_64": {
           "cmd": "./bin\\devin.exe",
           "archive": "https://static.devin.ai/cli/3000.3.27/devin-3000.3.27-x86_64-pc-windows.zip",
-          "args": ["acp"]
+          "args": [
+            "acp"
+          ]
         }
       }
     }
@@ -313,7 +373,9 @@
     "distribution": {
       "npx": {
         "package": "dimcode@0.3.2",
-        "args": ["acp"]
+        "args": [
+          "acp"
+        ]
       }
     }
   },
@@ -325,7 +387,9 @@
     "distribution": {
       "npx": {
         "package": "dirac-cli@0.4.32",
-        "args": ["--acp"]
+        "args": [
+          "--acp"
+        ]
       }
     }
   },
@@ -337,7 +401,11 @@
     "distribution": {
       "npx": {
         "package": "droid@0.187.0",
-        "args": ["exec", "--output-format", "acp-daemon"],
+        "args": [
+          "exec",
+          "--output-format",
+          "acp-daemon"
+        ],
         "env": {
           "DROID_DISABLE_AUTO_UPDATE": "true",
           "FACTORY_DROID_AUTO_UPDATE_ENABLED": "false"
@@ -353,7 +421,9 @@
     "distribution": {
       "uvx": {
         "package": "fast-agent-acp==0.9.30",
-        "args": ["-x"]
+        "args": [
+          "-x"
+        ]
       }
     }
   },
@@ -365,7 +435,9 @@
     "distribution": {
       "npx": {
         "package": "@google/gemini-cli@0.53.1",
-        "args": ["--acp"]
+        "args": [
+          "--acp"
+        ]
       }
     }
   },
@@ -377,7 +449,9 @@
     "distribution": {
       "npx": {
         "package": "@github/copilot@1.0.78",
-        "args": ["--acp"]
+        "args": [
+          "--acp"
+        ]
       }
     }
   },
@@ -401,24 +475,34 @@
       "binary": {
         "darwin-aarch64": {
           "cmd": "./goose",
-          "args": ["acp"]
+          "args": [
+            "acp"
+          ]
         },
         "darwin-x86_64": {
           "cmd": "./goose",
-          "args": ["acp"]
+          "args": [
+            "acp"
+          ]
         },
         "linux-aarch64": {
           "cmd": "./goose",
-          "args": ["acp"]
+          "args": [
+            "acp"
+          ]
         },
         "linux-x86_64": {
           "cmd": "./goose",
-          "args": ["acp"]
+          "args": [
+            "acp"
+          ]
         },
         "windows-x86_64": {
           "cmd": "./goose-package\\goose.exe",
           "archive": "https://github.com/block/goose/releases/download/v1.45.0/goose-x86_64-pc-windows-msvc.zip",
-          "args": ["acp"]
+          "args": [
+            "acp"
+          ]
         }
       }
     }
@@ -431,7 +515,10 @@
     "distribution": {
       "npx": {
         "package": "@xai-official/grok@0.2.120",
-        "args": ["agent", "stdio"]
+        "args": [
+          "agent",
+          "stdio"
+        ]
       }
     }
   },
@@ -445,27 +532,42 @@
         "darwin-aarch64": {
           "cmd": "./harn",
           "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.53/harn-aarch64-apple-darwin.tar.gz",
-          "args": ["serve", "acp"]
+          "args": [
+            "serve",
+            "acp"
+          ]
         },
         "darwin-x86_64": {
           "cmd": "./harn",
           "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.53/harn-x86_64-apple-darwin.tar.gz",
-          "args": ["serve", "acp"]
+          "args": [
+            "serve",
+            "acp"
+          ]
         },
         "linux-aarch64": {
           "cmd": "./harn",
           "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.53/harn-aarch64-unknown-linux-gnu.tar.gz",
-          "args": ["serve", "acp"]
+          "args": [
+            "serve",
+            "acp"
+          ]
         },
         "linux-x86_64": {
           "cmd": "./harn",
           "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.53/harn-x86_64-unknown-linux-gnu.tar.gz",
-          "args": ["serve", "acp"]
+          "args": [
+            "serve",
+            "acp"
+          ]
         },
         "windows-x86_64": {
           "cmd": "harn.exe",
           "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.53/harn-x86_64-pc-windows-msvc.zip",
-          "args": ["serve", "acp"]
+          "args": [
+            "serve",
+            "acp"
+          ]
         }
       }
     }
@@ -480,32 +582,44 @@
         "darwin-aarch64": {
           "cmd": "./Applications/junie.app/Contents/MacOS/junie",
           "archive": "https://github.com/JetBrains/junie/releases/download/2383.10/junie-release-2383.10-macos-aarch64.zip",
-          "args": ["--acp=true"]
+          "args": [
+            "--acp=true"
+          ]
         },
         "darwin-x86_64": {
           "cmd": "./Applications/junie.app/Contents/MacOS/junie",
           "archive": "https://github.com/JetBrains/junie/releases/download/2383.10/junie-release-2383.10-macos-amd64.zip",
-          "args": ["--acp=true"]
+          "args": [
+            "--acp=true"
+          ]
         },
         "linux-aarch64": {
           "cmd": "./junie-app/bin/junie",
           "archive": "https://github.com/JetBrains/junie/releases/download/2383.10/junie-release-2383.10-linux-aarch64.zip",
-          "args": ["--acp=true"]
+          "args": [
+            "--acp=true"
+          ]
         },
         "linux-x86_64": {
           "cmd": "./junie-app/bin/junie",
           "archive": "https://github.com/JetBrains/junie/releases/download/2383.10/junie-release-2383.10-linux-amd64.zip",
-          "args": ["--acp=true"]
+          "args": [
+            "--acp=true"
+          ]
         },
         "windows-x86_64": {
           "cmd": "./junie/junie.exe",
           "archive": "https://github.com/JetBrains/junie/releases/download/2383.10/junie-release-2383.10-windows-amd64.zip",
-          "args": ["--acp=true"]
+          "args": [
+            "--acp=true"
+          ]
         },
         "windows-aarch64": {
           "cmd": "./junie/junie.exe",
           "archive": "https://github.com/JetBrains/junie/releases/download/2383.10/junie-release-2383.10-windows-aarch64.zip",
-          "args": ["--acp=true"]
+          "args": [
+            "--acp=true"
+          ]
         }
       }
     }
@@ -518,33 +632,45 @@
     "distribution": {
       "npx": {
         "package": "@kilocode/cli@7.4.19",
-        "args": ["acp"]
+        "args": [
+          "acp"
+        ]
       },
       "binary": {
         "darwin-aarch64": {
           "cmd": "./kilo",
           "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.4.19/kilo-darwin-arm64.zip",
-          "args": ["acp"]
+          "args": [
+            "acp"
+          ]
         },
         "darwin-x86_64": {
           "cmd": "./kilo",
           "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.4.19/kilo-darwin-x64.zip",
-          "args": ["acp"]
+          "args": [
+            "acp"
+          ]
         },
         "linux-aarch64": {
           "cmd": "./kilo",
           "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.4.19/kilo-linux-arm64.tar.gz",
-          "args": ["acp"]
+          "args": [
+            "acp"
+          ]
         },
         "linux-x86_64": {
           "cmd": "./kilo",
           "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.4.19/kilo-linux-x64.tar.gz",
-          "args": ["acp"]
+          "args": [
+            "acp"
+          ]
         },
         "windows-x86_64": {
           "cmd": "./kilo.exe",
           "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.4.19/kilo-windows-x64.zip",
-          "args": ["acp"]
+          "args": [
+            "acp"
+          ]
         }
       }
     }
@@ -559,27 +685,37 @@
         "darwin-aarch64": {
           "cmd": "./kimi",
           "archive": "https://github.com/MoonshotAI/kimi-cli/releases/download/1.49.0/kimi-1.49.0-aarch64-apple-darwin.tar.gz",
-          "args": ["acp"]
+          "args": [
+            "acp"
+          ]
         },
         "linux-aarch64": {
           "cmd": "./kimi",
           "archive": "https://github.com/MoonshotAI/kimi-cli/releases/download/1.49.0/kimi-1.49.0-aarch64-unknown-linux-gnu.tar.gz",
-          "args": ["acp"]
+          "args": [
+            "acp"
+          ]
         },
         "linux-x86_64": {
           "cmd": "./kimi",
           "archive": "https://github.com/MoonshotAI/kimi-cli/releases/download/1.49.0/kimi-1.49.0-x86_64-unknown-linux-gnu.tar.gz",
-          "args": ["acp"]
+          "args": [
+            "acp"
+          ]
         },
         "windows-aarch64": {
           "cmd": "./kimi.exe",
           "archive": "https://github.com/MoonshotAI/kimi-cli/releases/download/1.49.0/kimi-1.49.0-aarch64-pc-windows-msvc.zip",
-          "args": ["acp"]
+          "args": [
+            "acp"
+          ]
         },
         "windows-x86_64": {
           "cmd": "./kimi.exe",
           "archive": "https://github.com/MoonshotAI/kimi-cli/releases/download/1.49.0/kimi-1.49.0-x86_64-pc-windows-msvc.zip",
-          "args": ["acp"]
+          "args": [
+            "acp"
+          ]
         }
       }
     }
@@ -592,7 +728,9 @@
     "distribution": {
       "uvx": {
         "package": "minion-code@0.1.44",
-        "args": ["acp"]
+        "args": [
+          "acp"
+        ]
       }
     }
   },
@@ -634,7 +772,9 @@
     "distribution": {
       "npx": {
         "package": "@compass-ai/nova@1.1.31",
-        "args": ["acp"]
+        "args": [
+          "acp"
+        ]
       }
     }
   },
@@ -648,32 +788,44 @@
         "darwin-aarch64": {
           "cmd": "./opencode",
           "archive": "https://github.com/anomalyco/opencode/releases/download/v1.18.12/opencode-darwin-arm64.zip",
-          "args": ["acp"]
+          "args": [
+            "acp"
+          ]
         },
         "darwin-x86_64": {
           "cmd": "./opencode",
           "archive": "https://github.com/anomalyco/opencode/releases/download/v1.18.12/opencode-darwin-x64.zip",
-          "args": ["acp"]
+          "args": [
+            "acp"
+          ]
         },
         "linux-aarch64": {
           "cmd": "./opencode",
           "archive": "https://github.com/anomalyco/opencode/releases/download/v1.18.12/opencode-linux-arm64.tar.gz",
-          "args": ["acp"]
+          "args": [
+            "acp"
+          ]
         },
         "linux-x86_64": {
           "cmd": "./opencode",
           "archive": "https://github.com/anomalyco/opencode/releases/download/v1.18.12/opencode-linux-x64.tar.gz",
-          "args": ["acp"]
+          "args": [
+            "acp"
+          ]
         },
         "windows-aarch64": {
           "cmd": "./opencode",
           "archive": "https://github.com/anomalyco/opencode/releases/download/v1.18.12/opencode-windows-arm64.zip",
-          "args": ["acp"]
+          "args": [
+            "acp"
+          ]
         },
         "windows-x86_64": {
           "cmd": "./opencode.exe",
           "archive": "https://github.com/anomalyco/opencode/releases/download/v1.18.12/opencode-windows-x64.zip",
-          "args": ["acp"]
+          "args": [
+            "acp"
+          ]
         }
       }
     }
@@ -699,32 +851,44 @@
         "darwin-aarch64": {
           "cmd": "./pool-darwin-arm64",
           "archive": "https://downloads.poolside.ai/pool/v1.0.14/pool-darwin-arm64.tar.gz",
-          "args": ["acp"]
+          "args": [
+            "acp"
+          ]
         },
         "darwin-x86_64": {
           "cmd": "./pool-darwin-amd64",
           "archive": "https://downloads.poolside.ai/pool/v1.0.14/pool-darwin-amd64.tar.gz",
-          "args": ["acp"]
+          "args": [
+            "acp"
+          ]
         },
         "linux-aarch64": {
           "cmd": "./pool-linux-arm64",
           "archive": "https://downloads.poolside.ai/pool/v1.0.14/pool-linux-arm64.tar.gz",
-          "args": ["acp"]
+          "args": [
+            "acp"
+          ]
         },
         "linux-x86_64": {
           "cmd": "./pool-linux-amd64",
           "archive": "https://downloads.poolside.ai/pool/v1.0.14/pool-linux-amd64.tar.gz",
-          "args": ["acp"]
+          "args": [
+            "acp"
+          ]
         },
         "windows-aarch64": {
           "cmd": "./pool-windows-arm64.exe",
           "archive": "https://downloads.poolside.ai/pool/v1.0.14/pool-windows-arm64.tar.gz",
-          "args": ["acp"]
+          "args": [
+            "acp"
+          ]
         },
         "windows-x86_64": {
           "cmd": "./pool-windows-amd64.exe",
           "archive": "https://downloads.poolside.ai/pool/v1.0.14/pool-windows-amd64.tar.gz",
-          "args": ["acp"]
+          "args": [
+            "acp"
+          ]
         }
       }
     }
@@ -737,7 +901,9 @@
     "distribution": {
       "npx": {
         "package": "@qoder-ai/qodercli@0.2.14",
-        "args": ["--acp"]
+        "args": [
+          "--acp"
+        ]
       }
     }
   },
@@ -749,7 +915,10 @@
     "distribution": {
       "npx": {
         "package": "@qwen-code/qwen-code@0.21.5",
-        "args": ["--acp", "--experimental-skills"]
+        "args": [
+          "--acp",
+          "--experimental-skills"
+        ]
       }
     }
   },
@@ -796,27 +965,37 @@
         "darwin-aarch64": {
           "cmd": "./stakpak",
           "archive": "https://github.com/stakpak/agent/releases/download/v0.3.88/stakpak-darwin-aarch64.tar.gz",
-          "args": ["acp"]
+          "args": [
+            "acp"
+          ]
         },
         "darwin-x86_64": {
           "cmd": "./stakpak",
           "archive": "https://github.com/stakpak/agent/releases/download/v0.3.88/stakpak-darwin-x86_64.tar.gz",
-          "args": ["acp"]
+          "args": [
+            "acp"
+          ]
         },
         "linux-aarch64": {
           "cmd": "./stakpak",
           "archive": "https://github.com/stakpak/agent/releases/download/v0.3.88/stakpak-linux-aarch64.tar.gz",
-          "args": ["acp"]
+          "args": [
+            "acp"
+          ]
         },
         "linux-x86_64": {
           "cmd": "./stakpak",
           "archive": "https://github.com/stakpak/agent/releases/download/v0.3.88/stakpak-linux-x86_64.tar.gz",
-          "args": ["acp"]
+          "args": [
+            "acp"
+          ]
         },
         "windows-x86_64": {
           "cmd": "./stakpak.exe",
           "archive": "https://github.com/stakpak/agent/releases/download/v0.3.88/stakpak-windows-x86_64.zip",
-          "args": ["acp"]
+          "args": [
+            "acp"
+          ]
         }
       }
     }
@@ -831,7 +1010,9 @@
         "darwin-aarch64": {
           "cmd": "./vtcode",
           "archive": "https://github.com/vinhnx/VTCode/releases/download/0.96.14/vtcode-0.96.14-aarch64-apple-darwin.tar.gz",
-          "args": ["acp"],
+          "args": [
+            "acp"
+          ],
           "env": {
             "VT_ACP_ENABLED": "1",
             "VT_ACP_ZED_ENABLED": "1"
@@ -840,7 +1021,9 @@
         "darwin-x86_64": {
           "cmd": "./vtcode",
           "archive": "https://github.com/vinhnx/VTCode/releases/download/0.96.14/vtcode-0.96.14-x86_64-apple-darwin.tar.gz",
-          "args": ["acp"],
+          "args": [
+            "acp"
+          ],
           "env": {
             "VT_ACP_ENABLED": "1",
             "VT_ACP_ZED_ENABLED": "1"
@@ -849,7 +1032,9 @@
         "linux-x86_64": {
           "cmd": "./vtcode",
           "archive": "https://github.com/vinhnx/VTCode/releases/download/0.96.14/vtcode-0.96.14-x86_64-unknown-linux-gnu.tar.gz",
-          "args": ["acp"],
+          "args": [
+            "acp"
+          ],
           "env": {
             "VT_ACP_ENABLED": "1",
             "VT_ACP_ZED_ENABLED": "1"
@@ -858,7 +1043,9 @@
         "windows-x86_64": {
           "cmd": "vtcode.exe",
           "archive": "https://github.com/vinhnx/VTCode/releases/download/0.96.14/vtcode-0.96.14-x86_64-pc-windows-msvc.zip",
-          "args": ["acp"],
+          "args": [
+            "acp"
+          ],
           "env": {
             "VT_ACP_ENABLED": "1",
             "VT_ACP_ZED_ENABLED": "1"

--- a/src/renderer/assets/agent-icons/acp/agents.json
+++ b/src/renderer/assets/agent-icons/acp/agents.json
@@ -7,9 +7,7 @@
     "distribution": {
       "npx": {
         "package": "agoragentic-mcp@1.3.0",
-        "args": [
-          "--acp"
-        ]
+        "args": ["--acp"]
       }
     }
   },
@@ -51,9 +49,7 @@
     "distribution": {
       "npx": {
         "package": "@augmentcode/auggie@0.34.0",
-        "args": [
-          "--acp"
-        ],
+        "args": ["--acp"],
         "env": {
           "AUGMENT_DISABLE_AUTO_UPDATE": "1"
         }
@@ -90,9 +86,7 @@
     "distribution": {
       "npx": {
         "package": "cline@3.0.49",
-        "args": [
-          "--acp"
-        ]
+        "args": ["--acp"]
       }
     }
   },
@@ -104,9 +98,7 @@
     "distribution": {
       "npx": {
         "package": "@tencent-ai/codebuddy-code@2.106.7",
-        "args": [
-          "--acp"
-        ]
+        "args": ["--acp"]
       }
     }
   },
@@ -131,50 +123,32 @@
         "darwin-aarch64": {
           "cmd": "./coco-1.0.73+180523.e6179a031de9-darwin-arm64/cortex",
           "archive": "https://sfc-repo.snowflakecomputing.com/cortex-code-cli/a4643c4278/1.0.73%2B180523.e6179a031de9/coco-1.0.73%2B180523.e6179a031de9-darwin-arm64.tar.gz",
-          "args": [
-            "acp",
-            "serve"
-          ]
+          "args": ["acp", "serve"]
         },
         "darwin-x86_64": {
           "cmd": "./coco-1.0.73+180523.e6179a031de9-darwin-amd64/cortex",
           "archive": "https://sfc-repo.snowflakecomputing.com/cortex-code-cli/a4643c4278/1.0.73%2B180523.e6179a031de9/coco-1.0.73%2B180523.e6179a031de9-darwin-amd64.tar.gz",
-          "args": [
-            "acp",
-            "serve"
-          ]
+          "args": ["acp", "serve"]
         },
         "linux-x86_64": {
           "cmd": "./coco-1.0.73+180523.e6179a031de9-linux-amd64/cortex",
           "archive": "https://sfc-repo.snowflakecomputing.com/cortex-code-cli/a4643c4278/1.0.73%2B180523.e6179a031de9/coco-1.0.73%2B180523.e6179a031de9-linux-amd64.tar.gz",
-          "args": [
-            "acp",
-            "serve"
-          ]
+          "args": ["acp", "serve"]
         },
         "linux-aarch64": {
           "cmd": "./coco-1.0.73+180523.e6179a031de9-linux-arm64/cortex",
           "archive": "https://sfc-repo.snowflakecomputing.com/cortex-code-cli/a4643c4278/1.0.73%2B180523.e6179a031de9/coco-1.0.73%2B180523.e6179a031de9-linux-arm64.tar.gz",
-          "args": [
-            "acp",
-            "serve"
-          ]
+          "args": ["acp", "serve"]
         },
         "windows-x86_64": {
           "cmd": "./coco-1.0.73+180523.e6179a031de9-windows-amd64/cortex.exe",
           "archive": "https://sfc-repo.snowflakecomputing.com/cortex-code-cli/a4643c4278/1.0.73%2B180523.e6179a031de9/coco-1.0.73%2B180523.e6179a031de9-windows-amd64.tar.gz",
-          "args": [
-            "acp",
-            "serve"
-          ]
+          "args": ["acp", "serve"]
         },
         "windows-aarch64": {
           "cmd": "./coco-1.0.73+180523.e6179a031de9-windows-arm64/cortex.exe",
           "archive": "https://sfc-repo.snowflakecomputing.com/cortex-code-cli/a4643c4278/1.0.73%2B180523.e6179a031de9/coco-1.0.73%2B180523.e6179a031de9-windows-arm64.tar.gz",
-          "args": [
-            "acp",
-            "serve"
-          ]
+          "args": ["acp", "serve"]
         }
       }
     }
@@ -215,37 +189,27 @@
         "darwin-aarch64": {
           "cmd": "./crow-cli",
           "archive": "https://github.com/crow-cli/crow-cli/releases/download/v0.1.24/crow-cli-darwin-aarch64.tar.gz",
-          "args": [
-            "acp"
-          ]
+          "args": ["acp"]
         },
         "darwin-x86_64": {
           "cmd": "./crow-cli",
           "archive": "https://github.com/crow-cli/crow-cli/releases/download/v0.1.24/crow-cli-darwin-x86_64.tar.gz",
-          "args": [
-            "acp"
-          ]
+          "args": ["acp"]
         },
         "linux-aarch64": {
           "cmd": "./crow-cli",
           "archive": "https://github.com/crow-cli/crow-cli/releases/download/v0.1.24/crow-cli-linux-aarch64.tar.gz",
-          "args": [
-            "acp"
-          ]
+          "args": ["acp"]
         },
         "linux-x86_64": {
           "cmd": "./crow-cli",
           "archive": "https://github.com/crow-cli/crow-cli/releases/download/v0.1.24/crow-cli-linux-x86_64.tar.gz",
-          "args": [
-            "acp"
-          ]
+          "args": ["acp"]
         },
         "windows-x86_64": {
           "cmd": "./crow-cli.exe",
           "archive": "https://github.com/crow-cli/crow-cli/releases/download/v0.1.24/crow-cli-windows-x86_64.zip",
-          "args": [
-            "acp"
-          ]
+          "args": ["acp"]
         }
       }
     }
@@ -260,44 +224,32 @@
         "darwin-aarch64": {
           "cmd": "./dist-package/cursor-agent",
           "archive": "https://downloads.cursor.com/lab/2026.07.23-e383d2b/darwin/arm64/agent-cli-package.tar.gz",
-          "args": [
-            "acp"
-          ]
+          "args": ["acp"]
         },
         "darwin-x86_64": {
           "cmd": "./dist-package/cursor-agent",
           "archive": "https://downloads.cursor.com/lab/2026.07.23-e383d2b/darwin/x64/agent-cli-package.tar.gz",
-          "args": [
-            "acp"
-          ]
+          "args": ["acp"]
         },
         "linux-aarch64": {
           "cmd": "./dist-package/cursor-agent",
           "archive": "https://downloads.cursor.com/lab/2026.07.23-e383d2b/linux/arm64/agent-cli-package.tar.gz",
-          "args": [
-            "acp"
-          ]
+          "args": ["acp"]
         },
         "linux-x86_64": {
           "cmd": "./dist-package/cursor-agent",
           "archive": "https://downloads.cursor.com/lab/2026.07.23-e383d2b/linux/x64/agent-cli-package.tar.gz",
-          "args": [
-            "acp"
-          ]
+          "args": ["acp"]
         },
         "windows-aarch64": {
           "cmd": "./dist-package\\cursor-agent.cmd",
           "archive": "https://downloads.cursor.com/lab/2026.07.23-e383d2b/windows/arm64/agent-cli-package.zip",
-          "args": [
-            "acp"
-          ]
+          "args": ["acp"]
         },
         "windows-x86_64": {
           "cmd": "./dist-package\\cursor-agent.cmd",
           "archive": "https://downloads.cursor.com/lab/2026.07.23-e383d2b/windows/x64/agent-cli-package.zip",
-          "args": [
-            "acp"
-          ]
+          "args": ["acp"]
         }
       }
     }
@@ -323,44 +275,32 @@
         "darwin-aarch64": {
           "cmd": "./bin/devin",
           "archive": "https://static.devin.ai/cli/3000.3.27/devin-3000.3.27-aarch64-apple-darwin.tar.gz",
-          "args": [
-            "acp"
-          ]
+          "args": ["acp"]
         },
         "darwin-x86_64": {
           "cmd": "./bin/devin",
           "archive": "https://static.devin.ai/cli/3000.3.27/devin-3000.3.27-x86_64-apple-darwin.tar.gz",
-          "args": [
-            "acp"
-          ]
+          "args": ["acp"]
         },
         "linux-aarch64": {
           "cmd": "./bin/devin",
           "archive": "https://static.devin.ai/cli/3000.3.27/devin-3000.3.27-aarch64-unknown-linux.tar.gz",
-          "args": [
-            "acp"
-          ]
+          "args": ["acp"]
         },
         "linux-x86_64": {
           "cmd": "./bin/devin",
           "archive": "https://static.devin.ai/cli/3000.3.27/devin-3000.3.27-x86_64-unknown-linux.tar.gz",
-          "args": [
-            "acp"
-          ]
+          "args": ["acp"]
         },
         "windows-aarch64": {
           "cmd": "./bin\\devin.exe",
           "archive": "https://static.devin.ai/cli/3000.3.27/devin-3000.3.27-aarch64-pc-windows.zip",
-          "args": [
-            "acp"
-          ]
+          "args": ["acp"]
         },
         "windows-x86_64": {
           "cmd": "./bin\\devin.exe",
           "archive": "https://static.devin.ai/cli/3000.3.27/devin-3000.3.27-x86_64-pc-windows.zip",
-          "args": [
-            "acp"
-          ]
+          "args": ["acp"]
         }
       }
     }
@@ -373,9 +313,7 @@
     "distribution": {
       "npx": {
         "package": "dimcode@0.3.2",
-        "args": [
-          "acp"
-        ]
+        "args": ["acp"]
       }
     }
   },
@@ -387,9 +325,7 @@
     "distribution": {
       "npx": {
         "package": "dirac-cli@0.4.32",
-        "args": [
-          "--acp"
-        ]
+        "args": ["--acp"]
       }
     }
   },
@@ -401,11 +337,7 @@
     "distribution": {
       "npx": {
         "package": "droid@0.187.0",
-        "args": [
-          "exec",
-          "--output-format",
-          "acp-daemon"
-        ],
+        "args": ["exec", "--output-format", "acp-daemon"],
         "env": {
           "DROID_DISABLE_AUTO_UPDATE": "true",
           "FACTORY_DROID_AUTO_UPDATE_ENABLED": "false"
@@ -421,9 +353,7 @@
     "distribution": {
       "uvx": {
         "package": "fast-agent-acp==0.9.30",
-        "args": [
-          "-x"
-        ]
+        "args": ["-x"]
       }
     }
   },
@@ -435,9 +365,7 @@
     "distribution": {
       "npx": {
         "package": "@google/gemini-cli@0.53.1",
-        "args": [
-          "--acp"
-        ]
+        "args": ["--acp"]
       }
     }
   },
@@ -449,9 +377,7 @@
     "distribution": {
       "npx": {
         "package": "@github/copilot@1.0.78",
-        "args": [
-          "--acp"
-        ]
+        "args": ["--acp"]
       }
     }
   },
@@ -475,34 +401,24 @@
       "binary": {
         "darwin-aarch64": {
           "cmd": "./goose",
-          "args": [
-            "acp"
-          ]
+          "args": ["acp"]
         },
         "darwin-x86_64": {
           "cmd": "./goose",
-          "args": [
-            "acp"
-          ]
+          "args": ["acp"]
         },
         "linux-aarch64": {
           "cmd": "./goose",
-          "args": [
-            "acp"
-          ]
+          "args": ["acp"]
         },
         "linux-x86_64": {
           "cmd": "./goose",
-          "args": [
-            "acp"
-          ]
+          "args": ["acp"]
         },
         "windows-x86_64": {
           "cmd": "./goose-package\\goose.exe",
           "archive": "https://github.com/block/goose/releases/download/v1.45.0/goose-x86_64-pc-windows-msvc.zip",
-          "args": [
-            "acp"
-          ]
+          "args": ["acp"]
         }
       }
     }
@@ -515,10 +431,7 @@
     "distribution": {
       "npx": {
         "package": "@xai-official/grok@0.2.120",
-        "args": [
-          "agent",
-          "stdio"
-        ]
+        "args": ["agent", "stdio"]
       }
     }
   },
@@ -532,42 +445,27 @@
         "darwin-aarch64": {
           "cmd": "./harn",
           "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.53/harn-aarch64-apple-darwin.tar.gz",
-          "args": [
-            "serve",
-            "acp"
-          ]
+          "args": ["serve", "acp"]
         },
         "darwin-x86_64": {
           "cmd": "./harn",
           "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.53/harn-x86_64-apple-darwin.tar.gz",
-          "args": [
-            "serve",
-            "acp"
-          ]
+          "args": ["serve", "acp"]
         },
         "linux-aarch64": {
           "cmd": "./harn",
           "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.53/harn-aarch64-unknown-linux-gnu.tar.gz",
-          "args": [
-            "serve",
-            "acp"
-          ]
+          "args": ["serve", "acp"]
         },
         "linux-x86_64": {
           "cmd": "./harn",
           "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.53/harn-x86_64-unknown-linux-gnu.tar.gz",
-          "args": [
-            "serve",
-            "acp"
-          ]
+          "args": ["serve", "acp"]
         },
         "windows-x86_64": {
           "cmd": "harn.exe",
           "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.53/harn-x86_64-pc-windows-msvc.zip",
-          "args": [
-            "serve",
-            "acp"
-          ]
+          "args": ["serve", "acp"]
         }
       }
     }
@@ -582,44 +480,32 @@
         "darwin-aarch64": {
           "cmd": "./Applications/junie.app/Contents/MacOS/junie",
           "archive": "https://github.com/JetBrains/junie/releases/download/2383.10/junie-release-2383.10-macos-aarch64.zip",
-          "args": [
-            "--acp=true"
-          ]
+          "args": ["--acp=true"]
         },
         "darwin-x86_64": {
           "cmd": "./Applications/junie.app/Contents/MacOS/junie",
           "archive": "https://github.com/JetBrains/junie/releases/download/2383.10/junie-release-2383.10-macos-amd64.zip",
-          "args": [
-            "--acp=true"
-          ]
+          "args": ["--acp=true"]
         },
         "linux-aarch64": {
           "cmd": "./junie-app/bin/junie",
           "archive": "https://github.com/JetBrains/junie/releases/download/2383.10/junie-release-2383.10-linux-aarch64.zip",
-          "args": [
-            "--acp=true"
-          ]
+          "args": ["--acp=true"]
         },
         "linux-x86_64": {
           "cmd": "./junie-app/bin/junie",
           "archive": "https://github.com/JetBrains/junie/releases/download/2383.10/junie-release-2383.10-linux-amd64.zip",
-          "args": [
-            "--acp=true"
-          ]
+          "args": ["--acp=true"]
         },
         "windows-x86_64": {
           "cmd": "./junie/junie.exe",
           "archive": "https://github.com/JetBrains/junie/releases/download/2383.10/junie-release-2383.10-windows-amd64.zip",
-          "args": [
-            "--acp=true"
-          ]
+          "args": ["--acp=true"]
         },
         "windows-aarch64": {
           "cmd": "./junie/junie.exe",
           "archive": "https://github.com/JetBrains/junie/releases/download/2383.10/junie-release-2383.10-windows-aarch64.zip",
-          "args": [
-            "--acp=true"
-          ]
+          "args": ["--acp=true"]
         }
       }
     }
@@ -632,45 +518,33 @@
     "distribution": {
       "npx": {
         "package": "@kilocode/cli@7.4.19",
-        "args": [
-          "acp"
-        ]
+        "args": ["acp"]
       },
       "binary": {
         "darwin-aarch64": {
           "cmd": "./kilo",
           "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.4.19/kilo-darwin-arm64.zip",
-          "args": [
-            "acp"
-          ]
+          "args": ["acp"]
         },
         "darwin-x86_64": {
           "cmd": "./kilo",
           "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.4.19/kilo-darwin-x64.zip",
-          "args": [
-            "acp"
-          ]
+          "args": ["acp"]
         },
         "linux-aarch64": {
           "cmd": "./kilo",
           "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.4.19/kilo-linux-arm64.tar.gz",
-          "args": [
-            "acp"
-          ]
+          "args": ["acp"]
         },
         "linux-x86_64": {
           "cmd": "./kilo",
           "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.4.19/kilo-linux-x64.tar.gz",
-          "args": [
-            "acp"
-          ]
+          "args": ["acp"]
         },
         "windows-x86_64": {
           "cmd": "./kilo.exe",
           "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.4.19/kilo-windows-x64.zip",
-          "args": [
-            "acp"
-          ]
+          "args": ["acp"]
         }
       }
     }
@@ -685,37 +559,27 @@
         "darwin-aarch64": {
           "cmd": "./kimi",
           "archive": "https://github.com/MoonshotAI/kimi-cli/releases/download/1.49.0/kimi-1.49.0-aarch64-apple-darwin.tar.gz",
-          "args": [
-            "acp"
-          ]
+          "args": ["acp"]
         },
         "linux-aarch64": {
           "cmd": "./kimi",
           "archive": "https://github.com/MoonshotAI/kimi-cli/releases/download/1.49.0/kimi-1.49.0-aarch64-unknown-linux-gnu.tar.gz",
-          "args": [
-            "acp"
-          ]
+          "args": ["acp"]
         },
         "linux-x86_64": {
           "cmd": "./kimi",
           "archive": "https://github.com/MoonshotAI/kimi-cli/releases/download/1.49.0/kimi-1.49.0-x86_64-unknown-linux-gnu.tar.gz",
-          "args": [
-            "acp"
-          ]
+          "args": ["acp"]
         },
         "windows-aarch64": {
           "cmd": "./kimi.exe",
           "archive": "https://github.com/MoonshotAI/kimi-cli/releases/download/1.49.0/kimi-1.49.0-aarch64-pc-windows-msvc.zip",
-          "args": [
-            "acp"
-          ]
+          "args": ["acp"]
         },
         "windows-x86_64": {
           "cmd": "./kimi.exe",
           "archive": "https://github.com/MoonshotAI/kimi-cli/releases/download/1.49.0/kimi-1.49.0-x86_64-pc-windows-msvc.zip",
-          "args": [
-            "acp"
-          ]
+          "args": ["acp"]
         }
       }
     }
@@ -728,9 +592,7 @@
     "distribution": {
       "uvx": {
         "package": "minion-code@0.1.44",
-        "args": [
-          "acp"
-        ]
+        "args": ["acp"]
       }
     }
   },
@@ -772,9 +634,7 @@
     "distribution": {
       "npx": {
         "package": "@compass-ai/nova@1.1.31",
-        "args": [
-          "acp"
-        ]
+        "args": ["acp"]
       }
     }
   },
@@ -788,44 +648,32 @@
         "darwin-aarch64": {
           "cmd": "./opencode",
           "archive": "https://github.com/anomalyco/opencode/releases/download/v1.18.12/opencode-darwin-arm64.zip",
-          "args": [
-            "acp"
-          ]
+          "args": ["acp"]
         },
         "darwin-x86_64": {
           "cmd": "./opencode",
           "archive": "https://github.com/anomalyco/opencode/releases/download/v1.18.12/opencode-darwin-x64.zip",
-          "args": [
-            "acp"
-          ]
+          "args": ["acp"]
         },
         "linux-aarch64": {
           "cmd": "./opencode",
           "archive": "https://github.com/anomalyco/opencode/releases/download/v1.18.12/opencode-linux-arm64.tar.gz",
-          "args": [
-            "acp"
-          ]
+          "args": ["acp"]
         },
         "linux-x86_64": {
           "cmd": "./opencode",
           "archive": "https://github.com/anomalyco/opencode/releases/download/v1.18.12/opencode-linux-x64.tar.gz",
-          "args": [
-            "acp"
-          ]
+          "args": ["acp"]
         },
         "windows-aarch64": {
           "cmd": "./opencode",
           "archive": "https://github.com/anomalyco/opencode/releases/download/v1.18.12/opencode-windows-arm64.zip",
-          "args": [
-            "acp"
-          ]
+          "args": ["acp"]
         },
         "windows-x86_64": {
           "cmd": "./opencode.exe",
           "archive": "https://github.com/anomalyco/opencode/releases/download/v1.18.12/opencode-windows-x64.zip",
-          "args": [
-            "acp"
-          ]
+          "args": ["acp"]
         }
       }
     }
@@ -851,44 +699,32 @@
         "darwin-aarch64": {
           "cmd": "./pool-darwin-arm64",
           "archive": "https://downloads.poolside.ai/pool/v1.0.14/pool-darwin-arm64.tar.gz",
-          "args": [
-            "acp"
-          ]
+          "args": ["acp"]
         },
         "darwin-x86_64": {
           "cmd": "./pool-darwin-amd64",
           "archive": "https://downloads.poolside.ai/pool/v1.0.14/pool-darwin-amd64.tar.gz",
-          "args": [
-            "acp"
-          ]
+          "args": ["acp"]
         },
         "linux-aarch64": {
           "cmd": "./pool-linux-arm64",
           "archive": "https://downloads.poolside.ai/pool/v1.0.14/pool-linux-arm64.tar.gz",
-          "args": [
-            "acp"
-          ]
+          "args": ["acp"]
         },
         "linux-x86_64": {
           "cmd": "./pool-linux-amd64",
           "archive": "https://downloads.poolside.ai/pool/v1.0.14/pool-linux-amd64.tar.gz",
-          "args": [
-            "acp"
-          ]
+          "args": ["acp"]
         },
         "windows-aarch64": {
           "cmd": "./pool-windows-arm64.exe",
           "archive": "https://downloads.poolside.ai/pool/v1.0.14/pool-windows-arm64.tar.gz",
-          "args": [
-            "acp"
-          ]
+          "args": ["acp"]
         },
         "windows-x86_64": {
           "cmd": "./pool-windows-amd64.exe",
           "archive": "https://downloads.poolside.ai/pool/v1.0.14/pool-windows-amd64.tar.gz",
-          "args": [
-            "acp"
-          ]
+          "args": ["acp"]
         }
       }
     }
@@ -901,9 +737,7 @@
     "distribution": {
       "npx": {
         "package": "@qoder-ai/qodercli@0.2.14",
-        "args": [
-          "--acp"
-        ]
+        "args": ["--acp"]
       }
     }
   },
@@ -915,10 +749,7 @@
     "distribution": {
       "npx": {
         "package": "@qwen-code/qwen-code@0.21.5",
-        "args": [
-          "--acp",
-          "--experimental-skills"
-        ]
+        "args": ["--acp", "--experimental-skills"]
       }
     }
   },
@@ -965,37 +796,27 @@
         "darwin-aarch64": {
           "cmd": "./stakpak",
           "archive": "https://github.com/stakpak/agent/releases/download/v0.3.88/stakpak-darwin-aarch64.tar.gz",
-          "args": [
-            "acp"
-          ]
+          "args": ["acp"]
         },
         "darwin-x86_64": {
           "cmd": "./stakpak",
           "archive": "https://github.com/stakpak/agent/releases/download/v0.3.88/stakpak-darwin-x86_64.tar.gz",
-          "args": [
-            "acp"
-          ]
+          "args": ["acp"]
         },
         "linux-aarch64": {
           "cmd": "./stakpak",
           "archive": "https://github.com/stakpak/agent/releases/download/v0.3.88/stakpak-linux-aarch64.tar.gz",
-          "args": [
-            "acp"
-          ]
+          "args": ["acp"]
         },
         "linux-x86_64": {
           "cmd": "./stakpak",
           "archive": "https://github.com/stakpak/agent/releases/download/v0.3.88/stakpak-linux-x86_64.tar.gz",
-          "args": [
-            "acp"
-          ]
+          "args": ["acp"]
         },
         "windows-x86_64": {
           "cmd": "./stakpak.exe",
           "archive": "https://github.com/stakpak/agent/releases/download/v0.3.88/stakpak-windows-x86_64.zip",
-          "args": [
-            "acp"
-          ]
+          "args": ["acp"]
         }
       }
     }
@@ -1010,9 +831,7 @@
         "darwin-aarch64": {
           "cmd": "./vtcode",
           "archive": "https://github.com/vinhnx/VTCode/releases/download/0.96.14/vtcode-0.96.14-aarch64-apple-darwin.tar.gz",
-          "args": [
-            "acp"
-          ],
+          "args": ["acp"],
           "env": {
             "VT_ACP_ENABLED": "1",
             "VT_ACP_ZED_ENABLED": "1"
@@ -1021,9 +840,7 @@
         "darwin-x86_64": {
           "cmd": "./vtcode",
           "archive": "https://github.com/vinhnx/VTCode/releases/download/0.96.14/vtcode-0.96.14-x86_64-apple-darwin.tar.gz",
-          "args": [
-            "acp"
-          ],
+          "args": ["acp"],
           "env": {
             "VT_ACP_ENABLED": "1",
             "VT_ACP_ZED_ENABLED": "1"
@@ -1032,9 +849,7 @@
         "linux-x86_64": {
           "cmd": "./vtcode",
           "archive": "https://github.com/vinhnx/VTCode/releases/download/0.96.14/vtcode-0.96.14-x86_64-unknown-linux-gnu.tar.gz",
-          "args": [
-            "acp"
-          ],
+          "args": ["acp"],
           "env": {
             "VT_ACP_ENABLED": "1",
             "VT_ACP_ZED_ENABLED": "1"
@@ -1043,9 +858,7 @@
         "windows-x86_64": {
           "cmd": "vtcode.exe",
           "archive": "https://github.com/vinhnx/VTCode/releases/download/0.96.14/vtcode-0.96.14-x86_64-pc-windows-msvc.zip",
-          "args": [
-            "acp"
-          ],
+          "args": ["acp"],
           "env": {
             "VT_ACP_ENABLED": "1",
             "VT_ACP_ZED_ENABLED": "1"

--- a/src/renderer/components/ErrorFallback.tsx
+++ b/src/renderer/components/ErrorFallback.tsx
@@ -24,6 +24,7 @@ export function ErrorFallback({
         {error.message || 'An unexpected error occurred.'}
       </p>
       <button
+        type="button"
         onClick={onRetry}
         className="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium bg-primary text-primary-foreground rounded-lg hover:bg-primary/90 transition-colors"
       >

--- a/src/renderer/components/agents/AgentLauncher.test.tsx
+++ b/src/renderer/components/agents/AgentLauncher.test.tsx
@@ -43,6 +43,7 @@ const {
   mockSetModel,
   mockAuthenticateAgent,
   mockInstallRegistryBinary,
+  mockInstallAcpAgent,
   mockAddAgentChatTab,
   mockRemapAgentChatSession,
   mockHideAgentLauncher,
@@ -72,6 +73,7 @@ const {
   mockSetModel: vi.fn(),
   mockAuthenticateAgent: vi.fn(),
   mockInstallRegistryBinary: vi.fn(),
+  mockInstallAcpAgent: vi.fn(),
   mockAddAgentChatTab: vi.fn(),
   mockRemapAgentChatSession: vi.fn(),
   mockHideAgentLauncher: vi.fn(),
@@ -187,6 +189,7 @@ vi.mock('@/hooks/use-resolved-supported-acp-agents', async () => {
 vi.mock('@/lib/acp-api', () => ({
   acpApi: {
     installRegistryBinary: mockInstallRegistryBinary,
+    installAcpAgent: mockInstallAcpAgent,
     probeRuntime: vi.fn(async () => ({ npx: true, uvx: true }))
   }
 }))
@@ -435,6 +438,7 @@ beforeEach(() => {
   mockSetMode.mockResolvedValue(undefined)
   mockSetModel.mockResolvedValue(undefined)
   mockInstallRegistryBinary.mockResolvedValue({ command: 'opencode.exe', args: ['acp'] })
+  mockInstallAcpAgent.mockResolvedValue({ command: 'opencode.exe', args: ['acp'] })
 })
 
 describe('AgentLauncher ACP new thread', () => {
@@ -867,14 +871,14 @@ describe('AgentLauncher ACP new thread', () => {
     renderLauncher()
 
     expect(await screen.findByText('Install required')).toBeInTheDocument()
-    expect(mockInstallRegistryBinary).not.toHaveBeenCalled()
+    expect(mockInstallAcpAgent).not.toHaveBeenCalled()
 
     fireEvent.click(screen.getByText('Install'))
 
-    await waitFor(() => expect(mockInstallRegistryBinary).toHaveBeenCalledTimes(1))
-    expect(mockInstallRegistryBinary).toHaveBeenCalledWith(
-      expect.objectContaining({ agentId: 'opencode', cmd: './opencode.exe', args: ['acp'] })
-    )
+    await waitFor(() => expect(mockInstallAcpAgent).toHaveBeenCalledTimes(1))
+    // CAP-6 / Story 9: the request is `{ agentId }` only; the host resolves
+    // everything from the trusted catalog.
+    expect(mockInstallAcpAgent).toHaveBeenCalledWith('opencode')
     await waitFor(() =>
       expect(mockSaveAgentConfig).toHaveBeenCalledWith(
         expect.objectContaining({

--- a/src/renderer/components/agents/AgentLauncher.test.tsx
+++ b/src/renderer/components/agents/AgentLauncher.test.tsx
@@ -3,7 +3,6 @@ import { MemoryRouter } from 'react-router-dom'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { TooltipProvider } from '@/components/ui/tooltip'
 import type { StoredAgentConfig } from '@/lib/acp-agents-persistence'
-import * as supportedAcpAgents from '@/lib/agents/supported-acp-agents'
 import {
   buildSupportedAcpAgents,
   pickDefaultSupportedAgent,
@@ -110,7 +109,7 @@ const {
   }
 }))
 
-const { mockSkills, mockToastError } = vi.hoisted(() => ({
+const { mockSkills, mockToastError, mockResolvedAgentsOverride } = vi.hoisted(() => ({
   // Override-able skills list (defaults to [] — web/no-skills parity). Skill
   // tests push entries here so useAgentSkills surfaces them in the slash menu.
   // `path` is required so the launch wire prompt can cite it.
@@ -122,7 +121,13 @@ const { mockSkills, mockToastError } = vi.hoisted(() => ({
       path: string
     }>
   },
-  mockToastError: vi.fn()
+  mockToastError: vi.fn(),
+  // CAP-6 / Story 8: the launcher resolves supported agents from the host
+  // catalog via `useResolvedSupportedAcpAgents`. Component tests mock the hook
+  // to the synchronous offline-first derivation so they can exercise launch
+  // behavior without the async catalog fetch. Set this to inject a specific
+  // entry list (e.g. the manual-install agent).
+  mockResolvedAgentsOverride: { current: null as SupportedAcpAgentEntry[] | null }
 }))
 
 vi.mock('sonner', () => ({
@@ -167,6 +172,17 @@ vi.mock('@/lib/dialog-api', () => ({
 vi.mock('@/hooks/use-acp-runtime-probe', () => ({
   useAcpRuntimeProbe: () => ({ npx: true, uvx: true })
 }))
+
+vi.mock('@/hooks/use-resolved-supported-acp-agents', async () => {
+  const actual = await vi.importActual<typeof import('@/lib/agents/supported-acp-agents')>(
+    '@/lib/agents/supported-acp-agents'
+  )
+  return {
+    useResolvedSupportedAcpAgents: (configs: readonly StoredAgentConfig[]) =>
+      mockResolvedAgentsOverride.current ??
+      actual.buildSupportedAcpAgents(configs, 'windows-x86_64')
+  }
+})
 
 vi.mock('@/lib/acp-api', () => ({
   acpApi: {
@@ -370,6 +386,9 @@ beforeEach(() => {
   // Start each test from a clean skill slate (web/no-skills default). Skill
   // tests override mockSkills.current.
   mockSkills.current = []
+  // Reset the supported-agents override (default: delegate to the offline-first
+  // derivation).
+  mockResolvedAgentsOverride.current = null
   acpStateRef.current = {
     agentConfigs: [],
     preparedSessions: {},
@@ -886,7 +905,7 @@ describe('AgentLauncher ACP new thread', () => {
       runtimeLauncher: null,
       unavailableReason: 'Install Legacy Agent from the vendor.'
     }
-    vi.spyOn(supportedAcpAgents, 'buildSupportedAcpAgents').mockReturnValue([manualEntry])
+    mockResolvedAgentsOverride.current = [manualEntry]
     mockPersistRead.mockResolvedValue({
       success: true,
       data: { agentId: 'acp-registry:legacy', mode: 'acp' }

--- a/src/renderer/components/agents/AgentLauncher.tsx
+++ b/src/renderer/components/agents/AgentLauncher.tsx
@@ -36,10 +36,9 @@ import { TermulMark } from '@/components/TermulMark'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
-import { useAcpRegistryCatalog } from '@/hooks/use-acp-registry-catalog'
-import { useAcpRuntimeProbe } from '@/hooks/use-acp-runtime-probe'
 import { useAgentSkills } from '@/hooks/use-agent-skills'
 import { useMentionRecents } from '@/hooks/use-mention-recents'
+import { useResolvedSupportedAcpAgents } from '@/hooks/use-resolved-supported-acp-agents'
 import type { StoredAgentConfig } from '@/lib/acp-agents-persistence'
 import {
   type AuthMethod,
@@ -49,12 +48,10 @@ import {
   type ProbeStatus
 } from '@/lib/acp-api'
 import type { StoredMcpServer } from '@/lib/acp-mcp-persistence'
-import { currentPlatformArch } from '@/lib/agents/acp-registry'
 import type { PrepareChatError } from '@/lib/agents/acp-spawn-errors'
 import { findBundledIconByKey } from '@/lib/agents/agent-icon-catalog'
 import { sanitizeInlineAgentSvg } from '@/lib/agents/sanitize-agent-icon'
 import {
-  buildSupportedAcpAgents,
   filterSupportedAcpAgents,
   installedBinaryConfig,
   manualBinaryConfig,
@@ -127,13 +124,7 @@ export function AgentLauncher({ paneId, className }: AgentLauncherProps): React.
   const projectLabel = activeProject?.name ?? 'this folder'
   const projectRoot = activeProjectId ? getDefaultCwdForProject(activeProjectId) : undefined
   const { skills } = useAgentSkills(projectRoot)
-  const platformArch = useMemo(() => currentPlatformArch(), [])
-  const runtime = useAcpRuntimeProbe()
-  const { activeRegistry } = useAcpRegistryCatalog()
-  const supportedAgents = useMemo(
-    () => buildSupportedAcpAgents(acpConfigs, platformArch, activeRegistry, runtime),
-    [acpConfigs, platformArch, activeRegistry, runtime]
-  )
+  const supportedAgents = useResolvedSupportedAcpAgents(acpConfigs)
 
   const selectedEntry = useMemo(
     () =>

--- a/src/renderer/components/agents/AgentLauncher.tsx
+++ b/src/renderer/components/agents/AgentLauncher.tsx
@@ -487,12 +487,12 @@ export function AgentLauncher({ paneId, className }: AgentLauncherProps): React.
       persistSelection(entry.configId)
       setInstallingConfigId(entry.configId)
       try {
-        const installed = await acpApi.installRegistryBinary({
-          agentId: entry.agent.id,
-          archiveUrl: entry.install.archiveUrl,
-          cmd: entry.install.cmd,
-          args: entry.install.args
-        })
+        // CAP-6 / Story 9: host-owned verified-atomic install. The request is
+        // `{ agentId }` only; the host resolves everything (archive URL, cmd,
+        // args, sha256) from the trusted catalog. The outcome's
+        // `{ command, args }` flows through `installedBinaryConfig` →
+        // `saveAgentConfig` unchanged.
+        const installed = await acpApi.installAcpAgent(entry.agent.id)
         const config = installedBinaryConfig(entry.agent, installed, { env: entry.install.env })
         await saveAgentConfig(config)
         setSelectedConfigId(config.id)

--- a/src/renderer/components/settings/AcpAgentsSettings.test.tsx
+++ b/src/renderer/components/settings/AcpAgentsSettings.test.tsx
@@ -31,6 +31,16 @@ vi.mock('@/hooks/use-acp-runtime-probe', () => ({
   useAcpRuntimeProbe: () => ({ npx: true, uvx: true })
 }))
 
+vi.mock('@/hooks/use-resolved-supported-acp-agents', async () => {
+  const actual = await vi.importActual<typeof import('@/lib/agents/supported-acp-agents')>(
+    '@/lib/agents/supported-acp-agents'
+  )
+  return {
+    useResolvedSupportedAcpAgents: (configs: readonly StoredAgentConfig[]) =>
+      actual.buildSupportedAcpAgents(configs, 'windows-x86_64')
+  }
+})
+
 describe('AcpAgentsSettings', () => {
   beforeEach(() => {
     stateRef.current.agentConfigs = []

--- a/src/renderer/components/settings/AcpAgentsSettings.tsx
+++ b/src/renderer/components/settings/AcpAgentsSettings.tsx
@@ -5,11 +5,9 @@ import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { useAcpRegistryCatalog } from '@/hooks/use-acp-registry-catalog'
-import { useAcpRuntimeProbe } from '@/hooks/use-acp-runtime-probe'
-import { currentPlatformArch } from '@/lib/agents/acp-registry'
+import { useResolvedSupportedAcpAgents } from '@/hooks/use-resolved-supported-acp-agents'
 import { findBundledIconByKey, normalizeIconSvg } from '@/lib/agents/agent-icon-catalog'
 import {
-  buildSupportedAcpAgents,
   filterSupportedAcpAgents,
   type SupportedAcpAgentEntry
 } from '@/lib/agents/supported-acp-agents'
@@ -222,10 +220,7 @@ function AgentRow({ entry }: AgentRowProps): React.JSX.Element {
  */
 export function AcpAgentsSettings(): React.JSX.Element {
   const [filter, setFilter] = useState('')
-  const platformArch = useMemo(() => currentPlatformArch(), [])
-  const runtime = useAcpRuntimeProbe()
   const {
-    activeRegistry,
     usingRemoteRegistry,
     remoteAvailable,
     advisorySummary,
@@ -233,13 +228,10 @@ export function AcpAgentsSettings(): React.JSX.Element {
     lastCheckedAt,
     checkForUpdates,
     applyRemoteRegistry,
-    useBundledRegistry
+    useBundledRegistry: switchToBundledRegistry
   } = useAcpRegistryCatalog()
   const agentConfigs = useAcpStore((s) => s.agentConfigs)
-  const supportedAgents = useMemo(
-    () => buildSupportedAcpAgents(agentConfigs, platformArch, activeRegistry, runtime),
-    [agentConfigs, platformArch, activeRegistry, runtime]
-  )
+  const supportedAgents = useResolvedSupportedAcpAgents(agentConfigs)
 
   const visible = useMemo(
     () => filterSupportedAcpAgents(supportedAgents, filter),
@@ -267,14 +259,26 @@ export function AcpAgentsSettings(): React.JSX.Element {
     })()
   }
 
-  const handleApplyRemote = (): void => {
-    applyRemoteRegistry()
-    const count = advisorySummary?.updatedCount ?? 0
-    toast.success(
-      count > 0
-        ? `Using remote registry (${count} update${count === 1 ? '' : 's'}).`
-        : 'Using remote registry.'
-    )
+  const handleApplyRemote = async (): Promise<void> => {
+    try {
+      await applyRemoteRegistry()
+      const count = advisorySummary?.updatedCount ?? 0
+      toast.success(
+        count > 0
+          ? `Using remote registry (${count} update${count === 1 ? '' : 's'}).`
+          : 'Using remote registry.'
+      )
+    } catch (err) {
+      toast.error(String(err))
+    }
+  }
+
+  const handleUseBundled = async (): Promise<void> => {
+    try {
+      await switchToBundledRegistry()
+    } catch (err) {
+      toast.error(String(err))
+    }
   }
 
   return (
@@ -300,7 +304,7 @@ export function AcpAgentsSettings(): React.JSX.Element {
           </Button>
         )}
         {usingRemoteRegistry && (
-          <Button type="button" size="sm" variant="ghost" onClick={useBundledRegistry}>
+          <Button type="button" size="sm" variant="ghost" onClick={handleUseBundled}>
             Use bundled registry
           </Button>
         )}

--- a/src/renderer/hooks/use-acp-agents.test.ts
+++ b/src/renderer/hooks/use-acp-agents.test.ts
@@ -46,6 +46,24 @@ vi.mock('@/lib/acp-api', () => ({
   }
 }))
 
+vi.mock('@/lib/agents/supported-acp-agents', async () => {
+  const actual = await vi.importActual<typeof import('@/lib/agents/supported-acp-agents')>(
+    '@/lib/agents/supported-acp-agents'
+  )
+  return {
+    ...actual,
+    // CAP-6 / Story 8: `useAcpAgents` resolves supported agents from the host
+    // catalog via `resolveSupportedAcpAgents`. Component tests delegate to the
+    // synchronous offline-first derivation so the prewarm selection assertions
+    // match the previous `buildSupportedAcpAgents(...)` behavior exactly.
+    resolveSupportedAcpAgents: async (configs: readonly StoredAgentConfig[]) =>
+      actual.buildSupportedAcpAgents(configs, 'windows-x86_64', undefined, {
+        npx: true,
+        uvx: true
+      })
+  }
+})
+
 vi.mock('@/stores/project-store', () => {
   const getState = () => ({ activeProjectId: projectRef.current.activeProjectId })
   const useProjectStore = (sel?: (s: ReturnType<typeof getState>) => unknown) =>

--- a/src/renderer/hooks/use-acp-agents.ts
+++ b/src/renderer/hooks/use-acp-agents.ts
@@ -1,12 +1,9 @@
 import type { LastSelectedAgent } from '@shared/types/persistence.types'
 import { PersistenceKeys } from '@shared/types/persistence.types'
 import { useEffect } from 'react'
-import { getActiveAcpRegistry } from '@/hooks/use-acp-registry-catalog'
-import { acpApi } from '@/lib/acp-api'
-import { currentPlatformArch } from '@/lib/agents/acp-registry'
 import {
-  buildSupportedAcpAgents,
-  pickDefaultSupportedAgent
+  pickDefaultSupportedAgent,
+  resolveSupportedAcpAgents
 } from '@/lib/agents/supported-acp-agents'
 import { persistenceApi } from '@/lib/api'
 import { getDefaultCwdForProject } from '@/lib/worktree-context'
@@ -32,20 +29,13 @@ export function useAcpAgents(): void {
     void (async () => {
       await loadAgentConfigs()
       if (cancelled) return
-      const runtime = await acpApi.probeRuntime()
-      if (cancelled) return
       const { agentConfigs, prewarmAgent } = useAcpStore.getState()
       const cwd = activeProjectId ? getDefaultCwdForProject(activeProjectId) : ''
       if (cwd.trim().length === 0) {
         setSelectedAgentConfigId(null)
         return
       }
-      const supportedAgents = buildSupportedAcpAgents(
-        agentConfigs,
-        currentPlatformArch(),
-        getActiveAcpRegistry(),
-        runtime
-      )
+      const supportedAgents = await resolveSupportedAcpAgents(agentConfigs)
       const persisted = await persistenceApi.read<unknown>(PersistenceKeys.lastSelectedAgent)
       if (cancelled) return
       const saved = persisted.success ? (persisted.data as Partial<LastSelectedAgent> | null) : null

--- a/src/renderer/hooks/use-acp-registry-catalog.ts
+++ b/src/renderer/hooks/use-acp-registry-catalog.ts
@@ -6,6 +6,7 @@ import {
   REGISTRY_AGENTS,
   type RegistryAgent
 } from '@/lib/agents/acp-registry'
+import { acpCatalogApi } from '@/lib/api'
 
 export interface RegistryUpdateSummary {
   updatedCount: number
@@ -47,8 +48,8 @@ export function useAcpRegistryCatalog(): {
   checking: boolean
   lastCheckedAt: string | null
   checkForUpdates: (forceRefresh?: boolean) => Promise<RegistryUpdateSummary | null>
-  applyRemoteRegistry: () => void
-  useBundledRegistry: () => void
+  applyRemoteRegistry: () => Promise<void>
+  useBundledRegistry: () => Promise<void>
 } {
   const [, bump] = useState(0)
   const [checking, setChecking] = useState(false)
@@ -85,19 +86,47 @@ export function useAcpRegistryCatalog(): {
     }
   }, [])
 
-  const applyRemoteRegistry = useCallback(() => {
-    if (!sharedAdvisoryAgents) return
-    sharedActiveRemote = true
-    notifyRegistryCatalogListeners()
-  }, [])
+  const applyRemoteRegistry = useCallback(
+    async () => {
+      if (!sharedAdvisoryAgents) return
+      // CAP-6 / Story 8: the opt-in is now host-persisted. The renderer's
+      // `applyRemoteRegistry()` becomes a call to `setCatalogOptIn(true)` so
+      // the host gates CDN augmentation (the host enforces "trusted or
+      // explicitly approved" before serving). The persisted state moves
+      // host-side. Surface a rejection (e.g. degraded mode) as a throw so the
+      // caller's UI does not flip local state to a success the host never
+      // persisted (UI/host split-brain).
+      const result = await acpCatalogApi.setCatalogOptIn(true)
+      if (!result.success) {
+        throw new Error(result.error ?? result.code ?? 'Could not apply the remote registry.')
+      }
+      sharedActiveRemote = true
+      notifyRegistryCatalogListeners()
+    },
+    [
+      /* deps */
+    ]
+  )
 
-  const useBundledRegistry = useCallback(() => {
-    sharedAdvisoryAgents = null
-    sharedAdvisorySummary = null
-    sharedActiveRemote = false
-    sharedLastCheckedAt = null
-    notifyRegistryCatalogListeners()
-  }, [])
+  const useBundledRegistry = useCallback(
+    async () => {
+      // CAP-6 / Story 8: clear the host-persisted opt-in so the next catalog
+      // resolution excludes CDN entries. Surface a rejection as a throw so the
+      // caller does not clear local state the host kept opted-in.
+      const result = await acpCatalogApi.setCatalogOptIn(false)
+      if (!result.success) {
+        throw new Error(result.error ?? result.code ?? 'Could not switch to the bundled registry.')
+      }
+      sharedAdvisoryAgents = null
+      sharedAdvisorySummary = null
+      sharedActiveRemote = false
+      sharedLastCheckedAt = null
+      notifyRegistryCatalogListeners()
+    },
+    [
+      /* deps */
+    ]
+  )
 
   return {
     activeRegistry: getActiveAcpRegistry(),

--- a/src/renderer/hooks/use-resolved-supported-acp-agents.ts
+++ b/src/renderer/hooks/use-resolved-supported-acp-agents.ts
@@ -1,0 +1,42 @@
+import { useEffect, useState } from 'react'
+import type { StoredAgentConfig } from '@/lib/acp-agents-persistence'
+import {
+  resolveSupportedAcpAgents,
+  type SupportedAcpAgentEntry
+} from '@/lib/agents/supported-acp-agents'
+
+/**
+ * Resolve supported ACP agents from the host-resolved catalog (CAP-6 / Story 8).
+ *
+ * The host is the single source of truth for OS, arch, runtime availability,
+ * and per-agent installability status — the renderer never probes
+ * `@tauri-apps/plugin-os` or PATH locally. Returns an empty list until the
+ * first catalog resolution completes so callers can render an empty/loading
+ * state without flashing the desktop-only `currentPlatformArch()` derivation.
+ * Re-resolves when `persistedConfigs` changes (e.g. the user saves a new agent
+ * config so it is projected as `ready`).
+ */
+export function useResolvedSupportedAcpAgents(
+  persistedConfigs: readonly StoredAgentConfig[]
+): readonly SupportedAcpAgentEntry[] {
+  const [entries, setEntries] = useState<readonly SupportedAcpAgentEntry[]>([])
+
+  useEffect(() => {
+    let cancelled = false
+    void resolveSupportedAcpAgents(persistedConfigs)
+      .then((resolved) => {
+        if (!cancelled) setEntries(resolved)
+      })
+      .catch(() => {
+        // A rejected catalog resolution must not leave the hook stuck or
+        // surface an unhandled rejection. Treat failure as "no agents"
+        // (callers fall back to default-agent selection which handles empty).
+        if (!cancelled) setEntries([])
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [persistedConfigs])
+
+  return entries
+}

--- a/src/renderer/lib/__tests__/parity-checklist.test.ts
+++ b/src/renderer/lib/__tests__/parity-checklist.test.ts
@@ -504,6 +504,105 @@ describe('Parity Checklist Automation', () => {
     })
   })
 
+  // CAP-6 / Story 8: ACP Catalog parity. Mirrors the Workspace Manifest block:
+  // the host-resolved catalog ships on THREE transports (Tauri command
+  // `acp_list_catalog` / `acp_set_catalog_opt_in`, HTTP `GET /acp/catalog` /
+  // `POST /acp/catalog/opt-in`, WS `list_acp_catalog` / `set_catalog_opt_in`).
+  // This block pins the TS-side parity (the Rust-side parity — router route +
+  // ws handler + Tauri command registration — is covered by the Rust test
+  // suite).
+  describe('ACP Catalog parity (CAP-6)', () => {
+    const TauriAdapter = join(LIB_DIR, 'tauri-acp-catalog-api.ts')
+    const WebAdapter = join(LIB_DIR, 'web-acp-catalog-api.ts')
+
+    it('tauri-acp-catalog-api.ts exists and exports the factory', () => {
+      expect(existsSync(TauriAdapter), 'tauri-acp-catalog-api.ts should exist').toBe(true)
+      expect(
+        fileContains(
+          'tauri-acp-catalog-api.ts',
+          /export\s+(const|function)\s+\bcreateTauriAcpCatalogApi\b/
+        ),
+        'should export createTauriAcpCatalogApi'
+      ).toBe(true)
+    })
+
+    it('web-acp-catalog-api.ts exists and exports the singleton', () => {
+      expect(existsSync(WebAdapter), 'web-acp-catalog-api.ts should exist').toBe(true)
+      expect(
+        fileContains('web-acp-catalog-api.ts', /export\s+const\s+\bwebAcpCatalogApi\b/),
+        'should export webAcpCatalogApi'
+      ).toBe(true)
+    })
+
+    it('facade singleton exists and branches Tauri vs web by isTauriContext()', () => {
+      const facade = join(LIB_DIR, 'acp-catalog-api.ts')
+      expect(existsSync(facade), 'acp-catalog-api.ts should exist').toBe(true)
+      const content = readFileSync(facade, 'utf-8')
+      expect(content).toMatch(/isTauriContext\(\)/)
+      expect(content).toMatch(/createTauriAcpCatalogApi/)
+      expect(content).toMatch(/webAcpCatalogApi/)
+    })
+
+    it('api.ts exports the acpCatalogApi singleton', () => {
+      const apiPath = join(LIB_DIR, 'api.ts')
+      const content = readFileSync(apiPath, 'utf-8')
+      expect(content).toMatch(/export\s*\{[^}]*\bacpCatalogApi\b[^}]*\}/)
+    })
+
+    it('Tauri adapter invokes the catalog commands (list_catalog + set_catalog_opt_in)', () => {
+      const content = readFileSync(TauriAdapter, 'utf-8')
+      expect(content).toMatch(/acp_list_catalog/)
+      expect(content).toMatch(/acp_set_catalog_opt_in/)
+    })
+
+    it('Web adapter hits the catalog routes (GET /acp/catalog + POST /acp/catalog/opt-in)', () => {
+      const content = readFileSync(WebAdapter, 'utf-8')
+      expect(content).toMatch(/\/acp\/catalog/)
+      expect(content).toMatch(/\/acp\/catalog\/opt-in/)
+      // Network/parse failures must map to `NETWORK_ERROR`.
+      expect(content).toMatch(/NETWORK_ERROR/)
+    })
+
+    it('both adapters expose listCatalog + setCatalogOptIn + isCatalogOptedIn on the typed facade', () => {
+      const tauri = readFileSync(TauriAdapter, 'utf-8')
+      const web = readFileSync(WebAdapter, 'utf-8')
+      for (const method of ['listCatalog', 'setCatalogOptIn', 'isCatalogOptedIn']) {
+        expect(tauri, `tauri-acp-catalog-api.ts should implement ${method}`).toMatch(
+          new RegExp(`\\b${method}\\s*\\(`)
+        )
+        expect(web, `web-acp-catalog-api.ts should implement ${method}`).toMatch(
+          new RegExp(`\\b${method}\\s*\\(`)
+        )
+      }
+    })
+
+    it('shared types file exists with expected exports', () => {
+      const typesPath = join(LIB_DIR, '..', '..', 'shared', 'types', 'acp-catalog.types.ts')
+      expect(existsSync(typesPath), 'acp-catalog.types.ts should exist').toBe(true)
+      const content = readFileSync(typesPath, 'utf-8')
+      expect(content).toMatch(/export\s+interface\s+AcpCatalog\b/)
+      expect(content).toMatch(/export\s+interface\s+CatalogAgent\b/)
+      expect(content).toMatch(/export\s+type\s+SupportedAcpAgentStatus\b/)
+      expect(content).toMatch(/export\s+type\s+CatalogSource\b/)
+      expect(content).toMatch(/export\s+interface\s+SetCatalogOptInRequest\b/)
+    })
+
+    it('ipc.types.ts declares the AcpCatalogIpcChannels map', () => {
+      const ipcPath = join(LIB_DIR, '..', '..', 'shared', 'types', 'ipc.types.ts')
+      const content = readFileSync(ipcPath, 'utf-8')
+      expect(content).toMatch(/AcpCatalogIpcChannels\b/)
+      expect(content).toMatch(/'acp:catalog:list'/)
+      expect(content).toMatch(/'acp:catalog:set_opt_in'/)
+    })
+
+    it('web-protocol.types.ts declares the WS request types for catalog', () => {
+      const protoPath = join(LIB_DIR, '..', '..', 'shared', 'types', 'web-protocol.types.ts')
+      const content = readFileSync(protoPath, 'utf-8')
+      expect(content).toMatch(/'list_acp_catalog'/)
+      expect(content).toMatch(/'set_catalog_opt_in'/)
+    })
+  })
+
   // Epic 7 — cross-client workspace continuity: the explicit host-default
   // change ships on THREE transports (Tauri command `set_host_default_project`,
   // HTTP `POST /projects/default`, WS `set_default_project` request). This

--- a/src/renderer/lib/__tests__/parity-checklist.test.ts
+++ b/src/renderer/lib/__tests__/parity-checklist.test.ts
@@ -603,6 +603,95 @@ describe('Parity Checklist Automation', () => {
     })
   })
 
+  // CAP-6 / Story 9: ACP Install parity. The host-owned verified-atomic
+  // install ships on THREE transports (Tauri command `acp_install_agent`,
+  // HTTP `POST /acp/install`, WS `install_acp_agent`). This block pins the
+  // TS-side parity (the Rust-side parity — router route + ws handler + Tauri
+  // command registration — is covered by the Rust test suite).
+  describe('ACP Install parity (CAP-6)', () => {
+    const TauriAdapter = join(LIB_DIR, 'tauri-acp-install-api.ts')
+    const WebAdapter = join(LIB_DIR, 'web-acp-install-api.ts')
+
+    it('tauri-acp-install-api.ts exists and exports the factory', () => {
+      expect(existsSync(TauriAdapter), 'tauri-acp-install-api.ts should exist').toBe(true)
+      expect(
+        fileContains(
+          'tauri-acp-install-api.ts',
+          /export\s+(const|function)\s+\bcreateTauriAcpInstallApi\b/
+        ),
+        'should export createTauriAcpInstallApi'
+      ).toBe(true)
+    })
+
+    it('web-acp-install-api.ts exists and exports the singleton', () => {
+      expect(existsSync(WebAdapter), 'web-acp-install-api.ts should exist').toBe(true)
+      expect(
+        fileContains('web-acp-install-api.ts', /export\s+const\s+\bwebAcpInstallApi\b/),
+        'should export webAcpInstallApi'
+      ).toBe(true)
+    })
+
+    it('facade singleton exists and branches Tauri vs web by isTauriContext()', () => {
+      const facade = join(LIB_DIR, 'acp-install-api.ts')
+      expect(existsSync(facade), 'acp-install-api.ts should exist').toBe(true)
+      const content = readFileSync(facade, 'utf-8')
+      expect(content).toMatch(/isTauriContext\(\)/)
+      expect(content).toMatch(/createTauriAcpInstallApi/)
+      expect(content).toMatch(/webAcpInstallApi/)
+    })
+
+    it('api.ts exports the acpInstallApi singleton', () => {
+      const apiPath = join(LIB_DIR, 'api.ts')
+      const content = readFileSync(apiPath, 'utf-8')
+      expect(content).toMatch(/export\s*\{[^}]*\bacpInstallApi\b[^}]*\}/)
+    })
+
+    it('Tauri adapter invokes the install command (acp_install_agent)', () => {
+      const content = readFileSync(TauriAdapter, 'utf-8')
+      expect(content).toMatch(/acp_install_agent/)
+    })
+
+    it('Web adapter hits the install route (POST /acp/install)', () => {
+      const content = readFileSync(WebAdapter, 'utf-8')
+      expect(content).toMatch(/\/acp\/install/)
+      // Network/parse failures must map to `NETWORK_ERROR`.
+      expect(content).toMatch(/NETWORK_ERROR/)
+    })
+
+    it('both adapters expose installAgent on the typed facade', () => {
+      const tauri = readFileSync(TauriAdapter, 'utf-8')
+      const web = readFileSync(WebAdapter, 'utf-8')
+      expect(tauri, 'tauri-acp-install-api.ts should implement installAgent').toMatch(
+        /\binstallAgent\s*\(/
+      )
+      expect(web, 'web-acp-install-api.ts should implement installAgent').toMatch(
+        /\binstallAgent\s*\(/
+      )
+    })
+
+    it('shared types file exists with expected exports', () => {
+      const typesPath = join(LIB_DIR, '..', '..', 'shared', 'types', 'acp-install.types.ts')
+      expect(existsSync(typesPath), 'acp-install.types.ts should exist').toBe(true)
+      const content = readFileSync(typesPath, 'utf-8')
+      expect(content).toMatch(/export\s+interface\s+InstallRequest\b/)
+      expect(content).toMatch(/export\s+interface\s+InstallOutcome\b/)
+      expect(content).toMatch(/export\s+type\s+InstallErrorCode\b/)
+    })
+
+    it('ipc.types.ts declares the AcpInstallIpcChannels map', () => {
+      const ipcPath = join(LIB_DIR, '..', '..', 'shared', 'types', 'ipc.types.ts')
+      const content = readFileSync(ipcPath, 'utf-8')
+      expect(content).toMatch(/AcpInstallIpcChannels\b/)
+      expect(content).toMatch(/'acp:install:install_agent'/)
+    })
+
+    it('web-protocol.types.ts declares the WS request type for install', () => {
+      const protoPath = join(LIB_DIR, '..', '..', 'shared', 'types', 'web-protocol.types.ts')
+      const content = readFileSync(protoPath, 'utf-8')
+      expect(content).toMatch(/'install_acp_agent'/)
+    })
+  })
+
   // Epic 7 — cross-client workspace continuity: the explicit host-default
   // change ships on THREE transports (Tauri command `set_host_default_project`,
   // HTTP `POST /projects/default`, WS `set_default_project` request). This

--- a/src/renderer/lib/__tests__/parity-checklist.test.ts
+++ b/src/renderer/lib/__tests__/parity-checklist.test.ts
@@ -738,4 +738,166 @@ describe('Parity Checklist Automation', () => {
       expect(content).toMatch(/\/projects\/default/)
     })
   })
+
+  // CAP-1/CAP-2: ACP history parity. The host owns the session transcript (the
+  // cross-client authority). The desktop reads it via the `acp_history_*`
+  // Tauri commands (ChatHistoryStore); the web/cross-client path serves it via
+  // the WS `get_session_payload` handler (SessionPersistence). There is NO HTTP
+  // `/acp/sessions` route BY DESIGN — the web client fetches the payload over
+  // the SAME WS connection (the host WS handler + durable store ARE the
+  // cross-client authority, not a separate HTTP route). This block pins both
+  // transports + the WS request types + the desktop facade.
+  describe('ACP History parity (CAP-1/CAP-2)', () => {
+    const HistoryFacade = join(LIB_DIR, 'acp-history-api.ts')
+    const ProtoTypes = join(LIB_DIR, '..', '..', 'shared', 'types', 'web-protocol.types.ts')
+    const WsRust = join(LIB_DIR, '..', '..', '..', 'src-tauri', 'src', 'web', 'ws.rs')
+
+    it('acp-history-api.ts exists + calls the host (invoke), never localStorage', () => {
+      expect(existsSync(HistoryFacade), 'acp-history-api.ts should exist').toBe(true)
+      const content = readFileSync(HistoryFacade, 'utf-8')
+      expect(content).toMatch(/invoke/) // desktop → host Tauri command
+      expect(content).toMatch(/acp_history_list/)
+      expect(content).toMatch(/acp_history_get/)
+      expect(content).not.toMatch(/localStorage(?:\.|\[)/) // host is the authority
+    })
+
+    it('web-protocol.types.ts declares the WS request types list_sessions + get_session_payload', () => {
+      expect(existsSync(ProtoTypes), 'web-protocol.types.ts should exist').toBe(true)
+      const content = readFileSync(ProtoTypes, 'utf-8')
+      expect(content).toMatch(/'list_sessions'/)
+      expect(content).toMatch(/'get_session_payload'/)
+    })
+
+    it('ws.rs implements handle_get_session_payload (the host cross-client authority)', () => {
+      // The web/cross-client path: the WS handler materializes the transcript
+      // from the host's durable store — no HTTP route, no client storage.
+      expect(existsSync(WsRust), 'ws.rs should exist').toBe(true)
+      const content = readFileSync(WsRust, 'utf-8')
+      expect(content).toMatch(/fn handle_get_session_payload/)
+      expect(content).toMatch(/handle_send_prompt/)
+    })
+  })
+
+  // CAP-4: Agent spawn metadata parity. The spawn RESPONSE (not the async
+  // `agent_spawned` event) is the single source of truth for the agent's
+  // negotiated capabilities + auth methods + stable namespace — the renderer
+  // populates them synchronously from the response. This block pins the Rust
+  // `SpawnOutcome` struct + the TS `SpawnAgentResult` shape + the WS request
+  // type + the Tauri command + the `agent_spawned` event channel.
+  describe('Agent Spawn Metadata parity (CAP-4)', () => {
+    const AcpApi = join(LIB_DIR, 'acp-api.ts')
+    const ProtoTypes = join(LIB_DIR, '..', '..', 'shared', 'types', 'web-protocol.types.ts')
+    const CommandsRust = join(LIB_DIR, '..', '..', '..', 'src-tauri', 'src', 'acp', 'commands.rs')
+    const ManagerRust = join(LIB_DIR, '..', '..', '..', 'src-tauri', 'src', 'acp', 'manager.rs')
+
+    it('Rust SpawnOutcome carries capabilities + auth_methods + stable_namespace', () => {
+      expect(existsSync(ManagerRust), 'manager.rs should exist').toBe(true)
+      const content = readFileSync(ManagerRust, 'utf-8')
+      expect(content).toMatch(/struct SpawnOutcome/)
+      expect(content).toMatch(/pub capabilities:/)
+      expect(content).toMatch(/pub auth_methods:/)
+      expect(content).toMatch(/pub stable_namespace:/)
+    })
+
+    it('TS SpawnAgentResult carries capabilities + authMethods + stableNamespace', () => {
+      expect(existsSync(AcpApi), 'acp-api.ts should exist').toBe(true)
+      const content = readFileSync(AcpApi, 'utf-8')
+      expect(content).toMatch(/interface SpawnAgentResult/)
+      expect(content).toMatch(/capabilities:\s*AgentCapabilities/)
+      expect(content).toMatch(/authMethods:\s*AuthMethod\[\]/)
+      expect(content).toMatch(/stableNamespace\?:\s*string/)
+    })
+
+    it('WS request type spawn_agent + the agent_spawned event are declared', () => {
+      expect(existsSync(ProtoTypes), 'web-protocol.types.ts should exist').toBe(true)
+      const content = readFileSync(ProtoTypes, 'utf-8')
+      expect(content).toMatch(/'spawn_agent'/)
+      expect(content).toMatch(/agent_spawned/) // the event channel (reliability tier)
+    })
+
+    it('Tauri command acp_spawn_agent is registered', () => {
+      expect(existsSync(CommandsRust), 'acp/commands.rs should exist').toBe(true)
+      const content = readFileSync(CommandsRust, 'utf-8')
+      expect(content).toMatch(/acp_spawn_agent/)
+    })
+  })
+
+  // Category E: cross-client host-authority composition. The host (Tauri
+  // `invoke` / HTTP `fetch` / WS handler + durable store) is the single
+  // authority for cross-client state — NOT the browser's `localStorage`. This
+  // block statically asserts every cross-client state facade reaches for the
+  // host, never the `localStorage` API:
+  //   - acp-history-api.ts          → invoke (desktop Tauri command)
+  //   - workspace-manifest-api.ts   → branches to host-backed adapters
+  //   - terminal-api.ts + adapters  → invoke (desktop) / WS (web)
+  //   - use-workspace-manifest-sync → reads via workspaceManifestApi.getManifest
+  //   - acp-transport.ts            → subscribes via WS subscribe + lastSeq
+  //
+  // NOTE: real-browser Playwright/Cypress tests (mobile suspension, reconnect,
+  // reload, handoff) are deferred pending a real-browser harness introduction
+  // (a separate infrastructure task). This static composition block is the
+  // contract-correct substitute: it proves the code paths reach for the host,
+  // not localStorage — the authority model the contract requires.
+  describe('Cross-client host-authority (CAP-1..6)', () => {
+    const HistoryFacade = join(LIB_DIR, 'acp-history-api.ts')
+    const ManifestFacade = join(LIB_DIR, 'workspace-manifest-api.ts')
+    const TerminalFacade = join(LIB_DIR, 'terminal-api.ts')
+    const TauriTerminalAdapter = join(LIB_DIR, 'tauri-terminal-api.ts')
+    const WebTerminalAdapter = join(LIB_DIR, 'web-terminal-api.ts')
+    const ManifestSyncHook = join(LIB_DIR, '..', 'hooks', 'use-workspace-manifest-sync.ts')
+    const Transport = join(LIB_DIR, 'acp-transport.ts')
+
+    it('acp-history-api.ts calls the host (invoke), never localStorage', () => {
+      expect(existsSync(HistoryFacade)).toBe(true)
+      const content = readFileSync(HistoryFacade, 'utf-8')
+      expect(content).toMatch(/invoke/)
+      expect(content).not.toMatch(/localStorage(?:\.|\[)/)
+    })
+
+    it('workspace-manifest-api.ts branches to host-backed adapters, never localStorage', () => {
+      expect(existsSync(ManifestFacade)).toBe(true)
+      const content = readFileSync(ManifestFacade, 'utf-8')
+      expect(content).toMatch(/isTauriContext\(\)/)
+      expect(content).not.toMatch(/localStorage(?:\.|\[)/)
+    })
+
+    it('terminal-api.ts + adapters route claims through the host (invoke/WS), never localStorage', () => {
+      expect(existsSync(TerminalFacade)).toBe(true)
+      const facade = readFileSync(TerminalFacade, 'utf-8')
+      expect(facade).toMatch(/isTauriContext\(\)/)
+      expect(facade).toMatch(/createTauriTerminalApi/)
+      expect(facade).not.toMatch(/localStorage(?:\.|\[)/)
+      // The Tauri adapter implements attach/rotateClaim/revokeClaim via invoke.
+      expect(existsSync(TauriTerminalAdapter)).toBe(true)
+      const tauri = readFileSync(TauriTerminalAdapter, 'utf-8')
+      expect(tauri).toMatch(/invoke/)
+      for (const m of ['attach', 'rotateClaim', 'revokeClaim']) {
+        expect(tauri, `tauri-terminal-api.ts should implement ${m}`).toMatch(
+          new RegExp(`\\b${m}\\s*\\(`)
+        )
+      }
+      expect(tauri).not.toMatch(/localStorage(?:\.|\[)/)
+      // The web adapter is WS-backed (the host WS is the authority) — no localStorage.
+      expect(existsSync(WebTerminalAdapter)).toBe(true)
+      expect(readFileSync(WebTerminalAdapter, 'utf-8')).not.toMatch(/localStorage(?:\.|\[)/)
+    })
+
+    it('use-workspace-manifest-sync reads via workspaceManifestApi.getManifest, never localStorage', () => {
+      expect(existsSync(ManifestSyncHook), 'use-workspace-manifest-sync.ts should exist').toBe(true)
+      const content = readFileSync(ManifestSyncHook, 'utf-8')
+      expect(content).toMatch(/workspaceManifestApi/)
+      expect(content).toMatch(/getManifest/)
+      expect(content).not.toMatch(/localStorage(?:\.|\[)/)
+    })
+
+    it('acp-transport.ts subscribes via WS subscribe + lastSeq, never localStorage as the cursor', () => {
+      expect(existsSync(Transport)).toBe(true)
+      const content = readFileSync(Transport, 'utf-8')
+      expect(content).toMatch(/subscribeSession/)
+      expect(content).toMatch(/lastSeq/)
+      // The cursor authority is the host (WS subscribe lastSeq / server
+      // watermark), never the `localStorage` persistence API.
+      expect(content).not.toMatch(/localStorage(?:\.|\[)/)
+    })
+  })
 })

--- a/src/renderer/lib/acp-api.ts
+++ b/src/renderer/lib/acp-api.ts
@@ -496,6 +496,20 @@ export async function acpInstallRegistryBinary(
   return getAcpTransport().installRegistryBinary(request)
 }
 
+/**
+ * CAP-6 / Story 9: host-owned verified-atomic install. The request is
+ * `{ agentId }` only; the host resolves everything (archive URL, cmd, args,
+ * sha256) from the trusted catalog. The outcome `{ command, args }` flows
+ * through `installedBinaryConfig` → `saveAgentConfig` unchanged. Mirrors the
+ * `acp_install_agent` Tauri command + `POST /acp/install` + WS
+ * `install_acp_agent` byte-for-byte.
+ */
+export async function acpInstallAcpAgent(
+  agentId: string
+): Promise<InstallAcpRegistryBinaryOutcome> {
+  return getAcpTransport().installAcpAgent(agentId)
+}
+
 export async function acpProbeRuntime(): Promise<AcpRuntimeAvailability> {
   return getAcpTransport().probeRuntime()
 }
@@ -733,6 +747,7 @@ export const acpApi = {
   setSessionReopenTimeout: acpSetSessionReopenTimeout,
   setFirstPromptWarmupTimeout: acpSetFirstPromptWarmupTimeout,
   installRegistryBinary: acpInstallRegistryBinary,
+  installAcpAgent: acpInstallAcpAgent,
   probeRuntime: acpProbeRuntime,
   probeMcpServer,
   listMcpTools,

--- a/src/renderer/lib/acp-catalog-api.ts
+++ b/src/renderer/lib/acp-catalog-api.ts
@@ -1,0 +1,30 @@
+/**
+ * ACP catalog API singleton (CAP-6 / Story 8).
+ *
+ * Resolves to the Tauri IPC impl when running inside a Tauri webview; the
+ * fetch-backed HTTP impl when running as a web/remote client. Both impls
+ * return the same `IpcResult<...>` shape byte-for-byte (the
+ * `parity-checklist.test.ts` pins this).
+ *
+ * The host is the single source of truth for: OS, arch, runtime availability,
+ * and per-agent installability status. Web clients consume the host's answer;
+ * they never probe `@tauri-apps/plugin-os` or PATH locally.
+ */
+
+import type { AcpCatalogApi } from '@shared/types/acp-catalog.types'
+import { createTauriAcpCatalogApi } from './tauri-acp-catalog-api'
+import { isTauriContext } from './tauri-runtime'
+import { webAcpCatalogApi } from './web-acp-catalog-api'
+
+/**
+ * Singleton `AcpCatalogApi` instance.
+ *
+ * Uses the Tauri IPC implementation when running in a Tauri webview.
+ * Uses the fetch-backed HTTP implementation when running in a browser.
+ */
+export const acpCatalogApi: AcpCatalogApi = isTauriContext()
+  ? createTauriAcpCatalogApi()
+  : webAcpCatalogApi
+
+export { createTauriAcpCatalogApi } from './tauri-acp-catalog-api'
+export { webAcpCatalogApi } from './web-acp-catalog-api'

--- a/src/renderer/lib/acp-install-api.ts
+++ b/src/renderer/lib/acp-install-api.ts
@@ -1,0 +1,32 @@
+/**
+ * ACP install API singleton (CAP-6 / Story 9).
+ *
+ * Resolves to the Tauri IPC impl when running inside a Tauri webview; the
+ * fetch-backed HTTP impl when running as a web/remote client. Both impls
+ * return the same `IpcResult<...>` shape byte-for-byte (the
+ * `parity-checklist.test.ts` pins this).
+ *
+ * The host is the single source of truth for the install: it resolves the
+ * agent by id from the catalog, downloads the HTTPS archive, verifies sha256
+ * (from the catalog's `binary.{os-arch}.sha256` field), extracts safely,
+ * atomically activates, serializes per-agent, records the manifest, and
+ * returns `{ command, args }`. The browser request carries only `{ agentId }`.
+ */
+
+import type { AcpInstallApi } from '@shared/types/acp-install.types'
+import { createTauriAcpInstallApi } from './tauri-acp-install-api'
+import { isTauriContext } from './tauri-runtime'
+import { webAcpInstallApi } from './web-acp-install-api'
+
+/**
+ * Singleton `AcpInstallApi` instance.
+ *
+ * Uses the Tauri IPC implementation when running in a Tauri webview.
+ * Uses the fetch-backed HTTP implementation when running in a browser.
+ */
+export const acpInstallApi: AcpInstallApi = isTauriContext()
+  ? createTauriAcpInstallApi()
+  : webAcpInstallApi
+
+export { createTauriAcpInstallApi } from './tauri-acp-install-api'
+export { webAcpInstallApi } from './web-acp-install-api'

--- a/src/renderer/lib/acp-transport.test.ts
+++ b/src/renderer/lib/acp-transport.test.ts
@@ -1595,6 +1595,7 @@ describe('createAcpTransport selection', () => {
   it('accepts an injected transport via test helper', async () => {
     const mock = {
       installRegistryBinary: vi.fn(),
+      installAcpAgent: vi.fn(),
       probeRuntime: vi.fn().mockResolvedValue({ npx: true, uvx: true }),
       fetchRegistrySnapshot: vi.fn(),
       spawnAgent: vi.fn(),

--- a/src/renderer/lib/acp-transport.test.ts
+++ b/src/renderer/lib/acp-transport.test.ts
@@ -35,6 +35,10 @@ class FakeWebSocket {
   /** Live agent ids for spawn_agent / list_agents / kill_agent stubs. */
   liveAgents = new Set<string>()
   switchProjectReply: unknown = null
+  /** CAP-6 / Story 8: when set, `list_acp_catalog` replies with this catalog
+   * payload; unset → falls through to the `not_implemented` fallback (so
+   * `probeRuntime`/`fetchRegistrySnapshot` degrade gracefully). */
+  catalogReply: unknown = null
   historyMode: 'server' | 'live_only' = 'server'
   runtimePolicy = {
     turnTimeoutMs: 3_600_000,
@@ -120,6 +124,14 @@ class FakeWebSocket {
     }
     if (req.type === 'switch_project' && this.switchProjectReply) {
       this.emitReply({ id: req.id, ok: true, payload: this.switchProjectReply })
+      return
+    }
+    // CAP-6 / Story 8: the WS transport resolves the ACP catalog through
+    // `list_acp_catalog` (the host's OS/arch/runtime + per-agent status). When
+    // `catalogReply` is set, reply with it; otherwise fall through to the
+    // `not_implemented` stub so `probeRuntime`/`fetchRegistrySnapshot` degrade.
+    if (req.type === 'list_acp_catalog' && this.catalogReply) {
+      this.emitReply({ id: req.id, ok: true, payload: this.catalogReply })
       return
     }
     if (req.type === 'create_session') {
@@ -348,6 +360,69 @@ describe('WsAcpTransport', () => {
     await transport.setFirstPromptWarmupTimeout(0)
 
     expect(sock.sent.length).toBe(sentBefore)
+    transport.dispose()
+  })
+
+  // CAP-6 / Story 8: the fake `probeRuntime`/`fetchRegistrySnapshot` stubs
+  // (hardcoded `{npx:true,uvx:true}` / `{agents:[]}`) are replaced by a real
+  // `list_acp_catalog` WS request — the host probes npx/uvx/node/bun/python3
+  // and returns the resolved catalog. These tests pin the request shape + the
+  // reply mapping + the graceful degradation when the host is unavailable.
+  it('probeRuntime sends list_acp_catalog and maps host.runtimes', async () => {
+    const transport = new WsAcpTransport({
+      url: 'ws://test/ws',
+      WebSocketImpl: FakeWebSocket as unknown as typeof WebSocket
+    })
+    await transport.connect()
+    const sock = (transport as unknown as { socket: FakeWebSocket }).socket
+    sock.catalogReply = {
+      host: {
+        os: 'linux',
+        arch: 'x86_64',
+        runtimes: { npx: true, uvx: false, node: true, bun: false, python3: true }
+      },
+      agents: []
+    }
+
+    const runtime = await transport.probeRuntime()
+    expect(runtime).toEqual({ npx: true, uvx: false })
+
+    const sent = sock.sent.map((s) => JSON.parse(s) as { type: string; payload: unknown })
+    expect(sent.some((r) => r.type === 'list_acp_catalog')).toBe(true)
+    transport.dispose()
+  })
+
+  it('fetchRegistrySnapshot sends list_acp_catalog and maps agents', async () => {
+    const transport = new WsAcpTransport({
+      url: 'ws://test/ws',
+      WebSocketImpl: FakeWebSocket as unknown as typeof WebSocket
+    })
+    await transport.connect()
+    const sock = (transport as unknown as { socket: FakeWebSocket }).socket
+    sock.catalogReply = {
+      host: { os: 'linux', arch: 'x86_64', runtimes: {} },
+      agents: [{ id: 'a', name: 'A', source: 'bundled', distribution: {} }]
+    }
+
+    const snapshot = await transport.fetchRegistrySnapshot()
+    expect(snapshot.agents).toHaveLength(1)
+    expect(snapshot.source).toBe('network')
+
+    const sent = sock.sent.map((s) => JSON.parse(s) as { type: string })
+    expect(sent.some((r) => r.type === 'list_acp_catalog')).toBe(true)
+    transport.dispose()
+  })
+
+  it('probeRuntime degrades to no-runtimes when the catalog is unavailable', async () => {
+    const transport = new WsAcpTransport({
+      url: 'ws://test/ws',
+      WebSocketImpl: FakeWebSocket as unknown as typeof WebSocket
+    })
+    await transport.connect()
+    // catalogReply unset → `list_acp_catalog` hits the not_implemented fallback;
+    // the transport catches and degrades gracefully.
+    const runtime = await transport.probeRuntime()
+    expect(runtime).toEqual({ npx: false, uvx: false })
     transport.dispose()
   })
 

--- a/src/renderer/lib/acp-transport.test.ts
+++ b/src/renderer/lib/acp-transport.test.ts
@@ -687,6 +687,52 @@ describe('WsAcpTransport', () => {
     transport.dispose()
   })
 
+  it('reload simulates cursor-replay-then-continue (fresh transport + fresh socket)', async () => {
+    // Category B/E: simulate a page reload by creating a FRESH transport
+    // whose `lastSeq` cursor is restored from the HOST (the cross-client
+    // authority — not the old transport's in-memory state, which a reload
+    // discards). The existing reconnect tests reuse the SAME transport
+    // instance; this creates a NEW one to model a true page reload where
+    // `seenTurnIds` + `lastSeq` are re-seeded from the host (e.g.
+    // `get_session_cursor`), then a NEW socket replays the tail.
+    const transport = new WsAcpTransport({
+      url: 'ws://test/ws',
+      WebSocketImpl: FakeWebSocket as unknown as typeof WebSocket
+    })
+    await transport.connect()
+    const sock = (transport as unknown as { socket: FakeWebSocket }).socket
+    const lastSeq = (transport as unknown as { lastSeq: Map<string, number> }).lastSeq
+    // Cursor pre-seeded to 5 (simulating the result of a host restore —
+    // the 5 events the previous page saw). The block comment above explains
+    // this models a host-driven cursor restore; this test does NOT call the
+    // host directly (it pre-seeds the cursor the host would have returned).
+    lastSeq.set('sess-reload', 5)
+
+    const calls: unknown[] = []
+    transport.onEvent('acp:tool_call', (p) => calls.push(p))
+    const chunks: unknown[] = []
+    transport.onEvent('acp:message_chunk', (p) => chunks.push(p))
+
+    // The NEW socket replays seqs <= 5 (already seen before the reload) — the
+    // fresh transport dedups them (never re-delivered).
+    sock.emit({ sid: 'sess-reload', seq: 4, type: 'tool_call', payload: { n: 4 } })
+    sock.emit({ sid: 'sess-reload', seq: 5, type: 'tool_call', payload: { n: 5 } })
+    expect(calls).toEqual([])
+
+    // Reliable seqs 6-10 are delivered in order, advancing the cursor.
+    for (let i = 6; i <= 10; i++) {
+      sock.emit({ sid: 'sess-reload', seq: i, type: 'tool_call', payload: { n: i } })
+    }
+    expect(calls).toEqual([6, 7, 8, 9, 10].map((n) => ({ n })))
+
+    // A lossy seq 11 is also delivered + the cursor advances to 11.
+    sock.emit({ sid: 'sess-reload', seq: 11, type: 'message_chunk', payload: { n: 11 } })
+    await Promise.resolve() // flush the lossy delivery path
+    expect(chunks).toEqual([{ n: 11 }])
+    expect(lastSeq.get('sess-reload')).toBe(11)
+    transport.dispose()
+  })
+
   it('on stale subscribe installs an atomic server-history snapshot', async () => {
     const transport = new WsAcpTransport({
       url: 'ws://test/ws',

--- a/src/renderer/lib/acp-transport.ts
+++ b/src/renderer/lib/acp-transport.ts
@@ -54,6 +54,21 @@ import type { AcpRuntimeAvailability } from '@/lib/agents/supported-acp-agents'
 import { isTauriContext } from '@/lib/tauri-runtime'
 import { webServerMcpProbe } from '@/lib/web-server-api'
 
+/**
+ * CAP-6 / Story 8: the host-resolved catalog shape returned by the WS
+ * `list_acp_catalog` request. Mirrors `AcpCatalog` from
+ * `@shared/types/acp-catalog.types` but kept local to avoid a cross-module
+ * import cycle (acp-transport ↔ acp-catalog-api). The shape is byte-identical.
+ */
+interface AcpCatalogFromHost {
+  host: {
+    os: string
+    arch: string
+    runtimes: { npx: boolean; uvx: boolean; node: boolean; bun: boolean; python3: boolean }
+  }
+  agents: unknown[]
+}
+
 /** Thrown on WS (and mapped) failures — callers may toast `.message`. */
 export class AcpTransportError extends Error {
   readonly code: string
@@ -568,8 +583,31 @@ export class WsAcpTransport implements AcpTransport {
     throw new AcpTransportError('unsupported', 'Registry binary install is desktop-only')
   }
 
+  /**
+   * CAP-6 / Story 8: probeRuntime is replaced by the host-resolved catalog.
+   * The web client calls `acpCatalogApi.listCatalog()` (the facade) which
+   * returns the host's `host.runtimes` block — the web client never probes
+   * `@tauri-apps/plugin-os` or PATH locally. This method now returns the
+   * host's runtime availability from the catalog; callers that only need the
+   * runtime probe (the existing `useAcpAgents` hook) switch to
+   * `listCatalog()` instead.
+   */
   async probeRuntime(): Promise<AcpRuntimeAvailability> {
-    return { npx: true, uvx: true }
+    // Delegate to the host-resolved catalog. The WS transport sends a
+    // `list_acp_catalog` request; the host probes npx/uvx/node/bun/python3
+    // and returns the result. This replaces the fake `{npx:true,uvx:true}`
+    // hardcoded stub (CAP-6: the host is the single source of truth).
+    try {
+      const catalog = await this.request<AcpCatalogFromHost>('list_acp_catalog', {})
+      return {
+        npx: catalog.host.runtimes.npx,
+        uvx: catalog.host.runtimes.uvx
+      }
+    } catch {
+      // Degrade gracefully: if the catalog is unavailable, assume no
+      // runtimes (the caller will mark agents as needs-runtime).
+      return { npx: false, uvx: false }
+    }
   }
 
   async probeMcpServer(server: McpServerConfig): Promise<ProbeResult> {
@@ -611,8 +649,30 @@ export class WsAcpTransport implements AcpTransport {
     // the first-prompt warmup timeout via TERMUL_ACP_FIRST_PROMPT_WARMUP_SECS.
   }
 
+  /**
+   * CAP-6 / Story 8: fetchRegistrySnapshot is replaced by the host-resolved
+   * catalog. The web client calls `acpCatalogApi.listCatalog()` (the facade)
+   * which returns the host's resolved catalog including CDN entries (when
+   * the opt-in is set). This method now delegates to the WS
+   * `list_acp_catalog` request; the fake `{agents:[]}` hardcoded stub is
+   * removed. Callers that need the full catalog (the registry-catalog hook)
+   * switch to `acpCatalogApi.listCatalog()` instead.
+   */
   async fetchRegistrySnapshot(_forceRefresh = false): Promise<AcpRegistrySnapshot> {
-    return { agents: [], source: 'empty', fetchedAt: null }
+    // Delegate to the host-resolved catalog. The host embeds the trusted
+    // bundled `agents.json` + optionally augments with the CDN snapshot
+    // (gated on the host-persisted opt-in). This replaces the fake
+    // `{agents:[], source:'empty'}` hardcoded stub.
+    try {
+      const catalog = await this.request<AcpCatalogFromHost>('list_acp_catalog', {})
+      return {
+        agents: catalog.agents,
+        source: 'network',
+        fetchedAt: null
+      }
+    } catch {
+      return { agents: [], source: 'empty', fetchedAt: null }
+    }
   }
 
   // --- Agent lifecycle (desktop parity over WS) ----------------------------

--- a/src/renderer/lib/acp-transport.ts
+++ b/src/renderer/lib/acp-transport.ts
@@ -13,6 +13,7 @@
  * (`.message` is the human string callers already toast).
  */
 
+import type { IpcResult } from '@shared/types/ipc.types'
 import type {
   ProjectSwitchCompletedEvent,
   SwitchProjectReply
@@ -84,6 +85,14 @@ export interface AcpTransport {
   installRegistryBinary(
     request: InstallAcpRegistryBinaryRequest
   ): Promise<InstallAcpRegistryBinaryOutcome>
+  /**
+   * CAP-6 / Story 9: host-owned verified-atomic install. The web/remote
+   * transport falls back to the `acpInstallApi` facade (Tauri vs HTTP
+   * resolved at runtime); the desktop transport delegates to the new
+   * `acp_install_agent` Tauri command. The request is `{ agentId }` only; the
+   * host resolves everything from the trusted catalog.
+   */
+  installAcpAgent(agentId: string): Promise<InstallAcpRegistryBinaryOutcome>
   probeRuntime(): Promise<AcpRuntimeAvailability>
   setTurnTimeout(secs: number | null): Promise<void>
   setTurnIdleTimeout(secs: number | null): Promise<void>
@@ -201,6 +210,22 @@ function createTauriAcpTransport(): AcpTransport {
   return {
     installRegistryBinary: (request) =>
       invoke<InstallAcpRegistryBinaryOutcome>('acp_install_registry_binary', { request }),
+    // CAP-6 / Story 9: the host-owned verified-atomic install. The Tauri
+    // adapter invokes the new `acp_install_agent` command (the host resolves
+    // the agent by id from the catalog — no browser-supplied URLs/args). The
+    // command returns `IpcResult<InstallOutcome>`; this adapter unwraps the
+    // envelope so the launcher's `installedBinaryConfig(installed, ...)` gets
+    // the bare `{ command, args }` (mirrors the web/WS transport). A failure
+    // throws `AcpTransportError` carrying the install error code.
+    installAcpAgent: async (agentId) => {
+      const result = await invoke<IpcResult<InstallAcpRegistryBinaryOutcome>>('acp_install_agent', {
+        request: { agentId }
+      })
+      if (result.success) {
+        return result.data
+      }
+      throw new AcpTransportError(result.code, result.error)
+    },
     probeRuntime: () => invoke<AcpRuntimeAvailability>('acp_probe_runtime'),
     setTurnTimeout: (secs) => invoke<void>('acp_set_turn_timeout', { secs }),
     setTurnIdleTimeout: (secs) => invoke<void>('acp_set_turn_idle_timeout', { secs }),
@@ -581,6 +606,25 @@ export class WsAcpTransport implements AcpTransport {
     _request: InstallAcpRegistryBinaryRequest
   ): Promise<InstallAcpRegistryBinaryOutcome> {
     throw new AcpTransportError('unsupported', 'Registry binary install is desktop-only')
+  }
+
+  /**
+   * CAP-6 / Story 9: host-owned verified-atomic install. The WS transport
+   * delegates to the `acpInstallApi` facade (resolves Tauri vs HTTP at runtime),
+   * so the web client gets the same verified install path as the desktop. The
+   * facade maps the `IpcResult<InstallOutcome>` success/failure into the
+   * transport's throw-on-error contract — a failure throws `AcpTransportError`
+   * carrying the install error code.
+   */
+  async installAcpAgent(agentId: string): Promise<InstallAcpRegistryBinaryOutcome> {
+    // Lazy import avoids a static cycle (acp-transport ↔ acp-install-api) at
+    // module load; the facade owns the `isTauriContext()` branching.
+    const { acpInstallApi } = await import('./acp-install-api')
+    const result = await acpInstallApi.installAgent(agentId)
+    if (result.success) {
+      return result.data
+    }
+    throw new AcpTransportError(result.code, result.error)
   }
 
   /**

--- a/src/renderer/lib/agents/supported-acp-agents.test.ts
+++ b/src/renderer/lib/agents/supported-acp-agents.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import type { StoredAgentConfig } from '@/lib/acp-agents-persistence'
 import type { RegistryAgent } from '@/lib/agents/acp-registry'
 import {
@@ -6,8 +6,17 @@ import {
   installedBinaryConfig,
   isSupportedAcpConfigId,
   manualBinaryConfig,
-  registryConfigId
+  registryConfigId,
+  resolveSupportedAcpAgents
 } from '@/lib/agents/supported-acp-agents'
+
+// CAP-6 / Story 8: `resolveSupportedAcpAgents` calls `acpCatalogApi.listCatalog()`
+// (the host-resolved catalog). Mock the facade so the wrapper is unit-tested in
+// isolation. The mock is hoisted + file-scoped; the existing
+// `buildSupportedAcpAgents` tests don't touch `acpCatalogApi`, so they're
+// unaffected.
+const { listCatalogMock } = vi.hoisted(() => ({ listCatalogMock: vi.fn() }))
+vi.mock('@/lib/api', () => ({ acpCatalogApi: { listCatalog: listCatalogMock } }))
 
 function agent(id: string, distribution: RegistryAgent['distribution'], name = id): RegistryAgent {
   return { id, name, version: '1.0.0', description: `${name} desc`, distribution }
@@ -189,5 +198,87 @@ describe('installedBinaryConfig', () => {
       env: { OPENCODE: '1' },
       allowTerminal: false
     })
+  })
+})
+
+// CAP-6 / Story 8: the host-resolved catalog wrapper. `resolveSupportedAcpAgents`
+// calls `acpCatalogApi.listCatalog()` and maps `CatalogAgent` →
+// `SupportedAcpAgentEntry`, consuming the host's `host.os`/`host.arch` (NOT the
+// renderer's `currentPlatformArch()` / `@tauri-apps/plugin-os`).
+describe('resolveSupportedAcpAgents', () => {
+  it('maps a host-resolved catalog agent to a supported entry', async () => {
+    listCatalogMock.mockResolvedValueOnce({
+      success: true,
+      data: {
+        host: {
+          os: 'linux',
+          arch: 'x86_64',
+          runtimes: { npx: true, uvx: false, node: true, bun: false, python3: true }
+        },
+        agents: [
+          {
+            id: 'test',
+            name: 'Test',
+            version: '1.0.0',
+            description: 'test agent',
+            source: 'bundled',
+            distribution: { npx: { package: 'test@1.0.0' } },
+            runtimeRequirements: ['npx'],
+            status: 'ready',
+            platformTargets: []
+          }
+        ]
+      }
+    })
+
+    const entries = await resolveSupportedAcpAgents([])
+
+    expect(listCatalogMock).toHaveBeenCalledTimes(1)
+    expect(entries).toHaveLength(1)
+    expect(entries[0]).toMatchObject({
+      id: 'test',
+      configId: 'acp-registry:test',
+      status: 'ready'
+    })
+  })
+
+  it('prefers a persisted config and marks it ready', async () => {
+    listCatalogMock.mockResolvedValueOnce({
+      success: true,
+      data: {
+        host: { os: 'linux', arch: 'x86_64', runtimes: {} },
+        agents: [
+          {
+            id: 'claude-acp',
+            name: 'Claude',
+            version: '1.0.0',
+            description: 'd',
+            source: 'bundled',
+            distribution: { npx: { package: 'claude' } },
+            runtimeRequirements: ['npx'],
+            status: 'needs-runtime',
+            platformTargets: []
+          }
+        ]
+      }
+    })
+    const saved = persisted('claude-acp', 'Claude Override')
+
+    const entries = await resolveSupportedAcpAgents([saved])
+
+    expect(entries[0]?.config).toBe(saved)
+    // Persisted configs are always 'ready' regardless of the host's status.
+    expect(entries[0]?.status).toBe('ready')
+  })
+
+  it('degrades to an empty list when the catalog is unavailable', async () => {
+    listCatalogMock.mockResolvedValueOnce({
+      success: false,
+      error: 'store unavailable',
+      code: 'ACP_CATALOG_UNAVAILABLE'
+    })
+
+    const entries = await resolveSupportedAcpAgents([])
+    expect(entries).toEqual([])
   })
 })

--- a/src/renderer/lib/agents/supported-acp-agents.ts
+++ b/src/renderer/lib/agents/supported-acp-agents.ts
@@ -5,6 +5,7 @@ import {
   type RegistryAgent,
   type RegistryBinaryTarget
 } from '@/lib/agents/acp-registry'
+import { acpCatalogApi } from '@/lib/api'
 
 const REGISTRY_AGENT_IDS = new Set(REGISTRY_AGENTS.map((agent) => agent.id))
 
@@ -269,4 +270,113 @@ export function isSupportedAcpConfigId(configId: string): boolean {
     ? configId.slice('acp-registry:'.length)
     : configId
   return REGISTRY_AGENT_IDS.has(id)
+}
+
+/**
+ * CAP-6 / Story 8: resolve supported ACP agents from the host-resolved
+ * catalog. Replaces the renderer-side `buildSupportedAcpAgents(...)` derivation
+ * (which used `@tauri-apps/plugin-os` — a desktop-only API) with a call to
+ * `acpCatalogApi.listCatalog()`. The host resolves OS/arch/runtime + per-agent
+ * `SupportedAcpAgentStatus`; the renderer maps `CatalogAgent` →
+ * `SupportedAcpAgentEntry` (preserving the existing export shape so callers
+ * like `useAcpAgents` don't change their consumption shape).
+ *
+ * The existing `buildSupportedAcpAgents(...)` is kept for backward compat
+ * (tests + existing callers that pass a platform arch directly); the call
+ * sites (`useAcpAgents`, `AgentLauncher`, `AcpAgentsSettings`) switch to this
+ * async wrapper.
+ */
+export async function resolveSupportedAcpAgents(
+  persistedConfigs: readonly StoredAgentConfig[]
+): Promise<SupportedAcpAgentEntry[]> {
+  const result = await acpCatalogApi.listCatalog()
+  if (!result.success) {
+    // Degrade gracefully: return an empty list (callers fall back to the
+    // default-agent selection which handles empty lists).
+    return []
+  }
+  const catalog = result.data
+  const persistedById = new Map(persistedConfigs.map((config) => [config.id, config]))
+  const entries: SupportedAcpAgentEntry[] = []
+
+  for (const agent of catalog.agents) {
+    const id = agent.id
+    const configId = registryConfigId(id)
+    const persisted = persistedById.get(configId)
+
+    // Map the host-resolved status to the existing SupportedAcpAgentEntry shape.
+    // The host already computed the status (ready / install-required /
+    // needs-runtime / manual-install / unavailable); we just project it.
+    const registryAgent: RegistryAgent = {
+      id: agent.id,
+      name: agent.name,
+      version: agent.version,
+      description: agent.description,
+      distribution: agent.distribution as RegistryAgent['distribution']
+    }
+
+    if (persisted) {
+      entries.push({
+        id,
+        configId,
+        agent: registryAgent,
+        config: persisted,
+        status: 'ready',
+        install: null,
+        manualInstall: null,
+        runtimeLauncher: null,
+        unavailableReason: null
+      })
+      continue
+    }
+
+    // Derive the install/manualInstall info from the distribution (for
+    // binary-distributed agents) — the host reports the status but the
+    // renderer still needs the archive URL + cmd for the install UI.
+    // The host keeps `host.os` as the raw `std::env::consts::OS` value
+    // ("macos" on macOS) for display, but the bundled catalog's binary map
+    // keys use "darwin-*". Map "macos" -> "darwin" for the binary-target
+    // lookup (mirrors the host's `host_platform_arch()` helper); without this
+    // the install/manualInstall cmd would miss every "darwin-*" entry on macOS.
+    const binaryMapOs = catalog.host.os === 'macos' ? 'darwin' : catalog.host.os
+    const derived = deriveAgentConfig(registryAgent, `${binaryMapOs}-${catalog.host.arch}`)
+
+    entries.push({
+      id,
+      configId,
+      agent: registryAgent,
+      config: derived.kind === 'runnable' ? toStoredConfig(registryAgent, derived.config) : null,
+      status: agent.status,
+      install:
+        derived.kind === 'needs-install' && derived.archiveUrl
+          ? {
+              archiveUrl: derived.archiveUrl,
+              cmd: derived.cmd,
+              args: derived.args,
+              env: derived.env
+            }
+          : null,
+      manualInstall:
+        derived.kind === 'needs-install' && !derived.archiveUrl
+          ? { cmd: derived.cmd, args: derived.args, env: derived.env }
+          : null,
+      runtimeLauncher:
+        derived.kind === 'runnable' &&
+        (derived.config.command === 'npx' || derived.config.command === 'uvx')
+          ? (derived.config.command as 'npx' | 'uvx')
+          : null,
+      unavailableReason:
+        agent.status === 'unavailable'
+          ? 'This agent is not available for your platform.'
+          : agent.status === 'needs-runtime'
+            ? runtimeUnavailableReason(
+                derived.kind === 'runnable' && derived.config.command === 'uvx' ? 'uvx' : 'npx'
+              )
+            : agent.status === 'manual-install' && derived.kind === 'needs-install'
+              ? manualInstallReason(registryAgent, derived.cmd, derived.args)
+              : null
+    })
+  }
+
+  return entries
 }

--- a/src/renderer/lib/api.ts
+++ b/src/renderer/lib/api.ts
@@ -9,6 +9,7 @@
  */
 
 export { acpApi } from './acp-api'
+export { acpCatalogApi } from './acp-catalog-api'
 export { clipboardApi } from './clipboard-api'
 export { dialogApi } from './dialog-api'
 export { filesystemApi } from './filesystem-api'

--- a/src/renderer/lib/api.ts
+++ b/src/renderer/lib/api.ts
@@ -10,6 +10,7 @@
 
 export { acpApi } from './acp-api'
 export { acpCatalogApi } from './acp-catalog-api'
+export { acpInstallApi } from './acp-install-api'
 export { clipboardApi } from './clipboard-api'
 export { dialogApi } from './dialog-api'
 export { filesystemApi } from './filesystem-api'

--- a/src/renderer/lib/tauri-acp-catalog-api.test.ts
+++ b/src/renderer/lib/tauri-acp-catalog-api.test.ts
@@ -1,0 +1,107 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+// Use vi.hoisted so the mock fn is available when vi.mock factory runs
+const { invokeMock } = vi.hoisted(() => ({
+  invokeMock: vi.fn()
+}))
+
+vi.mock('@tauri-apps/api/core', () => ({
+  invoke: invokeMock
+}))
+
+vi.mock('@/lib/tauri-runtime', () => ({
+  isTauriContext: () => true
+}))
+
+import type { AcpCatalog } from '@shared/types/acp-catalog.types'
+import { createTauriAcpCatalogApi } from './tauri-acp-catalog-api'
+
+describe('createTauriAcpCatalogApi', () => {
+  beforeEach(() => {
+    invokeMock.mockReset()
+  })
+
+  it('listCatalog invokes acp_list_catalog and maps IpcResult', async () => {
+    const catalog: AcpCatalog = {
+      host: {
+        os: 'linux',
+        arch: 'x86_64',
+        runtimes: { npx: true, uvx: false, node: true, bun: false, python3: true }
+      },
+      agents: []
+    }
+    invokeMock.mockResolvedValueOnce({ success: true, data: catalog })
+
+    const api = createTauriAcpCatalogApi()
+    const result = await api.listCatalog()
+
+    expect(invokeMock).toHaveBeenCalledWith('acp_list_catalog', { refresh: false })
+    expect(result.success).toBe(true)
+    expect(result.data).toEqual(catalog)
+  })
+
+  it('listCatalog passes refresh=true when requested', async () => {
+    invokeMock.mockResolvedValueOnce({ success: true, data: { host: {}, agents: [] } })
+
+    const api = createTauriAcpCatalogApi()
+    await api.listCatalog(true)
+
+    expect(invokeMock).toHaveBeenCalledWith('acp_list_catalog', { refresh: true })
+  })
+
+  it('listCatalog maps invoke failure to INVOKE_ERROR', async () => {
+    invokeMock.mockRejectedValueOnce(new Error('IPC panic'))
+
+    const api = createTauriAcpCatalogApi()
+    const result = await api.listCatalog()
+
+    expect(result.success).toBe(false)
+    expect(result.code).toBe('INVOKE_ERROR')
+    expect(result.error).toContain('IPC panic')
+  })
+
+  it('setCatalogOptIn invokes acp_set_catalog_opt_in with enabled', async () => {
+    invokeMock.mockResolvedValueOnce({ success: true, data: null })
+
+    const api = createTauriAcpCatalogApi()
+    const result = await api.setCatalogOptIn(true)
+
+    expect(invokeMock).toHaveBeenCalledWith('acp_set_catalog_opt_in', { enabled: true })
+    expect(result.success).toBe(true)
+  })
+
+  it('isCatalogOptedIn derives from listCatalog (registry entries present)', async () => {
+    invokeMock.mockResolvedValueOnce({
+      success: true,
+      data: {
+        host: { os: 'linux', arch: 'x86_64', runtimes: {} },
+        agents: [
+          { id: 'a', source: 'bundled' },
+          { id: 'b', source: 'registry' }
+        ]
+      }
+    })
+
+    const api = createTauriAcpCatalogApi()
+    const result = await api.isCatalogOptedIn()
+
+    expect(result.success).toBe(true)
+    expect(result.data).toBe(true)
+  })
+
+  it('isCatalogOptedIn derives from listCatalog (no registry entries)', async () => {
+    invokeMock.mockResolvedValueOnce({
+      success: true,
+      data: {
+        host: { os: 'linux', arch: 'x86_64', runtimes: {} },
+        agents: [{ id: 'a', source: 'bundled' }]
+      }
+    })
+
+    const api = createTauriAcpCatalogApi()
+    const result = await api.isCatalogOptedIn()
+
+    expect(result.success).toBe(true)
+    expect(result.data).toBe(false)
+  })
+})

--- a/src/renderer/lib/tauri-acp-catalog-api.ts
+++ b/src/renderer/lib/tauri-acp-catalog-api.ts
@@ -1,0 +1,110 @@
+/**
+ * Tauri IPC implementation of the ACP catalog facade (CAP-6 / Story 8).
+ *
+ * Mirrors the desktop `#[tauri::command] acp_list_catalog` +
+ * `acp_set_catalog_opt_in` handlers in `src-tauri/src/acp/commands.rs`. The
+ * Rust commands wrap their results in `IpcResult<T>`, so this adapter maps
+ * `invoke()` → `IpcResult<T>` without double-wrapping (mirrors
+ * `tauri-workspace-manifest-api.ts`'s `invokeIpc` pattern).
+ *
+ * The web/remote fallback lives in `web-acp-catalog-api.ts` and hits the two
+ * HTTP routes registered in `web/catalog_api.rs`. Both impls return the SAME
+ * `IpcResult<...>` shape byte-for-byte — the `parity-checklist.test.ts` pins
+ * this.
+ */
+
+import type { AcpCatalog, AcpCatalogApi } from '@shared/types/acp-catalog.types'
+import type { IpcResult } from '@shared/types/ipc.types'
+import { type InvokeArgs, invoke } from '@tauri-apps/api/core'
+
+import { isTauriContext } from './tauri-runtime'
+
+/** IPC command names matching the Rust `#[tauri::command]` declarations. */
+const IPC_COMMANDS = {
+  LIST_CATALOG: 'acp_list_catalog',
+  SET_OPT_IN: 'acp_set_catalog_opt_in'
+} as const
+
+/**
+ * Invoke a Tauri IPC command that already returns `IpcResult<T>` from Rust.
+ * Maps a thrown invoke failure (Rust panic, IPC serialization error) to
+ * `IpcResult { success: false, code: 'INVOKE_ERROR' }` so the renderer never
+ * sees a thrown exception from the IPC layer.
+ */
+async function invokeIpc<T>(command: string, args?: InvokeArgs): Promise<IpcResult<T>> {
+  try {
+    return await invoke<IpcResult<T>>(command, args)
+  } catch (error) {
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : String(error),
+      code: 'INVOKE_ERROR'
+    }
+  }
+}
+
+/**
+ * Build the Tauri IPC impl of [`AcpCatalogApi`]. Returns the typed facade;
+ * the singleton in `acp-catalog-api.ts` picks this when `isTauriContext()`
+ * is true.
+ *
+ * Outside a Tauri webview, every method returns
+ * `IpcResult { success: false, code: 'INVOKE_ERROR' }` — the facade singleton
+ * NEVER picks this impl when `!isTauriContext()`, but the guard is here for
+ * tests that construct this adapter directly.
+ */
+export function createTauriAcpCatalogApi(): AcpCatalogApi {
+  return {
+    async listCatalog(refresh?: boolean): Promise<IpcResult<AcpCatalog>> {
+      if (!isTauriContext()) {
+        return {
+          success: false,
+          error: 'acp_list_catalog requires the Tauri runtime',
+          code: 'INVOKE_ERROR'
+        }
+      }
+      return invokeIpc<AcpCatalog>(IPC_COMMANDS.LIST_CATALOG, {
+        refresh: refresh ?? false
+      })
+    },
+
+    async setCatalogOptIn(enabled: boolean): Promise<IpcResult<void>> {
+      if (!isTauriContext()) {
+        return {
+          success: false,
+          error: 'acp_set_catalog_opt_in requires the Tauri runtime',
+          code: 'INVOKE_ERROR'
+        }
+      }
+      return invokeIpc<void>(IPC_COMMANDS.SET_OPT_IN, { enabled })
+    },
+
+    async isCatalogOptedIn(): Promise<IpcResult<boolean>> {
+      // The opt-in state is host-persisted; the desktop resolves it through
+      // `listCatalog()` (the catalog response carries the resolved agents,
+      // and the opt-in is observable via whether CDN entries are present).
+      // A dedicated `acp_is_catalog_opt_in` command is deferred — the
+      // facade exposes the method so callers can probe, but the impl
+      // derives from `listCatalog()` for now.
+      if (!isTauriContext()) {
+        return {
+          success: false,
+          error: 'acp_is_catalog_opt_in requires the Tauri runtime',
+          code: 'INVOKE_ERROR'
+        }
+      }
+      // Derive from listCatalog: if any agent has source 'registry', the
+      // opt-in is on. This is a best-effort probe — a dedicated command
+      // would be cleaner but the spec says "single boolean opt-in" and the
+      // catalog response is the source of truth.
+      const result = await invokeIpc<AcpCatalog>(IPC_COMMANDS.LIST_CATALOG, {
+        refresh: false
+      })
+      if (!result.success) {
+        return result as IpcResult<boolean>
+      }
+      const optedIn = result.data?.agents.some((agent) => agent.source === 'registry') ?? false
+      return { success: true, data: optedIn }
+    }
+  }
+}

--- a/src/renderer/lib/tauri-acp-install-api.test.ts
+++ b/src/renderer/lib/tauri-acp-install-api.test.ts
@@ -1,0 +1,61 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+// Use vi.hoisted so the mock fn is available when vi.mock factory runs
+const { invokeMock } = vi.hoisted(() => ({
+  invokeMock: vi.fn()
+}))
+
+vi.mock('@tauri-apps/api/core', () => ({
+  invoke: invokeMock
+}))
+
+vi.mock('@/lib/tauri-runtime', () => ({
+  isTauriContext: () => true
+}))
+
+import { createTauriAcpInstallApi } from './tauri-acp-install-api'
+
+describe('createTauriAcpInstallApi', () => {
+  beforeEach(() => {
+    invokeMock.mockReset()
+  })
+
+  it('installAgent invokes acp_install_agent with { request: { agentId } } and maps IpcResult success', async () => {
+    const outcome = { command: '/path/to/opencode', args: ['acp'] }
+    invokeMock.mockResolvedValueOnce({ success: true, data: outcome })
+
+    const api = createTauriAcpInstallApi()
+    const result = await api.installAgent('opencode')
+
+    expect(invokeMock).toHaveBeenCalledWith('acp_install_agent', {
+      request: { agentId: 'opencode' }
+    })
+    expect(result.success).toBe(true)
+    expect(result.data).toEqual(outcome)
+  })
+
+  it('installAgent maps IpcResult failure (ACP_INSTALL_UNAVAILABLE)', async () => {
+    invokeMock.mockResolvedValueOnce({
+      success: false,
+      error: 'acp install store is unavailable',
+      code: 'ACP_INSTALL_UNAVAILABLE'
+    })
+
+    const api = createTauriAcpInstallApi()
+    const result = await api.installAgent('opencode')
+
+    expect(result.success).toBe(false)
+    expect(result.code).toBe('ACP_INSTALL_UNAVAILABLE')
+  })
+
+  it('installAgent maps invoke failure to INVOKE_ERROR', async () => {
+    invokeMock.mockRejectedValueOnce(new Error('IPC panic'))
+
+    const api = createTauriAcpInstallApi()
+    const result = await api.installAgent('opencode')
+
+    expect(result.success).toBe(false)
+    expect(result.code).toBe('INVOKE_ERROR')
+    expect(result.error).toContain('IPC panic')
+  })
+})

--- a/src/renderer/lib/tauri-acp-install-api.ts
+++ b/src/renderer/lib/tauri-acp-install-api.ts
@@ -1,0 +1,69 @@
+/**
+ * Tauri IPC implementation of the ACP install facade (CAP-6 / Story 9).
+ *
+ * Mirrors the desktop `#[tauri::command] acp_install_agent` handler in
+ * `src-tauri/src/acp/commands.rs`. The Rust command wraps its result in
+ * `IpcResult<T>`, so this adapter maps `invoke()` → `IpcResult<T>` without
+ * double-wrapping (mirrors `tauri-acp-catalog-api.ts`'s `invokeIpc` pattern).
+ *
+ * The web/remote fallback lives in `web-acp-install-api.ts` and hits the
+ * `POST /acp/install` route registered in `web/install_api.rs`. Both impls
+ * return the SAME `IpcResult<...>` shape byte-for-byte — the
+ * `parity-checklist.test.ts` pins this.
+ */
+
+import type { AcpInstallApi, InstallOutcome } from '@shared/types/acp-install.types'
+import type { IpcResult } from '@shared/types/ipc.types'
+import { type InvokeArgs, invoke } from '@tauri-apps/api/core'
+
+import { isTauriContext } from './tauri-runtime'
+
+/** IPC command name matching the Rust `#[tauri::command]` declaration. */
+const IPC_COMMANDS = {
+  INSTALL_AGENT: 'acp_install_agent'
+} as const
+
+/**
+ * Invoke a Tauri IPC command that already returns `IpcResult<T>` from Rust.
+ * Maps a thrown invoke failure (Rust panic, IPC serialization error) to
+ * `IpcResult { success: false, code: 'INVOKE_ERROR' }` so the renderer never
+ * sees a thrown exception from the IPC layer.
+ */
+async function invokeIpc<T>(command: string, args?: InvokeArgs): Promise<IpcResult<T>> {
+  try {
+    return await invoke<IpcResult<T>>(command, args)
+  } catch (error) {
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : String(error),
+      code: 'INVOKE_ERROR'
+    }
+  }
+}
+
+/**
+ * Build the Tauri IPC impl of [`AcpInstallApi`]. Returns the typed facade;
+ * the singleton in `acp-install-api.ts` picks this when `isTauriContext()`
+ * is true.
+ *
+ * Outside a Tauri webview, the method returns
+ * `IpcResult { success: false, code: 'INVOKE_ERROR' }` — the facade singleton
+ * NEVER picks this impl when `!isTauriContext()`, but the guard is here for
+ * tests that construct this adapter directly.
+ */
+export function createTauriAcpInstallApi(): AcpInstallApi {
+  return {
+    async installAgent(agentId: string): Promise<IpcResult<InstallOutcome>> {
+      if (!isTauriContext()) {
+        return {
+          success: false,
+          error: 'acp_install_agent requires the Tauri runtime',
+          code: 'INVOKE_ERROR'
+        }
+      }
+      return invokeIpc<InstallOutcome>(IPC_COMMANDS.INSTALL_AGENT, {
+        request: { agentId }
+      })
+    }
+  }
+}

--- a/src/renderer/lib/web-acp-catalog-api.test.ts
+++ b/src/renderer/lib/web-acp-catalog-api.test.ts
@@ -1,0 +1,130 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+// Mock isTauriContext to return false so the adapter uses fetch
+vi.mock('@/lib/tauri-runtime', () => ({
+  isTauriContext: () => false
+}))
+
+import type { AcpCatalog } from '@shared/types/acp-catalog.types'
+import { webAcpCatalogApi } from './web-acp-catalog-api'
+
+describe('webAcpCatalogApi', () => {
+  const fetchMock = vi.fn()
+
+  beforeEach(() => {
+    fetchMock.mockReset()
+    vi.stubGlobal('fetch', fetchMock)
+    vi.stubGlobal('window', { location: { origin: 'http://localhost:8080' } })
+  })
+
+  it('listCatalog hits GET /acp/catalog and maps IpcBody success', async () => {
+    const catalog: AcpCatalog = {
+      host: {
+        os: 'linux',
+        arch: 'x86_64',
+        runtimes: { npx: true, uvx: false, node: true, bun: false, python3: true }
+      },
+      agents: []
+    }
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ success: true, data: catalog })
+    })
+
+    const result = await webAcpCatalogApi.listCatalog()
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'http://localhost:8080/acp/catalog',
+      expect.objectContaining({ method: 'GET' })
+    )
+    expect(result.success).toBe(true)
+    expect(result.data).toEqual(catalog)
+  })
+
+  it('listCatalog appends ?refresh=true when refresh is true', async () => {
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ success: true, data: { host: {}, agents: [] } })
+    })
+
+    await webAcpCatalogApi.listCatalog(true)
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'http://localhost:8080/acp/catalog?refresh=true',
+      expect.objectContaining({ method: 'GET' })
+    )
+  })
+
+  it('listCatalog maps non-2xx HTTP to NETWORK_ERROR', async () => {
+    fetchMock.mockResolvedValueOnce({ ok: false, status: 500, statusText: 'Internal Server Error' })
+
+    const result = await webAcpCatalogApi.listCatalog()
+
+    expect(result.success).toBe(false)
+    expect(result.code).toBe('NETWORK_ERROR')
+  })
+
+  it('listCatalog maps fetch throw to NETWORK_ERROR', async () => {
+    fetchMock.mockRejectedValueOnce(new Error('network down'))
+
+    const result = await webAcpCatalogApi.listCatalog()
+
+    expect(result.success).toBe(false)
+    expect(result.code).toBe('NETWORK_ERROR')
+  })
+
+  it('setCatalogOptIn hits POST /acp/catalog/opt-in with enabled body', async () => {
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ success: true, data: null })
+    })
+
+    const result = await webAcpCatalogApi.setCatalogOptIn(true)
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'http://localhost:8080/acp/catalog/opt-in',
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({ enabled: true })
+      })
+    )
+    expect(result.success).toBe(true)
+  })
+
+  it('setCatalogOptIn maps IpcBody error', async () => {
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        success: false,
+        error: 'store unavailable',
+        code: 'ACP_CATALOG_UNAVAILABLE'
+      })
+    })
+
+    const result = await webAcpCatalogApi.setCatalogOptIn(false)
+
+    expect(result.success).toBe(false)
+    expect(result.code).toBe('ACP_CATALOG_UNAVAILABLE')
+  })
+
+  it('isCatalogOptedIn derives from listCatalog (registry entries present)', async () => {
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        success: true,
+        data: {
+          host: {},
+          agents: [
+            { id: 'a', source: 'bundled' },
+            { id: 'b', source: 'registry' }
+          ]
+        }
+      })
+    })
+
+    const result = await webAcpCatalogApi.isCatalogOptedIn()
+
+    expect(result.success).toBe(true)
+    expect(result.data).toBe(true)
+  })
+})

--- a/src/renderer/lib/web-acp-catalog-api.ts
+++ b/src/renderer/lib/web-acp-catalog-api.ts
@@ -1,0 +1,110 @@
+/**
+ * Fetch-based HTTP impl of the ACP catalog facade (CAP-6 / Story 8).
+ *
+ * Mirrors the desktop Tauri command impl over the two HTTP routes
+ * registered in `src-tauri/src/web/catalog_api.rs`. Transport/parse failures
+ * map to `IpcResult { success: false, code: 'NETWORK_ERROR' }` so the
+ * renderer never sees a thrown exception from the network layer.
+ *
+ * Routes (same-origin under `termul-server`):
+ * - `GET  /acp/catalog` — list (optional `?refresh=true`).
+ * - `POST /acp/catalog/opt-in` — set opt-in.
+ *
+ * The `IpcBody<T>` shape the HTTP routes return matches the renderer-side
+ * `IpcResult<T>` byte-for-byte — this adapter only maps a transport/parse
+ * failure to `NETWORK_ERROR`; a successful HTTP response is parsed into the
+ * success/failure body variant the route returned.
+ */
+
+import type { AcpCatalog, AcpCatalogApi } from '@shared/types/acp-catalog.types'
+import type { IpcResult } from '@shared/types/ipc.types'
+
+import { isTauriContext } from './tauri-runtime'
+
+/**
+ * Same-origin base for the embedded server. In web/remote mode the browser is
+ * served by `termul-server` itself, so `window.location.origin` is the server.
+ * Returns the empty string under Tauri (desktop build) so a misconfigured
+ * call fails fast rather than hitting a phantom origin.
+ */
+function serverBase(): string {
+  if (isTauriContext()) return ''
+  if (typeof window === 'undefined' || !window.location) return ''
+  return window.location.origin
+}
+
+/** Shape of the HTTP response body mirroring `IpcResult<T>`. */
+type IpcBody<T> = { success: true; data: T } | { success: false; error: string; code: string }
+
+/** Map any transport/parse failure to a uniform `IpcResult` failure. */
+function networkError(detail: string): IpcResult<never> {
+  return { success: false, error: detail, code: 'NETWORK_ERROR' }
+}
+
+/** Parse the `IpcBody<T>` JSON body into `IpcResult<T>`. */
+async function parseBody<T>(res: Response): Promise<IpcResult<T>> {
+  if (!res.ok) {
+    return networkError(`HTTP ${res.status} ${res.statusText}`)
+  }
+  let body: IpcBody<T>
+  try {
+    body = (await res.json()) as IpcBody<T>
+  } catch (err) {
+    return networkError(err instanceof Error ? err.message : 'invalid JSON')
+  }
+  if (body.success) {
+    return { success: true, data: body.data }
+  }
+  return { success: false, error: body.error, code: body.code }
+}
+
+/**
+ * The fetch-backed impl of [`AcpCatalogApi`]. The singleton in
+ * `acp-catalog-api.ts` picks this when `!isTauriContext()`.
+ */
+export const webAcpCatalogApi: AcpCatalogApi = {
+  listCatalog(refresh?: boolean): Promise<IpcResult<AcpCatalog>> {
+    const query = refresh ? '?refresh=true' : ''
+    return getJson<AcpCatalog>(`/acp/catalog${query}`)
+  },
+
+  setCatalogOptIn(enabled: boolean): Promise<IpcResult<void>> {
+    return postJson<void>('/acp/catalog/opt-in', { enabled })
+  },
+
+  async isCatalogOptedIn(): Promise<IpcResult<boolean>> {
+    // Derive from listCatalog: if any agent has source 'registry', the
+    // opt-in is on (the host only includes CDN entries when the opt-in is
+    // set AND the fetch succeeded).
+    const result = await getJson<AcpCatalog>('/acp/catalog')
+    if (!result.success) {
+      return result as IpcResult<boolean>
+    }
+    const optedIn = result.data?.agents.some((agent) => agent.source === 'registry') ?? false
+    return { success: true, data: optedIn }
+  }
+}
+
+/** GET and return the typed `IpcResult` body (or NETWORK_ERROR). */
+async function getJson<T>(path: string): Promise<IpcResult<T>> {
+  try {
+    const res = await fetch(`${serverBase()}${path}`, { method: 'GET' })
+    return await parseBody<T>(res)
+  } catch (err) {
+    return networkError(err instanceof Error ? err.message : String(err))
+  }
+}
+
+/** POST JSON and return the typed `IpcResult` body (or NETWORK_ERROR). */
+async function postJson<T>(path: string, body: unknown): Promise<IpcResult<T>> {
+  try {
+    const res = await fetch(`${serverBase()}${path}`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(body)
+    })
+    return await parseBody<T>(res)
+  } catch (err) {
+    return networkError(err instanceof Error ? err.message : String(err))
+  }
+}

--- a/src/renderer/lib/web-acp-install-api.test.ts
+++ b/src/renderer/lib/web-acp-install-api.test.ts
@@ -1,0 +1,76 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+// Mock isTauriContext to return false so the adapter uses fetch
+vi.mock('@/lib/tauri-runtime', () => ({
+  isTauriContext: () => false
+}))
+
+import { webAcpInstallApi } from './web-acp-install-api'
+
+describe('webAcpInstallApi', () => {
+  const fetchMock = vi.fn()
+
+  beforeEach(() => {
+    fetchMock.mockReset()
+    vi.stubGlobal('fetch', fetchMock)
+    vi.stubGlobal('window', { location: { origin: 'http://localhost:8080' } })
+  })
+
+  it('installAgent hits POST /acp/install with { agentId } body and maps IpcBody success', async () => {
+    const outcome = { command: '/path/to/opencode', args: ['acp'] }
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ success: true, data: outcome })
+    })
+
+    const result = await webAcpInstallApi.installAgent('opencode')
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'http://localhost:8080/acp/install',
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({ agentId: 'opencode' })
+      })
+    )
+    expect(result.success).toBe(true)
+    expect(result.data).toEqual(outcome)
+  })
+
+  it('installAgent maps non-2xx HTTP to NETWORK_ERROR', async () => {
+    fetchMock.mockResolvedValueOnce({
+      ok: false,
+      status: 500,
+      statusText: 'Internal Server Error'
+    })
+
+    const result = await webAcpInstallApi.installAgent('opencode')
+
+    expect(result.success).toBe(false)
+    expect(result.code).toBe('NETWORK_ERROR')
+  })
+
+  it('installAgent maps fetch throw to NETWORK_ERROR', async () => {
+    fetchMock.mockRejectedValueOnce(new Error('network down'))
+
+    const result = await webAcpInstallApi.installAgent('opencode')
+
+    expect(result.success).toBe(false)
+    expect(result.code).toBe('NETWORK_ERROR')
+  })
+
+  it('installAgent maps IpcBody error (INTEGRITY_MISMATCH)', async () => {
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        success: false,
+        error: 'downloaded archive sha256 does not match the catalog digest',
+        code: 'INTEGRITY_MISMATCH'
+      })
+    })
+
+    const result = await webAcpInstallApi.installAgent('tampered')
+
+    expect(result.success).toBe(false)
+    expect(result.code).toBe('INTEGRITY_MISMATCH')
+  })
+})

--- a/src/renderer/lib/web-acp-install-api.ts
+++ b/src/renderer/lib/web-acp-install-api.ts
@@ -1,0 +1,84 @@
+/**
+ * Fetch-based HTTP impl of the ACP install facade (CAP-6 / Story 9).
+ *
+ * Mirrors the desktop Tauri command impl over the HTTP route registered in
+ * `src-tauri/src/web/install_api.rs`. Transport/parse failures map to
+ * `IpcResult { success: false, code: 'NETWORK_ERROR' }` so the renderer never
+ * sees a thrown exception from the network layer.
+ *
+ * Route (same-origin under `termul-server`):
+ * - `POST /acp/install` — install (body `{ agentId }`).
+ *
+ * The `IpcBody<T>` shape the HTTP route returns matches the renderer-side
+ * `IpcResult<T>` byte-for-byte — this adapter only maps a transport/parse
+ * failure to `NETWORK_ERROR`; a successful HTTP response is parsed into the
+ * success/failure body variant the route returned.
+ */
+
+import type { AcpInstallApi, InstallOutcome } from '@shared/types/acp-install.types'
+import type { IpcResult } from '@shared/types/ipc.types'
+
+import { isTauriContext } from './tauri-runtime'
+
+/**
+ * Same-origin base for the embedded server. In web/remote mode the browser is
+ * served by `termul-server` itself, so `window.location.origin` is the server.
+ * Returns the empty string under Tauri (desktop build) so a misconfigured
+ * call fails fast rather than hitting a phantom origin.
+ */
+function serverBase(): string {
+  if (isTauriContext()) return ''
+  if (typeof window === 'undefined' || !window.location) return ''
+  return window.location.origin
+}
+
+/** Shape of the HTTP response body mirroring `IpcResult<T>`. */
+type IpcBody<T> = { success: true; data: T } | { success: false; error: string; code: string }
+
+/** Map any transport/parse failure to a uniform `IpcResult` failure. */
+function networkError(detail: string): IpcResult<never> {
+  return { success: false, error: detail, code: 'NETWORK_ERROR' }
+}
+
+/** Parse the `IpcBody<T>` JSON body into `IpcResult<T>`. */
+async function parseBody<T>(res: Response): Promise<IpcResult<T>> {
+  if (!res.ok) {
+    return networkError(`HTTP ${res.status} ${res.statusText}`)
+  }
+  let body: IpcBody<T>
+  try {
+    body = (await res.json()) as IpcBody<T>
+  } catch (err) {
+    return networkError(err instanceof Error ? err.message : 'invalid JSON')
+  }
+  if (body.success) {
+    return { success: true, data: body.data }
+  }
+  return { success: false, error: body.error, code: body.code }
+}
+
+/**
+ * POST JSON and return the typed `IpcResult` body (or NETWORK_ERROR).
+ */
+async function postJson<T>(path: string, body: unknown): Promise<IpcResult<T>> {
+  try {
+    const res = await fetch(`${serverBase()}${path}`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(body)
+    })
+    return await parseBody<T>(res)
+  } catch (err) {
+    return networkError(err instanceof Error ? err.message : String(err))
+  }
+}
+
+/**
+ * The fetch-backed impl of [`AcpInstallApi`]. The singleton in
+ * `acp-install-api.ts` picks this when `!isTauriContext()`.
+ */
+export const webAcpInstallApi: AcpInstallApi = {
+  installAgent(agentId: string): Promise<IpcResult<InstallOutcome>> {
+    return postJson<InstallOutcome>('/acp/install', { agentId })
+  }
+}

--- a/src/shared/types/acp-catalog.types.ts
+++ b/src/shared/types/acp-catalog.types.ts
@@ -1,0 +1,107 @@
+/**
+ * Host-owned ACP catalog contract (CAP-6 / Story 8).
+ *
+ * Mirrors the Rust serde shapes in `src-tauri/src/acp/catalog.rs` byte-for-byte
+ * (camelCase). The host resolves the catalog (OS/arch/runtime + per-agent
+ * `SupportedAcpAgentStatus`) and serves it across all three transports (Tauri
+ * command `acp_list_catalog`, HTTP `GET /acp/catalog`, WS `list_acp_catalog`).
+ * The renderer facade (`acp-catalog-api.ts`) resolves Tauri vs HTTP at runtime;
+ * the WS transport implements the real `listCatalog()` request.
+ *
+ * The catalog is credential-free, path-free, read-only host introspection —
+ * never carries `AgentConfig.env` (API keys) or resolved absolute executable
+ * paths. The opt-in is a single boolean that gates CDN registry augmentation.
+ */
+
+import type { IpcResult } from './ipc.types'
+
+/** The 5-state per-agent installability status. Mirrors the Rust enum. */
+export type SupportedAcpAgentStatus =
+  | 'ready'
+  | 'install-required'
+  | 'needs-runtime'
+  | 'manual-install'
+  | 'unavailable'
+
+/** Whether a catalog entry came from the trusted bundled baseline or the CDN. */
+export type CatalogSource = 'bundled' | 'registry'
+
+/** Host runtime availability. Mirrors `CatalogRuntimeAvailability` (camelCase). */
+export interface CatalogRuntimeAvailability {
+  npx: boolean
+  uvx: boolean
+  node: boolean
+  bun: boolean
+  python3: boolean
+}
+
+/** Host capability block: OS + arch + runtime availability. */
+export interface HostCapability {
+  os: string
+  arch: string
+  runtimes: CatalogRuntimeAvailability
+}
+
+/** A platform target pair (e.g. `{ os: 'linux', arch: 'x86_64' }`). */
+export interface PlatformTarget {
+  os: string
+  arch: string
+}
+
+/**
+ * One resolved catalog entry. Carries identity + distribution metadata +
+ * computed `status` + `runtimeRequirements` + `platformTargets`. Never
+ * carries `AgentConfig.env` (API keys) or resolved absolute executable paths.
+ */
+export interface CatalogAgent {
+  id: string
+  name: string
+  version: string
+  description: string
+  source: CatalogSource
+  /** The distribution metadata from the bundled/CDN catalog (passed through). */
+  distribution: Record<string, unknown>
+  /** Runtime requirements (e.g. `['npx']` for npx-distributed agents). */
+  runtimeRequirements: string[]
+  status: SupportedAcpAgentStatus
+  /** Platform targets for binary-distributed agents; empty for npx/uvx. */
+  platformTargets: PlatformTarget[]
+}
+
+/** The resolved catalog payload served across all three transports. */
+export interface AcpCatalog {
+  host: HostCapability
+  agents: CatalogAgent[]
+}
+
+/** `POST /acp/catalog/opt-in` + WS `set_catalog_opt_in` request body. */
+export interface SetCatalogOptInRequest {
+  enabled: boolean
+}
+
+/**
+ * `acp_list_catalog(refresh?: boolean)` — resolve the host-owned ACP catalog.
+ * Returns the host's OS/arch/runtime availability + per-agent resolved
+ * `SupportedAcpAgentStatus`. Mirrors `GET /acp/catalog` + WS `list_acp_catalog`.
+ */
+export type AcpCatalogListChannel = (refresh?: boolean) => Promise<IpcResult<AcpCatalog>>
+
+/**
+ * `acp_set_catalog_opt_in(enabled: boolean)` — persist the host opt-in flag
+ * that gates the CDN registry augmentation. Mirrors `POST /acp/catalog/opt-in`
+ * + WS `set_catalog_opt_in`.
+ */
+export type AcpCatalogSetOptInChannel = (enabled: boolean) => Promise<IpcResult<void>>
+
+/**
+ * The renderer-facing ACP catalog facade. Resolves to the Tauri command impl
+ * when running inside a Tauri webview, the HTTP fetch impl when running as a
+ * web/remote client. Both impls return the same `IpcResult<...>` shape
+ * byte-for-byte (the parity-checklist test pins this).
+ */
+export interface AcpCatalogApi {
+  listCatalog: AcpCatalogListChannel
+  setCatalogOptIn: AcpCatalogSetOptInChannel
+  /** Read the current opt-in flag (without mutating it). */
+  isCatalogOptedIn: () => Promise<IpcResult<boolean>>
+}

--- a/src/shared/types/acp-install.types.ts
+++ b/src/shared/types/acp-install.types.ts
@@ -1,0 +1,68 @@
+/**
+ * Host-owned verified-atomic ACP install contract (CAP-6 / Story 9).
+ *
+ * Mirrors the Rust serde shapes in `src-tauri/src/acp/install.rs` byte-for-byte
+ * (camelCase). The host downloads + verifies (sha256) + extracts + atomically
+ * activates ACP agent archives resolved from the catalog, records an
+ * installed-agents manifest, and serves `install_agent(agentId)` across all
+ * three transports (Tauri command `acp_install_agent`, HTTP `POST /acp/install`,
+ * WS `install_acp_agent`).
+ *
+ * The request is `{ agentId }` ONLY; the host resolves everything (archive URL,
+ * cmd, args, env, sha256) from the trusted catalog — never accepts
+ * browser-supplied URLs, commands, executable paths, or args.
+ */
+
+import type { IpcResult } from './ipc.types'
+
+/** `POST /acp/install` + WS `install_acp_agent` + Tauri `acp_install_agent` body. */
+export interface InstallRequest {
+  agentId: string
+}
+
+/**
+ * The install outcome (the existing contract the renderer wraps into
+ * `AgentConfig` via `installedBinaryConfig`). `command` is the absolute path
+ * to the resolved executable under the install root; `args` is the catalog
+ * target's `args` (or empty).
+ */
+export interface InstallOutcome {
+  command: string
+  args: string[]
+}
+
+/**
+ * Install error codes (SCREAMING_SNAKE_CASE, byte-identical across all three
+ * transports — Tauri `IpcResult.code`, HTTP `IpcBody.code`, WS
+ * `WsReply.err.code`). Mirrors the Rust `InstallError::code` strings.
+ */
+export type InstallErrorCode =
+  | 'INTEGRITY_MISMATCH'
+  | 'INTEGRITY_METADATA_MISSING'
+  | 'UNSUPPORTED_PLATFORM'
+  | 'ARCHIVE_TOO_LARGE'
+  | 'EXTRACTION_QUOTA_EXCEEDED'
+  | 'PATH_TRAVERSAL_DETECTED'
+  | 'DOWNLOAD_FAILED'
+  | 'CATALOG_AGENT_NOT_FOUND'
+  | 'NOT_INSTALLABLE'
+  | 'ACP_INSTALL_UNAVAILABLE'
+  | 'VALIDATION_ERROR'
+  | 'INSTALL_FAILED'
+
+/**
+ * `acp_install_agent(agentId)` — host-owned verified-atomic ACP install.
+ * Returns `{ command: absolute_path, args }` on success. Errors carry the
+ * codes above. Mirrors `POST /acp/install` + WS `install_acp_agent`.
+ */
+export type AcpInstallAgentChannel = (agentId: string) => Promise<IpcResult<InstallOutcome>>
+
+/**
+ * The renderer-facing ACP install facade. Resolves to the Tauri command impl
+ * when running inside a Tauri webview, the HTTP fetch impl when running as a
+ * web/remote client. Both impls return the same `IpcResult<...>` shape
+ * byte-for-byte (the parity-checklist test pins this).
+ */
+export interface AcpInstallApi {
+  installAgent: AcpInstallAgentChannel
+}

--- a/src/shared/types/ipc.types.ts
+++ b/src/shared/types/ipc.types.ts
@@ -1,4 +1,5 @@
 // IPC Result pattern from architecture.md
+import type { AcpCatalog } from './acp-catalog.types'
 import type { WorkspaceManifest, WriteOutcome } from './workspace-manifest.types'
 
 export type IpcResult<T> =
@@ -117,6 +118,17 @@ export type WorkspaceManifestIpcChannels = {
     manifest: WorkspaceManifest
   ) => IpcResult<WriteOutcome>
   'workspace:manifest:delete': (projectId: string) => IpcResult<void>
+}
+
+// CAP-6 / Story 8: ACP catalog IPC channels. Mirrors the two Tauri commands
+// (`acp_list_catalog` / `acp_set_catalog_opt_in`) and the two HTTP routes
+// (`GET /acp/catalog` / `POST /acp/catalog/opt-in`) — both transports return
+// the SAME `IpcResult<...>` shape byte-for-byte. The catalog is
+// credential-free, path-free, read-only host introspection. The opt-in is a
+// single boolean that gates CDN registry augmentation.
+export type AcpCatalogIpcChannels = {
+  'acp:catalog:list': (refresh?: boolean) => IpcResult<AcpCatalog>
+  'acp:catalog:set_opt_in': (enabled: boolean) => IpcResult<void>
 }
 
 // Event types for main -> renderer communication

--- a/src/shared/types/ipc.types.ts
+++ b/src/shared/types/ipc.types.ts
@@ -131,6 +131,18 @@ export type AcpCatalogIpcChannels = {
   'acp:catalog:set_opt_in': (enabled: boolean) => IpcResult<void>
 }
 
+// CAP-6 / Story 9: ACP install IPC channel. Mirrors the Tauri command
+// `acp_install_agent` and the HTTP route `POST /acp/install` — both transports
+// return the SAME `IpcResult<InstallOutcome>` shape byte-for-byte. The request
+// is `{ agentId }` only; the host resolves everything from the trusted catalog.
+// The declared channel type is honest about the actual invoke payload shape:
+// the Tauri adapter wraps `agentId` in a `request` object (Tauri's convention
+// for single-struct-arg commands), so the channel signature reflects that.
+import type { InstallOutcome } from './acp-install.types'
+export type AcpInstallIpcChannels = {
+  'acp:install:install_agent': (request: { agentId: string }) => IpcResult<InstallOutcome>
+}
+
 // Event types for main -> renderer communication
 // Terminal data callback — receives binary data as Uint8Array (via Tauri Channel)
 // Previously received string via event emitter; migrated to binary Channel API in ADR-002.2

--- a/src/shared/types/web-protocol.types.test.ts
+++ b/src/shared/types/web-protocol.types.test.ts
@@ -58,8 +58,8 @@ describe('web-protocol.types — event/request type registries (AC2)', () => {
     expect(WS_REQUEST_TYPES).toContain('get_session_payload')
   })
 
-  it('exports exactly 25 request types including ephemeral disposal and ping', () => {
-    expect(WS_REQUEST_TYPES).toHaveLength(25)
+  it('exports exactly 27 request types including ephemeral disposal, ping, and catalog', () => {
+    expect(WS_REQUEST_TYPES).toHaveLength(27)
     const expected = [
       'send_prompt',
       'cancel_prompt',
@@ -84,7 +84,10 @@ describe('web-protocol.types — event/request type registries (AC2)', () => {
       'list_persisted_sessions',
       'open_persisted_session',
       'get_session_payload',
-      'get_session_cursor'
+      'get_session_cursor',
+      // CAP-6 / Story 8: host-owned ACP catalog resolution.
+      'list_acp_catalog',
+      'set_catalog_opt_in'
     ]
     for (const name of expected) {
       expect(WS_REQUEST_TYPES).toContain(name)

--- a/src/shared/types/web-protocol.types.test.ts
+++ b/src/shared/types/web-protocol.types.test.ts
@@ -58,8 +58,8 @@ describe('web-protocol.types — event/request type registries (AC2)', () => {
     expect(WS_REQUEST_TYPES).toContain('get_session_payload')
   })
 
-  it('exports exactly 27 request types including ephemeral disposal, ping, and catalog', () => {
-    expect(WS_REQUEST_TYPES).toHaveLength(27)
+  it('exports exactly 28 request types including ephemeral disposal, ping, catalog, and install', () => {
+    expect(WS_REQUEST_TYPES).toHaveLength(28)
     const expected = [
       'send_prompt',
       'cancel_prompt',
@@ -87,7 +87,9 @@ describe('web-protocol.types — event/request type registries (AC2)', () => {
       'get_session_cursor',
       // CAP-6 / Story 8: host-owned ACP catalog resolution.
       'list_acp_catalog',
-      'set_catalog_opt_in'
+      'set_catalog_opt_in',
+      // CAP-6 / Story 9: host-owned verified-atomic ACP install.
+      'install_acp_agent'
     ]
     for (const name of expected) {
       expect(WS_REQUEST_TYPES).toContain(name)

--- a/src/shared/types/web-protocol.types.ts
+++ b/src/shared/types/web-protocol.types.ts
@@ -140,7 +140,12 @@ export const WS_REQUEST_TYPES = [
   // web client never probes `@tauri-apps/plugin-os` or PATH locally — the
   // host is the single source of truth.
   'list_acp_catalog',
-  'set_catalog_opt_in'
+  'set_catalog_opt_in',
+  // CAP-6 / Story 9: host-owned verified-atomic ACP install. The web client
+  // installs a catalog agent through `install_acp_agent` (the host downloads +
+  // verifies sha256 + extracts + atomically activates). The request is
+  // `{ agentId }` only; the host resolves everything from the trusted catalog.
+  'install_acp_agent'
 ] as const
 
 /** Union of all WS request `type` strings. */

--- a/src/shared/types/web-protocol.types.ts
+++ b/src/shared/types/web-protocol.types.ts
@@ -132,7 +132,15 @@ export const WS_REQUEST_TYPES = [
   // Unlike `recover_session_snapshot` (which re-registers a subscription),
   // this only returns the durable `{ sessionId, watermark }` so a refreshed
   // transport can seed `lastSeq` before its first subscribe.
-  'get_session_cursor'
+  'get_session_cursor',
+  // CAP-6 / Story 8: host-owned ACP catalog resolution. The web client
+  // resolves the catalog through `list_acp_catalog` (the host's OS/arch/
+  // runtime + per-agent `SupportedAcpAgentStatus`) + `set_catalog_opt_in`
+  // (the host-persisted opt-in that gates CDN registry augmentation). The
+  // web client never probes `@tauri-apps/plugin-os` or PATH locally — the
+  // host is the single source of truth.
+  'list_acp_catalog',
+  'set_catalog_opt_in'
 ] as const
 
 /** Union of all WS request `type` strings. */


### PR DESCRIPTION
## Summary

Completes the cross-client ACP continuity epic with CAP-6: a host-owned ACP catalog that resolves platform, architecture, and runtime availability, and a verified atomic installation flow that downloads, verifies (sha256), extracts, and atomically activates ACP agents from trusted catalog identities. Also includes end-to-end verification tests (Story 10) covering real-archive traversal, WS-handler dispatch, cross-client session restore, reload-simulation, and host-authority parity. This is the second half of the epic; PR #550 (CAP-1..5,7) was already merged to dev.

## Related Issue

No related issue — this is the second half of a self-contained epic derived from the verified parity research.

## Type of Change

- [x] feat: new feature
- [x] test: adds or updates tests

## What Changed

- CAP-6 (Story 8): Host-owned ACP catalog service — resolves OS/arch/runtime (npx/uvx/node/bun/python3), per-agent status (ready/install-required/needs-runtime/manual-install/unavailable), bundled + CDN catalog merge, opt-in gate. Three-transport parity (Tauri command + HTTP route + WS request type).
- CAP-6 (Story 9): Verified atomic ACP installation — sha256 integrity verification from catalog metadata (before extraction), per-agent serialization (TokioMutex map), atomic activation (backup/rename/restore), schema-versioned installed.json manifest (atomic write + corrupt-backup), archive protections (256 MiB download cap, 1 GiB extraction cap, 50K file count, path-traversal rejection). Three-transport parity with 12 error codes.
- Story 10: End-to-end verification — real-archive traversal tests (zip-slip, tar traversal, file-count quota), WS-handler dispatch tests (catalog, cross-client session restore), reload-simulation test (fresh transport + cursor replay), static parity blocks (ACP history, spawn metadata, cross-client host-authority).

Also fixes two CI gate issues (DirBuilder path + acp module re-exports in server_main.rs) caught by CI-Linux.

## How It Was Tested

- [x] `bun run ci` (Biome lint + format + imports, strict mode)
- [x] `bun run typecheck`
- [x] `bun run test` — 3317 passed, 43 skipped, 0 failed
- [x] `cargo clippy --all-targets --features standalone-server -- -D warnings` (in src-tauri)
- [ ] `cargo test` (in src-tauri) — compile-verified locally; runs on CI-Linux (pre-existing Windows DLL issue)
- [ ] Manual verification completed

## CI and Review Gate

- [ ] All CI checks pass (PR Validation, Rust Checks, Build Verification, Security Scans)
- [ ] Code review comments from CodeRabbit / Claude have been addressed or resolved
- [ ] No unresolved review findings remain

## Checklist

- [x] My PR title follows the conventional commit format used by this repo
- [x] I linked the related issue or explained why none exists
- [x] I updated docs when needed
- [x] I added or updated tests when needed
- [x] I verified the change does not introduce unrelated modifications
- [x] I read AGENTS.md and followed the contributor guidelines
- [ ] A human reviewed the complete diff before submission


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a host-managed catalog for supported ACP agents, including platform and runtime availability details.
  * Added optional registry opt-in with persistent settings and refresh support.
  * Added verified ACP agent installation and uninstall capabilities across desktop, web, and remote connections.
  * Added safe archive handling with integrity checks and standardized installation errors.
  * Added catalog and installation support through HTTP, WebSocket, and desktop interfaces.

* **Bug Fixes**
  * Improved error handling and graceful fallback when catalog or installation services are unavailable.
  * Fixed test-session prompt handling and retry button behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->