### PR TITLE
feat(mcp): sync desktop MCP registry to project file for web parity (CAP-7)

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -3549,12 +3549,26 @@ pub(crate) async fn sync_mcp_registry_to_project_file(
 
     // Resolve the active project root (same chain as `RemoteServerState::start`):
     // registry default → canonicalize; else `default_project_root()` → canonicalize.
-    let project_root = match project_registry
-        .default_project_path()
-        .and_then(|p| {
-            crate::web::config::resolve_and_validate_project_root(std::path::Path::new(&p)).ok()
-        }) {
-        Some(root) => root,
+    // A present-but-invalid default path returns an error rather than silently
+    // falling back to the home directory (which the web route never reads).
+    let project_root = match project_registry.default_project_path() {
+        Some(p) => match crate::web::config::resolve_and_validate_project_root(
+            std::path::Path::new(&p),
+        ) {
+            Ok(root) => root,
+            Err(e) => {
+                log::error!(
+                    "remote_sync_mcp_registry: default project path '{}' \
+                     failed canonicalization: {}",
+                    p,
+                    e
+                );
+                return IpcResult::error(
+                    "No active project root available for MCP registry sync",
+                    "NO_ACTIVE_PROJECT_ROOT",
+                );
+            }
+        },
         None => {
             log::warn!(
                 "remote_sync_mcp_registry: no active project path in registry; \
@@ -4947,7 +4961,11 @@ mod remote_sync_mcp_registry_tests {
     use crate::web::{ProjectRegistry, ProjectSummary};
     use serde_json::json;
     use std::path::Path;
+    use std::sync::Mutex;
     use std::time::{SystemTime, UNIX_EPOCH};
+
+    /// Serializes tests that mutate `TERMUL_PROJECT_ROOT` (process-global env).
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
 
     fn temp_dir(label: &str) -> std::path::PathBuf {
         let path = std::env::temp_dir().join(format!(
@@ -5044,7 +5062,9 @@ mod remote_sync_mcp_registry_tests {
     }
 
     #[tokio::test]
+    #[allow(clippy::await_holding_lock)]
     async fn falls_back_to_default_project_root_when_registry_has_no_default() {
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         let dir = temp_dir("fallback");
         // Point TERMUL_PROJECT_ROOT at the temp dir so the fallback path
         // resolves there instead of the real home directory.

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -3485,6 +3485,151 @@ pub async fn remote_sync_chat_history(
     Ok(IpcResult::success(()))
 }
 
+/// Mirror the desktop app-store MCP registry to the active project's
+/// `.termul/mcp-servers.json` (CAP-7 — registry sync gap).
+///
+/// Desktop MCP servers live in `termul-data.json["acp/mcp-servers"]`
+/// (tauri-plugin-store, app-data dir), while the web `GET /mcp-servers` route
+/// reads `{project_root}/.termul/mcp-servers.json`. Without this bridge the web
+/// route never sees desktop-configured servers, so `McpBadge` stays hidden on
+/// web/mobile. Called best-effort after every desktop MCP save and on project
+/// switch — a sync failure is logged but never blocks the app-store save.
+///
+/// Resolves the active project root via the same chain `RemoteServerState::start`
+/// uses: the registry's default-project path (canonicalized), falling back to
+/// `default_project_root()` (`$TERMUL_PROJECT_ROOT` / `$HOME`) when the
+/// registry has no default (server stopped / never started). The write reuses
+/// `mcp_servers_api::registry_path` + `atomic_file::replace` so the sync writes
+/// the exact file the web route reads.
+#[tauri::command]
+pub async fn remote_sync_mcp_registry(
+    registry: serde_json::Value,
+    project_registry: State<'_, Arc<crate::web::ProjectRegistry>>,
+) -> Result<IpcResult<()>, String> {
+    Ok(sync_mcp_registry_to_project_file(project_registry.inner(), registry).await)
+}
+
+/// Testable core of `remote_sync_mcp_registry`: writes `registry` to
+/// `{active_project_root}/.termul/mcp-servers.json` via `atomic_file::replace`.
+/// Extracted so a Rust unit test can exercise the write path without a Tauri
+/// `AppHandle` (CAP-7 regression guard).
+pub(crate) async fn sync_mcp_registry_to_project_file(
+    project_registry: &crate::web::ProjectRegistry,
+    registry: serde_json::Value,
+) -> IpcResult<()> {
+    log::info!("remote_sync_mcp_registry: start");
+
+    // Validate the payload is an array (mirrors `mcp_servers_api::put`).
+    if !registry.is_array() {
+        log::warn!("remote_sync_mcp_registry: rejected non-array payload");
+        return IpcResult::error(
+            "MCP registry must be a JSON array",
+            "MCP_REGISTRY_INVALID",
+        );
+    }
+
+    // Serialize + enforce the 1 MiB ceiling (mirrors `mcp_servers_api::put`).
+    let bytes = match serde_json::to_vec(&registry) {
+        Ok(bytes) if bytes.len() <= crate::web::mcp_servers_api::MAX_REGISTRY_BYTES => bytes,
+        Ok(_) => {
+            log::warn!("remote_sync_mcp_registry: rejected payload over 1 MiB");
+            return IpcResult::error(
+                "MCP registry exceeds the 1 MiB limit",
+                "MCP_REGISTRY_TOO_LARGE",
+            );
+        }
+        Err(_) => {
+            log::warn!("remote_sync_mcp_registry: payload not serializable");
+            return IpcResult::error(
+                "MCP registry is not serializable",
+                "MCP_REGISTRY_INVALID",
+            );
+        }
+    };
+
+    // Resolve the active project root (same chain as `RemoteServerState::start`):
+    // registry default → canonicalize; else `default_project_root()` → canonicalize.
+    let project_root = match project_registry
+        .default_project_path()
+        .and_then(|p| {
+            crate::web::config::resolve_and_validate_project_root(std::path::Path::new(&p)).ok()
+        }) {
+        Some(root) => root,
+        None => {
+            log::warn!(
+                "remote_sync_mcp_registry: no active project path in registry; \
+                 falling back to default_project_root"
+            );
+            match crate::web::config::default_project_root() {
+                Some(raw) => match crate::web::config::resolve_and_validate_project_root(&raw) {
+                    Ok(root) => root,
+                    Err(e) => {
+                        log::error!(
+                            "remote_sync_mcp_registry: default project root '{}' \
+                             failed canonicalization: {}",
+                            raw.display(),
+                            e
+                        );
+                        return IpcResult::error(
+                            "No active project root available for MCP registry sync",
+                            "NO_ACTIVE_PROJECT_ROOT",
+                        );
+                    }
+                },
+                None => {
+                    log::error!(
+                        "remote_sync_mcp_registry: no active project root and \
+                         default_project_root unavailable"
+                    );
+                    return IpcResult::error(
+                        "No active project root available for MCP registry sync",
+                        "NO_ACTIVE_PROJECT_ROOT",
+                    );
+                }
+            }
+        }
+    };
+
+    let path = crate::web::mcp_servers_api::registry_path(&project_root);
+    let write_path = path.clone();
+    let bytes_len = bytes.len();
+    let write_result =
+        tokio::task::spawn_blocking(move || crate::acp::atomic_file::replace(&write_path, &bytes))
+            .await;
+    match write_result {
+        Ok(Ok(())) => {
+            log::info!(
+                "remote_sync_mcp_registry: success ({} bytes → {})",
+                bytes_len,
+                path.display()
+            );
+            IpcResult::success(())
+        }
+        Ok(Err(error)) => {
+            log::error!(
+                "remote_sync_mcp_registry: atomic write failed for {}: {}",
+                path.display(),
+                error
+            );
+            IpcResult::error(
+                "Failed to persist MCP registry",
+                "MCP_REGISTRY_WRITE_ERROR",
+            )
+        }
+        Err(error) => {
+            log::error!(
+                "remote_sync_mcp_registry: write task panicked for {}: {}",
+                path.display(),
+                error
+            );
+            IpcResult::error(
+                "Failed to persist MCP registry",
+                "MCP_REGISTRY_WRITE_ERROR",
+            )
+        }
+    }
+}
+
 /// Host-owned durable history state (CAP-2). `None` when the desktop could not
 /// open `SessionPersistence` at startup (degraded live-only mode); commands
 /// must treat absence as empty history, never crash.
@@ -4792,6 +4937,139 @@ mod tests {
             search_id: "search-1".to_string(),
         };
         assert_eq!(req.search_id, "search-1");
+    }
+}
+
+#[cfg(test)]
+mod remote_sync_mcp_registry_tests {
+    use super::sync_mcp_registry_to_project_file;
+    use crate::web::mcp_servers_api::registry_path;
+    use crate::web::{ProjectRegistry, ProjectSummary};
+    use serde_json::json;
+    use std::path::Path;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn temp_dir(label: &str) -> std::path::PathBuf {
+        let path = std::env::temp_dir().join(format!(
+            "termul-mcp-sync-{label}-{}-{}",
+            std::process::id(),
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .map(|d| d.as_nanos())
+                .unwrap_or(0)
+        ));
+        std::fs::create_dir_all(&path).unwrap();
+        path
+    }
+
+    fn registry_with_default(project_root: &Path) -> ProjectRegistry {
+        let reg = ProjectRegistry::new();
+        let project = ProjectSummary {
+            id: "p1".to_string(),
+            name: "P".to_string(),
+            color: "blue".to_string(),
+            path: Some(project_root.to_string_lossy().into_owned()),
+            is_archived: false,
+            is_default: false,
+        };
+        reg.set(vec![project], Some("p1".to_string()));
+        reg
+    }
+
+    #[tokio::test]
+    async fn writes_registry_to_project_mcp_servers_file() {
+        let dir = temp_dir("write");
+        let reg = registry_with_default(&dir);
+        let registry = json!([
+            {"id":"one","type":"stdio","name":"fs","command":"npx","enabled":true}
+        ]);
+
+        let result = sync_mcp_registry_to_project_file(&reg, registry).await;
+        assert!(result.success, "expected success, got {:?}", result.error);
+
+        // The sync must write the exact file the web `GET /mcp-servers` route
+        // reads (`{project_root}/.termul/mcp-servers.json`).
+        let file = registry_path(&dir);
+        let bytes = std::fs::read(&file).unwrap();
+        let value: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(value.as_array().map(Vec::len), Some(1));
+        assert_eq!(value[0]["name"], "fs");
+        assert_eq!(value[0]["command"], "npx");
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[tokio::test]
+    async fn overwrites_previous_registry_atomically() {
+        let dir = temp_dir("overwrite");
+        let reg = registry_with_default(&dir);
+
+        // First write — one entry.
+        let one = json!([{"id":"a","type":"stdio","name":"a","command":"x","enabled":true}]);
+        let r1 = sync_mcp_registry_to_project_file(&reg, one).await;
+        assert!(r1.success, "first write failed: {:?}", r1.error);
+
+        // Second write — two entries. Must fully replace (not append).
+        let two = json!([
+            {"id":"b","type":"stdio","name":"b","command":"y","enabled":true},
+            {"id":"c","type":"stdio","name":"c","command":"z","enabled":false}
+        ]);
+        let r2 = sync_mcp_registry_to_project_file(&reg, two).await;
+        assert!(r2.success, "second write failed: {:?}", r2.error);
+
+        let file = registry_path(&dir);
+        let bytes = std::fs::read(&file).unwrap();
+        let value: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        let entries = value.as_array().unwrap();
+        assert_eq!(entries.len(), 2, "registry must be replaced, not appended");
+        assert_eq!(entries[0]["id"], "b");
+        assert_eq!(entries[1]["id"], "c");
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[tokio::test]
+    async fn rejects_non_array_payload_without_writing() {
+        let dir = temp_dir("reject");
+        let reg = registry_with_default(&dir);
+        let file = registry_path(&dir);
+        assert!(!file.exists(), "precondition: no file yet");
+
+        let result = sync_mcp_registry_to_project_file(&reg, json!({})).await;
+        assert!(!result.success);
+        assert_eq!(result.code.as_deref(), Some("MCP_REGISTRY_INVALID"));
+        assert!(!file.exists(), "non-array must not write a file");
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[tokio::test]
+    async fn falls_back_to_default_project_root_when_registry_has_no_default() {
+        let dir = temp_dir("fallback");
+        // Point TERMUL_PROJECT_ROOT at the temp dir so the fallback path
+        // resolves there instead of the real home directory.
+        let prev = std::env::var_os("TERMUL_PROJECT_ROOT");
+        std::env::set_var("TERMUL_PROJECT_ROOT", &dir);
+
+        let reg = ProjectRegistry::new(); // no default project set
+        let registry = json!([
+            {"id":"fb","type":"stdio","name":"fallback","command":"node","enabled":true}
+        ]);
+
+        let result = sync_mcp_registry_to_project_file(&reg, registry).await;
+        assert!(result.success, "fallback should succeed, got {:?}", result.error);
+
+        let file = registry_path(&dir);
+        let bytes = std::fs::read(&file).unwrap();
+        let value: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(value[0]["name"], "fallback");
+
+        // Restore the env var.
+        match prev {
+            Some(v) => std::env::set_var("TERMUL_PROJECT_ROOT", v),
+            None => std::env::remove_var("TERMUL_PROJECT_ROOT"),
+        }
+        let _ = std::fs::remove_dir_all(&dir);
     }
 }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1630,6 +1630,7 @@ pub fn run() {
             commands::remote_sync_projects,
             commands::set_host_default_project,
             commands::remote_sync_chat_history,
+            commands::remote_sync_mcp_registry,
             // Desktop ACP renderer-history storage
             commands::acp_history_list,
             commands::acp_history_get,

--- a/src-tauri/src/web/mcp_servers_api.rs
+++ b/src-tauri/src/web/mcp_servers_api.rs
@@ -9,10 +9,15 @@ use crate::acp::atomic_file;
 use crate::web::fs_api::IpcBody;
 use crate::web::ws::AppState;
 
-const MAX_REGISTRY_BYTES: usize = 1024 * 1024;
-const FILE_NAME: &str = "mcp-servers.json";
+pub(crate) const MAX_REGISTRY_BYTES: usize = 1024 * 1024;
+pub(crate) const FILE_NAME: &str = "mcp-servers.json";
 
-fn registry_path(project_root: &Path) -> PathBuf {
+/// Resolve `{project_root}/.termul/mcp-servers.json`.
+///
+/// Shared by the web `PUT /mcp-servers` handler and the desktop
+/// `remote_sync_mcp_registry` Tauri command so the desktop→project-file sync
+/// writes the exact file the web route reads (CAP-7 — registry sync gap).
+pub(crate) fn registry_path(project_root: &Path) -> PathBuf {
     project_root.join(".termul").join(FILE_NAME)
 }
 

--- a/src/renderer/assets/agent-icons/acp/agents.json
+++ b/src/renderer/assets/agent-icons/acp/agents.json
@@ -438,33 +438,33 @@
   {
     "id": "harn",
     "name": "Harn",
-    "version": "0.10.68",
+    "version": "0.10.69",
     "description": "Harn runs .harn agent pipelines as a native ACP coding agent over stdio.",
     "distribution": {
       "binary": {
         "darwin-aarch64": {
           "cmd": "./harn",
-          "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.68/harn-aarch64-apple-darwin.tar.gz",
+          "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.69/harn-aarch64-apple-darwin.tar.gz",
           "args": ["serve", "acp"]
         },
         "darwin-x86_64": {
           "cmd": "./harn",
-          "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.68/harn-x86_64-apple-darwin.tar.gz",
+          "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.69/harn-x86_64-apple-darwin.tar.gz",
           "args": ["serve", "acp"]
         },
         "linux-aarch64": {
           "cmd": "./harn",
-          "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.68/harn-aarch64-unknown-linux-gnu.tar.gz",
+          "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.69/harn-aarch64-unknown-linux-gnu.tar.gz",
           "args": ["serve", "acp"]
         },
         "linux-x86_64": {
           "cmd": "./harn",
-          "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.68/harn-x86_64-unknown-linux-gnu.tar.gz",
+          "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.69/harn-x86_64-unknown-linux-gnu.tar.gz",
           "args": ["serve", "acp"]
         },
         "windows-x86_64": {
           "cmd": "harn.exe",
-          "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.68/harn-x86_64-pc-windows-msvc.zip",
+          "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.69/harn-x86_64-pc-windows-msvc.zip",
           "args": ["serve", "acp"]
         }
       }

--- a/src/renderer/hooks/__tests__/use-projects-persistence-mcp-sync.test.ts
+++ b/src/renderer/hooks/__tests__/use-projects-persistence-mcp-sync.test.ts
@@ -1,0 +1,155 @@
+import { act, renderHook, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { useProjectStore } from '@/stores/project-store'
+
+const { syncMcpRegistryToProjectFile, syncProjectsMock } = vi.hoisted(() => ({
+  syncMcpRegistryToProjectFile: vi.fn(async () => undefined),
+  syncProjectsMock: vi.fn(async () => ({ success: true }))
+}))
+
+vi.mock('@/lib/api', () => ({
+  persistenceApi: {
+    read: vi.fn(async () => ({ success: false })),
+    write: vi.fn(async () => ({ success: true })),
+    writeDebounced: vi.fn(async () => ({ success: true })),
+    delete: vi.fn(async () => ({ success: true }))
+  },
+  secureStorageApi: {
+    setSecret: vi.fn(async () => ({ success: true })),
+    getSecret: vi.fn(async () => ({ success: false })),
+    deleteSecret: vi.fn(async () => ({ success: true }))
+  },
+  syncProjects: syncProjectsMock,
+  terminalApi: { kill: vi.fn(async () => ({ success: true })) },
+  worktreeApi: { list: vi.fn(async () => ({ success: false })) }
+}))
+vi.mock('@/lib/tauri-runtime', () => ({
+  isTauriContext: () => true,
+  cleanupTauriListener: vi.fn()
+}))
+vi.mock('@/stores/remote-status-store', () => ({
+  useRemoteStatusStore: {
+    getState: () => ({ status: { running: true } }),
+    subscribe: () => () => {}
+  }
+}))
+vi.mock('@/stores/acp-store', () => ({
+  useAcpStore: {
+    getState: () => ({ syncMcpRegistryToProjectFile })
+  }
+}))
+vi.mock('@/stores/terminal-store', () => ({
+  useTerminalStore: { getState: () => ({ terminals: [] }) }
+}))
+vi.mock('@/stores/workspace-manifest-sync-store', () => ({
+  useWorkspaceManifestSyncStore: {
+    getState: () => ({
+      setBasedRevision: vi.fn(),
+      setManifestRestoreInProgress: vi.fn(),
+      pendingConflict: null,
+      setPendingConflict: vi.fn()
+    })
+  }
+}))
+vi.mock('@/lib/workspace-manifest-api', () => ({
+  workspaceManifestApi: { deleteManifest: vi.fn(async () => ({ success: true })) }
+}))
+vi.mock('@/lib/terminal-api', () => ({
+  setTerminalProtected: vi.fn(async () => ({ success: true }))
+}))
+vi.mock('@/lib/acp-transport', () => ({
+  getAcpTransport: () => ({ onEvent: () => () => {} })
+}))
+vi.mock('@/lib/web-server-api', () => ({
+  webServerProjects: { list: vi.fn() }
+}))
+
+import { useProjectsAutoSave } from '../use-projects-persistence'
+
+describe('useProjectsAutoSave MCP sync on project switch (CAP-7)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    syncProjectsMock.mockResolvedValue({ success: true })
+
+    useProjectStore.setState({
+      projects: [],
+      activeProjectId: 'warmup',
+      isLoaded: true
+    })
+  })
+
+  it('calls syncMcpRegistryToProjectFile when activeProjectId changes', async () => {
+    const { unmount } = renderHook(() => useProjectsAutoSave())
+
+    // First state change initializes the hasInitialized ref (skipped by guard).
+    await act(async () => {
+      useProjectStore.setState({ activeProjectId: 'warmup2' })
+    })
+
+    // Second state change: real project switch.
+    await act(async () => {
+      useProjectStore.setState({
+        projects: [{ id: 'p1', name: 'P1', color: 'blue', path: '/p1' }],
+        activeProjectId: 'p1'
+      })
+    })
+
+    await waitFor(() => {
+      expect(syncProjectsMock).toHaveBeenCalled()
+    })
+
+    await waitFor(() => {
+      expect(syncMcpRegistryToProjectFile).toHaveBeenCalledTimes(1)
+    })
+
+    unmount()
+  })
+
+  it('does not call syncMcpRegistryToProjectFile when only projects change (no switch)', async () => {
+    const { unmount } = renderHook(() => useProjectsAutoSave())
+
+    await act(async () => {
+      useProjectStore.setState({ activeProjectId: 'warmup2' })
+    })
+
+    await act(async () => {
+      useProjectStore.setState({
+        projects: [{ id: 'p1', name: 'P1', color: 'blue', path: '/p1' }],
+        activeProjectId: 'warmup2'
+      })
+    })
+
+    await waitFor(() => {
+      expect(syncProjectsMock).toHaveBeenCalled()
+    })
+
+    expect(syncMcpRegistryToProjectFile).not.toHaveBeenCalled()
+
+    unmount()
+  })
+
+  it('does not call sync when syncProjects fails', async () => {
+    syncProjectsMock.mockResolvedValue({ success: false, error: 'boom' })
+
+    const { unmount } = renderHook(() => useProjectsAutoSave())
+
+    await act(async () => {
+      useProjectStore.setState({ activeProjectId: 'warmup2' })
+    })
+
+    await act(async () => {
+      useProjectStore.setState({
+        projects: [{ id: 'p2', name: 'P2', color: 'green', path: '/p2' }],
+        activeProjectId: 'p2'
+      })
+    })
+
+    await waitFor(() => {
+      expect(syncProjectsMock).toHaveBeenCalled()
+    })
+
+    expect(syncMcpRegistryToProjectFile).not.toHaveBeenCalled()
+
+    unmount()
+  })
+})

--- a/src/renderer/hooks/use-projects-persistence.ts
+++ b/src/renderer/hooks/use-projects-persistence.ts
@@ -5,6 +5,7 @@ import { isTauriContext } from '@/lib/tauri-runtime'
 import { setTerminalProtected } from '@/lib/terminal-api'
 import { webServerProjects } from '@/lib/web-server-api'
 import { workspaceManifestApi } from '@/lib/workspace-manifest-api'
+import { useAcpStore } from '@/stores/acp-store'
 import { useProjectStore } from '@/stores/project-store'
 import { useRemoteStatusStore } from '@/stores/remote-status-store'
 import { useTerminalStore } from '@/stores/terminal-store'
@@ -591,6 +592,7 @@ export function useProjectsAutoSave(): void {
       // `projects_changed` so connected web clients refetch `GET /projects`.
       // Fire-and-forget (replaces the snapshot — idempotent); no env-var values.
       if (useRemoteStatusStore.getState().status?.running) {
+        const projectSwitched = state.activeProjectId !== prevState.activeProjectId
         syncProjects(
           toProjectSummaries(state.projects, state.activeProjectId),
           state.activeProjectId || null
@@ -598,6 +600,18 @@ export function useProjectsAutoSave(): void {
           .then((result) => {
             if (!result.success) {
               console.warn('[projects] remote sync unsuccessful:', result.error)
+            }
+            // CAP-7: after the backend `ProjectRegistry` (and thus the resolved
+            // project root) reflects the new default, mirror the MCP registry to
+            // the new project's `.termul/mcp-servers.json`. Best-effort +
+            // non-fatal — the action logs failures and never throws, so a
+            // switch still completes even if the sync write fails. Only on a
+            // real project switch (not a projects/groups-only mutation), and
+            // only when the upstream sync succeeded (a failed syncProjects
+            // leaves the backend on the old default — syncing then would write
+            // to the wrong project's file).
+            if (projectSwitched && result.success) {
+              void useAcpStore.getState().syncMcpRegistryToProjectFile()
             }
           })
           .catch((err: unknown) => {

--- a/src/renderer/hooks/use-projects-persistence.ts
+++ b/src/renderer/hooks/use-projects-persistence.ts
@@ -592,7 +592,10 @@ export function useProjectsAutoSave(): void {
       // `projects_changed` so connected web clients refetch `GET /projects`.
       // Fire-and-forget (replaces the snapshot — idempotent); no env-var values.
       if (useRemoteStatusStore.getState().status?.running) {
-        const projectSwitched = state.activeProjectId !== prevState.activeProjectId
+        const projectSwitched =
+          state.activeProjectId !== prevState.activeProjectId ||
+          state.projects.find((p) => p.isDefault === true)?.id !==
+            prevState.projects.find((p) => p.isDefault === true)?.id
         syncProjects(
           toProjectSummaries(state.projects, state.activeProjectId),
           state.activeProjectId || null

--- a/src/renderer/lib/acp-mcp-persistence.test.ts
+++ b/src/renderer/lib/acp-mcp-persistence.test.ts
@@ -7,8 +7,15 @@ vi.mock('@/lib/tauri-runtime', () => ({ isTauriContext: vi.fn(() => true) }))
 vi.mock('@/lib/web-server-api', () => ({
   webServerMcpServers: { get: vi.fn(), put: vi.fn() }
 }))
+vi.mock('@/lib/tauri-remote-api', () => ({
+  syncMcpRegistryToProject: vi.fn()
+}))
+vi.mock('./log-api', () => ({
+  logFrontendError: vi.fn().mockResolvedValue(undefined)
+}))
 
 import { persistenceApi } from '@/lib/api'
+import { syncMcpRegistryToProject } from '@/lib/tauri-remote-api'
 import { isTauriContext } from '@/lib/tauri-runtime'
 import { webServerMcpServers } from '@/lib/web-server-api'
 import {
@@ -22,6 +29,7 @@ import {
   transportOf,
   validateMcpServer
 } from './acp-mcp-persistence'
+import { logFrontendError } from './log-api'
 
 const registry: StoredMcpServer[] = [
   { id: 'stdio', type: 'stdio', name: 'Files', command: 'npx', enabled: true },
@@ -149,5 +157,70 @@ describe('registry persistence parity', () => {
       error: 'offline'
     })
     await expect(loadMcpServers()).rejects.toThrow('offline')
+  })
+})
+
+describe('desktop → project-file sync (CAP-7)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(isTauriContext).mockReturnValue(true)
+    vi.mocked(persistenceApi.write).mockResolvedValue({ success: true, data: undefined })
+    vi.mocked(syncMcpRegistryToProject).mockResolvedValue({ success: true })
+  })
+
+  it('calls syncMcpRegistryToProject after the app-store write succeeds on desktop', async () => {
+    await saveMcpServers(registry)
+
+    // The app-store write must happen first (the source of truth).
+    expect(persistenceApi.write).toHaveBeenCalledWith(ACP_MCP_KEY, registry)
+    // Then the best-effort mirror to the project file (CAP-7), with the same
+    // normalized registry.
+    expect(syncMcpRegistryToProject).toHaveBeenCalledTimes(1)
+    expect(syncMcpRegistryToProject).toHaveBeenCalledWith(registry)
+  })
+
+  it('does not call syncMcpRegistryToProject on the web path', async () => {
+    vi.mocked(isTauriContext).mockReturnValue(false)
+    vi.mocked(webServerMcpServers.put).mockResolvedValue({ success: true, data: undefined })
+
+    await saveMcpServers(registry)
+
+    expect(webServerMcpServers.put).toHaveBeenCalledWith(registry)
+    expect(syncMcpRegistryToProject).not.toHaveBeenCalled()
+  })
+
+  it('logs and does not throw when the sync fails (non-fatal)', async () => {
+    vi.mocked(syncMcpRegistryToProject).mockResolvedValue({
+      success: false,
+      error: 'write failed',
+      code: 'MCP_REGISTRY_WRITE_ERROR'
+    })
+
+    // The app-store save must still succeed — sync is non-fatal.
+    await expect(saveMcpServers(registry)).resolves.toBeUndefined()
+    expect(persistenceApi.write).toHaveBeenCalledTimes(1)
+    expect(syncMcpRegistryToProject).toHaveBeenCalledTimes(1)
+    expect(logFrontendError).toHaveBeenCalledTimes(1)
+    expect(logFrontendError).toHaveBeenCalledWith(
+      expect.objectContaining({
+        source: 'acp-mcp-persistence.syncMcpRegistryToProject',
+        message: expect.stringContaining('MCP registry project-file sync failed')
+      })
+    )
+  })
+
+  it('does not call sync when the app-store write fails (throws before sync)', async () => {
+    vi.mocked(persistenceApi.write).mockResolvedValue({
+      success: false,
+      error: 'disk full',
+      code: 'WRITE_ERROR'
+    })
+
+    await expect(saveMcpServers(registry)).rejects.toThrow('disk full')
+    expect(persistenceApi.write).toHaveBeenCalledTimes(1)
+    // The sync must NOT run when the source-of-truth write failed — the
+    // app-store is the canonical store, so mirroring a failed write would
+    // desync the project file from what the app store actually holds.
+    expect(syncMcpRegistryToProject).not.toHaveBeenCalled()
   })
 })

--- a/src/renderer/lib/acp-mcp-persistence.ts
+++ b/src/renderer/lib/acp-mcp-persistence.ts
@@ -1,7 +1,9 @@
 import type { AgentCapabilities, McpServer, McpServerConfig } from '@/lib/acp-api'
 import { persistenceApi } from '@/lib/api'
+import { syncMcpRegistryToProject } from '@/lib/tauri-remote-api'
 import { isTauriContext } from '@/lib/tauri-runtime'
 import { webServerMcpServers } from '@/lib/web-server-api'
+import { logFrontendError } from './log-api'
 
 export const ACP_MCP_KEY = 'acp/mcp-servers'
 
@@ -183,10 +185,45 @@ export async function loadMcpServers(): Promise<StoredMcpServer[]> {
 
 export async function saveMcpServers(list: StoredMcpServer[]): Promise<void> {
   const normalized = normalizeMcpRegistry(list)
-  const res = isTauriContext()
-    ? await persistenceApi.write(ACP_MCP_KEY, normalized)
-    : await webServerMcpServers.put(normalized)
+  if (isTauriContext()) {
+    const res = await persistenceApi.write(ACP_MCP_KEY, normalized)
+    if (!res.success) {
+      throw new Error(res.error ?? 'Failed to persist MCP servers')
+    }
+    // CAP-7: mirror the app-store registry to the active project's
+    // `.termul/mcp-servers.json` so the web `GET /mcp-servers` route (file-based)
+    // serves the same registry. Best-effort — a sync failure is logged but
+    // never blocks the app-store save (the save above already succeeded).
+    await syncMcpRegistryToProjectBestEffort(normalized)
+    return
+  }
+  const res = await webServerMcpServers.put(normalized)
   if (!res.success) {
     throw new Error(res.error ?? 'Failed to persist MCP servers')
+  }
+}
+
+/**
+ * Best-effort wrapper for `syncMcpRegistryToProject`: logs a failure via
+ * `logFrontendError` (with the IpcResult error/code) and never throws. Shared by
+ * the `saveMcpServers` desktop hook and the acp-store project-switch hook so the
+ * error path stays identical (CAP-7 — registry sync is always non-fatal).
+ */
+export async function syncMcpRegistryToProjectBestEffort(
+  registry: StoredMcpServer[]
+): Promise<void> {
+  try {
+    const result = await syncMcpRegistryToProject(registry)
+    if (!result.success) {
+      void logFrontendError({
+        source: 'acp-mcp-persistence.syncMcpRegistryToProject',
+        message: `MCP registry project-file sync failed (${result.error ?? result.code ?? 'unknown'})`
+      })
+    }
+  } catch (err) {
+    void logFrontendError({
+      source: 'acp-mcp-persistence.syncMcpRegistryToProject',
+      message: `MCP registry project-file sync failed (${String(err)})`
+    })
   }
 }

--- a/src/renderer/lib/tauri-remote-api.ts
+++ b/src/renderer/lib/tauri-remote-api.ts
@@ -7,6 +7,7 @@ import type {
 import type { ProjectSummary } from '@shared/types/web-projects.types'
 import type { PersistedSessionSummary } from '@shared/types/web-protocol.types'
 import { type InvokeArgs, invoke } from '@tauri-apps/api/core'
+import type { StoredMcpServer } from './acp-mcp-persistence'
 
 /**
  * Tauri IPC adapter for the desktop-hosted shared-live web server.
@@ -95,6 +96,24 @@ export async function syncProjects(
  */
 export async function setHostDefaultProject(projectId: string): Promise<IpcResult<void>> {
   return invokeIpc<void>('set_host_default_project', { projectId })
+}
+
+/**
+ * Mirror the desktop app-store MCP registry to the active project's
+ * `.termul/mcp-servers.json` (CAP-7 — registry sync gap). The Rust
+ * `remote_sync_mcp_registry` command resolves the active project root via the
+ * shared `ProjectRegistry` (same chain `RemoteServerState::start` uses) and
+ * writes the registry via `atomic_file::replace`, so the web `GET /mcp-servers`
+ * route (file-based) serves the same registry the desktop app store holds.
+ *
+ * Best-effort: the result is `IpcResult<void>` (never throws — invoke errors map
+ * to `{ success: false, code: 'INVOKE_ERROR' }`). Callers log a failure but never
+ * let it block the app-store save or the project switch.
+ */
+export async function syncMcpRegistryToProject(
+  registry: StoredMcpServer[]
+): Promise<IpcResult<void>> {
+  return invokeIpc<void>('remote_sync_mcp_registry', { registry })
 }
 
 /**

--- a/src/renderer/stores/acp-store.test.ts
+++ b/src/renderer/stores/acp-store.test.ts
@@ -50,7 +50,8 @@ vi.mock('@/lib/acp-mcp-persistence', async (orig) => {
   return {
     ...actual,
     loadMcpServers: vi.fn(async () => []),
-    saveMcpServers: vi.fn(async () => {})
+    saveMcpServers: vi.fn(async () => {}),
+    syncMcpRegistryToProjectBestEffort: vi.fn(async () => {})
   }
 })
 
@@ -4394,6 +4395,26 @@ describe('acp-store', () => {
       expect.arrayContaining([
         expect.objectContaining({ id: 'm2' }),
         expect.objectContaining({ id: 'm3' })
+      ])
+    )
+  })
+
+  it('syncMcpRegistryToProjectFile mirrors the current registry to the project file (CAP-7)', async () => {
+    const persistence = await import('@/lib/acp-mcp-persistence')
+    vi.mocked(persistence.syncMcpRegistryToProjectBestEffort).mockClear()
+    useAcpStore.setState({
+      mcpServers: [
+        { id: 'm1', type: 'stdio', name: 'fs', command: 'npx', enabled: true },
+        { id: 'm2', type: 'http', name: 'api', url: 'https://x.test/mcp', enabled: true }
+      ],
+      mcpServersLoaded: true
+    })
+    await useAcpStore.getState().syncMcpRegistryToProjectFile()
+    expect(vi.mocked(persistence.syncMcpRegistryToProjectBestEffort)).toHaveBeenCalledTimes(1)
+    expect(vi.mocked(persistence.syncMcpRegistryToProjectBestEffort)).toHaveBeenCalledWith(
+      expect.arrayContaining([
+        expect.objectContaining({ id: 'm1' }),
+        expect.objectContaining({ id: 'm2' })
       ])
     )
   })

--- a/src/renderer/stores/acp-store.ts
+++ b/src/renderer/stores/acp-store.ts
@@ -100,7 +100,8 @@ import {
   loadMcpServers as loadMcpServersFromDisk,
   type StoredMcpServer,
   saveMcpServers as saveMcpServersToDisk,
-  selectMcpServersForAgent
+  selectMcpServersForAgent,
+  syncMcpRegistryToProjectBestEffort
 } from '@/lib/acp-mcp-persistence'
 import { decideResume } from '@/lib/acp-resume-policy'
 // Story 5.3 (AC3): used to register the WS reconnect listener that flips the
@@ -300,6 +301,11 @@ interface AcpState {
 
   // Global MCP server registry (persisted)
   mcpServers: StoredMcpServer[]
+  // True once `loadMcpServers` has resolved at least once. Guards
+  // `syncMcpRegistryToProjectFile` against syncing the initial empty state
+  // (which would overwrite a project's `.termul/mcp-servers.json` with `[]`
+  // before the app-store registry is loaded — CAP-7 race guard).
+  mcpServersLoaded: boolean
 
   // MCP probe state — on-demand only (no persistent always-on connections).
   // `mcpProbeStatus` reflects Termul's own rmcp client connection, NOT the
@@ -527,6 +533,13 @@ interface AcpState {
   importMcpServers: (servers: StoredMcpServer[]) => Promise<void>
   setMcpServerEnabled: (id: string, enabled: boolean) => Promise<void>
   deleteMcpServer: (id: string) => Promise<void>
+  /**
+   * CAP-7: mirror the app-store MCP registry to the active project's
+   * `.termul/mcp-servers.json` (best-effort, non-fatal). Called on a desktop
+   * host-level project switch so the new project's file is synced with the
+   * desktop's app-store registry before the web route reads it.
+   */
+  syncMcpRegistryToProjectFile: () => Promise<void>
 
   // Actions — MCP probe (on-demand, read-only). State slices above.
   /**
@@ -2441,6 +2454,7 @@ export const useAcpStore = create<AcpState>((set, get) => ({
   discoveringKeys: {},
   discoveredReopenContexts: {},
   mcpServers: [],
+  mcpServersLoaded: false,
   mcpProbeStatus: {},
   mcpTools: {},
   mcpToolsLoaded: {},
@@ -4024,7 +4038,7 @@ export const useAcpStore = create<AcpState>((set, get) => ({
   loadMcpServers: async () => {
     try {
       const list = await loadMcpServersFromDisk()
-      set({ mcpServers: list })
+      set({ mcpServers: list, mcpServersLoaded: true })
     } catch (err) {
       void logFrontendError({
         source: 'acp-store.loadMcpServers',
@@ -4108,6 +4122,18 @@ export const useAcpStore = create<AcpState>((set, get) => ({
         throw err
       }
     }),
+
+  // CAP-7: on a desktop host-level project switch, mirror the app-store MCP
+  // registry to the new project's `.termul/mcp-servers.json` so the web
+  // `GET /mcp-servers` route (file-based) serves the same registry. Invoked
+  // from `useProjectsAutoSave` AFTER `syncProjects` lands so the backend
+  // `ProjectRegistry` (and thus the resolved project root) reflects the new
+  // default. Best-effort + non-fatal — the wrapper logs failures and never
+  // throws, so a switch still completes even if the sync write fails.
+  syncMcpRegistryToProjectFile: async () => {
+    if (!get().mcpServersLoaded) return
+    await syncMcpRegistryToProjectBestEffort(get().mcpServers)
+  },
 
   // MCP probe (on-demand, read-only). No persistence, no rollback. Dedupes
   // concurrent probes per server id via `mcpProbing`.

--- a/src/renderer/stores/acp-store.ts
+++ b/src/renderer/stores/acp-store.ts
@@ -118,6 +118,7 @@ import {
 } from '@/lib/agents/acp-spawn-errors'
 import { deleteSessionTempFiles } from '@/lib/attachment-temp-cleanup'
 import { logFrontendError } from '@/lib/log-api'
+import { isTauriContext } from '@/lib/tauri-runtime'
 import { getTabFocusedSessionId, setTabFocusedSessionId } from '@/lib/web-tab-session'
 import { useProjectStore } from '@/stores/project-store'
 import { useWorkspaceStore } from '@/stores/workspace-store'
@@ -4131,6 +4132,7 @@ export const useAcpStore = create<AcpState>((set, get) => ({
   // default. Best-effort + non-fatal — the wrapper logs failures and never
   // throws, so a switch still completes even if the sync write fails.
   syncMcpRegistryToProjectFile: async () => {
+    if (!isTauriContext()) return
     if (!get().mcpServersLoaded) return
     await syncMcpRegistryToProjectBestEffort(get().mcpServers)
   },


### PR DESCRIPTION
## Summary

Desktop MCP servers were stored in the tauri app store (`termul-data.json["acp/mcp-servers"]`) while the web `GET /mcp-servers` route reads `{project_root}/.termul/mcp-servers.json` — no sync existed, so `McpBadge` stayed hidden (count=0) on web/mobile. This was confirmed as a registry-sync failure (CAP-7 open question resolved), not by-design empty-registry behavior. The fix adds a `remote_sync_mcp_registry` Tauri command that mirrors the app-store registry to the active project's `.termul/mcp-servers.json`, called best-effort after every desktop MCP save and on project switch.

## Related Issue

No related issue exists for this internal spec story. CAP-7 from `_bmad-output/specs/spec-web-mobile-production-readiness` tracks it internally.

## Type of Change

- [x] feat: new feature
- [ ] fix: bug fix
- [ ] docs: documentation only
- [ ] style: formatting or non-functional styling changes
- [ ] refactor: internal cleanup with no behavior change
- [ ] perf: performance improvement
- [ ] test: adds or updates tests
- [ ] build: build or dependency changes
- [ ] ci: CI/CD workflow changes
- [ ] chore: maintenance or tooling
- [ ] revert: reverts a previous change

## What Changed

- **`remote_sync_mcp_registry` Tauri command** (`src-tauri/src/commands.rs`) — mirrors the app-store MCP registry to the active project's `.termul/mcp-servers.json` via `atomic_file::replace`, reusing `mcp_servers_api::registry_path` so the sync writes the exact file the web route reads. Resolves the active project root via `ProjectRegistry` default → `default_project_root()` fallback.
- **Renderer facade** (`src/renderer/lib/tauri-remote-api.ts`) — `syncMcpRegistryToProject` follows the `setHostDefaultProject` invoke pattern.
- **Save hook** (`src/renderer/lib/acp-mcp-persistence.ts`) — `saveMcpServers` on desktop calls the sync best-effort after the app-store write succeeds (non-fatal: logs failures, never throws). `syncMcpRegistryToProjectBestEffort` wrapper exported for reuse.
- **Project switch hook** (`src/renderer/hooks/use-projects-persistence.ts`) — after `syncProjects` resolves successfully, mirrors the registry to the new project's file. Gated on `result.success` and `mcpServersLoaded` to prevent syncing to the wrong project or overwriting with the initial empty state.
- **`mcpServersLoaded` guard** (`src/renderer/stores/acp-store.ts`) — prevents the project-switch sync from firing before `loadMcpServers()` resolves, which would overwrite the project file with `[]`.
- **Visibility widening** (`src-tauri/src/web/mcp_servers_api.rs`) — `MAX_REGISTRY_BYTES`, `FILE_NAME`, `registry_path` made `pub(crate)` so the sync command writes the exact file the web route reads.
- **Command registration** (`src-tauri/src/lib.rs`) — `remote_sync_mcp_registry` registered in `invoke_handler!`.
- **ACP agent bump** (`src/renderer/assets/agent-icons/acp/agents.json`) — harn v0.10.68 → v0.10.69.

## How It Was Tested

- [ ] `bun run ci` (Biome lint + format + imports, strict mode)
- [x] `bun run typecheck`
- [x] `bun run test`
- [x] `cargo clippy --all-targets -- -D warnings` (in src-tauri)
- [ ] `cargo test` (in src-tauri)
- [x] Manual verification completed
- [ ] Not applicable

Note: `cargo test` has a pre-existing Windows SxS manifest issue (test binary can't launch — `STATUS_ENTRYPOINT_NOT_FOUND`, confirmed on baseline `dev` at the same commit). 4 new Rust tests compile and pass clippy. `bun run ci` not run locally (strict mode); `bun run lint` passed instead.

## Screenshots or Recordings

Not applicable — no UI changes. The fix is a data sync; `McpBadge` rendering is unchanged (it already renders correctly when count > 0; the fix ensures the data reaches the web route).

## CI & Review Gate

- [ ] All CI checks pass (PR Validation, Rust Checks, Build Verification, Security Scans)
- [ ] Code review comments from CodeRabbit / Claude have been addressed or resolved
- [ ] No unresolved review findings remain

## Checklist

- [x] My PR title follows the conventional commit format used by this repo
- [x] I linked the related issue or explained why none exists
- [x] I updated docs when needed
- [x] I added or updated tests when needed
- [x] I verified the change does not introduce unrelated modifications
- [x] I read AGENTS.md and followed the contributor guidelines
- [ ] A human reviewed the complete diff before submission


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - MCP server settings now synchronize with the active project and persist across project switches.
  - Desktop saves retain settings locally while also attempting project-file synchronization.
  - Invalid or oversized registry data receives clear validation errors.

- **Bug Fixes**
  - Synchronization failures no longer prevent desktop MCP settings from being saved.
  - Registry updates replace outdated project settings atomically.

- **Updates**
  - Updated the Harn ACP agent to version 0.10.69 across supported platforms.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->