### PR TITLE
fix(acp): include worktree fields in session-creation initializers

### DIFF
--- a/src-tauri/src/acp/manager.rs
+++ b/src-tauri/src/acp/manager.rs
@@ -1376,6 +1376,7 @@ impl AcpManager {
                 SessionCreationContext {
                     project_id: None,
                     ephemeral: true,
+                    ..Default::default()
                 },
             )
             .await;
@@ -4359,6 +4360,7 @@ mod tests {
                 runtime_agent_id: Some("runtime-1".to_string()),
                 project_id: Some("p-1".to_string()),
                 cwd: cwd.clone(),
+                ..Default::default()
             })
             .await
             .unwrap();


### PR DESCRIPTION
## Summary

`dev` does not compile. `bun run build:tauri` and `cargo clippy --all-targets` fail with `error[E0063]: missing fields worktree_branch and worktree_path in initializer of SessionCreationContext` at `src-tauri/src/acp/manager.rs:1376`.

Root cause: #590 (background title generation) added two new struct initializations — the ephemeral background title-gen session at `manager.rs:1376` and its test at `manager.rs:4357` — but did not include the `worktree_path`/`worktree_branch` fields that #591 (git worktree isolation) had already added to `SessionCreationContext` and `SessionRegistration`. Result: any build of `dev` fails at E0063.

## Related Issue

No issue exists. This is a build-break discovered when running `bun run build:tauri` on current `dev` (f05f6808).

## Type of Change

- [x] fix: bug fix

## What Changed

`src-tauri/src/acp/manager.rs` — added `..Default::default()` to two struct initializers that were missing the worktree fields:

1. `SessionCreationContext` in `maybe_generate_background_title` (line 1376) — the ephemeral background title-gen session has no worktree association, so `None` is correct.
2. `SessionRegistration` in the `maybe_generate_background_title_falls_back_on_spawn_failure` test (line 4357).

Both use the `..Default::default()` pattern already established at `web/ws.rs:1687`, `web/ws.rs:2063`, `session_persistence.rs:1260`, and `history_import.rs:160`. Both structs derive `Default`.

## How It Was Tested

- [x] `cargo clippy --all-targets -- -D warnings` (in src-tauri) — passes
- [x] `cargo check --lib` — passes (this is the target `build:tauri` needs)
- [ ] `cargo test` (in src-tauri) — test binary compiles (`cargo test --lib --no-run` succeeds) but local launch fails with `STATUS_ENTRYPOINT_NOT_FOUND` (0xc0000139), a pre-existing Windows WebView2 DLL loader issue unrelated to this 2-line compile fix. Verified by stashing the fix: without it, `dev` does not compile at all (2x E0063); the runtime DLL error was simply masked behind the compile error. CI runs on GitHub Actions with the proper WebView2 environment.

## CI & Review Gate

- [ ] All CI checks pass (PR Validation, Rust Checks, Build Verification, Security Scans)
- [ ] Code review comments from CodeRabbit / Claude have been addressed or resolved
- [ ] No unresolved review findings remain

## Checklist

- [x] My PR title follows the conventional commit format used by this repo
- [x] I linked the related issue or explained why none exists
- [x] I updated docs when needed (N/A — no docs describe these internal initializers)
- [x] I added or updated tests when needed (the existing test at line 4357 is updated to compile)
- [x] I verified the change does not introduce unrelated modifications
- [x] I read AGENTS.md and followed the contributor guidelines
- [ ] A human reviewed the complete diff before submission

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test and background-session setup reliability by applying default values to unspecified configuration fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->