### PR TITLE
fix(acp): persist desktop prompts before dispatch + reconcile relay sequence after background title

### DIFF
--- a/docs/api-contracts.md
+++ b/docs/api-contracts.md
@@ -379,6 +379,17 @@ See `docs/acp-agent-plan-compliance.md` for registry compliance tiers and agent 
 
 When a second prompt is rejected because a turn is already in flight, Rust returns a string containing the stable code `ACP_TURN_IN_PROGRESS` (matched by renderer `ACP_TURN_IN_PROGRESS_CODE` in `prompt-queue-orchestration.ts`). Do not reword this prefix without updating both sides.
 
+### `acp_send_prompt` durability ordering
+
+Desktop prompt persistence mirrors the WS `send_prompt` handler (`src-tauri/src/web/ws.rs`) so a transport failure can never erase an accepted user message. Before dispatching through `AcpManager::send_prompt`, the command:
+
+1. verifies authoritative session ownership (`AcpManager::owns_session`) — rejects a cross-agent session id before any durable write;
+2. resolves the ephemeral flag (`AcpManager::is_ephemeral_session`) — backend-ephemeral utility sessions are skipped (no durable history or sidebar row);
+3. for non-ephemeral sessions, persists the accepted prompt through `WsRelaySink::persist_user_prompt` (the relay sequence authority + durability barrier) with the same payload shape as the web path (`{agentId, sessionId, turnId, content}`; `turnId` is `null` on the desktop path);
+4. only then dispatches through `AcpManager::send_prompt`.
+
+A persistence failure rejects dispatch (the prompt is not erased) and is logged with session context only — never prompt content. This establishes first-message title provenance on restore: a reopened chat materializes the user bubble (from the durable `user_prompt` record) and derives the title, even for agents (e.g. OpenCode) that do not reliably send a live `session_info_update` title.
+
 ## Notes
 
 - This is an **internal desktop IPC API**, not a third-party/public integration API.

--- a/src-tauri/src/acp/commands.rs
+++ b/src-tauri/src/acp/commands.rs
@@ -10,12 +10,14 @@ use std::sync::Arc;
 use agent_client_protocol::schema::v1::{
     ContentBlock, ListSessionsResponse, McpServer, SessionConfigOption, StopReason, TextContent,
 };
+use serde_json::json;
 use tauri::State;
 
 use crate::acp::config::{require_config_id, AgentConfig, AgentId, SessionId};
 use crate::acp::manager::{
     AcpManager, NewSessionOutcome, SessionCreationContext, SessionReopenOutcome, SpawnOutcome,
 };
+use crate::web::WsRelaySink;
 
 /// Spawn an ACP agent subprocess and complete the `initialize` handshake.
 /// Returns the authoritative [`SpawnOutcome`] (capabilities + auth methods +
