### PR TITLE
fix: address CodeRabbit review findings from CAP-6 PR (#551)

### DIFF
--- a/src-tauri/src/acp/install.rs
+++ b/src-tauri/src/acp/install.rs
@@ -609,6 +609,20 @@ impl AcpInstallService {
                     "catalog binary target missing 'sha256' — cannot verify integrity",
                 )
             })?;
+        // Treat an empty or malformed sha256 as missing (mirrors the catalog's
+        // `compute_binary_status` tightening): the host cannot verify integrity
+        // against an invalid digest, so it must reject with
+        // `INTEGRITY_METADATA_MISSING` rather than relax the contract. Without
+        // this, an empty-string sha256 is "present" by the install path (the
+        // `.as_str()` above returns `Some("")`) but "absent" by the catalog's
+        // status computation — the launcher would offer an install the host
+        // must reject (split-brain).
+        if !is_valid_sha256_hex(sha256_hex) {
+            return Err(InstallError::new(
+                code::INTEGRITY_METADATA_MISSING,
+                "catalog binary target has an invalid 'sha256' — expected 64 hex chars",
+            ));
+        }
         let args: Vec<String> = target
             .get("args")
             .and_then(|a| a.as_array())
@@ -786,11 +800,39 @@ impl AcpInstallService {
             manifest.clone()
         };
         let root = self.root.clone();
-        if let Err(e) =
-            tokio::task::spawn_blocking(move || Self::persist_manifest_blocking(&root, &manifest_clone))
-                .await
+        // `spawn_blocking` returns `io::Result<()>` from the inner closure, so
+        // the outer `.await` is `Result<io::Result<()>, JoinError>` — handle
+        // BOTH layers. A manifest persist failure leaves a stale audit record
+        // (the binary is activated but the manifest does not reflect it), so
+        // surface it as an `INSTALL_FAILED` error rather than silently
+        // discarding it (the previous `if let Err(e)` only caught the
+        // `JoinError`, dropping the inner `io::Result` on the floor).
+        match tokio::task::spawn_blocking(move || {
+            Self::persist_manifest_blocking(&root, &manifest_clone)
+        })
+        .await
         {
-            log::error!("[acp-install] {} manifest persist task failed: {e}", crate::logging::session_id());
+            Ok(Ok(())) => {}
+            Ok(Err(e)) => {
+                log::error!(
+                    "[acp-install] {} manifest persist failed (stale audit record): {e}",
+                    crate::logging::session_id()
+                );
+                return Err(InstallError::new(
+                    code::INSTALL_FAILED,
+                    format!("manifest persist failed: {e}"),
+                ));
+            }
+            Err(e) => {
+                log::error!(
+                    "[acp-install] {} manifest persist task failed: {e}",
+                    crate::logging::session_id()
+                );
+                return Err(InstallError::new(
+                    code::INSTALL_FAILED,
+                    format!("manifest persist task failed: {e}"),
+                ));
+            }
         }
 
         let elapsed = started.elapsed();
