### PR TITLE
feat(worktree): isolate agent chats in git worktrees on launch

### DIFF
--- a/src-tauri/src/acp/chat_history_store.rs
+++ b/src-tauri/src/acp/chat_history_store.rs
@@ -42,6 +42,14 @@ pub struct ChatHistoryIndexEntry {
     pub last_activity_at: u64,
     pub message_count: u64,
     pub status: ChatHistoryStatus,
+    /// Worktree path the agent runs in (CAP-3). Additive: old entries
+    /// deserialize with `None` (the renderer-authored metadata payload omits
+    /// it for pre-feature sessions). Used by the CAP-4 relaunch lookup +
+    /// CAP-6 indicator.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub worktree_path: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub worktree_branch: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]

--- a/src-tauri/src/acp/commands.rs
+++ b/src-tauri/src/acp/commands.rs
@@ -47,8 +47,11 @@ pub async fn acp_list_agents(manager: State<'_, Arc<AcpManager>>) -> Result<Vec<
 
 /// Create a new session. `mcpServers` is passed through to `session/new` as-is.
 /// `projectId` (CAP-2 attribution) is optional; the renderer passes the owning
-/// project so the host-owned durable record is project-scoped.
+/// project so the host-owned durable record is project-scoped. `worktreePath` +
+/// `worktreeBranch` (CAP-3) are persisted for the chat indicator + the
+/// deleted-worktree fallback; state isolation still keys on `cwd`.
 #[tauri::command]
+#[allow(clippy::too_many_arguments)]
 pub async fn acp_new_session(
     manager: State<'_, Arc<AcpManager>>,
     agent_id: AgentId,
@@ -56,6 +59,8 @@ pub async fn acp_new_session(
     mcp_servers: Option<Vec<McpServer>>,
     ephemeral: Option<bool>,
     project_id: Option<String>,
+    worktree_path: Option<String>,
+    worktree_branch: Option<String>,
 ) -> Result<NewSessionOutcome, String> {
     manager
         .new_session_with_context(
@@ -65,6 +70,8 @@ pub async fn acp_new_session(
             SessionCreationContext {
                 project_id: project_id.filter(|id| !id.trim().is_empty()),
                 ephemeral: ephemeral.unwrap_or(false),
+                worktree_path: worktree_path.filter(|p| !p.trim().is_empty()),
+                worktree_branch: worktree_branch.filter(|b| !b.trim().is_empty()),
             },
         )
         .await

--- a/src-tauri/src/acp/history_import.rs
+++ b/src-tauri/src/acp/history_import.rs
@@ -157,6 +157,7 @@ async fn import_session(
         runtime_agent_id: (!agent_id.is_empty()).then(|| agent_id.clone()),
         project_id: project_id.map(str::to_string),
         cwd: PathBuf::from(cwd),
+        ..Default::default()
     };
     persistence
         .register_imported_session(registration, created_at, title)

--- a/src-tauri/src/acp/manager.rs
+++ b/src-tauri/src/acp/manager.rs
@@ -499,6 +499,14 @@ pub struct NewSessionOutcome {
 pub struct SessionCreationContext {
     pub project_id: Option<String>,
     pub ephemeral: bool,
+    /// Worktree path the agent runs in (CAP-3). When set, the durable record
+    /// carries it so relaunch reattaches without a second `git worktree add`
+    /// and the chat indicator (CAP-6) survives reload. State isolation still
+    /// keys on `cwd` (the worktree path) — this field is for the indicator +
+    /// deleted-worktree fallback only.
+    pub worktree_path: Option<String>,
+    /// Worktree branch (`chat/{id}`) — paired with `worktree_path`.
+    pub worktree_branch: Option<String>,
 }
 
 /// The `_session/question` ACP extension request (issue #411).
@@ -581,6 +589,8 @@ enum AcpCommand {
         runtime_agent_id: String,
         project_id: Option<String>,
         ephemeral: bool,
+        worktree_path: Option<String>,
+        worktree_branch: Option<String>,
         reply: oneshot::Sender<Result<NewSessionOutcome, String>>,
     },
     LoadSession {
@@ -970,6 +980,8 @@ impl AcpManager {
             runtime_agent_id: agent_id.0.clone(),
             project_id: context.project_id,
             ephemeral: context.ephemeral,
+            worktree_path: context.worktree_path,
+            worktree_branch: context.worktree_branch,
             reply,
         })
         .await
@@ -2208,6 +2220,8 @@ async fn run_command_loop(
                 runtime_agent_id,
                 project_id,
                 ephemeral,
+                worktree_path,
+                worktree_branch,
                 reply,
             } => {
                 let slot = reply_slot(reply);
@@ -2237,6 +2251,8 @@ async fn run_command_loop(
                                         runtime_agent_id: Some(runtime_agent_id),
                                         project_id,
                                         cwd: PathBuf::from(&cwd),
+                                        worktree_path,
+                                        worktree_branch,
                                     };
                                     if let Err(error) =
                                         persistence.register_session(registration).await

--- a/src-tauri/src/acp/session_payload.rs
+++ b/src-tauri/src/acp/session_payload.rs
@@ -255,6 +255,8 @@ mod tests {
             message_count: 0,
             tool_count: 0,
             last_seq: 0,
+            worktree_path: None,
+            worktree_branch: None,
         }
     }
 

--- a/src-tauri/src/acp/session_payload.rs
+++ b/src-tauri/src/acp/session_payload.rs
@@ -417,6 +417,8 @@ mod tests {
                 "messageCount": 0,
                 "lastSeq": 0,
                 "status": "active",
+                "worktreePath": "/work/project/.termul/worktrees/chat/abc123",
+                "worktreeBranch": "chat/abc123",
             })
         );
     }

--- a/src-tauri/src/acp/session_payload.rs
+++ b/src-tauri/src/acp/session_payload.rs
@@ -52,6 +52,13 @@ pub struct SessionPayloadMetadata {
     pub message_count: u64,
     pub last_seq: u64,
     pub status: PersistedSessionStatus,
+    /// Worktree the chat runs in (CAP-4/6). Carried through the materialized
+    /// payload so history reopen + post-reload resume preserve the worktree
+    /// binding the agent reattaches to.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub worktree_path: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub worktree_branch: Option<String>,
 }
 
 /// The renderer `ChatMessage` shape. camelCase keys; `seq` always present
@@ -108,6 +115,8 @@ pub fn materialize_session_payload(
         // lands an event between the metadata read and the replay.
         last_seq: records.last().map_or(metadata.last_seq, |record| record.seq),
         status: metadata.status.clone(),
+        worktree_path: metadata.worktree_path.clone(),
+        worktree_branch: metadata.worktree_branch.clone(),
     };
     MaterializedSessionPayload {
         metadata: payload_metadata,
@@ -255,8 +264,8 @@ mod tests {
             message_count: 0,
             tool_count: 0,
             last_seq: 0,
-            worktree_path: None,
-            worktree_branch: None,
+            worktree_path: Some("/work/project/.termul/worktrees/chat/abc123".to_string()),
+            worktree_branch: Some("chat/abc123".to_string()),
         }
     }
 
@@ -591,5 +600,21 @@ mod tests {
         let first = serde_json::to_value(materialize_session_payload(&meta, &records)).unwrap();
         let second = serde_json::to_value(materialize_session_payload(&meta, &records)).unwrap();
         assert_eq!(first, second, "materialization must be deterministic");
+    }
+
+    #[test]
+    fn materialized_payload_preserves_worktree_binding() {
+        // CAP-4/6: the worktree path + branch must survive materialization
+        // so history reopen and post-reload resume reattach to the bound
+        // worktree (not the project root) and the indicator can render.
+        let payload = materialize_session_payload(&metadata(), &[]);
+        assert_eq!(
+            payload.metadata.worktree_path.as_deref(),
+            Some("/work/project/.termul/worktrees/chat/abc123")
+        );
+        assert_eq!(
+            payload.metadata.worktree_branch.as_deref(),
+            Some("chat/abc123")
+        );
     }
 }

--- a/src-tauri/src/acp/session_persistence.rs
+++ b/src-tauri/src/acp/session_persistence.rs
@@ -65,6 +65,13 @@ pub struct SessionMetadata {
     pub message_count: u64,
     pub tool_count: u64,
     pub last_seq: u64,
+    /// Worktree path the agent runs in (CAP-3). Additive: old entries
+    /// deserialize with `None`. State isolation still keys on `cwd`; this
+    /// field powers the CAP-6 indicator + the deleted-worktree fallback.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub worktree_path: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub worktree_branch: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -86,6 +93,10 @@ pub struct SessionIndexEntry {
     pub tool_count: u64,
     pub last_seq: u64,
     pub resume_eligible: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub worktree_path: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub worktree_branch: Option<String>,
 }
 
 impl From<&SessionMetadata> for SessionIndexEntry {
@@ -105,6 +116,8 @@ impl From<&SessionMetadata> for SessionIndexEntry {
             tool_count: metadata.tool_count,
             last_seq: metadata.last_seq,
             resume_eligible: metadata.stable_agent_namespace.is_some(),
+            worktree_path: metadata.worktree_path.clone(),
+            worktree_branch: metadata.worktree_branch.clone(),
         }
     }
 }
@@ -116,13 +129,15 @@ pub struct SessionIndexFile {
     pub sessions: Vec<SessionIndexEntry>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct SessionRegistration {
     pub session_id: String,
     pub stable_agent_namespace: Option<String>,
     pub runtime_agent_id: Option<String>,
     pub project_id: Option<String>,
     pub cwd: PathBuf,
+    pub worktree_path: Option<String>,
+    pub worktree_branch: Option<String>,
 }
 
 #[derive(Debug)]
@@ -304,6 +319,8 @@ impl SessionPersistence {
             message_count: 0,
             tool_count: 0,
             last_seq: 0,
+            worktree_path: registration.worktree_path,
+            worktree_branch: registration.worktree_branch,
         };
         self.persist_metadata(&metadata)?;
         self.install_runtime(metadata.clone())?;
@@ -356,6 +373,8 @@ impl SessionPersistence {
             message_count: 0,
             tool_count: 0,
             last_seq: 0,
+            worktree_path: registration.worktree_path,
+            worktree_branch: registration.worktree_branch,
         };
         self.persist_metadata(&metadata)?;
         self.install_runtime(metadata.clone())?;
@@ -1177,6 +1196,7 @@ mod tests {
                 runtime_agent_id: Some("runtime-1".to_string()),
                 project_id: Some("project-1".to_string()),
                 cwd,
+                ..Default::default()
             })
             .await
             .unwrap();
@@ -1273,6 +1293,7 @@ mod tests {
                 runtime_agent_id: None,
                 project_id: None,
                 cwd: cwd2,
+                ..Default::default()
             })
             .await
             .unwrap();
@@ -1508,6 +1529,7 @@ mod tests {
                 runtime_agent_id: None,
                 project_id: None,
                 cwd: cwd2,
+                ..Default::default()
             })
             .await
             .unwrap();
@@ -1867,6 +1889,7 @@ mod tests {
                     runtime_agent_id: Some(format!("runtime-{session_id}")),
                     project_id: project.map(str::to_string),
                     cwd: cwd.clone(),
+                    ..Default::default()
                 })
                 .await
                 .unwrap();

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -953,9 +953,18 @@ pub async fn worktree_copy_include_files(
 ) -> Result<IpcResult<IncludeCopyResult>, String> {
     let validated_project = validate_and_stringify!(&project_path);
     let validated_worktree = validate_and_stringify!(&worktree_path);
-    match WorktreeManager::copy_worktree_include_files(&validated_project, &validated_worktree) {
-        Ok(result) => Ok(IpcResult::success(result)),
-        Err(e) => Ok(IpcResult::error(e.to_string(), e.error_code())),
+    // Filesystem walk + copy is blocking; offload from the async runtime.
+    match tokio::task::spawn_blocking(move || {
+        WorktreeManager::copy_worktree_include_files(&validated_project, &validated_worktree)
+    })
+    .await
+    {
+        Ok(Ok(result)) => Ok(IpcResult::success(result)),
+        Ok(Err(e)) => Ok(IpcResult::error(e.to_string(), e.error_code())),
+        Err(join_err) => Ok(IpcResult::error(
+            format!("worktree_copy_include_files join failed: {join_err}"),
+            "INTERNAL_ERROR",
+        )),
     }
 }
 

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -10,7 +10,10 @@ use crate::remote;
 use crate::trackers::{
     CwdTracker, ExitCodeTracker, GitCommit, GitStatus, GitStatusDetail, GitTracker,
 };
-use crate::worktree::{BranchEntry, DirtyStatus, GitWorktreeEntry, RemoveResult, WorktreeManager};
+use crate::worktree::{
+    BaseBranchInfo, BranchEntry, DirtyStatus, GitWorktreeEntry, IncludeCopyResult, RemoveResult,
+    WorktreeManager,
+};
 use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, HashMap};
 use std::io::{BufRead, BufReader, Read};
@@ -921,6 +924,36 @@ pub async fn worktree_merge_execute(
 ) -> Result<IpcResult<String>, String> {
     let validated_path = validate_and_stringify!(&worktree_path);
     match WorktreeManager::merge_execute(&validated_path, &target_branch) {
+        Ok(result) => Ok(IpcResult::success(result)),
+        Err(e) => Ok(IpcResult::error(e.to_string(), e.error_code())),
+    }
+}
+
+/// Resolve the default base branch for a new chat worktree (CAP-2).
+/// Returns the origin/HEAD default with a `main`/`master`/current fallback
+/// chain and a detached-HEAD flag so the launcher can force a base pick.
+#[tauri::command]
+pub async fn worktree_resolve_base_branch(
+    project_path: String,
+) -> Result<IpcResult<BaseBranchInfo>, String> {
+    let validated_path = validate_and_stringify!(&project_path);
+    match WorktreeManager::resolve_default_base_branch(&validated_path) {
+        Ok(info) => Ok(IpcResult::success(info)),
+        Err(e) => Ok(IpcResult::error(e.to_string(), e.error_code())),
+    }
+}
+
+/// Carry over untracked files listed in `.worktree-include` into a fresh
+/// worktree (CAP-5). Symlink/path-escape/already-present defenses run per
+/// file; the result reports `ran`/`copied`/`skipped` with per-file reasons.
+#[tauri::command]
+pub async fn worktree_copy_include_files(
+    project_path: String,
+    worktree_path: String,
+) -> Result<IpcResult<IncludeCopyResult>, String> {
+    let validated_project = validate_and_stringify!(&project_path);
+    let validated_worktree = validate_and_stringify!(&worktree_path);
+    match WorktreeManager::copy_worktree_include_files(&validated_project, &validated_worktree) {
         Ok(result) => Ok(IpcResult::success(result)),
         Err(e) => Ok(IpcResult::error(e.to_string(), e.error_code())),
     }
@@ -3520,6 +3553,8 @@ fn host_entry_to_desktop(entry: crate::acp::SessionIndexEntry) -> crate::acp::Ch
             crate::acp::PersistedSessionStatus::Error => crate::acp::ChatHistoryStatus::Error,
             crate::acp::PersistedSessionStatus::Closed => crate::acp::ChatHistoryStatus::Closed,
         },
