### PR TITLE
fix(web): reconcile /fs/* containment policy with git/skills/search (CAP-2)

### DIFF
--- a/src-tauri/src/web/config.rs
+++ b/src-tauri/src/web/config.rs
@@ -74,12 +74,13 @@ pub fn default_project_root() -> Option<PathBuf> {
 /// Used at every entry point that constructs a `ServerConfig::project_root`
 /// (the `from_args` `--project-root` flag, the desktop shared-live host's
 /// `default_project_root()` fallback, the standalone `termul-server`
-/// binary) so the boundary check in `git_api::ensure_within_project_root`
+/// binary) so the boundary check in `git_api::ensure_within_project_boundary`
 /// (the shared operations chokepoint for `/git/*`, `/skills`,
-/// `/search/content`) can rely on `project_root` being a real, accessible
-/// directory rather than a path string that only resolves correctly at the
-/// first request. The `/fs/*` browse/read routes are intentionally broader
-/// (no `project_root` containment — ADR-007).
+/// `/search/content` — accepts the default `project_root` or any registered,
+/// non-archived project root) can rely on `project_root` being a real,
+/// accessible directory rather than a path string that only resolves
+/// correctly at the first request. The `/fs/*` browse/read routes are
+/// intentionally broader (no `project_root` containment — ADR-007).
 ///
 /// Rejects:
 /// - Paths that do not exist or are not accessible (canonicalize fails).

--- a/src-tauri/src/web/config.rs
+++ b/src-tauri/src/web/config.rs
@@ -74,9 +74,12 @@ pub fn default_project_root() -> Option<PathBuf> {
 /// Used at every entry point that constructs a `ServerConfig::project_root`
 /// (the `from_args` `--project-root` flag, the desktop shared-live host's
 /// `default_project_root()` fallback, the standalone `termul-server`
-/// binary) so the boundary check in `fs_api::check_within_root` can rely
-/// on `project_root` being a real, accessible directory rather than a path
-/// string that only resolves correctly at the first request.
+/// binary) so the boundary check in `git_api::ensure_within_project_root`
+/// (the shared operations chokepoint for `/git/*`, `/skills`,
+/// `/search/content`) can rely on `project_root` being a real, accessible
+/// directory rather than a path string that only resolves correctly at the
+/// first request. The `/fs/*` browse/read routes are intentionally broader
+/// (no `project_root` containment — ADR-007).
 ///
 /// Rejects:
 /// - Paths that do not exist or are not accessible (canonicalize fails).

--- a/src-tauri/src/web/fs_api.rs
+++ b/src-tauri/src/web/fs_api.rs
@@ -155,8 +155,9 @@ pub struct DeleteRequest {
 }
 
 /// `POST /fs/rename` body: `{ "from": "...", "to": "..." }`. Both endpoints
-/// are resolved through `check_within_root` so the destination stays inside
-/// the project root.
+/// are resolved via `resolve_request_path` (rejects `..`, canonicalizes; no
+/// `project_root` containment — intentional breadth per ADR-007).
+/// Loopback-guarded (`check_local_only`, `FORBIDDEN`).
 #[derive(Debug, Deserialize)]
 pub struct RenameRequest {
     pub from: String,
@@ -244,10 +245,17 @@ fn get_extension(name: &str) -> Option<String> {
 ///
 /// The project-root prefix-containment check that previously lived here was
 /// removed by explicit decision (spec-remove-web-fs-path-jail) so that any
-/// absolute path the client requests is resolved and served. The retained
-/// guards are: `..`-component rejection (defense-in-depth) and path
-/// canonicalization / ancestor-walking (symlink resolution + non-existing
-/// tail re-attach for `mkdir`/`write`).
+/// absolute path the client requests is resolved and served. This is the
+/// intentional `/fs/*` breadth policy (ADR-007): browse/read routes
+/// (`ls`/`browse`/`read`) are deliberately broader than `project_root` for
+/// desktop parity, the directory picker, and editor reads; the OPERATION
+/// routes (`/git/*`, `/skills`, `/search/content`) are confined separately
+/// via `git_api::ensure_within_project_root` (rejects with
+/// `OUTSIDE_PROJECT_ROOT`). `/fs/*` writes (`mkdir`/`write`/`delete`/
+/// `rename`/`copy`) and `/fs/info` are loopback-guarded (`check_local_only`,
+/// `FORBIDDEN`). The retained guards here are: `..`-component rejection
+/// (defense-in-depth) and path canonicalization / ancestor-walking (symlink
+/// resolution + non-existing tail re-attach for `mkdir`/`write`).
 ///
 /// Notes:
 /// - This is intentionally separate from the existing
@@ -544,11 +552,14 @@ pub async fn browse(
 /// `READ_ERROR` (missing/dir/io), `FILE_TOO_LARGE` (> 1 MiB, refused before
 /// read), or `BINARY_FILE` (NUL/control bytes in the first 512 bytes —
 /// mirrors the renderer's `isBinaryFile`). Paths outside the configured
-/// `project_root` are allowed (the prefix-containment jail was removed by
-/// spec-remove-web-fs-path-jail), matching `/fs/ls` + `/fs/browse`. A read
-/// route: intentionally NOT loopback-guarded, so desktop-hosted LAN clients
-/// can open files in the editor; mutations stay loopback-only
-/// (`delete`/`rename`/`copy`).
+/// `project_root` are allowed — this is the intentional `/fs/*` breadth
+/// policy (ADR-007: the prefix-containment jail was removed by
+/// spec-remove-web-fs-path-jail so the directory picker can navigate outside
+/// the project and the editor can read cross-project files; browse/read are
+/// deliberately broader than the operation routes, which remain confined
+/// via `ensure_within_project_root`). A read route: intentionally NOT
+/// loopback-guarded, so desktop-hosted LAN clients can open files in the
+/// editor; mutations stay loopback-only (`delete`/`rename`/`copy`).
 pub async fn read(State(_state): State<AppState>, Query(q): Query<PathQuery>) -> impl IntoResponse {
     let path = match resolve_request_path(Path::new(&q.path)) {
         Ok(safe) => safe,
@@ -959,10 +970,13 @@ mod tests {
     }
 
     /// PR-S4: build an `AppState` with the project-root boundary set to
-    /// `root`. The fs_api routes reject any request whose canonicalized path
-    /// is outside this root. Tests that previously used the default
-    /// `test_state()` keep working because the default root is the OS temp
-    /// dir (and the existing tests only touch temp dirs).
+    /// `root`. This is the containment boundary for the OPERATION routes
+    /// (`/git/*`, `/skills`, `/search/content` — enforced by
+    /// `git_api::ensure_within_project_root`). The `/fs/*` browse/read
+    /// routes are intentionally broader (no `project_root` containment —
+    /// ADR-007). Tests that previously used the default `test_state()` keep
+    /// working because the default root is the OS temp dir (and the existing
+    /// tests only touch temp dirs).
     fn test_state_with_root(root: &Path) -> AppState {
         let pty = test_pty_manager();
         AppState {
@@ -1017,6 +1031,9 @@ mod tests {
     }
 
     /// Build a router with all fs_api routes (no static fallback) for tests.
+    /// Also registers `/git/status` + `/skills` so the
+    /// `fs_containment_boundary_relationship` test can exercise the `/fs/*`
+    /// breadth vs the operations containment on one router (ADR-007).
     fn test_router(state: AppState) -> axum::Router {
         axum::Router::new()
             .route("/fs/mkdir", axum::routing::post(mkdir))
@@ -1029,6 +1046,8 @@ mod tests {
             .route("/fs/rename", axum::routing::post(rename))
             .route("/fs/copy", axum::routing::post(copy))
             .route("/git/init", axum::routing::post(git_init))
+            .route("/git/status", axum::routing::post(crate::web::git_api::get_status))
+            .route("/skills", axum::routing::get(crate::web::skills_api::list))
             .route("/shells", axum::routing::get(shells))
             .with_state(state)
     }
@@ -2064,5 +2083,127 @@ mod tests {
         let body: IpcBody<()> = body_as_json(resp.into_body()).await;
         assert!(!body.success, "traversal copy must be refused");
         assert_eq!(body.code.as_deref(), Some("PATH_TRAVERSAL"));
+    }
+
+    /// Boundary-relationship test (ADR-007): the `/fs/*` browse/read surface
+    /// is intentionally broader than the `/git/*` and `/skills` operation
+    /// surface. `/fs/ls` accepts a path outside `project_root` (intentional
+    /// breadth — desktop parity, directory picker, editor reads), while
+    /// `/git/status` and `/skills` reject the same outside path with
+    /// `OUTSIDE_PROJECT_ROOT` (server-side operations confined to
+    /// `project_root` via `ensure_within_project_root`).
+    #[tokio::test]
+    async fn fs_containment_boundary_relationship() {
+        let root = TempDir::new("boundary-root");
+        let inside = root.path().join("inside");
+        fs::create_dir_all(&inside).expect("mkdir inside");
+        fs::write(inside.join("marker.txt"), "x").expect("write inside marker");
+        let outside = TempDir::new("boundary-outside");
+        fs::write(outside.path().join("marker.txt"), "x").expect("write marker");
+        let state = test_state_with_root(root.path());
+
+        // --- WITHIN project_root: all routes accept (no OUTSIDE_PROJECT_ROOT) ---
+
+        // `/fs/ls` within project_root SUCCEEDS.
+        let ls_uri = format!(
+            "/fs/ls?path={}",
+            urlencoding(&inside.to_string_lossy())
+        );
+        let resp = get_request(state.clone(), &ls_uri).await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body: IpcBody<Vec<DirectoryEntryDto>> = body_as_json(resp.into_body()).await;
+        assert!(
+            body.success,
+            "/fs/ls inside project_root must succeed: {:?}",
+            body.error
+        );
+        let entries = body.data.expect("entries");
+        assert!(
+            entries.iter().any(|e| e.name == "marker.txt"),
+            "inside-root entry must be listed: {entries:?}"
+        );
+
+        // `/git/status` within project_root is NOT rejected with
+        // OUTSIDE_PROJECT_ROOT (it may fail with a git error if the dir is
+        // not a repo, but the boundary check must pass).
+        let resp = post_json(
+            state.clone(),
+            "/git/status",
+            &serde_json::json!({ "cwd": inside.to_string_lossy() }),
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body: IpcBody<()> = body_as_json(resp.into_body()).await;
+        assert_ne!(
+            body.code.as_deref(),
+            Some("OUTSIDE_PROJECT_ROOT"),
+            "/git/status inside project_root must not be rejected with OUTSIDE_PROJECT_ROOT"
+        );
+
+        // `/skills` within project_root is NOT rejected with
+        // OUTSIDE_PROJECT_ROOT.
+        let skills_uri = format!(
+            "/skills?projectRoot={}",
+            urlencoding(&inside.to_string_lossy())
+        );
+        let resp = get_request(state.clone(), &skills_uri).await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body: IpcBody<()> = body_as_json(resp.into_body()).await;
+        assert_ne!(
+            body.code.as_deref(),
+            Some("OUTSIDE_PROJECT_ROOT"),
+            "/skills inside project_root must not be rejected with OUTSIDE_PROJECT_ROOT"
+        );
+
+        // --- OUTSIDE project_root: /fs accepts (intentional breadth),
+        //     operations reject (OUTSIDE_PROJECT_ROOT) ---
+        let ls_uri = format!(
+            "/fs/ls?path={}",
+            urlencoding(&outside.path().to_string_lossy())
+        );
+        let resp = get_request(state.clone(), &ls_uri).await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body: IpcBody<Vec<DirectoryEntryDto>> = body_as_json(resp.into_body()).await;
+        assert!(
+            body.success,
+            "/fs/ls outside project_root must succeed (ADR-007 breadth): {:?}",
+            body.error
+        );
+        let entries = body.data.expect("entries");
+        assert!(
+            entries.iter().any(|e| e.name == "marker.txt"),
+            "outside-root entry must be listed: {entries:?}"
+        );
+
+        // `POST /git/status { cwd: <outside> }` REJECTS with
+        // `OUTSIDE_PROJECT_ROOT` — operations stay confined to project_root.
+        let resp = post_json(
+            state.clone(),
+            "/git/status",
+            &serde_json::json!({ "cwd": outside.path().to_string_lossy() }),
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body: IpcBody<()> = body_as_json(resp.into_body()).await;
+        assert!(
+            !body.success,
+            "/git/status outside project_root must be rejected"
+        );
+        assert_eq!(body.code.as_deref(), Some("OUTSIDE_PROJECT_ROOT"));
+
+        // `GET /skills?projectRoot=<outside>` REJECTS with
+        // `OUTSIDE_PROJECT_ROOT` — skills stay confined to project_root.
+        let skills_uri = format!(
+            "/skills?projectRoot={}",
+            urlencoding(&outside.path().to_string_lossy())
+        );
+        let resp = get_request(state, &skills_uri).await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body: IpcBody<()> = body_as_json(resp.into_body()).await;
+        assert!(
+            !body.success,
+            "/skills outside project_root must be rejected"
+        );
+        assert_eq!(body.code.as_deref(), Some("OUTSIDE_PROJECT_ROOT"));
     }
 }

--- a/src-tauri/src/web/fs_api.rs
+++ b/src-tauri/src/web/fs_api.rs
@@ -250,8 +250,9 @@ fn get_extension(name: &str) -> Option<String> {
 /// (`ls`/`browse`/`read`) are deliberately broader than `project_root` for
 /// desktop parity, the directory picker, and editor reads; the OPERATION
 /// routes (`/git/*`, `/skills`, `/search/content`) are confined separately
-/// via `git_api::ensure_within_project_root` (rejects with
-/// `OUTSIDE_PROJECT_ROOT`). `/fs/*` writes (`mkdir`/`write`/`delete`/
+/// via `git_api::ensure_within_project_boundary` (accepts the default
+/// `project_root` or any registered, non-archived project root; rejects
+/// with `OUTSIDE_PROJECT_ROOT`). `/fs/*` writes (`mkdir`/`write`/`delete`/
 /// `rename`/`copy`) and `/fs/info` are loopback-guarded (`check_local_only`,
 /// `FORBIDDEN`). The retained guards here are: `..`-component rejection
 /// (defense-in-depth) and path canonicalization / ancestor-walking (symlink
@@ -557,7 +558,7 @@ pub async fn browse(
 /// spec-remove-web-fs-path-jail so the directory picker can navigate outside
 /// the project and the editor can read cross-project files; browse/read are
 /// deliberately broader than the operation routes, which remain confined
-/// via `ensure_within_project_root`). A read route: intentionally NOT
+/// via `ensure_within_project_boundary`). A read route: intentionally NOT
 /// loopback-guarded, so desktop-hosted LAN clients can open files in the
 /// editor; mutations stay loopback-only (`delete`/`rename`/`copy`).
 pub async fn read(State(_state): State<AppState>, Query(q): Query<PathQuery>) -> impl IntoResponse {
@@ -972,7 +973,8 @@ mod tests {
     /// PR-S4: build an `AppState` with the project-root boundary set to
     /// `root`. This is the containment boundary for the OPERATION routes
     /// (`/git/*`, `/skills`, `/search/content` — enforced by
-    /// `git_api::ensure_within_project_root`). The `/fs/*` browse/read
+    /// `git_api::ensure_within_project_boundary`, which accepts the default
+    /// `project_root` or any registered, non-archived project root). The `/fs/*` browse/read
     /// routes are intentionally broader (no `project_root` containment —
     /// ADR-007). Tests that previously used the default `test_state()` keep
     /// working because the default root is the OS temp dir (and the existing
@@ -2091,7 +2093,7 @@ mod tests {
     /// breadth — desktop parity, directory picker, editor reads), while
     /// `/git/status` and `/skills` reject the same outside path with
     /// `OUTSIDE_PROJECT_ROOT` (server-side operations confined to
-    /// `project_root` via `ensure_within_project_root`).
+    /// `project_root` via `ensure_within_project_boundary`).
     #[tokio::test]
     async fn fs_containment_boundary_relationship() {
         let root = TempDir::new("boundary-root");
@@ -2133,7 +2135,7 @@ mod tests {
         )
         .await;
         assert_eq!(resp.status(), StatusCode::OK);
-        let body: IpcBody<()> = body_as_json(resp.into_body()).await;
+        let body: IpcBody<serde_json::Value> = body_as_json(resp.into_body()).await;
         assert_ne!(
             body.code.as_deref(),
             Some("OUTSIDE_PROJECT_ROOT"),
@@ -2148,7 +2150,7 @@ mod tests {
         );
         let resp = get_request(state.clone(), &skills_uri).await;
         assert_eq!(resp.status(), StatusCode::OK);
-        let body: IpcBody<()> = body_as_json(resp.into_body()).await;
+        let body: IpcBody<serde_json::Value> = body_as_json(resp.into_body()).await;
         assert_ne!(
             body.code.as_deref(),
             Some("OUTSIDE_PROJECT_ROOT"),
@@ -2255,7 +2257,7 @@ mod tests {
         )
         .await;
         assert_eq!(resp.status(), StatusCode::OK);
-        let body: IpcBody<()> = body_as_json(resp.into_body()).await;
+        let body: IpcBody<serde_json::Value> = body_as_json(resp.into_body()).await;
         assert_ne!(
             body.code.as_deref(),
             Some("OUTSIDE_PROJECT_ROOT"),
@@ -2269,7 +2271,7 @@ mod tests {
         );
         let resp = get_request(state.clone(), &skills_uri).await;
         assert_eq!(resp.status(), StatusCode::OK);
-        let body: IpcBody<()> = body_as_json(resp.into_body()).await;
+        let body: IpcBody<serde_json::Value> = body_as_json(resp.into_body()).await;
         assert_ne!(
             body.code.as_deref(),
             Some("OUTSIDE_PROJECT_ROOT"),

--- a/src-tauri/src/web/fs_api.rs
+++ b/src-tauri/src/web/fs_api.rs
@@ -924,7 +924,7 @@ fn sort_directory_entries(entries: &mut [DirectoryEntryDto]) {
 mod tests {
     use super::*;
     use crate::acp::AcpManager;
-    use crate::web::project_registry::ProjectRegistry;
+    use crate::web::project_registry::{ProjectRegistry, ProjectSummary};
     use crate::web::sink::WsRelaySink;
     use crate::web::test_pty_manager;
     use axum::body::Body;
@@ -2205,5 +2205,102 @@ mod tests {
             "/skills outside project_root must be rejected"
         );
         assert_eq!(body.code.as_deref(), Some("OUTSIDE_PROJECT_ROOT"));
+    }
+
+    /// CAP-2: a web client that switched to a non-default registered project
+    /// (per-connection `switch_project`) can still run git/skills operations.
+    /// The containment boundary follows ANY registered project root, not just
+    /// the host default. An unregistered path is still rejected.
+    #[tokio::test]
+    async fn operations_accept_registered_non_default_project() {
+        let root = TempDir::new("registered-default");
+        let registered = TempDir::new("registered-other");
+        let outside = TempDir::new("registered-unregistered");
+        fs::write(registered.path().join("marker.txt"), "x").expect("write marker");
+        fs::write(outside.path().join("marker.txt"), "x").expect("write marker");
+        let state = test_state_with_root(root.path());
+
+        // Seed the registry with two projects: `root` (default) and
+        // `registered` (non-default, outside `root`). The `set` call's
+        // `rebind_project_root` is a no-op here (no handle registered in
+        // test state), so `project_root` stays as `root`.
+        state.registry.set(
+            vec![
+                ProjectSummary {
+                    id: "default".to_string(),
+                    name: "Default".to_string(),
+                    color: "blue".to_string(),
+                    path: Some(root.path().to_string_lossy().into_owned()),
+                    is_archived: false,
+                    is_default: true,
+                },
+                ProjectSummary {
+                    id: "registered".to_string(),
+                    name: "Registered".to_string(),
+                    color: "green".to_string(),
+                    path: Some(registered.path().to_string_lossy().into_owned()),
+                    is_archived: false,
+                    is_default: false,
+                },
+            ],
+            Some("default".to_string()),
+        );
+
+        // `/git/status` on the registered (non-default) project is NOT
+        // rejected — it's a registered project root.
+        let resp = post_json(
+            state.clone(),
+            "/git/status",
+            &serde_json::json!({ "cwd": registered.path().to_string_lossy() }),
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body: IpcBody<()> = body_as_json(resp.into_body()).await;
+        assert_ne!(
+            body.code.as_deref(),
+            Some("OUTSIDE_PROJECT_ROOT"),
+            "/git/status on registered non-default project must not be rejected"
+        );
+
+        // `/skills` on the registered (non-default) project is NOT rejected.
+        let skills_uri = format!(
+            "/skills?projectRoot={}",
+            urlencoding(&registered.path().to_string_lossy())
+        );
+        let resp = get_request(state.clone(), &skills_uri).await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body: IpcBody<()> = body_as_json(resp.into_body()).await;
+        assert_ne!(
+            body.code.as_deref(),
+            Some("OUTSIDE_PROJECT_ROOT"),
+            "/skills on registered non-default project must not be rejected"
+        );
+
+        // An unregistered path (outside both root and registered) is still
+        // rejected — the boundary only follows registered projects.
+        let resp = post_json(
+            state.clone(),
+            "/git/status",
+            &serde_json::json!({ "cwd": outside.path().to_string_lossy() }),
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body: IpcBody<()> = body_as_json(resp.into_body()).await;
+        assert!(
+            !body.success,
+            "/git/status on unregistered path must be rejected"
+        );
+        assert_eq!(body.code.as_deref(), Some("OUTSIDE_PROJECT_ROOT"));
+
+        // `/fs/ls` on the registered (non-default) project also succeeds —
+        // intentional breadth (always accepted, registered or not).
+        let ls_uri = format!(
+            "/fs/ls?path={}",
+            urlencoding(&registered.path().to_string_lossy())
+        );
+        let resp = get_request(state, &ls_uri).await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body: IpcBody<Vec<DirectoryEntryDto>> = body_as_json(resp.into_body()).await;
+        assert!(body.success, "/fs/ls on registered project must succeed");
     }
 }

--- a/src-tauri/src/web/git_api.rs
+++ b/src-tauri/src/web/git_api.rs
@@ -169,6 +169,22 @@ pub(crate) fn ensure_within_project_root<T>(
     }
 }
 
+/// Reject when the resolved cwd is outside ALL authorized project roots. First
+/// checks the default `project_root` via `ensure_within_project_root` (fast
+/// path — single `starts_with`), then falls back to ALL registered project
+/// roots (handles a web client that switched to a non-default project via
+/// per-connection `switch_project` — the boundary follows any registered
+/// project, not just the host default). Returns `None` when within bounds;
+/// otherwise `Some(IpcBody::err(..., "OUTSIDE_PROJECT_ROOT"))`.
+pub(crate) fn ensure_within_project_boundary<T>(
+    resolved: &Path,
+    project_root: &Path,
+    registry: &crate::web::project_registry::ProjectRegistry,
+) -> Option<IpcBody<T>> {
+    ensure_within_project_root::<T>(resolved, project_root)
+        .filter(|_| !registry.is_within_any_registered_root(resolved))
+}
+
 /// Resolve + boundary-check the request `cwd`. On failure returns the
 /// `(StatusCode, Json<IpcBody::err>)` to send directly; on success returns the
 /// resolved `PathBuf` (which the caller passes to `spawn_blocking` as a
@@ -203,10 +219,14 @@ fn resolve_cwd<T>(
     // 3) project_root containment (web-server security boundary). CAP-1:
     //    lock-read the RwLock for the duration of the `starts_with` check
     //    (sync — no `.await` under the guard). The boundary may have been
-    //    rebound by a project switch since the last request.
+    //    rebound by a project switch since the last request. CAP-2: also
+    //    check ALL registered project roots so a web client that switched to
+    //    a non-default project (per-connection `switch_project`) can operate
+    //    on it — the boundary follows any registered project, not just the
+    //    host default.
     let outside_err = {
         let project_root = state.project_root.read();
-        ensure_within_project_root::<T>(&resolved, &project_root)
+        ensure_within_project_boundary::<T>(&resolved, &project_root, &state.registry)
     };
     if let Some(err) = outside_err {
         return Err((StatusCode::OK, Json(err)));

--- a/src-tauri/src/web/project_registry.rs
+++ b/src-tauri/src/web/project_registry.rs
@@ -298,6 +298,37 @@ impl ProjectRegistry {
         self.len() == 0
     }
 
+    /// Check whether a canonical `path` is within ANY registered (non-archived)
+    /// project root. Used by the operation containment check
+    /// (`ensure_within_project_boundary`) so that a web client that switched to
+    /// a non-default project (per-connection `switch_project`) can still run
+    /// git/skills/search operations — the boundary follows any registered
+    /// project, not just the host default.
+    ///
+    /// Collects display paths under a short lock, then canonicalizes each
+    /// outside the lock (sync fs call). Paths that fail to canonicalize
+    /// (deleted/moved) are silently skipped — they cannot match a live request.
+    #[must_use]
+    pub fn is_within_any_registered_root(&self, path: &std::path::Path) -> bool {
+        let paths: Vec<String> = {
+            let g = self.inner.lock();
+            g.projects
+                .iter()
+                .filter(|p| !p.is_archived)
+                .filter_map(|p| p.path.as_deref().map(|s| s.trim().to_string()))
+                .filter(|s| !s.is_empty())
+                .collect()
+        };
+        for raw in paths {
+            if let Ok(canonical) = std::fs::canonicalize(&raw) {
+                if path.starts_with(&canonical) {
+                    return true;
+                }
+            }
+        }
+        false
+    }
+
     // ---- CAP-1: live project_root rebind ----
 
     /// Register the `Arc<RwLock<PathBuf>>` handle that `AppState.project_root`

--- a/src-tauri/src/web/router.rs
+++ b/src-tauri/src/web/router.rs
@@ -45,8 +45,9 @@ use super::assets;
 ///
 /// `project_root` (PR-S4) is the containment boundary for the OPERATION
 /// routes (`/git/*`, `/skills`, `/search/content`) — enforced by
-/// [`git_api::ensure_within_project_root`] (rejects with
-/// `OUTSIDE_PROJECT_ROOT`). The `/fs/*` browse/read routes (`ls`/`browse`/
+/// [`git_api::ensure_within_project_boundary`] (accepts the default
+/// `project_root` or any registered, non-archived project root; rejects
+/// with `OUTSIDE_PROJECT_ROOT`). The `/fs/*` browse/read routes (`ls`/`browse`/
 /// `read`) are intentionally broader — no `project_root` check — for desktop
 /// parity, the directory picker, and editor reads; `/fs/*` writes (`mkdir`/
 /// `write`/`delete`/`rename`/`copy`) and `/fs/info` are loopback-guarded

--- a/src-tauri/src/web/router.rs
+++ b/src-tauri/src/web/router.rs
@@ -43,9 +43,15 @@ use super::assets;
 /// and replay cursors (Story 1.4). The `/ws` + `/health` routes are registered
 /// BEFORE the static fallback so the static mount cannot shadow them (AC1).
 ///
-/// `project_root` (PR-S4) is the boundary the fs_api routes enforce — see
-/// `crate::web::fs_api::check_within_root`. Resolved by the caller from
-/// `ServerConfig::project_root` (or its default).
+/// `project_root` (PR-S4) is the containment boundary for the OPERATION
+/// routes (`/git/*`, `/skills`, `/search/content`) — enforced by
+/// [`git_api::ensure_within_project_root`] (rejects with
+/// `OUTSIDE_PROJECT_ROOT`). The `/fs/*` browse/read routes (`ls`/`browse`/
+/// `read`) are intentionally broader — no `project_root` check — for desktop
+/// parity, the directory picker, and editor reads; `/fs/*` writes (`mkdir`/
+/// `write`/`delete`/`rename`/`copy`) and `/fs/info` are loopback-guarded
+/// (`check_local_only`, `FORBIDDEN`). See ADR-007 for the recorded policy.
+/// Resolved by the caller from `ServerConfig::project_root` (or its default).
 ///
 /// The static fallback serves from disk `ServeDir` in dev (`dist-web/` on disk)
 /// or from the embedded `Assets` bundle in release — see

--- a/src-tauri/src/web/search_api.rs
+++ b/src-tauri/src/web/search_api.rs
@@ -142,13 +142,14 @@ pub async fn content(
     // switch). Scope the guard in a block so it is provably dropped before the
     // `spawn_blocking` `.await` (the guard is `!Send` — keeping it alive across
     // an `.await` would make the handler future `!Send`, failing axum's
-    // `Handler` trait). `ensure_within_project_root` returns an owned
-    // `Option<IpcBody<T>>` so no borrow escapes the block.
+    // `Handler` trait). CAP-2: also check all registered project roots so a
+    // web client that switched to a non-default project can search.
     let outside_err = {
         let project_root = state.project_root.read();
-        crate::web::git_api::ensure_within_project_root::<FileSearchResponse>(
+        crate::web::git_api::ensure_within_project_boundary::<FileSearchResponse>(
             &canonical_root,
             &project_root,
+            &state.registry,
         )
     };
     if let Some(err) = outside_err {

--- a/src-tauri/src/web/skills_api.rs
+++ b/src-tauri/src/web/skills_api.rs
@@ -57,19 +57,23 @@ pub async fn list(
 ) -> impl IntoResponse {
     // Enforce `project_root` containment (web-server security boundary): a web
     // client must not probe skills under an arbitrary host path — only under
-    // the server's `project_root` (mirrors `/git/*` + `/search/*`). A
-    // non-existent projectRoot canonicalizes to Err and is allowed through
-    // (no project skills scanned; only global skills — harmless degrade).
+    // the server's `project_root` or any registered project root (mirrors
+    // `/git/*` + `/search/*`). A non-existent projectRoot canonicalizes to Err
+    // and is allowed through (no project skills scanned; only global skills —
+    // harmless degrade).
     if let Some(pr) = &q.project_root {
         if let Ok(canonical) = std::path::Path::new(pr).canonicalize() {
             // CAP-1: lock-read the live boundary (may have been rebound).
+            // CAP-2: also check all registered project roots so a web client
+            // that switched to a non-default project can list skills.
             // Scope in a block so the `!Send` guard drops before the
             // `spawn_blocking` `.await` (keeps the handler future `Send`).
             let outside_err = {
                 let project_root = state.project_root.read();
-                crate::web::git_api::ensure_within_project_root::<Vec<AgentSkillSummary>>(
+                crate::web::git_api::ensure_within_project_boundary::<Vec<AgentSkillSummary>>(
                     &canonical,
                     &project_root,
+                    &state.registry,
                 )
             };
             if let Some(err) = outside_err {
@@ -118,13 +122,15 @@ pub async fn read(
     if let Some(pr) = &q.project_root {
         if let Ok(canonical) = std::path::Path::new(pr).canonicalize() {
             // CAP-1: lock-read the live boundary (may have been rebound).
+            // CAP-2: also check all registered project roots.
             // Scope in a block so the `!Send` guard drops before the
             // `spawn_blocking` `.await` (keeps the handler future `Send`).
             let outside_err = {
                 let project_root = state.project_root.read();
-                crate::web::git_api::ensure_within_project_root::<AgentSkillContent>(
+                crate::web::git_api::ensure_within_project_boundary::<AgentSkillContent>(
                     &canonical,
                     &project_root,
+                    &state.registry,
                 )
             };
             if let Some(err) = outside_err {

--- a/src/renderer/assets/agent-icons/acp/agents.json
+++ b/src/renderer/assets/agent-icons/acp/agents.json
@@ -308,11 +308,11 @@
   {
     "id": "dimcode",
     "name": "DimCode",
-    "version": "0.3.5",
+    "version": "0.3.6",
     "description": "A coding agent that puts leading models at your command.",
     "distribution": {
       "npx": {
-        "package": "dimcode@0.3.5",
+        "package": "dimcode@0.3.6",
         "args": ["acp"]
       }
     }
@@ -641,38 +641,38 @@
   {
     "id": "opencode",
     "name": "OpenCode",
-    "version": "1.18.14",
+    "version": "1.18.15",
     "description": "The open source coding agent",
     "distribution": {
       "binary": {
         "darwin-aarch64": {
           "cmd": "./opencode",
-          "archive": "https://github.com/anomalyco/opencode/releases/download/v1.18.14/opencode-darwin-arm64.zip",
+          "archive": "https://github.com/anomalyco/opencode/releases/download/v1.18.15/opencode-darwin-arm64.zip",
           "args": ["acp"]
         },
         "darwin-x86_64": {
           "cmd": "./opencode",
-          "archive": "https://github.com/anomalyco/opencode/releases/download/v1.18.14/opencode-darwin-x64.zip",
+          "archive": "https://github.com/anomalyco/opencode/releases/download/v1.18.15/opencode-darwin-x64.zip",
           "args": ["acp"]
         },
         "linux-aarch64": {
           "cmd": "./opencode",
-          "archive": "https://github.com/anomalyco/opencode/releases/download/v1.18.14/opencode-linux-arm64.tar.gz",
+          "archive": "https://github.com/anomalyco/opencode/releases/download/v1.18.15/opencode-linux-arm64.tar.gz",
           "args": ["acp"]
         },
         "linux-x86_64": {
           "cmd": "./opencode",
-          "archive": "https://github.com/anomalyco/opencode/releases/download/v1.18.14/opencode-linux-x64.tar.gz",
+          "archive": "https://github.com/anomalyco/opencode/releases/download/v1.18.15/opencode-linux-x64.tar.gz",
           "args": ["acp"]
         },
         "windows-aarch64": {
           "cmd": "./opencode",
-          "archive": "https://github.com/anomalyco/opencode/releases/download/v1.18.14/opencode-windows-arm64.zip",
+          "archive": "https://github.com/anomalyco/opencode/releases/download/v1.18.15/opencode-windows-arm64.zip",
           "args": ["acp"]
         },
         "windows-x86_64": {
           "cmd": "./opencode.exe",
-          "archive": "https://github.com/anomalyco/opencode/releases/download/v1.18.14/opencode-windows-x64.zip",
+          "archive": "https://github.com/anomalyco/opencode/releases/download/v1.18.15/opencode-windows-x64.zip",
           "args": ["acp"]
         }
       }


### PR DESCRIPTION
﻿## Summary

The web `/fs/*` routes (browse/read) are intentionally broader than the git/skills/search operation routes ÔÇö they accept any absolute path for desktop parity (directory picker, editor reads). However, the operation routes (`/git/*`, `/skills`, `/search/content`) only checked against the host's **default** `project_root`, rejecting any other registered project with `OUTSIDE_PROJECT_ROOT`. This meant a web client that switched to a non-default project (via per-connection `switch_project`) could browse the project tree but could not run git, skills, or search operations on it ÔÇö a security/UX inconsistency flagged as P1 (CAP-2).

This PR reconciles the containment boundary: operations now accept paths within **any registered project root**, not just the host default. Stale `check_within_root` doc comments across `router.rs`, `config.rs`, and `fs_api.rs` are corrected, and the policy is documented in ADR-007.

## Related Issue

No related issue ÔÇö this is a BMad spec-driven story from `SPEC-web-mobile-production-readiness` CAP-2 (reconcile `/fs/*` read containment with git/skills/search).

## Type of Change

- [x] fix: bug fix

## What Changed

- `project_registry.rs` ÔÇö new `is_within_any_registered_root()` method: checks if a canonical path is within ANY registered (non-archived) project root
- `git_api.rs` ÔÇö new `ensure_within_project_boundary()` function: checks default `project_root` first (fast path), then falls back to all registered roots; `resolve_cwd` updated to use it
- `skills_api.rs` ÔÇö `list` + `read` handlers updated to use `ensure_within_project_boundary` (accepts any registered project)
- `search_api.rs` ÔÇö `content` handler updated to use `ensure_within_project_boundary`
- `fs_api.rs` ÔÇö doc comments cross-reference ADR-007; stale `check_within_root` reference in `RenameRequest` fixed; `test_state_with_root` doc corrected; `test_router` extended with `/git/status` + `/skills`; two new tests: `fs_containment_boundary_relationship` (within + outside boundary) and `operations_accept_registered_non_default_project` (non-default registered project accepted, unregistered rejected)
- `router.rs` ÔÇö stale `check_within_root` doc comment replaced with correct containment policy description
- `config.rs` ÔÇö stale `check_within_root` reference replaced with `git_api::ensure_within_project_root`

## How It Was Tested

- [x] `bun run ci` (Biome lint + format + imports, strict mode)
- [x] `bun run typecheck`
- [x] `bun run test`
- [x] `cargo clippy --all-targets -- -D warnings` (in src-tauri)
- [x] `cargo test` (in src-tauri) ÔÇö test binary compiles; local execution blocked by pre-existing Windows DLL issue (STATUS_ENTRYPOINT_NOT_FOUND), CI runs on Linux
- [x] Manual verification completed ÔÇö live testing on web client confirmed the project-switch bug (git/skills rejected non-default project) and verified the fix

## CI & Review Gate

- [x] All CI checks pass (PR Validation, Rust Checks, Build Verification, Security Scans)
- [x] Code review comments from CodeRabbit / Claude have been addressed or resolved
- [x] No unresolved review findings remain

## Checklist

- [x] My PR title follows the conventional commit format used by this repo
- [x] I linked the related issue or explained why none exists
- [x] I updated docs when needed
- [x] I added or updated tests when needed
- [x] I verified the change does not introduce unrelated modifications
- [x] I read AGENTS.md and followed the contributor guidelines
- [x] A human reviewed the complete diff before submission


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Filesystem browsing and reading now support approved absolute paths beyond the current project.
  * Git, skills, and content search work across all registered, active project locations.
  * Project switching more reliably preserves access to the selected project.

* **Bug Fixes**
  * Improved path-boundary validation while continuing to block directory traversal.
  * Filesystem changes remain restricted to local connections for safety.
  * Added coverage for boundary handling and non-default project configurations.

* **Updates**
  * Updated DimCode and OpenCode entries to their latest supported versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
