### PR TITLE
fix(release): gate macOS preflight + codesign verify via env.APPLE_CERTIFICATE

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -132,6 +132,8 @@ jobs:
     needs: changelog
     if: github.event_name == 'push'
     runs-on: ${{ matrix.runner }}
+    env:
+      APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
     strategy:
       fail-fast: false
       matrix:
@@ -165,7 +167,7 @@ jobs:
           persist-credentials: false
 
       - name: Preflight Apple and updater credentials
-        if: startsWith(matrix.platform, 'macos-') && secrets.APPLE_CERTIFICATE != ''
+        if: startsWith(matrix.platform, 'macos-') && env.APPLE_CERTIFICATE != ''
         shell: bash
         env:
           APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
@@ -285,7 +287,7 @@ jobs:
           NODE
 
       - name: Verify macOS bundle library portability and signing
-        if: startsWith(matrix.platform, 'macos-') && secrets.APPLE_CERTIFICATE != ''
+        if: startsWith(matrix.platform, 'macos-') && env.APPLE_CERTIFICATE != ''
         shell: bash
         env:
           RUST_TARGET: ${{ matrix.rust_target }}


### PR DESCRIPTION
## Summary

Promote the release.yml macOS-gate fix to main so the v0.4.10 release pipeline can run. The previous attempt referenced `secrets.APPLE_CERTIFICATE` directly in step `if:` conditionals, which GitHub rejects (`secrets` context is unavailable in step `if:`), causing every release.yml run to fail with 0 jobs. This exposes the secret via job-level `env:` and gates on `env.APPLE_CERTIFICATE` instead.

## Related Issue

Closes #

No related issue - release hotfix promotion.

## Type of Change

- [ ] feat: new feature
- [ ] fix: bug fix
- [ ] docs: documentation only
- [ ] style: formatting or non-functional styling changes
- [ ] refactor: internal cleanup with no behavior change
- [ ] perf: performance improvement
- [ ] test: adds or updates tests
- [ ] build: build or dependency changes
- [x] ci: CI/CD workflow changes
- [ ] chore: maintenance or tooling
- [ ] revert: reverts a previous change

## What Changed

- `.github/workflows/release.yml`: added job-level `env: APPLE_CERTIFICATE` on the `build` job; both macOS-only steps now gate on `env.APPLE_CERTIFICATE != ''` (was the invalid `secrets.APPLE_CERTIFICATE`).

## How It Was Tested

- [x] `bun run ci` (Biome lint + format + imports, strict mode)
- [x] `bun run typecheck`
- [x] `bun run test`
- [x] `cargo clippy --all-targets -- -D warnings` (in src-tauri)
- [x] `cargo test` (in src-tauri)
- [x] Manual verification completed
- [ ] Not applicable

## Screenshots or Recordings

N/A - CI workflow change.

## CI & Review Gate

- [x] All CI checks pass (PR Validation, Rust Checks, Build Verification, Security Scans)
- [x] Code review comments from CodeRabbit / Claude have been addressed or resolved
- [x] No unresolved review findings remain

## Checklist

- [x] My PR title follows the conventional commit format used by this repo
- [x] I linked the related issue or explained why none exists
- [x] I updated docs when needed
- [x] I added or updated tests when needed
- [x] I verified the change does not introduce unrelated modifications
- [x] I read AGENTS.md and followed the contributor guidelines
- [x] A human reviewed the complete diff before submission
