### PR TITLE
fix(chat): preserve streamdown code line breaks

### DIFF
--- a/src/renderer/components/chat/chat-markdown-code.integration.test.tsx
+++ b/src/renderer/components/chat/chat-markdown-code.integration.test.tsx
@@ -1,0 +1,40 @@
+import { code as codePlugin } from '@streamdown/code'
+import { render, waitFor } from '@testing-library/react'
+import { Streamdown } from 'streamdown'
+import { TooltipProvider } from '@/components/ui/tooltip'
+import { ChatMarkdownCode } from './chat-markdown-code'
+
+describe('ChatMarkdownCode with Streamdown', () => {
+  it('renders non-empty and blank source lines as direct code span wrappers', async () => {
+    const { container } = render(
+      <TooltipProvider>
+        <Streamdown
+          mode="static"
+          plugins={{ code: codePlugin }}
+          components={{ code: ChatMarkdownCode }}
+          controls={false}
+          lineNumbers={false}
+          linkSafety={{ enabled: false }}
+        >
+          {'```javascript\nconst first = 1\n\nconst third = 3\n```'}
+        </Streamdown>
+      </TooltipProvider>
+    )
+
+    await waitFor(() => {
+      const blockBody = container.querySelector<HTMLElement>('[data-streamdown="code-block-body"]')
+      expect(blockBody).toBeInTheDocument()
+      expect(blockBody).toHaveClass('[&_code>span]:block')
+
+      const code = blockBody.querySelector('code')
+      expect(code).toBeInTheDocument()
+
+      const lineWrappers = code?.children ?? []
+      expect(lineWrappers).toHaveLength(3)
+      expect(lineWrappers[0]?.querySelectorAll(':scope > span').length).toBeGreaterThan(1)
+      expect(lineWrappers[0]).toHaveTextContent('const first = 1')
+      expect(lineWrappers[1]).toHaveTextContent(/^\s*$/)
+      expect(lineWrappers[2]).toHaveTextContent('const third = 3')
+    })
+  })
+})