+        worktree_path: entry.worktree_path,
+        worktree_branch: entry.worktree_branch,
     }
 }
 
@@ -4507,6 +4542,8 @@ mod tests {
             tool_count: 1,
             last_seq: 5,
             resume_eligible: true,
+            worktree_path: None,
+            worktree_branch: None,
         };
         let desktop = host_entry_to_desktop(entry);
         assert_eq!(desktop.id, "s-1");
@@ -4538,6 +4575,8 @@ mod tests {
             tool_count: 0,
             last_seq: 0,
             resume_eligible: false,
+            worktree_path: None,
+            worktree_branch: None,
         };
         let desktop = host_entry_to_desktop(bare);
         assert_eq!(desktop.agent_id, "");

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1520,6 +1520,9 @@ pub fn run() {
             commands::worktree_restore,
             commands::worktree_merge_preview,
             commands::worktree_merge_execute,
+            // Worktree-isolated agent chat (CAP-2 base resolution + CAP-5 include carry-over)
+            commands::worktree_resolve_base_branch,
+            commands::worktree_copy_include_files,
             // Filesystem/search commands
             commands::search_get_rg_info,
             commands::search_content,

--- a/src-tauri/src/web/sink.rs
+++ b/src-tauri/src/web/sink.rs
@@ -1425,6 +1425,7 @@ mod tests {
                 runtime_agent_id: None,
                 project_id: None,
                 cwd,
+                ..Default::default()
             })
             .await
             .unwrap();

--- a/src-tauri/src/web/ws.rs
+++ b/src-tauri/src/web/ws.rs
@@ -1678,6 +1678,7 @@ async fn handle_create_session(
             SessionCreationContext {
                 project_id,
                 ephemeral: parsed.ephemeral,
+                ..Default::default()
             },
         )
         .await
@@ -2053,6 +2054,7 @@ async fn execute_project_switch(
                     SessionCreationContext {
                         project_id: Some(target.project_id.clone()),
                         ephemeral: false,
+                        ..Default::default()
                     },
                 )
                 .await?;
@@ -3161,6 +3163,7 @@ mod tests {
                 runtime_agent_id: Some("agent-a".to_string()),
                 project_id: None,
                 cwd,
+                ..Default::default()
             })
             .await
             .unwrap();
@@ -3417,6 +3420,7 @@ mod tests {
                 runtime_agent_id: Some("agent-cross".to_string()),
                 project_id: None,
                 cwd: cwd.clone(),
+                ..Default::default()
             })
             .await
             .unwrap();
@@ -5041,6 +5045,7 @@ mod tests {
                 runtime_agent_id: Some("agent-1".to_string()),
                 project_id: Some("p-1".to_string()),
                 cwd,
+                ..Default::default()
             })
             .await
             .unwrap();
@@ -5100,6 +5105,7 @@ mod tests {
                 runtime_agent_id: Some("runtime-p".to_string()),
                 project_id: Some("p-1".to_string()),
                 cwd,
+                ..Default::default()
             })
             .await
             .unwrap();
@@ -5219,6 +5225,7 @@ mod tests {
                 runtime_agent_id: None,
                 project_id: None,
                 cwd,
+                ..Default::default()
             })
             .await
             .unwrap();
@@ -5269,6 +5276,7 @@ mod tests {
                 runtime_agent_id: None,
                 project_id: None,
                 cwd,
+                ..Default::default()
             })
             .await
             .unwrap();
@@ -5361,6 +5369,7 @@ mod tests {
                 runtime_agent_id: Some("agent-1".to_string()),
                 project_id: Some("p-1".to_string()),
                 cwd: cwd.clone(),
+                ..Default::default()
             })
             .await
             .unwrap();

--- a/src-tauri/src/worktree/mod.rs
+++ b/src-tauri/src/worktree/mod.rs
@@ -174,6 +174,48 @@ pub struct MergePreview {
 }
 
 // ============================================================================
+// Base Branch Resolution + Worktree-Include Carry-Over (CAP-2 / CAP-5)
+// ============================================================================
+
+/// Origin-aware default base branch + detached-HEAD guard for worktree
+/// creation (CAP-2). `current_branch` is `None` when the repo is in detached
+/// HEAD — the launcher must then force a base-branch pick before allowing a
+/// worktree launch.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BaseBranchInfo {
+    /// The branch `chat/{id}` should be created from: origin/HEAD → main →
+    /// master → current branch (last resort).
+    pub default_base: String,
+    /// Current checked-out branch, or `None` on detached HEAD.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub current_branch: Option<String>,
+    /// `true` when `git rev-parse --abbrev-ref HEAD` returns `HEAD`.
+    pub is_detached: bool,
+}
+
+/// Per-file skip reason for the `.worktree-include` carry-over (CAP-5).
+/// Surfaced to the renderer so the launcher can log per-file decisions.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct IncludeSkipReason {
+    pub path: String,
+    pub reason: String,
+}
+
+/// Result of `copy_worktree_include_files` (CAP-5). `ran` is the number of
+/// patterns that matched at least one file; `copied` is files actually
+/// copied; `skipped` carries per-file reasons (symlink, path-escape,
+/// already-present).
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct IncludeCopyResult {
+    pub ran: usize,
+    pub copied: usize,
+    pub skipped: Vec<IncludeSkipReason>,
+}
+
+// ============================================================================
 // Error Handling
 // ============================================================================
 
@@ -1303,8 +1345,265 @@ impl WorktreeManager {
 
         let ours_norm = normalize(ours);
         let theirs_norm = normalize(theirs);
-        
+
         ours_norm == theirs_norm && !ours_norm.is_empty()
+    }
+
+    // ========================================================================
+    // CAP-2: Origin-aware default base branch resolution + detached-HEAD guard
+    // ========================================================================
+
+    /// Resolve the default base branch for a new `chat/{id}` worktree.
+    ///
+    /// Order: `refs/remotes/origin/HEAD` → `main` → `master` → current branch.
+    /// `is_detached` is `true` when `git rev-parse --abbrev-ref HEAD` returns
+    /// `HEAD` (the launcher must then force a base-branch pick).
+    pub fn resolve_default_base_branch(project_path: &str) -> Result<BaseBranchInfo, WorktreeError> {
+        let (current_stdout, _) = run_git(
+            &["rev-parse", "--abbrev-ref", "HEAD"],
+            Some(project_path),
+        )?;
+        let current_raw = current_stdout.trim().to_string();
+        let is_detached = current_raw == "HEAD";
+        let current_branch = if is_detached { None } else { Some(current_raw.clone()) };
+
+        // 1. origin/HEAD (symbolic-ref --short)
+        let origin_default = run_git(
+            &["symbolic-ref", "--short", "refs/remotes/origin/HEAD"],
+            Some(project_path),
+        )
+        .map(|(out, _)| out.trim().to_string())
+        .ok()
+        .filter(|s| !s.is_empty());
+
+        // 2/3. main / master if they exist as local branches
+        let has_branch = |name: &str| -> bool {
+            run_git(&["rev-parse", "--verify", &format!("refs/heads/{name}")], Some(project_path))
+                .map(|(o, _)| o.trim().to_string())
+                .is_ok_and(|s| !s.is_empty())
+        };
+
+        let default_base = origin_default
+            .filter(|s| !s.is_empty())
+            .or_else(|| if has_branch("main") { Some("main".to_string()) } else { None })
+            .or_else(|| if has_branch("master") { Some("master".to_string()) } else { None })
+            .or_else(|| current_branch.clone())
+            // Final fallback: the detached raw value ("HEAD") is meaningless as
+            // a base; fall back to "main" as a safe default the launcher can
+            // override via the explicit CAP-2 picker.
+            .unwrap_or_else(|| "main".to_string());
+
+        Ok(BaseBranchInfo {
+            default_base,
+            current_branch,
+            is_detached,
+        })
+    }
+
+    // ========================================================================
+    // CAP-5: `.worktree-include` carry-over (bb pattern, symlink/escape defenses)
+    // ========================================================================
+
+    /// Copy untracked files listed in `.worktree-include` into a fresh worktree.
+    ///
+    /// Defenses (bb `copyWorktreeIncludeFiles`): skip symlinks, verify the
+    /// destination realpath is inside the worktree realpath (path-escape
+    /// defense), `COPYFILE_EXCL` (skip already-present), mkdir parent only
+    /// inside the worktree. Returns `{ ran, copied, skipped }` with per-file
+    /// skip reasons. Missing `.worktree-include` is a no-op (`ran=0`).
+    pub fn copy_worktree_include_files(
+        project_path: &str,
+        worktree_path: &str,
+    ) -> Result<IncludeCopyResult, WorktreeError> {
+        let include_path = Path::new(project_path).join(".worktree-include");
+        if !include_path.exists() {
+            log::debug!(
+                "[worktree-include] no .worktree-include at {}, skipping carry-over",
+                include_path.display()
+            );
+            return Ok(IncludeCopyResult {
+                ran: 0,
+                copied: 0,
+                skipped: Vec::new(),
+            });
+        }
+
+        let content = std::fs::read_to_string(&include_path)
+            .map_err(|e| WorktreeError::IoError(e.to_string()))?;
+        let patterns: Vec<String> = content
+            .lines()
+            .map(|l| l.trim())
+            .filter(|l| !l.is_empty() && !l.starts_with('#'))
+            .map(String::from)
+            .collect();
+
+        if patterns.is_empty() {
+            log::debug!(
+                "[worktree-include] {} has no patterns, skipping carry-over",
+                include_path.display()
+            );
+            return Ok(IncludeCopyResult {
+                ran: 0,
+                copied: 0,
+                skipped: Vec::new(),
+            });
+        }
+
+        let project_root = Path::new(project_path);
+        let worktree_root = Path::new(worktree_path);
+        let worktree_real = worktree_root
+            .canonicalize()
+            .map_err(|e| WorktreeError::IoError(format!("worktree realpath: {e}")))?;
+
+        let mut result = IncludeCopyResult {
+            ran: 0,
+            copied: 0,
+            skipped: Vec::new(),
+        };
+
+        for pattern in &patterns {
+            let regex = match glob_to_regex(pattern) {
+                Ok(re) => re,
+                Err(error) => {
+                    log::warn!(
+                        "[worktree-include] invalid pattern '{pattern}': {error}"
+                    );
+                    continue;
+                }
+            };
+            let mut matched_any = false;
+            // Walk the project root recursively, matching files against the glob.
+            let mut stack: Vec<std::path::PathBuf> = vec![project_root.to_path_buf()];
+            while let Some(dir) = stack.pop() {
+                let entries = match std::fs::read_dir(&dir) {
+                    Ok(e) => e,
+                    Err(error) => {
+                        log::debug!(
+                            "[worktree-include] skip unreadable dir {}: {error}",
+                            dir.display()
+                        );
+                        continue;
+                    }
+                };
+                for entry in entries.flatten() {
+                    let entry_path = entry.path();
+                    let ft = match entry.file_type() {
+                        Ok(t) => t,
+                        Err(_) => continue,
+                    };
+                    if ft.is_dir() {
+                        // Skip the worktree dir + .git to avoid recursion into self.
+                        if entry_path == worktree_root
+                            || entry_path.file_name().and_then(|n| n.to_str()) == Some(".git")
+                            || entry_path.file_name().and_then(|n| n.to_str()) == Some(".termul")
+                        {
+                            continue;
+                        }
+                        stack.push(entry_path);
+                        continue;
+                    }
+                    if !ft.is_file() {
+                        continue;
+                    }
+                    let rel = match entry_path.strip_prefix(project_root) {
+                        Ok(rel) => rel.to_path_buf(),
+                        Err(_) => continue,
+                    };
+                    let rel_str = rel.to_string_lossy().replace('\\', "/");
+                    if !regex.is_match(&rel_str) {
+                        continue;
+                    }
+                    matched_any = true;
+                    let dest = worktree_root.join(&rel);
+
+                    // Defense 1: skip symlinks (source side).
+                    let metadata = match std::fs::symlink_metadata(&entry_path) {
+                        Ok(m) => m,
+                        Err(error) => {
+                            result.skipped.push(IncludeSkipReason {
+                                path: rel_str.clone(),
+                                reason: format!("metadata error: {error}"),
+                            });
+                            continue;
+                        }
+                    };
+                    if metadata.file_type().is_symlink() {
+                        log::debug!(
+                            "[worktree-include] skip symlink '{}'",
+                            rel_str
+                        );
+                        result.skipped.push(IncludeSkipReason {
+                            path: rel_str.clone(),
+                            reason: "symlink".to_string(),
+                        });
+                        continue;
+                    }
+
+                    // Defense 2: path-escape — verify destination realpath is
+                    // inside the worktree realpath. Computed BEFORE mkdir/copy
+                    // (parent may not exist yet), so we check the *intended*
+                    // destination prefix against the worktree canonical root.
+                    let dest_real = dest
+                        .parent()
+                        .map(|p| p.canonicalize().unwrap_or_else(|_| p.to_path_buf()))
+                        .unwrap_or(worktree_real.clone())
+                        .join(dest.file_name().unwrap_or_default());
+                    if !dest_real.starts_with(&worktree_real) {
+                        log::warn!(
+                            "[worktree-include] skip path-escape '{}'",
+                            rel_str
+                        );
+                        result.skipped.push(IncludeSkipReason {
+                            path: rel_str.clone(),
+                            reason: "path-escape".to_string(),
+                        });
+                        continue;
+                    }
+
+                    // Defense 3: COPYFILE_EXCL — skip if already present.
+                    if dest.exists() {
+                        result.skipped.push(IncludeSkipReason {
+                            path: rel_str.clone(),
+                            reason: "already-present".to_string(),
+                        });
+                        continue;
+                    }
+
+                    // mkdir parent (only inside the worktree).
+                    if let Some(parent) = dest.parent() {
+                        if let Err(error) = std::fs::create_dir_all(parent) {
+                            result.skipped.push(IncludeSkipReason {
+                                path: rel_str.clone(),
+                                reason: format!("mkdir failed: {error}"),
+                            });
+                            continue;
+                        }
+                    }
+
+                    // Copy.
+                    if let Err(error) = std::fs::copy(&entry_path, &dest) {
+                        result.skipped.push(IncludeSkipReason {
+                            path: rel_str.clone(),
+                            reason: format!("copy failed: {error}"),
+                        });
+                        continue;
+                    }
+                    log::debug!("[worktree-include] copied '{rel_str}'");
+                    result.copied += 1;
+                }
+            }
+            if matched_any {
+                result.ran += 1;
+            }
+        }
+
+        log::info!(
+            "[worktree-include] carry-over ran={} copied={} skipped={}",
+            result.ran,
+            result.copied,
+            result.skipped.len()
+        );
+        Ok(result)
     }
 }
 
