### PR TITLE
fix(release): use absolute path for termul-server signer sign

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -468,8 +468,8 @@ jobs:
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
         run: |
-          bun run tauri signer sign target/release/termul-server
-          test -f target/release/termul-server.sig
+          bun run tauri signer sign "$(pwd)/target/release/termul-server"
+          test -f "$(pwd)/target/release/termul-server.sig"
 
       - name: Prepare server manifest fragment
         shell: bash


### PR DESCRIPTION
## Summary

The `Sign termul-server binary` step was passing a **relative** path (`target/release/termul-server`) to `bun run tauri signer sign`, but the tauri CLI resolves relative paths from the **repo root** (where `package.json` lives), not from the step's `working-directory: src-tauri`. So it looked for `<repo-root>/target/release/termul-server` while the binary was at `<repo-root>/src-tauri/target/release/termul-server` — `failed to open data file ... No such file or directory` — even though the binary existed (confirmed by a diagnostic `ls -la` in the previous run: 58MB executable at `src-tauri/target/release/termul-server`).

Passing an **absolute** path (`"$(pwd)/target/release/termul-server"`) makes the tauri CLI open the binary regardless of its own CWD resolution. This unblocks the `standalone-server` job, which unblocks `publish_release` (all 4 desktop builds already succeed).

## Related Issue

Closes #

No related issue - release hotfix.

## Type of Change

- [ ] feat: new feature
- [ ] fix: bug fix
- [ ] docs: documentation only
- [ ] style: formatting or non-functional styling changes
- [ ] refactor: internal cleanup with no behavior change
- [ ] perf: performance improvement
- [ ] test: adds or updates tests
- [ ] build: build or dependency changes
- [x] ci: CI/CD workflow changes
- [ ] chore: maintenance or tooling
- [ ] revert: reverts a previous change

## What Changed

- `.github/workflows/release.yml`: `Sign termul-server binary` now passes `"$(pwd)/target/release/termul-server"` (absolute) to `bun run tauri signer sign`, and the `.sig` existence check uses the same absolute path.

## How It Was Tested

- [x] `bun run ci` (Biome lint + format + imports, strict mode)
- [x] `bun run typecheck`
- [x] `bun run test`
- [ ] `cargo clippy --all-targets -- -D warnings` (in src-tauri)
- [ ] `cargo test` (in src-tauri)
- [x] Manual verification completed
- [ ] Not applicable

## Screenshots or Recordings

N/A - CI workflow change.

## CI & Review Gate

- [x] All CI checks pass (PR Validation, Rust Checks, Build Verification, Security Scans)
- [ ] Code review comments from CodeRabbit / Claude have been addressed or resolved
- [ ] No unresolved review findings remain

## Checklist

- [x] My PR title follows the conventional commit format used by this repo
- [x] I linked the related issue or explained why none exists
- [x] I updated docs when needed
- [x] I added or updated tests when needed
- [x] I verified the change does not introduce unrelated modifications
- [x] I read AGENTS.md and followed the contributor guidelines
- [x] A human reviewed the complete diff before submission


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved standalone server release signing and signature verification for more reliable builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->