### PR TITLE
fix(release): publish_release reads server artifact at root (upload-artifact flattens server-collected/)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -555,9 +555,9 @@ jobs:
             done < <(find "$root/assets" -maxdepth 1 -type f -print0)
           done
 
-          cp release-inputs/release-standalone-server/server-collected/termul-server release-assets/termul-server
-          cp release-inputs/release-standalone-server/server-collected/termul-server.sig release-assets/termul-server.sig
-          manifests+=("release-inputs/release-standalone-server/server-collected/server-manifest.json")
+          cp release-inputs/release-standalone-server/termul-server release-assets/termul-server
+          cp release-inputs/release-standalone-server/termul-server.sig release-assets/termul-server.sig
+          manifests+=("release-inputs/release-standalone-server/server-manifest.json")
 
           # Channel selection: stable (`v*` tag) vs Insider RC (`v*-rc.*` tag).
           # The merge validator derives the asset URL tag from the channel:


### PR DESCRIPTION
## Summary

`Validate, upload, and publish release` failed with `cp: cannot stat 'release-inputs/release-standalone-server/server-collected/termul-server': No such file or directory`, even though `Build termul-server (linux-x64)` succeeded and uploaded its artifact. `actions/upload-artifact` with `path: server-collected/` uploads the directory's **contents** (no `server-collected/` wrapper), so the downloaded files land at `release-inputs/release-standalone-server/termul-server` (root), not `.../server-collected/termul-server`. The desktop platform loop already reads its artifacts at root (`release-inputs/release-<platform>/platform-manifest.json`, no `collected/`), confirming the expected structure. This drops the extra `server-collected/` segment from the three server paths in `publish_release`.

## Related Issue

Closes #

No related issue - release hotfix.

## Type of Change

- [ ] feat: new feature
- [ ] fix: bug fix
- [ ] docs: documentation only
- [ ] style: formatting or non-functional styling changes
- [ ] refactor: internal cleanup with no behavior change
- [ ] perf: performance improvement
- [ ] test: adds or updates tests
- [ ] build: build or dependency changes
- [x] ci: CI/CD workflow changes
- [ ] chore: maintenance or tooling
- [ ] revert: reverts a previous change

## What Changed

- `.github/workflows/release.yml`: `publish_release`'s server `cp`/`manifests` paths now read `release-inputs/release-standalone-server/termul-server`, `termul-server.sig`, and `server-manifest.json` (was `.../server-collected/...`).

## How It Was Tested

- [x] `bun run ci` (Biome lint + format + imports, strict mode)
- [x] `bun run typecheck`
- [x] `bun run test`
- [ ] `cargo clippy --all-targets -- -D warnings` (in src-tauri)
- [ ] `cargo test` (in src-tauri)
- [x] Manual verification completed
- [ ] Not applicable

## Screenshots or Recordings

N/A - CI workflow change.

## CI & Review Gate

- [x] All CI checks pass (PR Validation, Rust Checks, Build Verification, Security Scans)
- [ ] Code review comments from CodeRabbit / Claude have been addressed or resolved
- [ ] No unresolved review findings remain

## Checklist

- [x] My PR title follows the conventional commit format used by this repo
- [x] I linked the related issue or explained why none exists
- [x] I updated docs when needed
- [x] I added or updated tests when needed
- [x] I verified the change does not introduce unrelated modifications
- [x] I read AGENTS.md and followed the contributor guidelines
- [x] A human reviewed the complete diff before submission


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the release process to retrieve server binaries, signatures, and manifests from their current artifact location.
  * No changes to the product’s user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->