@@ -1315,6 +1614,45 @@ struct ConflictBlock {
     /// Diff3 common-ancestor section when present; reserved for future suggestions.
     #[allow(dead_code)]
     base: String,
+}
+
+/// Convert a `.worktree-include` glob into a `Regex` for matching file paths
+/// relative to the project root (forward slashes). Supports:
+/// - `**` matches anything including `/`
+/// - `*` matches anything except `/`
+/// - `?` matches a single char (except `/`)
+/// - everything else is escaped literally.
+fn glob_to_regex(glob: &str) -> Result<regex::Regex, regex::Error> {
+    let mut out = String::with_capacity(glob.len() + 8);
+    out.push('^');
+    let mut chars = glob.chars().peekable();
+    while let Some(c) = chars.next() {
+        match c {
+            '*' => {
+                if chars.peek() == Some(&'*') {
+                    chars.next();
+                    // `**/` -> match any path prefix (including empty)
+                    if chars.peek() == Some(&'/') {
+                        chars.next();
+                        out.push_str("(?:.*/)?");
+                    } else {
+                        out.push_str(".*");
+                    }
+                } else {
+                    out.push_str("[^/]*");
+                }
+            }
+            '?' => out.push_str("[^/]"),
+            '.' | '+' | '(' | ')' | '|' | '[' | ']' | '{' | '}' | '^' | '$' | '\\' => {
+                out.push('\\');
+                out.push(c);
+            }
+            '/' => out.push('/'),
+            other => out.push(other),
+        }
+    }
+    out.push('$');
+    regex::Regex::new(&out)
 }
 
 /// Get an ISO 8601 timestamp string for the current time.
@@ -1793,6 +2131,203 @@ mod tests {
             !"/project/../other-worktree"
                 .contains(".termul/worktrees/")
         );
+    }
+
+    // --------------------------------------------------------------------
+    // CAP-2 / CAP-5 — worktree include carry-over + base-branch helpers
+    // --------------------------------------------------------------------
+
+    fn git_available() -> bool {
+        which_git().is_ok()
+    }
+
+    /// `glob_to_regex` matches exact filenames and simple wildcards.
+    #[test]
+    fn test_glob_to_regex_exact_and_wildcard() {
+        let exact = glob_to_regex(".env").unwrap();
+        assert!(exact.is_match(".env"));
+        assert!(!exact.is_match("config/.env"));
+        assert!(!exact.is_match("env"));
+
+        let star = glob_to_regex("*.env").unwrap();
+        assert!(star.is_match(".env"));
+        assert!(star.is_match("local.env"));
+        assert!(!star.is_match("config/local.env"));
+
+        let double = glob_to_regex("**/*.env").unwrap();
+        assert!(double.is_match(".env"));
+        assert!(double.is_match("config/local.env"));
+        assert!(double.is_match("a/b/c.env"));
+    }
+
+    #[test]
+    fn test_copy_worktree_include_files_no_include_file_is_noop() {
+        // No `.worktree-include` -> ran=0, copied=0, skipped=[]
+        let project = tempfile::tempdir().unwrap();
+        let worktree = tempfile::tempdir().unwrap();
+        let result = WorktreeManager::copy_worktree_include_files(
+            project.path().to_str().unwrap(),
+            worktree.path().to_str().unwrap(),
+        )
+        .expect("no-include path is a no-op, not an error");
+        assert_eq!(result.ran, 0);
+        assert_eq!(result.copied, 0);
+        assert!(result.skipped.is_empty());
+    }
+
+    #[test]
+    fn test_copy_worktree_include_files_copies_plain_file() {
+        let project = tempfile::tempdir().unwrap();
+        let worktree = tempfile::tempdir().unwrap();
+        // Source: an untracked .env in the project root.
+        std::fs::write(project.path().join(".env"), "SECRET=1\n").unwrap();
+        std::fs::write(project.path().join(".worktree-include"), ".env\n").unwrap();
+        let result = WorktreeManager::copy_worktree_include_files(
+            project.path().to_str().unwrap(),
+            worktree.path().to_str().unwrap(),
+        )
+        .expect("copy plain .env");
+        assert_eq!(result.ran, 1);
+        assert_eq!(result.copied, 1);
+        assert!(result.skipped.is_empty());
+        let copied = std::fs::read_to_string(worktree.path().join(".env")).unwrap();
+        assert_eq!(copied, "SECRET=1\n");
+    }
+
+    #[test]
+    fn test_copy_worktree_include_files_skips_symlink() {
+        let project = tempfile::tempdir().unwrap();
+        let worktree = tempfile::tempdir().unwrap();
+        // Real target + a symlink pointing outside.
+        let outside = tempfile::tempdir().unwrap();
+        std::fs::write(outside.path().join("real.env"), "SECRET=outside\n").unwrap();
+        let link = project.path().join("linked.env");
+        #[cfg(unix)]
+        std::os::unix::fs::symlink(outside.path().join("real.env"), &link).unwrap();
+        #[cfg(windows)]
+        {
+            // Symlink creation on Windows requires elevated privileges; fall
+            // back to a junction-ish test by skipping when we cannot create
+            // one. The defense is still exercised on Unix CI.
+            let result = std::os::windows::fs::symlink_file(
+                outside.path().join("real.env"),
+                &link,
+            );
+            if result.is_err() {
+                return;
+            }
+        }
+        std::fs::write(project.path().join(".worktree-include"), "linked.env\n").unwrap();
+        let result = WorktreeManager::copy_worktree_include_files(
+            project.path().to_str().unwrap(),
+            worktree.path().to_str().unwrap(),
+        )
+        .expect("symlink skip");
+        assert_eq!(result.copied, 0);
+        assert!(result.skipped.iter().any(|s| s.reason == "symlink"));
+    }
+
+    #[test]
+    fn test_copy_worktree_include_files_skips_already_present() {
+        let project = tempfile::tempdir().unwrap();
+        let worktree = tempfile::tempdir().unwrap();
+        std::fs::write(project.path().join(".env"), "SECRET=1\n").unwrap();
+        // Pre-create the destination -> COPYFILE_EXCL semantics.
+        std::fs::write(worktree.path().join(".env"), "PRE-EXISTING\n").unwrap();
+        std::fs::write(project.path().join(".worktree-include"), ".env\n").unwrap();
+        let result = WorktreeManager::copy_worktree_include_files(
+            project.path().to_str().unwrap(),
+            worktree.path().to_str().unwrap(),
+        )
+        .expect("already-present skip");
+        assert_eq!(result.copied, 0);
+        assert!(result.skipped.iter().any(|s| s.reason == "already-present"));
+        // The pre-existing file is NOT overwritten.
+        let kept = std::fs::read_to_string(worktree.path().join(".env")).unwrap();
+        assert_eq!(kept, "PRE-EXISTING\n");
+    }
+
+    #[test]
+    fn test_copy_worktree_include_files_skips_path_escape() {
+        let project = tempfile::tempdir().unwrap();
+        // Point worktree at a path that does not exist as a directory — the
+        // realpath canonicalize will fail and the helper returns an IoError,
+        // which is the path-escape / missing-worktree boundary.
+        let _ = tempfile::tempdir().unwrap();
+        std::fs::write(project.path().join("file.env"), "X\n").unwrap();
+        std::fs::write(project.path().join(".worktree-include"), "file.env\n").unwrap();
+        let missing_worktree = project.path().join(".termul").join("worktrees").join("missing");
+        let result = WorktreeManager::copy_worktree_include_files(
+            project.path().to_str().unwrap(),
+            missing_worktree.to_str().unwrap(),
+        );
+        assert!(result.is_err(), "missing worktree dir must error, not silently write outside");
+    }
+
+    #[test]
+    fn test_resolve_default_base_branch_falls_back_to_current_when_no_origin() {
+        if !git_available() {
+            return;
+        }
+        let project = tempfile::tempdir().unwrap();
+        // git init + a commit on a branch named "feat/x" so rev-parse works.
+        let p = project.path();
+        let run = |args: &[&str]| {
+            let mut cmd = quiet_command("git");
+            cmd.args(args).current_dir(p);
+            let _ = cmd.output();
+        };
+        run(&["init", "--quiet"]);
+        run(&["config", "user.email", "t@t.test"]);
+        run(&["config", "user.name", "t"]);
+        // Rename the default branch to feat/x so current_branch is non-default.
+        run(&["checkout", "-b", "feat/x"]);
+        std::fs::write(p.join("a.txt"), "a\n").unwrap();
+        run(&["add", "a.txt"]);
+        run(&["commit", "-m", "init", "--quiet"]);
+        let info = WorktreeManager::resolve_default_base_branch(p.to_str().unwrap())
+            .expect("resolve_default_base_branch on a fresh repo");
+        assert_eq!(info.current_branch.as_deref(), Some("feat/x"));
+        // No origin/HEAD and no main/master locally -> fall back to current.
+        assert_eq!(info.default_base, "feat/x");
+        assert!(!info.is_detached);
+    }
+
+    #[test]
+    fn test_resolve_default_base_branch_detached_head_flag() {
+        if !git_available() {
+            return;
+        }
+        let project = tempfile::tempdir().unwrap();
+        let p = project.path();
+        let run = |args: &[&str]| {
+            let mut cmd = quiet_command("git");
+            cmd.args(args).current_dir(p);
+            let _ = cmd.output();
+        };
+        run(&["init", "--quiet"]);
+        run(&["config", "user.email", "t@t.test"]);
+        run(&["config", "user.name", "t"]);
+        run(&["checkout", "-b", "main"]);
+        std::fs::write(p.join("a.txt"), "a\n").unwrap();
+        run(&["add", "a.txt"]);
+        run(&["commit", "-m", "init", "--quiet"]);
+        // Detach HEAD at the commit.
+        let head = {
+            let out = std::process::Command::new("git")
+                .args(["rev-parse", "HEAD"])
+                .current_dir(p)
+                .output()
+                .unwrap();
+            String::from_utf8_lossy(&out.stdout).trim().to_string()
+        };
+        run(&["checkout", &head]);
+        let info = WorktreeManager::resolve_default_base_branch(p.to_str().unwrap())
+            .expect("resolve_default_base_branch on detached HEAD");
+        assert!(info.is_detached);
+        assert!(info.current_branch.is_none());
+        // main exists locally -> default_base should be main (fallback chain).
+        assert_eq!(info.default_base, "main");
     }
 }
 

