### PR TITLE
fix(release): drop --target from termul-server build so binary lands at target/release/

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -453,7 +453,14 @@ jobs:
         run: >
           cargo build --release --bin termul-server
           --features standalone-server
-          --target x86_64-unknown-linux-gnu
+
+      - name: Locate termul-server binary
+        working-directory: src-tauri
+        shell: bash
+        run: |
+          echo "Searching for termul-server binary in target/..."
+          find target -name 'termul-server' -type f -print || true
+          ls -la target/release/termul-server 2>/dev/null || echo "target/release/termul-server NOT FOUND"
 
       - name: Sign termul-server binary
         working-directory: src-tauri
@@ -461,8 +468,8 @@ jobs:
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
         run: |
-          bun run tauri signer sign target/x86_64-unknown-linux-gnu/release/termul-server
-          test -f target/x86_64-unknown-linux-gnu/release/termul-server.sig
+          bun run tauri signer sign target/release/termul-server
+          test -f target/release/termul-server.sig
 
       - name: Prepare server manifest fragment
         shell: bash
@@ -471,7 +478,7 @@ jobs:
           TAG: ${{ github.ref_name }}
         run: |
           node scripts/release/prepare-server-artifacts.mjs \
-            --signature src-tauri/target/x86_64-unknown-linux-gnu/release/termul-server.sig \
+            --signature src-tauri/target/release/termul-server.sig \
             --tag "$TAG" \
             --version "$VERSION" \
             --output server-collected/server-manifest.json
@@ -480,8 +487,8 @@ jobs:
         shell: bash
         run: |
           mkdir -p server-collected
-          cp src-tauri/target/x86_64-unknown-linux-gnu/release/termul-server server-collected/termul-server
-          cp src-tauri/target/x86_64-unknown-linux-gnu/release/termul-server.sig server-collected/termul-server.sig
+          cp src-tauri/target/release/termul-server server-collected/termul-server
+          cp src-tauri/target/release/termul-server.sig server-collected/termul-server.sig
 
       - name: Upload termul-server workflow artifact
         uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0


### PR DESCRIPTION
## Summary

Promote the termul-server build-path fix to main so the v0.4.10 release pipeline's `standalone-server` job produces a signable binary and `publish_release` can run (all 4 desktop builds already succeed with the macOS-optional fix; this unblocks the server binary + manifest).

## Related Issue

Closes #

No related issue - release hotfix promotion.

## Type of Change

- [ ] feat: new feature
- [ ] fix: bug fix
- [ ] docs: documentation only
- [ ] style: formatting or non-functional styling changes
- [ ] refactor: internal cleanup with no behavior change
- [ ] perf: performance improvement
- [ ] test: adds or updates tests
- [ ] build: build or dependency changes
- [x] ci: CI/CD workflow changes
- [ ] chore: maintenance or tooling
- [ ] revert: reverts a previous change

## What Changed

- `.github/workflows/release.yml`: dropped `--target x86_64-unknown-linux-gnu` from the termul-server build (binary lands at `target/release/termul-server`); updated sign/prepare/stage path refs; added a `Locate termul-server binary` diagnostic.

## How It Was Tested

- [x] `bun run ci` (Biome lint + format + imports, strict mode)
- [x] `bun run typecheck`
- [x] `bun run test`
- [x] `cargo clippy --all-targets -- -D warnings` (in src-tauri)
- [x] `cargo test` (in src-tauri)
- [x] Manual verification completed
- [ ] Not applicable

## Screenshots or Recordings

N/A - CI workflow change.

## CI & Review Gate

- [x] All CI checks pass (PR Validation, Rust Checks, Build Verification, Security Scans)
- [x] Code review comments from CodeRabbit / Claude have been addressed or resolved
- [x] No unresolved review findings remain

## Checklist

- [x] My PR title follows the conventional commit format used by this repo
- [x] I linked the related issue or explained why none exists
- [x] I updated docs when needed
- [x] I added or updated tests when needed
- [x] I verified the change does not introduce unrelated modifications
- [x] I read AGENTS.md and followed the contributor guidelines
- [x] A human reviewed the complete diff before submission
