### PR TITLE
fix(release): normalize updater asset names (space->dot) to fix 404 downloads

### DIFF
--- a/scripts/release/prepare-platform-artifacts.mjs
+++ b/scripts/release/prepare-platform-artifacts.mjs
@@ -78,7 +78,7 @@ function releaseAssetName(artifact) {
     const appName = basename(artifact.path, artifact.ext).replaceAll(' ', '.')
     return `${appName}_${artifact.arch}${artifact.ext}`
   }
-  return basename(artifact.path)
+  return basename(artifact.path).replaceAll(' ', '.')
 }
 
 function assertNonEmptyString(value, description) {

--- a/scripts/release/prepare-platform-artifacts.test.ts
+++ b/scripts/release/prepare-platform-artifacts.test.ts
@@ -16,14 +16,21 @@ async function fixtureFile(root: string, relativePath: string, content = 'artifa
   return path
 }
 
-async function prepare(platform: string, paths: string[], root: string) {
+async function prepare(
+  platform: string,
+  paths: string[],
+  root: string,
+  options: { version?: string; tag?: string } = {}
+) {
+  const version = options.version ?? '1.2.3'
+  const tag = options.tag ?? 'v1.2.3'
   const artifactsPath = join(root, `${platform}-paths.json`)
   const outputPath = join(root, `${platform}-output`)
   await writeFile(artifactsPath, JSON.stringify(paths))
   const manifest = await preparePlatformArtifacts({
     platform,
-    version: '1.2.3',
-    tag: 'v1.2.3',
+    version,
+    tag,
     artifactsPath,
     outputPath
   })
@@ -120,6 +127,100 @@ describe('preparePlatformArtifacts', () => {
 
     await expect(prepare('windows-x64', [msi, first, second], root)).rejects.toThrow(
       'windows-x64 must have exactly one msi updater signature'
+    )
+  })
+
+  test('normalizes productName spaces to dots in Windows MSI and NSIS release asset names', async () => {
+    const root = await fixtureDir()
+    const msi = await fixtureFile(root, 'bundle/msi/Termul Manager_0.4.10_x64_en-US.msi')
+    const msiSig = await fixtureFile(
+      root,
+      'bundle/msi/Termul Manager_0.4.10_x64_en-US.msi.sig',
+      'msi-signature'
+    )
+    const exe = await fixtureFile(root, 'bundle/nsis/Termul Manager_0.4.10_x64-setup.exe')
+    const exeSig = await fixtureFile(
+      root,
+      'bundle/nsis/Termul Manager_0.4.10_x64-setup.exe.sig',
+      'nsis-signature'
+    )
+
+    const { manifest, outputPath } = await prepare(
+      'windows-x64',
+      [msi, msiSig, exe, exeSig],
+      root,
+      {
+        version: '0.4.10',
+        tag: 'v0.4.10'
+      }
+    )
+
+    const msiName = 'Termul.Manager_0.4.10_x64_en-US.msi'
+    const exeName = 'Termul.Manager_0.4.10_x64-setup.exe'
+    expect(manifest.assetNames).toContain(msiName)
+    expect(manifest.assetNames).toContain(`${msiName}.sig`)
+    expect(manifest.assetNames).toContain(exeName)
+    expect(manifest.assetNames).toContain(`${exeName}.sig`)
+    expect(manifest.platforms['windows-x86_64-msi'].url).toBe(
+      `https://github.com/gnoviawan/termul/releases/download/v0.4.10/${msiName}`
+    )
+    expect(manifest.platforms['windows-x86_64'].url).toBe(
+      manifest.platforms['windows-x86_64-msi'].url
+    )
+    expect(manifest.platforms['windows-x86_64-msi'].url).not.toMatch(/%20/)
+    expect(manifest.platforms['windows-x86_64-nsis'].url).toBe(
+      `https://github.com/gnoviawan/termul/releases/download/v0.4.10/${exeName}`
+    )
+    expect(manifest.platforms['windows-x86_64-nsis'].url).not.toMatch(/%20/)
+    expect(await readFile(join(outputPath, 'assets', msiName), 'utf8')).toBe('artifact')
+    expect(await readFile(join(outputPath, 'assets', `${msiName}.sig`), 'utf8')).toBe(
+      'msi-signature'
+    )
+    expect(await readFile(join(outputPath, 'assets', exeName), 'utf8')).toBe('artifact')
+    expect(await readFile(join(outputPath, 'assets', `${exeName}.sig`), 'utf8')).toBe(
+      'nsis-signature'
+    )
+  })
+
+  test('normalizes only the productName space in Linux rpm release asset names', async () => {
+    const root = await fixtureDir()
+    const paths: string[] = []
+    for (const [bundle, name] of [
+      ['appimage', 'Termul Manager_0.4.10_amd64.AppImage'],
+      ['deb', 'Termul Manager_0.4.10_amd64.deb'],
+      ['rpm', 'Termul Manager-0.4.10-1.x86_64.rpm']
+    ]) {
+      paths.push(await fixtureFile(root, `bundle/${bundle}/${name}`))
+      paths.push(await fixtureFile(root, `bundle/${bundle}/${name}.sig`, `${bundle}-signature`))
+    }
+
+    const { manifest, outputPath } = await prepare('linux-x64', paths, root, {
+      version: '0.4.10',
+      tag: 'v0.4.10'
+    })
+
+    const appimageName = 'Termul.Manager_0.4.10_amd64.AppImage'
+    const debName = 'Termul.Manager_0.4.10_amd64.deb'
+    const rpmName = 'Termul.Manager-0.4.10-1.x86_64.rpm'
+    for (const name of [appimageName, debName, rpmName]) {
+      expect(manifest.assetNames).toContain(name)
+      expect(manifest.assetNames).toContain(`${name}.sig`)
+    }
+    expect(manifest.platforms['linux-x86_64-appimage'].url).toBe(
+      `https://github.com/gnoviawan/termul/releases/download/v0.4.10/${appimageName}`
+    )
+    expect(manifest.platforms['linux-x86_64-appimage'].url).not.toMatch(/%20/)
+    expect(manifest.platforms['linux-x86_64-deb'].url).toBe(
+      `https://github.com/gnoviawan/termul/releases/download/v0.4.10/${debName}`
+    )
+    expect(manifest.platforms['linux-x86_64-deb'].url).not.toMatch(/%20/)
+    expect(manifest.platforms['linux-x86_64-rpm'].url).toBe(
+      `https://github.com/gnoviawan/termul/releases/download/v0.4.10/${rpmName}`
+    )
+    expect(manifest.platforms['linux-x86_64-rpm'].url).not.toMatch(/%20/)
+    expect(await readFile(join(outputPath, 'assets', rpmName), 'utf8')).toBe('artifact')
+    expect(await readFile(join(outputPath, 'assets', `${rpmName}.sig`), 'utf8')).toBe(
+      'rpm-signature'
     )
   })
 })


### PR DESCRIPTION
## Summary

The v0.4.10 auto-updater banner says "new version 0.4.10" but the download 404s for Windows and Linux desktop users. Root cause: Tauri builds bundles from `productName "Termul Manager"` (with a space), while the published GitHub release assets are dot-named (`Termul.Manager_*`). The release pipeline's `prepare-platform-artifacts.mjs` only dot-normalized macOS `.app.tar.gz`, so Windows MSI/NSIS and Linux AppImage/deb/rpm manifest URLs carried a literal space (`%20`) that 404'd against the dot-named assets. v0.4.8 worked because it used Tauri's built-in manifest (already dotted). This PR extends the space->dot normalization to every updater bundle and its `.sig` so the manifest URL, the copied asset, and the uploaded release asset all agree -- matching the macOS path and v0.4.8.

## Related Issue

No related issue. Reason: the v0.4.10 auto-updater 404 was reported directly in this session; no tracking issue exists for this release-infrastructure bug (issue 404 is an unrelated ACP chat-naming request).

## Type of Change

- [ ] feat: new feature
- [x] fix: bug fix
- [ ] docs: documentation only
- [ ] style: formatting or non-functional styling changes
- [ ] refactor: internal cleanup with no behavior change
- [ ] perf: performance improvement
- [ ] test: adds or updates tests
- [ ] build: build or dependency changes
- [ ] ci: CI/CD workflow changes
- [ ] chore: maintenance or tooling
- [ ] revert: reverts a previous change

## What Changed

- `scripts/release/prepare-platform-artifacts.mjs`: `releaseAssetName()`'s non-macOS branch now applies `.replaceAll(' ', '.')`, so Windows MSI/NSIS and Linux AppImage/deb/rpm asset names (and their `.sig`) are dot-normalized exactly like the macOS `.app.tar.gz` branch. One-line production change.
- `scripts/release/prepare-platform-artifacts.test.ts`: the `prepare` test helper gains an optional `{ version, tag }` option; added two regression tests using real space-named Tauri fixtures (`Termul Manager_0.4.10_*`) asserting the manifest URLs use dot names with no `%20`, `assetNames` use dot names, and copied asset files land under the dot names. The Linux test asserts AppImage + deb + rpm URLs; the Windows test verifies both MSI and NSIS asset + signature file contents.

## How It Was Tested

- [x] `bun run ci` (Biome lint + format + imports, strict mode)
- [x] `bun run typecheck`
- [x] `bun run test`
- [ ] `cargo clippy --all-targets -- -D warnings` (in src-tauri)
- [ ] `cargo test` (in src-tauri)
- [x] Manual verification completed
- [ ] Not applicable

Rust checks were not run locally: this diff touches no Rust (two files under `scripts/release/`), so CI's Rust Checks run on unchanged Rust. Manual verification: confirmed the published v0.4.10 `latest.json` carried space URLs (404) while the release assets were dot-named, and that the same build mechanism produced dot-named assets in the working v0.4.8 release.

## Screenshots or Recordings

Not applicable -- no UI changes; release-pipeline script and tests only.

## CI & Review Gate

- [ ] All CI checks pass (PR Validation, Rust Checks, Build Verification, Security Scans)
- [ ] Code review comments from CodeRabbit / Claude have been addressed or resolved
- [ ] No unresolved review findings remain

## Checklist

- [x] My PR title follows the conventional commit format used by this repo
- [x] I linked the related issue or explained why none exists
- [ ] I updated docs when needed
- [x] I added or updated tests when needed
- [x] I verified the change does not introduce unrelated modifications
- [x] I read AGENTS.md and followed the contributor guidelines
- [x] A human reviewed the complete diff before submission


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release asset naming by replacing spaces with periods when files lack recognized extensions.
  * Preserved existing architecture-specific naming for supported application archives and signature files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->