### PR TITLE
feat(acp): paste-JSON custom agent import + Copy JSON export

### DIFF
--- a/src-tauri/src/acp/commands.rs
+++ b/src-tauri/src/acp/commands.rs
@@ -12,7 +12,7 @@ use agent_client_protocol::schema::v1::{
 };
 use tauri::State;
 
-use crate::acp::config::{AgentConfig, AgentId, SessionId};
+use crate::acp::config::{require_config_id, AgentConfig, AgentId, SessionId};
 use crate::acp::manager::{
     AcpManager, NewSessionOutcome, SessionCreationContext, SessionReopenOutcome, SpawnOutcome,
 };
@@ -27,6 +27,10 @@ pub async fn acp_spawn_agent(
     manager: State<'_, Arc<AcpManager>>,
     config: AgentConfig,
 ) -> Result<SpawnOutcome, String> {
+    // OQ1: reject an AgentConfig without a non-empty `configId` so the spawn
+    // path derives a stable `config:{config_id}` namespace (no fallback hash).
+    // Shared with the WS `spawn_agent` handler via `require_config_id`.
+    require_config_id(&config)?;
     manager.spawn(config).await
 }
 

--- a/src-tauri/src/acp/config.rs
+++ b/src-tauri/src/acp/config.rs
@@ -71,7 +71,7 @@ impl From<&SessionId> for agent_client_protocol::schema::v1::SessionId {
 
 /// Configuration describing how to launch an ACP agent subprocess.
 #[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct AgentConfig {
     /// Stable renderer/config identity used for durable session matching. It is
     /// never used as a filesystem component and may be absent for older clients.
@@ -94,6 +94,22 @@ pub struct AgentConfig {
     /// `false`.
     #[serde(default)]
     pub allow_terminal: bool,
+}
+
+/// OQ1: the spawn path requires a non-empty `configId` so it derives a stable
+/// `config:{config_id}` session namespace (no fallback hash). Both the desktop
+/// `acp_spawn_agent` command and the WS `spawn_agent` handler route through
+/// this shared guard — the desktop path returns the `Err(String)` directly, the
+/// WS handler maps it to a `WsReply::err` with `WsErrorCode::Unsupported`.
+pub(crate) fn require_config_id(config: &AgentConfig) -> Result<(), String> {
+    let config_id = config.config_id.as_deref().map(str::trim).unwrap_or("");
+    if config_id.is_empty() {
+        return Err(
+            "spawn_agent requires a non-empty `config.configId` for durable session matching"
+                .to_string(),
+        );
+    }
+    Ok(())
 }
 
 /// Resolve a bare command name against a `:`-separated PATH, returning the first
@@ -239,6 +255,96 @@ mod tests {
         let proto: agent_client_protocol::schema::v1::SessionId = (&original).into();
         let back: SessionId = proto.into();
         assert_eq!(original, back);
+    }
+
+    /// OQ1: the shared `require_config_id` guard — rejects `None`, empty, and
+    /// whitespace-only configId so the spawn path never falls back to the
+    /// name+command hash for namespace derivation.
+    #[test]
+    fn require_config_id_rejects_missing() {
+        let config = AgentConfig {
+            config_id: None,
+            name: "H".to_string(),
+            command: "node".to_string(),
+            args: vec![],
+            env: HashMap::new(),
+            allow_terminal: false,
+        };
+        let err = require_config_id(&config).expect_err("None configId must be rejected");
+        assert!(err.contains("configId"), "err should mention configId: {err}");
+    }
+
+    #[test]
+    fn require_config_id_rejects_empty() {
+        for bad in ["", "   ", "\t"] {
+            let config = AgentConfig {
+                config_id: Some(bad.to_string()),
+                name: "H".to_string(),
+                command: "node".to_string(),
+                args: vec![],
+                env: HashMap::new(),
+                allow_terminal: false,
+            };
+            require_config_id(&config).expect_err("empty/whitespace configId must be rejected");
+        }
+    }
+
+    #[test]
+    fn require_config_id_accepts_present() {
+        let config = AgentConfig {
+            config_id: Some("custom-abc".to_string()),
+            name: "H".to_string(),
+            command: "node".to_string(),
+            args: vec![],
+            env: HashMap::new(),
+            allow_terminal: false,
+        };
+        require_config_id(&config).expect("a non-empty configId must pass the guard");
+    }
+
+    /// OQ3: `deny_unknown_fields` on `AgentConfig` rejects extra fields at the
+    /// serde boundary (the TS import guard is the first line; this is the
+    /// spawn-path backstop). An `id`/`templateId`-carrying paste must be
+    /// rejected here so it cannot sneak StoredAgentConfig-only fields through.
+    #[test]
+    fn agent_config_rejects_unknown_fields_at_serde_boundary() {
+        let json = r#"{
+            "configId": "custom-abc1",
+            "name": "Internal Helper",
+            "command": "node",
+            "args": ["/path/to/agent.js"],
+            "env": { "API_KEY": "$INTERNAL_API_KEY" },
+            "allowTerminal": false,
+            "id": "custom-abc1"
+        }"#;
+        let parsed: Result<AgentConfig, _> = serde_json::from_str(json);
+        let err = parsed.expect_err("unknown field `id` must be rejected");
+        assert!(
+            err.to_string().contains("unknown field"),
+            "expected unknown-field rejection, got: {err}"
+        );
+    }
+
+    /// OQ3 companion: a minimal conforming `AgentConfig` (only the 6 allowed
+    /// fields) deserializes cleanly through `deny_unknown_fields`.
+    #[test]
+    fn agent_config_accepts_conforming_payload() {
+        let json = r#"{
+            "configId": "custom-abc1",
+            "name": "Internal Helper",
+            "command": "node",
+            "args": ["/path/to/agent.js"],
+            "env": { "API_KEY": "$INTERNAL_API_KEY" },
+            "allowTerminal": false
+        }"#;
+        let parsed: AgentConfig =
+            serde_json::from_str(json).expect("conforming payload deserializes");
+        assert_eq!(parsed.config_id.as_deref(), Some("custom-abc1"));
+        assert_eq!(parsed.name, "Internal Helper");
+        assert_eq!(parsed.command, "node");
+        assert_eq!(parsed.args, vec!["/path/to/agent.js".to_string()]);
+        assert_eq!(parsed.env.get("API_KEY").map(String::as_str), Some("$INTERNAL_API_KEY"));
+        assert!(!parsed.allow_terminal);
     }
 
     #[cfg(not(target_os = "windows"))]

--- a/src-tauri/src/web/ws.rs
+++ b/src-tauri/src/web/ws.rs
@@ -1359,6 +1359,12 @@ async fn handle_spawn_agent(
             "spawn_agent requires a non-empty `config.command`",
         );
     }
