### PR TITLE
fix(release): gate macOS preflight + codesign verify via env.APPLE_CERTIFICATE

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -132,6 +132,8 @@ jobs:
     needs: changelog
     if: github.event_name == 'push'
     runs-on: ${{ matrix.runner }}
+    env:
+      APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
     strategy:
       fail-fast: false
       matrix:
@@ -165,7 +167,7 @@ jobs:
           persist-credentials: false
 
       - name: Preflight Apple and updater credentials
-        if: startsWith(matrix.platform, 'macos-') && secrets.APPLE_CERTIFICATE != ''
+        if: startsWith(matrix.platform, 'macos-') && env.APPLE_CERTIFICATE != ''
         shell: bash
         env:
           APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
@@ -285,7 +287,7 @@ jobs:
           NODE
 
       - name: Verify macOS bundle library portability and signing
-        if: startsWith(matrix.platform, 'macos-') && secrets.APPLE_CERTIFICATE != ''
+        if: startsWith(matrix.platform, 'macos-') && env.APPLE_CERTIFICATE != ''
         shell: bash
         env:
           RUST_TARGET: ${{ matrix.rust_target }}


### PR DESCRIPTION
## Summary

The earlier macOS-optional fix referenced `secrets.APPLE_CERTIFICATE` directly in step-level `if:` expressions, but the `secrets` context is NOT available in step `if:` conditionals — GitHub reports `Invalid workflow file: Unrecognized named-value: 'secrets'`, producing 0-job `failure` runs for every release.yml trigger (the v0.4.9 re-pushes and the v0.4.10 push all failed this way).

This exposes the secret via a job-level `env: APPLE_CERTIFICATE` and gates the steps on `env.APPLE_CERTIFICATE != ''` (the `env` context IS available in step `if:`). Behavior is unchanged: when `APPLE_CERTIFICATE` is unset, both macOS-only steps skip (v0.4.8 unsigned-bundle behavior); when the secret is later configured, the preflight + codesign verification re-engage automatically.

## Related Issue

Closes #

No related issue - release hotfix.

## Type of Change

- [ ] feat: new feature
- [ ] fix: bug fix
- [ ] docs: documentation only
- [ ] style: formatting or non-functional styling changes
- [ ] refactor: internal cleanup with no behavior change
- [ ] perf: performance improvement
- [ ] test: adds or updates tests
- [ ] build: build or dependency changes
- [x] ci: CI/CD workflow changes
- [ ] chore: maintenance or tooling
- [ ] revert: reverts a previous change

## What Changed

- `.github/workflows/release.yml`: added `env: APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}` at the `build` job level.
- `.github/workflows/release.yml`: `Preflight Apple and updater credentials` and `Verify macOS bundle library portability and signing` step `if:` now reference `env.APPLE_CERTIFICATE != ''` instead of the unavailable `secrets.APPLE_CERTIFICATE`.

## How It Was Tested

- [x] `bun run ci` (Biome lint + format + imports, strict mode)
- [x] `bun run typecheck`
- [x] `bun run test`
- [ ] `cargo clippy --all-targets -- -D warnings` (in src-tauri)
- [ ] `cargo test` (in src-tauri)
- [x] Manual verification completed
- [ ] Not applicable

## Screenshots or Recordings

N/A - CI workflow change.

## CI & Review Gate

- [x] All CI checks pass (PR Validation, Rust Checks, Build Verification, Security Scans)
- [ ] Code review comments from CodeRabbit / Claude have been addressed or resolved
- [ ] No unresolved review findings remain

## Checklist

- [x] My PR title follows the conventional commit format used by this repo
- [x] I linked the related issue or explained why none exists
- [x] I updated docs when needed
- [x] I added or updated tests when needed
- [x] I verified the change does not introduce unrelated modifications
- [x] I read AGENTS.md and followed the contributor guidelines
- [x] A human reviewed the complete diff before submission


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved macOS release validation by consistently handling Apple certificate configuration during builds.
  * Credential preflight and bundle verification now run conditionally when certificate credentials are available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->