### PR TITLE
fix(chat): make agent mode picker scrollable

### DIFF
--- a/src/renderer/components/chat/AgentHeader.test.tsx
+++ b/src/renderer/components/chat/AgentHeader.test.tsx
@@ -180,6 +180,16 @@ describe('ModeChip pending selection', () => {
     expect(button.querySelector('svg')).toBeTruthy()
   })
 
+  it('scrolls agent mode options when the list exceeds the viewport', () => {
+    render(
+      <ModeChip session={session('agent')} disabled={false} onSelect={vi.fn()} label="Agent" />
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: /^Agent$/ }))
+
+    expect(screen.getByTestId('mode-chip-options')).toHaveClass('max-h-[180px]', 'overflow-y-auto')
+  })
+
   it('shows optimistic mode label while pending', async () => {
     let resolveSelect!: () => void
     const onSelect = vi.fn(

--- a/src/renderer/components/chat/AgentHeader.tsx
+++ b/src/renderer/components/chat/AgentHeader.tsx
@@ -173,22 +173,26 @@ export function ModeChip({
       </PopoverTrigger>
       <PopoverContent align="start" side="top" className="w-56 p-1">
         <div className={SELECTOR_SECTION_LABEL}>{label}</div>
-        {modes.availableModes.map((m) => (
-          <button
-            key={m.id}
-            type="button"
-            onPointerDown={(event) => {
-              if ((event.button ?? 0) !== 0) return
-              event.preventDefault()
-              handleSelect(m.id)
-            }}
-            onClick={() => handleSelect(m.id)}
-            className={cn(SELECTOR_OPTION_ROW, m.id === displayValue && SELECTOR_OPTION_SELECTED)}
-          >
-            <span className="font-medium">{m.name}</span>
-            {m.description && <span className={SELECTOR_OPTION_DESCRIPTION}>{m.description}</span>}
-          </button>
-        ))}
+        <div data-testid="mode-chip-options" className="max-h-[180px] overflow-y-auto pr-1">
+          {modes.availableModes.map((m) => (
+            <button
+              key={m.id}
+              type="button"
+              onPointerDown={(event) => {
+                if ((event.button ?? 0) !== 0) return
+                event.preventDefault()
+                handleSelect(m.id)
+              }}
+              onClick={() => handleSelect(m.id)}
+              className={cn(SELECTOR_OPTION_ROW, m.id === displayValue && SELECTOR_OPTION_SELECTED)}
+            >
+              <span className="font-medium">{m.name}</span>
+              {m.description && (
+                <span className={SELECTOR_OPTION_DESCRIPTION}>{m.description}</span>
+              )}
+            </button>
+          ))}
+        </div>
       </PopoverContent>
     </Popover>
   )


### PR DESCRIPTION
## Summary

- When many ACP agent modes are available, the Agent mode popover grew without a height limit and modes above the viewport could not be selected.
- Cap the `ModeChip` options list with `max-h-[180px] overflow-y-auto`, matching the existing model picker pattern in `ConfigChip`.
- Covers both chat composer and agent launcher since they share `ModeChip`.

## Related Issue

Closes #595

No existing open or closed PRs address this scrollability bug.

## Type of Change

- [x] fix: bug fix
- [x] test: adds or updates tests

## What Changed

- Wrapped `ModeChip` available-mode buttons in a scrollable container (`data-testid="mode-chip-options"`) in `AgentHeader.tsx`.
- Added a unit test asserting the scroll classes on the mode options list.

## How It Was Tested

- [x] `bun run ci` (Biome lint + format + imports, strict mode)
- [x] `bun run typecheck`
- [x] `bun run test` (`AgentHeader.test.tsx` — 9 passed)
- [ ] `cargo clippy --all-targets -- -D warnings` (in src-tauri)
- [ ] `cargo test` (in src-tauri)
- [ ] Manual verification completed
- [x] Not applicable (frontend-only UI change; no Rust)

## Screenshots or Recordings

N/A — CSS scroll container on existing popover; behavior matches the model picker.

## CI & Review Gate

- [ ] All CI checks pass (PR Validation, Rust Checks, Build Verification, Security Scans)
- [ ] Code review comments from CodeRabbit / Claude have been addressed or resolved
- [ ] No unresolved review findings remain

## Checklist

- [x] My PR title follows the conventional commit format used by this repo
- [x] I linked the related issue or explained why none exists
- [x] I updated docs when needed
- [x] I added or updated tests when needed
- [x] I verified the change does not introduce unrelated modifications
- [x] I read AGENTS.md and followed the contributor guidelines
- [ ] A human reviewed the complete diff before submission


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved the mode selector layout to match other configuration controls.
  * Added horizontal scrolling for mode options when space is limited.
  * Mode descriptions now appear on a separate line for improved readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->