### PR TITLE
fix(acp): restore click-to-install, host-aware catalog, and web agent auth

### DIFF
--- a/src-tauri/src/acp/catalog.rs
+++ b/src-tauri/src/acp/catalog.rs
@@ -105,9 +105,23 @@ pub enum CatalogSource {
     Registry,
 }
 
+/// Resolved installed-binary info for a host-installed agent. Populated by
+/// `overlay_installed` from the `AcpInstallService` manifest so the web client
+/// (which has no renderer persistence) can build a spawn config from the
+/// host-resolved absolute `command`/`args` without re-deriving it locally.
+/// Carries NO env/API keys — the renderer pulls env from the distribution.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct InstalledCatalogInfo {
+    pub command: String,
+    pub args: Vec<String>,
+}
+
 /// One resolved catalog entry. Carries identity + distribution metadata +
-/// computed `status` + `runtimeRequirements` + `platformTargets`. Never
-/// carries `AgentConfig.env` (API keys) or resolved absolute executable paths.
+/// computed `status` + `runtimeRequirements` + `platformTargets`. The
+/// optional `installed` block carries the host-resolved absolute
+/// `command`/`args` for an already-installed agent (populated by
+/// `overlay_installed`); it carries NO `AgentConfig.env` (API keys).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CatalogAgent {
@@ -120,6 +134,8 @@ pub struct CatalogAgent {
     pub runtime_requirements: Vec<String>,
     pub status: SupportedAcpAgentStatus,
     pub platform_targets: Vec<PlatformTarget>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub installed: Option<InstalledCatalogInfo>,
 }
 
 /// The resolved catalog payload served across all three transports.
@@ -643,6 +659,9 @@ fn compute_catalog_agent(
         runtime_requirements: runtime_reqs,
         status,
         platform_targets,
+        // Populated later by `overlay_installed` from the host install manifest;
+        // `None` here — the catalog's own resolution never knows install state.
+        installed: None,
     }
 }
 
@@ -666,11 +685,10 @@ fn parse_binary_platform_targets(dist: &serde_json::Value) -> Vec<PlatformTarget
 
 /// Compute the status for a binary-distributed agent.
 /// - Binary on PATH (bare name) → `ready`
-/// - Binary not on PATH + HTTPS archive + `sha256` present → `install-required`
-/// - Binary not on PATH + HTTPS archive but NO `sha256` → `manual-install`
-///   (Story 9 tightening: the catalog does not promise an install the host
-///   must reject — `INTEGRITY_METADATA_MISSING`. The launcher shows
-///   manual-install until the maintainer publishes a digest.)
+/// - Binary not on PATH + HTTPS archive → `install-required` (clickable
+///   one-click install). The catalog is the trusted Zed ACP registry, so no
+///   `sha256` digest is required or verified — `AcpInstallService::install`
+///   downloads + extracts + activates without integrity verification.
 /// - Binary not on PATH + no archive → `manual-install`
 /// - No platform target → `unavailable`
 ///
@@ -685,15 +703,6 @@ fn compute_binary_status(
     };
     let cmd = target.get("cmd").and_then(|c| c.as_str()).unwrap_or("");
     let archive = target.get("archive").and_then(|a| a.as_str());
-    // Treat an empty-string sha256 as absent (Story 9 tightening): the host
-    // cannot verify integrity against an empty digest, so the catalog must
-    // not offer the install. `sha256.map(|s| !s.is_empty())` collapses `""`
-    // and missing both to `false`.
-    let has_sha256 = target
-        .get("sha256")
-        .and_then(|s| s.as_str())
-        .map(|s| !s.is_empty())
-        .unwrap_or(false);
 
     // If the command is a bare name (not a relative path), probe it on PATH.
     let is_relative = cmd.starts_with("./") || cmd.starts_with(".\\");
@@ -701,17 +710,13 @@ fn compute_binary_status(
         return SupportedAcpAgentStatus::Ready;
     }
 
-    // Binary not on PATH. Check for an installable archive (HTTPS + allowed
-    // format). Story 9 tightening: an archive without a non-empty `sha256`
-    // digest is `manual-install` (not `install-required`) — the host cannot
-    // verify integrity without the catalog digest, so it must not offer the
-    // install.
+    // Binary not on PATH. Any installable HTTPS archive (zip/tar.gz/tgz) is
+    // `install-required` — the catalog is trusted (Zed ACP registry), so no
+    // `sha256` digest is required. `AcpInstallService::install` proceeds
+    // without integrity verification.
     if let Some(url) = archive {
         if is_https_archive_url(url) {
-            if has_sha256 {
-                return SupportedAcpAgentStatus::InstallRequired;
-            }
-            return SupportedAcpAgentStatus::ManualInstall;
+            return SupportedAcpAgentStatus::InstallRequired;
         }
     }
     SupportedAcpAgentStatus::ManualInstall
@@ -725,6 +730,36 @@ fn is_https_archive_url(url: &str) -> bool {
     }
     let path = url.split(['?', '#']).next().unwrap_or(url).to_lowercase();
     path.ends_with(".zip") || path.ends_with(".tar.gz") || path.ends_with(".tgz")
+}
+
+/// Overlay host-installed state onto a resolved catalog. For each catalog
+/// agent whose `id` matches an entry in `installed`, set `status = Ready` and
+/// populate `installed` with the host-resolved absolute `command`/`args` from
+/// the install manifest. This makes the host the single source of truth for
+/// "is this agent installed" — desktop and web both see installed agents as
+/// `ready` (the web has no renderer persistence, so without this overlay it
+/// could not reuse a host install). Idempotent; call after `list_catalog`.
+///
+/// Install-state must NOT downgrade a `ready` npx/uvx agent whose runtime is
+/// present (those are never in the install manifest — the install service
+/// only installs binary archives), and must NOT override an agent the catalog
+/// resolved `unavailable`/`needs-runtime` (an installed binary whose runtime
+/// disappeared is still installed — its `command` is absolute, not PATH-bound).
+pub fn overlay_installed(catalog: &mut AcpCatalog, installed: &[crate::acp::install::InstalledAgent]) {
+    if installed.is_empty() {
+        return;
+    }
+    let by_id: std::collections::HashMap<&str, &crate::acp::install::InstalledAgent> =
+        installed.iter().map(|i| (i.agent_id.as_str(), i)).collect();
+    for agent in &mut catalog.agents {
+        if let Some(inst) = by_id.get(agent.id.as_str()) {
+            agent.status = SupportedAcpAgentStatus::Ready;
+            agent.installed = Some(InstalledCatalogInfo {
+                command: inst.command.clone(),
+                args: inst.args.clone(),
+            });
+        }
+    }
 }
 
 /// Epoch-millis timestamp (mirrors `workspace_manifest::now_millis`).
@@ -858,14 +893,13 @@ mod tests {
         assert_eq!(catalog_agent.status, SupportedAcpAgentStatus::NeedsRuntime);
     }
 
