### PR TITLE
fix(acp): apply pending launcher model across all ACP agents

### DIFF
--- a/src/renderer/stores/acp-store.ts
+++ b/src/renderer/stores/acp-store.ts
@@ -3257,29 +3257,27 @@ export const useAcpStore = create<AcpState>((set, get) => ({
     if (pending.modeId) {
       await get().setMode(sessionId, pending.modeId)
     }
+    let modelConfigIdHandled: string | null = null
     if (pending.modelId) {
-      const hasNative =
-        session.models?.availableModels.some((m) => m.modelId === pending.modelId) ?? false
       let applied = false
-      if (hasNative) {
-        await get().setModel(sessionId, pending.modelId)
-        applied = true
-      } else if (session.models) {
+      if (session.models) {
         try {
           await get().setModel(sessionId, pending.modelId)
           applied = true
         } catch {
-          const modelOpt = session.configOptions.find((o) => o.category === 'model')
-          if (modelOpt) {
-            await get().setConfigOption(sessionId, modelOpt.id, pending.modelId)
-            applied = true
-          }
+          // native setModel rejected; fall through to a model config option
         }
-      } else {
+      }
+      if (!applied) {
         const modelOpt = session.configOptions.find((o) => o.category === 'model')
         if (modelOpt) {
-          await get().setConfigOption(sessionId, modelOpt.id, pending.modelId)
-          applied = true
+          try {
+            await get().setConfigOption(sessionId, modelOpt.id, pending.modelId)
+            applied = true
+            modelConfigIdHandled = modelOpt.id
+          } catch {
+            // leave applied false; show toast and continue applying other options
+          }
         }
       }
       if (!applied) {
@@ -3289,6 +3287,7 @@ export const useAcpStore = create<AcpState>((set, get) => ({
       }
     }
     for (const [configId, valueId] of Object.entries(pending.configValues)) {
+      if (configId === modelConfigIdHandled) continue
       await get().setConfigOption(sessionId, configId, valueId)
     }
   },

--- a/src/renderer/stores/acp-store.ts
+++ b/src/renderer/stores/acp-store.ts
@@ -3260,13 +3260,32 @@ export const useAcpStore = create<AcpState>((set, get) => ({
     if (pending.modelId) {
       const hasNative =
         session.models?.availableModels.some((m) => m.modelId === pending.modelId) ?? false
+      let applied = false
       if (hasNative) {
         await get().setModel(sessionId, pending.modelId)
+        applied = true
+      } else if (session.models) {
+        try {
+          await get().setModel(sessionId, pending.modelId)
+          applied = true
+        } catch {
+          const modelOpt = session.configOptions.find((o) => o.category === 'model')
+          if (modelOpt) {
+            await get().setConfigOption(sessionId, modelOpt.id, pending.modelId)
+            applied = true
+          }
+        }
       } else {
         const modelOpt = session.configOptions.find((o) => o.category === 'model')
         if (modelOpt) {
           await get().setConfigOption(sessionId, modelOpt.id, pending.modelId)
+          applied = true
         }
+      }
+      if (!applied) {
+        toast.error('Selected model is not available in this session', {
+          description: `The model "${pending.modelId}" is not advertised by the agent and no model config option exists. Falling back to the agent's default model.`
+        })
       }
     }
     for (const [configId, valueId] of Object.entries(pending.configValues)) {


### PR DESCRIPTION
## Summary

When a user picked a model in the composer launcher (e.g. `gpt/gpt-5.6-sol` from a custom provider) and sent a chat, the live stream would silently use the agent's default model instead of the selected one. The selection was dropped without any error or toast, so the user only noticed when the wrong model answered.

Root cause: `applyPendingLauncherOptions` (acp-store.ts) gated `setModel` on the picked `modelId` being present in the agent's advertised `availableModels`. Custom-provider models that agents *accept* but don't *list* (and agents with no `model` config option) hit a silent no-op, leaving the agent's own `currentModelId` to win.

## Related Issue

No related issue. Reported through the composer UI: selecting `gpt-5.6-sol` in the launcher and sending a chat caused the stream to switch to a different model mid-flight.

Search for duplicate PRs (open and closed, keywords: "model", "applyPendingLauncherOptions", "silent model", "model selection") returned no PR addressing this drop. Closest prior PRs touched the model *picker UI* (`fix/acp-parameterized-picker-and-chip-pending`, `feat/pi-acp-thinking-model-refine`) - not the pending-options application path.

## Type of Change

- [x] fix: bug fix

## What Changed

`src/renderer/stores/acp-store.ts` - `applyPendingLauncherOptions`:

- Advertised in `availableModels` -> `setModel` (native ACP 0.14 `session/set_config_option` path, unchanged).
- Agent supports native models (`session.models` exists) but does **not** list the picked model -> attempt `setModel` anyway. Many agents accept model IDs they don't surface (custom-provider models). If the agent rejects, fall back to a `model`-category config option.
- Agent has no native model support -> try the `model` config option only (legacy path, unchanged).
- All paths fail -> `toast.error` instead of a silent drop, so the fallback to the agent default is visible and the user can correct the picker.

The fix is agent-agnostic: it applies across every ACP agent (codex, claude, gemini, cursor, opencode, pi-acp) regardless of whether the agent advertises models natively, via a config option, or both.

## How It Was Tested

- [x] `bun run ci` - **pre-existing failure on this worktree** (biome `ci` reports "No files were processed in the specified paths" due to the worktree path; reproduces on the unmodified base commit). Direct `biome ci --diagnostic-level=error src/renderer/stores/acp-store.ts` passes clean.
- [x] `bun run typecheck` - passes (node + web + test configs).
- [ ] `bun run test` - 4 failing suites are **pre-existing and unrelated** (`App.test.tsx`, `WorkspaceLayout.test.tsx`, `FileTreeNode.test.tsx`, `WorkspaceTabBar.test.tsx`); all fail on vite/jsdom `material-icon-theme` `?raw` SVG imports, not on `acp-store.ts`. Reproduces on the unmodified base commit. 3427 tests pass.
- [N/A] `cargo clippy` / `cargo test` - no Rust changes in this PR.
- [x] Manual verification completed - traced the launcher -> `finalizeChatLaunch` -> `applyPendingLauncherOptions` -> `setModel`/`setConfigOption` flow end to end.
- [x] No existing unit test covers `applyPendingLauncherOptions`; behavior change is small and guarded by try/catch.

## Screenshots or Recordings

Not a UI layout change. The only UI surface is a new `toast.error` that appears only when the selection cannot be applied (previously silent).

## CI & Review Gate

- [ ] All CI checks pass (PR Validation, Rust Checks, Build Verification, Security Scans) - awaiting run.
- [ ] Code review comments from CodeRabbit / Claude have been addressed or resolved - awaiting review.
- [ ] No unresolved review findings remain.

## Checklist

- [x] My PR title follows the conventional commit format used by this repo (`fix(acp): ...`)
- [x] I linked the related issue or explained why none exists
- [x] I updated docs when needed - no user-facing docs change; ACP model-setting behavior is internal
- [x] I added or updated tests when needed - no existing harness for `applyPendingLauncherOptions`; scope is intentionally minimal
- [x] I verified the change does not introduce unrelated modifications
- [x] I read AGENTS.md and followed the contributor guidelines
- [x] A human reviewed the complete diff before submission