@@ -138,9 +140,21 @@ pub async fn acp_list_sessions(
 
 /// Send a prompt turn. Accepts either structured ACP content blocks or, for
 /// convenience, a plain text string (wrapped into a single text block).
+///
+/// Desktop durability parity (CAP-2): before dispatching through
+/// `AcpManager::send_prompt`, a non-ephemeral session's accepted prompt is
+/// persisted through the `WsRelaySink` durability boundary — the same
+/// ordering the WS `send_prompt` handler uses (`web/ws.rs`). A transport
+/// failure after acceptance can therefore never erase the user message, and a
+/// restored chat materializes the user bubble + derives first-message title
+/// provenance. Ephemeral utility sessions are skipped (no durable history).
+/// The payload shape (`{agentId, sessionId, turnId, content}`) matches the
+/// web path byte-for-byte; `turnId` is `null` on the desktop path (the
+/// renderer's dedup is Tauri-event-based, not wire-level).
 #[tauri::command]
 pub async fn acp_send_prompt(
     manager: State<'_, Arc<AcpManager>>,
+    relay: State<'_, Arc<WsRelaySink>>,
     agent_id: AgentId,
     session_id: SessionId,
     content: Option<Vec<ContentBlock>>,
@@ -153,11 +167,78 @@ pub async fn acp_send_prompt(
         (Some(_), None) => return Err("prompt content must not be empty".to_string()),
         (None, None) => return Err("send_prompt requires either content or text".to_string()),
     };
+    // Ownership is authoritative driver state, not client input. Reject a
+    // cross-agent session id before persisting any durable prompt record
+    // (mirrors the WS `send_prompt` handler ordering).
+    match manager.owns_session(&agent_id, session_id.clone()).await {
+        Ok(true) => {}
+        Ok(false) => {
+            return Err("session does not belong to the supplied live agent".to_string())
+        }
+        Err(error) => return Err(error),
+    }
+    // Skip backend-ephemeral sessions — they have no durable history and must
+    // not produce a sidebar row. Matches the WS handler's ephemeral gate.
+    let ephemeral = match manager
+        .is_ephemeral_session(&agent_id, session_id.clone())
+        .await
+    {
+        Ok(value) => value,
+        Err(error) => {
+            log::warn!(
+                "[acp] failed to resolve ephemeral state for session {} (agent {}): {error}",
+                session_id.0,
+                agent_id.0
+            );
+            return Err(error);
+        }
+    };
+    if !ephemeral {
+        if let Err(error) = persist_accepted_prompt(relay.inner(), &agent_id, &session_id, &blocks)
+            .await
+        {
+            // Persistence failure rejects dispatch so a transport failure
+            // cannot erase an accepted user message. Log session context only
+            // — never the prompt content.
+            log::warn!(
+                "[acp] failed to persist accepted prompt for session {} (agent {}): {error}",
+                session_id.0,
+                agent_id.0
+            );
+            return Err(format!("failed to persist accepted prompt: {error}"));
+        }
+    }
     // Desktop path: no client turn-id (the renderer's dedup is Tauri-event-
     // based; the WS `turnId` field is Story 1.8's web concern). Pass `None`.
     manager
         .send_prompt(&agent_id, session_id, blocks, None)
         .await
+}
+
+/// Persist an accepted desktop prompt through the `WsRelaySink` durability
+/// boundary before ACP dispatch. Mirrors the WS `send_prompt` handler
+/// (`web/ws.rs`) payload shape (`{agentId, sessionId, turnId, content}`) so
+/// the durable `user_prompt` record and the restored user bubble are
+/// byte-identical across transports. `turnId` is `null` on the desktop path.
+/// Returns `Ok(())` when persisted (or when the relay has no durability
+/// attached — live-only mode), or `Err` when the flush failed; the caller
+/// must NOT dispatch on `Err`.
+pub(crate) async fn persist_accepted_prompt(
+    relay: &Arc<WsRelaySink>,
+    agent_id: &AgentId,
+    session_id: &SessionId,
+    blocks: &[ContentBlock],
+) -> Result<(), String> {
+    let payload = json!({
+        "agentId": agent_id.clone(),
+        "sessionId": session_id.clone(),
+        "turnId": null,
+        "content": blocks,
+    });
+    relay
+        .persist_user_prompt(session_id.0.as_str(), payload)
+        .await
+        .map(|_| ())
 }
 
 /// Cancel the active turn for a session.
@@ -523,6 +604,11 @@ pub fn acp_set_first_prompt_warmup_timeout(secs: Option<u64>) -> Result<(), Stri
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::acp::session_persistence::{SessionPersistence, SessionRegistration};
+    use crate::web::WsRelaySink;
+    use agent_client_protocol::schema::v1::{ContentBlock, TextContent};
+    use std::sync::Arc;
+    use std::time::{SystemTime, UNIX_EPOCH};
 
     /// Zero is meaningless for the three strictly-positive timeouts and must
     /// be rejected at the IPC boundary (the resolvers also filter it
@@ -535,5 +621,82 @@ mod tests {
         assert!(acp_set_turn_idle_timeout(Some(0)).is_err());
         assert!(acp_set_session_new_timeout(Some(0)).is_err());
         assert!(acp_set_session_reopen_timeout(Some(0)).is_err());
+    }
+
+    /// Regression: the desktop `acp_send_prompt` command persists an accepted
+    /// non-ephemeral prompt through `WsRelaySink` before dispatch (matching the
+    /// WS `send_prompt` handler ordering). This exercises the extracted
+    /// `persist_accepted_prompt` helper directly: it must write one durable
+    /// `user_prompt` record whose payload shape (`{agentId, sessionId, turnId,
+    /// content}`) matches the web path byte-for-byte, with `turnId: null` on
+    /// the desktop path. The command body calls this helper BEFORE
+    /// `AcpManager::send_prompt` and only when `is_ephemeral_session` returns
+    /// `false`; those ordering + ephemeral-skip invariants are enforced by the
+    /// command body structure (a full `acp_send_prompt` unit test would need a
+    /// real `AcpManager` + Tauri `State`, which is not constructible here).
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn persist_accepted_prompt_writes_durable_user_prompt_with_desktop_payload() {
+        let stamp = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let root = std::env::temp_dir().join(format!("termul-acp-prompt-persist-{stamp}"));
+        std::fs::create_dir_all(&root).unwrap();
+        let cwd = root.join("cwd");
+        std::fs::create_dir_all(&cwd).unwrap();
+        let persistence = SessionPersistence::open(root.join("sessions"))
+            .await
+            .unwrap();
+        persistence
+            .register_session(SessionRegistration {
+                session_id: "sess-desktop".to_string(),
+                stable_agent_namespace: None,
+                runtime_agent_id: None,
+                project_id: None,
+                cwd,
+                ..Default::default()
+            })
+            .await
+            .unwrap();
+        let relay = Arc::new(WsRelaySink::with_persistence(8, persistence.clone()));
+        let blocks = vec![ContentBlock::Text(TextContent::new("hello world"))];
+        persist_accepted_prompt(
+            &relay,
+            &AgentId("agent-1".to_string()),
+            &SessionId("sess-desktop".to_string()),
+            &blocks,
+        )
+        .await
+        .unwrap();
+
+        // The durable frontier advanced: one user_prompt record at seq 1.
+        assert_eq!(persistence.last_seq("sess-desktop").unwrap(), 1);
+        let metadata = persistence.metadata("sess-desktop").unwrap();
+        assert_eq!(metadata.message_count, 1);
+        // First-message title provenance is established from the user_prompt.
+        assert!(metadata.title.is_some(), "title derived from user_prompt");
+
+        // The durable record carries the desktop payload shape (matches the
+        // WS `send_prompt` handler): agentId, sessionId, turnId=null, content.
+        let records = persistence
+            .replay_after_async("sess-desktop".to_string(), 0)
+            .await
+            .unwrap();
+        assert_eq!(records.len(), 1);
+        let record = &records[0];
+        assert_eq!(record.type_, "user_prompt");
+        assert_eq!(record.seq, 1);
+        assert_eq!(record.payload["agentId"], "agent-1");
+        assert_eq!(record.payload["sessionId"], "sess-desktop");
+        assert!(
+            record.payload["turnId"].is_null(),
+            "desktop path: turnId must be null"
+        );
+        let content = record.payload["content"].as_array().unwrap();
+        assert_eq!(content.len(), 1);
+        assert_eq!(content[0]["text"], "hello world");
+
+        persistence.shutdown().await.unwrap();
+        let _ = std::fs::remove_dir_all(root);
     }
 }

