### PR TITLE
fix(release): publish_release reads server artifact at root

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -555,9 +555,9 @@ jobs:
             done < <(find "$root/assets" -maxdepth 1 -type f -print0)
           done
 
-          cp release-inputs/release-standalone-server/server-collected/termul-server release-assets/termul-server
-          cp release-inputs/release-standalone-server/server-collected/termul-server.sig release-assets/termul-server.sig
-          manifests+=("release-inputs/release-standalone-server/server-collected/server-manifest.json")
+          cp release-inputs/release-standalone-server/termul-server release-assets/termul-server
+          cp release-inputs/release-standalone-server/termul-server.sig release-assets/termul-server.sig
+          manifests+=("release-inputs/release-standalone-server/server-manifest.json")
 
           # Channel selection: stable (`v*` tag) vs Insider RC (`v*-rc.*` tag).
           # The merge validator derives the asset URL tag from the channel:


### PR DESCRIPTION
## Summary

Promote the publish_release server-artifact path fix to main so v0.4.10's `Validate, upload, and publish release` job can find the `termul-server` binary + signature + manifest (all build jobs already succeed).

## Related Issue

Closes #

No related issue - release hotfix promotion.

## Type of Change

- [ ] feat: new feature
- [ ] fix: bug fix
- [ ] docs: documentation only
- [ ] style: formatting or non-functional styling changes
- [ ] refactor: internal cleanup with no behavior change
- [ ] perf: performance improvement
- [ ] test: adds or updates tests
- [ ] build: build or dependency changes
- [x] ci: CI/CD workflow changes
- [ ] chore: maintenance or tooling
- [ ] revert: reverts a previous change

## What Changed

- `.github/workflows/release.yml`: `publish_release` reads the server artifact at `release-inputs/release-standalone-server/termul-server[.sig]` and `server-manifest.json` (was `.../server-collected/...`).

## How It Was Tested

- [x] `bun run ci` (Biome lint + format + imports, strict mode)
- [x] `bun run typecheck`
- [x] `bun run test`
- [x] `cargo clippy --all-targets -- -D warnings` (in src-tauri)
- [x] `cargo test` (in src-tauri)
- [x] Manual verification completed
- [ ] Not applicable

## Screenshots or Recordings

N/A - CI workflow change.

## CI & Review Gate

- [x] All CI checks pass (PR Validation, Rust Checks, Build Verification, Security Scans)
- [x] Code review comments from CodeRabbit / Claude have been addressed or resolved
- [x] No unresolved review findings remain

## Checklist

- [x] My PR title follows the conventional commit format used by this repo
- [x] I linked the related issue or explained why none exists
- [x] I updated docs when needed
- [x] I added or updated tests when needed
- [x] I verified the change does not introduce unrelated modifications
- [x] I read AGENTS.md and followed the contributor guidelines
- [x] A human reviewed the complete diff before submission