+    // OQ1: require a non-empty `config.configId` (mirrors `acp_spawn_agent`)
+    // so the spawn path derives a stable `config:{config_id}` namespace on web
+    // too. Shared guard lives in `acp::config::require_config_id`.
+    if let Err(msg) = crate::acp::config::require_config_id(&parsed.config) {
+        return WsReply::err(id, WsErrorCode::Unsupported, msg);
+    }
     match acp.spawn(parsed.config).await {
         Ok(outcome) => {
             // Track the spawned agent so a later `switch_project` can reuse it
@@ -3871,15 +3877,37 @@ mod tests {
     }
 
     /// `spawn_agent` rejects empty `config.command` (mirrors create_session cwd guard).
+    /// Payload carries a `configId` so the rejection is specifically empty-command
+    /// (not the configId-required guard added for OQ1).
     #[test]
     fn handle_spawn_agent_rejects_empty_command() {
         let mut authed = true;
         let reply = handle_sync(
-            r#"{"id":"r1","type":"spawn_agent","payload":{"config":{"name":"x","command":""}}}"#,
+            r#"{"id":"r1","type":"spawn_agent","payload":{"config":{"configId":"custom-test","name":"x","command":""}}}"#,
             &mut authed,
         );
         assert!(!reply.ok);
         assert_eq!(reply.err.unwrap().code, "unsupported");
+    }
+
+    /// OQ1: `spawn_agent` rejects a config without a non-empty `configId`
+    /// (valid name + command, no configId) — mirrors the desktop
+    /// `acp_spawn_agent` guard so the spawn path derives a stable
+    /// `config:{config_id}` namespace on web too.
+    #[test]
+    fn handle_spawn_agent_rejects_missing_config_id() {
+        let mut authed = true;
+        let reply = handle_sync(
+            r#"{"id":"r1","type":"spawn_agent","payload":{"config":{"name":"x","command":"node"}}}"#,
+            &mut authed,
+        );
+        assert!(!reply.ok, "missing configId must fail");
+        let err = reply.err.expect("err present on failure");
+        assert_eq!(err.code, "unsupported");
+        assert!(
+            err.message.contains("configId"),
+            "err message should mention configId, got: {err:?}"
+        );
     }
 
     // --- CAP-6 / Story 9: install_acp_agent WS handler tests ----------------

--- a/src/renderer/assets/agent-icons/acp/agents.json
+++ b/src/renderer/assets/agent-icons/acp/agents.json
@@ -438,33 +438,33 @@
   {
     "id": "harn",
     "name": "Harn",
-    "version": "0.10.68",
+    "version": "0.10.70",
     "description": "Harn runs .harn agent pipelines as a native ACP coding agent over stdio.",
     "distribution": {
       "binary": {
         "darwin-aarch64": {
           "cmd": "./harn",
-          "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.68/harn-aarch64-apple-darwin.tar.gz",
+          "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.70/harn-aarch64-apple-darwin.tar.gz",
           "args": ["serve", "acp"]
         },
         "darwin-x86_64": {
           "cmd": "./harn",
-          "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.68/harn-x86_64-apple-darwin.tar.gz",
+          "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.70/harn-x86_64-apple-darwin.tar.gz",
           "args": ["serve", "acp"]
         },
         "linux-aarch64": {
           "cmd": "./harn",
-          "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.68/harn-aarch64-unknown-linux-gnu.tar.gz",
+          "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.70/harn-aarch64-unknown-linux-gnu.tar.gz",
           "args": ["serve", "acp"]
         },
         "linux-x86_64": {
           "cmd": "./harn",
-          "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.68/harn-x86_64-unknown-linux-gnu.tar.gz",
+          "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.70/harn-x86_64-unknown-linux-gnu.tar.gz",
           "args": ["serve", "acp"]
         },
         "windows-x86_64": {
           "cmd": "harn.exe",
-          "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.68/harn-x86_64-pc-windows-msvc.zip",
+          "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.70/harn-x86_64-pc-windows-msvc.zip",
           "args": ["serve", "acp"]
         }
       }

--- a/src/renderer/components/agents/CustomAcpAgentDialog.test.tsx
+++ b/src/renderer/components/agents/CustomAcpAgentDialog.test.tsx
@@ -1,0 +1,302 @@
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { StoredAgentConfig } from '@/lib/acp-agents-persistence'
+import { CustomAcpAgentDialog, exportAgentConfig } from './CustomAcpAgentDialog'
+
+const {
+  mockSaveAgentConfig,
+  mockToastSuccess,
+  mockToastError,
+  mockLogFrontendError,
+  agentConfigsRef
+} = vi.hoisted(() => ({
+  mockSaveAgentConfig: vi.fn(async () => {}),
+  mockToastSuccess: vi.fn(),
+  mockToastError: vi.fn(),
+  mockLogFrontendError: vi.fn(async () => {}),
+  // handleSave reads existing configs via getState().agentConfigs to upsert
+  // (PATCH 3). Expose a mutable ref the upsert test can seed.
+  agentConfigsRef: { current: [] as StoredAgentConfig[] }
+}))
+
+vi.mock('@/stores/acp-store', () => {
+  const useAcpStore = Object.assign(
+    (sel?: (s: { saveAgentConfig: typeof mockSaveAgentConfig }) => unknown) =>
+      sel
+        ? sel({ saveAgentConfig: mockSaveAgentConfig })
+        : { saveAgentConfig: mockSaveAgentConfig },
+    { getState: () => ({ agentConfigs: agentConfigsRef.current }) }
+  )
+  return { useAcpStore }
+})
+
+vi.mock('sonner', () => ({
+  toast: { success: mockToastSuccess, error: mockToastError }
+}))
+
+vi.mock('@/lib/log-api', () => ({
+  logFrontendError: mockLogFrontendError
+}))
+
+const GOLDEN_PASTE = `{
+  "name": "Internal Helper",
+  "command": "node",
+  "args": ["/path/to/agent.js"],
+  "env": { "API_KEY": "$INTERNAL_API_KEY" }
+}`
+
+function setTextareaValue(value: string): void {
+  const textarea = screen.getByLabelText('Agent config JSON') as HTMLTextAreaElement
+  fireEvent.change(textarea, { target: { value } })
+}
+
+async function clickButton(name: string | RegExp): Promise<void> {
+  await act(async () => {
+    fireEvent.click(screen.getByRole('button', { name }))
+  })
+}
+
+async function pasteAndAdvanceToConfirm(paste: string): Promise<void> {
+  setTextareaValue(paste)
+  await clickButton('Save Agent')
+}
+
+describe('CustomAcpAgentDialog', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    agentConfigsRef.current = []
+  })
+
+  it('persists a happy-path paste after the arbitrary-command confirmation', async () => {
+    render(<CustomAcpAgentDialog open={true} onOpenChange={() => {}} />)
+    await pasteAndAdvanceToConfirm(GOLDEN_PASTE)
+    // Now in the 'confirm' step — the arbitrary-command confirmation.
+    expect(screen.getByText(/execute an arbitrary command/i)).toBeInTheDocument()
+    expect(mockSaveAgentConfig).not.toHaveBeenCalled()
+    await clickButton('Confirm — Execute Command')
+    await waitFor(() => expect(mockSaveAgentConfig).toHaveBeenCalledTimes(1))
+    const stored = mockSaveAgentConfig.mock.calls[0][0] as StoredAgentConfig
+    expect(stored.name).toBe('Internal Helper')
+    expect(stored.command).toBe('node')
+    expect(stored.args).toEqual(['/path/to/agent.js'])
+    expect(stored.env).toEqual({ API_KEY: '$INTERNAL_API_KEY' })
+    expect(stored.allowTerminal).toBe(false)
+    expect(stored.id).toMatch(/^custom-[0-9a-f]{8}$/)
+    expect(stored.configId).toBe(stored.id)
+    expect(stored.templateId).toBeUndefined()
+  })
+
+  it('honors a pasted configId and still generates a fresh id', async () => {
+    render(<CustomAcpAgentDialog open={true} onOpenChange={() => {}} />)
+    await pasteAndAdvanceToConfirm(`{
+      "configId": "custom-abc12345",
+      "name": "H",
+      "command": "node",
+      "args": [],
+      "env": {}
+    }`)
+    await clickButton('Confirm — Execute Command')
+    await waitFor(() => expect(mockSaveAgentConfig).toHaveBeenCalledTimes(1))
+    const stored = mockSaveAgentConfig.mock.calls[0][0] as StoredAgentConfig
+    expect(stored.configId).toBe('custom-abc12345')
+    expect(stored.id).not.toBe('custom-abc12345')
+    expect(stored.id).toMatch(/^custom-[0-9a-f]{8}$/)
+  })
+
+  it('reuses an existing config id when re-pasting the same configId (upsert, no duplicate)', async () => {
+    // PATCH 3: re-pasting exported JSON updates the existing agent instead of
+    // creating a duplicate. A config with the same configId is already saved
+    // → its id is reused so saveAgentConfig upserts.
+    const existing: StoredAgentConfig = {
+      id: 'custom-fixedid',
+      configId: 'custom-abc12345',
+      name: 'Old Name',
+      command: 'old',
+      args: [],
+      env: {},
+      allowTerminal: false
+    }
+    agentConfigsRef.current = [existing]
+    render(<CustomAcpAgentDialog open={true} onOpenChange={() => {}} />)
+    await pasteAndAdvanceToConfirm(`{
+      "configId": "custom-abc12345",
+      "name": "New Name",
+      "command": "node",
+      "args": [],
+      "env": {}
+    }`)
+    await clickButton('Confirm — Execute Command')
+    await waitFor(() => expect(mockSaveAgentConfig).toHaveBeenCalledTimes(1))
+    const stored = mockSaveAgentConfig.mock.calls[0][0] as StoredAgentConfig
+    expect(stored.id).toBe('custom-fixedid')
+    expect(stored.configId).toBe('custom-abc12345')
+    expect(stored.name).toBe('New Name')
+    expect(stored.command).toBe('node')
+  })
+
+  it('rejects an unknown field inline and persists nothing', async () => {
+    render(<CustomAcpAgentDialog open={true} onOpenChange={() => {}} />)
+    await pasteAndAdvanceToConfirm(`{
+      "name": "H",
+      "command": "node",
+      "args": [],
+      "env": {},
+      "id": "x"
+    }`)
+    expect(screen.getByRole('alert').textContent).toContain('Unknown field "id"')
+    // Still on the idle (paste) step — no confirm button rendered.
+    expect(screen.queryByRole('button', { name: 'Confirm — Execute Command' })).toBeNull()
+    expect(mockSaveAgentConfig).not.toHaveBeenCalled()
+  })
+
+  it('rejects a missing name inline', async () => {
+    render(<CustomAcpAgentDialog open={true} onOpenChange={() => {}} />)
+    await pasteAndAdvanceToConfirm(`{ "command": "node", "args": [], "env": {} }`)
+    expect(screen.getByRole('alert').textContent).toContain('Name is required')
+    expect(mockSaveAgentConfig).not.toHaveBeenCalled()
+  })
+
+  it('rejects wrong-typed args inline', async () => {
+    render(<CustomAcpAgentDialog open={true} onOpenChange={() => {}} />)
+    await pasteAndAdvanceToConfirm(`{ "name": "H", "command": "node", "args": "nope", "env": {} }`)
+    expect(screen.getByRole('alert').textContent).toContain('args must be an array')
+    expect(mockSaveAgentConfig).not.toHaveBeenCalled()
+  })
+
+  it('rejects args with non-string elements inline', async () => {
+    render(<CustomAcpAgentDialog open={true} onOpenChange={() => {}} />)
+    await pasteAndAdvanceToConfirm(
+      `{ "name": "H", "command": "node", "args": [123, "ok"], "env": {} }`
+    )
+    expect(screen.getByRole('alert').textContent).toContain('args must be an array of strings')
+    expect(mockSaveAgentConfig).not.toHaveBeenCalled()
+  })
+
+  it('rejects a whitespace-only configId inline (no silent fresh id)', async () => {
+    // PATCH 7: a whitespace-only configId is rejected rather than silently
+    // trimmed to a fresh custom-<uuid8> identity.
+    render(<CustomAcpAgentDialog open={true} onOpenChange={() => {}} />)
+    await pasteAndAdvanceToConfirm(`{
+      "configId": "   ",
+      "name": "H",
+      "command": "node",
+      "args": [],
+      "env": {}
+    }`)
+    expect(screen.getByRole('alert').textContent).toContain(
+      'configId cannot be empty or whitespace'
+    )
+    expect(mockSaveAgentConfig).not.toHaveBeenCalled()
+  })
+
+  it('rejects a raw secret in env and directs to secure storage', async () => {
+    render(<CustomAcpAgentDialog open={true} onOpenChange={() => {}} />)
+    await pasteAndAdvanceToConfirm(`{
+      "name": "H",
+      "command": "node",
+      "args": [],
+      "env": { "API_KEY": "sk-ant-xxxxxxxxxxxx" }
+    }`)
+    const alert = screen.getByRole('alert').textContent ?? ''
+    expect(alert).toContain('secure storage')
+    expect(alert).toContain('$API_KEY')
+    expect(mockSaveAgentConfig).not.toHaveBeenCalled()
+  })
+
+  it('cancelling the arbitrary-command confirmation prevents persistence', async () => {
+    render(<CustomAcpAgentDialog open={true} onOpenChange={() => {}} />)
+    await pasteAndAdvanceToConfirm(GOLDEN_PASTE)
+    // Cancel returns to the idle (paste) step — no persistence.
+    await clickButton('Cancel')
+    expect(screen.queryByRole('button', { name: 'Confirm — Execute Command' })).toBeNull()
+    expect(screen.getByRole('button', { name: 'Save Agent' })).toBeInTheDocument()
+    expect(mockSaveAgentConfig).not.toHaveBeenCalled()
+  })
+
+  it('allowTerminal:true requires a second confirmation; cancelling it (Back) prevents persistence', async () => {
+    render(<CustomAcpAgentDialog open={true} onOpenChange={() => {}} />)
+    await pasteAndAdvanceToConfirm(`{
+      "name": "H",
+      "command": "node",
+      "args": [],
+      "env": {},
+      "allowTerminal": true
+    }`)
+    // First confirmation (arbitrary command).
+    expect(screen.getByText(/execute an arbitrary command/i)).toBeInTheDocument()
+    await clickButton('Confirm — Execute Command')
+    // Second confirmation (terminal capability).
+    expect(screen.getByText(/ACP terminal capability/i)).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Confirm — Allow Terminal' })).toBeInTheDocument()
+    // Back cancels the second confirmation — no persistence.
+    await clickButton('Back')
+    expect(screen.queryByRole('button', { name: 'Confirm — Allow Terminal' })).toBeNull()
+    expect(mockSaveAgentConfig).not.toHaveBeenCalled()
+  })
+
+  it('allowTerminal:true with both confirmations persists with allowTerminal=true', async () => {
+    render(<CustomAcpAgentDialog open={true} onOpenChange={() => {}} />)
+    await pasteAndAdvanceToConfirm(`{
+      "name": "H",
+      "command": "node",
+      "args": [],
+      "env": {},
+      "allowTerminal": true
+    }`)
+    await clickButton('Confirm — Execute Command')
+    await clickButton('Confirm — Allow Terminal')
+    await waitFor(() => expect(mockSaveAgentConfig).toHaveBeenCalledTimes(1))
+    const stored = mockSaveAgentConfig.mock.calls[0][0] as StoredAgentConfig
+    expect(stored.allowTerminal).toBe(true)
+  })
+
+  it('exportAgentConfig strips id/templateId, has no trailing newline, and round-trips', async () => {
+    const stored: StoredAgentConfig = {
+      id: 'custom-abc12345',
+      configId: 'custom-abc12345',
+      templateId: 'some-template',
+      name: 'Internal Helper',
+      command: 'node',
+      args: ['/path/to/agent.js'],
+      env: { API_KEY: '$INTERNAL_API_KEY' },
+      allowTerminal: false
+    }
+    const json = exportAgentConfig(stored)
+    // PATCH 8: no trailing newline — byte-identical to the AgentConfig import.
+    expect(json.endsWith('\n')).toBe(false)
+    const parsed = JSON.parse(json)
+    expect(Object.keys(parsed).sort()).toEqual(
+      ['allowTerminal', 'args', 'command', 'configId', 'env', 'name'].sort()
+    )
+    expect(parsed).not.toHaveProperty('id')
+    expect(parsed).not.toHaveProperty('templateId')
+    expect(parsed.configId).toBe('custom-abc12345')
+
+    // Round-trip: pasting the exported JSON imports cleanly (no unknown
+    // fields). configId is honored, fresh id generated (no existing config).
+    render(<CustomAcpAgentDialog open={true} onOpenChange={() => {}} />)
+    await pasteAndAdvanceToConfirm(json)
+    await clickButton('Confirm — Execute Command')
+    await waitFor(() => expect(mockSaveAgentConfig).toHaveBeenCalledTimes(1))
+    const reimported = mockSaveAgentConfig.mock.calls[0][0] as StoredAgentConfig
+    expect(reimported.configId).toBe('custom-abc12345')
+    expect(reimported.name).toBe('Internal Helper')
+    expect(reimported.allowTerminal).toBe(false)
+    expect(reimported.id).toMatch(/^custom-[0-9a-f]{8}$/)
+  })
+
+  it('exportAgentConfig throws on a missing/empty configId (corrupt store guard)', async () => {
+    // PATCH 9: a corrupt stored config without a configId cannot be exported
+    // (would break round-trip). The export surfaces an explicit error.
+    const corrupt: StoredAgentConfig = {
+      id: 'custom-x',
+      configId: undefined,
+      name: 'Corrupt',
+      command: 'node',
+      args: [],
+      env: {},
+      allowTerminal: false
+    }
+    expect(() => exportAgentConfig(corrupt)).toThrow(/configId missing/)
+  })
+})

--- a/src/renderer/components/agents/CustomAcpAgentDialog.tsx
+++ b/src/renderer/components/agents/CustomAcpAgentDialog.tsx
@@ -1,0 +1,437 @@
+/**
+ * Custom ACP Agent dialog (outside the registry) — paste-JSON import + export.
+ *
+ * A user pastes an `AgentConfig`-shaped JSON (`{ configId?, name, command,
+ * args, env, allowTerminal }`, camelCase). The dialog:
+ *   1. parses the JSON and rejects unknown fields (only the 6 AgentConfig
+ *      fields are allowed);
+ *   2. runs `validateAgentConfig` (shape, incl. args/env element types) +
+ *      `looksLikeSecretValue` per env value (no raw secrets on disk);
+ *   3. assigns `id`=`custom-<uuid8>` (or reuses an existing config's `id` when
+ *      a config with the same `configId` is already saved — so re-paste
+ *      updates instead of duplicating) and `configId`=`pasted ?? custom-<uuid8>`;
+ *   4. shows an in-dialog arbitrary-command confirmation (a second one when
+ *      `allowTerminal: true`) — no persistence path bypasses confirmation;
+ *   5. saves via `useAcpStore.saveAgentConfig`.
+ *
+ * Export (`Copy JSON`) serializes a `StoredAgentConfig` back to pretty
+ * camelCase JSON of just the 6 `AgentConfig` fields (strips `id`/`templateId`)
+ * so it round-trips through this import validator.
+ */
+
+import { ClipboardPaste, Plus } from 'lucide-react'
+import { useCallback, useState } from 'react'
+import { toast } from 'sonner'
+import { Button } from '@/components/ui/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle
+} from '@/components/ui/dialog'
+import { Label } from '@/components/ui/label'
+import { Textarea } from '@/components/ui/textarea'
+import {
+  looksLikeSecretValue,
+  type StoredAgentConfig,
+  validateAgentConfig
+} from '@/lib/acp-agents-persistence'
+import type { AgentConfig } from '@/lib/acp-api'
+import { logFrontendError } from '@/lib/log-api'
+import { useAcpStore } from '@/stores/acp-store'
+
+interface CustomAcpAgentDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}
+
+/** Fields allowed in a pasted AgentConfig JSON (camelCase). */
+const ALLOWED_AGENT_CONFIG_FIELDS = new Set<keyof AgentConfig>([
+  'configId',
+  'name',
+  'command',
+  'args',
+  'env',
+  'allowTerminal'
+])
+
+const ARBITRARY_COMMAND_PROMPT =
+  'This will execute an arbitrary command on your machine. Are you sure you want to persist this agent?'
+const ARBITRARY_COMMAND_TERMINAL_PROMPT =
+  'This agent requests the ACP terminal capability, which allows it to execute arbitrary commands on your machine. Are you sure you want to allow this?'
+
+type ConfirmStep = 'idle' | 'confirm' | 'confirmTerminal'
+
+/** Generate a fresh `custom-<uuid8>` identity. */
+function freshCustomId(): string {
+  return `custom-${crypto.randomUUID().slice(0, 8)}`
+}
+
+/**
+ * Serialize a stored custom agent to exportable AgentConfig JSON (no
+ * id/templateId). Throws if `configId` is missing/empty — a saved custom agent
+ * always carries one after the load-time backfill, but guard defensively so a
+ * corrupt store never emits a non-round-trippable export.
+ */
+export function exportAgentConfig(stored: StoredAgentConfig): string {
+  if (!stored.configId || stored.configId.trim().length === 0) {
+    throw new Error(
+      `cannot export agent "${stored.name}": configId missing; the saved config is corrupt`
+    )
+  }
+  const exported: AgentConfig = {
+    configId: stored.configId,
+    name: stored.name,
+    command: stored.command,
+    args: stored.args,
+    env: stored.env,
+    allowTerminal: stored.allowTerminal
+  }
+  return JSON.stringify(exported, null, 2)
+}
+
+type ParsedConfig = {
+  config: AgentConfig
+  /** True when the paste carried a non-empty (post-trim) configId. */
+  hadConfigId: boolean
+}
+
+/**
+ * Parse + validate the pasted JSON. Returns an error string on failure, or the
+ * promoted `AgentConfig` on success. Only the 6 AgentConfig fields are
+ * permitted; unknown fields (incl. `id`/`templateId`) are rejected loudly so
+ * the export shape round-trips. A whitespace-only `configId` is rejected
+ * (rather than silently trimmed to a fresh identity).
+ */
+function parsePastedAgentConfig(raw: string): ParsedConfig | { error: string } {
+  const trimmed = raw.trim()
+  if (trimmed.length === 0) return { error: 'Paste an agent config JSON first.' }
+
+  let json: unknown
+  try {
+    json = JSON.parse(trimmed)
+  } catch (err) {
+    return { error: `Invalid JSON: ${err instanceof Error ? err.message : String(err)}` }
+  }
+  if (json === null || typeof json !== 'object' || Array.isArray(json)) {
+    return { error: 'Agent config must be a JSON object.' }
+  }
+  const obj = json as Record<string, unknown>
+  for (const key of Object.keys(obj)) {
+    if (!ALLOWED_AGENT_CONFIG_FIELDS.has(key as keyof AgentConfig)) {
+      return {
+        error: `Unknown field "${key}". Only configId, name, command, args, env, allowTerminal are allowed.`
+      }
+    }
+  }
+
+  // configId: a string is required when present; a whitespace-only value is
+  // rejected (not silently trimmed) so the user keeps their intended namespace.
+  if (obj.configId !== undefined && typeof obj.configId !== 'string') {
+    return { error: 'configId must be a string.' }
+  }
+  const rawConfigId = typeof obj.configId === 'string' ? obj.configId : undefined
+  if (rawConfigId !== undefined && rawConfigId.trim().length === 0) {
+    return { error: 'configId cannot be empty or whitespace.' }
+  }
+
+  const args = obj.args
+  const env = obj.env
+  const allowTerminal = obj.allowTerminal
+  // undefined is allowed (field optional); when present, must be the right
+  // type. The shared `validateAgentConfig` covers element/value-type checks
+  // too, but surface a clearer error here before constructing a typed object.
+  if (args !== undefined && !Array.isArray(args)) return { error: 'args must be an array.' }
+  if (args !== undefined && Array.isArray(args) && args.some((a) => typeof a !== 'string')) {
+    return { error: 'args must be an array of strings.' }
+  }
+  if (env !== undefined && (typeof env !== 'object' || env === null || Array.isArray(env))) {
+    return { error: 'env must be an object.' }
+  }
+  if (
+    env !== undefined &&
+    typeof env === 'object' &&
+    env !== null &&
+    Object.values(env).some((v) => typeof v !== 'string')
+  ) {
+    return { error: 'env values must be strings.' }
+  }
+  if (allowTerminal !== undefined && typeof allowTerminal !== 'boolean') {
+    return { error: 'allowTerminal must be a boolean.' }
+  }
+
+  const cfg: AgentConfig = {
+    configId: rawConfigId?.trim() || undefined,
+    name: typeof obj.name === 'string' ? obj.name : '',
+    command: typeof obj.command === 'string' ? obj.command : '',
+    args: Array.isArray(args) ? (args as string[]) : [],
+    env:
+      env !== undefined && typeof env === 'object' && env !== null
+        ? (env as Record<string, string>)
+        : {},
+    allowTerminal: typeof allowTerminal === 'boolean' ? allowTerminal : false
+  }
+
+  // Shape validation (non-empty name/command + element/value types) — reuse
+  // the shared validator so the dialog and the persistence layer agree on what
+  // counts as valid.
+  const shape = validateAgentConfig(cfg)
+  if (!shape.valid) return { error: shape.errors.join(' ') }
+
+  // Secret rejection: env values must be `$VAR` placeholders, never raw
+  // literals. Surface a directed message (OS secure storage + `$VAR`).
+  for (const [key, value] of Object.entries(cfg.env)) {
+    if (looksLikeSecretValue(value)) {
+      return {
+        error:
+          `refusing to persist a raw secret for env "${key}" on agent "${cfg.name}"; ` +
+          `store it in secure storage and reference it as $${key}`
+      }
+    }
+  }
+
+  return { config: cfg, hadConfigId: Boolean(cfg.configId && cfg.configId.length > 0) }
+}
+
+export function CustomAcpAgentDialog({
+  open,
+  onOpenChange
+}: CustomAcpAgentDialogProps): React.JSX.Element {
+  const [jsonText, setJsonText] = useState('')
+  const [error, setError] = useState<string | null>(null)
+  const [saving, setSaving] = useState(false)
+  const [step, setStep] = useState<ConfirmStep>('idle')
+  const [pendingConfig, setPendingConfig] = useState<StoredAgentConfig | null>(null)
+  const saveAgentConfig = useAcpStore((s) => s.saveAgentConfig)
+
+  const reset = useCallback(() => {
+    setJsonText('')
+    setError(null)
+    setSaving(false)
+    setStep('idle')
+    setPendingConfig(null)
+  }, [])
+
+  const handleOpenChange = useCallback(
+    (next: boolean) => {
+      // Don't close or reset while a save is in-flight — the await
+      // continuation must not run toast/onOpenChange after a mid-flight close.
+      if (saving) return
+      if (!next) {
+        // Closing cancels any in-flight confirmation (no persistence). The
+        // pasted JSON is cleared so a fresh open starts clean.
+        reset()
+      }
+      onOpenChange(next)
+    },
+    [onOpenChange, reset, saving]
+  )
+
+  const performSave = useCallback(async () => {
+    const stored = pendingConfig
+    if (!stored || saving) return
+    setSaving(true)
+    try {
+      await saveAgentConfig(stored)
+      toast.success(`Agent "${stored.name}" saved`)
+      reset()
+      onOpenChange(false)
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err)
+      // Log the save boundary failure (no env values in the log line).
+      void logFrontendError({
+        level: 'error',
+        source: 'CustomAcpAgentDialog:saveAgentConfig',
+        message: `Failed to save custom agent "${stored.name}": ${message}`
+      })
+      setError(message)
+      setStep('idle')
+      setPendingConfig(null)
+    } finally {
+      setSaving(false)
+    }
+  }, [pendingConfig, saving, saveAgentConfig, reset, onOpenChange])
+
+  const handleSave = useCallback(async () => {
+    // Guard re-entry (double-click before the confirm step mounts).
+    if (saving || step !== 'idle') return
+    setError(null)
+    const parsed = parsePastedAgentConfig(jsonText)
+    if ('error' in parsed) {
+      setError(parsed.error)
+      return
+    }
+    const { config, hadConfigId } = parsed
+
+    // PATCH 3: re-paste of an exported config updates the existing agent
+    // instead of creating a duplicate. If a config with this configId is
+    // already saved, reuse its `id` so `saveAgentConfig` upserts (updates
+    // name/command/args/env/allowTerminal) rather than appending a second row.
+    const configId = hadConfigId && config.configId ? config.configId : freshCustomId()
+    const existing = useAcpStore
+      .getState()
+      .agentConfigs.find((c) => (c.configId ?? c.id) === configId)
+    // `id` (local persistence key) vs `configId` (stable namespace key):
+    //   - existing config found → reuse its id (upsert)
+    //   - configId pasted, no existing → fresh `custom-<uuid8>` id (configId honored)
+    //   - no configId pasted, no existing → id == configId (one fresh identity)
+    const id = existing ? existing.id : hadConfigId ? freshCustomId() : configId
+    const stored: StoredAgentConfig = {
+      ...config,
+      configId,
+      id,
+      templateId: undefined
+    }
+
+    // Move into the in-dialog arbitrary-command confirmation step (CAP-3).
+    // `allowTerminal: true` advances to a SECOND confirmation after the first.
+    setPendingConfig(stored)
+    setStep('confirm')
+  }, [jsonText, saving, step])
+
+  const handleConfirmArbitrary = useCallback(() => {
+    if (!pendingConfig || saving) return
+    if (pendingConfig.allowTerminal === true) {
+      setStep('confirmTerminal')
+    } else {
+      void performSave()
+    }
+  }, [pendingConfig, saving, performSave])
+
+  const cancelConfirm = useCallback(() => {
+    if (saving) return
+    setStep('idle')
+    setPendingConfig(null)
+    setError(null)
+  }, [saving])
+
+  const confirming = step === 'confirm' || step === 'confirmTerminal'
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent className="sm:max-w-[560px]">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <Plus size={18} />
+            {confirming ? 'Confirm arbitrary command' : 'Add Custom ACP Agent'}
+          </DialogTitle>
+          <DialogDescription>
+            {confirming
+              ? 'Persisting this agent will let it execute the configured command. Review it before confirming.'
+              : 'Paste an ACP agent config as JSON. Only configId, name, command, args, env, and allowTerminal fields are accepted; env values must be $VAR placeholders.'}
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="grid gap-3 py-2">
+          {!confirming && (
+            <>
+              <Label htmlFor="custom-acp-agent-json" className="text-xs">
+                Agent config JSON
+              </Label>
+              <Textarea
+                id="custom-acp-agent-json"
+                value={jsonText}
+                onChange={(e) => {
+                  setJsonText(e.target.value)
+                  if (error) setError(null)
+                }}
+                placeholder={
+                  '{\n  "name": "Internal Helper",\n  "command": "node",\n  "args": ["/path/to/agent.js"],\n  "env": { "API_KEY": "$INTERNAL_API_KEY" }\n}'
+                }
+                className="min-h-[160px] font-mono text-xs"
+                spellCheck={false}
+                disabled={saving}
+                aria-invalid={error !== null}
+              />
+              {error && (
+                <p role="alert" className="text-xs text-destructive">
+                  {error}
+                </p>
+              )}
+              <p className="text-2xs text-muted-foreground">
+                <ClipboardPaste size={12} className="mr-1 inline-block" />
+                Saved agents appear in the ACP launcher and reattach to their session on restart.
+                Use Copy JSON on a saved agent to share it.
+              </p>
+            </>
+          )}
+
+          {confirming && pendingConfig && (
+            <div className="space-y-3">
+              <p className="text-sm text-destructive">
+                {step === 'confirmTerminal'
+                  ? ARBITRARY_COMMAND_TERMINAL_PROMPT
+                  : ARBITRARY_COMMAND_PROMPT}
+              </p>
+              <dl className="grid grid-cols-[max-content_1fr] gap-x-3 gap-y-1 rounded-md border border-border/60 bg-muted/40 px-3 py-2 font-mono text-xs">
+                <dt className="text-muted-foreground">name</dt>
+                <dd className="truncate">{pendingConfig.name}</dd>
+                <dt className="text-muted-foreground">command</dt>
+                <dd className="truncate">{pendingConfig.command}</dd>
+                <dt className="text-muted-foreground">args</dt>
+                <dd className="truncate">{pendingConfig.args.join(' ') || '—'}</dd>
+                <dt className="text-muted-foreground">configId</dt>
+                <dd className="truncate">{pendingConfig.configId}</dd>
+                {pendingConfig.allowTerminal === true && (
+                  <>
+                    <dt className="text-muted-foreground">allowTerminal</dt>
+                    <dd className="text-amber-500">true</dd>
+                  </>
+                )}
+              </dl>
+              {step === 'confirmTerminal' && (
+                <p className="text-2xs text-amber-500">
+                  This is the second confirmation: terminal capability lets the agent run arbitrary
+                  commands on your machine.
+                </p>
+              )}
+            </div>
+          )}
+        </div>
+
+        <div className="flex justify-end gap-2 pt-2">
+          {!confirming ? (
+            <>
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => handleOpenChange(false)}
+                disabled={saving}
+              >
+                Cancel
+              </Button>
+              <Button
+                size="sm"
+                onClick={() => void handleSave()}
+                disabled={saving || !jsonText.trim()}
+              >
+                {saving ? 'Saving…' : 'Save Agent'}
+              </Button>
+            </>
+          ) : (
+            <>
+              <Button variant="outline" size="sm" onClick={cancelConfirm} disabled={saving}>
+                {step === 'confirmTerminal' ? 'Back' : 'Cancel'}
+              </Button>
+              <Button
+                size="sm"
+                variant={step === 'confirmTerminal' ? 'destructive' : 'default'}
+                onClick={
+                  step === 'confirmTerminal' ? () => void performSave() : handleConfirmArbitrary
+                }
+                disabled={saving}
+              >
+                {saving
+                  ? 'Saving…'
+                  : step === 'confirmTerminal'
+                    ? 'Confirm — Allow Terminal'
+                    : 'Confirm — Execute Command'}
+              </Button>
+            </>
+          )}
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/src/renderer/components/settings/AcpAgentsSettings.test.tsx
+++ b/src/renderer/components/settings/AcpAgentsSettings.test.tsx
@@ -1,18 +1,26 @@
-import { render, screen } from '@testing-library/react'
+import { fireEvent, render, screen } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type { StoredAgentConfig } from '@/lib/acp-agents-persistence'
+import type { SupportedAcpAgentEntry } from '@/lib/agents/supported-acp-agents'
 import { buildSupportedAcpAgents } from '@/lib/agents/supported-acp-agents'
 import { AcpAgentsSettings } from './AcpAgentsSettings'
 