--- a/src-tauri/src/web/sink.rs
+++ b/src-tauri/src/web/sink.rs
@@ -1851,6 +1851,9 @@ mod tests {
             "acp:tool_call",
             &TestPayload::new("a", "sess-coll", "first"),
         );
+        // Flush so the async durable writer processes the enqueued event
+        // before we assert on `last_seq`.
+        persistence.flush_session("sess-coll").await.unwrap();
         assert_eq!(relay.session_watermark("sess-coll"), 1);
         assert_eq!(persistence.last_seq("sess-coll").unwrap(), 1);
 
@@ -1879,6 +1882,9 @@ mod tests {
             "acp:session_info_update",
             &TestPayload::new("a", "sess-coll", "title-sync"),
         );
+        // Flush so the async durable writer processes the enqueued event
+        // before we assert on `last_seq`.
+        persistence.flush_session("sess-coll").await.unwrap();
         assert_eq!(
             relay.session_watermark("sess-coll"),
             3,
@@ -1922,6 +1928,8 @@ mod tests {
             uuid::Uuid::new_v4()
         ));
         std::fs::create_dir_all(&root).unwrap();
+        let cwd = root.join("cwd");
+        std::fs::create_dir_all(&cwd).unwrap();
         let persistence = SessionPersistence::open(root.join("sessions"))
             .await
             .unwrap();
@@ -1931,7 +1939,7 @@ mod tests {
                 stable_agent_namespace: None,
                 runtime_agent_id: None,
                 project_id: None,
-                cwd: root.join("cwd"),
+                cwd,
                 ..Default::default()
             })
             .await

--- a/src-tauri/src/web/sink.rs
+++ b/src-tauri/src/web/sink.rs
@@ -440,7 +440,18 @@ impl WsRelaySink {
                 snapshot_events: Vec::new(),
                 base_seq: 1,
             });
-        state.last_seq = state.last_seq.saturating_add(1);
+        // Reconcile the cached frontier with the durable frontier before
+        // incrementing. Background title generation
+        // (`maybe_generate_background_title`) writes a durable
+        // `local_title_generated` event directly through
+        // `SessionPersistence::enqueue_event` (advancing durable `last_seq`
+        // past the relay's cached value) BEFORE the synthetic
+        // `session_info_update` reaches the relay. Without this
+        // reconciliation the relay would assign a seq that collides with the
+        // durable record, tripping the fail-closed `record.seq <=
+        // current.last_seq` check in `append_record` on the next durable
+        // enqueue.
+        state.last_seq = state.last_seq.max(durable_last).saturating_add(1);
         let seq = state.last_seq;
         let se = SequencedEvent::new(Some(sid.to_string()), seq, type_, payload);
         if state.events.is_empty() {
@@ -1007,13 +1018,22 @@ impl EventSink for WsRelaySink {
             }
         }
 
-        // CAP-2: history is now host-owned. When a session is created or
-        // finalized at the host (regardless of which client drove it), notify
-        // every connected client so sidebars refetch the host index instead of
-        // depending on a desktop renderer save. Only fires when durable
-        // persistence is attached (live-only mode has nothing to refetch).
+        // CAP-2: history is now host-owned. When a session is created,
+        // finalized, or its title metadata changes at the host (regardless of
+        // which client drove it), notify every connected client so sidebars
+        // refetch the host index instead of depending on a desktop renderer
+        // save. `session_info_update` covers agent-supplied titles;
+        // `local_title_generated` covers background title generation. Only
+        // fires when durable persistence is attached (live-only mode has
+        // nothing to refetch).
         if self.persistence().is_some()
-            && matches!(type_, "session_created" | "session_closed")
+            && matches!(
+                type_,
+                "session_created"
+                    | "session_closed"
+                    | "session_info_update"
+                    | "local_title_generated"
+            )
         {
             self.notify_history_changed();
         }
