### PR TITLE
fix(chat): always scroll ConfigChip option lists (make agent mode picker scrollable)

### DIFF
--- a/src/renderer/components/chat/AgentHeader.test.tsx
+++ b/src/renderer/components/chat/AgentHeader.test.tsx
@@ -190,6 +190,17 @@ describe('ModeChip pending selection', () => {
     expect(screen.getByTestId('mode-chip-options')).toHaveClass('max-h-[180px]', 'overflow-y-auto')
   })
 
+  it('scrolls config chip options even without maxVisibleOptions', () => {
+    render(<ConfigChip option={option('a')} disabled={false} onSelect={vi.fn()} />)
+
+    fireEvent.click(screen.getByRole('button', { name: /Alpha/ }))
+
+    expect(screen.getByTestId('config-chip-options')).toHaveClass(
+      'max-h-[180px]',
+      'overflow-y-auto'
+    )
+  })
+
   it('shows optimistic mode label while pending', async () => {
     let resolveSelect!: () => void
     const onSelect = vi.fn(

--- a/src/renderer/components/chat/AgentHeader.tsx
+++ b/src/renderer/components/chat/AgentHeader.tsx
@@ -99,8 +99,8 @@ export function ConfigChip({
           />
         )}
         <div
-          data-testid={searchable ? 'config-chip-model-options' : undefined}
-          className={cn(maxVisibleOptions && 'max-h-[180px] overflow-y-auto pr-1')}
+          data-testid={searchable ? 'config-chip-model-options' : 'config-chip-options'}
+          className="max-h-[180px] overflow-y-auto pr-1"
         >
           {filteredOptions.length > 0 ? (
             filteredOptions.map((v) => (
@@ -138,7 +138,10 @@ export function ConfigChip({
   )
 }
 
-/** A popover selector for the legacy modes API. */
+/**
+ * Popover for the native ACP `session.modes` API (`session/set_mode`).
+ * Prefer this over a duplicate `category: 'mode'` ConfigChip when both exist.
+ */
 export function ModeChip({
   session,
   disabled,
@@ -171,9 +174,12 @@ export function ModeChip({
           {current?.name ?? label}
         </ComposerPill>
       </PopoverTrigger>
-      <PopoverContent align="start" side="top" className="w-56 p-1">
+      <PopoverContent align="start" side="top" collisionPadding={8} className="w-56 p-1">
         <div className={SELECTOR_SECTION_LABEL}>{label}</div>
-        <div data-testid="mode-chip-options" className="max-h-[180px] overflow-y-auto pr-1">
+        <div
+          data-testid="mode-chip-options"
+          className="max-h-[180px] overflow-y-auto overscroll-contain pr-1"
+        >
           {modes.availableModes.map((m) => (
             <button
               key={m.id}


### PR DESCRIPTION
## Summary

- Follow-up to #606 / #595: ModeChip scrolling alone was not enough for agents whose long mode lists render through `ConfigChip`.
- `ConfigChip` only applied `max-h-[180px] overflow-y-auto` when `maxVisibleOptions` was set (model picker). Generic chips — including mode-like config options — grew past the viewport with no scrollbar.
- Always scroll the options list in `ConfigChip`, and keep ModeChip capped the same way.

## Related Issue

Closes #595

Prior attempt: #606 (merged) fixed ModeChip only; this covers the ConfigChip path that was still broken in practice.

## Type of Change

- [x] fix: bug fix
- [x] test: adds or updates tests

## What Changed

- `ConfigChip` options container always uses `max-h-[180px] overflow-y-auto` (adds `data-testid="config-chip-options"` for non-searchable chips).
- `ModeChip` keeps a scrollable options list with `collisionPadding` / `overscroll-contain`.
- Unit tests for both scroll containers.

## How It Was Tested

- [ ] `bun run ci` (Biome lint + format + imports, strict mode)
- [ ] `bun run typecheck`
- [ ] `bun run test`
- [ ] `cargo clippy --all-targets -- -D warnings` (in src-tauri)
- [ ] `cargo test` (in src-tauri)
- [x] Manual verification completed
- [x] Not applicable (frontend-only; cargo N/A)

Manual: OpenCode/cavecrew launcher with many agent modes — mode picker scrolls and off-viewport modes are selectable.

## Screenshots or Recordings

N/A — overflow scroll on existing composer popovers.

## CI & Review Gate

- [ ] All CI checks pass (PR Validation, Rust Checks, Build Verification, Security Scans)
- [ ] Code review comments from CodeRabbit / Claude have been addressed or resolved
- [ ] No unresolved review findings remain

## Checklist

- [x] My PR title follows the conventional commit format used by this repo
- [x] I linked the related issue or explained why none exists
- [x] I updated docs when needed
- [x] I added or updated tests when needed
- [x] I verified the change does not introduce unrelated modifications
- [x] I read AGENTS.md and followed the contributor guidelines
- [ ] A human reviewed the complete diff before submission


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved option menu behavior with consistent scrolling and layout.
  * Added spacing and overscroll handling to prevent popovers from colliding with screen edges.
* **Documentation**
  * Clarified the source of available session modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->