### PR TITLE
fix(release): make macOS Apple preflight + codesign verification optional

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -165,7 +165,7 @@ jobs:
           persist-credentials: false
 
       - name: Preflight Apple and updater credentials
-        if: startsWith(matrix.platform, 'macos-')
+        if: startsWith(matrix.platform, 'macos-') && secrets.APPLE_CERTIFICATE != ''
         shell: bash
         env:
           APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
@@ -285,7 +285,7 @@ jobs:
           NODE
 
       - name: Verify macOS bundle library portability and signing
-        if: startsWith(matrix.platform, 'macos-')
+        if: startsWith(matrix.platform, 'macos-') && secrets.APPLE_CERTIFICATE != ''
         shell: bash
         env:
           RUST_TARGET: ${{ matrix.rust_target }}


### PR DESCRIPTION
## Summary

The multi-channel release workflow (PR #558) added a strict `Preflight Apple and updater credentials` gate and a `Verify macOS bundle library portability and signing` step that REQUIRE Apple Developer credentials. The repo has never configured `APPLE_*` secrets (v0.4.8 shipped ad-hoc/unsigned macOS bundles using only the Tauri updater key), so the v0.4.9 release.yml macOS jobs fail at preflight before building anything.

This makes both macOS-specific gates conditional on `APPLE_CERTIFICATE` being configured. When the secret is unset, the steps are skipped (v0.4.8 behavior — unsigned/ad-hoc macOS bundles). When an Apple Developer Program is later configured, the preflight + codesign verification re-engage automatically with no further workflow change.

## Related Issue

Closes #

No related issue - release hotfix.

## Type of Change

- [ ] feat: new feature
- [ ] fix: bug fix
- [ ] docs: documentation only
- [ ] style: formatting or non-functional styling changes
- [ ] refactor: internal cleanup with no behavior change
- [ ] perf: performance improvement
- [ ] test: adds or updates tests
- [ ] build: build or dependency changes
- [x] ci: CI/CD workflow changes
- [ ] chore: maintenance or tooling
- [ ] revert: reverts a previous change

## What Changed

- `.github/workflows/release.yml`: gated `Preflight Apple and updater credentials` on `secrets.APPLE_CERTIFICATE != ''` (was `startsWith(matrix.platform, 'macos-')`).
- `.github/workflows/release.yml`: gated `Verify macOS bundle library portability and signing` on the same condition so unsigned bundles do not fail codesign/spctl/stapler checks.

## How It Was Tested

- [x] `bun run ci` (Biome lint + format + imports, strict mode)
- [x] `bun run typecheck`
- [x] `bun run test`
- [ ] `cargo clippy --all-targets -- -D warnings` (in src-tauri)
- [ ] `cargo test` (in src-tauri)
- [x] Manual verification completed
- [ ] Not applicable

## Screenshots or Recordings

N/A - CI workflow change.

## CI & Review Gate

- [x] All CI checks pass (PR Validation, Rust Checks, Build Verification, Security Scans)
- [ ] Code review comments from CodeRabbit / Claude have been addressed or resolved
- [ ] No unresolved review findings remain

## Checklist

- [x] My PR title follows the conventional commit format used by this repo
- [x] I linked the related issue or explained why none exists
- [x] I updated docs when needed
- [x] I added or updated tests when needed
- [x] I verified the change does not introduce unrelated modifications
- [x] I read AGENTS.md and followed the contributor guidelines
- [x] A human reviewed the complete diff before submission


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved macOS release builds by running credential checks and bundle verification only when Apple signing credentials are configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->