### PR TITLE
fix(mobile): clamp AgentLauncher empty-state horizontal overflow at 390px (CAP-5)

### DIFF
--- a/src/renderer/components/agents/AgentLauncher.test.tsx
+++ b/src/renderer/components/agents/AgentLauncher.test.tsx
@@ -1264,3 +1264,46 @@ describe('AgentLauncher slash menu parity (mid-text + command chip)', () => {
     expect(textarea).toHaveValue('')
   })
 })
+
+describe('AgentLauncher mobile empty-state overflow', () => {
+  // CAP-5 / ship-blocker P2: at a 390px mobile viewport the empty-state
+  // launcher (hero + suggestion cards + composer) must not clip past the
+  // right viewport edge. jsdom cannot measure layout, so this is a structural
+  // regression guard asserting the width-constraining Tailwind utilities are
+  // present on the launcher root, hero heading, composer column, and
+  // suggestion grid. Real-device no-clip is the production signal (see the
+  // spec's Verification section).
+  it('clamps horizontal overflow via overflow-x-hidden + width constraints', () => {
+    renderLauncher()
+
+    // The hero <h1> is the stable entry point (role + level). From it we walk
+    // the rendered tree to the hero div, launcher root, composer column, and
+    // suggestion grid — jsdom preserves the className strings exactly.
+    const heading = screen.getByRole('heading', {
+      level: 1,
+      name: /what should we do in/i
+    })
+    // Hero div wraps the logo + heading.
+    const hero = heading.parentElement!
+    // Launcher root is the hero's parent (the absolute inset-0 container).
+    const launcherRoot = hero.parentElement!
+    // Composer column is the sibling div after the hero, inside the launcher
+    // root. It carries `max-w-4xl` + the new `min-w-0`.
+    const composerColumn = Array.from(launcherRoot.children).find(
+      (el) => el !== hero && el.tagName === 'DIV'
+    )!
+    // Suggestion grid is the grid child inside the composer column.
+    const suggestionGrid = composerColumn.querySelector('div.grid')!
+
+    // Launcher root: `overflow-x-hidden` backstop + responsive padding.
+    expect(launcherRoot.className).toContain('overflow-x-hidden')
+    expect(launcherRoot.className).toContain('p-4')
+    expect(launcherRoot.className).toContain('sm:p-8')
+    // Hero div spans the content box; heading wraps instead of forcing width.
+    expect(hero.className).toContain('w-full')
+    expect(heading.className).toContain('break-words')
+    // Composer column + suggestion grid allow flex/grid children to shrink.
+    expect(composerColumn.className).toContain('min-w-0')
+    expect(suggestionGrid.className).toContain('min-w-0')
+  })
+})