@@ -1126,7 +1146,10 @@ pub fn broadcast_chat_history_changed(relay: &Arc<WsRelaySink>) {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::acp::session_persistence::SessionRegistration;
+    use crate::acp::session_persistence::{
+        now_millis, PersistedEventRecord, SessionPersistence, SessionRegistration,
+        SESSION_SCHEMA_VERSION,
+    };
     use serde::Serialize;
     use std::path::PathBuf;
     use std::time::{SystemTime, UNIX_EPOCH};
@@ -1789,6 +1812,152 @@ mod tests {
             drained.iter().all(|event| event.type_ != "chat_history_changed"),
             "no history notification without durable persistence"
         );
+    }
+
+    /// Regression: background title generation writes a durable
+    /// `local_title_generated` event directly through
+    /// `SessionPersistence::enqueue_event` (advancing durable `last_seq`)
+    /// BEFORE the synthetic `session_info_update` reaches the relay. The relay
+    /// must reconcile its cached `last_seq` with the durable frontier so it
+    /// assigns the NEXT unique seq — not a colliding one that the fail-closed
+    /// `append_record` check would reject.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn relay_reconciles_cached_seq_with_durable_frontier_after_background_title() {
+        let root = temp_dir("seq-reconcile");
+        let cwd = root.join("cwd");
+        std::fs::create_dir_all(&cwd).unwrap();
+        let persistence = SessionPersistence::open(root.join("sessions"))
+            .await
+            .unwrap();
+        persistence
+            .register_session(SessionRegistration {
+                session_id: "sess-coll".to_string(),
+                stable_agent_namespace: None,
+                runtime_agent_id: None,
+                project_id: None,
+                cwd,
+                ..Default::default()
+            })
+            .await
+            .unwrap();
+        let relay = Arc::new(WsRelaySink::with_persistence(8, persistence.clone()));
+        let sinks: Vec<Arc<dyn EventSink>> = vec![relay.clone()];
+
+        // 1. Relay emits a session-scoped event → assigns seq 1 (durable
+        //    last_seq advances to 1 via assign_and_append's enqueue).
+        fan_out(
+            &sinks,
+            Some("sess-coll"),
+            "acp:tool_call",
+            &TestPayload::new("a", "sess-coll", "first"),
+        );
+        assert_eq!(relay.session_watermark("sess-coll"), 1);
+        assert_eq!(persistence.last_seq("sess-coll").unwrap(), 1);
+
+        // 2. Background title gen writes durable seq 2 directly through
+        //    `SessionPersistence` (mirrors `maybe_generate_background_title`).
+        //    The relay's cached `last_seq` is still 1.
+        let record = PersistedEventRecord {
+            schema_version: SESSION_SCHEMA_VERSION,
+            session_id: "sess-coll".to_string(),
+            seq: 2,
+            type_: "local_title_generated".to_string(),
+            recorded_at: now_millis(),
+            payload: json!({"sessionId": "sess-coll", "title": "Generated Title"}),
+        };
+        persistence.enqueue_event(record).unwrap();
+        persistence.flush_session("sess-coll").await.unwrap();
+        assert_eq!(persistence.last_seq("sess-coll").unwrap(), 2);
+
+        // 3. Synthetic `session_info_update` through the relay must assign
+        //    seq 3 (reconciled: max(cached=1, durable=2) + 1 = 3), NOT a
+        //    colliding seq 2. Without reconciliation the durable enqueue
+        //    would be rejected by the fail-closed `seq > last_seq` check.
+        fan_out(
+            &sinks,
+            Some("sess-coll"),
+            "acp:session_info_update",
+            &TestPayload::new("a", "sess-coll", "title-sync"),
+        );
+        assert_eq!(
+            relay.session_watermark("sess-coll"),
+            3,
+            "relay reconciles cached frontier with durable frontier"
+        );
+        assert_eq!(
+            persistence.last_seq("sess-coll").unwrap(),
+            3,
+            "durable enqueue accepted (no collision)"
+        );
+
+        // 4. Persistence stays healthy: a subsequent flush + direct enqueue
+        //    at the next seq succeeds (proving no corrupt/gapped log).
+        persistence.flush_session("sess-coll").await.unwrap();
+        let next_record = PersistedEventRecord {
+            schema_version: SESSION_SCHEMA_VERSION,
+            session_id: "sess-coll".to_string(),
+            seq: 4,
+            type_: "tool_call".to_string(),
+            recorded_at: now_millis(),
+            payload: json!({"sessionId": "sess-coll"}),
+        };
+        assert!(
+            persistence.enqueue_event(next_record).is_ok(),
+            "subsequent durable enqueue succeeds (healthy sequence)"
+        );
+
+        persistence.shutdown().await.unwrap();
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    /// Title metadata events (`session_info_update` for agent-supplied titles,
+    /// `local_title_generated` for background titles) fan a
+    /// `chat_history_changed` notification so connected sidebars refetch the
+    /// host index and pick up the new title. Extends the
+    /// `session_lifecycle_broadcasts_history_changed_when_persistent` coverage.
+    #[tokio::test]
+    async fn title_metadata_events_broadcast_history_changed_when_persistent() {
+        let root = std::env::temp_dir().join(format!(
+            "termul-sink-title-broadcast-{}",
+            uuid::Uuid::new_v4()
+        ));
+        std::fs::create_dir_all(&root).unwrap();
+        let persistence = SessionPersistence::open(root.join("sessions"))
+            .await
+            .unwrap();
+        persistence
+            .register_session(SessionRegistration {
+                session_id: "sess-title".to_string(),
+                stable_agent_namespace: None,
+                runtime_agent_id: None,
+                project_id: None,
+                cwd: root.join("cwd"),
+                ..Default::default()
+            })
+            .await
+            .unwrap();
+        let relay = Arc::new(WsRelaySink::with_persistence(8, persistence.clone()));
+        let (_client, mut rx, _replay) = relay.subscribe("sess-title", None).await;
+
+        for type_ in ["acp:session_info_update", "acp:local_title_generated"] {
+            relay.emit(&AcpEvent {
+                sid: Some("sess-title".to_string()),
+                type_,
+                payload: json!({"agentId": "a-1", "sessionId": "sess-title", "title": "T"}),
+            });
+        }
+
+        let drained = drain_rx(&mut rx);
+        let notifications = drained
+            .iter()
+            .filter(|event| event.type_ == "chat_history_changed")
+            .count();
+        assert_eq!(
+            notifications, 2,
+            "each title metadata event fans one chat_history_changed"
+        );
+        persistence.shutdown().await.unwrap();
+        let _ = std::fs::remove_dir_all(root);
     }
 
     /// AD-4: `CapturingEventSink` accumulates only `agent_message_chunk`