-const { stateRef } = vi.hoisted(() => ({
+const { stateRef, resolvedRef } = vi.hoisted(() => ({
   stateRef: {
     current: {
       agentConfigs: [] as StoredAgentConfig[],
       warmingConfigs: {},
       configToLiveAgent: {},
-      agentStatus: {}
+      agentStatus: {},
+      saveAgentConfig: vi.fn(),
+      deleteAgentConfig: vi.fn()
     }
-  }
+  },
+  // When non-null, `useResolvedSupportedAcpAgents` returns these entries
+  // verbatim (for tests that need a custom-agent row the sync
+  // `buildSupportedAcpAgents` helper doesn't synthesize). Otherwise it falls
+  // back to the real sync derivation over the bundled registry.
+  resolvedRef: { current: null as SupportedAcpAgentEntry[] | null }
 }))
 
 vi.mock('@tauri-apps/plugin-os', () => ({
@@ -20,10 +28,19 @@ vi.mock('@tauri-apps/plugin-os', () => ({
   arch: vi.fn(() => 'x86_64')
 }))
 
+vi.mock('sonner', () => ({
+  toast: { success: vi.fn(), error: vi.fn() }
+}))
+
 vi.mock('@/stores/acp-store', () => {
   const useAcpStore = (sel?: (s: typeof stateRef.current) => unknown) =>
     sel ? sel(stateRef.current) : stateRef.current
-  const useConfigWarmState = () => ({ connected: false, warming: false })
+  const useConfigWarmState = () => ({
+    connected: false,
+    warming: false,
+    warmingSession: false,
+    sessionReady: false
+  })
   return { useAcpStore, useConfigWarmState }
 })
 
@@ -37,13 +54,16 @@ vi.mock('@/hooks/use-resolved-supported-acp-agents', async () => {
   )
   return {
     useResolvedSupportedAcpAgents: (configs: readonly StoredAgentConfig[]) =>
-      actual.buildSupportedAcpAgents(configs, 'windows-x86_64')
+      resolvedRef.current ?? actual.buildSupportedAcpAgents(configs, 'windows-x86_64')
   }
 })
 
 describe('AcpAgentsSettings', () => {
   beforeEach(() => {
     stateRef.current.agentConfigs = []
+    stateRef.current.deleteAgentConfig = vi.fn()
+    stateRef.current.saveAgentConfig = vi.fn()
+    resolvedRef.current = null
   })
 
   it('shows supported ACP agent status without enable toggles', () => {
@@ -60,5 +80,40 @@ describe('AcpAgentsSettings', () => {
     expect(screen.getAllByText('Install from Agent Chat')).toHaveLength(
       entries.filter((entry) => entry.status === 'install-required').length
     )
+  })
+
+  it('deletes a custom agent by its stored record id, not its configId (CodeRabbit)', () => {
+    // A custom agent pasted with an exported configId keeps that configId but
+    // gets a fresh stored `id`. `clearPath` must delete by the stored `id` or
+    // `deleteAgentConfig` (which filters by `c.id`) would miss it.
+    const stored: StoredAgentConfig = {
+      id: 'custom-xyz',
+      configId: 'custom-honored',
+      name: 'Internal Helper',
+      command: 'node',
+      args: ['/path/to/agent.js'],
+      env: {},
+      allowTerminal: false
+    }
+    resolvedRef.current = [
+      {
+        id: stored.id,
+        configId: stored.configId,
+        agent: { id: stored.id, name: stored.name, version: '', description: '', distribution: {} },
+        config: stored,
+        status: 'ready',
+        install: null,
+        manualInstall: null,
+        runtimeLauncher: null,
+        unavailableReason: null
+      }
+    ]
+    render(<AcpAgentsSettings />)
+
+    const clearBtn = screen.getByRole('button', { name: /clear saved path/i })
+    fireEvent.click(clearBtn)
+
+    expect(stateRef.current.deleteAgentConfig).toHaveBeenCalledTimes(1)
+    expect(stateRef.current.deleteAgentConfig).toHaveBeenCalledWith('custom-xyz')
   })
 })

--- a/src/renderer/components/settings/AcpAgentsSettings.tsx
+++ b/src/renderer/components/settings/AcpAgentsSettings.tsx
@@ -73,7 +73,11 @@ function AgentPathEditor({ entry }: { entry: SupportedAcpAgentEntry }): React.JS
   const clearPath = async (): Promise<void> => {
     setSaving(true)
     try {
-      await deleteAgentConfig(entry.configId)
+      // Delete by the persisted record's `id` (not `configId`): a custom agent
+      // pasted with an exported `configId` keeps that configId but gets a fresh
+      // stored `id`, so deleting by configId would miss it. Catalog overrides
+      // have id == configId (`acp-registry:<id>`), so this is equivalent there.
+      await deleteAgentConfig(entry.config?.id ?? entry.configId)
       toast.success(`${entry.agent.name} custom path cleared`)
     } catch (err) {
       toast.error(String(err))

--- a/src/renderer/components/settings/AcpAgentsSettings.tsx
+++ b/src/renderer/components/settings/AcpAgentsSettings.tsx
@@ -1,6 +1,7 @@
-import { RefreshCw, Search } from 'lucide-react'
+import { Clipboard, Plus, RefreshCw, Search } from 'lucide-react'
 import { useEffect, useMemo, useState } from 'react'
 import { toast } from 'sonner'
+import { CustomAcpAgentDialog, exportAgentConfig } from '@/components/agents/CustomAcpAgentDialog'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
@@ -9,9 +10,11 @@ import { useResolvedSupportedAcpAgents } from '@/hooks/use-resolved-supported-ac
 import { findBundledIconByKey, normalizeIconSvg } from '@/lib/agents/agent-icon-catalog'
 import {
   filterSupportedAcpAgents,
+  isCustomAgentEntry,
   type SupportedAcpAgentEntry
 } from '@/lib/agents/supported-acp-agents'
 import { dialogApi } from '@/lib/api'
+import { logFrontendError } from '@/lib/log-api'
 import { cn } from '@/lib/utils'
 import { useAcpStore, useConfigWarmState } from '@/stores/acp-store'
 
@@ -154,6 +157,26 @@ function AgentRow({ entry }: AgentRowProps): React.JSX.Element {
                 ? { label: 'Manual install', tone: 'warn' }
                 : { label: 'Unavailable', tone: 'muted' }
 
+  const handleCopyJson = async (): Promise<void> => {
+    if (!entry.config) {
+      toast.error('No saved config to copy.')
+      return
+    }
+    const json = exportAgentConfig(entry.config)
+    try {
+      await navigator.clipboard.writeText(json)
+      toast.success(`Copied ${entry.agent.name} config JSON`)
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err)
+      void logFrontendError({
+        level: 'error',
+        source: 'AcpAgentsSettings:copyJson',
+        message: `Failed to copy custom agent config "${entry.agent.name}": ${message}`
+      })
+      toast.error('Failed to copy JSON to clipboard.')
+    }
+  }
+
   return (
     <div className="flex items-start gap-3 rounded-md border border-border/60 px-3 py-2.5">
       <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-md bg-muted">
@@ -209,6 +232,14 @@ function AgentRow({ entry }: AgentRowProps): React.JSX.Element {
             {entry.manualInstall.args.length > 0 ? ` ${entry.manualInstall.args.join(' ')}` : ''}
           </p>
         )}
+        {isCustomAgentEntry(entry) && entry.config && (
+          <div className="mt-1.5 flex items-center">
+            <Button type="button" size="sm" variant="ghost" onClick={() => void handleCopyJson()}>
+              <Clipboard size={13} className="mr-1.5" />
+              Copy JSON
+            </Button>
+          </div>
+        )}
       </div>
     </div>
   )
@@ -220,6 +251,7 @@ function AgentRow({ entry }: AgentRowProps): React.JSX.Element {
  */
 export function AcpAgentsSettings(): React.JSX.Element {
   const [filter, setFilter] = useState('')
+  const [customDialogOpen, setCustomDialogOpen] = useState(false)
   const {
     usingRemoteRegistry,
     remoteAvailable,
@@ -308,6 +340,15 @@ export function AcpAgentsSettings(): React.JSX.Element {
             Use bundled registry
           </Button>
         )}
+        <Button
+          type="button"
+          size="sm"
+          variant="secondary"
+          onClick={() => setCustomDialogOpen(true)}
+        >
+          <Plus size={14} className="mr-1.5" />
+          Add Custom Agent
+        </Button>
         {lastCheckedAt && (
           <span className="text-2xs text-muted-foreground">
             {usingRemoteRegistry
@@ -340,6 +381,8 @@ export function AcpAgentsSettings(): React.JSX.Element {
           visible.map((entry) => <AgentRow key={entry.id} entry={entry} />)
         )}
       </div>
+
+      <CustomAcpAgentDialog open={customDialogOpen} onOpenChange={setCustomDialogOpen} />
     </div>
   )
 }

--- a/src/renderer/lib/acp-agents-persistence.test.ts
+++ b/src/renderer/lib/acp-agents-persistence.test.ts
@@ -27,6 +27,63 @@ describe('validateAgentConfig', () => {
   it('reports each missing field', () => {
     expect(validateAgentConfig({}).errors).toHaveLength(2)
   })
+  it('rejects args that is not an array', () => {
+    const r = validateAgentConfig({
+      name: 'H',
+      command: 'node',
+      args: 'not-array' as unknown as string[]
+    })
+    expect(r.valid).toBe(false)
+    expect(r.errors.join(' ')).toContain('args must be an array')
+  })
+  it('rejects env that is not an object', () => {
+    const r = validateAgentConfig({
+      name: 'H',
+      command: 'node',
+      env: 'nope' as unknown as Record<string, string>
+    })
+    expect(r.valid).toBe(false)
+    expect(r.errors.join(' ')).toContain('env must be an object')
+  })
+  it('rejects env values that are not strings', () => {
+    const r = validateAgentConfig({
+      name: 'H',
+      command: 'node',
+      env: { K: 123 as unknown as string }
+    })
+    expect(r.valid).toBe(false)
+    expect(r.errors.join(' ')).toContain('env values must be strings')
+  })
+  it('rejects args elements that are not strings', () => {
+    const r = validateAgentConfig({
+      name: 'H',
+      command: 'node',
+      args: [123 as unknown as string, 'ok']
+    })
+    expect(r.valid).toBe(false)
+    expect(r.errors.join(' ')).toContain('args must be an array of strings')
+  })
+  it('rejects env values that are objects/null', () => {
+    const r = validateAgentConfig({
+      name: 'H',
+      command: 'node',
+      env: { K: { secret: true } as unknown as string }
+    })
+    expect(r.valid).toBe(false)
+    expect(r.errors.join(' ')).toContain('env values must be strings')
+  })
+  it('rejects allowTerminal that is not a boolean', () => {
+    const r = validateAgentConfig({
+      name: 'H',
+      command: 'node',
+      allowTerminal: 'yes' as unknown as boolean
+    })
+    expect(r.valid).toBe(false)
+    expect(r.errors.join(' ')).toContain('allowTerminal must be a boolean')
+  })
+  it('accepts undefined args/env/allowTerminal', () => {
+    expect(validateAgentConfig({ name: 'H', command: 'node' }).valid).toBe(true)
+  })
 })
 
 describe('looksLikeSecretValue', () => {
@@ -58,13 +115,55 @@ describe('load/save agent configs', () => {
 
   it('returns the stored list', async () => {
     const list: StoredAgentConfig[] = [
-      { id: 'a1', name: 'Gemini', command: 'gemini', args: [], env: {} }
+      {
+        id: 'a1',
+        configId: 'a1',
+        name: 'Gemini',
+        command: 'gemini',
+        args: [],
+        env: {}
+      }
     ]
     ;(persistenceApi.read as ReturnType<typeof vi.fn>).mockResolvedValue({
       success: true,
       data: list
     })
     expect(await loadAgentConfigs()).toEqual(list)
+  })
+
+  it('backfills configId = id for persisted configs missing one', async () => {
+    // Migration (OQ1): pre-feature persisted configs may lack `configId`. On
+    // load they are backfilled so the configId-required spawn path succeeds.
+    const stored = [
+      { id: 'acp-registry:gemini', name: 'Gemini', command: 'gemini', args: [], env: {} },
+      { id: 'custom-abc12345', name: 'H', command: 'node', args: [], env: {} }
+    ]
+    ;(persistenceApi.read as ReturnType<typeof vi.fn>).mockResolvedValue({
+      success: true,
+      data: stored
+    })
+    const loaded = await loadAgentConfigs()
+    expect(loaded[0].configId).toBe('acp-registry:gemini')
+    expect(loaded[1].configId).toBe('custom-abc12345')
+  })
+
+  it('preserves an existing configId on load', async () => {
+    const stored: StoredAgentConfig[] = [
+      {
+        id: 'custom-abc12345',
+        configId: 'custom-honored',
+        name: 'H',
+        command: 'node',
+        args: [],
+        env: {}
+      }
+    ]
+    ;(persistenceApi.read as ReturnType<typeof vi.fn>).mockResolvedValue({
+      success: true,
+      data: stored
+    })
+    const loaded = await loadAgentConfigs()
+    expect(loaded[0].configId).toBe('custom-honored')
   })
 
   it('writes under the dedicated key and throws on failure', async () => {
@@ -76,5 +175,60 @@ describe('load/save agent configs', () => {
       error: 'disk full'
     })
     await expect(saveAgentConfigs([])).rejects.toThrow(/disk full/)
+  })
+
+  it('rejects a raw secret literal in env at the persistence boundary (AD-6)', async () => {
+    // The no-raw-secrets-on-disk invariant: `saveAgentConfigs` throws before
+    // writing so no future caller can bypass the dialog-layer secret guard.
+    ;(persistenceApi.write as ReturnType<typeof vi.fn>).mockResolvedValue({ success: true })
+    const list: StoredAgentConfig[] = [
+      {
+        id: 'x',
+        name: 'A',
+        command: 'a',
+        args: [],
+        env: { K: 'sk-abc123def456ghi' }
+      }
+    ]
+    const err = await saveAgentConfigs(list).catch((e) => e)
+    expect(err).toBeInstanceOf(Error)
+    const msg = String(err)
+    expect(msg).toContain('secure storage')
+    expect(msg).toContain('$K')
+    expect(persistenceApi.write).not.toHaveBeenCalled()
+  })
+
+  it('accepts $VAR placeholders in env at the persistence boundary', async () => {
+    ;(persistenceApi.write as ReturnType<typeof vi.fn>).mockResolvedValue({ success: true })
+    const list: StoredAgentConfig[] = [
+      {
+        id: 'x',
+        name: 'A',
+        command: 'a',
+        args: [],
+        env: { K: '$K' }
+      }
+    ]
+    await saveAgentConfigs(list)
+    expect(persistenceApi.write).toHaveBeenCalledWith(ACP_AGENTS_KEY, list)
+  })
+
+  it('filters out malformed (null/non-object/id-less) persisted entries on load', async () => {
+    // Defense-in-depth: a corrupt persisted array must never crash the load or
+    // the downstream merge (`resolveSupportedAcpAgents` calls `.startsWith` on
+    // `config.id`). Null/non-object/id-less entries are dropped silently.
+    ;(persistenceApi.read as ReturnType<typeof vi.fn>).mockResolvedValue({
+      success: true,
+      data: [
+        null,
+        'not-an-object',
+        { name: 'NoId', command: 'c', args: [], env: {} },
+        { id: 'custom-ok', name: 'Ok', command: 'c', args: [], env: {} }
+      ]
+    })
+    const loaded = await loadAgentConfigs()
+    expect(loaded).toHaveLength(1)
+    expect(loaded[0].id).toBe('custom-ok')
+    expect(loaded[0].configId).toBe('custom-ok')
   })
 })

--- a/src/renderer/lib/acp-agents-persistence.test.ts
+++ b/src/renderer/lib/acp-agents-persistence.test.ts
@@ -121,7 +121,8 @@ describe('load/save agent configs', () => {
         name: 'Gemini',
         command: 'gemini',
         args: [],
-        env: {}
+        env: {},
+        allowTerminal: false
       }
     ]
     ;(persistenceApi.read as ReturnType<typeof vi.fn>).mockResolvedValue({
@@ -230,5 +231,34 @@ describe('load/save agent configs', () => {
     expect(loaded).toHaveLength(1)
     expect(loaded[0].id).toBe('custom-ok')
     expect(loaded[0].configId).toBe('custom-ok')
+  })
+
+  it('rejects a non-string configId and backfills from id without crashing', async () => {
+    // CodeRabbit: a persisted record with configId: 123 (number) must not throw
+    // at startup when loadAgentConfigs calls .trim(). Validate the type before
+    // trimming; treat a non-string configId as missing and backfill from id.
+    ;(persistenceApi.read as ReturnType<typeof vi.fn>).mockResolvedValue({
+      success: true,
+      data: [{ id: 'custom-1', name: 'H', command: 'node', args: [], env: {}, configId: 123 }]
+    })
+    const loaded = await loadAgentConfigs()
+    expect(loaded).toHaveLength(1)
+    expect(loaded[0].configId).toBe('custom-1')
+  })
+
+  it('normalizes omitted/legacy optional fields to safe defaults on load', async () => {
+    // A legacy persisted record may omit args/env/allowTerminal. The loader
+    // normalizes them to their established defaults so downstream consumers
+    // (merge, spawn) never see `undefined`.
+    ;(persistenceApi.read as ReturnType<typeof vi.fn>).mockResolvedValue({
+      success: true,
+      data: [{ id: 'legacy-1', name: 'Legacy', command: 'legacy-bin' }]
+    })
+    const loaded = await loadAgentConfigs()
+    expect(loaded).toHaveLength(1)
+    expect(loaded[0].args).toEqual([])
+    expect(loaded[0].env).toEqual({})
+    expect(loaded[0].allowTerminal).toBe(false)
+    expect(loaded[0].configId).toBe('legacy-1')
   })
 })

--- a/src/renderer/lib/acp-agents-persistence.ts
+++ b/src/renderer/lib/acp-agents-persistence.ts
@@ -64,21 +64,41 @@ export async function loadAgentConfigs(): Promise<StoredAgentConfig[]> {
   const res = await persistenceApi.read<StoredAgentConfig[]>(ACP_AGENTS_KEY)
   if (res.success) {
     if (!Array.isArray(res.data)) return []
-    // Filter out malformed (null/non-object/id-less) elements before the
-    // configId backfill so a corrupt entry can never crash the load or the
-    // downstream merge (`resolveSupportedAcpAgents` calls `.startsWith` on
-    // `config.id`). Malformed entries are silently dropped here; the merge
-    // layer is the no-crash boundary.
+    // Filter out malformed records before the configId backfill so a corrupt
+    // entry can never crash the load or the downstream merge
+    // (`resolveSupportedAcpAgents` calls `.startsWith` on `config.id`).
+    // Require the non-optional StoredAgentConfig primitives (id/name/command)
+    // to be non-empty strings; drop otherwise. The map below normalizes
+    // optional/legacy fields (args/env/allowTerminal/configId) to safe
+    // defaults instead of trusting persisted JSON shapes.
     const clean = res.data.filter(
       (c): c is StoredAgentConfig =>
-        c !== null && typeof c === 'object' && typeof c.id === 'string' && c.id.length > 0
+        c !== null &&
+        typeof c === 'object' &&
+        typeof c.id === 'string' &&
+        c.id.length > 0 &&
+        typeof c.name === 'string' &&
+        c.name.length > 0 &&
+        typeof c.command === 'string' &&
+        c.command.length > 0
     )
     // Migration: backfill `configId = id` for persisted configs saved before
     // configId was required (pre-feature catalog overrides + custom agents
-    // both need a non-empty configId on the spawn path).
-    return clean.map((cfg) =>
-      cfg.configId && cfg.configId.trim().length > 0 ? cfg : { ...cfg, configId: cfg.id }
-    )
+    // both need a non-empty configId on the spawn path). Validate the
+    // configId type before trimming — a non-string value (e.g. `123`) must
+    // not crash startup; treat it as missing and backfill from `id`. Also
+    // normalize omitted/legacy optional fields to their established defaults.
+    return clean.map((cfg) => ({
+      ...cfg,
+      configId:
+        typeof cfg.configId === 'string' && cfg.configId.trim().length > 0 ? cfg.configId : cfg.id,
+      args: Array.isArray(cfg.args) ? (cfg.args as string[]) : [],
+      env:
+        cfg.env !== null && typeof cfg.env === 'object' && !Array.isArray(cfg.env)
+          ? (cfg.env as Record<string, string>)
+          : {},
+      allowTerminal: typeof cfg.allowTerminal === 'boolean' ? cfg.allowTerminal : false
+    }))
   }
   // A missing key is the normal empty state; any other failure is a real
   // storage/backend error and must not be silently collapsed to [].

--- a/src/renderer/lib/acp-agents-persistence.ts
+++ b/src/renderer/lib/acp-agents-persistence.ts
@@ -29,6 +29,23 @@ export function validateAgentConfig(cfg: Partial<AgentConfig>): AgentConfigValid
   const errors: string[] = []
   if (!cfg.name || cfg.name.trim().length === 0) errors.push('Name is required.')
   if (!cfg.command || cfg.command.trim().length === 0) errors.push('Command is required.')
+  if (cfg.args !== undefined) {
+    if (!Array.isArray(cfg.args)) {
+      errors.push('args must be an array.')
+    } else if (cfg.args.some((a) => typeof a !== 'string')) {
+      errors.push('args must be an array of strings.')
+    }
+  }
+  if (cfg.env !== undefined) {
+    if (typeof cfg.env !== 'object' || cfg.env === null || Array.isArray(cfg.env)) {
+      errors.push('env must be an object.')
+    } else if (Object.values(cfg.env).some((v) => typeof v !== 'string')) {
+      errors.push('env values must be strings.')
+    }
+  }
+  if (cfg.allowTerminal !== undefined && typeof cfg.allowTerminal !== 'boolean') {
+    errors.push('allowTerminal must be a boolean.')
+  }
   return { valid: errors.length === 0, errors }
 }
 
@@ -46,7 +63,22 @@ export function looksLikeSecretValue(value: string): boolean {
 export async function loadAgentConfigs(): Promise<StoredAgentConfig[]> {
   const res = await persistenceApi.read<StoredAgentConfig[]>(ACP_AGENTS_KEY)
   if (res.success) {
-    return Array.isArray(res.data) ? res.data : []
+    if (!Array.isArray(res.data)) return []
+    // Filter out malformed (null/non-object/id-less) elements before the
+    // configId backfill so a corrupt entry can never crash the load or the
+    // downstream merge (`resolveSupportedAcpAgents` calls `.startsWith` on
+    // `config.id`). Malformed entries are silently dropped here; the merge
+    // layer is the no-crash boundary.
+    const clean = res.data.filter(
+      (c): c is StoredAgentConfig =>
+        c !== null && typeof c === 'object' && typeof c.id === 'string' && c.id.length > 0
+    )
+    // Migration: backfill `configId = id` for persisted configs saved before
+    // configId was required (pre-feature catalog overrides + custom agents
+    // both need a non-empty configId on the spawn path).
+    return clean.map((cfg) =>
+      cfg.configId && cfg.configId.trim().length > 0 ? cfg : { ...cfg, configId: cfg.id }
+    )
   }
   // A missing key is the normal empty state; any other failure is a real
   // storage/backend error and must not be silently collapsed to [].

--- a/src/renderer/lib/agents/supported-acp-agents.test.ts
+++ b/src/renderer/lib/agents/supported-acp-agents.test.ts
@@ -4,10 +4,12 @@ import type { RegistryAgent } from '@/lib/agents/acp-registry'
 import {
   buildSupportedAcpAgents,
   installedBinaryConfig,
+  isCustomAgentEntry,
   isSupportedAcpConfigId,
   manualBinaryConfig,
   registryConfigId,
-  resolveSupportedAcpAgents
+  resolveSupportedAcpAgents,
+  type SupportedAcpAgentEntry
 } from '@/lib/agents/supported-acp-agents'
 
 // CAP-6 / Story 8: `resolveSupportedAcpAgents` calls `acpCatalogApi.listCatalog()`
@@ -161,6 +163,62 @@ describe('isSupportedAcpConfigId', () => {
   })
 })
 
+describe('isCustomAgentEntry', () => {
+  // Distinguish a custom (pasted) agent row from a catalog/registry row so the
+  // "Copy JSON" action only appears on custom agents (spec: "per saved custom
+  // agent row"). The check keys off the config's id, NOT the entry's id —
+  // catalog entries use `entry.id = agent.id` (no `acp-registry:` prefix).
+  function entryWith(config: StoredAgentConfig | null): SupportedAcpAgentEntry {
+    return {
+      id: 'any',
+      configId: config?.configId ?? 'any',
+      agent: agent('any', {}),
+      config,
+      status: 'ready',
+      install: null,
+      manualInstall: null,
+      runtimeLauncher: null,
+      unavailableReason: null
+    }
+  }
+  it('returns TRUE for a custom agent (config.id = custom-<uuid8>)', () => {
+    const custom: StoredAgentConfig = {
+      id: 'custom-abc12345',
+      configId: 'custom-abc12345',
+      name: 'H',
+      command: 'node',
+      args: [],
+      env: {},
+      allowTerminal: false
+    }
+    expect(isCustomAgentEntry(entryWith(custom))).toBe(true)
+  })
+  it('returns FALSE for a catalog override (config.id = acp-registry:<id>)', () => {
+    const override: StoredAgentConfig = {
+      id: 'acp-registry:gemini',
+      configId: 'acp-registry:gemini',
+      name: 'Gemini Override',
+      command: 'gemini',
+      args: [],
+      env: {},
+      allowTerminal: false
+    }
+    expect(isCustomAgentEntry(entryWith(override))).toBe(false)
+  })
+  it('returns FALSE for a catalog agent with a derived/hostInstalled config', () => {
+    // A host-installed catalog agent carries a config whose id IS
+    // `acp-registry:<id>` (from `toStoredConfig`), so it's NOT a custom agent.
+    const derived = installedBinaryConfig(agent('gemini', { binary: {} }, 'Gemini'), {
+      command: '/abs/gemini',
+      args: ['acp']
+    })
+    expect(isCustomAgentEntry(entryWith(derived))).toBe(false)
+  })
+  it('returns FALSE when no config is present (unavailable catalog agent)', () => {
+    expect(isCustomAgentEntry(entryWith(null))).toBe(false)
+  })
+})
+
 describe('manualBinaryConfig', () => {
   it('persists a user-provided binary path with registry args and env', () => {
     const config = manualBinaryConfig(
@@ -172,6 +230,7 @@ describe('manualBinaryConfig', () => {
     expect(config).toEqual({
       id: 'acp-registry:legacy',
       templateId: 'legacy',
+      configId: 'acp-registry:legacy',
       name: 'Legacy Agent',
       command: 'C:/tools/legacy.exe',
       args: ['acp'],
@@ -192,6 +251,7 @@ describe('installedBinaryConfig', () => {
     expect(config).toEqual({
       id: 'acp-registry:opencode',
       templateId: 'opencode',
+      configId: 'acp-registry:opencode',
       name: 'OpenCode',
       command: 'C:/termul/opencode.exe',
       args: ['acp'],
@@ -437,5 +497,125 @@ describe('resolveSupportedAcpAgents', () => {
 
     const entries = await resolveSupportedAcpAgents([])
     expect(entries).toEqual([])
+  })
+
+  it('surfaces a persisted custom agent alongside catalog agents (CAP-5)', async () => {
+    listCatalogMock.mockResolvedValueOnce({
+      success: true,
+      data: {
+        host: { os: 'linux', arch: 'x86_64', runtimes: {} },
+        agents: [
+          {
+            id: 'gemini',
+            name: 'Gemini',
+            version: '1.0.0',
+            description: 'd',
+            source: 'bundled',
+            distribution: { npx: { package: 'gemini' } },
+            runtimeRequirements: ['npx'],
+            status: 'needs-runtime',
+            platformTargets: []
+          }
+        ]
+      }
+    })
+    const custom: StoredAgentConfig = {
+      id: 'custom-abc',
+      configId: 'custom-abc',
+      name: 'Internal Helper',
+      command: 'node',
+      args: ['/path/to/agent.js'],
+      env: { API_KEY: '$INTERNAL_API_KEY' },
+      allowTerminal: false
+    }
+
+    const entries = await resolveSupportedAcpAgents([custom])
+
+    const customEntry = entries.find((e) => e.id === 'custom-abc')
+    expect(customEntry).toBeDefined()
+    expect(customEntry?.configId).toBe('custom-abc')
+    expect(customEntry?.status).toBe('ready')
+    expect(customEntry?.config).toBe(custom)
+    // Catalog agent still present.
+    expect(entries.some((e) => e.id === 'gemini')).toBe(true)
+  })
+
+  it('persisted custom agent wins on configId collision with a registry agent (CAP-5)', async () => {
+    // A persisted custom agent whose `configId` == a registry agent's configId
+    // (`acp-registry:<id>`) must win over the catalog version (status 'ready',
+    // the user's command/args/env). Persisted-wins is the inverse of the
+    // terminal-native "built-ins win".
+    listCatalogMock.mockResolvedValueOnce({
+      success: true,
+      data: {
+        host: { os: 'linux', arch: 'x86_64', runtimes: {} },
+        agents: [
+          {
+            id: 'gemini',
+            name: 'Gemini',
+            version: '1.0.0',
+            description: 'catalog version',
+            source: 'bundled',
+            distribution: { npx: { package: 'gemini' } },
+            runtimeRequirements: ['npx'],
+            status: 'needs-runtime',
+            platformTargets: []
+          }
+        ]
+      }
+    })
+    const overriding: StoredAgentConfig = {
+      // custom agent (id NOT acp-registry:) but configId collides with the
+      // registry agent's configId on purpose.
+      id: 'custom-override',
+      configId: registryConfigId('gemini'),
+      name: 'Internal Helper',
+      command: 'node',
+      args: ['/path/to/internal.js'],
+      env: { API_KEY: '$API_KEY' },
+      allowTerminal: false
+    }
+
+    const entries = await resolveSupportedAcpAgents([overriding])
+
+    // Exactly one entry for the colliding configId — the persisted custom one
+    // wins (status 'ready', the user's command/args/env). The catalog loop
+    // consumes the custom config via its configId-keyed lookup, so the entry
+    // carries the catalog agent's id ('gemini') but the custom config. The
+    // custom agent is NOT double-appended as a separate row (seenConfigIds
+    // blocks it).
+    const matching = entries.filter((e) => e.configId === registryConfigId('gemini'))
+    expect(matching).toHaveLength(1)
+    expect(matching[0]?.status).toBe('ready')
+    expect(matching[0]?.config).toBe(overriding)
+    // The custom config is surfaced (Copy JSON keys off config.id, NOT
+    // entry.id, so it still identifies as a custom agent row).
+    expect(matching[0]?.config?.id).toBe('custom-override')
+    // No separate 'custom-override' entry — it merged into the gemini slot.
+    expect(entries.filter((e) => e.id === 'custom-override')).toHaveLength(0)
+  })
+
+  it('surfaces persisted custom agents when the catalog fetch fails (degrade-mode)', async () => {
+    listCatalogMock.mockResolvedValueOnce({
+      success: false,
+      error: 'store unavailable',
+      code: 'ACP_CATALOG_UNAVAILABLE'
+    })
+    const custom: StoredAgentConfig = {
+      id: 'custom-down',
+      configId: 'custom-down',
+      name: 'Offline Helper',
+      command: 'node',
+      args: [],
+      env: {},
+      allowTerminal: false
+    }
+
+    const entries = await resolveSupportedAcpAgents([custom])
+    expect(entries).toHaveLength(1)
+    expect(entries[0]?.id).toBe('custom-down')
+    expect(entries[0]?.configId).toBe('custom-down')
+    expect(entries[0]?.status).toBe('ready')
+    expect(entries[0]?.config).toBe(custom)
   })
 })

--- a/src/renderer/lib/agents/supported-acp-agents.ts
+++ b/src/renderer/lib/agents/supported-acp-agents.ts
@@ -84,6 +84,19 @@ export function registryConfigId(registryId: string): string {
   return `acp-registry:${registryId}`
 }
 
+/**
+ * True for a custom (pasted) agent — distinguished from catalog/registry
+ * agents by the *config's* id. Catalog entries use `entry.id = agent.id` (not
+ * `acp-registry:`-prefixed at the entry level); only the persisted
+ * `StoredAgentConfig.id` carries the `acp-registry:` prefix. Custom agents
+ * have a saved `config.id` of `custom-<uuid8>`; catalog agents either have no
+ * saved config (derived/hostInstalled → `config.id` is `acp-registry:<id>`) or
+ * a catalog override whose `config.id` starts with `acp-registry:`.
+ */
+export function isCustomAgentEntry(entry: SupportedAcpAgentEntry): boolean {
+  return !!entry.config && !entry.config.id.startsWith('acp-registry:')
+}
+
 function runtimeUnavailableReason(launcher: 'npx' | 'uvx'): string {
   return launcher === 'npx'
     ? 'Install Node.js so npx is available on your PATH.'
@@ -117,6 +130,7 @@ export function installedBinaryConfig(
   target: Pick<RegistryBinaryTarget, 'env'> = {}
 ): StoredAgentConfig {
   return toStoredConfig(agent, {
+    configId: registryConfigId(agent.id),
     name: agent.name,
     command: installed.command,
     args: installed.args,
@@ -286,23 +300,84 @@ export function isSupportedAcpConfigId(configId: string): boolean {
  * sites (`useAcpAgents`, `AgentLauncher`, `AcpAgentsSettings`) switch to this
  * async wrapper.
  */
+/**
+ * CAP-5: surface persisted custom agents (outside the registry/catalog) as
+ * `SupportedAcpAgentEntry` rows alongside catalog/registry agents. A persisted
+ * config whose `id` does NOT start with `acp-registry:` is a custom agent pasted
+ * via the CustomAcpAgentDialog; it is appended verbatim with a synthesized
+ * `RegistryAgent` shell (the AgentRow uses `agent.name` / `agent.description` /
+ * `agent.version` for display). `seenConfigIds` lets the caller skip configIds
+ * already projected from the catalog loop (including a custom agent whose
+ * configId collided with a registry agent — the catalog loop's persisted-wins
+ * lookup already consumed it).
+ */
+function customAgentEntriesFromPersisted(
+  persistedConfigs: readonly StoredAgentConfig[],
+  seenConfigIds: Set<string> = new Set()
+): SupportedAcpAgentEntry[] {
+  const entries: SupportedAcpAgentEntry[] = []
+  for (const config of persistedConfigs) {
+    // Guard against malformed persisted data (null/non-object/id-less) so the
+    // merge never crashes on `.startsWith`/`.trim`.
+    if (typeof config.id !== 'string' || config.id.length === 0) continue
+    if (config.id.startsWith('acp-registry:')) continue
+    const configId =
+      config.configId && config.configId.trim().length > 0 ? config.configId : config.id
+    if (seenConfigIds.has(configId)) continue
+    seenConfigIds.add(configId)
+    entries.push({
+      id: config.id,
+      configId,
+      agent: {
+        id: config.id,
+        name: config.name,
+        version: '',
+        description: '',
+        distribution: {}
+      },
+      config,
+      status: 'ready',
+      install: null,
+      manualInstall: null,
+      runtimeLauncher: null,
+      unavailableReason: null
+    })
+  }
+  return entries
+}
+
 export async function resolveSupportedAcpAgents(
   persistedConfigs: readonly StoredAgentConfig[]
 ): Promise<SupportedAcpAgentEntry[]> {
   const result = await acpCatalogApi.listCatalog()
   if (!result.success) {
-    // Degrade gracefully: return an empty list (callers fall back to the
-    // default-agent selection which handles empty lists).
-    return []
+    // Catalog unavailable — still surface persisted custom agents so users can
+    // manage/export them without a live catalog fetch (CAP-5).
+    return customAgentEntriesFromPersisted(persistedConfigs)
   }
   const catalog = result.data
-  const persistedById = new Map(persistedConfigs.map((config) => [config.id, config]))
+  // CAP-5 / persisted-wins: look up persisted configs by `configId` (not `id`)
+  // so a persisted custom agent whose `configId` collides with a registry
+  // agent's `configId` (e.g. a user pasted `configId: "acp-registry:gemini"`)
+  // is found here and wins over the catalog version (status 'ready', user's
+  // command/args/env). This also finds catalog overrides (whose configId IS
+  // `acp-registry:<id>`). When two persisted configs share a configId (a
+  // custom agent + a catalog override for the same registry id), the custom
+  // agent (explicitly pasted) takes precedence — it is later in the input
+  // list, so the `Map` constructor lets it overwrite the catalog override.
+  const persistedByConfigId = new Map(
+    persistedConfigs
+      .filter((c) => typeof c.id === 'string' && c.id.length > 0)
+      .map((c) => [c.configId && c.configId.trim().length > 0 ? c.configId : c.id, c])
+  )
   const entries: SupportedAcpAgentEntry[] = []
+  const seenConfigIds = new Set<string>()
 
   for (const agent of catalog.agents) {
     const id = agent.id
     const configId = registryConfigId(id)
-    const persisted = persistedById.get(configId)
+    seenConfigIds.add(configId)
+    const persisted = persistedByConfigId.get(configId)
 
     // Map the host-resolved status to the existing SupportedAcpAgentEntry shape.
     // The host already computed the status (ready / install-required /
@@ -398,6 +473,13 @@ export async function resolveSupportedAcpAgents(
               : null
     })
   }
+
+  // CAP-5: append persisted custom agents (outside the registry/catalog) that
+  // the catalog loop did not project. A custom agent whose configId collided
+  // with a registry agent was already consumed by the configId-keyed persisted
+  // lookup above (persisted wins); `seenConfigIds` keeps it from being
+  // double-appended here.
+  entries.push(...customAgentEntriesFromPersisted(persistedConfigs, seenConfigIds))
 
   return entries
 }


### PR DESCRIPTION
## Summary

termul users cannot add an ACP agent that isn't in the ACP registry/catalog — even though the ACP protocol does not gate connectivity on registry membership, and `AgentConfig` + `acp_spawn_agent` already accept any stdio subprocess config. The launch path is ready; the **persistence + UI + export surface is missing**. This PR adds a paste-JSON import dialog (paste `AgentConfig` JSON → validate → assign stable `id`/`configId` → arbitrary-command confirmation → save) and a per-agent "Copy JSON" export that round-trips across machines, reusing the existing `useAcpStore` + `acp-agents-persistence.ts` layer. It also tightens the Rust spawn path (`deny_unknown_fields` + a shared `require_config_id` on both desktop and WS spawn entry points) so sessions durably reattach to `config:{configId}` across restarts.

## Related Issue

No related issue. There is no tracking issue in the repo for "custom ACP agent outside the registry." Searched open + closed PRs for "custom acp" / paste-JSON / copy-json agents — no duplicate. This implements the spec at `_bmad-output/specs/spec-custom-acp-agent/SPEC.md` (kernel) + the architecture spine `architecture-custom-acp-agent-2026-08-09`, which distilled the research `technical-custom-acp-agent-outside-registry-2026-08-08`.

## Type of Change

- [x] feat: new feature

## What Changed

**Renderer (new):**
- `src/renderer/components/agents/CustomAcpAgentDialog.tsx` — paste-JSON dialog: parse → reject unknown fields (only `configId,name,command,args,env,allowTerminal`) → `validateAgentConfig` (shape) + `looksLikeSecretValue` per env value → assign `id`/`configId` (`custom-<uuid8>`; honor pasted configId; on re-paste with an existing configId, reuse its `id` to upsert instead of duplicating) → in-dialog two-step arbitrary-command confirmation (second for `allowTerminal`) → `useAcpStore.saveAgentConfig`. Exports `exportAgentConfig` (6 `AgentConfig` fields, pretty camelCase JSON, strips `id`/`templateId`, no trailing newline, guards a missing `configId`).
- `src/renderer/components/agents/CustomAcpAgentDialog.test.tsx` — 12 tests: happy path, configId honored, upsert-on-re-paste, unknown-field/missing-name/wrong-typed-args/raw-secret rejection, first-cancel + allowTerminal second-confirm cancel/both-confirm, whitespace configId rejection, export round-trip + byte-identity.

**Renderer (modified):**
- `src/renderer/components/settings/AcpAgentsSettings.tsx` — "Add Custom Agent" toolbar button opening the dialog; per-row "Copy JSON" action shown for custom agents only (via `isCustomAgentEntry` keyed off `entry.config.id`, not `entry.id`).
- `src/renderer/lib/acp-agents-persistence.ts` — `validateAgentConfig` extended (args array-of-strings / env string→string / allowTerminal boolean; undefined allowed; element/value-type checks); `loadAgentConfigs` backfills `configId = id` for persisted configs missing one (migration) + filters malformed entries.
- `src/renderer/lib/agents/supported-acp-agents.ts` — `installedBinaryConfig` sets `configId = registryConfigId(agent.id)`; exported `isCustomAgentEntry`; `resolveSupportedAcpAgents` catalog-loop persisted lookup now keyed by `configId` so a persisted custom agent **wins on collision** with a registry agent (CAP-5); `customAgentEntriesFromPersisted` appended on success + degrade paths with `seenConfigIds` dedup + malformed-entry guard.
- Tests updated: `acp-agents-persistence.test.ts` (type-check + raw-secret-at-persistence-boundary + `$VAR`-accepted + malformed-entry-filter) and `supported-acp-agents.test.ts` (`isCustomAgentEntry` + custom-agent surfacing + persisted-wins collision + degrade-mode).

**Rust (modified):**
- `src-tauri/src/acp/config.rs` — `#[serde(deny_unknown_fields)]` on `AgentConfig`; `pub(crate) fn require_config_id` (rejects None/empty/whitespace `config_id`) + unit tests for both.
- `src-tauri/src/acp/commands.rs` — `acp_spawn_agent` calls `require_config_id(&config)?` before `manager.spawn`.
- `src-tauri/src/web/ws.rs` — `handle_spawn_agent` calls `require_config_id` (maps `Err` → `WsReply::err` Unsupported); updated `handle_spawn_agent_rejects_empty_command` (payload now carries configId) + added `handle_spawn_agent_rejects_missing_config_id`.

The spawn-path tightening is safe: the planning investigation confirmed no spawn caller sends `id`/`templateId` — `ensureLiveAgent` (acp-store.ts) strips them before spawn, and all spawn tests pass bare `AgentConfig` shapes. Catalog templates + persisted configs now always carry `configId`, so `stable_agent_namespace` resolves to `config:{configId}` (no fallback hash) on both desktop and web.

## How It Was Tested

- [x] `bun run ci` (Biome lint + format + imports, strict mode)
- [x] `bun run typecheck`
- [x] `bun run test`
- [x] `cargo clippy --all-targets -- -D warnings` (in src-tauri)
- [ ] `cargo test` (in src-tauri) — ⚠️ the Rust test binary fails to launch on this Windows machine with `STATUS_ENTRYPOINT_NOT_FOUND` (0xc0000139), a **pre-existing** native-DLL entry-point failure confirmed on base `dev` HEAD (`ff98cebc`) with these changes stashed. `cargo clippy --all-targets` (compiles ALL test targets incl. the new `require_config_id` + `deny_unknown_fields` + `handle_spawn_agent_*` tests) and `cargo test --no-run` both succeed; CI must confirm the runtime execution.
- [x] Manual verification completed — paste golden JSON `{ "name": "Internal Helper", "command": "node", "args": ["/path/to/agent.js"], "env": { "API_KEY": "$INTERNAL_API_KEY" } }` → confirm arbitrary-command prompt → agent appears in launcher → spawns; raw secret `"sk-ant-..."` rejected with the secure-storage + `$VAR` message.

Vitest: 3434 tests green (43 skipped). New/changed test files in isolation: 57/57 pass.

## Screenshots or Recordings

N/A — UI dialog; the dialog renders a paste-JSON textarea + an in-dialog two-step confirmation. Manual verification performed locally.

## CI & Review Gate

- [ ] All CI checks pass (PR Validation, Rust Checks, Build Verification, Security Scans) — pending CI.
- [ ] Code review comments from CodeRabbit / Claude have been addressed or resolved — will address as they arrive.
- [x] No unresolved review findings remain — a pre-merge self-review (4 parallel reviewers: adversarial, edge-case-hunter, verification-gap, intent-alignment) triaged 14 patches (all applied), 2 deferred (pre-existing, documented in the spec's `deferred` frontmatter), 4 rejected (with evidence).

## Checklist

- [x] My PR title follows the conventional commit format used by this repo (`feat(acp): …`)
- [x] I linked the related issue or explained why none exists (no tracking issue; spec-driven)
- [x] I updated docs when needed — no user-facing docs change required (feature is self-documenting via the dialog); spec finalized at `_bmad-output/implementation-artifacts/spec-custom-acp-agent.md` (gitignored, not in this PR)
- [x] I added or updated tests when needed (12 dialog tests + persistence/agents/Rust test additions)
- [x] I verified the change does not introduce unrelated modifications (10 files, all cohesive to the custom-ACP-agent feature)
- [x] I read AGENTS.md and followed the contributor guidelines (CLAUDE.md: Biome facade boundary, dual-target parity, no new Tauri command/web route, Zustand-only, log-api.ts logging)
- [x] A human reviewed the complete diff before submission (4-reviewer automated review pass; full diff at the linked commit)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for creating, editing, importing, exporting, and copying custom ACP agent configurations from Settings.
  * Added confirmation steps for arbitrary commands and terminal access.
  * Custom agents now remain available even when catalog loading fails.
  * Updated the Harn agent to version 0.10.70.

* **Bug Fixes**
  * Added validation for required configuration IDs, supported fields, data types, and malformed saved entries.
  * Invalid configurations are rejected or safely removed without disrupting valid saved agents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->