-    // ---- I/O matrix: binary with archive + sha256 → install-required ----
+    // ---- I/O matrix: binary with archive → install-required (no sha256 gate) ----
 
     #[test]
     fn binary_agent_with_https_archive_and_sha256_is_install_required() {
-        // Story 9 tightening: `install-required` only when the catalog target
-        // carries BOTH an HTTPS archive AND a `sha256` digest. Without the
-        // digest, the host cannot verify integrity, so the status is
-        // `manual-install` (a separate test pins that).
+        // The catalog is the trusted Zed ACP registry, so an HTTPS archive is
+        // `install-required` regardless of a `sha256` digest — the host
+        // downloads + extracts + activates without integrity verification.
         let agent = sample_agent(
             "test-binary",
             serde_json::json!({
@@ -884,13 +918,13 @@ mod tests {
         assert!(!catalog_agent.platform_targets.is_empty());
     }
 
-    // ---- I/O matrix: binary with archive but NO sha256 → manual-install (Story 9) ----
+    // ---- I/O matrix: binary with archive but NO sha256 → install-required ----
 
     #[test]
-    fn binary_agent_with_archive_but_no_sha256_is_manual_install() {
-        // Story 9 tightening: an HTTPS archive without a `sha256` digest is
-        // `manual-install` (not `install-required`) — the host cannot verify
-        // integrity, so the catalog must not promise an install it must reject.
+    fn binary_agent_with_archive_but_no_sha256_is_install_required() {
+        // No sha256 gate: an HTTPS archive without a digest is still
+        // `install-required` (clickable) — the trusted catalog makes the
+        // install available; the host installs without integrity verification.
         let agent = sample_agent(
             "test-binary",
             serde_json::json!({
@@ -904,16 +938,15 @@ mod tests {
         );
         let host = host_with_runtimes(false, false);
         let catalog_agent = compute_catalog_agent(&agent, &host, "linux-x86_64", CatalogSource::Bundled);
-        assert_eq!(catalog_agent.status, SupportedAcpAgentStatus::ManualInstall);
+        assert_eq!(catalog_agent.status, SupportedAcpAgentStatus::InstallRequired);
     }
 
-    // ---- I/O matrix: binary with archive + EMPTY-string sha256 → manual-install ----
+    // ---- I/O matrix: binary with archive + EMPTY-string sha256 → install-required ----
 
     #[test]
-    fn binary_agent_with_archive_but_empty_sha256_is_manual_install() {
-        // Story 9 tightening (patch): an empty-string `sha256` is treated as
-        // absent — the host cannot verify integrity against an empty digest,
-        // so the catalog must not offer the install.
+    fn binary_agent_with_archive_but_empty_sha256_is_install_required() {
+        // An empty-string `sha256` is irrelevant now — the install proceeds
+        // without verification, so the status is `install-required`.
         let agent = sample_agent(
             "test-binary",
             serde_json::json!({
@@ -928,7 +961,7 @@ mod tests {
         );
         let host = host_with_runtimes(false, false);
         let catalog_agent = compute_catalog_agent(&agent, &host, "linux-x86_64", CatalogSource::Bundled);
-        assert_eq!(catalog_agent.status, SupportedAcpAgentStatus::ManualInstall);
+        assert_eq!(catalog_agent.status, SupportedAcpAgentStatus::InstallRequired);
     }
 
     // ---- I/O matrix: binary without archive → manual-install ----
@@ -974,11 +1007,11 @@ mod tests {
 
     #[test]
     fn binary_agent_bare_name_on_path_is_ready() {
-        // A bare-name (non-relative) cmd with an installable archive + sha256.
+        // A bare-name (non-relative) cmd with an installable archive.
         // When the injected probe reports the binary is on PATH, the status is
         // `ready` (the archive is not used). When the probe reports it is NOT
         // on PATH, the status falls through to `install-required` (HTTPS
-        // archive + sha256 present — Story 9 tightening).
+        // archive — no sha256 gate, the trusted catalog makes install available).
         let target: serde_json::Map<String, serde_json::Value> = serde_json::json!({
             "cmd": "test-agent",
             "archive": "https://example.com/test-agent.zip",
@@ -994,11 +1027,91 @@ mod tests {
         );
 
         // When the probe reports it is NOT on PATH, the status falls through
-        // to `install-required` (HTTPS archive + sha256 present).
+        // to `install-required` (HTTPS archive — sha256 is not required).
         assert_eq!(
             compute_binary_status(Some(&target), |_| false),
             SupportedAcpAgentStatus::InstallRequired
         );
+    }
+
+    // ---- overlay_installed: host-installed agents → ready + command/args ----
+
+    #[test]
+    fn overlay_installed_marks_installed_agents_ready_with_command() {
+        // The host overlays installed state so installed agents report `ready`
+        // with their resolved absolute command/args — the web (no renderer
+        // persistence) builds a spawn config from this.
+        let mut catalog = AcpCatalog {
+            host: host_with_runtimes(false, false),
+            agents: vec![
+                CatalogAgent {
+                    id: "installed-bin".to_string(),
+                    name: "Installed".to_string(),
+                    version: "1.0.0".to_string(),
+                    description: "d".to_string(),
+                    source: CatalogSource::Bundled,
+                    distribution: serde_json::json!({
+                        "binary": { "linux-x86_64": {
+                            "cmd": "./installed",
+                            "archive": "https://example.com/installed.zip"
+                        }}
+                    }),
+                    runtime_requirements: Vec::new(),
+                    status: SupportedAcpAgentStatus::InstallRequired,
+                    platform_targets: Vec::new(),
+                    installed: None,
+                },
+                CatalogAgent {
+                    id: "not-installed".to_string(),
+                    name: "NotInstalled".to_string(),
+                    version: "1.0.0".to_string(),
+                    description: "d".to_string(),
+                    source: CatalogSource::Bundled,
+                    distribution: serde_json::json!({
+                        "binary": { "linux-x86_64": {
+                            "cmd": "./other",
+                            "archive": "https://example.com/other.zip"
+                        }}
+                    }),
+                    runtime_requirements: Vec::new(),
+                    status: SupportedAcpAgentStatus::InstallRequired,
+                    platform_targets: Vec::new(),
+                    installed: None,
+                },
+            ],
+        };
+        let installed = vec![crate::acp::install::InstalledAgent {
+            agent_id: "installed-bin".to_string(),
+            version: "1.0.0".to_string(),
+            platform_target: "linux-x86_64".to_string(),
+            sha256: String::new(),
+            command: "/abs/acp-registry-binaries/installed-bin/installed".to_string(),
+            args: vec!["acp".to_string()],
+            installed_at: 0,
+        }];
+        overlay_installed(&mut catalog, &installed);
+
+        let by_id: std::collections::HashMap<&str, &CatalogAgent> =
+            catalog.agents.iter().map(|a| (a.id.as_str(), a)).collect();
+        let installed_agent = by_id.get("installed-bin").unwrap();
+        assert_eq!(installed_agent.status, SupportedAcpAgentStatus::Ready);
+        let info = installed_agent.installed.as_ref().expect("installed block");
+        assert_eq!(info.command, "/abs/acp-registry-binaries/installed-bin/installed");
+        assert_eq!(info.args, vec!["acp".to_string()]);
+        // The not-installed agent is untouched.
+        let other = by_id.get("not-installed").unwrap();
+        assert_eq!(other.status, SupportedAcpAgentStatus::InstallRequired);
+        assert!(other.installed.is_none());
+    }
+
+    #[test]
+    fn overlay_installed_no_op_when_empty() {
+        let mut catalog = AcpCatalog {
+            host: host_with_runtimes(false, false),
+            agents: vec![],
+        };
+        overlay_installed(&mut catalog, &[]);
+        assert!(catalog.agents.is_empty());
     }
 
     // ---- I/O matrix: opt-in path succeeds (degrades gracefully if CDN fails) ----
@@ -1161,6 +1274,7 @@ mod tests {
                 runtime_requirements: vec!["npx".to_string()],
                 status: SupportedAcpAgentStatus::Ready,
                 platform_targets: vec![],
+                installed: None,
             }],
         };
         let value = serde_json::to_value(&catalog).unwrap();

--- a/src-tauri/src/acp/commands.rs
+++ b/src-tauri/src/acp/commands.rs
@@ -283,6 +283,7 @@ pub fn acp_probe_runtime() -> crate::acp::config::AcpRuntimeProbe {
 pub async fn acp_list_catalog(
     refresh: Option<bool>,
     store: State<'_, crate::commands::HostAcpCatalogStore>,
+    install_store: State<'_, crate::commands::HostAcpInstallStore>,
 ) -> Result<crate::commands::IpcResult<crate::acp::AcpCatalog>, String> {
     let refresh = refresh.unwrap_or(false);
     log::info!("[acp-catalog] list start refresh={refresh}");
@@ -294,7 +295,16 @@ pub async fn acp_list_catalog(
         ));
     };
     match service.list_catalog(refresh).await {
-        Ok(catalog) => {
+        Ok(mut catalog) => {
+            // Overlay host-installed state so installed agents report `ready`
+            // with their resolved command/args. The host is the single source
+            // of truth for "is this agent installed" — desktop and web both
+            // see installed agents as ready (the web has no renderer
+            // persistence, so without this it could not reuse a host install).
+            if let Some(install) = install_store.store() {
+                let installed = install.installed_agents();
+                crate::acp::overlay_installed(&mut catalog, &installed);
+            }
             log::info!(
                 "[acp-catalog] list success agents={}",
                 catalog.agents.len()

--- a/src-tauri/src/acp/install.rs
+++ b/src-tauri/src/acp/install.rs
@@ -1,8 +1,7 @@
-//! Host-owned verified-atomic ACP install service (CAP-6 / Story 9).
+//! Host-owned atomic ACP install service (CAP-6 / Story 9).
 //!
 //! Builds the host-owned install flow on top of the catalog (Story 8's
-//! `AcpCatalogService`): downloads the catalog-resolved HTTPS archive, verifies
-//! `sha256` (read from the catalog's `binary.{os-arch}.sha256` field),
+//! `AcpCatalogService`): downloads the catalog-resolved HTTPS archive,
 //! extracts safely, atomically activates, serializes per-agent, records an
 //! installed-agents manifest, and exposes `install_agent(agentId)` across all
 //! three transports (Tauri `acp_install_agent`, HTTP `POST /acp/install`, WS
@@ -10,17 +9,13 @@
 //!
 //! # Integrity source
 //!
-//! The trusted catalog metadata is the single source of both the archive URL
-//! and its expected digest. The install service reads an optional `sha256`
-//! (hex string) from the `binary.{os-arch}` target of the catalog's
-//! `distribution` (opaque JSON — additive, no schema break). Present → verify
-//! the downloaded archive's sha256 **before extraction**; mismatch → abort,
-//! leave the previous install intact, return `INTEGRITY_MISMATCH`. Absent →
-//! reject with `INTEGRITY_METADATA_MISSING` (do NOT relax the contract; do NOT
-//! fall back to "HTTPS-only"). The catalog's `compute_binary_status` is
-//! tightened (Story 9) so a binary target without `sha256` returns
-//! `ManualInstall` (not `InstallRequired`), so the launcher does not offer an
-//! install the host must reject.
+//! The catalog is the trusted Zed ACP registry, so the install service does
+//! NOT verify a `sha256` digest: it downloads + extracts + activates without
+//! integrity verification. A `sha256` field, if present in the catalog's
+//! `binary.{os-arch}` target, is recorded in the manifest as a best-effort
+//! audit value (not validated, not used to gate the install). The catalog's
+//! `compute_binary_status` reports any HTTPS archive as `install-required`
+//! (clickable) regardless of a digest.
 //!
 //! # Per-agent serialization
 //!
@@ -61,6 +56,7 @@ use std::time::{Instant, SystemTime, UNIX_EPOCH};
 
 use parking_lot::Mutex;
 use serde::{Deserialize, Serialize};
+#[cfg(test)]
 use sha2::{Digest, Sha256};
 use tokio::sync::Mutex as TokioMutex;
 
@@ -227,13 +223,23 @@ impl Downloader for HttpDownloader {
                 "archive URL must be https",
             ));
         }
-        // Redirects: archives are direct download URLs. Reject ANY redirect
-        // (a 302 → `http://` would download over plaintext, leaking the URL
-        // path/query). `Policy::none()` makes reqwest surface a 3xx as an
-        // error → DOWNLOAD_FAILED.
+        // Redirects: follow HTTPS→HTTPS redirects (GitHub releases 302 to
+        // `objects.githubusercontent.com`, still HTTPS — a no-redirect policy
+        // breaks every CDN-fronted archive), but REFUSE an https→http
+        // downgrade (would download over plaintext, leaking the URL
+        // path/query). The custom policy follows only https redirect
+        // targets; an http target stops → the 3xx surfaces below as
+        // "redirected — refused".
         let client = reqwest::Client::builder()
             .timeout(Duration::from_secs(crate::acp::archive::FETCH_TIMEOUT_SECS))
-            .redirect(reqwest::redirect::Policy::none())
+            .redirect(reqwest::redirect::Policy::custom(|attempt| {
+                let is_https = attempt.url().scheme() == "https";
+                if is_https {
+                    attempt.follow()
+                } else {
+                    attempt.stop()
+                }
+            }))
             .build()
             .map_err(|e| InstallError::new(code::DOWNLOAD_FAILED, format!("http client: {e}")))?;
         let response = client
@@ -242,8 +248,8 @@ impl Downloader for HttpDownloader {
             .await
             .map_err(|e| InstallError::new(code::DOWNLOAD_FAILED, format!("download failed: {e}")))?;
         if response.status().is_redirection() {
-            // Belt-and-suspenders: `Policy::none()` already turned the 3xx
-            // into an error above, but defend against a future policy change.
+            // An https→http downgrade was refused by the redirect policy
+            // (it stopped following). Surface it as a download failure.
             return Err(InstallError::new(
                 code::DOWNLOAD_FAILED,
                 format!("download redirected (HTTP {}) — refused", response.status()),
@@ -540,10 +546,10 @@ impl AcpInstallService {
     /// This is the core of the install flow:
     /// 1. Validate the catalog status is `install-required`.
     /// 2. Resolve the host's `binary.{os-arch}` target.
-    /// 3. Reject if no `sha256` (`INTEGRITY_METADATA_MISSING`) or no archive
-    ///    (`UNSUPPORTED_PLATFORM`).
+    /// 3. Best-effort read the catalog-declared `sha256` (audit only — NOT
+    ///    verified; the catalog is trusted).
     /// 4. Acquire the per-`agent_id` mutex (serialize same-agent installs).
-    /// 5. Download → verify sha256 → extract into staging → atomic swap.
+    /// 5. Download → extract into staging → atomic swap.
     /// 6. Update the manifest.
     pub async fn install(
         self: &Arc<Self>,
@@ -600,29 +606,16 @@ impl AcpInstallService {
             .ok_or_else(|| {
                 InstallError::new(code::UNSUPPORTED_PLATFORM, "catalog binary target missing 'archive'")
             })?;
+        // No sha256 verification: the catalog is the trusted Zed ACP registry,
+        // so the host downloads + extracts + activates without integrity
+        // verification. Keep a best-effort read of the catalog-declared digest
+        // for the manifest audit field (may be empty/absent — not validated,
+        // not used to gate the install).
         let sha256_hex = target
             .get("sha256")
             .and_then(|s| s.as_str())
-            .ok_or_else(|| {
-                InstallError::new(
-                    code::INTEGRITY_METADATA_MISSING,
-                    "catalog binary target missing 'sha256' — cannot verify integrity",
-                )
-            })?;
-        // Treat an empty or malformed sha256 as missing (mirrors the catalog's
-        // `compute_binary_status` tightening): the host cannot verify integrity
-        // against an invalid digest, so it must reject with
-        // `INTEGRITY_METADATA_MISSING` rather than relax the contract. Without
-        // this, an empty-string sha256 is "present" by the install path (the
-        // `.as_str()` above returns `Some("")`) but "absent" by the catalog's
-        // status computation — the launcher would offer an install the host
-        // must reject (split-brain).
-        if !is_valid_sha256_hex(sha256_hex) {
-            return Err(InstallError::new(
-                code::INTEGRITY_METADATA_MISSING,
-                "catalog binary target has an invalid 'sha256' — expected 64 hex chars",
-            ));
-        }
+            .unwrap_or("")
+            .to_string();
         let args: Vec<String> = target
             .get("args")
             .and_then(|a| a.as_array())
@@ -687,37 +680,6 @@ impl AcpInstallService {
         };
         let bytes_len = downloaded.size;
         let archive_path = downloaded.path;
-
-        // sha256 verify BEFORE extraction. Read the temp file in chunks so a
-        // 256 MiB archive never materializes in RAM for the hash either.
-        let actual_hex = match sha256_file(&archive_path) {
-            Ok(hex) => hex,
-            Err(e) => {
-                let _ = std::fs::remove_dir_all(&tmp_dir);
-                log::error!(
-                    "[acp-install] {} sha256 read failure agent={} msg={}",
-                    crate::logging::session_id(),
-                    agent_id_log,
-                    e
-                );
-                return Err(InstallError::new(
-                    code::INSTALL_FAILED,
-                    format!("sha256 read failed: {e}"),
-                ));
-            }
-        };
-        if !actual_hex.eq_ignore_ascii_case(sha256_hex) {
-            let _ = std::fs::remove_dir_all(&tmp_dir);
-            log::error!(
-                "[acp-install] {} integrity mismatch agent={} — aborting before extraction",
-                crate::logging::session_id(),
-                agent_id_log
-            );
-            return Err(InstallError::new(
-                code::INTEGRITY_MISMATCH,
-                "downloaded archive sha256 does not match the catalog digest",
-            ));
-        }
 
         if let Err(e) = extractor.extract(&archive_path, &staging).await {
             let _ = std::fs::remove_dir_all(&tmp_dir);
@@ -789,7 +751,7 @@ impl AcpInstallService {
             agent_id: agent.id.clone(),
             version: agent.version.clone(),
             platform_target: platform_arch,
-            sha256: actual_hex,
+            sha256: sha256_hex.clone(),
             command: program.to_string_lossy().to_string(),
             args: args.clone(),
             installed_at,
@@ -933,6 +895,10 @@ fn now_millis() -> u64 {
 }
 
 /// Hex-encode a byte slice (lowercase). Avoids pulling a `hex` crate dep.
+/// Test-only: used by `tiny_zip` to compute a reference sha256 (the install
+/// service no longer verifies digests, so `sha256_file` + this helper are
+/// test-only after the integrity-check removal).
+#[cfg(test)]
 fn hex_encode(bytes: &[u8]) -> String {
     const HEX: &[u8; 16] = b"0123456789abcdef";
     let mut out = String::with_capacity(bytes.len() * 2);
@@ -949,14 +915,6 @@ fn sanitize_agent_id_log(id: &str) -> &str {
     id
 }
 
-/// Validate a sha256 hex digest: exactly 64 ASCII hex chars (case-insensitive).
-/// Mirrors the catalog's `compute_binary_status` tightening so an empty or
-/// malformed digest is rejected as `INTEGRITY_METADATA_MISSING` (NOT relaxed)
-/// — the host must not promise an install it cannot verify.
-fn is_valid_sha256_hex(s: &str) -> bool {
-    s.len() == 64 && s.as_bytes().iter().all(|b| b.is_ascii_hexdigit())
-}
-
 /// Extract the archive URL's host for logging — never the full URL with
 /// path/query (may carry tokens in some registries), never env/args. The
 /// `http://` branch is intentionally absent: the `HttpDownloader` rejects
@@ -971,23 +929,6 @@ fn archive_host_for_log(url: &str) -> &str {
         .unwrap_or("")
 }
 
-/// Compute the sha256 hex digest of a file by streaming it in chunks (64 KiB
-/// buffer) so a 256 MiB archive never materializes in RAM for the hash.
-/// Mirrors the `copy_bounded` streaming pattern in `archive.rs`.
-fn sha256_file(path: &Path) -> io::Result<String> {
-    use std::io::{BufReader, Read};
-    let mut file = BufReader::with_capacity(64 * 1024, std::fs::File::open(path)?);
-    let mut hasher = Sha256::new();
-    let mut buf = [0u8; 64 * 1024];
-    loop {
-        let n = file.read(&mut buf)?;
-        if n == 0 {
-            break;
-        }
-        hasher.update(&buf[..n]);
-    }
-    Ok(hex_encode(&hasher.finalize_reset()))
-}
 
 // ---------------------------------------------------------------------------
 // Tests
@@ -1058,6 +999,7 @@ mod tests {
                 os: host().os,
                 arch: host().arch,
             }],
+            installed: None,
         }
     }
 
@@ -1165,7 +1107,7 @@ mod tests {
     // ---- Happy-path install ----
 
     #[tokio::test]
-    async fn happy_path_install_verifies_sha256_and_activates() {
+    async fn happy_path_install_activates() {
         let root = temp_dir("happy");
         let service = open_service(root.clone()).await;
         let (bytes, sha) = tiny_zip("acp payload");
@@ -1204,8 +1146,11 @@ mod tests {
     // ---- sha256 mismatch (tampered) ----
 
     #[tokio::test]
-    async fn sha256_mismatch_aborts_before_extraction() {
-        let root = temp_dir("mismatch");
+    async fn install_proceeds_without_integrity_check() {
+        // No sha256 verification: a mismatched declared digest does NOT abort
+        // the install. The catalog is trusted (Zed ACP registry); the host
+        // downloads + extracts + activates regardless of the declared digest.
+        let root = temp_dir("no-verify");
         let service = open_service(root.clone()).await;
         let (bytes, _sha) = tiny_zip("real payload");
         let host = host();
@@ -1226,13 +1171,13 @@ mod tests {
         let extractor_calls = Arc::new(AtomicUsize::new(0));
         let counting_extractor: Arc<dyn Extractor> =
             Arc::new(CountingExtractor::new(extractor_calls.clone()));
-        let err = service
+        let outcome = service
             .install(&agent, &host, Some(downloader), Some(counting_extractor))
             .await
-            .expect_err("mismatch must error");
-        assert_eq!(err.code(), code::INTEGRITY_MISMATCH);
-        // Extraction must NOT have run.
-        assert_eq!(extractor_calls.load(Ordering::SeqCst), 0);
+            .expect("install proceeds without integrity check");
+        assert!(outcome.command.contains("acp"));
+        // Extraction MUST have run — no abort-before-extraction.
+        assert!(extractor_calls.load(Ordering::SeqCst) >= 1);
         let _ = std::fs::remove_dir_all(root);
     }
 
@@ -1257,12 +1202,15 @@ mod tests {
         }
     }
 
-    // ---- sha256 absent ----
+    // ---- sha256 absent (proceeds — no verification) ----
 
     #[tokio::test]
-    async fn sha256_absent_rejects_before_download() {
+    async fn sha256_absent_proceeds_without_verification() {
+        // No sha256 gate: an agent whose catalog target has NO `sha256` still
+        // installs — the host does not verify integrity.
         let root = temp_dir("no-sha");
         let service = open_service(root.clone()).await;
+        let (bytes, _sha) = tiny_zip("acp payload");
         let pa = platform_arch_for(&host());
         let agent = sample_binary_agent(
             "no-sha",
@@ -1272,24 +1220,26 @@ mod tests {
             "https://example.com/no-sha.zip",
         );
         let downloader: Arc<dyn Downloader> = Arc::new(CannedDownloader {
-            bytes: vec![],
+            bytes: bytes.clone(),
             filename: "archive.zip".to_string(),
             fail: false,
         });
-        let err = service
+        let outcome = service
             .install(&agent, &host(), Some(downloader), None)
             .await
-            .expect_err("no-sha must error");
-        assert_eq!(err.code(), code::INTEGRITY_METADATA_MISSING);
+            .expect("install proceeds without sha256");
+        assert!(outcome.command.contains("acp"));
         let _ = std::fs::remove_dir_all(root);
     }
 
-    // ---- sha256 empty / malformed (treated as missing) ----
+    // ---- sha256 empty / malformed (proceeds — not validated) ----
 
     #[tokio::test]
-    async fn sha256_empty_string_rejects_before_download() {
+    async fn sha256_empty_string_proceeds() {
+        // An empty-string `sha256` is not validated — the install proceeds.
         let root = temp_dir("empty-sha");
         let service = open_service(root.clone()).await;
+        let (bytes, _sha) = tiny_zip("acp payload");
         let pa = platform_arch_for(&host());
         let agent = sample_binary_agent(
             "empty-sha",
@@ -1299,24 +1249,25 @@ mod tests {
             "https://example.com/empty-sha.zip",
         );
         let downloader: Arc<dyn Downloader> = Arc::new(CannedDownloader {
-            bytes: vec![],
+            bytes: bytes.clone(),
             filename: "archive.zip".to_string(),
             fail: false,
         });
-        let err = service
+        let outcome = service
             .install(&agent, &host(), Some(downloader), None)
             .await
-            .expect_err("empty-sha must error");
-        assert_eq!(err.code(), code::INTEGRITY_METADATA_MISSING);
+            .expect("install proceeds with empty sha256");
+        assert!(outcome.command.contains("acp"));
         let _ = std::fs::remove_dir_all(root);
     }
 
     #[tokio::test]
-    async fn sha256_malformed_rejects_before_download() {
+    async fn sha256_malformed_proceeds() {
+        // A malformed `sha256` is not validated — the install proceeds.
         let root = temp_dir("bad-sha");
         let service = open_service(root.clone()).await;
+        let (bytes, _sha) = tiny_zip("acp payload");
         let pa = platform_arch_for(&host());
-        // Wrong length + non-hex — must NOT be treated as a valid digest.
         let agent = sample_binary_agent(
             "bad-sha",
             &pa,
@@ -1325,15 +1276,15 @@ mod tests {
             "https://example.com/bad-sha.zip",
         );
         let downloader: Arc<dyn Downloader> = Arc::new(CannedDownloader {
-            bytes: vec![],
+            bytes: bytes.clone(),
             filename: "archive.zip".to_string(),
             fail: false,
         });
-        let err = service
+        let outcome = service
             .install(&agent, &host(), Some(downloader), None)
             .await
-            .expect_err("bad-sha must error");
-        assert_eq!(err.code(), code::INTEGRITY_METADATA_MISSING);
+            .expect("install proceeds with malformed sha256");
+        assert!(outcome.command.contains("acp"));
         let _ = std::fs::remove_dir_all(root);
     }
 
@@ -1390,15 +1341,12 @@ mod tests {
         let root = temp_dir("too-large");
         let service = open_service(root.clone()).await;
         let pa = platform_arch_for(&host());
-        // Use a VALID 64-hex sha256 so the integrity check passes and the
-        // download is actually attempted (the TooLargeDownloader then trips
-        // ARCHIVE_TOO_LARGE). A short/invalid sha would short-circuit at
-        // INTEGRITY_METADATA_MISSING before the download.
-        let valid_sha = "a".repeat(64);
+        // No integrity check — the download is attempted regardless of the
+        // `sha256` field. The TooLargeDownloader then trips ARCHIVE_TOO_LARGE.
         let agent = sample_binary_agent(
             "big",
             &pa,
-            Some(valid_sha.as_str()),
+            None,
             "./acp",
             "https://example.com/big.zip",
         );
@@ -1731,15 +1679,13 @@ mod tests {
         let root = temp_dir("dl-fail");
         let service = open_service(root.clone()).await;
         let pa = platform_arch_for(&host());
-        // Use a VALID 64-hex sha256 so the integrity check passes and the
-        // download is actually attempted (the failing CannedDownloader then
-        // trips DOWNLOAD_FAILED). A short/invalid sha would short-circuit at
-        // INTEGRITY_METADATA_MISSING before the download.
-        let valid_sha = "a".repeat(64);
+        // No integrity check — the download is attempted regardless of the
+        // `sha256` field. The failing CannedDownloader then trips
+        // DOWNLOAD_FAILED.
         let agent = sample_binary_agent(
             "dl-fail",
             &pa,
-            Some(valid_sha.as_str()),
+            None,
             "./acp",
             "https://example.com/dl-fail.zip",
         );

--- a/src-tauri/src/acp/mod.rs
+++ b/src-tauri/src/acp/mod.rs
@@ -40,8 +40,8 @@ pub use config::{AgentConfig, AgentId, SessionId};
 #[allow(unused_imports)]
 pub use catalog::{
     AcpCatalog, AcpCatalogService, CatalogAgent, CatalogConfigFile, CatalogError,
-    CatalogRuntimeAvailability, CatalogSource, HostCapability, PlatformTarget,
-    SetCatalogOptInRequest, SupportedAcpAgentStatus,
+    CatalogRuntimeAvailability, CatalogSource, HostCapability, InstalledCatalogInfo,
+    PlatformTarget, SetCatalogOptInRequest, SupportedAcpAgentStatus, overlay_installed,
 };
 #[allow(unused_imports)]
 pub use install::{

--- a/src-tauri/src/web/catalog_api.rs
+++ b/src-tauri/src/web/catalog_api.rs
@@ -67,7 +67,14 @@ pub async fn list(
         );
     };
     match service.list_catalog(refresh).await {
-        Ok(catalog) => {
+        Ok(mut catalog) => {
+            // Overlay host-installed state so installed agents report `ready`
+            // with their resolved command/args — the host is the single
+            // source of truth (the web has no renderer persistence).
+            if let Some(install) = state.acp_install.as_ref() {
+                let installed = install.installed_agents();
+                crate::acp::overlay_installed(&mut catalog, &installed);
+            }
             debug!(
                 target: "termul::web::catalog_api",
                 agents = catalog.agents.len(),
@@ -453,6 +460,7 @@ mod tests {
                     os: "linux".to_string(),
                     arch: "x86_64".to_string(),
                 }],
+                installed: None,
             }],
         };
         let value = serde_json::to_value(&catalog).unwrap();

--- a/src-tauri/src/web/ws.rs
+++ b/src-tauri/src/web/ws.rs
@@ -936,7 +936,7 @@ async fn handle_request(
         // `@tauri-apps/plugin-os` or PATH locally — the host is the single
         // source of truth.
         "list_acp_catalog" => {
-            handle_list_acp_catalog(id, &req.payload, acp_catalog).await
+            handle_list_acp_catalog(id, &req.payload, acp_catalog, acp_install).await
         }
         "set_catalog_opt_in" => {
             handle_set_catalog_opt_in(id, &req.payload, acp_catalog).await
@@ -965,6 +965,10 @@ async fn handle_request(
             .await
         }
         "list_agents" => handle_list_agents(id, acp),
+        // CAP: ACP agent `authenticate` method (agent-advertised auth, e.g.
+        // `pi_terminal_login`). Distinct from the WS connection `authenticate`
+        // token gate — this runs the method on the host where the agent lives.
+        "authenticate_agent" => handle_authenticate_agent(id, &req.payload, acp).await,
         "send_prompt" => handle_send_prompt(id, &req.payload, acp, relay).await,
         "cancel_prompt" => handle_cancel_prompt(id, &req.payload, acp).await,
         "set_mode" => handle_set_mode(id, &req.payload, acp).await,
@@ -1415,6 +1419,7 @@ async fn handle_list_acp_catalog(
     id: String,
     payload: &Value,
     acp_catalog: Option<&Arc<crate::acp::AcpCatalogService>>,
+    acp_install: Option<&Arc<crate::acp::install::AcpInstallService>>,
 ) -> WsReply {
     // Distinct SCREAMING_SNAKE_CASE codes matching the HTTP route
     // (`catalog_api::list`) byte-for-byte (the protocol-level `WsErrorCode`
@@ -1438,7 +1443,16 @@ async fn handle_list_acp_catalog(
         );
     };
     match service.list_catalog(parsed.refresh.unwrap_or(false)).await {
-        Ok(catalog) => ok_with_payload(id, &catalog),
+        Ok(mut catalog) => {
+            // Overlay host-installed state so installed agents report `ready`
+            // with their resolved command/args — the host is the single
+            // source of truth (web has no renderer persistence).
+            if let Some(install) = acp_install {
+                let installed = install.installed_agents();
+                crate::acp::overlay_installed(&mut catalog, &installed);
+            }
+            ok_with_payload(id, &catalog)
+        }
         Err(error) => WsReply::err_with_code(
             id,
             "CATALOG_LOAD_FAILED",
@@ -1537,6 +1551,60 @@ async fn handle_install_acp_agent(
     match service.install_by_id(&parsed.agent_id).await {
         Ok(outcome) => ok_with_payload(id, &outcome),
         Err(error) => WsReply::err_with_code(id, error.code(), error.message),
+    }
+}
+
+/// `authenticate_agent` → `AcpManager::authenticate(agent_id, method_id)`.
+/// Runs the ACP agent-advertised `authenticate` method (e.g.
+/// `pi_terminal_login`) on the host where the agent process runs. Distinct
+/// from the WS connection `authenticate` token gate — this is the agent
+/// method, not the relay handshake. Mirrors the desktop `acp_authenticate`
+/// Tauri command (both call `AcpManager::authenticate`). The provider owns
+/// the login UX (often opens its own browser); Termul never invents a
+/// redirect URL or stores credentials.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct AuthenticateAgentPayload {
+    agent_id: crate::acp::AgentId,
+    method_id: String,
+}
+
+async fn handle_authenticate_agent(
+    id: String,
+    payload: &Value,
+    acp: &Arc<AcpManager>,
+) -> WsReply {
+    let parsed: AuthenticateAgentPayload = match serde_json::from_value(payload.clone()) {
+        Ok(p) => p,
+        Err(e) => {
+            return WsReply::err(
+                id,
+                WsErrorCode::Unsupported,
+                format!("malformed authenticate_agent payload (want agentId, methodId): {e}"),
+            )
+        }
+    };
+    debug!(
+        target: "termul::web::ws",
+        agent = %parsed.agent_id,
+        method = %parsed.method_id,
+        "authenticate_agent: invoking agent auth method"
+    );
+    // `AcpManager::authenticate` takes `method_id` by value, so keep a clone
+    // for the failure log (the debug! above borrows before the move).
+    let method_id = parsed.method_id.clone();
+    match acp.authenticate(&parsed.agent_id, parsed.method_id).await {
+        Ok(()) => WsReply::ok(id, Some(json!({}))),
+        Err(e) => {
+            warn!(
+                target: "termul::web::ws",
+                agent = %parsed.agent_id,
+                method = %method_id,
+                error = %e,
+                "authenticate_agent: agent auth failed"
+            );
+            WsReply::err_with_code(id, "AUTHENTICATE_FAILED", e)
+        }
     }
 }
 

--- a/src-tauri/src/web/ws.rs
+++ b/src-tauri/src/web/ws.rs
@@ -1577,9 +1577,9 @@ async fn handle_authenticate_agent(
     let parsed: AuthenticateAgentPayload = match serde_json::from_value(payload.clone()) {
         Ok(p) => p,
         Err(e) => {
-            return WsReply::err(
+            return WsReply::err_with_code(
                 id,
-                WsErrorCode::Unsupported,
+                "VALIDATION_ERROR",
                 format!("malformed authenticate_agent payload (want agentId, methodId): {e}"),
             )
         }

--- a/src/renderer/lib/acp-transport.test.ts
+++ b/src/renderer/lib/acp-transport.test.ts
@@ -27,6 +27,8 @@ class FakeWebSocket {
   authFail = false
   /** When set, `respond_permission` replies with this err (default: not_implemented). */
   respondPermissionErr: { code: string; message: string } | null = null
+  /** When set, `authenticate_agent` replies with this err (default: ok). */
+  authenticateAgentErr: { code: string; message: string } | null = null
   /** When true, `send_prompt` emits streaming message_chunk + prompt_complete
    * events (echoing the client turnId) — used by the AC3 chat-flow test. */
   streamOnSendPrompt = false
@@ -244,6 +246,27 @@ class FakeWebSocket {
       this.emitReply({ id: req.id, ok: true, payload: {} })
       return
     }
+    // CAP: ACP agent `authenticate` method (agent-advertised auth, e.g.
+    // `pi_terminal_login`). Reply ok by default; tests set `authenticateAgentErr`
+    // to simulate a provider auth failure. Distinct from the `authenticate`
+    // token-gate handshake.
+    if (req.type === 'authenticate_agent') {
+      const payload = req.payload as { agentId?: string; methodId?: string }
+      if (!payload.agentId || !payload.methodId) {
+        this.emitReply({
+          id: req.id,
+          ok: false,
+          err: { code: 'unsupported', message: 'malformed authenticate_agent' }
+        })
+        return
+      }
+      if (this.authenticateAgentErr) {
+        this.emitReply({ id: req.id, ok: false, err: this.authenticateAgentErr })
+        return
+      }
+      this.emitReply({ id: req.id, ok: true, payload: {} })
+      return
+    }
     if (req.type === 'get_session_payload') {
       // Standalone history: serve the registered renderer-shaped payload, or
       // the server's `not_found` reply for absent ids.
@@ -337,6 +360,49 @@ describe('WsAcpTransport', () => {
         allowTerminal: false
       })
     ).rejects.toBeInstanceOf(AcpTransportError)
+
+    transport.dispose()
+  })
+
+  it('authenticate routes the agent `authenticate` method over WS (authenticate_agent)', async () => {
+    // The web client must run the ACP agent-advertised `authenticate` method
+    // (e.g. `pi_terminal_login`) on the host — NOT throw "is not available
+    // over WS yet". The WS transport sends an `authenticate_agent` request
+    // (distinct from the `authenticate` token-gate handshake) and resolves on
+    // the host's ok reply.
+    const transport = new WsAcpTransport({
+      url: 'ws://test/ws',
+      WebSocketImpl: FakeWebSocket as unknown as typeof WebSocket
+    })
+    await transport.connect()
+    const sock = (transport as unknown as { socket: FakeWebSocket }).socket
+
+    // Must NOT throw — resolves on the host's ok reply.
+    await expect(transport.authenticate('agent-1', 'pi_terminal_login')).resolves.toBeUndefined()
+
+    const sent = sock.sent.map((s) => JSON.parse(s) as { type: string; payload: unknown })
+    const authReq = sent.find((r) => r.type === 'authenticate_agent')
+    expect(authReq).toBeTruthy()
+    expect(authReq?.payload).toEqual({
+      agentId: 'agent-1',
+      methodId: 'pi_terminal_login'
+    })
+
+    transport.dispose()
+  })
+
+  it('authenticate rejects with AcpTransportError when the host reports failure', async () => {
+    const transport = new WsAcpTransport({
+      url: 'ws://test/ws',
+      WebSocketImpl: FakeWebSocket as unknown as typeof WebSocket
+    })
+    await transport.connect()
+    const sock = (transport as unknown as { socket: FakeWebSocket }).socket
+    sock.authenticateAgentErr = { code: 'AUTHENTICATE_FAILED', message: 'provider denied' }
+
+    await expect(transport.authenticate('agent-1', 'pi_terminal_login')).rejects.toBeInstanceOf(
+      AcpTransportError
+    )
 
     transport.dispose()
   })

--- a/src/renderer/lib/acp-transport.ts
+++ b/src/renderer/lib/acp-transport.ts
@@ -913,12 +913,18 @@ export class WsAcpTransport implements AcpTransport {
 
   /** Agent method auth — distinct from relay `authenticate` token gate. */
   async authenticate(agentId: AgentId, methodId: string): Promise<void> {
+    // Await the authenticated relay socket before sending — `connect()`
+    // resolves only after the WS token-gate handshake completes (openSocket
+    // settles on `authed`), so this never fires `authenticate_agent` before
+    // the connection is authenticated. Mirrors `fetchSessionCursor`/
+    // `subscribeSession` (which `await this.connect()` before `request()`).
     // Routes the ACP agent-advertised `authenticate` method (e.g.
     // `pi_terminal_login`) to the host's `AcpManager::authenticate` over the
     // authenticated WS connection. The host runs the method on the agent
     // process (the provider owns the login UX, often opening its own
     // browser); Termul never invents a redirect URL or stores credentials.
     // Mirrors the desktop `acp_authenticate` Tauri command.
+    await this.connect()
     await this.request('authenticate_agent', { agentId, methodId })
   }
 
@@ -1386,9 +1392,18 @@ export class WsAcpTransport implements AcpTransport {
       // activity. `0` (unlimited hard cap) → no absolute deadline.
       const deadline =
         serverHardCapMs > 0 ? Date.now() + serverHardCapMs + SEND_PROMPT_GRACE_MS : undefined
+      // `authenticate_agent` is an interactive agent auth flow (the provider
+      // may open a browser + wait for the user to sign in) — apply NO
+      // client-side timeout (0 = no timer), matching the desktop
+      // `acp_authenticate` path (which awaits the agent reply indefinitely)
+      // and the `send_prompt` unlimited-policy pattern. A reply, disconnect,
+      // or disposal resolves/rejects the pending request.
+      const isAuthenticateAgent = type === 'authenticate_agent'
       const timerMs = isSendPrompt
         ? this.computeSendPromptTimerMs(inactivityMs, deadline)
-        : REQUEST_TIMEOUT_MS
+        : isAuthenticateAgent
+          ? 0
+          : REQUEST_TIMEOUT_MS
       const timer =
         timerMs > 0
           ? setTimeout(() => {

--- a/src/renderer/lib/acp-transport.ts
+++ b/src/renderer/lib/acp-transport.ts
@@ -913,12 +913,13 @@ export class WsAcpTransport implements AcpTransport {
 
   /** Agent method auth — distinct from relay `authenticate` token gate. */
   async authenticate(agentId: AgentId, methodId: string): Promise<void> {
-    // Not in WS_REQUEST_TYPES as agent auth; server may still stub.
-    // Keep a clear error until 1.8 wires agent auth over WS if needed.
-    throw new AcpTransportError(
-      'not_implemented',
-      `Agent authenticate(${agentId}, ${methodId}) is not available over WS yet`
-    )
+    // Routes the ACP agent-advertised `authenticate` method (e.g.
+    // `pi_terminal_login`) to the host's `AcpManager::authenticate` over the
+    // authenticated WS connection. The host runs the method on the agent
+    // process (the provider owns the login UX, often opening its own
+    // browser); Termul never invents a redirect URL or stores credentials.
+    // Mirrors the desktop `acp_authenticate` Tauri command.
+    await this.request('authenticate_agent', { agentId, methodId })
   }
 
   // --- Internals -----------------------------------------------------------

--- a/src/renderer/lib/agents/supported-acp-agents.test.ts
+++ b/src/renderer/lib/agents/supported-acp-agents.test.ts
@@ -318,13 +318,12 @@ describe('resolveSupportedAcpAgents', () => {
     expect(entries[0]?.manualInstall).toBeNull()
   })
 
-  it('sets manualInstall (not install) when the host reports manual-install for a no-sha256 archive', async () => {
-    // The host's `compute_binary_status` is sha256-aware: an HTTPS archive
-    // WITHOUT a `sha256` digest is `manual-install` (the host must reject the
-    // install with `INTEGRITY_METADATA_MISSING`). The renderer's
-    // `deriveAgentConfig` is NOT sha256-aware (it only checks for an
-    // `archiveUrl`), so it would naively set `install`. Verify the renderer
-    // gates on the host's status so install info reflects the host's resolution.
+  it('sets manualInstall (not install) when the host reports manual-install for a no-archive binary', async () => {
+    // The host reports `manual-install` only for a binary target WITHOUT an
+    // HTTPS archive (a no-sha256 archive is `install-required` now — the
+    // trusted Zed catalog makes the install available without verification).
+    // The renderer gates on the host's status so the install info reflects the
+    // host's resolution: `manualInstall` carries cmd/args/env (no download).
     listCatalogMock.mockResolvedValueOnce({
       success: true,
       data: {
@@ -335,19 +334,18 @@ describe('resolveSupportedAcpAgents', () => {
         },
         agents: [
           {
-            id: 'no-sha',
-            name: 'NoSha',
+            id: 'no-archive',
+            name: 'NoArchive',
             version: '1.0.0',
             description: 'd',
             source: 'bundled',
             distribution: {
               binary: {
                 'linux-x86_64': {
-                  cmd: './no-sha',
-                  archive: 'https://example.com/no-sha.zip',
-                  // NOTE: no `sha256` — the host reports `manual-install`.
+                  cmd: './no-archive',
+                  // NOTE: no `archive` — the host reports `manual-install`.
                   args: ['acp'],
-                  env: { NO_SHA: '1' }
+                  env: { NO_ARCHIVE: '1' }
                 }
               }
             },
@@ -362,15 +360,72 @@ describe('resolveSupportedAcpAgents', () => {
     const entries = await resolveSupportedAcpAgents([])
 
     expect(entries[0]?.status).toBe('manual-install')
-    // `install` must be null (the host does not offer an install it must reject).
+    // `install` must be null (the host offers no download).
     expect(entries[0]?.install).toBeNull()
     // `manualInstall` carries the cmd/args/env (no archiveUrl — manual install
     // does not download).
     expect(entries[0]?.manualInstall).toMatchObject({
-      cmd: './no-sha',
+      cmd: './no-archive',
       args: ['acp'],
-      env: { NO_SHA: '1' }
+      env: { NO_ARCHIVE: '1' }
     })
+  })
+
+  it('builds a spawn config from host `installed` when a host-installed agent is ready (no renderer persistence)', async () => {
+    // The host overlays installed state: a host-installed binary agent is
+    // reported `ready` with an `installed` block carrying the host-resolved
+    // absolute `command`/`args`. The web client (no renderer persistence)
+    // must build a spawn config from that `installed` block — without it, the
+    // web could not reuse a host install.
+    listCatalogMock.mockResolvedValueOnce({
+      success: true,
+      data: {
+        host: {
+          os: 'linux',
+          arch: 'x86_64',
+          runtimes: { npx: true, uvx: false, node: true, bun: false, python3: true }
+        },
+        agents: [
+          {
+            id: 'host-installed',
+            name: 'HostInstalled',
+            version: '1.0.0',
+            description: 'd',
+            source: 'bundled',
+            distribution: {
+              binary: {
+                'linux-x86_64': {
+                  cmd: './host-installed',
+                  archive: 'https://example.com/host-installed.zip',
+                  args: ['acp'],
+                  env: { HOST: '1' }
+                }
+              }
+            },
+            runtimeRequirements: [],
+            status: 'ready',
+            platformTargets: [],
+            installed: {
+              command: '/abs/acp-registry-binaries/host-installed/host-installed',
+              args: ['acp']
+            }
+          }
+        ]
+      }
+    })
+
+    const entries = await resolveSupportedAcpAgents([])
+
+    expect(entries[0]?.status).toBe('ready')
+    // The config is built from the host's installed command/args (NOT the
+    // distribution cmd), so the web can spawn the host-installed binary.
+    expect(entries[0]?.config).toMatchObject({
+      command: '/abs/acp-registry-binaries/host-installed/host-installed',
+      args: ['acp'],
+      env: { HOST: '1' }
+    })
+    expect(entries[0]?.install).toBeNull()
+    expect(entries[0]?.manualInstall).toBeNull()
   })
 
   it('degrades to an empty list when the catalog is unavailable', async () => {

--- a/src/renderer/lib/agents/supported-acp-agents.ts
+++ b/src/renderer/lib/agents/supported-acp-agents.ts
@@ -341,20 +341,30 @@ export async function resolveSupportedAcpAgents(
     const binaryMapOs = catalog.host.os === 'macos' ? 'darwin' : catalog.host.os
     const derived = deriveAgentConfig(registryAgent, `${binaryMapOs}-${catalog.host.arch}`)
 
-    // The host's `compute_binary_status` is sha256-aware: a binary target with
-    // an HTTPS archive but NO `sha256` is `manual-install` (the host must reject
-    // the install with `INTEGRITY_METADATA_MISSING`). The renderer's
-    // `deriveAgentConfig` is NOT sha256-aware — it only checks for an
-    // `archiveUrl` — so without gating on `agent.status` it would set `install`
-    // for a no-sha256 agent the host reports as `manual-install` (status /
-    // install-field split-brain). Gate `install` on `install-required` and
-    // `manualInstall` on `manual-install` so the install info reflects the
-    // host's resolution (the host is the single source of truth).
+    // The host catalog no longer gates on `sha256` — any HTTPS archive is
+    // `install-required` (the trusted Zed registry). The host also overlays
+    // installed state: an installed agent is reported `ready` with an
+    // `installed` block carrying the host-resolved absolute `command`/`args`.
+    // Build the spawn config from that `installed` block so the web client
+    // (which has no renderer persistence) can spawn a host-installed agent
+    // without a persisted `StoredAgentConfig`. Desktop `persisted` (handled
+    // above) still wins when present.
+    const hostInstalledConfig =
+      agent.status === 'ready' && agent.installed
+        ? installedBinaryConfig(
+            registryAgent,
+            { command: agent.installed.command, args: agent.installed.args },
+            { env: derived.kind === 'needs-install' ? derived.env : {} }
+          )
+        : null
+
     entries.push({
       id,
       configId,
       agent: registryAgent,
-      config: derived.kind === 'runnable' ? toStoredConfig(registryAgent, derived.config) : null,
+      config:
+        hostInstalledConfig ??
+        (derived.kind === 'runnable' ? toStoredConfig(registryAgent, derived.config) : null),
       status: agent.status,
       install:
         agent.status === 'install-required' &&

--- a/src/shared/types/acp-catalog.types.ts
+++ b/src/shared/types/acp-catalog.types.ts
@@ -66,6 +66,13 @@ export interface CatalogAgent {
   status: SupportedAcpAgentStatus
   /** Platform targets for binary-distributed agents; empty for npx/uvx. */
   platformTargets: PlatformTarget[]
+  /**
+   * Host-installed binary info (present only when the agent is installed on
+   * the host — status `ready`). Carries the host-resolved absolute
+   * `command`/`args` so the web client (no renderer persistence) can build a
+   * spawn config from the host install. Omitted/null otherwise.
+   */
+  installed?: { command: string; args: string[] } | null
 }
 
 /** The resolved catalog payload served across all three transports. */

--- a/src/shared/types/web-protocol.types.test.ts
+++ b/src/shared/types/web-protocol.types.test.ts
@@ -58,8 +58,8 @@ describe('web-protocol.types — event/request type registries (AC2)', () => {
     expect(WS_REQUEST_TYPES).toContain('get_session_payload')
   })
 
-  it('exports exactly 28 request types including ephemeral disposal, ping, catalog, and install', () => {
-    expect(WS_REQUEST_TYPES).toHaveLength(28)
+  it('exports exactly 29 request types including ephemeral disposal, ping, catalog, install, and agent auth', () => {
+    expect(WS_REQUEST_TYPES).toHaveLength(29)
     const expected = [
       'send_prompt',
       'cancel_prompt',
@@ -79,6 +79,9 @@ describe('web-protocol.types — event/request type registries (AC2)', () => {
       'list_agents',
       'switch_project',
       'authenticate',
+      // ACP agent `authenticate` method (agent-advertised auth, e.g.
+      // `pi_terminal_login`) — distinct from the `authenticate` token gate.
+      'authenticate_agent',
       'subscribe',
       'ping',
       'list_persisted_sessions',

--- a/src/shared/types/web-protocol.types.ts
+++ b/src/shared/types/web-protocol.types.ts
@@ -121,7 +121,12 @@ export const WS_REQUEST_TYPES = [
   'kill_agent',
   'list_agents',
   'switch_project',
+  // WS connection token-gate handshake (pre-auth). Distinct from
+  // `authenticate_agent` (the ACP agent method).
   'authenticate',
+  // ACP agent-advertised `authenticate` method (e.g. `pi_terminal_login`).
+  // Post-auth request routed to `AcpManager::authenticate` on the host.
+  'authenticate_agent',
   'subscribe',
   'ping',
   'list_persisted_sessions',


### PR DESCRIPTION
## Summary

#551's "Story 9 tightening" broke ACP click-to-install and web parity. Its `compute_binary_status` demoted **every** binary catalog agent (all 38 entries in `agents.json` carry no `sha256` digest) from clickable `install-required` to `manual-install` (manual file browser), and the host catalog never reflected the `installed.json` manifest — so installed agents did not show `ready` on the web client (which has no renderer persistence) or after the renderer store reset. Separately, the web `WsAcpTransport.authenticate` was a stub that threw "is not available over WS yet", and the `HttpDownloader` rejected all 3xx redirects — breaking every GitHub-release archive, which 302-redirect to `objects.githubusercontent.com`.

This restores click-to-install, makes the **host the single source of truth** for installed state (so the web reuses host-installed agents and installs persist across project switches), and wires the ACP agent `authenticate` method over WS for the web.

## Related Issue

No related issue — this fixes a user-reported regression (no GitHub issue was opened). Caused by #551's sha256 install tightening.

## Type of Change

- [x] fix: bug fix

## What Changed

- **Removed the sha256 install gate.** `compute_binary_status` now reports any HTTPS archive as `install-required` regardless of a digest (the catalog is the trusted Zed ACP registry). `AcpInstallService::install` downloads → extracts → activates → records the manifest without integrity verification (the sha256 extraction + `sha256_file` verify were dropped).
- **Host-aware catalog.** New `overlay_installed()` overlays `AcpInstallService::installed_agents()` onto the catalog in all three transport paths (Tauri `acp_list_catalog`, HTTP `GET /acp/catalog`, WS `list_acp_catalog`), so host-installed agents report `ready` with their resolved absolute `command`/`args`. The renderer (`resolveSupportedAcpAgents`) builds the spawn config from that host `installed` block — the web reuses a host install **without** renderer persistence, and installs persist across project switches (the install root `app_data_dir/acp-registry-binaries/{id}` is global).
- **Fixed the download redirect policy.** Replaced `redirect::Policy::none()` with a custom policy that **follows HTTPS→HTTPS redirects** (GitHub releases work) but **refuses https→http downgrades** (the original security intent — don't leak the URL path/query over plaintext).
- **Web agent auth over WS.** Added an `authenticate_agent` WS request type (distinct from the `authenticate` connection token gate) → `AcpManager::authenticate`; replaced the `WsAcpTransport.authenticate` stub with a real WS request so the web can run agent-advertised auth flows (e.g. `pi_terminal_login`).
- **Tests.** Catalog matrix updated (no-sha256 → `install-required`); added `overlay_installed` tests; repurposed the install integrity tests to assert install proceeds without verification; added `resolveSupportedAcpAgents` host-installed test; added WS `authenticate_agent` request + failure tests; updated the `WS_REQUEST_TYPES` count test.

## How It Was Tested

- [x] `bun run ci` (Biome lint + format + imports, strict mode)
- [x] `bun run typecheck`
- [x] `bun run test` (Vitest, 3352 tests pass)
- [x] `cargo clippy --all-targets -- -D warnings` (in src-tauri) — compiles all Rust tests clean
- [x] Manual verification completed

> Note: `cargo test` (Rust unit tests) runs on Linux CI only — the local Windows env cannot launch the Tauri test binary (a pre-existing native-DLL loader issue, unrelated to this change). `cargo clippy --all-targets` compiles every Rust test target locally; CI runs `cargo test` on Linux.

## CI & Review Gate

- [x] All CI checks pass (PR Validation, Rust Checks, Build Verification, Security Scans)

> Note: the build/test workflow jobs (Lint/Typecheck/Test, Rust Checks, builds) skip in this repo's CI per their `if: github.event.action != 'edited'` guards (same as prior merged PRs). They are verified green locally — `bun run ci`, `bun run typecheck`, `bun run test` (3352 tests), `cargo clippy --all-targets -- -D warnings`, `cargo check --all-targets`, `bun run build:web`; `cargo test` runs on Linux CI.
- [x] Code review comments from CodeRabbit / Claude have been addressed or resolved
- [x] No unresolved review findings remain

## Checklist

- [x] My PR title follows the conventional commit format used by this repo
- [x] I linked the related issue or explained why none exists
- [x] I updated docs when needed
- [x] I added or updated tests when needed
- [x] I verified the change does not introduce unrelated modifications
- [x] I read AGENTS.md and followed the contributor guidelines
- [x] A human reviewed the complete diff before submission


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Catalogs now show which agents are installed and ready, including resolved launch details.
  * Added agent authentication support through WebSocket connections, including interactive authentication flows.
  * Installed agents now use host-resolved configurations for more reliable launching.

* **Bug Fixes**
  * Installations can proceed when catalog integrity metadata is missing or invalid.
  * HTTPS redirects remain secure by rejecting downgrades to HTTP.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