--- a/src/renderer/stores/acp-store.test.ts
+++ b/src/renderer/stores/acp-store.test.ts
@@ -80,6 +80,7 @@ import { invoke } from '@tauri-apps/api/core'
 import {
   _clearPayloadCacheForTesting,
   getCachedSessionPayload,
+  loadSessionIndex,
   setCachedSessionPayload
 } from '@/lib/acp-history-persistence'
 import {
@@ -97,6 +98,7 @@ import {
   _resetInFlightHistoryOpensForTesting,
   _resetInFlightPreparedForTesting,
   _resetLoadingOlderForTesting,
+  _resetSessionIndexLoadGenerationForTesting,
   agentReuseKey,
   type ChatMessage,
   collectProjectsWithActiveAgentChat,
@@ -264,6 +266,7 @@ describe('acp-store', () => {
     _resetInFlightPreparedForTesting()
     _resetCoalesceForTesting()
     _resetEphemeralSessionIdsForTesting()
+    _resetSessionIndexLoadGenerationForTesting()
     useAcpStore.setState(FRESH)
   })
 
@@ -3899,6 +3902,178 @@ describe('acp-store', () => {
     await flushTurnEnd()
     expect(useAcpStore.getState().sessions['s-replay'].replaying).toBeNull()
     vi.mocked(invoke).mockReset()
+  })
+
+  it('projects a title that arrived during session/load replay once the replay window closes', async () => {
+    useAcpStore.setState((s) => ({
+      agents: { ...s.agents, 'agent-1': { id: 'agent-1', capabilities: { loadSession: true } } },
+      agentStatus: { ...s.agentStatus, 'agent-1': 'connected' },
+      sessionIndex: [
+        {
+          id: 's-replay-title',
+          agentId: 'agent-1',
+          agentConfigId: 'cfg-1',
+          title: 'Untitled Chat',
+          cwd: '/w',
+          projectId: 'p1',
+          createdAt: 1,
+          lastActivityAt: 2,
+          messageCount: 1,
+          lastSeq: 1,
+          status: 'closed'
+        }
+      ]
+    }))
+    const { loadSessionPayload } = await import('@/lib/acp-history-persistence')
+    ;(loadSessionPayload as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      metadata: {
+        id: 's-replay-title',
+        agentId: 'agent-1',
+        title: 'Untitled Chat',
+        cwd: '/w',
+        projectId: 'p1',
+        createdAt: 1,
+        lastActivityAt: 2,
+        messageCount: 1,
+        status: 'closed'
+      },
+      messages: [
+        {
+          id: 'm1',
+          role: 'user',
+          blocks: [{ type: 'text', text: 'q' }],
+          streaming: false,
+          timestamp: 0
+        }
+      ]
+    })
+    vi.mocked(invoke).mockImplementation(async (cmd: string) => {
+      if (cmd !== 'acp_load_session') {
+        throw new Error(`unexpected invoke command in replay-title test: ${cmd}`)
+      }
+      // Replay a chunk (flips replaying to 'streaming' so the replay window
+      // stays open one macrotask past the response).
+      useAcpStore.getState()._onMessageChunk({
+        agentId: 'agent-1',
+        sessionId: 's-replay-title',
+        role: 'user',
+        content: { type: 'text', text: 'replayed q' }
+      })
+      // During replay, a session_info_update arrives with a real title. The
+      // live session title updates immediately, but persistSession must be
+      // skipped (replaying is truthy) so the index stays Untitled.
+      useAcpStore.getState()._onSessionInfoUpdate({
+        agentId: 'agent-1',
+        sessionId: 's-replay-title',
+        title: 'Agent Title'
+      })
+      return undefined
+    })
+    await useAcpStore.getState().openHistorySession('s-replay-title')
+    // Title is set on the session during replay.
+    expect(useAcpStore.getState().sessions['s-replay-title'].title).toBe('Agent Title')
+    // Index still shows Untitled (persistSession skipped during replay).
+    expect(useAcpStore.getState().sessionIndex.find((e) => e.id === 's-replay-title')?.title).toBe(
+      'Untitled Chat'
+    )
+    // Replay window still open.
+    expect(useAcpStore.getState().sessions['s-replay-title'].replaying).toBe('streaming')
+    await flushTurnEnd()
+    // Replay cleared -> persistSession projects the title into the index.
+    expect(useAcpStore.getState().sessions['s-replay-title'].replaying).toBeNull()
+    expect(useAcpStore.getState().sessionIndex.find((e) => e.id === 's-replay-title')?.title).toBe(
+      'Agent Title'
+    )
+    vi.mocked(invoke).mockReset()
+  })
+
+  it('does not remove a locally-created session or revert a title when a stale index load resolves', async () => {
+    const localActivity = Date.now()
+    useAcpStore.setState({
+      sessions: {
+        's-local': {
+          id: 's-local',
+          agentId: 'agent-1',
+          cwd: '/work',
+          projectId: 'p1',
+          status: 'active',
+          title: 'Important Title',
+          activeTurn: false,
+          openTurnId: null,
+          modes: null,
+          models: null,
+          configOptions: [],
+          lastError: null,
+          createdAt: localActivity
+        },
+        's-titled': {
+          id: 's-titled',
+          agentId: 'agent-1',
+          cwd: '/work',
+          projectId: 'p1',
+          status: 'active',
+          title: 'My Title',
+          activeTurn: false,
+          openTurnId: null,
+          modes: null,
+          models: null,
+          configOptions: [],
+          lastError: null,
+          createdAt: localActivity
+        }
+      },
+      messages: { 's-local': [], 's-titled': [] },
+      sessionIndex: [
+        {
+          id: 's-local',
+          agentId: 'agent-1',
+          agentConfigId: 'cfg-1',
+          title: 'Important Title',
+          cwd: '/work',
+          projectId: 'p1',
+          createdAt: localActivity,
+          lastActivityAt: localActivity,
+          messageCount: 0,
+          status: 'active'
+        },
+        {
+          id: 's-titled',
+          agentId: 'agent-1',
+          agentConfigId: 'cfg-1',
+          title: 'My Title',
+          cwd: '/work',
+          projectId: 'p1',
+          createdAt: localActivity,
+          lastActivityAt: localActivity,
+          messageCount: 0,
+          status: 'active'
+        }
+      ]
+    })
+    // Stale host response: omits s-local entirely; s-titled present but with
+    // an Untitled fallback + older activity (the request predates the local
+    // title mutation).
+    vi.mocked(loadSessionIndex).mockResolvedValueOnce([
+      {
+        id: 's-titled',
+        agentId: 'agent-1',
+        agentConfigId: 'cfg-1',
+        title: 'Untitled Chat',
+        cwd: '/work',
+        projectId: 'p1',
+        createdAt: localActivity,
+        lastActivityAt: localActivity - 1000,
+        messageCount: 0,
+        status: 'active'
+      }
+    ])
+    await useAcpStore.getState().loadSessionIndex()
+    const index = useAcpStore.getState().sessionIndex
+    // s-local preserved (live session, absent from stale host response).
+    expect(index.some((e) => e.id === 's-local')).toBe(true)
+    expect(index.find((e) => e.id === 's-local')?.title).toBe('Important Title')
+    // s-titled keeps the newer local title (not reverted to Untitled).
+    expect(index.find((e) => e.id === 's-titled')?.title).toBe('My Title')
   })
 
   it('openHistorySession accepts straggler chunks of an in-progress replay after load resolves', async () => {

--- a/src/renderer/stores/acp-store.ts
+++ b/src/renderer/stores/acp-store.ts
@@ -821,6 +821,13 @@ function withSessionResumeError(
  * End a session/load replay after the macrotask queue drains, so replayed
  * chunks that lose the IPC race against the `acp_load_session` response are
  * still accepted (mirrors `scheduleTurnEnd`). Idempotent when already cleared.
+ *
+ * After clearing `replaying`, projects a title that arrived during replay into
+ * the session index: a `session_info_update` that landed while `replaying` was
+ * truthy set `session.title` but was skipped by `persistSession` (which guards
+ * on `session.replaying`). Now that replay has cleared, `persistSession` can
+ * safely project the title so the sidebar converges without a partial
+ * transcript projection.
  */
 function scheduleReplayEnd(
   set: TurnEndSetter,
@@ -829,14 +836,26 @@ function scheduleReplayEnd(
 ): void {
   setTimeout(() => {
     if (!isCurrentSessionReopen(sessionId, reopenGeneration)) return
+    let replayCleared = false
     set((s) => {
       const current = s.sessions[sessionId]
       if (!current?.replaying) return {}
+      replayCleared = true
       return {
         messages: finalizeStreaming(s.messages, sessionId),
         sessions: { ...s.sessions, [sessionId]: { ...current, replaying: null } }
       }
     })
+    // Project a replay-time title into the index once replay has cleared.
+    // Gate on `sessionIndex` membership like the other projection calls so an
+    // un-promoted (ephemeral) session is never persisted by a replay event.
+    if (replayCleared) {
+      const state = useAcpStore.getState()
+      const session = state.sessions[sessionId]
+      if (session?.title && state.sessionIndex.some((e) => e.id === sessionId)) {
+        persistSession(state, sessionId, (entries) => set({ sessionIndex: entries }))
+      }
+    }
   }, 0)
 }
 
@@ -1191,6 +1210,54 @@ function persistSession(
   }
   const nextIndex = [entry, ...state.sessionIndex.filter((e) => e.id !== sessionId)]
   setIndex(nextIndex)
+}
+
+/**
+ * Merge a host session-index response with the locally-known projection so a
+ * stale async load cannot remove a just-created row or revert a
+ * freshly-titled session to `Untitled Chat`. Preserves local entries that are
+ * newer than the host response (match by id, keep the one with the newer
+ * `lastActivityAt`) or absent from it but belonging to a live session (created
+ * locally and not yet flushed to the durable index). The initial empty-load
+ * case (no local entries) applies the host response verbatim.
+ */
+function mergeSessionIndexEntries(
+  local: SessionIndexEntry[],
+  host: SessionIndexEntry[],
+  liveSessionIds: Set<SessionId>
+): SessionIndexEntry[] {
+  if (local.length === 0) return host
+  const hostById = new Map(host.map((e) => [e.id, e] as const))
+  const merged: SessionIndexEntry[] = [...host]
+  const mergedIds = new Set(host.map((e) => e.id))
+  for (const entry of local) {
+    const hostEntry = hostById.get(entry.id)
+    if (hostEntry) {
+      // Host has this entry: keep the newer projection. On ties, prefer
+      // local (the source of the freshest title) so a same-millisecond
+      // host flush cannot revert a just-set title to `Untitled Chat`.
+      if ((entry.lastActivityAt ?? 0) >= (hostEntry.lastActivityAt ?? 0)) {
+        const idx = merged.findIndex((e) => e.id === entry.id)
+        if (idx >= 0) {
+          // Field-level merge: carry forward host-only durable fields
+          // (messageCount, lastSeq) so the local projection does not
+          // regress durable-advanced metadata while preserving the
+          // local title/activity.
+          merged[idx] = {
+            ...hostEntry,
+            ...entry,
+            messageCount: Math.max(entry.messageCount ?? 0, hostEntry.messageCount ?? 0),
+            lastSeq: Math.max(entry.lastSeq ?? 0, hostEntry.lastSeq ?? 0)
+          }
+        }
+      }
+    } else if (liveSessionIds.has(entry.id) && !mergedIds.has(entry.id)) {
+      // Host omits it but it is a live session (created/restored locally and
+      // not yet flushed to the durable index): keep the local projection.
+      merged.push(entry)
+    }
+  }
+  return merged
 }
 
 /**
@@ -1574,6 +1641,14 @@ const inFlightDiscoveredOpens = new Map<SessionId, InFlightDiscoveredOpen>()
  */
 const sessionReopenGenerations = new Map<SessionId, number>()
 
+/**
+ * Monotonic generation counter for `loadSessionIndex`. An older async index
+ * request that resolves after a local session/title mutation must not replace
+ * or downgrade the local projection; the stale response is discarded when the
+ * generation is no longer current.
+ */
+let sessionIndexLoadGeneration = 0
+
 /** Sessions with an in-flight `retryCrashedSession` (re-launch + replay + re-send).
  * Dedupes concurrent Retry clicks so only one reopen+send runs per session. */
 const inFlightCrashedRetries = new Set<SessionId>()
@@ -1655,6 +1730,11 @@ export function _resetInFlightHistoryOpensForTesting(): void {
     if (tracker.timer) clearTimeout(tracker.timer)
   }
   restorePreloadTrackers.clear()
+}
+
+/** Test-only: reset the index load generation counter between tests. */
+export function _resetSessionIndexLoadGenerationForTesting(): void {
+  sessionIndexLoadGeneration = 0
 }
 
 type EnsureLiveAgentOptions = {
@@ -3565,11 +3645,23 @@ export const useAcpStore = create<AcpState>((set, get) => ({
   },
 
   loadSessionIndex: async () => {
+    // Bump the monotonic generation so a stale response that resolves after a
+    // local session/title mutation is discarded rather than overwriting the
+    // newer projection.
+    const generation = ++sessionIndexLoadGeneration
     const entries = await loadSessionIndexFromDisk()
+    if (generation !== sessionIndexLoadGeneration) return
     // Continue the placeholder counter from the highest persisted suffix so a
     // restart doesn't restart at 1 and collide with existing `Untitled Chat N`.
     rebaseUntitledCounter(entries)
-    set({ sessionIndex: entries })
+    // Merge with the locally-known projection so a stale response cannot
+    // remove a just-created row or revert a freshly-titled session. The
+    // initial empty-load case (no local entries) applies the host response
+    // verbatim.
+    const current = get().sessionIndex
+    const liveSessionIds = new Set(Object.keys(get().sessions) as SessionId[])
+    const merged = mergeSessionIndexEntries(current, entries, liveSessionIds)
+    set({ sessionIndex: merged })
   },
 
   openHistorySession: async (id) => {


### PR DESCRIPTION
## Summary

Desktop ACP prompts (especially with OpenCode) were dispatched without persisting the authoritative `user_prompt` record, causing restored chats to omit user messages and titles to stay "Untitled". Background title generation could also collide with the relay sequence, poisoning the persistence writer. Renderer index loads could revert newer rows/titles via stale async responses, and titles arriving during `session/load` replay never reached the sidebar.

**Root causes identified (via codebase-memory MCP graph investigation):**

1. **Desktop prompts were never durably persisted** — `acp_send_prompt` dispatched directly to `AcpManager::send_prompt` without the `WsRelaySink::persist_user_prompt` call the web path uses. This meant restored chats could omit user messages, first-message title provenance was never established, and background title generation never triggered (it depends on `title_source == DerivedFirstMessage`). This is the primary reason OpenCode sessions stayed "Untitled" — OpenCode does not reliably emit live `session_info_update` title notifications, and Termul's fallback title mechanisms were never activated.

2. **Background title generation collided with the relay sequence** — `maybe_generate_background_title` wrote a durable `local_title_generated` event at seq N+1, then the synthetic `session_info_update` through `WsRelaySink` could reuse seq N+1 (the relay's cached frontier was stale). The fail-closed corruption check rejected the duplicate, marking the writer unhealthy. Subsequent history reads, flushes, or prompt writes could fail, explaining intermittent missing history after title generation.

3. **Renderer timing races** — stale async `loadSessionIndex` responses unconditionally replaced `sessionIndex`, removing just-created rows or reverting titles to "Untitled". Titles arriving during `session/load` replay set `session.title` but `persistSession` skipped projection while `replaying` was truthy, and `scheduleReplayEnd` cleared replay without a catch-up projection.

## Related Issue

No related issue — investigation revealed the root cause. The user reported: titles not renaming when using OpenCode ACP, and chat history intermittently missing some sessions.

## Type of Change

- [x] fix: bug fix

## What Changed

- **`src-tauri/src/acp/commands.rs`**: `acp_send_prompt` now persists accepted non-ephemeral desktop prompts through `WsRelaySink::persist_user_prompt` before dispatching through `AcpManager::send_prompt`, matching the web path's durability ordering. Ownership check (`owns_session`) rejects cross-agent session ids before any durable write. Ephemeral sessions are skipped (no durable history). The `persist_accepted_prompt` helper builds the same `{agentId, sessionId, turnId, content}` payload as the WS path (`turnId: null` on desktop). Persistence failure rejects dispatch so a transport failure cannot erase an accepted user message.

- **`src-tauri/src/web/sink.rs`**: `assign_and_append` now reconciles the relay's cached `last_seq` with the durable frontier (`max(cached, durable) + 1`) before incrementing, preventing sequence collisions when background title generation advances the durable frontier past the relay's cached value. `EventSink::emit` now broadcasts `chat_history_changed` for `session_info_update` and `local_title_generated` events (not just `session_created`/`session_closed`), so connected browser clients refetch titles.

- **`src/renderer/stores/acp-store.ts`**: `loadSessionIndex` now uses a monotonic generation counter to discard stale async responses, and `mergeSessionIndexEntries` preserves locally-known entries that are newer than or absent from the host response (field-level merge carries forward host-only `messageCount`/`lastSeq`). `scheduleReplayEnd` now projects a replay-time title into the session index once replay clears, so titles that arrived during `session/load` reach the sidebar.

- **Tests**: Rust regression for desktop prompt persistence + sequence collision; renderer regressions for stale index replacement + replay title convergence.

- **`docs/api-contracts.md`**: Documented the `acp_send_prompt` durability ordering.

## How It Was Tested

- [x] `bun run ci` (Biome lint + format + imports, strict mode)
- [x] `bun run typecheck`
- [x] `bun run test` (3487 passed, 0 failed)
- [x] `cargo clippy --all-targets -- -D warnings` (in src-tauri)
- [ ] `cargo test` (in src-tauri) — pre-existing Windows DLL issue (tests compile, CI will run them)
- [x] Manual verification completed

## CI & Review Gate

- [ ] All CI checks pass (PR Validation, Rust Checks, Build Verification, Security Scans)
- [ ] Code review comments from CodeRabbit / Claude have been addressed or resolved
- [ ] No unresolved review findings remain

## Checklist

- [x] My PR title follows the conventional commit format used by this repo
- [x] I linked the related issue or explained why none exists
- [x] I updated docs when needed
- [x] I added or updated tests when needed
- [x] I verified the change does not introduce unrelated modifications
- [x] I read AGENTS.md and followed the contributor guidelines
- [x] A human reviewed the complete diff before submission


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Durable sessions now save prompts before sending them, while ephemeral sessions skip persistence.
  - Session ownership is verified before prompts are dispatched.
  - Session titles and metadata now stay synchronized across chat history and session lists.

- **Bug Fixes**
  - Prevented message sequence conflicts during background updates.
  - Improved session restoration and replay so locally created sessions and durable metadata are preserved.

- **Documentation**
  - Documented prompt persistence, ordering, payload requirements, and failure handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->