### PR TITLE
fix(skills): resolve project root for skill discovery in worktree sessions

### DIFF
--- a/src/renderer/assets/agent-icons/acp/agents.json
+++ b/src/renderer/assets/agent-icons/acp/agents.json
@@ -372,11 +372,11 @@
   {
     "id": "github-copilot-cli",
     "name": "GitHub Copilot",
-    "version": "1.0.78",
+    "version": "1.0.79",
     "description": "GitHub's AI pair programmer",
     "distribution": {
       "npx": {
-        "package": "@github/copilot@1.0.78",
+        "package": "@github/copilot@1.0.79",
         "args": ["--acp"]
       }
     }
@@ -438,33 +438,33 @@
   {
     "id": "harn",
     "name": "Harn",
-    "version": "0.10.71",
+    "version": "0.10.73",
     "description": "Harn runs .harn agent pipelines as a native ACP coding agent over stdio.",
     "distribution": {
       "binary": {
         "darwin-aarch64": {
           "cmd": "./harn",
-          "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.71/harn-aarch64-apple-darwin.tar.gz",
+          "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.73/harn-aarch64-apple-darwin.tar.gz",
           "args": ["serve", "acp"]
         },
         "darwin-x86_64": {
           "cmd": "./harn",
-          "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.71/harn-x86_64-apple-darwin.tar.gz",
+          "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.73/harn-x86_64-apple-darwin.tar.gz",
           "args": ["serve", "acp"]
         },
         "linux-aarch64": {
           "cmd": "./harn",
-          "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.71/harn-aarch64-unknown-linux-gnu.tar.gz",
+          "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.73/harn-aarch64-unknown-linux-gnu.tar.gz",
           "args": ["serve", "acp"]
         },
         "linux-x86_64": {
           "cmd": "./harn",
-          "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.71/harn-x86_64-unknown-linux-gnu.tar.gz",
+          "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.73/harn-x86_64-unknown-linux-gnu.tar.gz",
           "args": ["serve", "acp"]
         },
         "windows-x86_64": {
           "cmd": "harn.exe",
-          "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.71/harn-x86_64-pc-windows-msvc.zip",
+          "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.73/harn-x86_64-pc-windows-msvc.zip",
           "args": ["serve", "acp"]
         }
       }
@@ -744,11 +744,11 @@
   {
     "id": "qwen-code",
     "name": "Qwen Code",
-    "version": "0.21.8",
+    "version": "0.21.9",
     "description": "Alibaba's Qwen coding assistant",
     "distribution": {
       "npx": {
-        "package": "@qwen-code/qwen-code@0.21.8",
+        "package": "@qwen-code/qwen-code@0.21.9",
         "args": ["--acp", "--experimental-skills"]
       }
     }

--- a/src/renderer/components/agents/AgentLauncher.test.tsx
+++ b/src/renderer/components/agents/AgentLauncher.test.tsx
@@ -204,7 +204,8 @@ vi.mock('@/lib/acp-api', () => ({
 }))
 
 vi.mock('@/lib/worktree-context', () => ({
-  getDefaultCwdForProject: () => '/work'
+  getDefaultCwdForProject: () => '/work',
+  getProjectRootPath: () => '/work'
 }))
 
 vi.mock('@/lib/tauri-runtime', () => ({

--- a/src/renderer/components/agents/AgentLauncher.tsx
+++ b/src/renderer/components/agents/AgentLauncher.tsx
@@ -82,7 +82,7 @@ import { platform as osPlatform } from '@/lib/tauri-os'
 import { isTauriContext } from '@/lib/tauri-runtime'
 import { cn } from '@/lib/utils'
 import { type BaseBranchInfo, worktreeApi } from '@/lib/worktree-api'
-import { getDefaultCwdForProject } from '@/lib/worktree-context'
+import { getDefaultCwdForProject, getProjectRootPath } from '@/lib/worktree-context'
 import {
   type AcpSession,
   agentReuseKey,
@@ -156,7 +156,11 @@ export function AgentLauncher({ paneId, className }: AgentLauncherProps): React.
   // not just the resolved default.
   const [branches, setBranches] = useState<string[]>([])
   const [worktreeCreating, setWorktreeCreating] = useState(false)
-  const { skills } = useAgentSkills(projectRoot)
+  // Skills live at {project.path}/.agents/skills/ which is gitignored and
+  // excluded from worktree symlinks, so resolve against the main project root
+  // — not the worktree CWD which has no .agents/skills/.
+  const skillsRoot = activeProjectId ? getProjectRootPath(activeProjectId) : undefined
+  const { skills } = useAgentSkills(skillsRoot)
   const supportedAgents = useResolvedSupportedAcpAgents(acpConfigs)
 
   const selectedEntry = useMemo(

--- a/src/renderer/components/chat/AgentChatPanel.tsx
+++ b/src/renderer/components/chat/AgentChatPanel.tsx
@@ -10,7 +10,7 @@ import { useOskViewport } from '@/hooks/use-osk-viewport'
 import type { AvailableCommand, ContentBlock, PlanEntry, SessionId, ToolCall } from '@/lib/acp-api'
 import { extractSkillNames } from '@/lib/skill-tokens'
 import { isTauriContext } from '@/lib/tauri-runtime'
-import { getDefaultCwdForProject } from '@/lib/worktree-context'
+import { getDefaultCwdForProject, getProjectRootPath } from '@/lib/worktree-context'
 import { useAcpMessages, useAcpSession, useAcpStore, usePromptQueue } from '@/stores/acp-store'
 import { isAgentDeadError } from '@/stores/prompt-queue-orchestration'
 import { AgentConnectionLamp } from './AgentConnectionLamp'
@@ -79,7 +79,11 @@ export function AgentChatPanel({
   // Available skills (with paths) so retry can re-frame the wire from the
   // token names in the last user message (skill paths are not persisted with
   // the message — see the spec's Never: no new ContentBlock type).
-  const { skills: availableSkills } = useAgentSkills(session?.cwd)
+  // Skills live at {project.path}/.agents/skills/ which is gitignored and
+  // excluded from worktree symlinks, so resolve against the main project root
+  // — not session.cwd which may be a worktree path with no .agents/skills/.
+  const skillsProjectRoot = session ? getProjectRootPath(session.projectId) : undefined
+  const { skills: availableSkills } = useAgentSkills(skillsProjectRoot)
   const imageCapable = useAcpStore((s) =>
     session ? Boolean(s.agents[session.agentId]?.capabilities?.promptCapabilities?.image) : false
   )
@@ -499,6 +503,7 @@ export function AgentChatPanel({
       ) : (
         <ChatInputBar
           session={session}
+          projectRoot={skillsProjectRoot}
           busy={session.activeTurn}
           disabled={isClosed}
           imageCapable={imageCapable}

--- a/src/renderer/lib/worktree-context.ts
+++ b/src/renderer/lib/worktree-context.ts
@@ -10,6 +10,19 @@ import { useProjectStore } from '@/stores/project-store'
 import type { Project, Worktree } from '@/types/project'
 
 /**
+ * Get the main project root path (ignoring any active worktree).
+ *
+ * Skills are stored at `{project.path}/.agents/skills/`, which is gitignored
+ * (`/.agents`) and excluded from worktree symlinks (`SYMLINK_EXCLUSION_LIST`).
+ * A worktree path therefore has no `.agents/skills/`, so skill discovery must
+ * always resolve against the main project root — never the worktree CWD.
+ */
+export function getProjectRootPath(projectId: string): string {
+  const project = useProjectStore.getState().projects.find((p) => p.id === projectId)
+  return project?.path ?? ''
+}
+
+/**
  * Get the default CWD for a project, resolving from the active worktree if set.
  * Falls back to the project root path if no active worktree or worktree not found.
  */


### PR DESCRIPTION
## Summary

When a new agent chat session is launched in a git worktree, the skills slash menu in the chat UI (ChatInputBar) shows zero skills — even though the launcher composer showed them before launch. This is because .agents/skills/ is gitignored (/.agents) and explicitly excluded from worktree symlinks (SYMLINK_EXCLUSION_LIST in src-tauri/src/worktree/mod.rs), so the worktree CWD has no .agents/skills/ directory. Skill discovery was resolving against the worktree path (session.cwd) instead of the main project root (project.path).

## Related Issue

No related issue. Searched open and closed PRs targeting dev — no duplicates found.

## Type of Change

- [x] fix: bug fix

## What Changed

1. **src/renderer/lib/worktree-context.ts** — Added getProjectRootPath(projectId) that returns project.path (the main project root) without resolving to an active worktree. This is the correct source for skill discovery since .agents/skills/ only exists at the main project root.

2. **src/renderer/components/chat/AgentChatPanel.tsx** — Skills discovery now uses getProjectRootPath(session.projectId) instead of session?.cwd (the worktree path). Passes projectRoot={skillsProjectRoot} to ChatInputBar (previously this prop was omitted, causing ChatInputBar to fall back to session.cwd).

3. **src/renderer/components/agents/AgentLauncher.tsx** — Skills discovery now uses getProjectRootPath(activeProjectId) instead of projectRoot (which may be a project-level worktree path via getDefaultCwdForProject). This fixes the same bug when a project-level active worktree is set.

4. **src/renderer/components/agents/AgentLauncher.test.tsx** — Updated worktree-context mock to include the new getProjectRootPath export.

5. **src/renderer/assets/agent-icons/acp/agents.json** — Synced bundled ACP registry to upstream (qwen-code 0.21.9, harn 0.10.73, github-copilot 1.0.79) to pass the ACP Registry Bundle Freshness check.

## How It Was Tested

- [x] un run ci (Biome lint + format + imports, strict mode) — ran iome check on changed files directly
- [x] un run typecheck
- [x] un run test — 96 tests across AgentChatPanel, AgentLauncher, ChatInputBar, chat-responsive suites
- [x] cargo clippy --all-targets -- -D warnings (in src-tauri) — CI Rust Checks passed
- [x] cargo test (in src-tauri) — CI Rust Checks passed
- [x] Manual verification completed

### Manual verification
- Confirmed .agents/ is gitignored (.gitignore:85: /.agents)
- Confirmed .agents is in SYMLINK_EXCLUSION_LIST (src-tauri/src/worktree/mod.rs:40)
- Confirmed the worktree at 794e9d3 has no .agents/skills/ directory
- Confirmed 53 project-local skills exist at the main project root E:\open-source\PecutAPP\termul\.agents\skills\
- Traced session cwd flow: session.cwd is set to the worktree path on launch (via launchCwd in AgentLauncher → createLaunchPlaceholder / inalizeChatLaunch → createSession)

## CI & Review Gate

- [x] All CI checks pass (PR Validation, Rust Checks, Build Verification, Security Scans)
- [x] Code review comments from CodeRabbit / Claude have been addressed or resolved
- [x] No unresolved review findings remain

## Checklist

- [x] My PR title follows the conventional commit format used by this repo
- [x] I linked the related issue or explained why none exists
- [x] I updated docs when needed
- [x] I added or updated tests when needed
- [x] I verified the change does not introduce unrelated modifications
- [x] I read AGENTS.md and followed the contributor guidelines
- [x] A human reviewed the complete diff before submission