@@ -905,6 +947,14 @@ fn hex_encode(bytes: &[u8]) -> String {
 /// but this is a single chokepoint).
 fn sanitize_agent_id_log(id: &str) -> &str {
     id
+}
+
+/// Validate a sha256 hex digest: exactly 64 ASCII hex chars (case-insensitive).
+/// Mirrors the catalog's `compute_binary_status` tightening so an empty or
+/// malformed digest is rejected as `INTEGRITY_METADATA_MISSING` (NOT relaxed)
+/// — the host must not promise an install it cannot verify.
+fn is_valid_sha256_hex(s: &str) -> bool {
+    s.len() == 64 && s.as_bytes().iter().all(|b| b.is_ascii_hexdigit())
 }
 
 /// Extract the archive URL's host for logging — never the full URL with
@@ -1234,6 +1284,59 @@ mod tests {
         let _ = std::fs::remove_dir_all(root);
     }
 
+    // ---- sha256 empty / malformed (treated as missing) ----
+
+    #[tokio::test]
+    async fn sha256_empty_string_rejects_before_download() {
+        let root = temp_dir("empty-sha");
+        let service = open_service(root.clone()).await;
+        let pa = platform_arch_for(&host());
+        let agent = sample_binary_agent(
+            "empty-sha",
+            &pa,
+            Some(""),
+            "./acp",
+            "https://example.com/empty-sha.zip",
+        );
+        let downloader: Arc<dyn Downloader> = Arc::new(CannedDownloader {
+            bytes: vec![],
+            filename: "archive.zip".to_string(),
+            fail: false,
+        });
+        let err = service
+            .install(&agent, &host(), Some(downloader), None)
+            .await
+            .expect_err("empty-sha must error");
+        assert_eq!(err.code(), code::INTEGRITY_METADATA_MISSING);
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[tokio::test]
+    async fn sha256_malformed_rejects_before_download() {
+        let root = temp_dir("bad-sha");
+        let service = open_service(root.clone()).await;
+        let pa = platform_arch_for(&host());
+        // Wrong length + non-hex — must NOT be treated as a valid digest.
+        let agent = sample_binary_agent(
+            "bad-sha",
+            &pa,
+            Some("not-a-real-digest"),
+            "./acp",
+            "https://example.com/bad-sha.zip",
+        );
+        let downloader: Arc<dyn Downloader> = Arc::new(CannedDownloader {
+            bytes: vec![],
+            filename: "archive.zip".to_string(),
+            fail: false,
+        });
+        let err = service
+            .install(&agent, &host(), Some(downloader), None)
+            .await
+            .expect_err("bad-sha must error");
+        assert_eq!(err.code(), code::INTEGRITY_METADATA_MISSING);
+        let _ = std::fs::remove_dir_all(root);
+    }
+
     // ---- unsupported platform ----
 
     #[tokio::test]
@@ -1287,10 +1390,15 @@ mod tests {
         let root = temp_dir("too-large");
         let service = open_service(root.clone()).await;
         let pa = platform_arch_for(&host());
+        // Use a VALID 64-hex sha256 so the integrity check passes and the
+        // download is actually attempted (the TooLargeDownloader then trips
+        // ARCHIVE_TOO_LARGE). A short/invalid sha would short-circuit at
+        // INTEGRITY_METADATA_MISSING before the download.
+        let valid_sha = "a".repeat(64);
         let agent = sample_binary_agent(
             "big",
             &pa,
-            Some("abc"),
+            Some(valid_sha.as_str()),
             "./acp",
             "https://example.com/big.zip",
         );
@@ -1623,10 +1731,15 @@ mod tests {
         let root = temp_dir("dl-fail");
         let service = open_service(root.clone()).await;
         let pa = platform_arch_for(&host());
+        // Use a VALID 64-hex sha256 so the integrity check passes and the
+        // download is actually attempted (the failing CannedDownloader then
+        // trips DOWNLOAD_FAILED). A short/invalid sha would short-circuit at
+        // INTEGRITY_METADATA_MISSING before the download.
+        let valid_sha = "a".repeat(64);
         let agent = sample_binary_agent(
             "dl-fail",
             &pa,
-            Some("abc"),
+            Some(valid_sha.as_str()),
             "./acp",
             "https://example.com/dl-fail.zip",
         );
@@ -1813,6 +1926,12 @@ mod tests {
         let err = service.install_by_id("").await.expect_err("empty id errors");
         assert_eq!(err.code(), code::VALIDATION_ERROR);
         let err = service.install_by_id("../escape").await.expect_err("bad id errors");
+        assert_eq!(err.code(), code::VALIDATION_ERROR);
+        // Bare `.` / `..` denote the current/parent directory and would escape
+        // the install root via `root.join(&agent.id)` (CWE-22) — reject.
+        let err = service.install_by_id(".").await.expect_err("dot id errors");
+        assert_eq!(err.code(), code::VALIDATION_ERROR);
+        let err = service.install_by_id("..").await.expect_err("dotdot id errors");
         assert_eq!(err.code(), code::VALIDATION_ERROR);
         let _ = std::fs::remove_dir_all(root);
     }

--- a/src-tauri/src/acp_registry_snapshot.rs
+++ b/src-tauri/src/acp_registry_snapshot.rs
@@ -60,7 +60,11 @@ struct CachedSnapshot {
 }
 
 pub fn is_safe_agent_id(id: &str) -> bool {
+    // Reject `.` and `..` outright: the per-character allow-list admits them
+    // (every char is `.`), but they denote the current/parent directory and
+    // would escape the install root via `root.join(&agent.id)` (CWE-22).
     !id.is_empty()
+        && !matches!(id, "." | "..")
         && id.len() <= 128
         && id
             .chars()
@@ -235,5 +239,16 @@ mod tests {
     fn skips_agents_without_distribution() {
         let body = r#"{ "agents": [ { "id": "broken" } ] }"#;
         assert!(parse_snapshot(body).unwrap().is_empty());
+    }
+
+    #[test]
+    fn is_safe_agent_id_rejects_dot_and_dotdot() {
+        // `.` / `..` denote the current/parent directory and would escape the
+        // install root via `root.join(&agent.id)` (CWE-22) — reject outright.
+        assert!(!is_safe_agent_id("."));
+        assert!(!is_safe_agent_id(".."));
+        // Dotted ids that are NOT bare `.`/`..` remain valid.
+        assert!(is_safe_agent_id("com.example.agent"));
+        assert!(is_safe_agent_id("claude-acp"));
     }
 }

--- a/src-tauri/src/web/install_api.rs
+++ b/src-tauri/src/web/install_api.rs
@@ -23,15 +23,16 @@
 
 use axum::{
     body::Bytes,
-    extract::State,
+    extract::{ConnectInfo, State},
     http::StatusCode,
     response::IntoResponse,
     Json,
 };
+use std::net::SocketAddr;
 use tracing::{info, warn};
 
 use crate::acp::install::{code, InstallOutcome, InstallRequest};
-use crate::web::fs_api::IpcBody;
+use crate::web::fs_api::{check_local_only, IpcBody};
 use crate::web::ws::AppState;
 
 /// `POST /acp/install` — install a catalog agent.
@@ -43,10 +44,19 @@ use crate::web::ws::AppState;
 ///
 /// Degrade-mode (`acp_install: None`) returns
 /// `IpcBody::err(..., code::ACP_INSTALL_UNAVAILABLE)`.
+///
+/// Loopback-only guard (CWE-306): the install route mutates host state
+/// (downloads + verifies + atomically activates an agent binary + records the
+/// installed-agents manifest), so a LAN peer on a `0.0.0.0` bind must not
+/// reach it. Mirrors the fs/git/workspace write routes' `check_local_only`.
 pub async fn install(
     State(state): State<AppState>,
+    ConnectInfo(peer): ConnectInfo<SocketAddr>,
     body: Bytes,
 ) -> impl IntoResponse {
+    if let Some(forbidden) = check_local_only::<InstallOutcome>(peer) {
+        return (StatusCode::OK, Json(forbidden));
+    }
     let req: InstallRequest = match serde_json::from_slice(&body) {
         Ok(req) => req,
         Err(error) => {
@@ -109,10 +119,29 @@ mod tests {
     use crate::acp::install::AcpInstallService;
     use crate::web::ws::HistoryMode;
     use axum::body::Body;
+    use axum::extract::ConnectInfo;
     use axum::http::{Request, StatusCode};
     use axum::routing::post;
+    use std::net::SocketAddr;
     use std::sync::Arc;
     use tower::ServiceExt;
+
+    /// Loopback peer used by the `ConnectInfo<SocketAddr>` extractor in tests.
+    fn loopback_peer() -> SocketAddr {
+        SocketAddr::from(([127, 0, 0, 1], 54321))
+    }
+
+    /// Build a `POST /acp/install` request carrying the loopback
+    /// `ConnectInfo` extension the handler now requires.
+    fn install_request(body: &'static [u8]) -> Request<Body> {
+        Request::builder()
+            .method("POST")
+            .uri("/acp/install")
+            .header("content-type", "application/json")
+            .extension(ConnectInfo(loopback_peer()))
+            .body(Body::from(body.to_vec()))
+            .expect("build request")
+    }
 
     /// Temp directory removed on drop (including panic paths).
     struct TempDir(std::path::PathBuf);
@@ -206,11 +235,29 @@ mod tests {
     async fn install_degraded_returns_unavailable() {
         let state = state_without_store().await;
         let resp = test_router(state)
+            .oneshot(install_request(br#"{"agentId":"opencode"}"#))
+            .await
+            .expect("router response");
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body: IpcBody<InstallOutcome> = body_as_json(resp.into_body()).await;
+        assert!(!body.success);
+        assert_eq!(body.code.as_deref(), Some(code::ACP_INSTALL_UNAVAILABLE));
+    }
+
+    // ---- Loopback guard (CWE-306) ----
+
+    #[tokio::test]
+    async fn install_rejects_non_loopback_peer() {
+        let dir = TempDir::new("install-remote-peer");
+        let state = state_with_store(dir.path()).await;
+        // A LAN peer on a `0.0.0.0` bind must not reach the install route.
+        let resp = test_router(state)
             .oneshot(
                 Request::builder()
                     .method("POST")
                     .uri("/acp/install")
                     .header("content-type", "application/json")
+                    .extension(ConnectInfo(SocketAddr::from(([10, 0, 0, 5], 54321))))
                     .body(Body::from(br#"{"agentId":"opencode"}"#.to_vec()))
                     .expect("build request"),
             )
@@ -219,7 +266,7 @@ mod tests {
         assert_eq!(resp.status(), StatusCode::OK);
         let body: IpcBody<InstallOutcome> = body_as_json(resp.into_body()).await;
         assert!(!body.success);
-        assert_eq!(body.code.as_deref(), Some(code::ACP_INSTALL_UNAVAILABLE));
+        assert_eq!(body.code.as_deref(), Some("FORBIDDEN"));
     }
 
     // ---- deny_unknown_fields rejection ----
@@ -229,14 +276,7 @@ mod tests {
         let dir = TempDir::new("install-reject");
         let state = state_with_store(dir.path()).await;
         let resp = test_router(state)
-            .oneshot(
-                Request::builder()
-                    .method("POST")
-                    .uri("/acp/install")
-                    .header("content-type", "application/json")
-                    .body(Body::from(br#"{"agentId":"opencode","extra":"junk"}"#.to_vec()))
-                    .expect("build request"),
-            )
+            .oneshot(install_request(br#"{"agentId":"opencode","extra":"junk"}"#))
             .await
             .expect("router response");
         assert_eq!(
@@ -254,14 +294,7 @@ mod tests {
         let dir = TempDir::new("install-malformed");
         let state = state_with_store(dir.path()).await;
         let resp = test_router(state)
-            .oneshot(
-                Request::builder()
-                    .method("POST")
-                    .uri("/acp/install")
-                    .header("content-type", "application/json")
-                    .body(Body::from(b"{ not valid json".to_vec()))
-                    .expect("build request"),
-            )
+            .oneshot(install_request(b"{ not valid json"))
             .await
             .expect("router response");
         assert_eq!(resp.status(), StatusCode::OK);
@@ -277,14 +310,7 @@ mod tests {
         let dir = TempDir::new("install-empty-id");
         let state = state_with_store(dir.path()).await;
         let resp = test_router(state)
-            .oneshot(
-                Request::builder()
-                    .method("POST")
-                    .uri("/acp/install")
-                    .header("content-type", "application/json")
-                    .body(Body::from(br#"{"agentId":""}"#.to_vec()))
-                    .expect("build request"),
-            )
+            .oneshot(install_request(br#"{"agentId":""}"#))
             .await
             .expect("router response");
         assert_eq!(resp.status(), StatusCode::OK);
@@ -300,14 +326,7 @@ mod tests {
         let dir = TempDir::new("install-unknown");
         let state = state_with_store(dir.path()).await;
         let resp = test_router(state)
-            .oneshot(
-                Request::builder()
-                    .method("POST")
-                    .uri("/acp/install")
-                    .header("content-type", "application/json")
-                    .body(Body::from(br#"{"agentId":"does-not-exist"}"#.to_vec()))
-                    .expect("build request"),
-            )
+            .oneshot(install_request(br#"{"agentId":"does-not-exist"}"#))
             .await
             .expect("router response");
         assert_eq!(resp.status(), StatusCode::OK);

--- a/src-tauri/src/web/ws.rs
+++ b/src-tauri/src/web/ws.rs
@@ -1416,28 +1416,32 @@ async fn handle_list_acp_catalog(
     payload: &Value,
     acp_catalog: Option<&Arc<crate::acp::AcpCatalogService>>,
 ) -> WsReply {
+    // Distinct SCREAMING_SNAKE_CASE codes matching the HTTP route
+    // (`catalog_api::list`) byte-for-byte (the protocol-level `WsErrorCode`
+    // enum is snake_case and collapses these to `Unsupported`, masking the
+    // real failure for the renderer). `err_with_code` carries the raw string.
     let parsed: ListAcpCatalogPayload = match serde_json::from_value(payload.clone()) {
         Ok(p) => p,
         Err(e) => {
-            return WsReply::err(
+            return WsReply::err_with_code(
                 id,
-                WsErrorCode::Unsupported,
+                "VALIDATION_ERROR",
                 format!("malformed list_acp_catalog payload: {e}"),
             )
         }
     };
     let Some(service) = acp_catalog.cloned() else {
-        return WsReply::err(
+        return WsReply::err_with_code(
             id,
-            WsErrorCode::Unsupported,
+            "ACP_CATALOG_UNAVAILABLE",
             "acp catalog store is unavailable",
         );
     };
     match service.list_catalog(parsed.refresh.unwrap_or(false)).await {
         Ok(catalog) => ok_with_payload(id, &catalog),
-        Err(error) => WsReply::err(
+        Err(error) => WsReply::err_with_code(
             id,
-            WsErrorCode::Unsupported,
+            "CATALOG_LOAD_FAILED",
             format!("catalog load failed: {error}"),
         ),
     }
@@ -1456,28 +1460,34 @@ async fn handle_set_catalog_opt_in(
     payload: &Value,
     acp_catalog: Option<&Arc<crate::acp::AcpCatalogService>>,
 ) -> WsReply {
+    // Distinct SCREAMING_SNAKE_CASE codes matching the HTTP route
+    // (`catalog_api::set_opt_in`) byte-for-byte. A malformed payload is
+    // `VALIDATION_ERROR`, a missing store is `ACP_CATALOG_UNAVAILABLE`, and a
+    // persistence failure is `ACP_CATALOG_OPT_IN_FAILED` (NOT collapsed to
+    // `Unsupported`, which the renderer could not distinguish from a genuine
+    // catalog-load failure).
     let parsed: SetCatalogOptInPayload = match serde_json::from_value(payload.clone()) {
         Ok(p) => p,
         Err(e) => {
-            return WsReply::err(
+            return WsReply::err_with_code(
                 id,
-                WsErrorCode::Unsupported,
+                "VALIDATION_ERROR",
                 format!("malformed set_catalog_opt_in payload (want enabled): {e}"),
             )
         }
     };
     let Some(service) = acp_catalog.cloned() else {
-        return WsReply::err(
+        return WsReply::err_with_code(
             id,
-            WsErrorCode::Unsupported,
+            "ACP_CATALOG_UNAVAILABLE",
             "acp catalog store is unavailable",
         );
     };
     match service.set_opt_in(parsed.enabled) {
         Ok(()) => WsReply::ok(id, Some(json!({}))),
-        Err(error) => WsReply::err(
+        Err(error) => WsReply::err_with_code(
             id,
-            WsErrorCode::Unsupported,
+            "ACP_CATALOG_OPT_IN_FAILED",
             format!("opt-in persistence failed: {error}"),
         ),
     }
@@ -3212,6 +3222,91 @@ mod tests {
         assert!(reply.err.is_none(), "no err code on success");
         assert!(catalog.is_opt_in(), "opt-in persisted (host authority)");
         let _ = std::fs::remove_dir_all(root);
+    }
+
+    // ---- CAP-6 deferred 8.3: distinct catalog error codes (parity with HTTP) ----
+    //
+    // The catalog WS handlers previously collapsed ALL failures to
+    // `WsErrorCode::Unsupported`. These prove the handlers now emit the same
+    // SCREAMING_SNAKE_CASE codes as the HTTP routes (`catalog_api.rs`):
+    // `ACP_CATALOG_UNAVAILABLE` (degraded), `VALIDATION_ERROR` (malformed).
+
+    /// Like `handle_request_with_catalog` but with NO catalog store attached
+    /// (degraded mode — `acp_catalog: None`).
+    async fn handle_request_without_catalog(text: &str) -> WsReply {
+        let relay = Arc::new(WsRelaySink::new());
+        let acp = Arc::new(AcpManager::new(vec![]));
+        let (tx, _rx) = mpsc::unbounded_channel::<Outbound>();
+        let mut subs = Vec::new();
+        let registry = Arc::new(ProjectRegistry::new());
+        let mut current_agent: Option<AgentId> = None;
+        let current_session = Arc::new(parking_lot::Mutex::new(None::<SessionId>));
+        let current_project = Arc::new(parking_lot::Mutex::new(None::<String>));
+        let switch_queue = Arc::new(tokio::sync::Mutex::new(ProjectSwitchQueue::default()));
+        let mut authed = true;
+        handle_request(
+            text,
+            &mut authed,
+            &acp,
+            &relay,
+            &registry,
+            None,
+            None,
+            &tx,
+            &mut subs,
+            &mut current_agent,
+            &current_session,
+            &current_project,
+            &switch_queue,
+            HistoryMode::LiveOnly,
+            None,
+            None,
+        )
+        .await
+    }
+
+    #[tokio::test]
+    async fn list_acp_catalog_degraded_returns_unavailable() {
+        let reply = handle_request_without_catalog(
+            r#"{"id":"r1","type":"list_acp_catalog","payload":{}}"#,
+        )
+        .await;
+        assert!(!reply.ok);
+        assert_eq!(reply.err.as_ref().unwrap().code, "ACP_CATALOG_UNAVAILABLE");
+    }
+
+    #[tokio::test]
+    async fn set_catalog_opt_in_degraded_returns_unavailable() {
+        let reply = handle_request_without_catalog(
+            r#"{"id":"r1","type":"set_catalog_opt_in","payload":{"enabled":true}}"#,
+        )
+        .await;
+        assert!(!reply.ok);
+        assert_eq!(reply.err.as_ref().unwrap().code, "ACP_CATALOG_UNAVAILABLE");
+    }
+
+    #[tokio::test]
+    async fn list_acp_catalog_malformed_payload_returns_validation_error() {
+        // A non-bool `refresh` fails the `ListAcpCatalogPayload` serde.
+        let reply = handle_request_without_catalog(
+            r#"{"id":"r1","type":"list_acp_catalog","payload":{"refresh":"not-a-bool"}}"#,
+        )
+        .await;
+        assert!(!reply.ok);
+        assert_eq!(reply.err.as_ref().unwrap().code, "VALIDATION_ERROR");
+    }
+
+    #[tokio::test]
+    async fn set_catalog_opt_in_malformed_payload_returns_validation_error() {
+        // Missing `enabled` fails `deny_unknown_fields`-less payload... actually
+        // `SetCatalogOptInPayload` has no `default`, so a missing `enabled`
+        // fails serde (the field is required).
+        let reply = handle_request_without_catalog(
+            r#"{"id":"r1","type":"set_catalog_opt_in","payload":{"notEnabled":true}}"#,
+        )
+        .await;
+        assert!(!reply.ok);
+        assert_eq!(reply.err.as_ref().unwrap().code, "VALIDATION_ERROR");
     }
 
     // ---- Cross-client host-authority (Category C / Recovery Matrix: Browser A → Browser B) ----

--- a/src/renderer/hooks/use-acp-registry-catalog.ts
+++ b/src/renderer/hooks/use-acp-registry-catalog.ts
@@ -88,7 +88,16 @@ export function useAcpRegistryCatalog(): {
 
   const applyRemoteRegistry = useCallback(
     async () => {
-      if (!sharedAdvisoryAgents) return
+      if (!sharedAdvisoryAgents) {
+        // Throw (do NOT silently return): a silent return would let the caller's
+        // UI flip to a "using remote registry" state the host never opted into
+        // (UI/host split-brain). The Settings caller wraps this in a try/catch
+        // that surfaces the error as a toast, so the user is told to check for
+        // updates before applying.
+        throw new Error(
+          'No remote registry snapshot has been fetched. Check for updates before applying.'
+        )
+      }
       // CAP-6 / Story 8: the opt-in is now host-persisted. The renderer's
       // `applyRemoteRegistry()` becomes a call to `setCatalogOptIn(true)` so
       // the host gates CDN augmentation (the host enforces "trusted or

--- a/src/renderer/lib/acp-transport.ts
+++ b/src/renderer/lib/acp-transport.ts
@@ -610,21 +610,19 @@ export class WsAcpTransport implements AcpTransport {
 
   /**
    * CAP-6 / Story 9: host-owned verified-atomic install. The WS transport
-   * delegates to the `acpInstallApi` facade (resolves Tauri vs HTTP at runtime),
-   * so the web client gets the same verified install path as the desktop. The
-   * facade maps the `IpcResult<InstallOutcome>` success/failure into the
-   * transport's throw-on-error contract — a failure throws `AcpTransportError`
-   * carrying the install error code.
+   * routes the install through the authenticated WS connection
+   * (`install_acp_agent`), NOT a separate HTTP POST — the server's
+   * `handle_install_acp_agent` resolves the agent by id from the trusted
+   * catalog, downloads + verifies sha256 + atomically activates. `handleReply`
+   * maps the WS reply: success → resolve with the `InstallOutcome` payload
+   * `{ command, args }`; failure → reject with `AcpTransportError` carrying
+   * the install-specific SCREAMING_SNAKE_CASE code (via
+   * `WsReply::err_with_code`, byte-identical to the Tauri `IpcResult.code` +
+   * HTTP `IpcBody.code`). The request is `{ agentId }` only; the host resolves
+   * everything from the trusted catalog.
    */
   async installAcpAgent(agentId: string): Promise<InstallAcpRegistryBinaryOutcome> {
-    // Lazy import avoids a static cycle (acp-transport ↔ acp-install-api) at
-    // module load; the facade owns the `isTauriContext()` branching.
-    const { acpInstallApi } = await import('./acp-install-api')
-    const result = await acpInstallApi.installAgent(agentId)
-    if (result.success) {
-      return result.data
-    }
-    throw new AcpTransportError(result.code, result.error)
+    return this.request<InstallAcpRegistryBinaryOutcome>('install_acp_agent', { agentId })
   }
 
   /**
@@ -702,13 +700,21 @@ export class WsAcpTransport implements AcpTransport {
    * removed. Callers that need the full catalog (the registry-catalog hook)
    * switch to `acpCatalogApi.listCatalog()` instead.
    */
-  async fetchRegistrySnapshot(_forceRefresh = false): Promise<AcpRegistrySnapshot> {
+  async fetchRegistrySnapshot(forceRefresh = false): Promise<AcpRegistrySnapshot> {
     // Delegate to the host-resolved catalog. The host embeds the trusted
     // bundled `agents.json` + optionally augments with the CDN snapshot
     // (gated on the host-persisted opt-in). This replaces the fake
     // `{agents:[], source:'empty'}` hardcoded stub.
+    //
+    // The WS `list_acp_catalog` payload field is `refresh` (camelCase, matching
+    // the Rust `ListAcpCatalogPayload.refresh` + the HTTP `?refresh=true` query).
+    // Propagate `forceRefresh` so an explicit user refresh bypasses the host's
+    // 60s TTL — the previous `{}` left `refresh` defaulted to `false`, so a
+    // "check for updates" action could serve a stale cached catalog.
     try {
-      const catalog = await this.request<AcpCatalogFromHost>('list_acp_catalog', {})
+      const catalog = await this.request<AcpCatalogFromHost>('list_acp_catalog', {
+        refresh: forceRefresh
+      })
       return {
         agents: catalog.agents,
         source: 'network',

--- a/src/renderer/lib/agents/supported-acp-agents.test.ts
+++ b/src/renderer/lib/agents/supported-acp-agents.test.ts
@@ -271,6 +271,108 @@ describe('resolveSupportedAcpAgents', () => {
     expect(entries[0]?.status).toBe('ready')
   })
 
+  it('sets install info only when the host reports install-required', async () => {
+    listCatalogMock.mockResolvedValueOnce({
+      success: true,
+      data: {
+        host: {
+          os: 'linux',
+          arch: 'x86_64',
+          runtimes: { npx: true, uvx: false, node: true, bun: false, python3: true }
+        },
+        agents: [
+          {
+            id: 'opencode',
+            name: 'Opencode',
+            version: '1.0.0',
+            description: 'd',
+            source: 'bundled',
+            distribution: {
+              binary: {
+                'linux-x86_64': {
+                  cmd: './opencode',
+                  archive: 'https://example.com/opencode.zip',
+                  sha256: 'a'.repeat(64),
+                  args: ['acp'],
+                  env: { OPENCODE: '1' }
+                }
+              }
+            },
+            runtimeRequirements: [],
+            status: 'install-required',
+            platformTargets: []
+          }
+        ]
+      }
+    })
+
+    const entries = await resolveSupportedAcpAgents([])
+
+    expect(entries[0]?.status).toBe('install-required')
+    expect(entries[0]?.install).toMatchObject({
+      archiveUrl: 'https://example.com/opencode.zip',
+      cmd: './opencode',
+      args: ['acp'],
+      env: { OPENCODE: '1' }
+    })
+    expect(entries[0]?.manualInstall).toBeNull()
+  })
+
+  it('sets manualInstall (not install) when the host reports manual-install for a no-sha256 archive', async () => {
+    // The host's `compute_binary_status` is sha256-aware: an HTTPS archive
+    // WITHOUT a `sha256` digest is `manual-install` (the host must reject the
+    // install with `INTEGRITY_METADATA_MISSING`). The renderer's
+    // `deriveAgentConfig` is NOT sha256-aware (it only checks for an
+    // `archiveUrl`), so it would naively set `install`. Verify the renderer
+    // gates on the host's status so install info reflects the host's resolution.
+    listCatalogMock.mockResolvedValueOnce({
+      success: true,
+      data: {
+        host: {
+          os: 'linux',
+          arch: 'x86_64',
+          runtimes: { npx: true, uvx: false, node: true, bun: false, python3: true }
+        },
+        agents: [
+          {
+            id: 'no-sha',
+            name: 'NoSha',
+            version: '1.0.0',
+            description: 'd',
+            source: 'bundled',
+            distribution: {
+              binary: {
+                'linux-x86_64': {
+                  cmd: './no-sha',
+                  archive: 'https://example.com/no-sha.zip',
+                  // NOTE: no `sha256` — the host reports `manual-install`.
+                  args: ['acp'],
+                  env: { NO_SHA: '1' }
+                }
+              }
+            },
+            runtimeRequirements: [],
+            status: 'manual-install',
+            platformTargets: []
+          }
+        ]
+      }
+    })
+
+    const entries = await resolveSupportedAcpAgents([])
+
+    expect(entries[0]?.status).toBe('manual-install')
+    // `install` must be null (the host does not offer an install it must reject).
+    expect(entries[0]?.install).toBeNull()
+    // `manualInstall` carries the cmd/args/env (no archiveUrl — manual install
+    // does not download).
+    expect(entries[0]?.manualInstall).toMatchObject({
+      cmd: './no-sha',
+      args: ['acp'],
+      env: { NO_SHA: '1' }
+    })
+  })
+
   it('degrades to an empty list when the catalog is unavailable', async () => {
     listCatalogMock.mockResolvedValueOnce({
       success: false,

--- a/src/renderer/lib/agents/supported-acp-agents.ts
+++ b/src/renderer/lib/agents/supported-acp-agents.ts
@@ -341,6 +341,15 @@ export async function resolveSupportedAcpAgents(
     const binaryMapOs = catalog.host.os === 'macos' ? 'darwin' : catalog.host.os
     const derived = deriveAgentConfig(registryAgent, `${binaryMapOs}-${catalog.host.arch}`)
 
+    // The host's `compute_binary_status` is sha256-aware: a binary target with
+    // an HTTPS archive but NO `sha256` is `manual-install` (the host must reject
+    // the install with `INTEGRITY_METADATA_MISSING`). The renderer's
+    // `deriveAgentConfig` is NOT sha256-aware — it only checks for an
+    // `archiveUrl` — so without gating on `agent.status` it would set `install`
+    // for a no-sha256 agent the host reports as `manual-install` (status /
+    // install-field split-brain). Gate `install` on `install-required` and
+    // `manualInstall` on `manual-install` so the install info reflects the
+    // host's resolution (the host is the single source of truth).
     entries.push({
       id,
       configId,
@@ -348,7 +357,9 @@ export async function resolveSupportedAcpAgents(
       config: derived.kind === 'runnable' ? toStoredConfig(registryAgent, derived.config) : null,
       status: agent.status,
       install:
-        derived.kind === 'needs-install' && derived.archiveUrl
+        agent.status === 'install-required' &&
+        derived.kind === 'needs-install' &&
+        derived.archiveUrl
           ? {
               archiveUrl: derived.archiveUrl,
               cmd: derived.cmd,
@@ -357,7 +368,7 @@ export async function resolveSupportedAcpAgents(
             }
           : null,
       manualInstall:
-        derived.kind === 'needs-install' && !derived.archiveUrl
+        agent.status === 'manual-install' && derived.kind === 'needs-install'
           ? { cmd: derived.cmd, args: derived.args, env: derived.env }
           : null,
       runtimeLauncher:

--- a/src/renderer/lib/tauri-acp-catalog-api.ts
+++ b/src/renderer/lib/tauri-acp-catalog-api.ts
@@ -80,12 +80,20 @@ export function createTauriAcpCatalogApi(): AcpCatalogApi {
     },
 
     async isCatalogOptedIn(): Promise<IpcResult<boolean>> {
-      // The opt-in state is host-persisted; the desktop resolves it through
-      // `listCatalog()` (the catalog response carries the resolved agents,
-      // and the opt-in is observable via whether CDN entries are present).
-      // A dedicated `acp_is_catalog_opt_in` command is deferred — the
-      // facade exposes the method so callers can probe, but the impl
-      // derives from `listCatalog()` for now.
+      // TODO(CAP-6 follow-up): `isCatalogOptedIn` currently INFERS the opt-in
+      // state from the catalog contents (any agent with `source: 'registry'`
+      // ⇒ opted-in). This is a heavy lift to do correctly: inferring from
+      // catalog contents conflates "opt-in is on" with "the CDN fetch
+      // succeeded AND returned agents" — a failed/empty CDN fetch reads as
+      // opted-out even when the host persisted `opt_in_cdn: true`. The correct
+      // fix is a dedicated host endpoint (`acp_is_catalog_opt_in` Tauri
+      // command + `GET /acp/catalog/opt-in` HTTP route + WS
+      // `is_catalog_opted_in`) that reads the persisted boolean directly, but
+      // that requires adding the endpoint across all three transports + the
+      // catalog service's persisted-config reader, plus parity tests. Deferred
+      // — tracked as a CAP-6 follow-up. Until then, this best-effort probe
+      // derives from `listCatalog()` so callers can surface an approximate
+      // state (the Settings UI disables the toggle based on it).
       if (!isTauriContext()) {
         return {
           success: false,

--- a/src/renderer/lib/web-acp-catalog-api.ts
+++ b/src/renderer/lib/web-acp-catalog-api.ts
@@ -73,9 +73,12 @@ export const webAcpCatalogApi: AcpCatalogApi = {
   },
 
   async isCatalogOptedIn(): Promise<IpcResult<boolean>> {
-    // Derive from listCatalog: if any agent has source 'registry', the
-    // opt-in is on (the host only includes CDN entries when the opt-in is
-    // set AND the fetch succeeded).
+    // TODO(CAP-6 follow-up): see `tauri-acp-catalog-api.ts::isCatalogOptedIn` —
+    // this infers the opt-in from catalog contents (any `source: 'registry'`
+    // agent ⇒ opted-in), which conflates "opt-in is on" with "the CDN fetch
+    // succeeded". A dedicated host endpoint (`GET /acp/catalog/opt-in`) is the
+    // correct fix; deferred as a heavy lift (needs the endpoint across all
+    // three transports + parity tests).
     const result = await getJson<AcpCatalog>('/acp/catalog')
     if (!result.success) {
       return result as IpcResult<boolean>


### PR DESCRIPTION
## Summary

Addresses all 10 CodeRabbit review findings from PR #551 (CAP-6 host ACP catalog + verified atomic installation). Fixes 9 findings (3 security, 3 data integrity, 3 functional), defers 1 heavy-lift finding with a documented TODO. The fixes harden the install path against path traversal, loopback enforcement, sha256 validation, manifest write error handling, WS error code parity, and renderer status computation correctness.

## Related Issue

No related issue — follow-up to PR #551 CodeRabbit review.

## Type of Change

- [x] fix: bug fix
- [x] test: adds or updates tests

## What Changed

- Security: `is_safe_agent_id` rejects `.` and `..` (CWE-22 path traversal)
- Security: `POST /acp/install` guarded with `check_local_only` (loopback enforcement)
- Security: Catalog WS handlers use distinct error codes (not collapsed to `Unsupported`)
- Data: sha256 validated as 64 hex chars before download (empty/malformed → `INTEGRITY_METADATA_MISSING`)
- Data: Manifest write error handling covers both `JoinError` and inner `io::Result`
- Data: `installAcpAgent` WS transport uses WS request (not HTTP facade bypass)
- Functional: `applyRemoteRegistry` throws when no snapshot (no silent UI/host split-brain)
- Functional: `forceRefresh` propagated to `list_acp_catalog` WS payload
- Functional: `install-required` status gated on host resolution (not renderer heuristic)
- Deferred: `isCatalogOptedIn` host endpoint (TODO comment — heavy lift across 3 transports)

## How It Was Tested

- [x] `bun run ci` (Biome lint + format + imports, strict mode)
- [x] `bun run typecheck`
- [x] `bun run test` — 3319 passed, 43 skipped, 0 failed
- [x] `cargo clippy --all-targets --features standalone-server -- -D warnings` (in src-tauri)
- [ ] `cargo test` (in src-tauri) — compile-verified locally; runs on CI-Linux (pre-existing Windows DLL issue)
- [ ] Manual verification completed

## CI and Review Gate

- [ ] All CI checks pass (PR Validation, Rust Checks, Build Verification, Security Scans)
- [ ] Code review comments from CodeRabbit / Claude have been addressed or resolved
- [ ] No unresolved review findings remain

## Checklist

- [x] My PR title follows the conventional commit format used by this repo
- [x] I linked the related issue or explained why none exists
- [x] I updated docs when needed
- [x] I added or updated tests when needed
- [x] I verified the change does not introduce unrelated modifications
- [x] I read AGENTS.md and followed the contributor guidelines
- [ ] A human reviewed the complete diff before submission


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * ACP installations now require valid integrity metadata and reject unsafe agent identifiers.
  * Local installation requests reject connections from non-loopback addresses.

* **Bug Fixes**
  * Installation and catalog persistence failures now report clear errors instead of being silently ignored.
  * Catalog actions provide consistent error codes across transports.
  * Remote catalog application now requires a successful prior refresh.

* **Improvements**
  * Installation options now accurately reflect whether automatic or manual installation is supported.
  * Registry refresh requests honor forced-refresh selections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->