### PR TITLE
fix(release): drop APPLE_* env from tauri-action + disable standalone-server cache-on-failure

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -132,8 +132,6 @@ jobs:
     needs: changelog
     if: github.event_name == 'push'
     runs-on: ${{ matrix.runner }}
-    env:
-      APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
     strategy:
       fail-fast: false
       matrix:
@@ -258,12 +256,6 @@ jobs:
           TAURI_SIGNING_PUBLIC_KEY: ${{ secrets.TAURI_SIGNING_PUBLIC_KEY }}
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
-          APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
-          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
-          APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
-          APPLE_ID: ${{ secrets.APPLE_ID }}
-          APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
-          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
         with:
           tauriScript: bun run tauri
           args: ${{ matrix.args }} --config src-tauri/tauri.conf.prod.json
@@ -435,7 +427,7 @@ jobs:
         uses: swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae # v2
         with:
           workspaces: src-tauri
-          cache-on-failure: true
+          cache-on-failure: false
 
       - name: Install Bun dependencies
         run: bun install --frozen-lockfile


### PR DESCRIPTION
## Summary

Two release.yml fixes so the v0.4.10 pipeline can complete:

1. **macOS ad-hoc/unsigned builds (like v0.4.8)** — the `tauri-action` step was passing `APPLE_*` env vars even when the secrets were empty, and tauri-action treats the env key's *presence* (not its value) as "sign", so it ran `security import` on an empty cert and failed (`failed to import keychain certificate`). v0.4.8's release.yml never passed `APPLE_*` to tauri-action, so macOS bundles built ad-hoc/unsigned. This removes both the job-level `env: APPLE_CERTIFICATE` and the tauri-action `APPLE_*` env block, restoring v0.4.8 behavior. The `Preflight` + `Verify macOS` steps stay in the file but skip cleanly (`env.APPLE_CERTIFICATE != ''` is false when unset).
2. **termul-server cache poison** — `cache-on-failure: true` on the `standalone-server` job's `Cache Rust` step saved a broken cache from prior failed runs (cargo's fingerprint said the `termul-server` bin was up-to-date but the file was absent), so every subsequent run "Finished" without producing the binary. Setting `cache-on-failure: false` prevents future poison; the existing poisoned caches will be deleted before re-running.

To re-engage Apple signing later: re-add the `APPLE_*` block to the `tauri-action` step's `env:` and the `env: APPLE_CERTIFICATE` at the `build` job level (the Preflight + Verify steps will then run automatically).

## Related Issue

Closes #

No related issue - release hotfix.

## Type of Change

- [ ] feat: new feature
- [ ] fix: bug fix
- [ ] docs: documentation only
- [ ] style: formatting or non-functional styling changes
- [ ] refactor: internal cleanup with no behavior change
- [ ] perf: performance improvement
- [ ] test: adds or updates tests
- [ ] build: build or dependency changes
- [x] ci: CI/CD workflow changes
- [ ] chore: maintenance or tooling
- [ ] revert: reverts a previous change

## What Changed

- `.github/workflows/release.yml`: removed job-level `env: APPLE_CERTIFICATE` from the `build` job.
- `.github/workflows/release.yml`: removed the 6 `APPLE_*` env entries from the `tauri-action` step (restores v0.4.8 ad-hoc/unsigned macOS builds).
- `.github/workflows/release.yml`: `standalone-server` job `Cache Rust` `cache-on-failure: true` -> `false`.

## How It Was Tested

- [x] `bun run ci` (Biome lint + format + imports, strict mode)
- [x] `bun run typecheck`
- [x] `bun run test`
- [ ] `cargo clippy --all-targets -- -D warnings` (in src-tauri)
- [ ] `cargo test` (in src-tauri)
- [x] Manual verification completed
- [ ] Not applicable

## Screenshots or Recordings

N/A - CI workflow change.

## CI & Review Gate

- [x] All CI checks pass (PR Validation, Rust Checks, Build Verification, Security Scans)
- [ ] Code review comments from CodeRabbit / Claude have been addressed or resolved
- [ ] No unresolved review findings remain

## Checklist

- [x] My PR title follows the conventional commit format used by this repo
- [x] I linked the related issue or explained why none exists
- [x] I updated docs when needed
- [x] I added or updated tests when needed
- [x] I verified the change does not introduce unrelated modifications
- [x] I read AGENTS.md and followed the contributor guidelines
- [x] A human reviewed the complete diff before submission


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved macOS release credential handling by limiting checks to the steps that require them.
  * Prevented failed standalone server builds from being cached.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->