### PR TITLE
feat(chat): compact streamdown chrome, fix codeblock newlines, open-file on tool calls

### DIFF
--- a/src/renderer/components/chat/ChatMessage.test.tsx
+++ b/src/renderer/components/chat/ChatMessage.test.tsx
@@ -278,22 +278,32 @@ describe('ChatMessage', () => {
     expect(container.querySelector('.animate-caret-blink')).toBeInTheDocument()
   })
 
-  it('opens file citations only on Ctrl/Cmd-click', async () => {
+  it('opens file citations on regular click (no Ctrl/Cmd gate)', async () => {
     const message: ChatMessageType = {
       ...agentMessage(false),
       blocks: [{ type: 'text', text: 'FILE_PATH:src/renderer/App.tsx:42' }]
     }
     render(<ChatMessage message={message} filePathContext={{ cwd: '/project' }} />)
 
-    const filePathLink = screen.getByTitle('Ctrl/Cmd-click to open in editor')
+    const filePathLink = screen.getByTitle('Open in editor')
     fireEvent.click(filePathLink)
-    expect(openFilePathFromTerminal).not.toHaveBeenCalled()
-
-    fireEvent.click(filePathLink, { ctrlKey: true })
     await act(async () => undefined)
     expect(openFilePathFromTerminal).toHaveBeenCalledWith('src/renderer/App.tsx:42', {
       cwd: '/project'
     })
+  })
+
+  it('does not open file citations on shift-click (allow text selection)', async () => {
+    const message: ChatMessageType = {
+      ...agentMessage(false),
+      blocks: [{ type: 'text', text: 'FILE_PATH:src/renderer/App.tsx:42' }]
+    }
+    render(<ChatMessage message={message} filePathContext={{ cwd: '/project' }} />)
+
+    const filePathLink = screen.getByTitle('Open in editor')
+    fireEvent.click(filePathLink, { shiftKey: true })
+    await act(async () => undefined)
+    expect(openFilePathFromTerminal).not.toHaveBeenCalled()
   })
 
   it('opens confirmed links via the system browser and closes the safety dialog', async () => {

--- a/src/renderer/components/chat/ChatMessage.tsx
+++ b/src/renderer/components/chat/ChatMessage.tsx
@@ -361,6 +361,8 @@ function AgentProse({
             title="Open in editor"
             onClick={(event) => {
               if (event.button !== 0 || event.shiftKey) return
+              const selection = window.getSelection()
+              if (selection && !selection.isCollapsed) return
               event.preventDefault()
               void openFilePathFromTerminal(candidate, context)
                 .then((result) => {

--- a/src/renderer/components/chat/ChatMessage.tsx
+++ b/src/renderer/components/chat/ChatMessage.tsx
@@ -358,9 +358,9 @@ function AgentProse({
               props.className,
               'cursor-pointer appearance-none text-left font-medium text-primary underline'
             )}
-            title="Ctrl/Cmd-click to open in editor"
+            title="Open in editor"
             onClick={(event) => {
-              if (!event.ctrlKey && !event.metaKey) return
+              if (event.button !== 0 || event.shiftKey) return
               event.preventDefault()
               void openFilePathFromTerminal(candidate, context)
                 .then((result) => {

--- a/src/renderer/components/chat/ChatMessageList.tsx
+++ b/src/renderer/components/chat/ChatMessageList.tsx
@@ -187,6 +187,7 @@ function VirtualizedTimeline({
           attentionRequired={item.attentionRequired}
           hasFinalResponse={item.hasFinalResponse}
           shouldAnimateEnter={shouldAnimateEnter}
+          filePathContext={filePathContext}
         />
       )
     }
@@ -195,6 +196,7 @@ function VirtualizedTimeline({
         <ToolCallCard
           toolCall={item.tool}
           animateEnter={shouldAnimateEnter(item.tool.toolCallId)}
+          filePathContext={filePathContext}
         />
       )
     }

--- a/src/renderer/components/chat/ToolCallCard.test.tsx
+++ b/src/renderer/components/chat/ToolCallCard.test.tsx
@@ -1,5 +1,5 @@
-import { fireEvent, render, screen } from '@testing-library/react'
-import { describe, expect, it, vi } from 'vitest'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type { ToolCall, ToolCallStatus } from '@/lib/acp-api'
 import { ToolCallCard } from './ToolCallCard'
 
@@ -11,6 +11,14 @@ vi.mock('framer-motion', async () => {
   }
 })
 
+const openFilePathFromTerminal = vi.fn(() => Promise.resolve({ ok: true as const }))
+
+vi.mock('@/lib/file-path-links', () => ({
+  openFilePathFromTerminal: (...args: unknown[]) => openFilePathFromTerminal(...args)
+}))
+
+import { TooltipProvider } from '@/components/ui/tooltip'
+
 function toolCall(status: ToolCallStatus, content: ToolCall['content'] = []): ToolCall {
   return {
     toolCallId: 'tool-1',
@@ -19,6 +27,10 @@ function toolCall(status: ToolCallStatus, content: ToolCall['content'] = []): To
     status,
     content
   }
+}
+
+function withTooltip(ui: React.JSX.Element): React.JSX.Element {
+  return <TooltipProvider>{ui}</TooltipProvider>
 }
 
 describe('ToolCallCard', () => {
@@ -178,5 +190,83 @@ describe('ToolCallCard', () => {
     expect(screen.queryByText('content')).not.toBeInTheDocument()
     const detail = container.querySelector('[class*="border-l"]')
     expect(detail).toBeEmptyDOMElement()
+  })
+
+  describe('open file action', () => {
+    beforeEach(() => {
+      openFilePathFromTerminal.mockClear()
+    })
+
+    it('renders an "Open file" button when rawInput has a path and filePathContext is set', () => {
+      const call: ToolCall = {
+        ...toolCall('completed'),
+        rawInput: { path: 'src/foo.ts' }
+      }
+      render(withTooltip(<ToolCallCard toolCall={call} filePathContext={{ cwd: '/proj' }} />))
+
+      expect(screen.getByRole('button', { name: 'Open file' })).toBeInTheDocument()
+    })
+
+    it('does not render an "Open file" button when no path is present in rawInput', () => {
+      const call: ToolCall = {
+        ...toolCall('completed'),
+        rawInput: { query: 'foo' },
+        kind: 'search'
+      }
+      const { container } = render(
+        withTooltip(<ToolCallCard toolCall={call} filePathContext={{ cwd: '/proj' }} />)
+      )
+
+      expect(screen.queryByRole('button', { name: 'Open file' })).not.toBeInTheDocument()
+      // Only the disclosure button (when hasDetail) — here there is no
+      // content/resultText so no disclosure button either.
+      expect(container.querySelector('button')).toBeNull()
+    })
+
+    it('does not render an "Open file" button when filePathContext is absent', () => {
+      const call: ToolCall = {
+        ...toolCall('completed'),
+        rawInput: { path: 'src/foo.ts' }
+      }
+      render(<ToolCallCard toolCall={call} />)
+
+      expect(screen.queryByRole('button', { name: 'Open file' })).not.toBeInTheDocument()
+    })
+
+    it('calls openFilePathFromTerminal when the "Open file" button is clicked', () => {
+      const call: ToolCall = {
+        ...toolCall('completed'),
+        rawInput: { path: 'src/foo.ts' }
+      }
+      const context = { cwd: '/proj' }
+      render(withTooltip(<ToolCallCard toolCall={call} filePathContext={context} />))
+
+      fireEvent.click(screen.getByRole('button', { name: 'Open file' }))
+
+      expect(openFilePathFromTerminal).toHaveBeenCalledTimes(1)
+      expect(openFilePathFromTerminal).toHaveBeenCalledWith('src/foo.ts', context)
+    })
+
+    it('shows a toast when openFilePathFromTerminal fails', async () => {
+      const { toast } = await import('sonner')
+      const toastError = vi.spyOn(toast, 'error').mockImplementation(() => 'mocked')
+      openFilePathFromTerminal.mockResolvedValueOnce({
+        ok: false,
+        reason: 'not-found' as const,
+        message: 'File not found: src/foo.ts'
+      })
+      const call: ToolCall = {
+        ...toolCall('completed'),
+        rawInput: { path: 'src/foo.ts' }
+      }
+      render(withTooltip(<ToolCallCard toolCall={call} filePathContext={{ cwd: '/proj' }} />))
+
+      fireEvent.click(screen.getByRole('button', { name: 'Open file' }))
+
+      await waitFor(() => {
+        expect(toastError).toHaveBeenCalledWith('File not found: src/foo.ts')
+      })
+      toastError.mockRestore()
+    })
   })
 })

--- a/src/renderer/components/chat/ToolCallCard.tsx
+++ b/src/renderer/components/chat/ToolCallCard.tsx
@@ -30,9 +30,9 @@ import { type ToolIconName, toolIconName } from './tool-call-format'
 import {
   describeToolCall,
   firstString,
-  PATH_KEYS,
   READABLE_TEXT_KEYS,
-  readableOutput
+  readableOutput,
+  toolCallPath
 } from './tool-call-summary'
 
 /** Common prop shape shared by lucide icons and the bundled RobotIcon. */
@@ -183,15 +183,13 @@ const FILE_OPEN_KINDS = new Set(['read', 'edit', 'delete', 'move'])
 /**
  * Best-effort extraction of a file path from a tool call's `rawInput`, using
  * the shared `PATH_KEYS` set so the chip's primary path and the open-file
- * button stay in sync. Returns undefined when no path-like field is present.
+ * button stay in sync. Falls back to `diffInfo(content).path` for edit calls
+ * whose path lives only in the diff content. Returns undefined when no
+ * path-like field is present.
  */
 function toolCallFilePath(toolCall: ToolCall): string | undefined {
   if (!FILE_OPEN_KINDS.has(toolCall.kind ?? '')) return undefined
-  const input =
-    toolCall.rawInput && typeof toolCall.rawInput === 'object'
-      ? (toolCall.rawInput as Record<string, unknown>)
-      : null
-  return firstString(input, PATH_KEYS) ?? undefined
+  return toolCallPath(toolCall)
 }
 
 function ToolCallCardComponent({

--- a/src/renderer/components/chat/ToolCallCard.tsx
+++ b/src/renderer/components/chat/ToolCallCard.tsx
@@ -3,6 +3,7 @@ import {
   AlertCircle,
   Brain,
   ChevronRight,
+  ExternalLink,
   FilePen,
   FileText,
   FolderInput,
@@ -13,10 +14,14 @@ import {
   Trash2,
   Wrench
 } from 'lucide-react'
-import { memo, useEffect, useRef, useState } from 'react'
+import { memo, useCallback, useEffect, useRef, useState } from 'react'
+import { toast } from 'sonner'
 import robotIconRaw from '@/assets/agent-icons/robot-01.svg?raw'
 import { CollapseExpandMotion } from '@/components/ui/collapse-expand-motion'
+import { IconActionButton } from '@/components/ui/icon-action-button'
 import type { ContentBlock, ToolCall, ToolCallContent } from '@/lib/acp-api'
+import { type FilePathResolutionContext, openFilePathFromTerminal } from '@/lib/file-path-links'
+import { logFrontendError } from '@/lib/log-api'
 import { cn } from '@/lib/utils'
 import { MediaBlocks } from './ChatMessage'
 import { bubbleEnter, CHEVRON_TRANSITION } from './chat-motion'
@@ -25,6 +30,7 @@ import { type ToolIconName, toolIconName } from './tool-call-format'
 import {
   describeToolCall,
   firstString,
+  PATH_KEYS,
   READABLE_TEXT_KEYS,
   readableOutput
 } from './tool-call-summary'
@@ -167,11 +173,31 @@ interface ToolCallCardProps {
   toolCall: ToolCall
   /** Play enter animation only for newly arrived tool calls. */
   animateEnter?: boolean
+  /** Filesystem roots used to resolve an "Open file" action on file tool calls. */
+  filePathContext?: FilePathResolutionContext
+}
+
+/** Kinds whose `rawInput` carries a file path worth offering to open in the editor. */
+const FILE_OPEN_KINDS = new Set(['read', 'edit', 'delete', 'move'])
+
+/**
+ * Best-effort extraction of a file path from a tool call's `rawInput`, using
+ * the shared `PATH_KEYS` set so the chip's primary path and the open-file
+ * button stay in sync. Returns undefined when no path-like field is present.
+ */
+function toolCallFilePath(toolCall: ToolCall): string | undefined {
+  if (!FILE_OPEN_KINDS.has(toolCall.kind ?? '')) return undefined
+  const input =
+    toolCall.rawInput && typeof toolCall.rawInput === 'object'
+      ? (toolCall.rawInput as Record<string, unknown>)
+      : null
+  return firstString(input, PATH_KEYS) ?? undefined
 }
 
 function ToolCallCardComponent({
   toolCall,
-  animateEnter = true
+  animateEnter = true,
+  filePathContext
 }: ToolCallCardProps): React.JSX.Element {
   const reduced = useReducedMotion() ?? false
   const Icon = ICONS[toolIconName(toolCall)]
@@ -203,7 +229,30 @@ function ToolCallCardComponent({
   const { verb, primary, detail, diffStat } = describeToolCall(toolCall)
   const enter = bubbleEnter('neutral', reduced)
 
-  const row = (
+  const openFilePath = filePathContext ? toolCallFilePath(toolCall) : undefined
+  const openFile = useCallback(() => {
+    if (!openFilePath || !filePathContext) return
+    void openFilePathFromTerminal(openFilePath, filePathContext)
+      .then((result) => {
+        if (!result.ok) toast.error(result.message)
+      })
+      .catch((error: unknown) => {
+        void logFrontendError({
+          level: 'warn',
+          source: 'ToolCallCard.openFile',
+          message: `Failed to open ${openFilePath}: ${String(error)}`
+        })
+        toast.error('Failed to open file from chat.')
+      })
+  }, [openFilePath, filePathContext])
+
+  // Row summary (icon + label + meta) lives inside the disclosure button so
+  // clicking the label toggles details. The open-file button and chevron are
+  // rendered as siblings outside the disclosure button — nesting a <button>
+  // inside the disclosure <button> is invalid HTML, so they stay at the row
+  // level. Visual order (icon, label, meta/diffStat, open-file, duration,
+  // alert, chevron) is preserved by the flex container below.
+  const rowSummary = (
     <>
       <Icon
         size={13}
@@ -227,22 +276,6 @@ function ToolCallCardComponent({
           <span className="shrink-0 text-3xs tabular-nums text-muted-foreground">{detail}</span>
         )
       )}
-      {durationMs != null && (
-        <span className="hidden shrink-0 text-3xs tabular-nums text-muted-foreground group-hover/tool:inline">
-          {formatDuration(durationMs)}
-        </span>
-      )}
-      {failed && <AlertCircle size={12} className="shrink-0 text-destructive" />}
-      {hasDetail && (
-        <motion.span
-          aria-hidden="true"
-          className="shrink-0 text-muted-foreground"
-          animate={{ rotate: open ? 90 : 0 }}
-          transition={reduced ? { duration: 0 } : CHEVRON_TRANSITION}
-        >
-          <ChevronRight size={13} />
-        </motion.span>
-      )}
     </>
   )
 
@@ -259,19 +292,44 @@ function ToolCallCardComponent({
       transition={enter.transition}
     >
       <div className="relative z-10">
-        {hasDetail ? (
-          <button
-            type="button"
-            onClick={() => setOpen((v) => !v)}
-            aria-expanded={open}
-            data-press-feedback="off"
-            className="flex min-h-7 w-full items-center gap-2 px-1 py-1 text-left text-xs outline-none transition-colors hover:text-foreground focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring"
-          >
-            {row}
-          </button>
-        ) : (
-          <div className="flex min-h-7 items-center gap-2 px-1 py-1 text-xs">{row}</div>
-        )}
+        <div className="flex min-h-7 items-center gap-2 px-1 py-1 text-xs">
+          {hasDetail ? (
+            <button
+              type="button"
+              onClick={() => setOpen((v) => !v)}
+              aria-expanded={open}
+              data-press-feedback="off"
+              className="flex min-h-7 min-w-0 flex-1 items-center gap-2 text-left text-xs outline-none transition-colors hover:text-foreground focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring"
+            >
+              {rowSummary}
+            </button>
+          ) : (
+            <div className="flex min-h-7 min-w-0 flex-1 items-center gap-2 text-xs">
+              {rowSummary}
+            </div>
+          )}
+          {openFilePath ? (
+            <IconActionButton label="Open file" onClick={openFile} size="sm">
+              <ExternalLink />
+            </IconActionButton>
+          ) : null}
+          {durationMs != null && (
+            <span className="hidden shrink-0 text-3xs tabular-nums text-muted-foreground group-hover/tool:inline">
+              {formatDuration(durationMs)}
+            </span>
+          )}
+          {failed && <AlertCircle size={12} className="shrink-0 text-destructive" />}
+          {hasDetail && (
+            <motion.span
+              aria-hidden="true"
+              className="shrink-0 text-muted-foreground"
+              animate={{ rotate: open ? 90 : 0 }}
+              transition={reduced ? { duration: 0 } : CHEVRON_TRANSITION}
+            >
+              <ChevronRight size={13} />
+            </motion.span>
+          )}
+        </div>
         {hasDetail && (
           <CollapseExpandMotion open={open}>
             <div className="ml-4 flex flex-col gap-1.5 border-l border-border/50 px-2 pb-2 pt-1.5">

--- a/src/renderer/components/chat/TurnActivity.tsx
+++ b/src/renderer/components/chat/TurnActivity.tsx
@@ -4,6 +4,7 @@ import { useEffect, useRef, useState } from 'react'
 import { CollapseExpandMotion } from '@/components/ui/collapse-expand-motion'
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible'
 import { ShimmerText } from '@/components/ui/shimmer-text'
+import type { FilePathResolutionContext } from '@/lib/file-path-links'
 import { cn } from '@/lib/utils'
 import { ChatMessage } from './ChatMessage'
 import { CHEVRON_TRANSITION } from './chat-motion'
@@ -19,6 +20,8 @@ interface TurnActivityProps {
   attentionRequired: boolean
   hasFinalResponse: boolean
   shouldAnimateEnter: (id: string) => boolean
+  /** Filesystem roots used for "Open file" actions on file tool calls. */
+  filePathContext?: FilePathResolutionContext
 }
 
 /** Borderless, turn-level disclosure for reasoning, tools, and intermediate narration. */
@@ -28,7 +31,8 @@ export function TurnActivity({
   durationMs,
   attentionRequired,
   hasFinalResponse,
-  shouldAnimateEnter
+  shouldAnimateEnter,
+  filePathContext
 }: TurnActivityProps): React.JSX.Element {
   const reduced = useReducedMotion() ?? false
   const [open, setOpen] = useState(active || (!attentionRequired && !hasFinalResponse))
@@ -76,6 +80,7 @@ export function TurnActivity({
                     key={item.key}
                     toolCall={item.tool}
                     animateEnter={shouldAnimateEnter(item.tool.toolCallId)}
+                    filePathContext={filePathContext}
                   />
                 )
               }
@@ -95,6 +100,7 @@ export function TurnActivity({
                   showHeader={false}
                   isLast={active && index === items.length - 1}
                   animateEnter={shouldAnimateEnter(item.message.id)}
+                  filePathContext={filePathContext}
                 />
               )
             })}

--- a/src/renderer/components/chat/chat-markdown-code.test.tsx
+++ b/src/renderer/components/chat/chat-markdown-code.test.tsx
@@ -39,11 +39,11 @@ describe('ChatMarkdownCode', () => {
     expect(getByTestId('code-block').getAttribute('data-code')).toBe('line1\nline2\nline3')
   })
 
-  it('joins array children with newline when any segment carries a newline (no node value)', () => {
+  it('recurses through array children preserving embedded newlines (no node value)', () => {
     const { getByTestId } = render(
       withTooltip(
         <ChatMarkdownCode className="language-ts" data-block>
-          {['line1\nline2', 'line3']}
+          {['line1\n', 'line2\n', 'line3']}
         </ChatMarkdownCode>
       )
     )

--- a/src/renderer/components/chat/chat-markdown-code.test.tsx
+++ b/src/renderer/components/chat/chat-markdown-code.test.tsx
@@ -1,0 +1,76 @@
+import { render } from '@testing-library/react'
+import { createContext } from 'react'
+import { describe, expect, it, vi } from 'vitest'
+import { TooltipProvider } from '@/components/ui/tooltip'
+
+vi.mock('streamdown', () => {
+  const StreamdownContext = createContext({ lineNumbers: false, isAnimating: false })
+  return {
+    StreamdownContext,
+    Streamdown: () => null,
+    // Capture the `code` prop so tests can assert newline preservation.
+    CodeBlock: (props: { code?: string; children?: React.ReactNode }) => (
+      <div data-testid="code-block" data-code={props.code ?? ''}>
+        {props.children}
+      </div>
+    )
+  }
+})
+
+vi.mock('@streamdown/mermaid', () => ({ mermaid: () => {} }))
+
+import { ChatMarkdownCode } from './chat-markdown-code'
+
+function withTooltip(ui: React.JSX.Element): React.JSX.Element {
+  return <TooltipProvider>{ui}</TooltipProvider>
+}
+
+describe('ChatMarkdownCode', () => {
+  it('preserves newlines in a multi-line fenced code block via the node value', () => {
+    const node = { value: 'line1\nline2\nline3' }
+    const { getByTestId } = render(
+      withTooltip(
+        <ChatMarkdownCode className="language-ts" data-block node={node}>
+          {['line1', 'line2', 'line3']}
+        </ChatMarkdownCode>
+      )
+    )
+
+    expect(getByTestId('code-block').getAttribute('data-code')).toBe('line1\nline2\nline3')
+  })
+
+  it('joins array children with newline when any segment carries a newline (no node value)', () => {
+    const { getByTestId } = render(
+      withTooltip(
+        <ChatMarkdownCode className="language-ts" data-block>
+          {['line1\nline2', 'line3']}
+        </ChatMarkdownCode>
+      )
+    )
+
+    expect(getByTestId('code-block').getAttribute('data-code')).toBe('line1\nline2\nline3')
+  })
+
+  it('renders inline code with the inline-code data attribute', () => {
+    const { container } = render(withTooltip(<ChatMarkdownCode>inline snippet</ChatMarkdownCode>))
+
+    const code = container.querySelector('code')
+    expect(code).toHaveAttribute('data-streamdown', 'inline-code')
+  })
+
+  it('passes the compact size class to the copy/download action buttons', () => {
+    const { getAllByRole } = render(
+      withTooltip(
+        <ChatMarkdownCode className="language-ts" data-block>
+          {'const x = 1'}
+        </ChatMarkdownCode>
+      )
+    )
+
+    // IconActionButton renders a <button>; the sm variant applies size-6 (not size-11).
+    for (const button of getAllByRole('button')) {
+      expect(button).toHaveClass('size-6')
+      expect(button).not.toHaveClass('size-11')
+    }
+  })
+})

--- a/src/renderer/components/chat/chat-markdown-code.tsx
+++ b/src/renderer/components/chat/chat-markdown-code.tsx
@@ -20,14 +20,22 @@ const MERMAID_PLUGIN = mermaidPlugin
 const LANGUAGE_RE = /language-([^\s]+)/
 
 /** Pull fenced-code text out of Streamdown's `code` children shapes. */
-function childrenToCode(children: ReactNode): string {
+function childrenToCode(children: ReactNode, node?: unknown): string {
+  // Prefer the raw markdown node value — it preserves the original newlines
+  // that React's children-array shape would collapse when joined with ''.
+  const nodeValue = (node as { value?: string } | null | undefined)?.value
+  if (typeof nodeValue === 'string') return nodeValue
+
   if (typeof children === 'string') return children
   if (isValidElement<{ children?: ReactNode }>(children)) {
     const nested = children.props.children
     if (typeof nested === 'string') return nested
   }
   if (Array.isArray(children)) {
-    return children.map((child) => childrenToCode(child as ReactNode)).join('')
+    const parts = children.map((child) => childrenToCode(child as ReactNode))
+    // Join with '\n' only when any segment carries a newline; otherwise ''
+    // preserves the inline-code path's compact rendering.
+    return parts.some((p) => p.includes('\n')) ? parts.join('\n') : parts.join('')
   }
   return ''
 }
@@ -67,7 +75,12 @@ function CodeCopyAction({ code }: { code: string }): React.JSX.Element {
   }, [code, isAnimating])
 
   return (
-    <IconActionButton label={copied ? 'Copied' : 'Copy'} onClick={copy} disabled={isAnimating}>
+    <IconActionButton
+      label={copied ? 'Copied' : 'Copy'}
+      onClick={copy}
+      disabled={isAnimating}
+      size="sm"
+    >
       <IconSwap iconKey={copied}>{copied ? <Check className="text-success" /> : <Copy />}</IconSwap>
     </IconActionButton>
   )
@@ -93,7 +106,7 @@ function CodeDownloadAction({
   }, [code, isAnimating, language])
 
   return (
-    <IconActionButton label="Download" onClick={download} disabled={isAnimating}>
+    <IconActionButton label="Download" onClick={download} disabled={isAnimating} size="sm">
       <Download />
     </IconActionButton>
   )
@@ -111,13 +124,13 @@ type ChatMarkdownCodeProps = ComponentPropsWithoutRef<'code'> & {
 export function ChatMarkdownCode({
   className,
   children,
-  node: _node,
+  node,
   ...props
 }: ChatMarkdownCodeProps): React.JSX.Element {
   const { lineNumbers } = useContext(StreamdownContext)
   const isInline = !('data-block' in props)
   const language = languageFromClassName(className)
-  const code = childrenToCode(children)
+  const code = childrenToCode(children, node)
 
   if (isInline) {
     return (

--- a/src/renderer/components/chat/chat-markdown-code.tsx
+++ b/src/renderer/components/chat/chat-markdown-code.tsx
@@ -28,14 +28,10 @@ function childrenToCode(children: ReactNode, node?: unknown): string {
 
   if (typeof children === 'string') return children
   if (isValidElement<{ children?: ReactNode }>(children)) {
-    const nested = children.props.children
-    if (typeof nested === 'string') return nested
+    return childrenToCode(children.props.children)
   }
   if (Array.isArray(children)) {
-    const parts = children.map((child) => childrenToCode(child as ReactNode))
-    // Join with '\n' only when any segment carries a newline; otherwise ''
-    // preserves the inline-code path's compact rendering.
-    return parts.some((p) => p.includes('\n')) ? parts.join('\n') : parts.join('')
+    return children.map((child) => childrenToCode(child as ReactNode)).join('')
   }
   return ''
 }

--- a/src/renderer/components/chat/chat-markdown-table.test.tsx
+++ b/src/renderer/components/chat/chat-markdown-table.test.tsx
@@ -1,17 +1,33 @@
 import { render, screen } from '@testing-library/react'
-import { createContext } from 'react'
+import { createContext, type ReactNode } from 'react'
 import { describe, expect, it, vi } from 'vitest'
+import { TooltipProvider } from '@/components/ui/tooltip'
 
 vi.mock('streamdown', () => {
   const StreamdownContext = createContext({ controls: false, isAnimating: false })
   return {
     StreamdownContext,
-    TableCopyDropdown: ({ children }: { children: React.ReactNode }) => <>{children}</>,
-    TableDownloadDropdown: ({ children }: { children: React.ReactNode }) => <>{children}</>
+    TableCopyDropdown: ({ children }: { children: ReactNode }) => <>{children}</>,
+    TableDownloadDropdown: ({ children }: { children: ReactNode }) => <>{children}</>
   }
 })
 
+// Same context instance the component consumes (mocked module export).
+import { StreamdownContext } from 'streamdown'
 import { ChatMarkdownTable } from './chat-markdown-table'
+
+const CONTROLS_ENABLED = {
+  controls: { table: { copy: true, download: true, fullscreen: true } },
+  isAnimating: false
+}
+
+function withControlsEnabled(ui: ReactNode): React.JSX.Element {
+  return (
+    <TooltipProvider>
+      <StreamdownContext.Provider value={CONTROLS_ENABLED}>{ui}</StreamdownContext.Provider>
+    </TooltipProvider>
+  )
+}
 
 describe('ChatMarkdownTable', () => {
   it('rerenders growing streamed children even when the class name is unchanged', () => {
@@ -72,5 +88,62 @@ describe('ChatMarkdownTable', () => {
     expect(scrollRegion?.tagName).toBe('SECTION')
     expect(scrollRegion).toHaveAttribute('tabindex', '0')
     expect(scrollRegion).toHaveAttribute('aria-label', 'Markdown table')
+  })
+
+  it('uses the compact my-1 margin on the wrapper (not my-2)', () => {
+    const { container } = render(
+      <ChatMarkdownTable>
+        <tbody>
+          <tr>
+            <td>cell</td>
+          </tr>
+        </tbody>
+      </ChatMarkdownTable>
+    )
+
+    const wrapper = container.querySelector('[data-streamdown="table-wrapper"]')
+    expect(wrapper).toHaveClass('my-1')
+    expect(wrapper).not.toHaveClass('my-2')
+  })
+
+  it('renders compact (size-6) toolbar buttons when controls are enabled', () => {
+    const { container, getAllByRole } = render(
+      withControlsEnabled(
+        <ChatMarkdownTable>
+          <tbody>
+            <tr>
+              <td>cell</td>
+            </tr>
+          </tbody>
+        </ChatMarkdownTable>
+      )
+    )
+
+    // Toolbar IconActionButtons use the sm variant → size-6, never size-11.
+    for (const button of getAllByRole('button')) {
+      expect(button).toHaveClass('size-6')
+      expect(button).not.toHaveClass('size-11')
+    }
+
+    // The toolbar's IconActionGroup carries dense (px-1 py-0.5), not the
+    // default px-1.5 py-1, so the chrome matches the compact button size.
+    const toolbar = container.querySelector('[data-streamdown="table-toolbar"]')
+    const group = toolbar?.firstElementChild
+    expect(group).toHaveClass('px-1', 'py-0.5')
+    expect(group).not.toHaveClass('px-1.5', 'py-1')
+  })
+
+  it('IconActionGroup dense variant applies compact padding', async () => {
+    const { IconActionGroup } = await import('@/components/ui/icon-action-button')
+    const { container } = render(
+      <TooltipProvider>
+        <IconActionGroup dense>
+          <span>child</span>
+        </IconActionGroup>
+      </TooltipProvider>
+    )
+    const group = container.firstElementChild
+    expect(group).toHaveClass('px-1', 'py-0.5')
+    expect(group).not.toHaveClass('px-1.5', 'py-1')
   })
 })

--- a/src/renderer/components/chat/chat-markdown-table.tsx
+++ b/src/renderer/components/chat/chat-markdown-table.tsx
@@ -60,7 +60,12 @@ function TableFullscreen({
 
   return (
     <>
-      <IconActionButton label="View fullscreen" onClick={() => setOpen(true)} disabled={disabled}>
+      <IconActionButton
+        label="View fullscreen"
+        onClick={() => setOpen(true)}
+        disabled={disabled}
+        size="sm"
+      >
         <Maximize2 />
       </IconActionButton>
       {open
@@ -84,7 +89,7 @@ function TableFullscreen({
                 role="presentation"
               >
                 <div className="flex items-center justify-end p-4">
-                  <IconActionGroup className="gap-0.5 px-1 py-0.5">
+                  <IconActionGroup className="gap-0.5" dense>
                     {showCopy ? (
                       <TableCopyDropdown>
                         <Copy />
@@ -95,7 +100,7 @@ function TableFullscreen({
                         <Download />
                       </TableDownloadDropdown>
                     ) : null}
-                    <IconActionButton label="Exit fullscreen" onClick={close}>
+                    <IconActionButton label="Exit fullscreen" onClick={close} size="sm">
                       <X />
                     </IconActionButton>
                   </IconActionGroup>
@@ -135,7 +140,7 @@ function ChatMarkdownTableComponent({
 
   return (
     <div
-      className="my-2 min-w-0 overflow-hidden rounded-md border border-border/50"
+      className="my-1 min-w-0 overflow-hidden rounded-md border border-border/40"
       data-streamdown="table-wrapper"
     >
       {toolbar ? (
@@ -143,7 +148,7 @@ function ChatMarkdownTableComponent({
           className="flex justify-end border-b border-border/40 px-1 py-0.5"
           data-streamdown="table-toolbar"
         >
-          <IconActionGroup className="gap-0.5 px-1 py-0.5">
+          <IconActionGroup className="gap-0.5" dense>
             {showCopy ? (
               <TableCopyDropdown>
                 <Copy />

--- a/src/renderer/components/chat/tool-call-summary.ts
+++ b/src/renderer/components/chat/tool-call-summary.ts
@@ -120,6 +120,20 @@ function diffInfo(content: ToolCallContent[]): {
   return { path, added, removed, hasDiff }
 }
 
+/**
+ * Shared best-effort file-path resolver for a tool call. Checks `rawInput`
+ * against `PATH_KEYS`, then falls back to `diffInfo(content).path`. Used by
+ * both `describeToolCall` (chip label) and `ToolCallCard`'s open-file action
+ * so they stay in sync.
+ */
+export function toolCallPath(toolCall: ToolCall): string | undefined {
+  const input = asRecord(toolCall.rawInput)
+  const fromInput = firstString(input, PATH_KEYS)
+  if (fromInput) return fromInput
+  const content = toolCall.content ?? []
+  return diffInfo(content).path
+}
+
 /** "L<start>-<end>" from common range keys, or null when not derivable. */
 function lineRange(input: Record<string, unknown> | null): string | null {
   const start = firstNumber(input, ['startLine', 'start_line', 'start', 'line', 'lineStart'])
@@ -199,13 +213,13 @@ export function describeToolCall(toolCall: ToolCall): ToolCallSummary {
     case 'read':
     case 'delete':
     case 'move': {
-      const p = firstString(input, PATH_KEYS) ?? diffInfo(content).path
+      const p = toolCallPath(toolCall)
       const primary = p ? baseName(p) : (title ?? 'file')
       return { verb, primary, detail: toolCall.kind === 'read' ? lineRange(input) : null }
     }
     case 'edit': {
       const diff = diffInfo(content)
-      const p = firstString(input, PATH_KEYS) ?? diff.path
+      const p = toolCallPath(toolCall)
       const primary = p ? baseName(p) : (title ?? 'file')
       let detail: string | null = null
       let diffStat: { added: number; removed: number } | null = null

--- a/src/renderer/components/chat/tool-call-summary.ts
+++ b/src/renderer/components/chat/tool-call-summary.ts
@@ -49,7 +49,7 @@ function firstNumber(obj: Record<string, unknown> | null, keys: string[]): numbe
   return undefined
 }
 
-const PATH_KEYS = [
+export const PATH_KEYS = [
   'path',
   'filePath',
   'file_path',

--- a/src/renderer/components/ui/icon-action-button.test.tsx
+++ b/src/renderer/components/ui/icon-action-button.test.tsx
@@ -54,6 +54,32 @@ describe('IconActionButton', () => {
     expect(button).toHaveClass('disabled:text-muted-foreground/50')
     expect(button).not.toHaveClass('disabled:opacity-50')
   })
+
+  it('renders a 24px (size-6) slot when size="sm"', () => {
+    render(
+      <TooltipProvider>
+        <IconActionButton label="Copy" onClick={() => {}} size="sm">
+          <span>icon</span>
+        </IconActionButton>
+      </TooltipProvider>
+    )
+    const button = screen.getByRole('button', { name: 'Copy' })
+    expect(button).toHaveClass('size-6')
+    expect(button).not.toHaveClass('size-11')
+  })
+
+  it('defaults to the 44px (size-11) slot when size is omitted', () => {
+    render(
+      <TooltipProvider>
+        <IconActionButton label="Copy" onClick={() => {}}>
+          <span>icon</span>
+        </IconActionButton>
+      </TooltipProvider>
+    )
+    const button = screen.getByRole('button', { name: 'Copy' })
+    expect(button).toHaveClass('size-11')
+    expect(button).not.toHaveClass('size-6')
+  })
 })
 
 describe('IconActionGroup', () => {
@@ -65,5 +91,24 @@ describe('IconActionGroup', () => {
     )
     expect(container.firstElementChild).toHaveClass('rounded-md')
     expect(container.firstElementChild).toHaveClass('border-sidebar')
+  })
+
+  it('applies dense (px-1 py-0.5) padding when dense is true', () => {
+    const { container } = render(
+      <IconActionGroup dense>
+        <span>child</span>
+      </IconActionGroup>
+    )
+    expect(container.firstElementChild).toHaveClass('px-1', 'py-0.5')
+    expect(container.firstElementChild).not.toHaveClass('px-1.5', 'py-1')
+  })
+
+  it('uses default (px-1.5 py-1) padding when dense is omitted', () => {
+    const { container } = render(
+      <IconActionGroup>
+        <span>child</span>
+      </IconActionGroup>
+    )
+    expect(container.firstElementChild).toHaveClass('px-1.5', 'py-1')
   })
 })

--- a/src/renderer/components/ui/icon-action-button.tsx
+++ b/src/renderer/components/ui/icon-action-button.tsx
@@ -9,20 +9,28 @@ interface IconActionButtonProps {
   children: ReactNode
   disabled?: boolean
   className?: string
+  /**
+   * Layout size. `default` keeps the 44×44 WCAG touch slot (footer/user
+   * controls). `sm` drops to 24px for dense streamdown chrome (code-block
+   * actions, table toolbar, tool-call rows) — the glyph size is unchanged.
+   */
+  size?: 'default' | 'sm'
 }
 
 /**
  * Compact chat/streamdown-style icon control: color-only hover, shared
  * tooltip, press scale from global button feedback. Layout slot is 44×44
  * (WCAG touch) with a centered Streamdown-sized glyph so adjacent actions
- * never share overlapping hit regions.
+ * never share overlapping hit regions. Pass `size="sm"` for dense chrome
+ * (code-block actions, table toolbar) where 44px is visually too heavy.
  */
 export function IconActionButton({
   label,
   onClick,
   children,
   disabled = false,
-  className
+  className,
+  size = 'default'
 }: IconActionButtonProps): React.JSX.Element {
   return (
     <Tooltip>
@@ -33,8 +41,9 @@ export function IconActionButton({
           disabled={disabled}
           onClick={onClick}
           className={cn(
-            // 44×44 layout slot; glyph stays Streamdown-sized via [&_svg].
-            'relative inline-flex size-11 shrink-0 items-center justify-center',
+            size === 'sm'
+              ? 'relative inline-flex size-6 shrink-0 items-center justify-center'
+              : 'relative inline-flex size-11 shrink-0 items-center justify-center',
             'cursor-pointer text-muted-foreground transition-colors duration-150',
             'hover:text-foreground disabled:cursor-not-allowed disabled:text-muted-foreground/50',
             // Let explicit success/destructive tokens on the glyph win over muted.
@@ -53,19 +62,29 @@ export function IconActionButton({
 interface IconActionGroupProps {
   children: ReactNode
   className?: string
+  /**
+   * Tighten padding for dense chrome hosting `size="sm"` buttons (code-block
+   * actions, table toolbar). Defaults to `false` for footer MessageActions.
+   */
+  dense?: boolean
 }
 
 /**
  * Streamdown code-action pill chrome — border, sidebar wash, backdrop blur.
  * Use around MessageActions so footer/user controls match code-block actions.
+ * Pass `dense` for the compact variant that pairs with `size="sm"` buttons.
  */
-export function IconActionGroup({ children, className }: IconActionGroupProps): React.JSX.Element {
+export function IconActionGroup({
+  children,
+  className,
+  dense = false
+}: IconActionGroupProps): React.JSX.Element {
   return (
     <div
       className={cn(
         'pointer-events-auto flex shrink-0 items-center gap-2 rounded-md border border-sidebar',
-        'bg-sidebar/80 px-1.5 py-1',
-        'supports-[backdrop-filter]:bg-sidebar/70 supports-[backdrop-filter]:backdrop-blur',
+        'bg-sidebar/80 supports-[backdrop-filter]:bg-sidebar/70 supports-[backdrop-filter]:backdrop-blur',
+        dense ? 'px-1 py-0.5' : 'px-1.5 py-1',
         className
       )}
     >

--- a/src/renderer/components/ui/icon-action-button.tsx
+++ b/src/renderer/components/ui/icon-action-button.tsx
@@ -42,7 +42,7 @@ export function IconActionButton({
           onClick={onClick}
           className={cn(
             size === 'sm'
-              ? 'relative inline-flex size-6 shrink-0 items-center justify-center'
+              ? 'relative inline-flex size-6 shrink-0 items-center justify-center p-0'
               : 'relative inline-flex size-11 shrink-0 items-center justify-center',
             'cursor-pointer text-muted-foreground transition-colors duration-150',
             'hover:text-foreground disabled:cursor-not-allowed disabled:text-muted-foreground/50',

--- a/src/renderer/index.css
+++ b/src/renderer/index.css
@@ -764,6 +764,14 @@
   .chat-streamdown [data-streamdown="code-block-body"] code {
     line-height: inherit;
   }
+  /* Streamdown code-block action buttons: pin to 24px so the size="sm"
+     IconActionButton stays compact even when streamdown's own CSS sizes
+     the action slot. Mirrors the table-toolbar override below. */
+  .chat-streamdown [data-streamdown="code-block-actions"] button {
+    width: 1.5rem;
+    height: 1.5rem;
+    padding: 0;
+  }
 
   /* Streamdown table dropdown triggers: same 24px hit box as IconActionButton. */
   .chat-streamdown [data-streamdown="table-toolbar"] .relative {

--- a/src/renderer/index.css
+++ b/src/renderer/index.css
@@ -803,6 +803,34 @@
     height: 0.875rem;
     flex-shrink: 0;
   }
+  /* Fullscreen table toolbar is portaled to document.body, so it's outside
+     .chat-streamdown — scope by the data attribute instead. Mirrors the
+     in-page table-toolbar override for compact 24px dropdown triggers. */
+  [data-streamdown="table-fullscreen"] button {
+    display: inline-flex;
+    width: 1.5rem;
+    height: 1.5rem;
+    padding: 0;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+    color: hsl(var(--muted-foreground));
+    transition-property: color;
+    transition-duration: 150ms;
+  }
+  [data-streamdown="table-fullscreen"] button:hover {
+    color: hsl(var(--foreground));
+  }
+  [data-streamdown="table-fullscreen"] button:disabled {
+    cursor: not-allowed;
+    opacity: 0.5;
+  }
+  [data-streamdown="table-fullscreen"] button svg {
+    display: block;
+    width: 0.875rem;
+    height: 0.875rem;
+    flex-shrink: 0;
+  }
   .chat-streamdown [data-streamdown="table"] {
     min-width: max-content;
     font-size: 0.875rem;


### PR DESCRIPTION
## Summary

The chat streamdown rendering had several polish gaps: (1) the header/toolbar on tables and codeblocks (where copy/download controls live) was too large and visually prominent — `IconActionButton` was 44px where streamdown's own defaults use ~24px; (2) fenced code blocks rendered inline (newlines collapsed) instead of as multi-line blocks; (3) file-path links inside tables/prose appeared "blocked" because they required Ctrl/Cmd-click to open; (4) tool call cards had no "open file in editor" action when the tool call references a file path.

## Related Issue

No related issue — this is a direct UX polish request from the project maintainer to compact streamdown chrome, fix codeblock newlines, and add open-file on tool calls.

## Type of Change

- [x] feat: new feature

## What Changed

- **`IconActionButton`**: Added `size="sm"` (24px) variant for dense streamdown chrome (code-block actions, table toolbar, tool-call rows); default stays 44px for WCAG touch targets. Added `dense` prop to `IconActionGroup` for compact padding (`px-1 py-0.5`).
- **`chat-markdown-code.tsx`**: Fixed `childrenToCode` to prefer the markdown `node.value` (raw text with original newlines) instead of joining array children with `''` which collapsed newlines. Pass `size="sm"` to copy/download action buttons.
- **`chat-markdown-table.tsx`**: Pass `size="sm"` to all toolbar `IconActionButton`s. Use `dense` on `IconActionGroup`. Reduce wrapper `my-2` -> `my-1`, border `/50` -> `/40`.
- **`ChatMessage.tsx`**: Remove the Ctrl/Cmd-click gate on file-path links so regular click opens the file. Add `button !== 0 || shiftKey` guard to preserve text selection and middle-click.
- **`ToolCallCard.tsx`**: Add `filePathContext` prop. Extract file path from `toolCall.rawInput` using `PATH_KEYS` for `read`/`edit`/`delete`/`move` kinds. Render an "Open file" `IconActionButton` (`size="sm"`, `ExternalLink` icon). Row restructured to avoid nested `<button>` elements.
- **`ChatMessageList.tsx` + `TurnActivity.tsx`**: Wire `filePathContext` through to `ToolCallCard` and `ChatMessage`.
- **`tool-call-summary.ts`**: Export `PATH_KEYS`.
- **`index.css`**: Add CSS safety net for `[data-streamdown="code-block-actions"] button` sizing (24px).
- **Tests**: New `chat-markdown-code.test.tsx` (4 tests). Extended `chat-markdown-table.test.tsx` (3), `ToolCallCard.test.tsx` (5), `icon-action-button.test.tsx` (3), `ChatMessage.test.tsx` (2 shift-click guard).

## How It Was Tested

- [x] `bun run typecheck`
- [x] `bun run test`
- [ ] `cargo clippy --all-targets -- -D warnings` (in src-tauri) — no Rust changes in this PR
- [ ] `cargo test` (in src-tauri) — no Rust changes in this PR
- [x] Manual verification completed

## CI & Review Gate

- [ ] All CI checks pass (PR Validation, Rust Checks, Build Verification, Security Scans)
- [ ] Code review comments from CodeRabbit / Claude have been addressed or resolved
- [ ] No unresolved review findings remain

## Checklist

- [x] My PR title follows the conventional commit format used by this repo
- [x] I linked the related issue or explained why none exists
- [x] I updated docs when needed
- [x] I added or updated tests when needed
- [x] I verified the change does not introduce unrelated modifications
- [x] I read AGENTS.md and followed the contributor guidelines
- [x] A human reviewed the complete diff before submission
