### PR TITLE
feat(chat): refine composer workspace controls

### DIFF
--- a/src/renderer/assets/agent-icons/acp/agents.json
+++ b/src/renderer/assets/agent-icons/acp/agents.json
@@ -308,11 +308,11 @@
   {
     "id": "dimcode",
     "name": "DimCode",
-    "version": "0.3.8",
+    "version": "0.3.9",
     "description": "A coding agent that puts leading models at your command.",
     "distribution": {
       "npx": {
-        "package": "dimcode@0.3.8",
+        "package": "dimcode@0.3.9",
         "args": ["acp"]
       }
     }
@@ -438,33 +438,33 @@
   {
     "id": "harn",
     "name": "Harn",
-    "version": "0.10.70",
+    "version": "0.10.71",
     "description": "Harn runs .harn agent pipelines as a native ACP coding agent over stdio.",
     "distribution": {
       "binary": {
         "darwin-aarch64": {
           "cmd": "./harn",
-          "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.70/harn-aarch64-apple-darwin.tar.gz",
+          "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.71/harn-aarch64-apple-darwin.tar.gz",
           "args": ["serve", "acp"]
         },
         "darwin-x86_64": {
           "cmd": "./harn",
-          "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.70/harn-x86_64-apple-darwin.tar.gz",
+          "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.71/harn-x86_64-apple-darwin.tar.gz",
           "args": ["serve", "acp"]
         },
         "linux-aarch64": {
           "cmd": "./harn",
-          "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.70/harn-aarch64-unknown-linux-gnu.tar.gz",
+          "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.71/harn-aarch64-unknown-linux-gnu.tar.gz",
           "args": ["serve", "acp"]
         },
         "linux-x86_64": {
           "cmd": "./harn",
-          "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.70/harn-x86_64-unknown-linux-gnu.tar.gz",
+          "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.71/harn-x86_64-unknown-linux-gnu.tar.gz",
           "args": ["serve", "acp"]
         },
         "windows-x86_64": {
           "cmd": "harn.exe",
-          "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.70/harn-x86_64-pc-windows-msvc.zip",
+          "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.71/harn-x86_64-pc-windows-msvc.zip",
           "args": ["serve", "acp"]
         }
       }

--- a/src/renderer/components/agents/AgentLauncher.test.tsx
+++ b/src/renderer/components/agents/AgentLauncher.test.tsx
@@ -1502,6 +1502,14 @@ describe('AgentLauncher worktree isolation', () => {
       }
     )
     await screen.findByRole('option', { name: /feat\/x/ })
+
+    for (const name of ['Isolation mode', 'Base branch']) {
+      expect(screen.getByRole('combobox', { name })).toHaveClass(
+        'focus-visible:ring-2',
+        'focus-visible:ring-ring',
+        'focus-visible:ring-offset-2'
+      )
+    }
   })
 
   it('renders worktree controls in a separate context strip below the composer', () => {

--- a/src/renderer/components/agents/AgentLauncher.test.tsx
+++ b/src/renderer/components/agents/AgentLauncher.test.tsx
@@ -1412,8 +1412,8 @@ describe('AgentLauncher mobile empty-state overflow', () => {
     renderLauncher()
 
     // The hero <h1> is the stable entry point (role + level). From it we walk
-    // the rendered tree to the hero div, launcher root, composer column, and
-    // suggestion grid — jsdom preserves the className strings exactly.
+    // the rendered tree to the hero div, launcher root, and composer column —
+    // jsdom preserves the className strings exactly.
     const heading = screen.getByRole('heading', {
       level: 1,
       name: /what should we do in/i
@@ -1427,8 +1427,6 @@ describe('AgentLauncher mobile empty-state overflow', () => {
     const composerColumn = Array.from(launcherRoot.children).find(
       (el) => el !== hero && el.tagName === 'DIV'
     )!
-    // Suggestion grid is the grid child inside the composer column.
-    const suggestionGrid = composerColumn.querySelector('div.grid')!
 
     // Launcher root: `overflow-x-hidden` backstop + responsive padding.
     expect(launcherRoot.className).toContain('overflow-x-hidden')
@@ -1437,9 +1435,8 @@ describe('AgentLauncher mobile empty-state overflow', () => {
     // Hero div spans the content box; heading wraps instead of forcing width.
     expect(hero.className).toContain('w-full')
     expect(heading.className).toContain('break-words')
-    // Composer column + suggestion grid allow flex/grid children to shrink.
+    // Composer column allows flex children to shrink.
     expect(composerColumn.className).toContain('min-w-0')
-    expect(suggestionGrid.className).toContain('min-w-0')
   })
 })
 
@@ -1490,16 +1487,40 @@ describe('AgentLauncher worktree isolation', () => {
     })
   })
 
-  // CAP-1: headline reads `What should we do in {project} on {branch}`
-  it('renders the project git branch in the headline (CAP-1)', () => {
+  // CAP-1: the launcher surfaces an isolation-mode selector for git repos;
+  // the project branch appears as a worktree base option.
+  it('surfaces the project git branch as a worktree base option (CAP-1)', async () => {
     renderLauncher()
-    expect(screen.getByRole('heading', { level: 1, name: /on feat\/x/i })).toBeInTheDocument()
+    expect(
+      screen.getByRole('heading', { level: 1, name: /what should we do in/i })
+    ).toBeInTheDocument()
+    expect(screen.getByRole('combobox', { name: 'Isolation mode' })).toBeInTheDocument()
+    fireEvent.change(
+      screen.getByRole('combobox', { name: 'Isolation mode' }) as HTMLSelectElement,
+      {
+        target: { value: 'worktree' }
+      }
+    )
+    await screen.findByRole('option', { name: /feat\/x/ })
   })
 
-  it('renders "detached" in the headline when gitBranch is null (CAP-1)', () => {
+  it('renders worktree controls in a separate context strip below the composer', () => {
+    renderLauncher()
+    const composer = document.querySelector('[data-agent-launcher-composer="true"]')
+    const contextStrip = document.querySelector('[data-agent-launcher-context-strip="true"]')
+
+    expect(composer).toBeInTheDocument()
+    expect(contextStrip).toBeInTheDocument()
+    expect(composer).not.toContainElement(contextStrip)
+    expect(composer?.compareDocumentPosition(contextStrip as Node)).toBe(
+      Node.DOCUMENT_POSITION_FOLLOWING
+    )
+  })
+
+  it('shows the isolation selector when gitBranch is null (CAP-1)', () => {
     mockProjectOverride.current = { isGitRepo: true, gitBranch: null }
     renderLauncher()
-    expect(screen.getByRole('heading', { level: 1, name: /on detached/i })).toBeInTheDocument()
+    expect(screen.getByRole('combobox', { name: 'Isolation mode' })).toBeInTheDocument()
   })
 
   // CAP-2: selector hidden on web / non-repo
@@ -1507,6 +1528,7 @@ describe('AgentLauncher worktree isolation', () => {
     vi.mocked(isTauriContext).mockReturnValue(true)
     mockProjectOverride.current = null // no isGitRepo
     renderLauncher()
+    expect(screen.queryByRole('combobox', { name: 'Base branch' })).not.toBeInTheDocument()
     expect(screen.queryByRole('combobox', { name: 'Isolation mode' })).not.toBeInTheDocument()
   })
 
@@ -1514,23 +1536,29 @@ describe('AgentLauncher worktree isolation', () => {
     vi.mocked(isTauriContext).mockReturnValue(false)
     mockProjectOverride.current = { isGitRepo: true, gitBranch: 'feat/x' }
     renderLauncher()
+    expect(screen.queryByRole('combobox', { name: 'Base branch' })).not.toBeInTheDocument()
     expect(screen.queryByRole('combobox', { name: 'Isolation mode' })).not.toBeInTheDocument()
   })
 
-  /** Switch the isolation mode via the native `<select>` shim. */
-  function selectIsolationMode(label: string): void {
-    const select = screen.getByRole('combobox', { name: 'Isolation mode' }) as HTMLSelectElement
-    const option = Array.from(select.options).find((o) => o.textContent === label)
-    fireEvent.change(select, { target: { value: option?.value ?? 'worktree' } })
+  /**
+   * Switch to New worktree mode via the isolation-mode selector, then pick the
+   * base branch from the context-strip selector via the native `<select>` shim.
+   * Waits for the branch option to populate from the async base-branch
+   * resolution.
+   */
+  async function chooseWorktreeBaseBranch(branch: string): Promise<void> {
+    const mode = screen.getByRole('combobox', { name: 'Isolation mode' }) as HTMLSelectElement
+    fireEvent.change(mode, { target: { value: 'worktree' } })
+    await screen.findByRole('option', { name: new RegExp(branch) })
+    const base = screen.getByRole('combobox', { name: 'Base branch' }) as HTMLSelectElement
+    fireEvent.change(base, { target: { value: branch } })
   }
 
   // CAP-3: launch in worktree mode calls worktreeApi.create once with chat/{id}
   // then copyIncludeFiles, then threads cwd=worktreePath
   it('creates a worktree, copies includes, and threads cwd=worktreePath on launch (CAP-3)', async () => {
     renderLauncher()
-    selectIsolationMode('Worktree')
-    // Wait for base-branch resolution to settle
-    await waitFor(() => expect(mockWorktreeResolveBaseBranch).toHaveBeenCalled())
+    await chooseWorktreeBaseBranch('feat/x')
 
     fireEvent.change(screen.getByLabelText('Agent prompt'), { target: { value: 'hi wt' } })
     fireEvent.click(screen.getByLabelText('Start agent chat'))
@@ -1598,8 +1626,7 @@ describe('AgentLauncher worktree isolation', () => {
         }
       })
     renderLauncher()
-    selectIsolationMode('Worktree')
-    await waitFor(() => expect(mockWorktreeResolveBaseBranch).toHaveBeenCalled())
+    await chooseWorktreeBaseBranch('feat/x')
 
     fireEvent.change(screen.getByLabelText('Agent prompt'), { target: { value: 'collide' } })
     fireEvent.click(screen.getByLabelText('Start agent chat'))
@@ -1617,22 +1644,36 @@ describe('AgentLauncher worktree isolation', () => {
     expect(finalizeArgs.worktreeBranch).toBe(`${firstBranch}-2`)
   })
 
-  // CAP-2: detached HEAD blocks launch until a base is picked
-  it('disables launch on detached HEAD in worktree mode until a base is picked (CAP-2)', async () => {
+  // CAP-2: on detached HEAD, worktree mode blocks launch until a base branch
+  // is picked from the context-strip selector.
+  it('blocks worktree launch on detached HEAD until a base branch is picked (CAP-2)', async () => {
     mockWorktreeResolveBaseBranch.mockResolvedValue({
       success: true,
       data: { defaultBase: 'main', currentBranch: undefined, isDetached: true }
     })
     renderLauncher()
-    selectIsolationMode('Worktree')
+    fireEvent.change(
+      screen.getByRole('combobox', { name: 'Isolation mode' }) as HTMLSelectElement,
+      {
+        target: { value: 'worktree' }
+      }
+    )
     // Wait for the base-branch resolution to settle so the detached-HEAD hint
     // renders (the effect runs async after mode selection).
-    await waitFor(() => expect(mockWorktreeResolveBaseBranch).toHaveBeenCalled())
-
-    const sendButton = screen.getByLabelText('Start agent chat')
+    await waitFor(() => expect(screen.getByText(/detached head/i)).toBeInTheDocument())
     // No base picked + detached HEAD -> disabled
-    expect(sendButton).toBeDisabled()
-    // Hint is visible
-    expect(screen.getByText(/detached head/i)).toBeInTheDocument()
+    expect(screen.getByLabelText('Start agent chat')).toBeDisabled()
+
+    // Picking a base branch unblocks the worktree launch off that ref.
+    await screen.findByRole('option', { name: /main/ })
+    const select = screen.getByRole('combobox', { name: 'Base branch' }) as HTMLSelectElement
+    fireEvent.change(select, { target: { value: 'main' } })
+
+    fireEvent.change(screen.getByLabelText('Agent prompt'), { target: { value: 'hi' } })
+    fireEvent.click(screen.getByLabelText('Start agent chat'))
+
+    await waitFor(() => expect(mockWorktreeCreate).toHaveBeenCalledTimes(1))
+    const createArgs = mockWorktreeCreate.mock.calls[0][0] as { startRef: string }
+    expect(createArgs.startRef).toBe('main')
   })
 })

--- a/src/renderer/components/agents/AgentLauncher.tsx
+++ b/src/renderer/components/agents/AgentLauncher.tsx
@@ -1282,7 +1282,7 @@ export function AgentLauncher({ paneId, className }: AgentLauncherProps): React.
               >
                 <SelectTrigger
                   aria-label="Isolation mode"
-                  className="h-7 min-h-7 w-auto shrink-0 gap-1.5 border-0 bg-transparent px-2.5 py-0 text-xs font-medium text-muted-foreground/70 hover:bg-accent/40 hover:text-foreground/80 focus:outline-none focus:ring-0 focus:ring-offset-0 data-[state=open]:bg-accent/40 [&>svg]:h-3.5 [&>svg]:w-3.5 [&>svg]:opacity-70"
+                  className="h-7 min-h-7 w-auto shrink-0 gap-1.5 border-0 bg-transparent px-2.5 py-0 text-xs font-medium text-muted-foreground/70 hover:bg-accent/40 hover:text-foreground/80 focus:outline-none focus:ring-0 focus:ring-offset-0 focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 data-[state=open]:bg-accent/40 [&>svg]:h-3.5 [&>svg]:w-3.5 [&>svg]:opacity-70"
                 >
                   {isolationMode === 'worktree' ? (
                     <FolderGit2 className="size-3.5 shrink-0" />
@@ -1307,7 +1307,7 @@ export function AgentLauncher({ paneId, className }: AgentLauncherProps): React.
                   <Select value={baseBranch ?? ''} onValueChange={(value) => setBaseBranch(value)}>
                     <SelectTrigger
                       aria-label="Base branch"
-                      className="h-7 min-h-7 w-auto min-w-0 gap-1.5 border-0 bg-transparent px-2.5 py-0 text-xs font-medium text-muted-foreground/70 hover:bg-accent/40 hover:text-foreground/80 focus:outline-none focus:ring-0 focus:ring-offset-0 data-[state=open]:bg-accent/40 [&>span]:truncate [&>svg]:h-3.5 [&>svg]:w-3.5 [&>svg]:opacity-70"
+                      className="h-7 min-h-7 w-auto min-w-0 gap-1.5 border-0 bg-transparent px-2.5 py-0 text-xs font-medium text-muted-foreground/70 hover:bg-accent/40 hover:text-foreground/80 focus:outline-none focus:ring-0 focus:ring-offset-0 focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 data-[state=open]:bg-accent/40 [&>span]:truncate [&>svg]:h-3.5 [&>svg]:w-3.5 [&>svg]:opacity-70"
                     >
                       <GitBranch className="size-3.5 shrink-0" />
                       <SelectValue placeholder="Base branch" />

--- a/src/renderer/components/agents/AgentLauncher.tsx
+++ b/src/renderer/components/agents/AgentLauncher.tsx
@@ -1,6 +1,15 @@
 import type { LastSelectedAgent } from '@shared/types/persistence.types'
 import { PersistenceKeys } from '@shared/types/persistence.types'
-import { ArrowUp, Check, Download, FolderOpen, Loader2 } from 'lucide-react'
+import {
+  ArrowUp,
+  Check,
+  Download,
+  Folder,
+  FolderGit2,
+  FolderOpen,
+  GitBranch,
+  Loader2
+} from 'lucide-react'
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { toast } from 'sonner'
 import {
@@ -458,11 +467,11 @@ export function AgentLauncher({ paneId, className }: AgentLauncherProps): React.
     }
   }, [persistSelection, selectedConfigId, supportedAgents])
 
-  // CAP-2: when worktree mode is selected on a desktop git project, resolve
-  // the origin-aware default base branch once so the picker can default to it.
-  // Detached HEAD is surfaced so the launcher can force a base pick.
+  // CAP-2: resolve the origin-aware default base branch and local branch list
+  // once per desktop git project so the context-strip picker is ready when the
+  // user switches to worktree mode.
   useEffect(() => {
-    if (!canUseWorktree || isolationMode !== 'worktree' || !projectRoot) return
+    if (!canUseWorktree || !projectRoot) return
     let cancelled = false
     void (async () => {
       try {
@@ -470,14 +479,6 @@ export function AgentLauncher({ paneId, className }: AgentLauncherProps): React.
         if (cancelled) return
         if (result.success && result.data) {
           setBaseBranchInfo(result.data)
-          // Default the picker to the resolved base only when the user has
-          // not yet picked AND the repo is NOT in detached HEAD. On detached
-          // HEAD the user must explicitly pick a base (CAP-2 constraint).
-          setBaseBranch((prev) => {
-            if (prev) return prev
-            if (result.data!.isDetached) return null
-            return result.data!.defaultBase
-          })
           // Fetch local branches so the picker lists every valid option
           // (detached-HEAD users can pick any branch).
           const branchResult = await worktreeApi.branches(projectRoot)
@@ -506,7 +507,15 @@ export function AgentLauncher({ paneId, className }: AgentLauncherProps): React.
     return () => {
       cancelled = true
     }
-  }, [canUseWorktree, isolationMode, projectRoot])
+  }, [canUseWorktree, projectRoot])
+
+  // CAP-2: entering worktree mode defaults the picker to the resolved base
+  // branch. Detached HEAD skips the auto-fill so the user must pick.
+  useEffect(() => {
+    if (isolationMode !== 'worktree' || baseBranch || !baseBranchInfo || baseBranchInfo.isDetached)
+      return
+    setBaseBranch(baseBranchInfo.defaultBase)
+  }, [isolationMode, baseBranch, baseBranchInfo])
 
   useEffect(() => {
     if (!activeConfigId || !projectRoot || selectedEntry?.status !== 'ready' || !selectedConfig)
@@ -1007,7 +1016,7 @@ export function AgentLauncher({ paneId, className }: AgentLauncherProps): React.
     }
     add(baseBranchInfo?.currentBranch, true)
     add(baseBranchInfo?.defaultBase)
-    add(projectGitBranch)
+    add(projectGitBranch, true)
     for (const b of branches) add(b)
     return out
   })()
@@ -1025,9 +1034,7 @@ export function AgentLauncher({ paneId, className }: AgentLauncherProps): React.
       <div className="mb-8 flex w-full flex-col items-center gap-4 text-center">
         <TermulMark size={48} className="text-foreground" />
         <h1 className="break-words text-3xl font-medium tracking-tight text-foreground md:text-4xl">
-          {`What should we do in ${projectLabel} on ${
-            projectGitBranch ?? (projectIsGitRepo ? 'detached' : 'no branch')
-          }?`}
+          {`What should we do in ${projectLabel}?`}
         </h1>
       </div>
 
@@ -1052,7 +1059,8 @@ export function AgentLauncher({ paneId, className }: AgentLauncherProps): React.
           )}
           {/* biome-ignore lint/a11y/noStaticElementInteractions: drop zone for attachments; the file picker button is the accessible path */}
           <div
-            className="rounded-2xl border border-border/60 bg-card transition-colors focus-within:border-border"
+            data-agent-launcher-composer="true"
+            className="relative z-10 rounded-2xl border border-border/60 bg-card transition-colors focus-within:border-border"
             onDragOver={canDropPaste ? (e) => e.preventDefault() : undefined}
             onDrop={
               canDropPaste
@@ -1118,54 +1126,6 @@ export function AgentLauncher({ paneId, className }: AgentLauncherProps): React.
               onRemove={removeAttachment}
               className="px-5 pt-4"
             />
-            {canUseWorktree && (
-              <div className="flex items-center gap-2 px-5 pb-1 pt-3 text-xs text-muted-foreground">
-                <Select
-                  value={isolationMode}
-                  onValueChange={(value) =>
-                    value === 'current' || value === 'worktree'
-                      ? setIsolationMode(value)
-                      : undefined
-                  }
-                >
-                  <SelectTrigger
-                    aria-label="Isolation mode"
-                    className="h-7 w-[140px] gap-1 px-2 text-xs"
-                  >
-                    <SelectValue />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="current">Current branch</SelectItem>
-                    <SelectItem value="worktree">Worktree</SelectItem>
-                  </SelectContent>
-                </Select>
-                {isolationMode === 'worktree' && (
-                  <Select
-                    value={baseBranch ?? undefined}
-                    onValueChange={(value) => setBaseBranch(value)}
-                  >
-                    <SelectTrigger
-                      aria-label="Worktree base branch"
-                      className="h-7 w-[180px] gap-1 px-2 text-xs"
-                    >
-                      <SelectValue placeholder={baseBranchInfo?.defaultBase ?? 'base branch'} />
-                    </SelectTrigger>
-                    <SelectContent>
-                      {baseOptions.map((opt) => (
-                        <SelectItem key={opt.value} value={opt.value}>
-                          {opt.label}
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
-                )}
-                {isolationMode === 'worktree' && baseBranchInfo?.isDetached && !baseBranch && (
-                  <span className="text-destructive">
-                    Detached HEAD — pick a base branch to launch
-                  </span>
-                )}
-              </div>
-            )}
             <div className="px-5 pb-2 pt-4">
               {/* Transparent-textarea overlay: mirrors the value with inline
                   SkillChip pills. The textarea text is transparent with a
@@ -1231,6 +1191,7 @@ export function AgentLauncher({ paneId, className }: AgentLauncherProps): React.
                   onLoadTools={(id) => {
                     void loadMcpTools(id)
                   }}
+                  compact
                 />
               </div>
               <div className="flex min-w-0 flex-wrap items-center justify-end gap-2.5">
@@ -1308,27 +1269,61 @@ export function AgentLauncher({ paneId, className }: AgentLauncherProps): React.
               </div>
             </div>
           </div>
-        </div>
-
-        <div className="grid min-w-0 gap-2 md:grid-cols-3">
-          {SUGGESTIONS.map((suggestion) => (
-            <button
-              key={suggestion.title}
-              type="button"
-              onClick={() => {
-                setPrompt(suggestion.prompt)
-                setActiveCommand(null)
-                updateMentions(suggestion.prompt, suggestion.prompt.length)
-                textareaRef.current?.focus()
-              }}
-              className="rounded-2xl border border-border bg-card/60 px-4 py-3 text-left transition-colors hover:bg-muted/45"
+          {canUseWorktree && (
+            <div
+              data-agent-launcher-context-strip="true"
+              className="relative z-0 mx-auto -mt-4 flex w-[calc(100%-2.75rem)] min-w-0 items-center justify-between gap-2 rounded-b-2xl border border-t-0 border-border/60 bg-card/60 px-2 pb-1 pt-5"
             >
-              <div className="text-sm font-medium text-foreground">{suggestion.title}</div>
-              <div className="mt-1 text-xs leading-relaxed text-muted-foreground">
-                {suggestion.description}
-              </div>
-            </button>
-          ))}
+              <Select
+                value={isolationMode}
+                onValueChange={(value) =>
+                  value === 'current' || value === 'worktree' ? setIsolationMode(value) : undefined
+                }
+              >
+                <SelectTrigger
+                  aria-label="Isolation mode"
+                  className="h-7 min-h-7 w-auto shrink-0 gap-1.5 border-0 bg-transparent px-2.5 py-0 text-xs font-medium text-muted-foreground/70 hover:bg-accent/40 hover:text-foreground/80 focus:outline-none focus:ring-0 focus:ring-offset-0 data-[state=open]:bg-accent/40 [&>svg]:h-3.5 [&>svg]:w-3.5 [&>svg]:opacity-70"
+                >
+                  {isolationMode === 'worktree' ? (
+                    <FolderGit2 className="size-3.5 shrink-0" />
+                  ) : (
+                    <Folder className="size-3.5 shrink-0" />
+                  )}
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="current">Local</SelectItem>
+                  <SelectItem value="worktree">New worktree</SelectItem>
+                </SelectContent>
+              </Select>
+
+              {isolationMode === 'worktree' && (
+                <div className="flex min-w-0 items-center justify-end gap-2">
+                  {!baseBranch && baseBranchInfo?.isDetached && (
+                    <span className="truncate text-xs text-destructive">
+                      Detached HEAD - pick a base
+                    </span>
+                  )}
+                  <Select value={baseBranch ?? ''} onValueChange={(value) => setBaseBranch(value)}>
+                    <SelectTrigger
+                      aria-label="Base branch"
+                      className="h-7 min-h-7 w-auto min-w-0 gap-1.5 border-0 bg-transparent px-2.5 py-0 text-xs font-medium text-muted-foreground/70 hover:bg-accent/40 hover:text-foreground/80 focus:outline-none focus:ring-0 focus:ring-offset-0 data-[state=open]:bg-accent/40 [&>span]:truncate [&>svg]:h-3.5 [&>svg]:w-3.5 [&>svg]:opacity-70"
+                    >
+                      <GitBranch className="size-3.5 shrink-0" />
+                      <SelectValue placeholder="Base branch" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {baseOptions.map((opt) => (
+                        <SelectItem key={opt.value} value={opt.value}>
+                          {opt.label}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+              )}
+            </div>
+          )}
         </div>
       </div>
     </div>
@@ -1851,21 +1846,3 @@ const EntryGlyph = memo(function EntryGlyph({
     </span>
   )
 })
-
-const SUGGESTIONS = [
-  {
-    title: 'Find the next best task',
-    description: 'Look across the recent project work and current repo state.',
-    prompt: 'Find the next best task for this project.'
-  },
-  {
-    title: 'Do a focused quality pass',
-    description: 'Audit this project for the most likely rough edge from recent work.',
-    prompt: 'Do a focused quality pass on this project.'
-  },
-  {
-    title: 'Prepare a project handoff',
-    description: 'Summarize what matters in this project right now.',
-    prompt: 'Prepare a clean project handoff.'
-  }
-] as const

--- a/src/renderer/components/chat/ChatInputBar.test.tsx
+++ b/src/renderer/components/chat/ChatInputBar.test.tsx
@@ -186,6 +186,28 @@ describe('ChatInputBar config controls', () => {
     vi.clearAllMocks()
   })
 
+  it('renders worktree context below the composer without keyboard helper text', () => {
+    renderInputBar({
+      session: {
+        ...session(),
+        cwd: '/work/.termul/worktrees/abcd1234',
+        worktreePath: '/work/.termul/worktrees/abcd1234',
+        worktreeBranch: 'chat/abcd1234'
+      }
+    })
+
+    const composer = document.querySelector('[data-chat-composer="true"]')
+    const contextStrip = document.querySelector('[data-chat-composer-context-strip="true"]')
+
+    expect(composer).toBeInTheDocument()
+    expect(contextStrip).toBeInTheDocument()
+    expect(composer).not.toContainElement(contextStrip)
+    expect(screen.getByText('New worktree')).toBeInTheDocument()
+    expect(screen.getByText('chat/abcd1234')).toBeInTheDocument()
+    expect(screen.queryByText(/Shift\+Enter/i)).not.toBeInTheDocument()
+    expect(screen.queryByText(/to send|to queue|newline/i)).not.toBeInTheDocument()
+  })
+
   it('uses model config and native Agent/mode picker without duplicate Agent chips', async () => {
     const s = session()
     const configOptions = [
@@ -327,10 +349,10 @@ describe('ChatInputBar MCP badge (Story 1.8)', () => {
     mockMcpCount.current = 0
   })
 
-  it('hides the MCP badge when no MCP servers are configured', () => {
+  it('hides the compact MCP icon when no MCP servers are configured', () => {
     mockMcpCount.current = 0
     renderInputBar()
-    // The badge returns null at count 0 — no "MCP servers attached" text.
+    expect(screen.queryByRole('img', { name: /MCP servers/i })).not.toBeInTheDocument()
     expect(screen.queryByText(/MCP servers attached/i)).not.toBeInTheDocument()
   })
 

--- a/src/renderer/components/chat/ChatInputBar.tsx
+++ b/src/renderer/components/chat/ChatInputBar.tsx
@@ -1,6 +1,6 @@
 import { BorderBeam } from 'border-beam'
 import { AnimatePresence, motion, useReducedMotion } from 'framer-motion'
-import { ArrowUp, Paperclip, Square } from 'lucide-react'
+import { ArrowUp, Folder, FolderGit2, GitBranch, Paperclip, Square } from 'lucide-react'
 import { type DragEvent, type KeyboardEvent, useCallback, useEffect, useRef, useState } from 'react'
 import { toast } from 'sonner'
 import { useAgentSkills } from '@/hooks/use-agent-skills'
@@ -121,16 +121,26 @@ export function ChatInputBar({
 }: ChatInputBarProps): React.JSX.Element {
   const usableConfigOptions = configOptions.filter((o) => o.options.length > 0)
   const hasConfigOptions = usableConfigOptions.length > 0
-  // CAP-6: worktree/branch indicator. Worktree mode shows the session's
-  // worktree path + branch; current-branch mode falls back to the project's
-  // reactive `gitBranch`. Switching chats re-renders via `session`.
+  // CAP-6: worktree/branch indicator. Short by design: `{branch} · {mode}`
+  // (worktree chats show their `chat/*` branch, not the long worktree path —
+  // the path stays on the hover tooltip). Current-branch mode falls back to
+  // the project's reactive `gitBranch`. Switching chats re-renders via
+  // `session`.
   const projectGitBranch = useProjectStore(
     (s) => s.projects.find((p) => p.id === session.projectId)?.gitBranch ?? null
   )
   const isolationLabel =
     session.worktreePath && session.worktreeBranch
-      ? `${session.worktreePath} · ${session.worktreeBranch}`
-      : (session.worktreeBranch ?? projectGitBranch ?? null)
+      ? `${session.worktreeBranch} · New worktree`
+      : projectGitBranch
+        ? `${projectGitBranch} · Local`
+        : (session.worktreeBranch ?? null)
+  const isolationModeLabel = session.worktreePath ? 'New worktree' : 'Local'
+  const isolationBranch = session.worktreeBranch ?? projectGitBranch
+  const isolationTitle =
+    isolationLabel && session.worktreePath
+      ? `${isolationLabel} — ${session.worktreePath}`
+      : isolationLabel
   const {
     model,
     thoughtLevel,
@@ -238,7 +248,6 @@ export function ChatInputBar({
     }
   }, [draftKey, seedNonce, canPersistDraft])
   const [sending, setSending] = useState(false)
-  const [focused, setFocused] = useState(false)
   const [dragActive, setDragActive] = useState(false)
   const dragDepth = useRef(0)
   const reduced = useReducedMotion() ?? false
@@ -559,6 +568,7 @@ export function ChatInputBar({
       onLoadTools={(id) => {
         void loadMcpTools(id)
       }}
+      compact
     />
   )
 
@@ -596,6 +606,7 @@ export function ChatInputBar({
         <ComposerBeamShell busy={busy} reduced={reduced}>
           {/* biome-ignore lint/a11y/noStaticElementInteractions: drop zone for attachments; the file picker button is the accessible path */}
           <div
+            data-chat-composer="true"
             className={cn(
               'relative rounded-2xl border border-border/60 bg-card transition-[border-color,box-shadow]',
               'focus-within:border-border focus-within:ring-2 focus-within:ring-inset focus-within:ring-ring',
@@ -643,13 +654,6 @@ export function ChatInputBar({
                   // let layout settle. Guarded against focus-loop thrash (the OSK
                   // can re-focus the textarea as it animates; only the first
                   // focus per OSK-open window triggers the scroll).
-                  onFocus={() => {
-                    setFocused(true)
-                    // OSK-open scroll is handled by the `osk.isOskOpen`
-                    // transition effect above (the OSK state can lag the focus
-                    // event, so reading it here was unreliable).
-                  }}
-                  onBlur={() => setFocused(false)}
                   // Story 5.3 (T2.4): mobile keyboards show a "send" affordance.
                   // Do NOT change Enter keyboard semantics — handleKeyDown still
                   // routes Enter→send only when the slash menu is closed.
@@ -675,67 +679,68 @@ export function ChatInputBar({
               </div>
             </div>
             <div
-              className="flex items-center justify-between gap-3 px-2.5 pb-2.5"
+              className="flex items-end justify-between gap-3 px-3 pb-3"
               data-composer-toolbar={toolbarMode}
             >
-              {toolbarMode === 'narrow' ? (
-                (() => {
-                  // Use the underlying availability conditions, not JSX-element
-                  // truthiness — a chip element is always truthy even when it
-                  // renders null internally, which made this empty-row guard
-                  // unreachable in narrow mode.
-                  const agentModesAvailable =
-                    session.modes != null && session.modes.availableModes.length > 0
-                  const hasRow1 = agentModesAvailable || Boolean(modelChip)
-                  const hasRow2 = hasConfigOptions || mcpCount > 0
-                  if (!hasRow1 && !hasRow2) return null
-                  return (
-                    <div className="flex min-w-0 flex-1 flex-col gap-2">
-                      {hasRow1 && (
-                        <div
-                          className="flex min-w-0 flex-wrap items-center gap-2"
-                          data-composer-toolbar-row="1"
-                        >
-                          {agentModeChip}
-                          {modelChip}
-                        </div>
-                      )}
-                      {hasRow2 && (
-                        <div
-                          className="flex min-w-0 flex-wrap items-center gap-2"
-                          data-composer-toolbar-row="2"
-                        >
-                          {thoughtChip}
-                          {fastModeToggle}
-                          {genericChips}
-                          {mcpBadge}
-                        </div>
-                      )}
-                    </div>
-                  )
-                })()
-              ) : (
-                <div
-                  className="flex min-w-0 flex-wrap items-center gap-2"
-                  data-composer-toolbar-row="single"
-                >
-                  {modelChip}
-                  {thoughtChip}
-                  {fastModeToggle}
-                  {genericChips}
-                  {agentModeChip}
-                  {mcpBadge}
-                </div>
-              )}
+              <div className="flex min-w-0 items-center gap-2">
+                {canPick && <AttachFilesButton onClick={() => void pickFiles()} />}
+                {mcpBadge}
+              </div>
               <div
                 className={cn(
-                  'flex shrink-0 items-center gap-2',
-                  toolbarMode === 'narrow' && 'self-end'
+                  'flex min-w-0 flex-wrap items-end justify-end gap-2.5',
+                  toolbarMode === 'narrow' && 'flex-1'
                 )}
               >
+                {toolbarMode === 'narrow' ? (
+                  (() => {
+                    // Use the underlying availability conditions, not JSX-element
+                    // truthiness — a chip element is always truthy even when it
+                    // renders null internally, which made this empty-row guard
+                    // unreachable in narrow mode.
+                    const agentModesAvailable =
+                      session.modes != null && session.modes.availableModes.length > 0
+                    const hasRow1 = agentModesAvailable || Boolean(modelChip)
+                    const hasRow2 = hasConfigOptions
+                    if (!hasRow1 && !hasRow2) return null
+                    return (
+                      <div className="flex min-w-0 flex-1 flex-col items-end gap-2">
+                        {hasRow1 && (
+                          <div
+                            className="flex min-w-0 flex-wrap items-center justify-end gap-2"
+                            data-composer-toolbar-row="1"
+                          >
+                            {modelChip}
+                            {agentModeChip}
+                          </div>
+                        )}
+                        {hasRow2 && (
+                          <div
+                            className="flex min-w-0 flex-wrap items-center justify-end gap-2"
+                            data-composer-toolbar-row="2"
+                          >
+                            {thoughtChip}
+                            {fastModeToggle}
+                            {genericChips}
+                          </div>
+                        )}
+                      </div>
+                    )
+                  })()
+                ) : (
+                  <div
+                    className="flex min-w-0 flex-wrap items-center justify-end gap-2.5"
+                    data-composer-toolbar-row="single"
+                  >
+                    {modelChip}
+                    {thoughtChip}
+                    {fastModeToggle}
+                    {genericChips}
+                    {agentModeChip}
+                  </div>
+                )}
                 <ContextUsageIndicator usage={sessionUsage} messages={messages} />
-                {canPick && <AttachFilesButton onClick={() => void pickFiles()} />}
-                <div className="relative size-8 shrink-0 overflow-visible">
+                <div className="relative size-[34px] shrink-0 overflow-visible">
                   <AnimatePresence initial={false} mode="popLayout">
                     {showStop ? (
                       <motion.button
@@ -750,7 +755,7 @@ export function ChatInputBar({
                         exit={iconMotion.exit}
                         transition={iconMotion.transition}
                         className={cn(
-                          'absolute inset-0 flex items-center justify-center rounded-md bg-foreground text-background transition-transform hover:bg-foreground/90 active:scale-[0.97]',
+                          'absolute inset-0 flex items-center justify-center rounded-lg bg-foreground text-background transition-transform hover:bg-foreground/90 active:scale-[0.97]',
                           EMBOSSED_BUTTON
                         )}
                       >
@@ -770,7 +775,7 @@ export function ChatInputBar({
                         exit={iconMotion.exit}
                         transition={iconMotion.transition}
                         className={cn(
-                          'absolute inset-0 flex items-center justify-center rounded-md transition-transform',
+                          'absolute inset-0 flex items-center justify-center rounded-lg transition-transform',
                           canSend
                             ? cn(
                                 'bg-foreground text-background hover:bg-foreground/90 active:scale-[0.97]',
@@ -779,7 +784,7 @@ export function ChatInputBar({
                             : 'cursor-not-allowed bg-muted text-muted-foreground'
                         )}
                       >
-                        <ArrowUp size={14} strokeWidth={2.5} />
+                        <ArrowUp size={18} />
                       </motion.button>
                     )}
                   </AnimatePresence>
@@ -789,38 +794,32 @@ export function ChatInputBar({
           </div>
         </ComposerBeamShell>
         <div
-          className={cn(
-            'flex items-center justify-between gap-2 px-1 pt-1.5 text-3xs text-muted-foreground transition-opacity duration-150',
-            focused ? 'opacity-100' : 'opacity-0'
-          )}
+          data-chat-composer-context-strip="true"
+          className="relative z-0 mx-auto -mt-4 flex w-[calc(100%-2.75rem)] min-w-0 items-center justify-between gap-2 rounded-b-2xl border border-t-0 border-border/60 bg-card/60 px-2 pb-1 pt-5 text-xs text-muted-foreground"
         >
-          {isolationLabel ? (
-            <span className="truncate" title={isolationLabel}>
-              {isolationLabel}
+          <span className="inline-flex shrink-0 items-center gap-1.5 px-2.5 font-medium text-muted-foreground/70">
+            {session.worktreePath ? (
+              <FolderGit2 className="size-3.5" aria-hidden="true" />
+            ) : (
+              <Folder className="size-3.5" aria-hidden="true" />
+            )}
+            {isolationModeLabel}
+          </span>
+          {isolationBranch ? (
+            <span
+              className="inline-flex min-w-0 items-center justify-end gap-1.5 px-2.5 font-medium text-muted-foreground/70"
+              title={isolationTitle ?? undefined}
+            >
+              <GitBranch className="size-3.5 shrink-0" aria-hidden="true" />
+              <span className="truncate">{isolationBranch}</span>
             </span>
           ) : (
             <span />
-          )}
-          {showStop ? (
-            <>
-              <KbdHint k="Esc" /> to stop
-            </>
-          ) : (
-            <>
-              <KbdHint k="Enter" /> {busy ? 'to queue' : 'to send'}
-              <span className="mx-1.5 text-border">·</span>
-              <KbdHint k="Shift+Enter" /> newline
-            </>
           )}
         </div>
       </div>
     </div>
   )
-}
-
-/** Inline keyboard-key hint used in the composer footer. */
-function KbdHint({ k }: { k: string }): React.JSX.Element {
-  return <kbd className="mr-1 font-mono text-[0.6rem] font-medium text-foreground">{k}</kbd>
 }
 
 /**
@@ -837,7 +836,7 @@ function ComposerBeamShell({
   children: React.ReactNode
 }): React.JSX.Element {
   if (reduced) {
-    return <div className="w-full">{children}</div>
+    return <div className="relative z-10 w-full">{children}</div>
   }
   return (
     <BorderBeam
@@ -846,7 +845,7 @@ function ComposerBeamShell({
       theme="auto"
       borderRadius={16}
       active={busy}
-      className="w-full"
+      className="relative z-10 w-full"
     >
       {children}
     </BorderBeam>

--- a/src/renderer/components/chat/McpBadge.test.tsx
+++ b/src/renderer/components/chat/McpBadge.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from '@testing-library/react'
+import { fireEvent, render, screen, within } from '@testing-library/react'
 import { describe, expect, it, vi } from 'vitest'
 import { McpBadge } from './McpBadge'
 
@@ -9,6 +9,11 @@ function openPopover(): void {
 describe('McpBadge (Story 1.8 — read-only MCP badge in composer)', () => {
   it('is hidden when no MCP servers are attached (count <= 0) and no server list', () => {
     const { container } = render(<McpBadge count={0} />)
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('hides the compact composer icon when no servers are configured', () => {
+    const { container } = render(<McpBadge count={0} compact />)
     expect(container).toBeEmptyDOMElement()
   })
 
@@ -33,6 +38,18 @@ describe('McpBadge popover (per-server enable/disable + status dot)', () => {
   it('renders at count 0 when servers exist (discoverable entry point)', () => {
     render(<McpBadge count={0} servers={servers} onToggle={vi.fn()} />)
     expect(screen.getByRole('button', { name: /mcp servers/i })).toBeInTheDocument()
+  })
+
+  it('keeps the full management popover behind the compact composer trigger', () => {
+    render(<McpBadge count={2} servers={servers} onToggle={vi.fn()} compact />)
+
+    const trigger = screen.getByRole('button', { name: /mcp servers/i })
+    expect(trigger.className).toContain('size-7')
+    expect(within(trigger).getByText('2')).toHaveClass('sr-only')
+
+    fireEvent.click(trigger)
+    expect(screen.getByText('Files')).toBeInTheDocument()
+    expect(screen.getByText('Remote')).toBeInTheDocument()
   })
 
   it('lists each server with a visible status label inside the popover', () => {

--- a/src/renderer/components/chat/McpBadge.tsx
+++ b/src/renderer/components/chat/McpBadge.tsx
@@ -16,6 +16,8 @@ interface McpBadgeProps {
   /** Number of MCP servers attached to this session (badge summary count). */
   count: number
   className?: string
+  /** Compact ghost trigger used in composer footers; popover content is unchanged. */
+  compact?: boolean
   /**
    * Per-server enable/disable popover (chatbox). When omitted (or empty), the
    * badge degrades to the read-only count pill (backward-compat — no popover).
@@ -68,6 +70,7 @@ function statusLabel(status: ProbeStatus | undefined): string {
 export function McpBadge({
   count,
   className,
+  compact = false,
   servers,
   onToggle,
   probeStatus,
@@ -83,12 +86,15 @@ export function McpBadge({
     return (
       <span
         className={cn(
-          'inline-flex items-center gap-1 rounded-full border border-border/60 bg-muted/40 px-2 py-0.5 text-3xs font-medium text-muted-foreground',
+          compact
+            ? 'inline-flex size-7 items-center justify-center rounded-md text-muted-foreground/70'
+            : 'inline-flex items-center gap-1 rounded-full border border-border/60 bg-muted/40 px-2 py-0.5 text-3xs font-medium text-muted-foreground',
           className
         )}
+        title={compact ? `${count} MCP servers attached` : undefined}
       >
         <Plug className="size-3" aria-hidden="true" />
-        <span className="tabular-nums">{count}</span>
+        <span className={cn('tabular-nums', compact && 'sr-only')}>{count}</span>
         <span className="sr-only">MCP servers attached</span>
       </span>
     )
@@ -104,6 +110,7 @@ export function McpBadge({
       tools={tools}
       onLoadTools={onLoadTools}
       className={className}
+      compact={compact}
     />
   )
 }
@@ -117,6 +124,7 @@ interface PopoverProps {
   tools?: Record<string, McpToolInfo[]>
   onLoadTools?: (id: string) => void
   className?: string
+  compact: boolean
 }
 
 function McpPopover({
@@ -127,7 +135,8 @@ function McpPopover({
   probeError,
   tools,
   onLoadTools,
-  className
+  className,
+  compact
 }: PopoverProps): React.JSX.Element {
   const [open, setOpen] = useState(false)
   return (
@@ -136,13 +145,15 @@ function McpPopover({
         <button
           type="button"
           className={cn(
-            'inline-flex items-center gap-1 rounded-full border border-border/60 bg-muted/40 px-2 py-0.5 text-3xs font-medium text-muted-foreground transition-colors hover:bg-muted/70 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring',
+            compact
+              ? 'inline-flex size-7 items-center justify-center rounded-md text-muted-foreground/70 transition-colors hover:bg-accent/40 hover:text-foreground/80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring'
+              : 'inline-flex items-center gap-1 rounded-full border border-border/60 bg-muted/40 px-2 py-0.5 text-3xs font-medium text-muted-foreground transition-colors hover:bg-muted/70 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring',
             className
           )}
           aria-label={`MCP servers — ${count} attached. Click to manage per-server enable/disable.`}
         >
           <PlugZap className="size-3" aria-hidden="true" />
-          <span className="tabular-nums">{count}</span>
+          <span className={cn('tabular-nums', compact && 'sr-only')}>{count}</span>
         </button>
       </PopoverTrigger>
       <PopoverContent align="start" className="w-72 p-3 text-xs">
@@ -207,6 +218,7 @@ function McpServerRow({
         {onToggle && (
           <Switch
             checked={enabled}
+            className="h-4 w-7 border [&>span]:h-3 [&>span]:w-3 [&>span[data-state=checked]]:translate-x-3"
             aria-label={`${enabled ? 'Disable' : 'Enable'} ${server.name}`}
             onCheckedChange={(checked) => {
               if (checked === enabled) return

--- a/src/renderer/components/chat/chat-responsive.test.tsx
+++ b/src/renderer/components/chat/chat-responsive.test.tsx
@@ -312,7 +312,7 @@ describe('Story 5.1 responsive chat layout', () => {
 
     expect(within(row2 as HTMLElement).getByRole('button', { name: 'High' })).toBeInTheDocument()
     expect(
-      within(row2 as HTMLElement).getByRole('button', { name: /MCP servers/i })
+      within(toolbar as HTMLElement).getByRole('button', { name: /MCP servers/i })
     ).toBeInTheDocument()
     expect(screen.getByRole('button', { name: /Send message/i })).toBeInTheDocument()
   })

--- a/src/renderer/stores/acp-store.ts
+++ b/src/renderer/stores/acp-store.ts
@@ -208,8 +208,9 @@ export interface AcpSession {
   /**
    * Worktree path + branch the agent runs in (CAP-3). Additive: absent on
    * current-branch-mode sessions. When set, the chat indicator (CAP-6) shows
-   * `{worktreePath} · {worktreeBranch}`; relaunch reattaches to the stored
-   * path (no second `git worktree add`). State isolation still keys on `cwd`.
+   * `{worktreeBranch} · New worktree` (the full worktree path stays on the
+   * hover tooltip); relaunch reattaches to the stored path (no second
+   * `git worktree add`). State isolation still keys on `cwd`.
    */
   worktreePath?: string
   worktreeBranch?: string


### PR DESCRIPTION
## Summary

- Refines the new-agent launcher and active-chat composer so workspace context is readable without crowding the primary input controls.
- Moves Local/New worktree and branch context into an attached strip, aligns launcher and chat toolbar ordering, and makes MCP management compact while preserving its full popover.
- Removes suggestion cards and keyboard-helper copy that competed with the composer.

## Related Issue

No related issue exists. This is a focused follow-up to the worktree chat UX introduced by #591, based on direct launcher/composer usability feedback; searches of open and closed PRs found no duplicate refinement.

## Type of Change

- [x] feat: new feature
- [ ] fix: bug fix
- [ ] docs: documentation only
- [ ] style: formatting or non-functional styling changes
- [ ] refactor: internal cleanup with no behavior change
- [ ] perf: performance improvement
- [x] test: adds or updates tests
- [ ] build: build or dependency changes
- [ ] ci: CI/CD workflow changes
- [ ] chore: maintenance or tooling
- [ ] revert: reverts a previous change

## What Changed

- Simplified the launcher headline and removed the three suggestion cards.
- Moved launcher isolation mode and worktree base selection into an attached context strip below the composer.
- Added the same attached Local/New worktree and branch strip to active chat sessions, with the full worktree path retained in the tooltip.
- Reordered composer controls so attachment and MCP actions stay left while model, configuration, agent, context, and send controls stay right.
- Added a compact 28px MCP trigger, hid it when no servers are configured, retained server/tool management, and reduced the server toggle footprint.
- Removed Enter, Shift+Enter, queue, newline, and Escape helper text.
- Added structural, worktree-selection, compact-MCP, and responsive regression coverage.

## How It Was Tested

- [ ] `bun run ci` (Biome lint + format + imports, strict mode)
- [x] `bun run typecheck`
- [ ] `bun run test`
- [x] `cargo clippy --all-targets -- -D warnings` (in src-tauri)
- [ ] `cargo test` (in src-tauri)
- [x] Manual verification completed
- [ ] Not applicable

Additional local evidence:

- Targeted Biome CI passed for all 8 changed files. The repository-level `bun run ci` reports `No files were processed in the specified paths` because this `.termul/worktrees/...` checkout is ignored when Biome receives `.`.
- Focused launcher/chat/MCP/responsive suite passed: 4 files, 92 tests.
- Full Vitest is not green locally because the unrelated `NewProjectModal.test.tsx` web-create test times out waiting for a mocked mkdir request; earlier full runs also exposed worktree dependency-resolution/allow-list issues.
- `cargo test` compiles the test binary but this Windows host cannot launch it (`0xc0000139`, `STATUS_ENTRYPOINT_NOT_FOUND`).
- `bun run build:frontend:tauri` and `bun run build:web` passed.
- `git diff --check` passed.

## Screenshots or Recordings

No capture is attached. The desktop app was launched locally during implementation to verify the composer and attached context-strip layout; desktop and web production builds also complete successfully.

## CI & Review Gate

- [ ] All CI checks pass (PR Validation, Rust Checks, Build Verification, Security Scans)
- [ ] Code review comments from CodeRabbit / Claude have been addressed or resolved
- [ ] No unresolved review findings remain

## Checklist

- [x] My PR title follows the conventional commit format used by this repo
- [x] I linked the related issue or explained why none exists
- [x] I updated docs when needed
- [x] I added or updated tests when needed
- [x] I verified the change does not introduce unrelated modifications
- [x] I read AGENTS.md and followed the contributor guidelines
- [x] A human reviewed the complete diff before submission

Documentation note: no standalone docs change is needed because this is a refinement of existing composer/worktree controls; the inline `AcpSession` worktree display contract was updated.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a compact worktree and branch context strip beneath the message composer.
  * Added responsive toolbar layouts and path tooltips for clearer project context.
  * Added compact MCP controls with icon-only buttons and count tooltips.

* **Improvements**
  * Improved worktree mode defaults and base-branch selection.
  * Updated launcher icons and simplified launcher titles.
  * Refined send/stop button sizing and composer layout.
  * Updated worktree indicators to show the active branch and new-worktree status.
  * Updated available agent versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->