--- a/src/renderer/components/chat/chat-markdown-code.test.tsx
+++ b/src/renderer/components/chat/chat-markdown-code.test.tsx
@@ -8,9 +8,13 @@ vi.mock('streamdown', () => {
   return {
     StreamdownContext,
     Streamdown: () => null,
-    // Capture the `code` prop so tests can assert newline preservation.
-    CodeBlock: (props: { code?: string; children?: React.ReactNode }) => (
-      <div data-testid="code-block" data-code={props.code ?? ''}>
+    // Capture source and presentation props without reproducing Streamdown internals.
+    CodeBlock: (props: { code?: string; className?: string; children?: React.ReactNode }) => (
+      <div
+        data-testid="code-block"
+        data-code={props.code ?? ''}
+        data-class-name={props.className ?? ''}
+      >
         {props.children}
       </div>
     )
@@ -26,7 +30,7 @@ function withTooltip(ui: React.JSX.Element): React.JSX.Element {
 }
 
 describe('ChatMarkdownCode', () => {
-  it('preserves newlines in a multi-line fenced code block via the node value', () => {
+  it('preserves and visually separates multi-line fenced code via the node value', () => {
     const node = { value: 'line1\nline2\nline3' }
     const { getByTestId } = render(
       withTooltip(
@@ -36,7 +40,24 @@ describe('ChatMarkdownCode', () => {
       )
     )
 
-    expect(getByTestId('code-block').getAttribute('data-code')).toBe('line1\nline2\nline3')
+    const codeBlock = getByTestId('code-block')
+    expect(codeBlock.getAttribute('data-code')).toBe('line1\nline2\nline3')
+    expect(codeBlock.getAttribute('data-class-name')).toContain('[&_code>span]:block')
+  })
+
+  it('preserves a blank line and forwards the direct-line layout selector', () => {
+    const node = { value: 'line1\n\nline3' }
+    const { getByTestId } = render(
+      withTooltip(
+        <ChatMarkdownCode className="language-ts" data-block node={node}>
+          {['line1', '', 'line3']}
+        </ChatMarkdownCode>
+      )
+    )
+
+    const codeBlock = getByTestId('code-block')
+    expect(codeBlock.getAttribute('data-code')).toBe('line1\n\nline3')
+    expect(codeBlock.getAttribute('data-class-name')).toContain('[&_code>span]:block')
   })
 
   it('recurses through array children preserving embedded newlines (no node value)', () => {
@@ -56,6 +77,7 @@ describe('ChatMarkdownCode', () => {
 
     const code = container.querySelector('code')
     expect(code).toHaveAttribute('data-streamdown', 'inline-code')
+    expect(code).not.toHaveClass('[&_code>span]:block')
   })
 
   it('passes the compact size class to the copy/download action buttons', () => {

--- a/src/renderer/components/chat/chat-markdown-code.tsx
+++ b/src/renderer/components/chat/chat-markdown-code.tsx
@@ -165,7 +165,7 @@ export function ChatMarkdownCode({
     <CodeBlock
       code={code}
       language={language || 'text'}
-      className={className}
+      className={cn('[&_code>span]:block', className)}
       lineNumbers={lineNumbers}
     >
       <CodeDownloadAction code={code} language={language || 'text'} />


### PR DESCRIPTION
## Summary

- Fix the remaining visual newline regression in Streamdown fenced code blocks. The source text already retained newlines, which is why copy/download output was correct, but highlighted line wrappers rendered inline when chat disabled line numbers.
- Apply block layout only to Streamdown's direct per-line spans and add real Streamdown 2.5 + Shiki integration coverage for non-empty and blank lines.

## Related Issue

No related issue exists. This is a focused follow-up to merged PR #600, whose source-extraction fix preserved copied newlines but did not correct the still-observed visual line layout. Searches across open and closed PRs found no other overlapping follow-up.

## Type of Change

- [ ] feat: new feature
- [x] fix: bug fix
- [ ] docs: documentation only
- [ ] style: formatting or non-functional styling changes
- [ ] refactor: internal cleanup with no behavior change
- [ ] perf: performance improvement
- [x] test: adds or updates tests
- [ ] build: build or dependency changes
- [ ] ci: CI/CD workflow changes
- [ ] chore: maintenance or tooling
- [ ] revert: reverts a previous change

## What Changed

- Add `[&_code>span]:block` to the non-Mermaid fenced `CodeBlock` path so Streamdown 2.5 line wrappers remain visually separated when `lineNumbers={false}`.
- Preserve inline-code, Mermaid, syntax-highlighting, copy, and download behavior without mutating the code string.
- Extend unit coverage for newline preservation, blank-line input, selector forwarding, inline-code isolation, and compact controls.
- Add an integration test using the real installed Streamdown and Shiki code plugin to verify one direct wrapper per source line, including an empty middle line.

## How It Was Tested

- [ ] `bun run ci` (Biome lint + format + imports, strict mode) - this nested `.termul` worktree is ignored wholesale by Biome's VCS integration, so the wrapper processes zero files; targeted Biome lint on all changed files passed.
- [x] `bun run typecheck`
- [ ] `bun run test` - focused changed-surface tests pass (2 files, 6 tests); the full suite has pre-existing linked-worktree failures in four material-icon asset suites and one unrelated `NewProjectModal` test.
- [x] `cargo clippy --all-targets -- -D warnings` (in src-tauri)
- [ ] `cargo test` (in src-tauri) - compilation completes, but the local Windows test binary exits before the harness with `STATUS_ENTRYPOINT_NOT_FOUND`; GitHub CI is the clean-checkout authority.
- [ ] Manual verification completed
- [ ] Not applicable

Additional successful checks: `bun run build:frontend:tauri`, `bun run build:web`, focused real-Streamdown integration tests, targeted Biome lint, and `git diff --check`.

## Screenshots or Recordings

No screenshot was captured. The regression is the generated code-line box model, and the new integration test exercises the real Streamdown 2.5 + Shiki DOM, including the visually significant empty-line wrapper.

## CI & Review Gate

- [ ] All CI checks pass (PR Validation, Rust Checks, Build Verification, Security Scans)
- [x] Code review comments from CodeRabbit / Claude have been addressed or resolved
- [x] No unresolved review findings remain

## Checklist

- [x] My PR title follows the conventional commit format used by this repo
- [x] I linked the related issue or explained why none exists
- [x] I updated docs when needed - no documentation change is required for this rendering bug
- [x] I added or updated tests when needed
- [x] I verified the change does not introduce unrelated modifications
- [x] I read AGENTS.md and followed the contributor guidelines
- [x] A human reviewed the complete diff before submission