--- a/src-tauri/src/worktree/mod.rs
+++ b/src-tauri/src/worktree/mod.rs
@@ -1367,14 +1367,18 @@ impl WorktreeManager {
         let is_detached = current_raw == "HEAD";
         let current_branch = if is_detached { None } else { Some(current_raw.clone()) };
 
-        // 1. origin/HEAD (symbolic-ref --short)
+        // 1. origin/HEAD (symbolic-ref --short). `symbolic-ref --short` returns
+        // the remote-tracking short name (e.g. `origin/main`); strip the
+        // `origin/` qualifier so the result lives in the local-branch
+        // namespace the launcher's base picker compares against.
         let origin_default = run_git(
             &["symbolic-ref", "--short", "refs/remotes/origin/HEAD"],
             Some(project_path),
         )
         .map(|(out, _)| out.trim().to_string())
         .ok()
-        .filter(|s| !s.is_empty());
+        .filter(|s| !s.is_empty())
+        .map(|s| s.strip_prefix("origin/").unwrap_or(&s).to_string());
 
         // 2/3. main / master if they exist as local branches
         let has_branch = |name: &str| -> bool {
@@ -1384,7 +1388,6 @@ impl WorktreeManager {
         };
 
         let default_base = origin_default
-            .filter(|s| !s.is_empty())
             .or_else(|| if has_branch("main") { Some("main".to_string()) } else { None })
             .or_else(|| if has_branch("master") { Some("master".to_string()) } else { None })
             .or_else(|| current_branch.clone())
@@ -1461,141 +1464,170 @@ impl WorktreeManager {
             skipped: Vec::new(),
         };
 
-        for pattern in &patterns {
-            let regex = match glob_to_regex(pattern) {
-                Ok(re) => re,
+        // Compile all patterns once (avoid O(patterns × files) re-walks per
+        // pattern). Invalid patterns are warned and skipped.
+        let compiled: Vec<regex::Regex> = patterns
+            .iter()
+            .filter_map(|p| match glob_to_regex(p) {
+                Ok(re) => Some(re),
                 Err(error) => {
-                    log::warn!(
-                        "[worktree-include] invalid pattern '{pattern}': {error}"
+                    log::warn!("[worktree-include] invalid pattern '{p}': {error}");
+                    None
+                }
+            })
+            .collect();
+        if compiled.is_empty() {
+            log::debug!(
+                "[worktree-include] {} has no valid patterns, skipping carry-over",
+                include_path.display()
+            );
+            return Ok(result);
+        }
+        let mut matched = vec![false; compiled.len()];
+
+        // Directories pruned at descent time (never recursed into).
+        const PRUNE_DIRS: &[&str] = &[".git", ".termul", "node_modules", "target", "dist"];
+
+        // Single recursive walk: each file is tested against every compiled
+        // pattern (the first match copies it once; later matches only mark the
+        // pattern as ran).
+        let mut stack: Vec<std::path::PathBuf> = vec![project_root.to_path_buf()];
+        while let Some(dir) = stack.pop() {
+            let entries = match std::fs::read_dir(&dir) {
+                Ok(e) => e,
+                Err(error) => {
+                    log::debug!(
+                        "[worktree-include] skip unreadable dir {}: {error}",
+                        dir.display()
                     );
                     continue;
                 }
             };
-            let mut matched_any = false;
-            // Walk the project root recursively, matching files against the glob.
-            let mut stack: Vec<std::path::PathBuf> = vec![project_root.to_path_buf()];
-            while let Some(dir) = stack.pop() {
-                let entries = match std::fs::read_dir(&dir) {
-                    Ok(e) => e,
-                    Err(error) => {
-                        log::debug!(
-                            "[worktree-include] skip unreadable dir {}: {error}",
-                            dir.display()
-                        );
-                        continue;
-                    }
+            for entry in entries.flatten() {
+                let entry_path = entry.path();
+                let ft = match entry.file_type() {
+                    Ok(t) => t,
+                    Err(_) => continue,
                 };
-                for entry in entries.flatten() {
-                    let entry_path = entry.path();
-                    let ft = match entry.file_type() {
-                        Ok(t) => t,
-                        Err(_) => continue,
-                    };
-                    if ft.is_dir() {
-                        // Skip the worktree dir + .git to avoid recursion into self.
-                        if entry_path == worktree_root
-                            || entry_path.file_name().and_then(|n| n.to_str()) == Some(".git")
-                            || entry_path.file_name().and_then(|n| n.to_str()) == Some(".termul")
-                        {
-                            continue;
-                        }
-                        stack.push(entry_path);
-                        continue;
-                    }
-                    if !ft.is_file() {
-                        continue;
-                    }
-                    let rel = match entry_path.strip_prefix(project_root) {
-                        Ok(rel) => rel.to_path_buf(),
-                        Err(_) => continue,
-                    };
-                    let rel_str = rel.to_string_lossy().replace('\\', "/");
-                    if !regex.is_match(&rel_str) {
-                        continue;
-                    }
-                    matched_any = true;
-                    let dest = worktree_root.join(&rel);
 
-                    // Defense 1: skip symlinks (source side).
-                    let metadata = match std::fs::symlink_metadata(&entry_path) {
-                        Ok(m) => m,
-                        Err(error) => {
-                            result.skipped.push(IncludeSkipReason {
-                                path: rel_str.clone(),
-                                reason: format!("metadata error: {error}"),
-                            });
-                            continue;
-                        }
+                // Defense 1: symlinks (source side). On Unix `file_type()`
+                // reports `is_symlink()` without following; on Windows the
+                // `symlink_metadata` check is authoritative. A symlink is never
+                // recursed into or copied — if a pattern matches its path it
+                // is recorded as a symlink skip so the user sees the carry-over
+                // declined it.
+                let is_symlink = ft.is_symlink()
+                    || std::fs::symlink_metadata(&entry_path)
+                        .map(|m| m.file_type().is_symlink())
+                        .unwrap_or(false);
+                if is_symlink {
+                    let rel_str = match entry_path.strip_prefix(project_root) {
+                        Ok(rel) => rel.to_string_lossy().replace('\\', "/"),
+                        Err(_) => continue,
                     };
-                    if metadata.file_type().is_symlink() {
-                        log::debug!(
-                            "[worktree-include] skip symlink '{}'",
-                            rel_str
-                        );
+                    if compiled.iter().any(|re| re.is_match(&rel_str)) {
+                        log::debug!("[worktree-include] skip symlink '{}'", rel_str);
                         result.skipped.push(IncludeSkipReason {
-                            path: rel_str.clone(),
+                            path: rel_str,
                             reason: "symlink".to_string(),
                         });
+                    }
+                    continue;
+                }
+
+                if ft.is_dir() {
+                    let name = entry_path.file_name().and_then(|n| n.to_str());
+                    // Skip the worktree itself (compare canonicalized paths so a
+                    // differently-spelled entry to the same worktree still
+                    // prunes), repo metadata, and build/dep trees.
+                    if name.is_some_and(|n| PRUNE_DIRS.contains(&n))
+                        || entry_path
+                            .canonicalize()
+                            .map(|p| p == worktree_real)
+                            .unwrap_or(false)
+                    {
                         continue;
                     }
+                    stack.push(entry_path);
+                    continue;
+                }
+                if !ft.is_file() {
+                    continue;
+                }
+                let rel_str = match entry_path.strip_prefix(project_root) {
+                    Ok(rel) => rel.to_string_lossy().replace('\\', "/"),
+                    Err(_) => continue,
+                };
+                let mut hit = false;
+                for (i, re) in compiled.iter().enumerate() {
+                    if re.is_match(&rel_str) {
+                        matched[i] = true;
+                        hit = true;
+                    }
+                }
+                if !hit {
+                    continue;
+                }
+                let dest = worktree_root.join(&rel_str);
 
-                    // Defense 2: path-escape — verify destination realpath is
-                    // inside the worktree realpath. Computed BEFORE mkdir/copy
-                    // (parent may not exist yet), so we check the *intended*
-                    // destination prefix against the worktree canonical root.
-                    let dest_real = dest
-                        .parent()
-                        .map(|p| p.canonicalize().unwrap_or_else(|_| p.to_path_buf()))
-                        .unwrap_or(worktree_real.clone())
-                        .join(dest.file_name().unwrap_or_default());
-                    if !dest_real.starts_with(&worktree_real) {
-                        log::warn!(
-                            "[worktree-include] skip path-escape '{}'",
-                            rel_str
-                        );
+                // Defense 2: path-escape — the destination parent MUST
+                // canonicalize to a real path inside the worktree. Reject
+                // (skip) when canonicalization fails; never fall back to the
+                // non-canonical parent, which could write outside the worktree.
+                let dest_parent_real = match dest.parent().map(std::path::Path::canonicalize) {
+                    Some(Ok(p)) => p,
+                    _ => {
+                        log::warn!("[worktree-include] skip path-escape '{}'", rel_str);
                         result.skipped.push(IncludeSkipReason {
                             path: rel_str.clone(),
                             reason: "path-escape".to_string(),
                         });
                         continue;
                     }
-
-                    // Defense 3: COPYFILE_EXCL — skip if already present.
-                    if dest.exists() {
-                        result.skipped.push(IncludeSkipReason {
-                            path: rel_str.clone(),
-                            reason: "already-present".to_string(),
-                        });
-                        continue;
-                    }
-
-                    // mkdir parent (only inside the worktree).
-                    if let Some(parent) = dest.parent() {
-                        if let Err(error) = std::fs::create_dir_all(parent) {
-                            result.skipped.push(IncludeSkipReason {
-                                path: rel_str.clone(),
-                                reason: format!("mkdir failed: {error}"),
-                            });
-                            continue;
-                        }
-                    }
-
-                    // Copy.
-                    if let Err(error) = std::fs::copy(&entry_path, &dest) {
-                        result.skipped.push(IncludeSkipReason {
-                            path: rel_str.clone(),
-                            reason: format!("copy failed: {error}"),
-                        });
-                        continue;
-                    }
-                    log::debug!("[worktree-include] copied '{rel_str}'");
-                    result.copied += 1;
+                };
+                let dest_real = dest_parent_real.join(dest.file_name().unwrap_or_default());
+                if !dest_real.starts_with(&worktree_real) {
+                    log::warn!("[worktree-include] skip path-escape '{}'", rel_str);
+                    result.skipped.push(IncludeSkipReason {
+                        path: rel_str.clone(),
+                        reason: "path-escape".to_string(),
+                    });
+                    continue;
                 }
-            }
-            if matched_any {
-                result.ran += 1;
+
+                // Defense 3: COPYFILE_EXCL — skip if already present.
+                if dest.exists() {
+                    result.skipped.push(IncludeSkipReason {
+                        path: rel_str.clone(),
+                        reason: "already-present".to_string(),
+                    });
+                    continue;
+                }
+
+                // mkdir parent (only inside the worktree).
+                if let Some(parent) = dest.parent() {
+                    if let Err(error) = std::fs::create_dir_all(parent) {
+                        result.skipped.push(IncludeSkipReason {
+                            path: rel_str.clone(),
+                            reason: format!("mkdir failed: {error}"),
+                        });
+                        continue;
+                    }
+                }
+
+                // Copy.
+                if let Err(error) = std::fs::copy(&entry_path, &dest) {
+                    result.skipped.push(IncludeSkipReason {
+                        path: rel_str.clone(),
+                        reason: format!("copy failed: {error}"),
+                    });
+                    continue;
+                }
+                log::debug!("[worktree-include] copied '{rel_str}'");
+                result.copied += 1;
             }
         }
+        result.ran = matched.iter().filter(|b| **b).count();
 
         log::info!(
             "[worktree-include] carry-over ran={} copied={} skipped={}",
@@ -1623,9 +1655,18 @@ struct ConflictBlock {
 /// - `?` matches a single char (except `/`)
 /// - everything else is escaped literally.
 fn glob_to_regex(glob: &str) -> Result<regex::Regex, regex::Error> {
-    let mut out = String::with_capacity(glob.len() + 8);
+    // Normalize: strip one leading slash so root-anchored patterns (e.g.
+    // `/foo`) match the relative walk paths (which have no leading slash).
+    // A trailing slash marks a recursive directory pattern (`foo/` matches
+    // `foo/bar`, `foo/baz/qux`, ...) — append `.*` so it matches descendants.
+    let trailing_dir = glob.ends_with('/');
+    let trimmed = glob
+        .strip_prefix('/')
+        .unwrap_or(glob)
+        .trim_end_matches('/');
+    let mut out = String::with_capacity(trimmed.len() + 8);
     out.push('^');
-    let mut chars = glob.chars().peekable();
+    let mut chars = trimmed.chars().peekable();
     while let Some(c) = chars.next() {
         match c {
             '*' => {
@@ -1650,6 +1691,9 @@ fn glob_to_regex(glob: &str) -> Result<regex::Regex, regex::Error> {
             '/' => out.push('/'),
             other => out.push(other),
         }
+    }
+    if trailing_dir {
+        out.push_str(".*");
     }
     out.push('$');
     regex::Regex::new(&out)
@@ -2248,12 +2292,11 @@ mod tests {
     }
 
     #[test]
-    fn test_copy_worktree_include_files_skips_path_escape() {
+    fn test_copy_worktree_include_files_errors_when_worktree_dir_missing() {
         let project = tempfile::tempdir().unwrap();
         // Point worktree at a path that does not exist as a directory — the
         // realpath canonicalize will fail and the helper returns an IoError,
         // which is the path-escape / missing-worktree boundary.
-        let _ = tempfile::tempdir().unwrap();
         std::fs::write(project.path().join("file.env"), "X\n").unwrap();
         std::fs::write(project.path().join(".worktree-include"), "file.env\n").unwrap();
         let missing_worktree = project.path().join(".termul").join("worktrees").join("missing");
@@ -2267,6 +2310,7 @@ mod tests {
     #[test]
     fn test_resolve_default_base_branch_falls_back_to_current_when_no_origin() {
         if !git_available() {
+            eprintln!("skipped: git not available on PATH");
             return;
         }
         let project = tempfile::tempdir().unwrap();
@@ -2296,6 +2340,7 @@ mod tests {
     #[test]
     fn test_resolve_default_base_branch_detached_head_flag() {
         if !git_available() {
+            eprintln!("skipped: git not available on PATH");
             return;
         }
         let project = tempfile::tempdir().unwrap();

--- a/src/renderer/assets/agent-icons/acp/agents.json
+++ b/src/renderer/assets/agent-icons/acp/agents.json
@@ -438,33 +438,33 @@
   {
     "id": "harn",
     "name": "Harn",
-    "version": "0.10.68",
+    "version": "0.10.70",
     "description": "Harn runs .harn agent pipelines as a native ACP coding agent over stdio.",
     "distribution": {
       "binary": {
         "darwin-aarch64": {
           "cmd": "./harn",
-          "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.68/harn-aarch64-apple-darwin.tar.gz",
+          "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.70/harn-aarch64-apple-darwin.tar.gz",
           "args": ["serve", "acp"]
         },
         "darwin-x86_64": {
           "cmd": "./harn",
-          "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.68/harn-x86_64-apple-darwin.tar.gz",
+          "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.70/harn-x86_64-apple-darwin.tar.gz",
           "args": ["serve", "acp"]
         },
         "linux-aarch64": {
           "cmd": "./harn",
-          "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.68/harn-aarch64-unknown-linux-gnu.tar.gz",
+          "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.70/harn-aarch64-unknown-linux-gnu.tar.gz",
           "args": ["serve", "acp"]
         },
         "linux-x86_64": {
           "cmd": "./harn",
-          "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.68/harn-x86_64-unknown-linux-gnu.tar.gz",
+          "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.70/harn-x86_64-unknown-linux-gnu.tar.gz",
           "args": ["serve", "acp"]
         },
         "windows-x86_64": {
           "cmd": "harn.exe",
-          "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.68/harn-x86_64-pc-windows-msvc.zip",
+          "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.70/harn-x86_64-pc-windows-msvc.zip",
           "args": ["serve", "acp"]
         }
       }

--- a/src/renderer/components/agents/AgentLauncher.test.tsx
+++ b/src/renderer/components/agents/AgentLauncher.test.tsx
@@ -8,6 +8,7 @@ import {
   pickDefaultSupportedAgent,
   type SupportedAcpAgentEntry
 } from '@/lib/agents/supported-acp-agents'
+import { isTauriContext } from '@/lib/tauri-runtime'
 import type { AcpSession } from '@/stores/acp-store'
 import { __resetLauncherSelectionCache, AgentLauncher } from './AgentLauncher'
 
@@ -111,26 +112,34 @@ const {
   }
 }))
 
-const { mockSkills, mockToastError, mockResolvedAgentsOverride } = vi.hoisted(() => ({
-  // Override-able skills list (defaults to [] — web/no-skills parity). Skill
-  // tests push entries here so useAgentSkills surfaces them in the slash menu.
-  // `path` is required so the launch wire prompt can cite it.
-  mockSkills: {
-    current: [] as Array<{
-      name: string
-      description: string
-      scope: string
-      path: string
-    }>
-  },
-  mockToastError: vi.fn(),
-  // CAP-6 / Story 8: the launcher resolves supported agents from the host
-  // catalog via `useResolvedSupportedAcpAgents`. Component tests mock the hook
-  // to the synchronous offline-first derivation so they can exercise launch
-  // behavior without the async catalog fetch. Set this to inject a specific
-  // entry list (e.g. the manual-install agent).
-  mockResolvedAgentsOverride: { current: null as SupportedAcpAgentEntry[] | null }
-}))
+const { mockSkills, mockToastError, mockResolvedAgentsOverride, mockProjectOverride } = vi.hoisted(
+  () => ({
+    // Override-able skills list (defaults to [] — web/no-skills parity). Skill
+    // tests push entries here so useAgentSkills surfaces them in the slash menu.
+    // `path` is required so the launch wire prompt can cite it.
+    mockSkills: {
+      current: [] as Array<{
+        name: string
+        description: string
+        scope: string
+        path: string
+      }>
+    },
+    mockToastError: vi.fn(),
+    // CAP-6 / Story 8: the launcher resolves supported agents from the host
+    // catalog via `useResolvedSupportedAcpAgents`. Component tests mock the hook
+    // to the synchronous offline-first derivation so they can exercise launch
+    // behavior without the async catalog fetch. Set this to inject a specific
+    // entry list (e.g. the manual-install agent).
+    mockResolvedAgentsOverride: { current: null as SupportedAcpAgentEntry[] | null },
+    // CAP-2/3 worktree-mode override: the default project mock is a non-git
+    // folder so the worktree selector is hidden. Worktree tests push a git
+    // project + branch here so `canUseWorktree` becomes true.
+    mockProjectOverride: {
+      current: null as { isGitRepo?: boolean; gitBranch?: string | null } | null
+    }
+  })
+)
 
 vi.mock('sonner', () => ({
   toast: { error: mockToastError, success: vi.fn() }
@@ -198,14 +207,126 @@ vi.mock('@/lib/worktree-context', () => ({
   getDefaultCwdForProject: () => '/work'
 }))
 
+vi.mock('@/lib/tauri-runtime', () => ({
+  isTauriContext: vi.fn(() => false)
+}))
+
+// Radix Select portals don't render reliably under jsdom; shim with a native
+// `<select>`. `Select` walks its children for `SelectItem`s and exposes them
+// via context so `SelectTrigger` can render one `<select>` with all options.
+vi.mock('@/components/ui/select', async () => {
+  const { createContext, useContext, Children, isValidElement } = await import('react')
+  type Item = { value: string; label: React.ReactNode }
+  const SelectCtx = createContext<{
+    value?: string
+    onValueChange?: (v: string) => void
+    items: Item[]
+  }>({ items: [] })
+  const SelectItem = (_props: { value: string; children: React.ReactNode }) => null
+  return {
+    Select: ({
+      value,
+      onValueChange,
+      children
+    }: {
+      value?: string
+      onValueChange?: (v: string) => void
+      children: React.ReactNode
+    }) => {
+      const items: Item[] = []
+      const walk = (node: React.ReactNode): void => {
+        if (!isValidElement(node)) return
+        if (node.type === SelectItem) {
+          items.push({ value: node.props.value, label: node.props.children })
+        }
+        Children.forEach(node.props.children, walk)
+      }
+      Children.forEach(children, walk)
+      return (
+        <SelectCtx.Provider value={{ value, onValueChange, items }}>{children}</SelectCtx.Provider>
+      )
+    },
+    SelectTrigger: ({
+      className,
+      children,
+      ...props
+    }: {
+      className?: string
+      children?: React.ReactNode
+      [k: string]: unknown
+    }) => {
+      const ctx = useContext(SelectCtx)
+      const ariaLabel = (props as Record<string, unknown>)['aria-label'] as string | undefined
+      return (
+        <select
+          className={className}
+          value={ctx.value ?? ''}
+          onChange={(e) => ctx.onValueChange?.(e.target.value)}
+          aria-label={ariaLabel}
+        >
+          {ctx.items.map((item) => (
+            <option key={item.value} value={item.value}>
+              {item.label}
+            </option>
+          ))}
+        </select>
+      )
+    },
+    SelectValue: () => null,
+    SelectContent: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+    SelectItem,
+    SelectGroup: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+    SelectLabel: () => null,
+    SelectSeparator: () => null,
+    SelectScrollUpButton: () => null,
+    SelectScrollDownButton: () => null
+  }
+})
+
+const { mockWorktreeCreate, mockWorktreeCopyInclude, mockWorktreeResolveBaseBranch } = vi.hoisted(
+  () => ({
+    mockWorktreeCreate: vi.fn(),
+    mockWorktreeCopyInclude: vi.fn(),
+    mockWorktreeResolveBaseBranch: vi.fn()
+  })
+)
+
+vi.mock('@/lib/worktree-api', () => ({
+  worktreeApi: {
+    create: mockWorktreeCreate,
+    copyIncludeFiles: mockWorktreeCopyInclude,
+    resolveBaseBranch: mockWorktreeResolveBaseBranch,
+    list: vi.fn(),
+    remove: vi.fn(),
+    branches: vi.fn(),
+    checkDirty: vi.fn(),
+    removeAllManaged: vi.fn(),
+    parseGitignore: vi.fn(),
+    createSymlinks: vi.fn(),
+    ensureSymlinks: vi.fn(),
+    archive: vi.fn(),
+    restore: vi.fn(),
+    mergePreview: vi.fn(),
+    mergeExecute: vi.fn()
+  }
+}))
+
 vi.mock('@/stores/project-store', () => {
+  const baseProject = { id: 'p1', name: 'P', path: '/work', defaultShell: undefined }
   const state = {
     activeProjectId: 'p1',
-    projects: [{ id: 'p1', name: 'P', path: '/work', defaultShell: undefined }]
+    projects: [baseProject]
   }
-  const useProjectStore = (sel?: (s: typeof state) => unknown) => (sel ? sel(state) : state)
+  const withOverride = () => ({
+    ...state,
+    projects: state.projects.map((p) => ({ ...p, ...(mockProjectOverride.current ?? {}) }))
+  })
+  const useProjectStore = (sel?: (s: typeof state) => unknown) => {
+    const merged = withOverride()
+    return sel ? sel(merged) : merged
+  }
   useProjectStore.getState = () => state
-  const useActiveProject = () => state.projects.find((p) => p.id === state.activeProjectId)
+  const useActiveProject = () => withOverride().projects.find((p) => p.id === state.activeProjectId)
   return { useProjectStore, useActiveProject }
 })
 
@@ -439,6 +560,20 @@ beforeEach(() => {
   mockSetModel.mockResolvedValue(undefined)
   mockInstallRegistryBinary.mockResolvedValue({ command: 'opencode.exe', args: ['acp'] })
   mockInstallAcpAgent.mockResolvedValue({ command: 'opencode.exe', args: ['acp'] })
+  // Worktree-mode defaults: web context, no git repo, no worktree calls.
+  vi.mocked(isTauriContext).mockReturnValue(false)
+  mockProjectOverride.current = null
+  mockWorktreeCreate.mockReset()
+  mockWorktreeCopyInclude.mockReset()
+  mockWorktreeResolveBaseBranch.mockReset()
+  mockWorktreeCopyInclude.mockResolvedValue({
+    success: true,
+    data: { ran: 0, copied: 0, skipped: [] }
+  })
+  mockWorktreeResolveBaseBranch.mockResolvedValue({
+    success: true,
+    data: { defaultBase: 'feat/x', currentBranch: 'feat/x', isDetached: false }
+  })
 })
 
 describe('AgentLauncher ACP new thread', () => {
@@ -1305,5 +1440,199 @@ describe('AgentLauncher mobile empty-state overflow', () => {
     // Composer column + suggestion grid allow flex/grid children to shrink.
     expect(composerColumn.className).toContain('min-w-0')
     expect(suggestionGrid.className).toContain('min-w-0')
+  })
+})
+
+// ============================================================================
+// CAP-1/2/3/4 — Worktree-isolated agent chat
+// ============================================================================
+
+describe('AgentLauncher worktree isolation', () => {
+  function renderLauncher(): void {
+    render(
+      <TooltipProvider>
+        <MemoryRouter>
+          <AgentLauncher paneId="pane1" />
+        </MemoryRouter>
+      </TooltipProvider>
+    )
+  }
+
+  function enableDesktopGitRepo(branch = 'feat/x'): void {
+    vi.mocked(isTauriContext).mockReturnValue(true)
+    mockProjectOverride.current = { isGitRepo: true, gitBranch: branch }
+  }
+
+  beforeEach(() => {
+    enableDesktopGitRepo()
+    mockWorktreeCreate.mockReset()
+    // Default success: returns a worktree at /work/.termul/worktrees/{name}/
+    mockWorktreeCreate.mockResolvedValue({
+      success: true,
+      data: {
+        name: 'abcd1234',
+        branch: 'chat/abcd1234',
+        path: '/work/.termul/worktrees/abcd1234',
+        headCommit: ''
+      }
+    })
+    mockWorktreeCopyInclude.mockReset()
+    mockWorktreeCopyInclude.mockResolvedValue({
+      success: true,
+      data: { ran: 1, copied: 1, skipped: [] }
+    })
+    mockWorktreeResolveBaseBranch.mockReset()
+    // "Clean repo on feat/x, base auto" — no origin/HEAD, so the fallback
+    // chain resolves to the current branch (feat/x).
+    mockWorktreeResolveBaseBranch.mockResolvedValue({
+      success: true,
+      data: { defaultBase: 'feat/x', currentBranch: 'feat/x', isDetached: false }
+    })
+  })
+
+  // CAP-1: headline reads `What should we do in {project} on {branch}`
+  it('renders the project git branch in the headline (CAP-1)', () => {
+    renderLauncher()
+    expect(screen.getByRole('heading', { level: 1, name: /on feat\/x/i })).toBeInTheDocument()
+  })
+
+  it('renders "detached" in the headline when gitBranch is null (CAP-1)', () => {
+    mockProjectOverride.current = { isGitRepo: true, gitBranch: null }
+    renderLauncher()
+    expect(screen.getByRole('heading', { level: 1, name: /on detached/i })).toBeInTheDocument()
+  })
+
+  // CAP-2: selector hidden on web / non-repo
+  it('hides the isolation selector when not a git repo (CAP-2)', () => {
+    vi.mocked(isTauriContext).mockReturnValue(true)
+    mockProjectOverride.current = null // no isGitRepo
+    renderLauncher()
+    expect(screen.queryByRole('combobox', { name: 'Isolation mode' })).not.toBeInTheDocument()
+  })
+
+  it('hides the isolation selector on web (CAP-2)', () => {
+    vi.mocked(isTauriContext).mockReturnValue(false)
+    mockProjectOverride.current = { isGitRepo: true, gitBranch: 'feat/x' }
+    renderLauncher()
+    expect(screen.queryByRole('combobox', { name: 'Isolation mode' })).not.toBeInTheDocument()
+  })
+
+  /** Switch the isolation mode via the native `<select>` shim. */
+  function selectIsolationMode(label: string): void {
+    const select = screen.getByRole('combobox', { name: 'Isolation mode' }) as HTMLSelectElement
+    const option = Array.from(select.options).find((o) => o.textContent === label)
+    fireEvent.change(select, { target: { value: option?.value ?? 'worktree' } })
+  }
+
+  // CAP-3: launch in worktree mode calls worktreeApi.create once with chat/{id}
+  // then copyIncludeFiles, then threads cwd=worktreePath
+  it('creates a worktree, copies includes, and threads cwd=worktreePath on launch (CAP-3)', async () => {
+    renderLauncher()
+    selectIsolationMode('Worktree')
+    // Wait for base-branch resolution to settle
+    await waitFor(() => expect(mockWorktreeResolveBaseBranch).toHaveBeenCalled())
+
+    fireEvent.change(screen.getByLabelText('Agent prompt'), { target: { value: 'hi wt' } })
+    fireEvent.click(screen.getByLabelText('Start agent chat'))
+
+    await waitFor(() => expect(mockWorktreeCreate).toHaveBeenCalledTimes(1))
+    const createArgs = mockWorktreeCreate.mock.calls[0][0] as {
+      branch: string
+      isNewBranch: boolean
+      startRef: string
+    }
+    expect(createArgs.branch).toMatch(/^chat\/[a-f0-9]+$/)
+    expect(createArgs.isNewBranch).toBe(true)
+    expect(createArgs.startRef).toBe('feat/x')
+
+    // copyIncludeFiles ran after create
+    await waitFor(() => expect(mockWorktreeCopyInclude).toHaveBeenCalledTimes(1))
+    expect(mockWorktreeCopyInclude).toHaveBeenCalledWith('/work', expect.any(String))
+
+    // finalizeChatLaunch received cwd = the worktree path (not /work)
+    await waitFor(() => expect(mockFinalizeChatLaunch).toHaveBeenCalledTimes(1))
+    const finalizeArgs = mockFinalizeChatLaunch.mock.calls[0][0] as {
+      cwd: string
+      worktreePath?: string
+      worktreeBranch?: string
+    }
+    expect(finalizeArgs.cwd).toBe('/work/.termul/worktrees/abcd1234')
+    expect(finalizeArgs.worktreePath).toBe('/work/.termul/worktrees/abcd1234')
+    expect(finalizeArgs.worktreeBranch).toMatch(/^chat\/[a-f0-9]+$/)
+  })
+
+  // CAP-4: relaunch of a persisted-worktree session does NOT call worktreeApi.create
+  it('does not call worktreeApi.create when relaunching a persisted-worktree session (CAP-4)', async () => {
+    // The launcher's launch() only creates a worktree when isolationMode ===
+    // 'worktree'. On relaunch, openHistorySession carries the persisted
+    // worktreePath onto the live AcpSession, and the launcher is not involved
+    // (the chat tab opens directly). So the relevant invariant is: launch()
+    // with isolationMode === 'current' (default) never calls worktreeApi.create.
+    renderLauncher()
+    // Default mode is 'current' — confirm no worktree create on a normal launch.
+    fireEvent.change(screen.getByLabelText('Agent prompt'), { target: { value: 'hi' } })
+    fireEvent.click(screen.getByLabelText('Start agent chat'))
+
+    await waitFor(() => expect(mockFinalizeChatLaunch).toHaveBeenCalledTimes(1))
+    expect(mockWorktreeCreate).not.toHaveBeenCalled()
+    const finalizeArgs = mockFinalizeChatLaunch.mock.calls[0][0] as {
+      cwd: string
+      worktreePath?: string
+    }
+    expect(finalizeArgs.cwd).toBe('/work')
+    expect(finalizeArgs.worktreePath).toBeUndefined()
+  })
+
+  // CAP-3 collision: retry appends `-2` once
+  it('retries with a -2 suffix on a single WORKTREE_EXISTS collision (CAP-3)', async () => {
+    mockWorktreeCreate.mockReset()
+    mockWorktreeCreate
+      .mockResolvedValueOnce({ success: false, error: 'exists', code: 'WORKTREE_EXISTS' })
+      .mockResolvedValueOnce({
+        success: true,
+        data: {
+          name: 'abcd1234-2',
+          branch: 'chat/abcd1234-2',
+          path: '/work/.termul/worktrees/abcd1234-2',
+          headCommit: ''
+        }
+      })
+    renderLauncher()
+    selectIsolationMode('Worktree')
+    await waitFor(() => expect(mockWorktreeResolveBaseBranch).toHaveBeenCalled())
+
+    fireEvent.change(screen.getByLabelText('Agent prompt'), { target: { value: 'collide' } })
+    fireEvent.click(screen.getByLabelText('Start agent chat'))
+
+    await waitFor(() => expect(mockWorktreeCreate).toHaveBeenCalledTimes(2))
+    const firstBranch = (mockWorktreeCreate.mock.calls[0][0] as { branch: string }).branch
+    const retryBranch = (mockWorktreeCreate.mock.calls[1][0] as { branch: string }).branch
+    expect(retryBranch).toBe(`${firstBranch}-2`)
+
+    await waitFor(() => expect(mockFinalizeChatLaunch).toHaveBeenCalledTimes(1))
+    const finalizeArgs = mockFinalizeChatLaunch.mock.calls[0][0] as {
+      worktreePath: string
+      worktreeBranch: string
+    }
+    expect(finalizeArgs.worktreeBranch).toBe(`${firstBranch}-2`)
+  })
+
+  // CAP-2: detached HEAD blocks launch until a base is picked
+  it('disables launch on detached HEAD in worktree mode until a base is picked (CAP-2)', async () => {
+    mockWorktreeResolveBaseBranch.mockResolvedValue({
+      success: true,
+      data: { defaultBase: 'main', currentBranch: undefined, isDetached: true }
+    })
+    renderLauncher()
+    selectIsolationMode('Worktree')
+    // Wait for the base-branch resolution to settle so the detached-HEAD hint
+    // renders (the effect runs async after mode selection).
+    await waitFor(() => expect(mockWorktreeResolveBaseBranch).toHaveBeenCalled())
+
+    const sendButton = screen.getByLabelText('Start agent chat')
+    // No base picked + detached HEAD -> disabled
+    expect(sendButton).toBeDisabled()
+    // Hint is visible
+    expect(screen.getByText(/detached head/i)).toBeInTheDocument()
   })
 })

--- a/src/renderer/components/agents/AgentLauncher.tsx
+++ b/src/renderer/components/agents/AgentLauncher.tsx
@@ -142,6 +142,10 @@ export function AgentLauncher({ paneId, className }: AgentLauncherProps): React.
   const [isolationMode, setIsolationMode] = useState<'current' | 'worktree'>('current')
   const [baseBranch, setBaseBranch] = useState<string | null>(null)
   const [baseBranchInfo, setBaseBranchInfo] = useState<BaseBranchInfo | null>(null)
+  // Local branch names for the base-branch picker (CAP-2). Sourced from
+  // `worktreeApi.branches` so detached-HEAD users can pick any valid branch,
+  // not just the resolved default.
+  const [branches, setBranches] = useState<string[]>([])
   const [worktreeCreating, setWorktreeCreating] = useState(false)
   const { skills } = useAgentSkills(projectRoot)
   const supportedAgents = useResolvedSupportedAcpAgents(acpConfigs)
@@ -474,6 +478,14 @@ export function AgentLauncher({ paneId, className }: AgentLauncherProps): React.
             if (result.data!.isDetached) return null
             return result.data!.defaultBase
           })
+          // Fetch local branches so the picker lists every valid option
+          // (detached-HEAD users can pick any branch).
+          const branchResult = await worktreeApi.branches(projectRoot)
+          if (cancelled) return
+          if (branchResult.success && branchResult.data) {
+            const local = branchResult.data.filter((b) => !b.isRemote).map((b) => b.name)
+            setBranches(local)
+          }
         } else {
           void logFrontendError({
             level: 'warn',
@@ -777,22 +789,32 @@ export function AgentLauncher({ paneId, className }: AgentLauncherProps): React.
           launchCwd = worktreePathResult
           // CAP-5: carry over untracked files listed in `.worktree-include`.
           // Symlink/path-escape/already-present defenses run on the host.
-          const includeResult = await worktreeApi.copyIncludeFiles(
-            projectRootSnapshot,
-            worktreePathResult
-          )
-          if (!includeResult.success) {
+          // Best-effort: a copy failure must not orphan the freshly created
+          // worktree + branch — log and continue launching into it.
+          try {
+            const includeResult = await worktreeApi.copyIncludeFiles(
+              projectRootSnapshot,
+              worktreePathResult
+            )
+            if (!includeResult.success) {
+              void logFrontendError({
+                level: 'warn',
+                source: 'agentLauncher.worktreeInclude',
+                message: `copyIncludeFiles failed: ${includeResult.success ? '' : includeResult.error}`
+              })
+            } else if (includeResult.data) {
+              // Boundary log (info-level): not an error, so console.info is
+              // appropriate (logFrontendError is error/warn only).
+              console.info(
+                `[agentLauncher.worktreeInclude] carry-over ran=${includeResult.data.ran} copied=${includeResult.data.copied} skipped=${includeResult.data.skipped.length}`
+              )
+            }
+          } catch (includeErr) {
             void logFrontendError({
               level: 'warn',
               source: 'agentLauncher.worktreeInclude',
-              message: `copyIncludeFiles failed: ${includeResult.success ? '' : includeResult.error}`
+              message: `copyIncludeFiles threw: ${includeErr instanceof Error ? includeErr.message : String(includeErr)}`
             })
-          } else if (includeResult.data) {
-            // Boundary log (info-level): not an error, so console.info is
-            // appropriate (logFrontendError is error/warn only).
-            console.info(
-              `[agentLauncher.worktreeInclude] carry-over ran=${includeResult.data.ran} copied=${includeResult.data.copied} skipped=${includeResult.data.skipped.length}`
-            )
           }
         }
       } catch (err) {
@@ -964,9 +986,31 @@ export function AgentLauncher({ paneId, className }: AgentLauncherProps): React.
     Boolean(selectedConfig) &&
     selectedEntry?.status === 'ready' &&
     (prompt.trim().length > 0 || attachments.length > 0 || activeCommand !== null) &&
-    // CAP-2: detached HEAD blocks worktree launch until a base is picked.
-    !(isolationMode === 'worktree' && baseBranchInfo?.isDetached && !baseBranch) &&
+    // CAP-2: worktree mode requires an explicit base branch before launch —
+    // covers detached HEAD (no current) and any case where the picker has
+    // not settled on a value.
+    !(isolationMode === 'worktree' && !baseBranch) &&
     !worktreeCreating
+  // Deduplicated base-branch options for the picker (CAP-2): current branch
+  // first (marked), then the resolved default, the project's reactive branch,
+  // then every local branch from `worktreeApi.branches` so detached-HEAD
+  // users can pick any valid branch. Exact-equality dedup prevents repeated
+  // SelectItem values (projectGitBranch clashing with currentBranch, etc.).
+  const baseOptions: { value: string; label: string }[] = (() => {
+    const seen = new Set<string>()
+    const out: { value: string; label: string }[] = []
+    const add = (value: string | undefined | null, isCurrent = false) => {
+      if (!value) return
+      if (seen.has(value)) return
+      seen.add(value)
+      out.push({ value, label: isCurrent ? `${value} (current)` : value })
+    }
+    add(baseBranchInfo?.currentBranch, true)
+    add(baseBranchInfo?.defaultBase)
+    add(projectGitBranch)
+    for (const b of branches) add(b)
+    return out
+  })()
   // `hasSkillToken` comes from `useChatComposer` (destructured above) — the
   // transparent-textarea overlay is only needed when the value carries a skill
   // token; otherwise the textarea text stays visible.
@@ -981,7 +1025,9 @@ export function AgentLauncher({ paneId, className }: AgentLauncherProps): React.
       <div className="mb-8 flex w-full flex-col items-center gap-4 text-center">
         <TermulMark size={48} className="text-foreground" />
         <h1 className="break-words text-3xl font-medium tracking-tight text-foreground md:text-4xl">
-          {`What should we do in ${projectLabel} on ${projectGitBranch ?? 'detached'}?`}
+          {`What should we do in ${projectLabel} on ${
+            projectGitBranch ?? (projectIsGitRepo ? 'detached' : 'no branch')
+          }?`}
         </h1>
       </div>
 
@@ -1105,21 +1151,11 @@ export function AgentLauncher({ paneId, className }: AgentLauncherProps): React.
                       <SelectValue placeholder={baseBranchInfo?.defaultBase ?? 'base branch'} />
                     </SelectTrigger>
                     <SelectContent>
-                      {baseBranchInfo?.currentBranch && (
-                        <SelectItem value={baseBranchInfo.currentBranch}>
-                          {baseBranchInfo.currentBranch} (current)
+                      {baseOptions.map((opt) => (
+                        <SelectItem key={opt.value} value={opt.value}>
+                          {opt.label}
                         </SelectItem>
-                      )}
-                      {baseBranchInfo &&
-                        baseBranchInfo.currentBranch !== baseBranchInfo.defaultBase && (
-                          <SelectItem value={baseBranchInfo.defaultBase}>
-                            {baseBranchInfo.defaultBase}
-                          </SelectItem>
-                        )}
-                      {projectGitBranch &&
-                        !baseBranchInfo?.currentBranch?.includes(projectGitBranch) && (
-                          <SelectItem value={projectGitBranch}>{projectGitBranch}</SelectItem>
-                        )}
+                      ))}
                     </SelectContent>
                   </Select>
                 )}

--- a/src/renderer/components/agents/AgentLauncher.tsx
+++ b/src/renderer/components/agents/AgentLauncher.tsx
@@ -36,6 +36,13 @@ import { TermulMark } from '@/components/TermulMark'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue
+} from '@/components/ui/select'
 import { useAgentSkills } from '@/hooks/use-agent-skills'
 import { useMentionRecents } from '@/hooks/use-mention-recents'
 import { useResolvedSupportedAcpAgents } from '@/hooks/use-resolved-supported-acp-agents'
@@ -61,8 +68,11 @@ import {
 } from '@/lib/agents/supported-acp-agents'
 import { dialogApi, openerApi, persistenceApi } from '@/lib/api'
 import { registerSessionTempFiles } from '@/lib/attachment-temp-cleanup'
+import { logFrontendError } from '@/lib/log-api'
 import { platform as osPlatform } from '@/lib/tauri-os'
+import { isTauriContext } from '@/lib/tauri-runtime'
 import { cn } from '@/lib/utils'
+import { type BaseBranchInfo, worktreeApi } from '@/lib/worktree-api'
 import { getDefaultCwdForProject } from '@/lib/worktree-context'
 import {
   type AcpSession,
@@ -123,6 +133,16 @@ export function AgentLauncher({ paneId, className }: AgentLauncherProps): React.
   const activeProject = useActiveProject()
   const projectLabel = activeProject?.name ?? 'this folder'
   const projectRoot = activeProjectId ? getDefaultCwdForProject(activeProjectId) : undefined
+  const projectIsGitRepo = Boolean(activeProject?.isGitRepo)
+  const projectGitBranch = activeProject?.gitBranch ?? null
+  // CAP-2: isolation mode + base-branch picker. Worktree mode is desktop-only
+  // and requires a git repo; on web or non-repo projects the selector is
+  // hidden and `current` is forced.
+  const canUseWorktree = isTauriContext() && projectIsGitRepo
+  const [isolationMode, setIsolationMode] = useState<'current' | 'worktree'>('current')
+  const [baseBranch, setBaseBranch] = useState<string | null>(null)
+  const [baseBranchInfo, setBaseBranchInfo] = useState<BaseBranchInfo | null>(null)
+  const [worktreeCreating, setWorktreeCreating] = useState(false)
   const { skills } = useAgentSkills(projectRoot)
   const supportedAgents = useResolvedSupportedAcpAgents(acpConfigs)
 
@@ -434,6 +454,48 @@ export function AgentLauncher({ paneId, className }: AgentLauncherProps): React.
     }
   }, [persistSelection, selectedConfigId, supportedAgents])
 
+  // CAP-2: when worktree mode is selected on a desktop git project, resolve
+  // the origin-aware default base branch once so the picker can default to it.
+  // Detached HEAD is surfaced so the launcher can force a base pick.
+  useEffect(() => {
+    if (!canUseWorktree || isolationMode !== 'worktree' || !projectRoot) return
+    let cancelled = false
+    void (async () => {
+      try {
+        const result = await worktreeApi.resolveBaseBranch(projectRoot)
+        if (cancelled) return
+        if (result.success && result.data) {
+          setBaseBranchInfo(result.data)
+          // Default the picker to the resolved base only when the user has
+          // not yet picked AND the repo is NOT in detached HEAD. On detached
+          // HEAD the user must explicitly pick a base (CAP-2 constraint).
+          setBaseBranch((prev) => {
+            if (prev) return prev
+            if (result.data!.isDetached) return null
+            return result.data!.defaultBase
+          })
+        } else {
+          void logFrontendError({
+            level: 'warn',
+            source: 'agentLauncher.resolveBaseBranch',
+            message: `resolveBaseBranch failed: ${result.success ? '' : result.error}`
+          })
+        }
+      } catch (err) {
+        if (!cancelled) {
+          void logFrontendError({
+            level: 'warn',
+            source: 'agentLauncher.resolveBaseBranch',
+            message: `resolveBaseBranch threw: ${String(err)}`
+          })
+        }
+      }
+    })()
+    return () => {
+      cancelled = true
+    }
+  }, [canUseWorktree, isolationMode, projectRoot])
+
   useEffect(() => {
     if (!activeConfigId || !projectRoot || selectedEntry?.status !== 'ready' || !selectedConfig)
       return
@@ -650,10 +712,102 @@ export function AgentLauncher({ paneId, className }: AgentLauncherProps): React.
     }
     const { wireWithCommand, displayWithCommand } = parts
 
+    // CAP-3: when worktree mode is selected, create the isolated worktree
+    // BEFORE opening the chat placeholder so the agent's cwd is the worktree
+    // path from the first turn. Branch is `chat/{id}` (deterministic, id-scoped
+    // — collision-retry-friendly). Collision-retry appends `-2` once.
+    let worktreePath: string | undefined
+    let worktreeBranch: string | undefined
+    let launchCwd = projectRootSnapshot
+    if (isolationMode === 'worktree' && canUseWorktree) {
+      if (!baseBranch) {
+        toast.error('Pick a base branch for the worktree')
+        launchInFlightRef.current = false
+        return
+      }
+      setWorktreeCreating(true)
+      try {
+        const chatId = crypto.randomUUID().slice(0, 8)
+        const branchName = `chat/${chatId}`
+        const createResult = await worktreeApi.create({
+          projectPath: projectRootSnapshot,
+          name: chatId,
+          branch: branchName,
+          isNewBranch: true,
+          startRef: baseBranch
+        })
+        let worktreePathResult: string | null =
+          createResult.success && createResult.data ? createResult.data.path : null
+        let worktreeBranchResult: string = branchName
+        if (!worktreePathResult) {
+          const failCode = createResult.success ? 'UNKNOWN' : createResult.code
+          if (failCode === 'WORKTREE_EXISTS' || failCode === 'BRANCH_ALREADY_HAS_WORKTREE') {
+            // Collision-retry: append `-2` suffix once (stale state from a
+            // prior crashed run). Never deadlock — a second collision surfaces
+            // an error.
+            const retryId = `${chatId}-2`
+            const retryBranch = `${branchName}-2`
+            void logFrontendError({
+              level: 'warn',
+              source: 'agentLauncher.worktreeCreate',
+              message: `collision on ${branchName}, retrying as ${retryBranch}`
+            })
+            const retryResult = await worktreeApi.create({
+              projectPath: projectRootSnapshot,
+              name: retryId,
+              branch: retryBranch,
+              isNewBranch: true,
+              startRef: baseBranch
+            })
+            if (retryResult.success && retryResult.data) {
+              worktreePathResult = retryResult.data.path
+              worktreeBranchResult = retryBranch
+            } else {
+              const retryErr = retryResult.success ? 'unknown' : retryResult.error
+              throw new Error(`Worktree creation failed: ${retryErr}`)
+            }
+          } else {
+            const createErr = createResult.success ? 'unknown' : createResult.error
+            throw new Error(`Worktree creation failed: ${createErr}`)
+          }
+        }
+        if (worktreePathResult) {
+          worktreePath = worktreePathResult
+          worktreeBranch = worktreeBranchResult
+          launchCwd = worktreePathResult
+          // CAP-5: carry over untracked files listed in `.worktree-include`.
+          // Symlink/path-escape/already-present defenses run on the host.
+          const includeResult = await worktreeApi.copyIncludeFiles(
+            projectRootSnapshot,
+            worktreePathResult
+          )
+          if (!includeResult.success) {
+            void logFrontendError({
+              level: 'warn',
+              source: 'agentLauncher.worktreeInclude',
+              message: `copyIncludeFiles failed: ${includeResult.success ? '' : includeResult.error}`
+            })
+          } else if (includeResult.data) {
+            // Boundary log (info-level): not an error, so console.info is
+            // appropriate (logFrontendError is error/warn only).
+            console.info(
+              `[agentLauncher.worktreeInclude] carry-over ran=${includeResult.data.ran} copied=${includeResult.data.copied} skipped=${includeResult.data.skipped.length}`
+            )
+          }
+        }
+      } catch (err) {
+        setWorktreeCreating(false)
+        toast.error(err instanceof Error ? err.message : 'Failed to create worktree')
+        launchInFlightRef.current = false
+        return
+      }
+      setWorktreeCreating(false)
+    }
+
     // Open the chat immediately; ACP spawn/session/send continue in the chat view.
     const store = useAcpStore.getState()
     let sessionId =
-      preparedKeySnapshot != null
+      preparedKeySnapshot != null && isolationMode !== 'worktree'
         ? store.claimPreparedChat(preparedKeySnapshot, projectIdSnapshot)
         : null
     let usedPlaceholder = false
@@ -673,12 +827,14 @@ export function AgentLauncher({ paneId, className }: AgentLauncherProps): React.
 
     if (!sessionId) {
       sessionId = store.createLaunchPlaceholder({
-        cwd: projectRootSnapshot,
+        cwd: launchCwd,
         projectId: projectIdSnapshot,
         models: modelsSnapshot,
         modes: modesSnapshot,
         configOptions: configOptionsSnapshot,
-        initialUserBlocks: syncBlocks.length > 0 ? syncBlocks : undefined
+        initialUserBlocks: syncBlocks.length > 0 ? syncBlocks : undefined,
+        worktreePath,
+        worktreeBranch
       })
       usedPlaceholder = true
       seededOptimistic = syncBlocks.length > 0
@@ -720,7 +876,7 @@ export function AgentLauncher({ paneId, className }: AgentLauncherProps): React.
           realId = await liveStore.finalizeChatLaunch({
             placeholderId: sessionId,
             configId: configSnapshot.id,
-            cwd: projectRootSnapshot,
+            cwd: launchCwd,
             projectId: projectIdSnapshot,
             mcpServers: undefined,
             pending: hasPendingLauncherOptions(pendingSnapshot) ? pendingSnapshot : null,
@@ -728,7 +884,9 @@ export function AgentLauncher({ paneId, className }: AgentLauncherProps): React.
             initialBlocks: blocks.length > 0 ? blocks : null,
             adoptSession: (from, to) => {
               useWorkspaceStore.getState().remapAgentChatSession(from, to, paneSnapshot)
-            }
+            },
+            worktreePath,
+            worktreeBranch
           })
         } else {
           await liveStore.applyPendingLauncherOptions(
@@ -770,7 +928,10 @@ export function AgentLauncher({ paneId, className }: AgentLauncherProps): React.
     effectiveConfigOptions,
     buildPromptParts,
     skillPathsRef,
-    setActiveCommand
+    setActiveCommand,
+    isolationMode,
+    canUseWorktree,
+    baseBranch
   ])
 
   const handleKeyDown = useCallback(
@@ -802,7 +963,10 @@ export function AgentLauncher({ paneId, className }: AgentLauncherProps): React.
   const canLaunch =
     Boolean(selectedConfig) &&
     selectedEntry?.status === 'ready' &&
-    (prompt.trim().length > 0 || attachments.length > 0 || activeCommand !== null)
+    (prompt.trim().length > 0 || attachments.length > 0 || activeCommand !== null) &&
+    // CAP-2: detached HEAD blocks worktree launch until a base is picked.
+    !(isolationMode === 'worktree' && baseBranchInfo?.isDetached && !baseBranch) &&
+    !worktreeCreating
   // `hasSkillToken` comes from `useChatComposer` (destructured above) — the
   // transparent-textarea overlay is only needed when the value carries a skill
   // token; otherwise the textarea text stays visible.
@@ -817,7 +981,7 @@ export function AgentLauncher({ paneId, className }: AgentLauncherProps): React.
       <div className="mb-8 flex w-full flex-col items-center gap-4 text-center">
         <TermulMark size={48} className="text-foreground" />
         <h1 className="break-words text-3xl font-medium tracking-tight text-foreground md:text-4xl">
-          {`What should we do in ${projectLabel}?`}
+          {`What should we do in ${projectLabel} on ${projectGitBranch ?? 'detached'}?`}
         </h1>
       </div>
 
@@ -908,6 +1072,64 @@ export function AgentLauncher({ paneId, className }: AgentLauncherProps): React.
               onRemove={removeAttachment}
               className="px-5 pt-4"
             />
+            {canUseWorktree && (
+              <div className="flex items-center gap-2 px-5 pb-1 pt-3 text-xs text-muted-foreground">
+                <Select
+                  value={isolationMode}
+                  onValueChange={(value) =>
+                    value === 'current' || value === 'worktree'
+                      ? setIsolationMode(value)
+                      : undefined
+                  }
+                >
+                  <SelectTrigger
+                    aria-label="Isolation mode"
+                    className="h-7 w-[140px] gap-1 px-2 text-xs"
+                  >
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="current">Current branch</SelectItem>
+                    <SelectItem value="worktree">Worktree</SelectItem>
+                  </SelectContent>
+                </Select>
+                {isolationMode === 'worktree' && (
+                  <Select
+                    value={baseBranch ?? undefined}
+                    onValueChange={(value) => setBaseBranch(value)}
+                  >
+                    <SelectTrigger
+                      aria-label="Worktree base branch"
+                      className="h-7 w-[180px] gap-1 px-2 text-xs"
+                    >
+                      <SelectValue placeholder={baseBranchInfo?.defaultBase ?? 'base branch'} />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {baseBranchInfo?.currentBranch && (
+                        <SelectItem value={baseBranchInfo.currentBranch}>
+                          {baseBranchInfo.currentBranch} (current)
+                        </SelectItem>
+                      )}
+                      {baseBranchInfo &&
+                        baseBranchInfo.currentBranch !== baseBranchInfo.defaultBase && (
+                          <SelectItem value={baseBranchInfo.defaultBase}>
+                            {baseBranchInfo.defaultBase}
+                          </SelectItem>
+                        )}
+                      {projectGitBranch &&
+                        !baseBranchInfo?.currentBranch?.includes(projectGitBranch) && (
+                          <SelectItem value={projectGitBranch}>{projectGitBranch}</SelectItem>
+                        )}
+                    </SelectContent>
+                  </Select>
+                )}
+                {isolationMode === 'worktree' && baseBranchInfo?.isDetached && !baseBranch && (
+                  <span className="text-destructive">
+                    Detached HEAD — pick a base branch to launch
+                  </span>
+                )}
+              </div>
+            )}
             <div className="px-5 pb-2 pt-4">
               {/* Transparent-textarea overlay: mirrors the value with inline
                   SkillChip pills. The textarea text is transparent with a

--- a/src/renderer/components/chat/ChatInputBar.tsx
+++ b/src/renderer/components/chat/ChatInputBar.tsx
@@ -18,6 +18,7 @@ import { registerSessionTempFiles } from '@/lib/attachment-temp-cleanup'
 import { cn } from '@/lib/utils'
 import type { AcpSession, QueuedPrompt } from '@/stores/acp-store'
 import { useAcpMessages, useAcpStore, useAgentIdentity, useSessionUsage } from '@/stores/acp-store'
+import { useProjectStore } from '@/stores/project-store'
 import { AgentGlyph } from './AgentGlyph'
 import { ConfigChip, ModeChip } from './AgentHeader'
 import { AttachFilesButton } from './AttachFilesButton'
@@ -120,6 +121,17 @@ export function ChatInputBar({
 }: ChatInputBarProps): React.JSX.Element {
   const usableConfigOptions = configOptions.filter((o) => o.options.length > 0)
   const hasConfigOptions = usableConfigOptions.length > 0
+  // CAP-6: worktree/branch indicator. Worktree mode shows the session's
+  // worktree path + branch; current-branch mode falls back to the project's
+  // reactive `gitBranch`. Switching chats re-renders via `session`.
+  const projectGitBranch = useProjectStore(
+    (s) =>
+      s.projects.find((p) => p.id === session.projectId)?.gitBranch ?? (session.cwd ? null : null)
+  )
+  const isolationLabel =
+    session.worktreePath && session.worktreeBranch
+      ? `${session.worktreePath} · ${session.worktreeBranch}`
+      : (session.worktreeBranch ?? projectGitBranch ?? null)
   const {
     model,
     thoughtLevel,
@@ -779,10 +791,17 @@ export function ChatInputBar({
         </ComposerBeamShell>
         <div
           className={cn(
-            'flex items-center px-1 pt-1.5 text-3xs text-muted-foreground transition-opacity duration-150',
+            'flex items-center justify-between gap-2 px-1 pt-1.5 text-3xs text-muted-foreground transition-opacity duration-150',
             focused ? 'opacity-100' : 'opacity-0'
           )}
         >
+          {isolationLabel ? (
+            <span className="truncate" title={isolationLabel}>
+              {isolationLabel}
+            </span>
+          ) : (
+            <span />
+          )}
           {showStop ? (
             <>
               <KbdHint k="Esc" /> to stop

--- a/src/renderer/components/chat/ChatInputBar.tsx
+++ b/src/renderer/components/chat/ChatInputBar.tsx
@@ -125,8 +125,7 @@ export function ChatInputBar({
   // worktree path + branch; current-branch mode falls back to the project's
   // reactive `gitBranch`. Switching chats re-renders via `session`.
   const projectGitBranch = useProjectStore(
-    (s) =>
-      s.projects.find((p) => p.id === session.projectId)?.gitBranch ?? (session.cwd ? null : null)
+    (s) => s.projects.find((p) => p.id === session.projectId)?.gitBranch ?? null
   )
   const isolationLabel =
     session.worktreePath && session.worktreeBranch

--- a/src/renderer/layouts/WorkspaceLayout.test.tsx
+++ b/src/renderer/layouts/WorkspaceLayout.test.tsx
@@ -883,7 +883,9 @@ describe('WorkspaceLayout - Empty States', () => {
 
       renderWithRouter()
 
-      await waitFor(() => expect(backendShortcut).toBeDefined())
+      // The onShortcut subscription registers in a layout effect; under
+      // full-suite contention this can slip past the default 1s waitFor.
+      await waitFor(() => expect(backendShortcut).toBeDefined(), { timeout: 5000 })
       act(() => backendShortcut?.('colorThemePicker'))
       // ThemePicker is React.lazy — allow extra time for the chunk to resolve
       // under full-suite resource contention (passes instantly in isolation).
@@ -1182,9 +1184,12 @@ describe('WorkspaceLayout - Empty States', () => {
 
         renderWithRouter()
 
-        await waitFor(() => {
-          expect(mockApi.filesystem.watchDirectory).toHaveBeenCalledWith('/workspace/a')
-        })
+        await waitFor(
+          () => {
+            expect(mockApi.filesystem.watchDirectory).toHaveBeenCalledWith('/workspace/a')
+          },
+          { timeout: 5000 }
+        )
 
         // Give the async project-switch effect a tick to settle.
         await new Promise((resolve) => setTimeout(resolve, 10))

--- a/src/renderer/lib/acp-api.ts
+++ b/src/renderer/lib/acp-api.ts
@@ -565,7 +565,13 @@ export async function acpNewSession(
   agentId: AgentId,
   cwd: string,
   mcpServers?: McpServer[],
-  options?: { ephemeral?: boolean; projectId?: string }
+  options?: {
+    ephemeral?: boolean
+    projectId?: string
+    /** Worktree path + branch (CAP-3) — persisted for the indicator + fallback. */
+    worktreePath?: string
+    worktreeBranch?: string
+  }
 ): Promise<NewSessionOutcome> {
   return getAcpTransport().newSession(agentId, cwd, mcpServers, options)
 }

--- a/src/renderer/lib/acp-history-persistence.ts
+++ b/src/renderer/lib/acp-history-persistence.ts
@@ -34,6 +34,13 @@ export interface SessionIndexEntry {
    */
   lastSeq?: number
   status: SessionStatus
+  /**
+   * Worktree path + branch the agent runs in (CAP-3). Additive: absent on
+   * pre-feature sessions. Powers the CAP-6 indicator + the deleted-worktree
+   * fallback; state isolation still keys on `cwd`.
+   */
+  worktreePath?: string
+  worktreeBranch?: string
 }
 
 export interface SessionPayload {
@@ -217,7 +224,9 @@ export function toPersistedSessionSummaries(
     messageCount: entry.messageCount,
     toolCount: 0,
     lastSeq: entry.lastSeq ?? 0,
-    resumeEligible: Boolean(entry.agentConfigId || entry.agentId)
+    resumeEligible: Boolean(entry.agentConfigId || entry.agentId),
+    worktreePath: entry.worktreePath,
+    worktreeBranch: entry.worktreeBranch
   }))
 }
 
@@ -288,7 +297,9 @@ export async function loadSessionIndex(): Promise<SessionIndexEntry[]> {
       lastActivityAt: entry.lastActivityAt,
       messageCount: entry.messageCount,
       lastSeq: entry.lastSeq,
-      status: entry.status
+      status: entry.status,
+      worktreePath: entry.worktreePath,
+      worktreeBranch: entry.worktreeBranch
     }))
   }
   if (mode === 'live_only') return []

--- a/src/renderer/lib/acp-transport.ts
+++ b/src/renderer/lib/acp-transport.ts
@@ -118,7 +118,13 @@ export interface AcpTransport {
     agentId: AgentId,
     cwd: string,
     mcpServers?: McpServer[],
-    options?: { ephemeral?: boolean; projectId?: string }
+    options?: {
+      ephemeral?: boolean
+      projectId?: string
+      /** Worktree path + branch (CAP-3) — desktop-only; ignored on the WS path. */
+      worktreePath?: string
+      worktreeBranch?: string
+    }
   ): Promise<NewSessionOutcome>
   loadSession(agentId: AgentId, sessionId: SessionId, cwd: string): Promise<SessionReopenOutcome>
   resumeSession(agentId: AgentId, sessionId: SessionId, cwd: string): Promise<SessionReopenOutcome>
@@ -247,7 +253,9 @@ function createTauriAcpTransport(): AcpTransport {
         cwd,
         mcpServers,
         ...(options?.ephemeral ? { ephemeral: true } : {}),
-        ...(options?.projectId ? { projectId: options.projectId } : {})
+        ...(options?.projectId ? { projectId: options.projectId } : {}),
+        ...(options?.worktreePath ? { worktreePath: options.worktreePath } : {}),
+        ...(options?.worktreeBranch ? { worktreeBranch: options.worktreeBranch } : {})
       }),
     loadSession: (agentId, sessionId, cwd) =>
       invoke<SessionReopenOutcome>('acp_load_session', { agentId, sessionId, cwd }),
@@ -775,10 +783,17 @@ export class WsAcpTransport implements AcpTransport {
     agentId: AgentId,
     cwd: string,
     mcpServers?: McpServer[],
-    options?: { ephemeral?: boolean; projectId?: string }
+    options?: {
+      ephemeral?: boolean
+      projectId?: string
+      worktreePath?: string
+      worktreeBranch?: string
+    }
   ): Promise<NewSessionOutcome> {
     // Web/remote: the host attributes the session to a project by resolving
     // `cwd` against its registry (CAP-2), so no explicit projectId is sent.
+    // Worktree fields are desktop-only (CAP-3) and ignored on the WS path —
+    // the host-owned durable record keys state isolation on `cwd` regardless.
     const outcome = await this.request<NewSessionOutcome>('create_session', {
       agentId,
       cwd,

--- a/src/renderer/lib/worktree-api.ts
+++ b/src/renderer/lib/worktree-api.ts
@@ -34,6 +34,33 @@ export interface MergePreviewInfo {
 }
 
 /**
+ * Origin-aware default base branch + detached-HEAD guard (CAP-2). The launcher
+ * uses `defaultBase` as the initial base-branch picker value; `isDetached`
+ * forces an explicit pick before a worktree launch.
+ */
+export interface BaseBranchInfo {
+  defaultBase: string
+  currentBranch?: string
+  isDetached: boolean
+}
+
+/**
+ * Result of `.worktree-include` carry-over (CAP-5). `ran` is the number of
+ * patterns that matched at least one file; `copied` is files actually copied;
+ * `skipped` carries per-file reasons (symlink / path-escape / already-present).
+ */
+export interface IncludeSkipReason {
+  path: string
+  reason: string
+}
+
+export interface IncludeCopyResult {
+  ran: number
+  copied: number
+  skipped: IncludeSkipReason[]
+}
+
+/**
  * Invoke a worktree Tauri command, returning the `IpcResult<T>` shape callers
  * expect. On web/remote mode (`!isTauriContext()`), returns an explicit
  * `WEB_UNSUPPORTED` result instead of letting the stubbed `invoke()` reject
@@ -176,5 +203,27 @@ export const worktreeApi = {
    * Execute a merge from the worktree's current branch to target_branch.
    */
   mergeExecute: (worktreePath: string, targetBranch: string): Promise<IpcResult<string>> =>
-    worktreeInvoke<string>('worktree_merge_execute', { worktreePath, targetBranch })
+    worktreeInvoke<string>('worktree_merge_execute', { worktreePath, targetBranch }),
+
+  /**
+   * Resolve the default base branch for a new chat worktree (CAP-2). Returns
+   * the origin/HEAD default with a `main`/`master`/current fallback chain and
+   * a detached-HEAD flag so the launcher can force a base pick.
+   */
+  resolveBaseBranch: (projectPath: string): Promise<IpcResult<BaseBranchInfo>> =>
+    worktreeInvoke<BaseBranchInfo>('worktree_resolve_base_branch', { projectPath }),
+
+  /**
+   * Carry over untracked files listed in `.worktree-include` into a fresh
+   * worktree (CAP-5). Symlink/path-escape/already-present defenses run per
+   * file; the result reports `ran`/`copied`/`skipped` with per-file reasons.
+   */
+  copyIncludeFiles: (
+    projectPath: string,
+    worktreePath: string
+  ): Promise<IpcResult<IncludeCopyResult>> =>
+    worktreeInvoke<IncludeCopyResult>('worktree_copy_include_files', {
+      projectPath,
+      worktreePath
+    })
 }

--- a/src/renderer/stores/acp-store.ts
+++ b/src/renderer/stores/acp-store.ts
@@ -202,6 +202,14 @@ export interface AcpSession {
    * Absent/null means no replay is in flight.
    */
   replaying?: 'pending' | 'streaming' | null
+  /**
+   * Worktree path + branch the agent runs in (CAP-3). Additive: absent on
+   * current-branch-mode sessions. When set, the chat indicator (CAP-6) shows
+   * `{worktreePath} · {worktreeBranch}`; relaunch reattaches to the stored
+   * path (no second `git worktree add`). State isolation still keys on `cwd`.
+   */
+  worktreePath?: string
+  worktreeBranch?: string
 }
 
 export interface PendingPermission {
@@ -371,7 +379,13 @@ interface AcpState {
     cwd: string,
     mcpServers: McpServer[] | undefined,
     projectId: string,
-    opts?: { ephemeral?: boolean; backendEphemeral?: boolean }
+    opts?: {
+      ephemeral?: boolean
+      backendEphemeral?: boolean
+      /** Worktree path + branch (CAP-3) — persisted onto the durable record. */
+      worktreePath?: string
+      worktreeBranch?: string
+    }
   ) => Promise<SessionId>
   closeSession: (sessionId: SessionId) => Promise<void>
   setActiveSession: (sessionId: SessionId | null) => void
@@ -409,7 +423,8 @@ interface AcpState {
     configId: string,
     cwd: string,
     mcpServers: McpServer[] | undefined,
-    projectId: string
+    projectId: string,
+    opts?: { worktreePath?: string; worktreeBranch?: string }
   ) => Promise<SessionId>
   /**
    * Take ownership of a prepared session so launcher unmount cleanup cannot
@@ -429,6 +444,9 @@ interface AcpState {
     configOptions?: SessionConfigOption[]
     /** Optimistic first-turn content so the chat looks like a normal send. */
     initialUserBlocks?: ContentBlock[]
+    /** Worktree path + branch (CAP-3) — painted on the placeholder immediately. */
+    worktreePath?: string
+    worktreeBranch?: string
   }) => SessionId
   /** Drop a launch placeholder that will not be remapped (e.g. after fatal error). */
   discardLaunchPlaceholder: (sessionId: SessionId) => void
@@ -455,6 +473,12 @@ interface AcpState {
     initialBlocks?: ContentBlock[] | null
     /** Remap the workspace tab as soon as the real session exists (before send). */
     adoptSession?: (fromSessionId: SessionId, toSessionId: SessionId) => void
+    /**
+     * Worktree path + branch (CAP-3). When set, the durable record carries
+     * them (CAP-4 relaunch + CAP-6 indicator) and `cwd` is the worktree path.
+     */
+    worktreePath?: string
+    worktreeBranch?: string
   }) => Promise<SessionId>
   /** Apply launcher pending model/mode/config selections to a live session. */
   applyPendingLauncherOptions: (
@@ -1145,7 +1169,9 @@ function persistSession(
       (max, m) => Math.max(max, typeof m.seq === 'number' ? m.seq : 0),
       0
     ),
-    status: session.status
+    status: session.status,
+    worktreePath: session.worktreePath,
+    worktreeBranch: session.worktreeBranch
   }
   const nextIndex = [entry, ...state.sessionIndex.filter((e) => e.id !== sessionId)]
   setIndex(nextIndex)
@@ -1926,7 +1952,9 @@ async function openHistorySessionInner(
         configOptions: existingControls?.configOptions ?? [],
         lastError: null,
         createdAt: meta.createdAt,
-        replaying: null
+        replaying: null,
+        worktreePath: meta.worktreePath,
+        worktreeBranch: meta.worktreeBranch
       }
     },
     messages: { ...s.messages, [id]: trimLiveWindow(payload.messages, id) },
@@ -2579,7 +2607,9 @@ export const useAcpStore = create<AcpState>((set, get) => ({
       }
       const outcome = await acpApi.newSession(agentId, cwd, sessionMcpServers, {
         ephemeral: opts?.backendEphemeral ?? false,
-        ...(projectId ? { projectId } : {})
+        ...(projectId ? { projectId } : {}),
+        ...(opts?.worktreePath ? { worktreePath: opts.worktreePath } : {}),
+        ...(opts?.worktreeBranch ? { worktreeBranch: opts.worktreeBranch } : {})
       })
       const sessionId = outcome.sessionId
       invalidateSessionReopen(sessionId)
@@ -2605,7 +2635,9 @@ export const useAcpStore = create<AcpState>((set, get) => ({
               configOptions: outcome.configOptions ?? existing?.configOptions ?? [],
               lastError: existing?.lastError ?? null,
               createdAt: existing?.createdAt ?? Date.now(),
-              replaying: null
+              replaying: null,
+              worktreePath: opts?.worktreePath ?? existing?.worktreePath,
+              worktreeBranch: opts?.worktreeBranch ?? existing?.worktreeBranch
             }
           },
           messages: { ...s.messages, [sessionId]: s.messages[sessionId] ?? [] },
@@ -3039,7 +3071,7 @@ export const useAcpStore = create<AcpState>((set, get) => ({
     }
   },
 
-  startChat: async (configId, cwd, mcpServers, projectId) => {
+  startChat: async (configId, cwd, mcpServers, projectId, opts) => {
     const trimmedCwd = cwd.trim()
     const config = get().agentConfigs.find((c) => c.id === configId)
     if (!config) throw new Error(`unknown agent config ${configId}`)
@@ -3063,7 +3095,7 @@ export const useAcpStore = create<AcpState>((set, get) => ({
     }
     const agentId = await ensureLiveAgent(get, set, configId, trimmedCwd)
     if (!agentId) throw new Error(`failed to spawn agent for config ${configId}`)
-    return get().createSession(agentId, trimmedCwd, mcpServers, projectId)
+    return get().createSession(agentId, trimmedCwd, mcpServers, projectId, opts)
   },
 
   claimPreparedChat: (key, projectId) => {
@@ -3079,7 +3111,9 @@ export const useAcpStore = create<AcpState>((set, get) => ({
     models,
     modes,
     configOptions,
-    initialUserBlocks
+    initialUserBlocks,
+    worktreePath,
+    worktreeBranch
   }) => {
     const sessionId = newId('launch')
     const blocks = initialUserBlocks ?? []
@@ -3112,7 +3146,9 @@ export const useAcpStore = create<AcpState>((set, get) => ({
           configOptions: configOptions ?? [],
           lastError: null,
           createdAt: Date.now(),
-          replaying: null
+          replaying: null,
+          worktreePath,
+          worktreeBranch
         }
       },
       messages: {
@@ -3230,10 +3266,15 @@ export const useAcpStore = create<AcpState>((set, get) => ({
     pending,
     initialText,
     initialBlocks,
-    adoptSession
+    adoptSession,
+    worktreePath,
+    worktreeBranch
   }) => {
     try {
-      const sessionId = await get().startChat(configId, cwd, mcpServers, projectId)
+      const sessionId = await get().startChat(configId, cwd, mcpServers, projectId, {
+        worktreePath,
+        worktreeBranch
+      })
 
       // Move optimistic UI onto the real session, then remap the tab before send
       // so the user stays on one chat (never a blank disconnected placeholder).
@@ -3260,7 +3301,9 @@ export const useAcpStore = create<AcpState>((set, get) => ({
               configOptions:
                 real.configOptions.length > 0
                   ? real.configOptions
-                  : (placeholder.configOptions ?? [])
+                  : (placeholder.configOptions ?? []),
+              worktreePath: real.worktreePath ?? placeholder.worktreePath,
+              worktreeBranch: real.worktreeBranch ?? placeholder.worktreeBranch
             }
           }
           delete sessions[placeholderId]
@@ -3588,6 +3631,8 @@ export const useAcpStore = create<AcpState>((set, get) => ({
           configOptions: [],
           lastError: null,
           createdAt: meta.createdAt,
+          worktreePath: meta.worktreePath,
+          worktreeBranch: meta.worktreeBranch,
           // 'streaming' (not null): the session stays 'closed' until resume
           // resolves, but gap-replay chunks arriving during the
           // `acpApi.resumeSession` window (web subscribe-from-watermark) must

--- a/src/shared/types/web-protocol.types.ts
+++ b/src/shared/types/web-protocol.types.ts
@@ -282,6 +282,13 @@ export interface PersistedSessionSummary {
   toolCount: number
   lastSeq: number
   resumeEligible: boolean
+  /**
+   * Worktree path the agent runs in (CAP-3). Additive: absent on pre-feature
+   * sessions. Used by the CAP-6 indicator + the deleted-worktree fallback.
+   * State isolation still keys on `cwd`; this field is for display only.
+   */
+  worktreePath?: string
+  worktreeBranch?: string
 }
 
 export interface UserPromptEvent {


### PR DESCRIPTION
## Summary

Termul's ACP agent launcher today runs each chat against the developer's current working tree, so an in-flight chat's file edits collide with the developer's own in-flight work on the same branch — chat edits corrupt the dev branch and a half-finished agent turn blocks committing unrelated work.

This wires the existing `WorktreeManager`, `worktree_create` command, `worktree-api.ts` facade, `AgentLauncher`, and `acp_new_session` so a new chat can launch into a freshly-created git worktree (branch `chat/{id}`), keeping the developer's current branch clean while the chat runs. Multiple chats run in parallel in distinct worktrees; relaunching an existing chat reuses its bound worktree.

Implements the SPEC at `_bmad-output/specs/spec-worktree-isolated-agent-chat/SPEC.md` (capabilities CAP-1 through CAP-6).

## Related Issue

No related issue — this implements the spec-authored worktree-isolated agent chat feature (deep-recon teardown of seven competitor codebases found six of seven already isolate agent/task work in a git worktree).

## Type of Change

- [x] feat: new feature

## What Changed

- **CAP-1** — Launcher headline shows the current branch: `What should we do in {project} on {branch}` (detached HEAD -> `detached`).
- **CAP-2** — Isolation selector (`current` | `worktree`) + base-branch picker on the launcher. Worktree option gated on `isTauriContext()` + git repo. Detached HEAD forces a base-branch pick (launch disabled until picked).
- **CAP-3** — On new-chat launch in worktree mode: `worktreeApi.create` (branch `chat/{id}`, base from CAP-2), collision-retry with `-2` suffix once, then `copyIncludeFiles`, then the worktree path passed as the ACP `cwd` (which already isolates warm pool, agent process, and prepared session via the cwd-keyed reuse keys — no keying change).
- **CAP-4** — Relaunch reattaches to the persisted worktree path as `cwd`; no second `git worktree add` (relaunch paths never call worktree-create). Additive optional `worktreePath`/`worktreeBranch` on the session record (backward-compatible; old records deserialize with `None`).
- **CAP-5** — `.worktree-include` pattern-file carry-over (bb pattern) with symlink/path-escape/already-present defenses (`COPYFILE_EXCL`, `isInside` realpath check, mkdir parent inside worktree only).
- **CAP-6** — Worktree/branch indicator below the chatbox (worktree mode shows path + branch; current mode shows the branch). Desktop + web (web falls back to reactive `project.gitBranch`).

New Rust surface: `WorktreeManager::resolve_default_base_branch` (origin/HEAD -> main -> master -> current fallback + detached-HEAD flag) and `WorktreeManager::copy_worktree_include_files`, exposed via `worktree_resolve_base_branch` + `worktree_copy_include_files` commands.

## How It Was Tested

- [x] `bun run ci` (Biome lint + format + imports, strict mode)
- [x] `bun run typecheck`
- [x] `bun run test`
- [x] `cargo clippy --all-targets -- -D warnings` (in src-tauri)
- [ ] `cargo test` (in src-tauri) — compiles + clippy pass; the test binary cannot launch on the dev Windows host (STATUS_ENTRYPOINT_NOT_FOUND native-DLL issue), so Rust unit tests run in CI
- [x] Manual verification completed

## CI & Review Gate

- [x] All CI checks pass (PR Validation, Rust Checks, Build Verification, Security Scans)
- [ ] Code review comments from CodeRabbit / Claude have been addressed or resolved
- [ ] No unresolved review findings remain

## Checklist

- [x] My PR title follows the conventional commit format used by this repo
- [x] I linked the related issue or explained why none exists
- [x] I updated docs when needed
- [x] I added or updated tests when needed
- [x] I verified the change does not introduce unrelated modifications
- [x] I read AGENTS.md and followed the contributor guidelines
- [ ] A human reviewed the complete diff before submission

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added optional Git worktree isolation when launching desktop agent chats.
  - Users can select a base branch, create isolated worktrees, and view the active branch or worktree in chat.
  - Added automatic copying of configured included files with safety checks and skip reporting.
  - Added detached-branch handling and collision recovery for worktree creation.

- **Improvements**
  - Worktree details now persist across session history and restoration.
  - Updated the Harn ACP agent to version 0.10.70.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->