--- a/src/renderer/components/agents/AgentLauncher.tsx
+++ b/src/renderer/components/agents/AgentLauncher.tsx
@@ -809,16 +809,19 @@ export function AgentLauncher({ paneId, className }: AgentLauncherProps): React.
 
   return (
     <div
-      className={cn('absolute inset-0 flex flex-col items-center justify-center p-8', className)}
+      className={cn(
+        'absolute inset-0 flex flex-col items-center justify-center overflow-x-hidden p-4 sm:p-8',
+        className
+      )}
     >
-      <div className="mb-8 flex flex-col items-center gap-4 text-center">
+      <div className="mb-8 flex w-full flex-col items-center gap-4 text-center">
         <TermulMark size={48} className="text-foreground" />
-        <h1 className="text-3xl font-medium tracking-tight text-foreground md:text-4xl">
+        <h1 className="break-words text-3xl font-medium tracking-tight text-foreground md:text-4xl">
           {`What should we do in ${projectLabel}?`}
         </h1>
       </div>
 
-      <div className="flex w-full max-w-4xl flex-col gap-4">
+      <div className="flex min-w-0 w-full max-w-4xl flex-col gap-4">
         <div className="relative">
           {slashOpen && (
             <SlashCommandMenu
@@ -1049,7 +1052,7 @@ export function AgentLauncher({ paneId, className }: AgentLauncherProps): React.
           </div>
         </div>
 
-        <div className="grid gap-2 md:grid-cols-3">
+        <div className="grid min-w-0 gap-2 md:grid-cols-3">
           {SUGGESTIONS.map((suggestion) => (
             <button
               key={suggestion.title}


### PR DESCRIPTION
## Summary

At a 390px mobile viewport the web empty-state launcher (the "What should we do in {project}?" hero, the three suggestion cards, and the composer) overflowed horizontally and clipped past the right viewport edge — a visible production-readiness defect on a narrow screen (research D2-5 / D5 L8; ship-blocker P2 / CAP-5). The `text-3xl` hero heading had no width constraint, so it drove the centered flex column wider than the 390px viewport, and the `<main overflow-hidden>` ancestor then clipped the overflow (hero tail, rightmost suggestion card, and composer send button invisible). This fixes CAP-5 of the web-mobile-production-readiness spec so the mobile shell is usable on a phone browser served by `termul-server`.

## Related Issue

No related issue — this is a production-readiness ship-blocker (P2 / CAP-5) tracked in the spec at `_bmad-output/specs/spec-web-mobile-production-readiness/` and `ship-blockers.md`, not a GitHub issue.

## Type of Change

- [x] fix: bug fix

## What Changed

- `src/renderer/components/agents/AgentLauncher.tsx` — launcher root gains `overflow-x-hidden` (horizontal-only backstop that preserves the vertical float of the slash/mention menus; not `overflow-hidden`) and responsive padding `p-4 sm:p-8` (more content room on mobile: 390-32=358px vs the old 390-64=326px content box).
- `src/renderer/components/agents/AgentLauncher.tsx` — hero div gains `w-full` and the `<h1>` gains `break-words`, so the "What should we do in {project}?" heading wraps within the content box instead of driving the flex column to ~450px.
- `src/renderer/components/agents/AgentLauncher.tsx` — composer column and suggestion grid gain `min-w-0` so flex/grid children can shrink below their min-content width on narrow viewports.
- `src/renderer/components/agents/AgentLauncher.test.tsx` — new structural regression test asserting the width-constraining Tailwind utilities are present on the launcher root, hero, composer column, and suggestion grid (jsdom cannot measure layout; real-device no-clip at 390px is the production signal).

## Screenshots or Recordings

N/A — verify on a real device or headed CDP at a 390px viewport. The original finding was headless-captured (medium confidence per `ship-blockers.md`), so a real-device / true-emulation check is the production signal, not a screenshot.

## How It Was Tested

- [x] `bun run ci` (Biome lint + format + imports, strict mode)
- [x] `bun run typecheck`
- [x] `bun run test`
- [x] `cargo clippy --all-targets -- -D warnings` (in src-tauri)
- [ ] `cargo test` (in src-tauri) — compiles cleanly (`cargo test --no-run` passes); local runtime is blocked by a pre-existing Windows `STATUS_ENTRYPOINT_NOT_FOUND` (0xc0000139) DLL-loader issue affecting the whole test binary, documented across prior stories and not caused by this renderer-only change. CI runs `cargo test` on Linux.
- [ ] Manual verification completed — deferred: real-device / headed-CDP no-clip check at 390px is the production signal, not a CI gate.
- [ ] Not applicable

## CI & Review Gate

- [ ] All CI checks pass (PR Validation, Rust Checks, Build Verification, Security Scans)
- [ ] Code review comments from CodeRabbit / Claude have been addressed or resolved
- [ ] No unresolved review findings remain

## Checklist

- [x] My PR title follows the conventional commit format used by this repo
- [x] I linked the related issue or explained why none exists
- [x] I updated docs when needed
- [x] I added or updated tests when needed
- [x] I verified the change does not introduce unrelated modifications
- [x] I read AGENTS.md and followed the contributor guidelines
- [x] A human reviewed the complete diff before submission


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved the launcher layout on narrow screens.
  * Prevented horizontal overflow and improved responsive spacing.
  * Enhanced heading wrapping and suggestions grid behavior for smaller widths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->