### PR TITLE
feat(acp): host-injected termul_plan MCP tool as first-class plan UI

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -95,19 +95,27 @@ async-process = "2"
 #    handling, improving agent-subprocess reliability on all platforms.
 agent-client-protocol = "1.3"
 
-# MCP client probe (on-demand `initialize` + `tools/list`). rmcp is already in
-# the dep tree transitively via the vendored ACP (which enables `server` +
-# `transport-io`); this direct dep adds the CLIENT transport features Termul's
-# own probe needs. Resolved to 1.7.0 from `^1.2.0`. The `client-side-sse`
-# feature is rmcp's SSE stream parser (consumed by the streamable-http client);
-# rmcp 1.7.0 removed the standalone legacy SSE transport (CHANGELOG #562), so
-# `type: 'sse'` servers are probed via the modern streamable-http client (which
-# still speaks `text/event-stream`). See `src/acp/mcp_probe.rs`.
+# rmcp (Rust MCP SDK). Two consumers in this crate:
+#  1. `src/acp/mcp_probe.rs` — on-demand CLIENT probe (`initialize` + `tools/list`
+#     against a renderer-supplied server config). Uses `client`,
+#     `transport-child-process`, `transport-streamable-http-client-reqwest`,
+#     `client-side-sse` (rmcp's SSE stream parser, consumed by the
+#     streamable-http client which still speaks `text/event-stream` after rmcp
+#     1.7 dropped the standalone legacy SSE transport — CHANGELOG #562).
+#  2. `src/acp/host_mcp/` — the host-injected `termul_plan` MCP SERVER, served
+#     over stdio by a self-spawned child of the host binary. Uses `server`,
+#     `transport-io` (`rmcp::transport::io::stdio()`), and `macros`
+#     (`#[tool_router]` / `#[tool]` / `#[tool_handler]`; the `#[tool]` macro
+#     re-exports `rmcp::schemars` for `JsonSchema` derives — no direct `schemars`
+#     dep needed). Resolved to 1.8.0 from `^1.2.0`.
 rmcp = { version = "1.2.0", features = [
     "client",
     "transport-child-process",
     "transport-streamable-http-client-reqwest",
     "client-side-sse",
+    "server",
+    "transport-io",
+    "macros",
 ] }
 
 # Regex and parsing

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -108,7 +108,7 @@ agent-client-protocol = "1.3"
 #     (`#[tool_router]` / `#[tool]` / `#[tool_handler]`; the `#[tool]` macro
 #     re-exports `rmcp::schemars` for `JsonSchema` derives — no direct `schemars`
 #     dep needed). Resolved to 1.8.0 from `^1.2.0`.
-rmcp = { version = "1.2.0", features = [
+rmcp = { version = "1.4.0", features = [
     "client",
     "transport-child-process",
     "transport-streamable-http-client-reqwest",

--- a/src-tauri/src/acp/host_mcp/child.rs
+++ b/src-tauri/src/acp/host_mcp/child.rs
@@ -1,0 +1,276 @@
+//! Child side of the host-injected plan tool.
+//!
+//! Entered via the hidden `--internal-mcp-plan-server` subcommand (both the
+//! desktop `termul-manager` and standalone `termul-server` binaries branch on
+//! this flag in `main` / `server_main` BEFORE any Tauri/AppHandle setup). The
+//! agent spawns `current_exe() --internal-mcp-plan-server` as the injected
+//! `McpServer::Stdio`; the child inherits the agent-provided stdin/stdout (the
+//! MCP stdio transport).
+//!
+//! The child runs an rmcp MCP SERVER over stdio exposing the `termul_plan`
+//! tool. On each `tools/call`, it opens a fresh TCP connection to the parent
+//! (port + token from env), forwards the input, and returns the parent's reply
+//! to the agent. Minimal runtime: no Tauri plugins, no `AppHandle`, no sinks —
+//! works identically on desktop + standalone.
+
+use rmcp::handler::server::wrapper::Parameters;
+use rmcp::service::serve_server;
+use rmcp::{tool, tool_router};
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::net::TcpStream;
+
+use crate::acp::host_mcp::{
+    FrameReply, FrameRequest, TermulPlanInput, ENV_AGENT_ID, ENV_PORT, ENV_SESSION_ID, ENV_TOKEN,
+};
+
+/// Env-derived configuration for the child. Extracted so the arg parser is
+/// unit-testable without touching `std::env`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ChildConfig {
+    pub port: u16,
+    pub token: String,
+    pub session_id: String,
+    pub agent_id: String,
+}
+
+/// Parse the child's env (`TERMUL_PLAN_PORT` / `_TOKEN` / `_SESSION_ID` /
+/// `_AGENT_ID`). Returns an error string (not an enum) so `run()` can print it
+/// verbatim to stderr + exit 1 — matching the matrix's "child exits non-zero
+/// within 5s" AC.
+pub fn parse_env() -> Result<ChildConfig, String> {
+    let port: u16 = std::env::var(ENV_PORT)
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .ok_or_else(|| format!("missing or invalid {ENV_PORT}"))?;
+    let token = std::env::var(ENV_TOKEN)
+        .ok()
+        .filter(|v| !v.trim().is_empty())
+        .ok_or_else(|| format!("missing {ENV_TOKEN}"))?;
+    let session_id = std::env::var(ENV_SESSION_ID)
+        .ok()
+        .filter(|v| !v.trim().is_empty())
+        .ok_or_else(|| format!("missing {ENV_SESSION_ID}"))?;
+    // AGENT_ID is optional (used only for logging in the parent); absent → "".
+    let agent_id = std::env::var(ENV_AGENT_ID).unwrap_or_default();
+    Ok(ChildConfig { port, token, session_id, agent_id })
+}
+
+/// Subcommand entrypoint. Called from `main.rs` (desktop) / `server_main.rs`
+/// (standalone) when the first arg is `--internal-mcp-plan-server`. Returns an
+/// `i32` exit code so both call sites can use it (`std::process::exit` on
+/// desktop, `ExitCode::from(code as u8)` on standalone). Never returns
+/// normally on failure — prints an error to stderr + returns non-zero.
+pub fn run() -> i32 {
+    let config = match parse_env() {
+        Ok(c) => c,
+        Err(msg) => {
+            eprintln!("[host-mcp-child] {msg}");
+            return 1;
+        }
+    };
+
+    let runtime = match tokio::runtime::Builder::new_current_thread().enable_all().build() {
+        Ok(rt) => rt,
+        Err(e) => {
+            eprintln!("[host-mcp-child] failed to start runtime: {e}");
+            return 1;
+        }
+    };
+
+    match runtime.block_on(serve_mcp_server(config)) {
+        Ok(()) => 0,
+        Err(e) => {
+            eprintln!("[host-mcp-child] {e}");
+            1
+        }
+    }
+}
+
+/// The rmcp MCP server service backing `termul_plan`. Holds the per-session
+/// connection info (port + token + session_id) so each `tools/call` can open a
+/// fresh TCP connection to the parent.
+struct TermulPlanServer {
+    config: ChildConfig,
+}
+
+/// rmcp derives the `tools/list` entry from the `#[tool]` attribute; the input
+/// type must implement `schemars::JsonSchema` so rmcp can generate the
+/// `inputSchema`. We re-export the shared `TermulPlanInput` (defined in
+/// `host_mcp::mod`) — it already derives `JsonSchema`.
+///
+/// `server_handler` on `#[tool_router]` auto-generates the `ServerHandler` impl
+/// (no separate `impl ServerHandler` block needed — adding one would duplicate
+/// the impl + fail to compile).
+#[tool_router(server_handler)]
+impl TermulPlanServer {
+    #[tool(
+        name = "termul_plan",
+        description = "Update the execution plan / todo list shown in the Termul plan panel. Call this instead of a built-in todo tool so the user sees a unified plan UI across all agents."
+    )]
+    async fn termul_plan(
+        &self,
+        Parameters(input): Parameters<TermulPlanInput>,
+    ) -> String {
+        match forward_to_parent(&self.config, &input).await {
+            Ok(msg) => msg,
+            Err(e) => {
+                // Surface the error to the agent as the tool result text. The
+                // agent sees the failure + can retry / fall back; the session
+                // keeps running.
+                format!("termul_plan error: {e}")
+            }
+        }
+    }
+}
+
+/// Connect to the parent TCP listener, send one frame, read one reply.
+/// Fresh connection per call (localhost, sub-ms) — simplest + most robust.
+async fn forward_to_parent(
+    config: &ChildConfig,
+    input: &TermulPlanInput,
+) -> Result<String, String> {
+    let mut stream = TcpStream::connect(("127.0.0.1", config.port))
+        .await
+        .map_err(|e| format!("connect to parent failed: {e}"))?;
+    let req = FrameRequest {
+        token: config.token.clone(),
+        session_id: config.session_id.clone(),
+        todos: input.todos.clone(),
+    };
+    let mut buf = serde_json::to_vec(&req).map_err(|e| format!("encode frame: {e}"))?;
+    buf.push(b'\n');
+    stream
+        .write_all(&buf)
+        .await
+        .map_err(|e| format!("write frame: {e}"))?;
+
+    let mut reader = BufReader::new(stream);
+    let mut line = String::new();
+    reader
+        .read_line(&mut line)
+        .await
+        .map_err(|e| format!("read reply: {e}"))?;
+    let reply: FrameReply =
+        serde_json::from_str(&line).map_err(|e| format!("decode reply: {e}"))?;
+    if reply.ok {
+        Ok("plan updated".to_string())
+    } else {
+        Err(reply.error.unwrap_or_else(|| "unknown error".to_string()))
+    }
+}
+
+/// Drive the rmcp server over stdio. Returns when the agent closes stdin
+/// (normal disconnect) or the server fails to initialize.
+async fn serve_mcp_server(config: ChildConfig) -> Result<(), String> {
+    let (stdin, stdout) = rmcp::transport::io::stdio();
+    let service = TermulPlanServer { config };
+    let running = serve_server(service, (stdin, stdout))
+        .await
+        .map_err(|e| format!("mcp server initialize failed: {e}"))?;
+    // Wait until the transport closes (agent disconnect → stdin EOF).
+    running
+        .waiting()
+        .await
+        .map_err(|e| format!("mcp server ended with error: {e}"))?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn set_env(port: &str, token: &str, session: &str, agent: &str) {
+        std::env::set_var(ENV_PORT, port);
+        std::env::set_var(ENV_TOKEN, token);
+        std::env::set_var(ENV_SESSION_ID, session);
+        std::env::set_var(ENV_AGENT_ID, agent);
+    }
+
+    fn clear_env() {
+        std::env::remove_var(ENV_PORT);
+        std::env::remove_var(ENV_TOKEN);
+        std::env::remove_var(ENV_SESSION_ID);
+        std::env::remove_var(ENV_AGENT_ID);
+    }
+
+    // `parse_env` reads `std::env` — these tests are not parallel-safe, so
+    // serialize them with a shared lock.
+    static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    #[test]
+    fn parse_env_rejects_missing_port() {
+        let _g = ENV_LOCK.lock().unwrap();
+        clear_env();
+        std::env::set_var(ENV_TOKEN, "tok");
+        std::env::set_var(ENV_SESSION_ID, "sess");
+        let err = parse_env().expect_err("missing PORT must error");
+        assert!(err.contains(ENV_PORT));
+        clear_env();
+    }
+
+    #[test]
+    fn parse_env_rejects_missing_token() {
+        let _g = ENV_LOCK.lock().unwrap();
+        clear_env();
+        std::env::set_var(ENV_PORT, "1234");
+        std::env::set_var(ENV_SESSION_ID, "sess");
+        let err = parse_env().expect_err("missing TOKEN must error");
+        assert!(err.contains(ENV_TOKEN));
+        clear_env();
+    }
+
+    #[test]
+    fn parse_env_rejects_missing_session_id() {
+        let _g = ENV_LOCK.lock().unwrap();
+        clear_env();
+        std::env::set_var(ENV_PORT, "1234");
+        std::env::set_var(ENV_TOKEN, "tok");
+        let err = parse_env().expect_err("missing SESSION_ID must error");
+        assert!(err.contains(ENV_SESSION_ID));
+        clear_env();
+    }
+
+    #[test]
+    fn parse_env_rejects_blank_token() {
+        let _g = ENV_LOCK.lock().unwrap();
+        clear_env();
+        set_env("1234", "   ", "sess", "agent");
+        let err = parse_env().expect_err("blank TOKEN must error");
+        assert!(err.contains(ENV_TOKEN));
+        clear_env();
+    }
+
+    #[test]
+    fn parse_env_rejects_non_numeric_port() {
+        let _g = ENV_LOCK.lock().unwrap();
+        clear_env();
+        set_env("not-a-port", "tok", "sess", "agent");
+        let err = parse_env().expect_err("non-numeric PORT must error");
+        assert!(err.contains(ENV_PORT));
+        clear_env();
+    }
+
+    #[test]
+    fn parse_env_accepts_valid_config() {
+        let _g = ENV_LOCK.lock().unwrap();
+        clear_env();
+        set_env("4242", "tok-abc", "sess-xyz", "agent-1");
+        let cfg = parse_env().expect("valid env must parse");
+        assert_eq!(cfg.port, 4242);
+        assert_eq!(cfg.token, "tok-abc");
+        assert_eq!(cfg.session_id, "sess-xyz");
+        assert_eq!(cfg.agent_id, "agent-1");
+        clear_env();
+    }
+
+    #[test]
+    fn parse_env_agent_id_is_optional() {
+        let _g = ENV_LOCK.lock().unwrap();
+        clear_env();
+        set_env("4242", "tok", "sess", "");
+        std::env::remove_var(ENV_AGENT_ID);
+        let cfg = parse_env().expect("AGENT_ID is optional");
+        assert_eq!(cfg.agent_id, "");
+        clear_env();
+    }
+}

--- a/src-tauri/src/acp/host_mcp/child.rs
+++ b/src-tauri/src/acp/host_mcp/child.rs
@@ -125,7 +125,21 @@ impl TermulPlanServer {
 
 /// Connect to the parent TCP listener, send one frame, read one reply.
 /// Fresh connection per call (localhost, sub-ms) — simplest + most robust.
+/// The whole round trip is bounded so a wedged parent can't hang the agent's
+/// tool call indefinitely.
 async fn forward_to_parent(
+    config: &ChildConfig,
+    input: &TermulPlanInput,
+) -> Result<String, String> {
+    // 10s covers a healthy round trip many times over; a parent that can't
+    // reply by then is wedged and the agent deserves a clear timeout error.
+    const ROUND_TRIP: std::time::Duration = std::time::Duration::from_secs(10);
+    tokio::time::timeout(ROUND_TRIP, forward_to_parent_inner(config, input))
+        .await
+        .map_err(|_| "parent round trip timed out".to_string())?
+}
+
+async fn forward_to_parent_inner(
     config: &ChildConfig,
     input: &TermulPlanInput,
 ) -> Result<String, String> {

--- a/src-tauri/src/acp/host_mcp/mod.rs
+++ b/src-tauri/src/acp/host_mcp/mod.rs
@@ -48,6 +48,17 @@ pub const TERMUL_PLAN_TOOL_DESCRIPTION: &str = "Update the execution plan / todo
 /// `current_exe() --internal-mcp-plan-server` with the connection info in env.
 pub const CHILD_ARG: &str = "--internal-mcp-plan-server";
 
+/// True when the current process was spawned as the host-injected plan child
+/// (the agent spawned `current_exe() --internal-mcp-plan-server`). Used by
+/// BOTH binaries' `main` to branch BEFORE Tauri/app init. Matches the flag at
+/// ANY position in argv (the standalone binary collects args into a Vec, the
+/// desktop binary reads `args().nth(1)` — this helper unifies the rule so the
+/// two entrypoints can't drift).
+#[must_use]
+pub fn is_child_invocation() -> bool {
+    std::env::args().skip(1).any(|arg| arg == CHILD_ARG)
+}
+
 /// Env vars set on the injected `McpServer::Stdio` (carrying connection info
 /// to the child). Prefixed `TERMUL_PLAN_` to avoid collisions with agent env.
 pub const ENV_PORT: &str = "TERMUL_PLAN_PORT";

--- a/src-tauri/src/acp/host_mcp/mod.rs
+++ b/src-tauri/src/acp/host_mcp/mod.rs
@@ -1,0 +1,303 @@
+//! Host-injected `termul_plan` MCP tool — first-class plan UI for every ACP agent.
+//!
+//! Termul auto-injects a host-side MCP server into every `session/new`
+//! `mcp_servers` list (see `AcpManager::new_session_with_context`). The agent
+//! discovers it like any MCP tool and calls it instead of a built-in todo
+//! tool. When called, the host updates a per-session plan cache and emits a
+//! synthetic `acp:plan_update` event via `events::fan_out` so the existing
+//! renderer `PlanPanel` renders it — no translation of agents' own tools.
+//!
+//! Architecture (see `spec-acp-host-todo-plan-tool.md`):
+//! - `parent` — in-process TCP listener on `127.0.0.1:<ephemeral>` (one shared
+//!   across sessions, started lazily). Per-call frame: `{token, session_id,
+//!   todos}`; verifies the token, maps todos → `PlanEntry`, emits the event.
+//! - `child` — `--internal-mcp-plan-server` subcommand entrypoint. The agent
+//!   spawns `current_exe()` with this flag (the McpServer::Stdio config built
+//!   in `new_session_with_context`). Runs an rmcp MCP SERVER over stdio
+//!   exposing `termul_plan`; on each call, opens a fresh TCP connection to the
+//!   parent, forwards the input, returns the parent's reply.
+//!
+//! Desktop + standalone parity: no `tauri-plugin-mcp-bridge` / `AppHandle` —
+//! pure `rmcp` + tokio, works on both binaries.
+
+pub mod child;
+pub mod parent;
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use agent_client_protocol::schema::v1::{Plan, PlanEntry, PlanEntryPriority, PlanEntryStatus};
+use parking_lot::Mutex;
+use rmcp::schemars;
+use serde::{Deserialize, Serialize};
+
+use crate::acp::config::{AgentId, SessionId};
+use crate::acp::events::{self, PlanUpdateEvent};
+use crate::web::EventSink;
+
+/// The MCP tool name the agent sees in `tools/list`.
+pub const TERMUL_PLAN_TOOL_NAME: &str = "termul_plan";
+
+/// Human-readable description shown to the agent in `tools/list`.
+pub const TERMUL_PLAN_TOOL_DESCRIPTION: &str = "Update the execution plan / todo list shown \
+    in the Termul plan panel. Call this instead of a built-in todo tool so the user sees a \
+    unified plan UI across all agents.";
+
+/// The hidden subcommand flag the child detects in argv (passed as the sole
+/// arg of the injected `McpServer::Stdio`). The agent spawns
+/// `current_exe() --internal-mcp-plan-server` with the connection info in env.
+pub const CHILD_ARG: &str = "--internal-mcp-plan-server";
+
+/// Env vars set on the injected `McpServer::Stdio` (carrying connection info
+/// to the child). Prefixed `TERMUL_PLAN_` to avoid collisions with agent env.
+pub const ENV_PORT: &str = "TERMUL_PLAN_PORT";
+pub const ENV_TOKEN: &str = "TERMUL_PLAN_TOKEN";
+pub const ENV_SESSION_ID: &str = "TERMUL_PLAN_SESSION_ID";
+pub const ENV_AGENT_ID: &str = "TERMUL_PLAN_AGENT_ID";
+
+/// Input the agent sends to `termul_plan` (the `arguments` of `tools/call`).
+/// Also re-used as the parent–child TCP frame body (one todo per plan entry).
+#[derive(Debug, Clone, Deserialize, Serialize, schemars::JsonSchema)]
+pub struct TermulPlanInput {
+    /// The complete list of plan entries — each update is a FULL REPLACE
+    /// (matches the ACP `plan_update` semantics the renderer already enforces).
+    pub todos: Vec<TermulPlanTodo>,
+}
+
+/// One todo item. `status`/`priority` are optional strings (the agent may omit
+/// them); the host maps unknown/absent values to ACP defaults.
+#[derive(Debug, Clone, Deserialize, Serialize, schemars::JsonSchema)]
+pub struct TermulPlanTodo {
+    /// Human-readable description of the task.
+    pub content: String,
+    /// Optional status: `"pending"` | `"in_progress"` | `"completed"`.
+    /// Unknown/absent → `Pending`.
+    #[serde(default)]
+    pub status: Option<String>,
+    /// Optional priority: `"high"` | `"medium"` | `"low"`.
+    /// Unknown/absent → `Low`.
+    #[serde(default)]
+    pub priority: Option<String>,
+}
+
+/// Parent-bound TCP frame. One frame per connection (request/response).
+/// Carries a `session_id` that is a HOST-GENERATED PROVISIONAL id (not the
+/// real ACP session_id, which the agent generates during `session/new` and the
+/// host doesn't know at injection time). The parent binds the provisional id
+/// → real `session_id` after the `session/new` response arrives, then emits
+/// the plan_update for the real id. The `token` authenticates the child.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct FrameRequest {
+    pub token: String,
+    pub session_id: String,
+    pub todos: Vec<TermulPlanTodo>,
+}
+
+/// Parent reply frame (one per connection).
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct FrameReply {
+    pub ok: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
+impl FrameReply {
+    #[must_use]
+    pub fn ok() -> Self {
+        Self { ok: true, error: None }
+    }
+
+    #[must_use]
+    pub fn err(msg: impl Into<String>) -> Self {
+        Self { ok: false, error: Some(msg.into()) }
+    }
+}
+
+/// Map the agent's todo input → ACP `PlanEntry` list, preserving order.
+/// Unknown `status`/`priority` strings fall back to `Pending`/`Low` (the ACP
+/// enums are `#[non_exhaustive]`; only the three named variants are produced).
+#[must_use]
+pub fn map_todos_to_plan_entries(todos: &[TermulPlanTodo]) -> Vec<PlanEntry> {
+    todos
+        .iter()
+        .map(|todo| {
+            let priority = match todo.priority.as_deref().map(str::trim).unwrap_or("").to_ascii_lowercase().as_str() {
+                "high" => PlanEntryPriority::High,
+                "medium" => PlanEntryPriority::Medium,
+                _ => PlanEntryPriority::Low,
+            };
+            let status = match todo.status.as_deref().map(str::trim).unwrap_or("").to_ascii_lowercase().as_str() {
+                "in_progress" | "inprogress" | "in-progress" => PlanEntryStatus::InProgress,
+                "completed" | "done" | "complete" => PlanEntryStatus::Completed,
+                _ => PlanEntryStatus::Pending,
+            };
+            PlanEntry::new(todo.content.clone(), priority, status)
+        })
+        .collect()
+}
+
+/// In-memory plan cache (per session). v1 is emit-and-cache; durable
+/// persistence across resume is deferred (Ask First). Kept as a seam so a
+/// future persistence layer can read the latest plan without re-deriving it.
+#[derive(Default)]
+pub struct PlanStore {
+    inner: Mutex<HashMap<String, Vec<PlanEntry>>>,
+}
+
+impl PlanStore {
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Replace the cached plan for a session (full-replace semantics).
+    pub fn set(&self, session_id: &str, entries: Vec<PlanEntry>) {
+        self.inner.lock().insert(session_id.to_string(), entries);
+    }
+
+    /// Read the cached plan for a session (clone).
+    #[must_use]
+    pub fn get(&self, session_id: &str) -> Option<Vec<PlanEntry>> {
+        self.inner.lock().get(session_id).cloned()
+    }
+
+    /// Drop the cached plan for a session (on close/dispose).
+    pub fn drop_session(&self, session_id: &str) {
+        self.inner.lock().remove(session_id);
+    }
+}
+
+/// Emit a synthetic `acp:plan_update` for a session. Respects the empty-entries
+/// = clear contract: passing `entries: vec![]` emits a `Plan` with an empty
+/// list, which the renderer's `_onPlanUpdate` maps to `dropPlanForSession`.
+///
+/// `agent_id` is the Termul-side `AgentId` (used for the wire event payload);
+/// the renderer keys plan state by `session_id`.
+pub fn emit_plan_update(
+    sinks: &[Arc<dyn EventSink>],
+    agent_id: &AgentId,
+    session_id: &SessionId,
+    entries: Vec<PlanEntry>,
+) {
+    let plan = Plan::new(entries);
+    let event = PlanUpdateEvent {
+        agent_id: agent_id.clone(),
+        session_id: session_id.clone(),
+        plan,
+    };
+    events::fan_out(
+        sinks,
+        Some(session_id.0.as_str()),
+        events::EVENT_PLAN_UPDATE,
+        &event,
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Mutex as StdMutex;
+    use crate::web::sink::AcpEvent;
+    use serde_json::Value;
+
+    /// Test sink that captures every emitted event (for plan_update assertions).
+    #[derive(Default)]
+    struct CapturingSink {
+        events: StdMutex<Vec<(String, Value)>>,
+    }
+
+    impl EventSink for CapturingSink {
+        fn emit(&self, event: &AcpEvent) {
+            let type_ = event.type_.to_string();
+            let payload = event.payload.clone();
+            self.events.lock().unwrap().push((type_, payload));
+        }
+    }
+
+    fn make_ids() -> (AgentId, SessionId) {
+        (AgentId::new(), SessionId::new("sess-test"))
+    }
+
+    #[test]
+    fn map_todos_preserves_order_and_maps_status_priority() {
+        let todos = vec![
+            TermulPlanTodo { content: "a".into(), status: Some("in_progress".into()), priority: Some("high".into()) },
+            TermulPlanTodo { content: "b".into(), status: Some("completed".into()), priority: Some("medium".into()) },
+            TermulPlanTodo { content: "c".into(), status: None, priority: None },
+        ];
+        let entries = map_todos_to_plan_entries(&todos);
+        assert_eq!(entries.len(), 3);
+        assert_eq!(entries[0].content, "a");
+        assert_eq!(entries[0].status, PlanEntryStatus::InProgress);
+        assert_eq!(entries[0].priority, PlanEntryPriority::High);
+        assert_eq!(entries[1].status, PlanEntryStatus::Completed);
+        assert_eq!(entries[1].priority, PlanEntryPriority::Medium);
+        // Defaults: Pending + Low.
+        assert_eq!(entries[2].status, PlanEntryStatus::Pending);
+        assert_eq!(entries[2].priority, PlanEntryPriority::Low);
+    }
+
+    #[test]
+    fn map_todos_unknown_status_priority_falls_back() {
+        let todos = vec![TermulPlanTodo {
+            content: "x".into(),
+            status: Some("bogus".into()),
+            priority: Some("nope".into()),
+        }];
+        let entries = map_todos_to_plan_entries(&todos);
+        assert_eq!(entries[0].status, PlanEntryStatus::Pending);
+        assert_eq!(entries[0].priority, PlanEntryPriority::Low);
+    }
+
+    #[test]
+    fn emit_plan_update_fires_event_with_entries() {
+        let sink = Arc::new(CapturingSink::default());
+        let sinks: Vec<Arc<dyn EventSink>> = vec![sink.clone()];
+        let (agent_id, session_id) = make_ids();
+        let todos = vec![
+            TermulPlanTodo { content: "one".into(), status: None, priority: None },
+            TermulPlanTodo { content: "two".into(), status: None, priority: None },
+            TermulPlanTodo { content: "three".into(), status: None, priority: None },
+        ];
+        let entries = map_todos_to_plan_entries(&todos);
+        emit_plan_update(&sinks, &agent_id, &session_id, entries);
+
+        let captured = sink.events.lock().unwrap();
+        assert_eq!(captured.len(), 1);
+        let (type_, payload) = &captured[0];
+        assert_eq!(type_, events::EVENT_PLAN_UPDATE);
+        assert_eq!(payload["agentId"], agent_id.0);
+        assert_eq!(payload["sessionId"], session_id.0);
+        assert_eq!(payload["plan"]["entries"].as_array().unwrap().len(), 3);
+        assert_eq!(payload["plan"]["entries"][0]["content"], "one");
+    }
+
+    #[test]
+    fn emit_plan_update_empty_entries_emits_clear() {
+        // The renderer's `_onPlanUpdate` treats `entries.length === 0` as
+        // "clear the plan" (dropPlanForSession). Verify the host emits exactly
+        // that shape for an empty todos list.
+        let sink = Arc::new(CapturingSink::default());
+        let sinks: Vec<Arc<dyn EventSink>> = vec![sink.clone()];
+        let (agent_id, session_id) = make_ids();
+        emit_plan_update(&sinks, &agent_id, &session_id, vec![]);
+
+        let captured = sink.events.lock().unwrap();
+        assert_eq!(captured.len(), 1);
+        let (type_, payload) = &captured[0];
+        assert_eq!(type_, events::EVENT_PLAN_UPDATE);
+        let entries = payload["plan"]["entries"].as_array().unwrap();
+        assert!(entries.is_empty(), "empty todos must emit an empty entries array");
+    }
+
+    #[test]
+    fn frame_reply_serializes_ok_and_err() {
+        let ok = serde_json::to_value(FrameReply::ok()).unwrap();
+        assert_eq!(ok["ok"], true);
+        assert!(ok.get("error").is_none() || ok["error"].is_null());
+
+        let err = serde_json::to_value(FrameReply::err("auth rejected")).unwrap();
+        assert_eq!(err["ok"], false);
+        assert_eq!(err["error"], "auth rejected");
+    }
+}

--- a/src-tauri/src/acp/host_mcp/parent.rs
+++ b/src-tauri/src/acp/host_mcp/parent.rs
@@ -18,13 +18,14 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use parking_lot::Mutex;
-use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::io::{AsyncBufReadExt, AsyncReadExt, AsyncWriteExt, BufReader};
 use tokio::net::TcpListener;
-use tokio::runtime::Runtime;
 use uuid::Uuid;
 
 use crate::acp::config::{AgentId, SessionId};
-use crate::acp::host_mcp::{emit_plan_update, map_todos_to_plan_entries, FrameReply, FrameRequest};
+use crate::acp::host_mcp::{
+    emit_plan_update, map_todos_to_plan_entries, FrameReply, FrameRequest, PlanStore,
+};
 use crate::web::EventSink;
 
 /// Per-session auth + routing context, keyed by the random token.
@@ -42,7 +43,8 @@ struct SessionAuth {
 }
 
 /// The shared host plan server. Owns the listener thread + the per-session
-/// token map + a clone of the AcpManager sinks (for emitting `plan_update`).
+/// token map + a `PlanStore` cache + a clone of the AcpManager sinks (for
+/// emitting `plan_update`).
 pub struct HostPlanServer {
     /// Set once the dedicated thread has bound the listener.
     port: std::sync::OnceLock<u16>,
@@ -51,6 +53,10 @@ pub struct HostPlanServer {
     sinks: Vec<Arc<dyn EventSink>>,
     /// token -> SessionAuth. One entry per registered session.
     sessions: Mutex<HashMap<String, SessionAuth>>,
+    /// Per-session plan cache (emit-and-cache). v1 doesn't persist; this is
+    /// the seam a future persistence layer reads from on resume. Updated in
+    /// `process_request` (set on emit) + `unregister_*` (drop on close).
+    plan_store: PlanStore,
 }
 
 impl HostPlanServer {
@@ -67,6 +73,7 @@ impl HostPlanServer {
             port: std::sync::OnceLock::new(),
             sinks,
             sessions: Mutex::new(HashMap::new()),
+            plan_store: PlanStore::new(),
         });
         let server_for_thread = Arc::clone(&server);
         let (port_tx, port_rx) = std::sync::mpsc::channel::<u16>();
@@ -77,7 +84,10 @@ impl HostPlanServer {
         let _handle: std::thread::JoinHandle<()> = std::thread::Builder::new()
             .name("termul-host-mcp".to_string())
             .spawn(move || {
-                let runtime = match Runtime::new() {
+                let runtime = match tokio::runtime::Builder::new_current_thread()
+                    .enable_all()
+                    .build()
+                {
                     Ok(rt) => rt,
                     Err(e) => {
                         log::error!("[host-mcp] failed to start runtime: {e}");
@@ -110,7 +120,10 @@ impl HostPlanServer {
                                 });
                             }
                             Err(e) => {
+                                // A transient accept failure (e.g. EMFILE) must
+                                // not hot-loop. Brief backoff, then retry.
                                 log::warn!("[host-mcp] accept failed: {e}");
+                                tokio::time::sleep(std::time::Duration::from_millis(100)).await;
                             }
                         }
                     }
@@ -183,6 +196,23 @@ impl HostPlanServer {
     pub fn unregister_session(&self, real_session_id: &str) {
         let mut sessions = self.sessions.lock();
         sessions.retain(|_, auth| auth.real_session_id.as_deref() != Some(real_session_id));
+        drop(sessions);
+        self.plan_store.drop_session(real_session_id);
+    }
+
+    /// Drop a registration by token (used when `session/new` fails AFTER
+    /// `register_session` but before `bind_session` — the real session_id
+    /// isn't known, so `unregister_session` can't be keyed by it).
+    pub fn unregister_by_token(&self, token: &str) {
+        let real_sid = {
+            let mut sessions = self.sessions.lock();
+            sessions
+                .remove(token)
+                .and_then(|auth| auth.real_session_id)
+        };
+        if let Some(sid) = real_sid {
+            self.plan_store.drop_session(&sid);
+        }
     }
 
     #[must_use]
@@ -190,16 +220,27 @@ impl HostPlanServer {
         *self.port.get().unwrap_or(&0)
     }
 
-    /// Handle one child connection: read a single newline-delimited JSON frame,
-    /// authenticate, emit the plan_update, reply. One frame per connection
-    /// (simplest + robust; localhost TCP connect is sub-ms).
+    /// Handle one child connection: read a single newline-delimited JSON frame
+    /// (capped + timeout-bounded so a wedged/idle peer can't grow `line`
+    /// unbounded or hold the task open), authenticate, emit the plan_update,
+    /// reply. One frame per connection (simplest + robust; localhost TCP
+    /// connect is sub-ms).
     async fn handle_conn(self: Arc<Self>, stream: tokio::net::TcpStream) -> std::io::Result<()> {
         let (reader, mut writer) = stream.into_split();
-        let mut reader = BufReader::new(reader);
-        let mut line = String::new();
+        // Cap the request at 1 MiB so a misbehaving peer can't grow `line`
+        // unbounded. The largest plausible plan (hundreds of todos) is well
+        // under this.
+        const MAX_FRAME: u64 = 1024 * 1024;
+        const READ_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
+        let mut reader = BufReader::new(reader.take(MAX_FRAME));
 
-        // One request line. A short read / EOF = child died → just close.
-        let n = reader.read_line(&mut line).await?;
+        let mut line = String::new();
+        // Bound the read so an idle peer that connects but never sends is
+        // dropped instead of holding the task forever.
+        let n = match tokio::time::timeout(READ_TIMEOUT, reader.read_line(&mut line)).await {
+            Ok(Ok(n)) => n,
+            Ok(Err(_)) | Err(_) => return Ok(()),
+        };
         if n == 0 {
             return Ok(());
         }
@@ -258,7 +299,10 @@ impl HostPlanServer {
         let real_session_id = match &auth.real_session_id {
             Some(sid) => sid.clone(),
             None => {
-                log::warn!("[host-mcp] dropped call: session not yet bound (provisional {})", auth.provisional_sid);
+                log::warn!(
+                    "[host-mcp] dropped call: session not yet bound (provisional {})",
+                    auth.provisional_sid
+                );
                 return FrameReply::err("session not ready");
             }
         };
@@ -266,8 +310,11 @@ impl HostPlanServer {
         // Map todos → PlanEntry + emit. Empty todos = clear (renderer drops).
         let entries = map_todos_to_plan_entries(&req.todos);
         let agent_id = AgentId(auth.agent_id.clone());
-        let session_id = SessionId(real_session_id);
+        let session_id = SessionId(real_session_id.clone());
         let count = entries.len();
+        // Cache the latest plan (emit-and-cache) so a future persistence layer
+        // can read it without re-deriving from replayed events.
+        self.plan_store.set(&real_session_id, entries.clone());
         emit_plan_update(&self.sinks, &agent_id, &session_id, entries);
         log::info!(
             "[host-mcp] emitted plan_update for session {} ({} entries)",
@@ -284,6 +331,7 @@ mod tests {
     use std::sync::Mutex as StdMutex;
     use tokio::io::AsyncWriteExt;
     use tokio::net::TcpStream;
+    use tokio::runtime::Runtime;
 
     #[derive(Default)]
     struct CapturingSink {

--- a/src-tauri/src/acp/host_mcp/parent.rs
+++ b/src-tauri/src/acp/host_mcp/parent.rs
@@ -1,0 +1,403 @@
+//! Parent side of the host-injected plan tool: an in-process TCP listener that
+//! the self-spawned child connects to on each `termul_plan` call.
+//!
+//! One shared listener serves all sessions (started lazily by `AcpManager` on
+//! first `new_session_with_context`). Each session is registered with a random
+//! token + a host-generated PROVISIONAL session_id (the real ACP session_id
+//! isn't known until `session/new` returns). After the response, `AcpManager`
+//! calls `bind_session(token, real_session_id)` so the parent can emit
+//! `plan_update` for the real id. The child presents the token + provisional id
+//! per call; the parent verifies the token, ignores stale unbound entries, and
+//! emits.
+//!
+//! Runs on a dedicated OS thread with a current-thread tokio runtime (mirrors
+//! the per-agent driver-thread model in `AcpManager`) — works on both the
+//! desktop binary and the standalone `termul-server` (no `AppHandle`).
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use parking_lot::Mutex;
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::net::TcpListener;
+use tokio::runtime::Runtime;
+use uuid::Uuid;
+
+use crate::acp::config::{AgentId, SessionId};
+use crate::acp::host_mcp::{emit_plan_update, map_todos_to_plan_entries, FrameReply, FrameRequest};
+use crate::web::EventSink;
+
+/// Per-session auth + routing context, keyed by the random token.
+#[derive(Clone)]
+struct SessionAuth {
+    /// Host-generated provisional id (passed to the child via env, echoed in
+    /// the frame for defense-in-depth — does NOT match the real ACP id).
+    provisional_sid: String,
+    agent_id: String,
+    /// The real ACP session_id, bound after `session/new` returns. `None`
+    /// until `bind_session` is called; a call arriving before binding is
+    /// rejected (the agent can't call tools before `session/new` completes,
+    /// so this is purely defensive).
+    real_session_id: Option<String>,
+}
+
+/// The shared host plan server. Owns the listener thread + the per-session
+/// token map + a clone of the AcpManager sinks (for emitting `plan_update`).
+pub struct HostPlanServer {
+    /// Set once the dedicated thread has bound the listener.
+    port: std::sync::OnceLock<u16>,
+    /// Cloned at construction; never changes (AcpManager's sinks are
+    /// `Vec<Arc<dyn EventSink>>` fixed at creation).
+    sinks: Vec<Arc<dyn EventSink>>,
+    /// token -> SessionAuth. One entry per registered session.
+    sessions: Mutex<HashMap<String, SessionAuth>>,
+}
+
+impl HostPlanServer {
+    /// Start the in-process TCP listener on `127.0.0.1:<ephemeral>` and spawn
+    /// the dedicated accept-loop thread. Blocks until the port is known (so
+    /// `register_session` callers see a valid port immediately).
+    ///
+    /// The sinks are the AcpManager's event sinks (`TauriEventSink` on desktop,
+    /// `WsRelaySink` on standalone). `fan_out` over zero sinks is a no-op, so a
+    /// unit-test `HostPlanServer` with `vec![]` is legal (just emits nothing).
+    #[must_use]
+    pub fn start(sinks: Vec<Arc<dyn EventSink>>) -> Arc<Self> {
+        let server = Arc::new(Self {
+            port: std::sync::OnceLock::new(),
+            sinks,
+            sessions: Mutex::new(HashMap::new()),
+        });
+        let server_for_thread = Arc::clone(&server);
+        let (port_tx, port_rx) = std::sync::mpsc::channel::<u16>();
+
+        // Detached dedicated thread: own current-thread tokio runtime so the
+        // listener is driven independently of the AcpManager's per-agent
+        // driver threads + the desktop's Tauri runtime.
+        let _handle: std::thread::JoinHandle<()> = std::thread::Builder::new()
+            .name("termul-host-mcp".to_string())
+            .spawn(move || {
+                let runtime = match Runtime::new() {
+                    Ok(rt) => rt,
+                    Err(e) => {
+                        log::error!("[host-mcp] failed to start runtime: {e}");
+                        let _ = port_tx.send(0);
+                        return;
+                    }
+                };
+                runtime.block_on(async move {
+                    let listener = match TcpListener::bind("127.0.0.1:0").await {
+                        Ok(l) => l,
+                        Err(e) => {
+                            log::error!("[host-mcp] bind failed: {e}");
+                            let _ = port_tx.send(0);
+                            return;
+                        }
+                    };
+                    let port = listener.local_addr().map(|addr| addr.port()).unwrap_or(0);
+                    let _ = server_for_thread.port.set(port);
+                    let _ = port_tx.send(port);
+                    log::info!("[host-mcp] listening on 127.0.0.1:{port}");
+
+                    loop {
+                        match listener.accept().await {
+                            Ok((stream, peer)) => {
+                                let server = Arc::clone(&server_for_thread);
+                                tokio::spawn(async move {
+                                    if let Err(e) = server.handle_conn(stream).await {
+                                        log::warn!("[host-mcp] conn from {peer} ended with error: {e}");
+                                    }
+                                });
+                            }
+                            Err(e) => {
+                                log::warn!("[host-mcp] accept failed: {e}");
+                            }
+                        }
+                    }
+                });
+            })
+            .expect("spawn termul-host-mcp thread");
+
+        // Block until the dedicated thread has bound + published the port.
+        // (If the thread failed to bind, `port` is 0 — `register_session`
+        // will surface a 0 port and the child will fail to connect + log.)
+        let _ = port_rx.recv();
+        server
+    }
+
+    /// Register a session at injection time (before `session/new` is sent).
+    /// Returns `(port, token, provisional_session_id)` to inject into the
+    /// `McpServer::Stdio` env: `TERMUL_PLAN_PORT`, `TERMUL_PLAN_TOKEN`,
+    /// `TERMUL_PLAN_SESSION_ID`.
+    ///
+    /// The real ACP session_id isn't known yet — call `bind_session` after the
+    /// `session/new` response arrives to bind it to the token.
+    #[must_use]
+    pub fn register_session(&self, agent_id: &str) -> (u16, String, String) {
+        let token = Uuid::new_v4().to_string();
+        let provisional_sid = Uuid::new_v4().to_string();
+        {
+            let mut sessions = self.sessions.lock();
+            sessions.insert(
+                token.clone(),
+                SessionAuth {
+                    provisional_sid: provisional_sid.clone(),
+                    agent_id: agent_id.to_string(),
+                    real_session_id: None,
+                },
+            );
+        }
+        let port = self.port();
+        log::debug!(
+            "[host-mcp] registered agent {agent_id} on port {port} (provisional sid {provisional_sid})"
+        );
+        (port, token, provisional_sid)
+    }
+
+    /// Bind the real ACP session_id (returned by `session/new`) to a token.
+    /// Called by `AcpManager::new_session_with_context` after the agent
+    /// responds. No-op (logged) if the token is unknown (e.g. the session was
+    /// for an ephemeral background gen that wasn't registered).
+    pub fn bind_session(&self, token: &str, real_session_id: &str) {
+        let mut sessions = self.sessions.lock();
+        match sessions.get_mut(token) {
+            Some(auth) => {
+                auth.real_session_id = Some(real_session_id.to_string());
+                log::debug!(
+                    "[host-mcp] bound token → session {real_session_id} (agent {})",
+                    auth.agent_id
+                );
+            }
+            None => {
+                log::warn!(
+                    "[host-mcp] bind_session: unknown token (session {real_session_id} not registered)"
+                );
+            }
+        }
+    }
+
+    /// Drop a session's auth entry (on close/dispose). Scans by the bound real
+    /// session_id. Best-effort — the renderer's `_onPlanUpdate` already guards
+    /// closed sessions, so a stale in-flight call is harmless, but evicting
+    /// avoids token reuse + bounds the map size.
+    pub fn unregister_session(&self, real_session_id: &str) {
+        let mut sessions = self.sessions.lock();
+        sessions.retain(|_, auth| auth.real_session_id.as_deref() != Some(real_session_id));
+    }
+
+    #[must_use]
+    pub fn port(&self) -> u16 {
+        *self.port.get().unwrap_or(&0)
+    }
+
+    /// Handle one child connection: read a single newline-delimited JSON frame,
+    /// authenticate, emit the plan_update, reply. One frame per connection
+    /// (simplest + robust; localhost TCP connect is sub-ms).
+    async fn handle_conn(self: Arc<Self>, stream: tokio::net::TcpStream) -> std::io::Result<()> {
+        let (reader, mut writer) = stream.into_split();
+        let mut reader = BufReader::new(reader);
+        let mut line = String::new();
+
+        // One request line. A short read / EOF = child died → just close.
+        let n = reader.read_line(&mut line).await?;
+        if n == 0 {
+            return Ok(());
+        }
+
+        let reply: FrameReply = match serde_json::from_str::<FrameRequest>(&line) {
+            Ok(req) => self.process_request(req).await,
+            Err(e) => {
+                log::warn!("[host-mcp] malformed frame: {e}");
+                FrameReply::err("malformed request")
+            }
+        };
+
+        // Reply (newline-delimited JSON).
+        let mut buf = match serde_json::to_vec(&reply) {
+            Ok(v) => v,
+            Err(e) => {
+                log::error!("[host-mcp] failed to serialize reply: {e}");
+                return Ok(());
+            }
+        };
+        buf.push(b'\n');
+        writer.write_all(&buf).await?;
+        Ok(())
+    }
+
+    /// Authenticate + dispatch a validated frame. Returns the reply (ok/err).
+    async fn process_request(&self, req: FrameRequest) -> FrameReply {
+        // Look up the token. Unknown token = reject (don't disclose which
+        // sessions exist — constant-time isn't necessary for localhost-only,
+        // but we never echo the token back).
+        let auth = {
+            let sessions = self.sessions.lock();
+            match sessions.get(&req.token) {
+                Some(a) => a.clone(),
+                None => {
+                    log::warn!("[host-mcp] auth rejected (unknown token)");
+                    return FrameReply::err("auth rejected");
+                }
+            }
+        };
+
+        // Defense-in-depth: the provisional session_id in the frame must
+        // match the one the token was minted with.
+        if auth.provisional_sid != req.session_id {
+            log::warn!(
+                "[host-mcp] auth rejected (provisional sid mismatch): token has {}, frame has {}",
+                auth.provisional_sid,
+                req.session_id
+            );
+            return FrameReply::err("auth rejected");
+        }
+
+        // The real session_id must be bound (post `session/new`). If not, the
+        // agent called the tool before the session was created — shouldn't
+        // happen, but reject defensively.
+        let real_session_id = match &auth.real_session_id {
+            Some(sid) => sid.clone(),
+            None => {
+                log::warn!("[host-mcp] dropped call: session not yet bound (provisional {})", auth.provisional_sid);
+                return FrameReply::err("session not ready");
+            }
+        };
+
+        // Map todos → PlanEntry + emit. Empty todos = clear (renderer drops).
+        let entries = map_todos_to_plan_entries(&req.todos);
+        let agent_id = AgentId(auth.agent_id.clone());
+        let session_id = SessionId(real_session_id);
+        let count = entries.len();
+        emit_plan_update(&self.sinks, &agent_id, &session_id, entries);
+        log::info!(
+            "[host-mcp] emitted plan_update for session {} ({} entries)",
+            session_id,
+            count
+        );
+        FrameReply::ok()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Mutex as StdMutex;
+    use tokio::io::AsyncWriteExt;
+    use tokio::net::TcpStream;
+
+    #[derive(Default)]
+    struct CapturingSink {
+        events: StdMutex<Vec<String>>,
+    }
+
+    impl EventSink for CapturingSink {
+        fn emit(&self, event: &crate::web::sink::AcpEvent) {
+            if event.type_ == crate::acp::events::EVENT_PLAN_UPDATE {
+                self.events.lock().unwrap().push(event.type_.to_string());
+            }
+        }
+    }
+
+    async fn connect_and_send(port: u16, frame: &serde_json::Value) -> serde_json::Value {
+        let mut stream = TcpStream::connect(("127.0.0.1", port)).await.unwrap();
+        let mut buf = serde_json::to_vec(frame).unwrap();
+        buf.push(b'\n');
+        stream.write_all(&buf).await.unwrap();
+        let mut reader = BufReader::new(stream);
+        let mut line = String::new();
+        reader.read_line(&mut line).await.unwrap();
+        serde_json::from_str(&line).unwrap_or(serde_json::Value::Null)
+    }
+
+    #[test]
+    fn register_returns_valid_port_token_provisional() {
+        let server = HostPlanServer::start(vec![]);
+        let (port, token, provisional) = server.register_session("agent-1");
+        assert!(port > 0, "port must be bound by the dedicated thread");
+        assert!(!token.is_empty());
+        assert!(!provisional.is_empty());
+        assert_ne!(token, provisional, "token and provisional sid must differ");
+    }
+
+    #[test]
+    fn unbound_call_is_rejected_before_bind() {
+        // Before `bind_session` is called, the real session_id is unknown — a
+        // call arriving in that window is rejected (the agent can't legally
+        // call tools before `session/new` returns, but we defend anyway).
+        let server = HostPlanServer::start(vec![Arc::new(CapturingSink::default())]);
+        let (port, token, provisional) = server.register_session("agent-1");
+        let runtime = Runtime::new().unwrap();
+        runtime.block_on(async move {
+            let frame = serde_json::json!({
+                "token": token,
+                "session_id": provisional,
+                "todos": [{"content": "x"}],
+            });
+            let reply = connect_and_send(port, &frame).await;
+            assert_eq!(reply["ok"], false);
+            assert_eq!(reply["error"], "session not ready");
+        });
+    }
+
+    #[test]
+    fn token_provisional_mismatch_is_rejected() {
+        // A valid token paired with the wrong provisional session_id is
+        // rejected (defense-in-depth against a leaked token + guessed sid).
+        let server = HostPlanServer::start(vec![Arc::new(CapturingSink::default())]);
+        let (port, token, _provisional) = server.register_session("agent-1");
+        let runtime = Runtime::new().unwrap();
+        runtime.block_on(async move {
+            let frame = serde_json::json!({
+                "token": token,
+                "session_id": "wrong-provisional",
+                "todos": [{"content": "x"}],
+            });
+            let reply = connect_and_send(port, &frame).await;
+            assert_eq!(reply["ok"], false);
+            assert_eq!(reply["error"], "auth rejected");
+        });
+    }
+
+    #[test]
+    fn bound_session_emits_plan_update() {
+        let sink = Arc::new(CapturingSink::default());
+        let server = HostPlanServer::start(vec![sink.clone()]);
+        let (port, token, provisional) = server.register_session("agent-1");
+        server.bind_session(&token, "sess-real");
+
+        let runtime = Runtime::new().unwrap();
+        runtime.block_on(async move {
+            let frame = serde_json::json!({
+                "token": token,
+                "session_id": provisional,
+                "todos": [
+                    {"content": "one"},
+                    {"content": "two", "status": "in_progress", "priority": "high"},
+                ],
+            });
+            let reply = connect_and_send(port, &frame).await;
+            assert_eq!(reply["ok"], true);
+        });
+        // The capturing sink records plan_update event names.
+        let captured = sink.events.lock().unwrap();
+        assert_eq!(captured.len(), 1, "exactly one plan_update must be emitted");
+    }
+
+    #[test]
+    fn bad_token_alone_is_rejected() {
+        // Unknown token — rejected even with a plausible provisional sid.
+        let server = HostPlanServer::start(vec![Arc::new(CapturingSink::default())]);
+        let (port, _token, _provisional) = server.register_session("agent-1");
+        let runtime = Runtime::new().unwrap();
+        runtime.block_on(async move {
+            let frame = serde_json::json!({
+                "token": "bogus-token",
+                "session_id": "bogus-sid",
+                "todos": [{"content": "x"}],
+            });
+            let reply = connect_and_send(port, &frame).await;
+            assert_eq!(reply["ok"], false);
+            assert_eq!(reply["error"], "auth rejected");
+        });
+    }
+}

--- a/src-tauri/src/acp/manager.rs
+++ b/src-tauri/src/acp/manager.rs
@@ -32,8 +32,8 @@ use std::time::Duration;
 
 use agent_client_protocol::schema::v1::{
     AgentCapabilities, AuthMethod, AuthenticateRequest, CancelNotification, CloseSessionRequest,
-    ContentBlock, InitializeRequest, ListSessionsResponse, LoadSessionRequest, LoadSessionResponse,
-    McpServer, NewSessionRequest, PromptRequest,
+    ContentBlock, EnvVariable, InitializeRequest, ListSessionsResponse, LoadSessionRequest,
+    LoadSessionResponse, McpServer, McpServerStdio, NewSessionRequest, PromptRequest,
     RequestPermissionOutcome, RequestPermissionResponse, ResumeSessionRequest,
     ResumeSessionResponse, SelectedPermissionOutcome, SessionConfigOption,
     SetSessionConfigOptionRequest, SetSessionModeRequest, StopReason,
@@ -790,6 +790,14 @@ pub struct AcpManager {
     /// one agent lifetime. Cleared on agent drop (driver self-reap) so a
     /// re-spawned agent re-warmups.
     warmup_done: Arc<Mutex<HashSet<AgentId>>>,
+    /// Host-injected `termul_plan` MCP server (one shared TCP listener across
+    /// all sessions, started lazily on first `new_session_with_context`).
+    /// Injects a self-spawned stdio child into every non-ephemeral session's
+    /// `mcp_servers`; the child forwards `termul_plan` calls back here, and
+    /// `host_mcp::emit_plan_update` emits a synthetic `acp:plan_update` so the
+    /// existing renderer `PlanPanel` renders it. See `host_mcp::mod` + the spec
+    /// `spec-acp-host-todo-plan-tool.md`.
+    host_plan_server: Mutex<Option<Arc<crate::acp::host_mcp::parent::HostPlanServer>>>,
 }
 
 /// Extract the concatenated text from a `Vec<ContentBlock>` for the
@@ -900,6 +908,7 @@ impl AcpManager {
             persistence: None,
             in_flight_title_gens: Arc::new(Mutex::new(HashSet::new())),
             warmup_done: Arc::new(Mutex::new(HashSet::new())),
+            host_plan_server: Mutex::new(None),
         }
     }
 
@@ -915,7 +924,23 @@ impl AcpManager {
             persistence: Some(persistence),
             in_flight_title_gens: Arc::new(Mutex::new(HashSet::new())),
             warmup_done: Arc::new(Mutex::new(HashSet::new())),
+            host_plan_server: Mutex::new(None),
         }
+    }
+
+    /// Lazily start the host-injected plan MCP server (one shared TCP
+    /// listener). Clones `self.sinks` once on first call; subsequent calls
+    /// return the cached `Arc`. Bound to `127.0.0.1:<ephemeral>` on a
+    /// dedicated thread — works on desktop + standalone (no `AppHandle`).
+    #[must_use]
+    fn host_plan_server(&self) -> Arc<crate::acp::host_mcp::parent::HostPlanServer> {
+        let mut guard = self.host_plan_server.lock();
+        if let Some(srv) = guard.as_ref() {
+            return Arc::clone(srv);
+        }
+        let srv = crate::acp::host_mcp::parent::HostPlanServer::start(self.sinks.clone());
+        *guard = Some(Arc::clone(&srv));
+        srv
     }
 
     /// Spawn an ACP agent: launch the subprocess, complete `initialize`, and
@@ -1129,11 +1154,32 @@ impl AcpManager {
             .get(agent_id)
             .map(|entry| (entry.capabilities.clone(), entry.stable_namespace.clone()))
             .ok_or_else(|| format!("unknown agent: {agent_id}"))?;
-        gate_mcp_servers(&caps, &mcp_servers)?;
+
+        // Host-injected `termul_plan` MCP tool: prepend a self-spawned stdio
+        // child to every non-ephemeral session's mcp_servers so the agent
+        // discovers + calls it as a first-class tool (see `host_mcp::mod` +
+        // spec `spec-acp-host-todo-plan-tool.md`). The real ACP session_id
+        // isn't known until the response, so register with a provisional id
+        // now + bind after `session/new` returns.
+        let (combined_mcp_servers, plan_token): (Vec<McpServer>, Option<String>) =
+            if !context.ephemeral {
+                let server = self.host_plan_server();
+                let (port, token, provisional_sid) = server.register_session(&agent_id.0);
+                let internal =
+                    build_internal_plan_stdio(&agent_id.0, port, &token, &provisional_sid);
+                // Prepend so the internal server is first in the agent's tool list.
+                let mut combined = internal;
+                combined.extend(mcp_servers);
+                (combined, Some(token))
+            } else {
+                (mcp_servers, None)
+            };
+        gate_mcp_servers(&caps, &combined_mcp_servers)?;
+
         let tx = self.command_tx(agent_id)?;
-        send_command(&tx, |reply| AcpCommand::NewSession {
+        let outcome = send_command(&tx, |reply| AcpCommand::NewSession {
             cwd,
-            mcp_servers,
+            mcp_servers: combined_mcp_servers,
             stable_agent_namespace,
             runtime_agent_id: agent_id.0.clone(),
             project_id: context.project_id,
@@ -1142,7 +1188,15 @@ impl AcpManager {
             worktree_branch: context.worktree_branch,
             reply,
         })
-        .await
+        .await?;
+
+        // Bind the real session_id to the plan token so the parent can emit
+        // plan_update for the right session when the agent calls termul_plan.
+        if let Some(token) = plan_token {
+            self.host_plan_server()
+                .bind_session(&token, &outcome.session_id.0);
+        }
+        Ok(outcome)
     }
 
     /// Load an existing session. Gated on the agent's `loadSession` capability.
@@ -1925,6 +1979,34 @@ fn gate_mcp_servers(caps: &AgentCapabilities, servers: &[McpServer]) -> Result<(
         }
     }
     Ok(())
+}
+
+/// Build the internal `termul_plan` MCP server config (stdio self-spawn) to
+/// prepend into a session's `mcp_servers`. The agent spawns
+/// `current_exe() --internal-mcp-plan-server` as a child; the child reads
+/// `TERMUL_PLAN_PORT` / `_TOKEN` / `_SESSION_ID` / `_AGENT_ID` from env,
+/// runs an rmcp MCP server over stdio, and forwards `termul_plan` calls to
+/// the parent TCP listener. The internal server is `McpServer::Stdio`, which
+/// `gate_mcp_servers` accepts unconditionally (stdio is mandatory in ACP), so
+/// no gate relaxation is needed.
+fn build_internal_plan_stdio(
+    agent_id: &str,
+    port: u16,
+    token: &str,
+    provisional_sid: &str,
+) -> Vec<McpServer> {
+    let exe = std::env::current_exe()
+        .unwrap_or_else(|_| std::path::PathBuf::from("termul-manager"));
+    let env = vec![
+        EnvVariable::new(crate::acp::host_mcp::ENV_PORT, port.to_string()),
+        EnvVariable::new(crate::acp::host_mcp::ENV_TOKEN, token.to_string()),
+        EnvVariable::new(crate::acp::host_mcp::ENV_SESSION_ID, provisional_sid.to_string()),
+        EnvVariable::new(crate::acp::host_mcp::ENV_AGENT_ID, agent_id.to_string()),
+    ];
+    let stdio = McpServerStdio::new("termul-plan".to_string(), exe)
+        .args(vec![crate::acp::host_mcp::CHILD_ARG.to_string()])
+        .env(env);
+    vec![McpServer::Stdio(stdio)]
 }
 
 /// Map the agent's advertised `initialize` auth methods to the renderer-facing

--- a/src-tauri/src/acp/manager.rs
+++ b/src-tauri/src/acp/manager.rs
@@ -791,13 +791,15 @@ pub struct AcpManager {
     /// re-spawned agent re-warmups.
     warmup_done: Arc<Mutex<HashSet<AgentId>>>,
     /// Host-injected `termul_plan` MCP server (one shared TCP listener across
-    /// all sessions, started lazily on first `new_session_with_context`).
-    /// Injects a self-spawned stdio child into every non-ephemeral session's
-    /// `mcp_servers`; the child forwards `termul_plan` calls back here, and
-    /// `host_mcp::emit_plan_update` emits a synthetic `acp:plan_update` so the
-    /// existing renderer `PlanPanel` renders it. See `host_mcp::mod` + the spec
+    /// all sessions, started EAGERLY in the constructor so the first
+    /// `new_session_with_context` doesn't block a Tokio worker thread on the
+    /// bind + port-publish handshake). Injects a self-spawned stdio child
+    /// into every non-ephemeral session's `mcp_servers`; the child forwards
+    /// `termul_plan` calls back here, and `host_mcp::emit_plan_update` emits a
+    /// synthetic `acp:plan_update` so the existing renderer `PlanPanel`
+    /// renders it. See `host_mcp::mod` + the spec
     /// `spec-acp-host-todo-plan-tool.md`.
-    host_plan_server: Mutex<Option<Arc<crate::acp::host_mcp::parent::HostPlanServer>>>,
+    host_plan_server: Arc<crate::acp::host_mcp::parent::HostPlanServer>,
 }
 
 /// Extract the concatenated text from a `Vec<ContentBlock>` for the
@@ -902,13 +904,18 @@ impl AcpManager {
     /// exercise the command channel) — `fan_out` over zero sinks is a no-op.
     #[must_use]
     pub fn new(sinks: Vec<Arc<dyn EventSink>>) -> Self {
+        // Eagerly start the host-injected plan MCP server (one shared TCP
+        // listener) here — in the SYNC constructor — so the async
+        // `new_session_with_context` path never blocks a Tokio worker on the
+        // bind + port-publish handshake. Cheap: `sinks.clone()` is Arc-only.
+        let host_plan_server = crate::acp::host_mcp::parent::HostPlanServer::start(sinks.clone());
         Self {
             sinks,
             agents: Arc::new(Mutex::new(HashMap::new())),
             persistence: None,
             in_flight_title_gens: Arc::new(Mutex::new(HashSet::new())),
             warmup_done: Arc::new(Mutex::new(HashSet::new())),
-            host_plan_server: Mutex::new(None),
+            host_plan_server,
         }
     }
 
@@ -918,29 +925,15 @@ impl AcpManager {
         sinks: Vec<Arc<dyn EventSink>>,
         persistence: Arc<SessionPersistence>,
     ) -> Self {
+        let host_plan_server = crate::acp::host_mcp::parent::HostPlanServer::start(sinks.clone());
         Self {
             sinks,
             agents: Arc::new(Mutex::new(HashMap::new())),
             persistence: Some(persistence),
             in_flight_title_gens: Arc::new(Mutex::new(HashSet::new())),
             warmup_done: Arc::new(Mutex::new(HashSet::new())),
-            host_plan_server: Mutex::new(None),
+            host_plan_server,
         }
-    }
-
-    /// Lazily start the host-injected plan MCP server (one shared TCP
-    /// listener). Clones `self.sinks` once on first call; subsequent calls
-    /// return the cached `Arc`. Bound to `127.0.0.1:<ephemeral>` on a
-    /// dedicated thread — works on desktop + standalone (no `AppHandle`).
-    #[must_use]
-    fn host_plan_server(&self) -> Arc<crate::acp::host_mcp::parent::HostPlanServer> {
-        let mut guard = self.host_plan_server.lock();
-        if let Some(srv) = guard.as_ref() {
-            return Arc::clone(srv);
-        }
-        let srv = crate::acp::host_mcp::parent::HostPlanServer::start(self.sinks.clone());
-        *guard = Some(Arc::clone(&srv));
-        srv
     }
 
     /// Spawn an ACP agent: launch the subprocess, complete `initialize`, and
@@ -1160,11 +1153,12 @@ impl AcpManager {
         // discovers + calls it as a first-class tool (see `host_mcp::mod` +
         // spec `spec-acp-host-todo-plan-tool.md`). The real ACP session_id
         // isn't known until the response, so register with a provisional id
-        // now + bind after `session/new` returns.
+        // now + bind after `session/new` returns. If session creation fails,
+        // evict the token so it doesn't leak (CodeRabbit #6).
         let (combined_mcp_servers, plan_token): (Vec<McpServer>, Option<String>) =
             if !context.ephemeral {
-                let server = self.host_plan_server();
-                let (port, token, provisional_sid) = server.register_session(&agent_id.0);
+                let (port, token, provisional_sid) =
+                    self.host_plan_server.register_session(&agent_id.0);
                 let internal =
                     build_internal_plan_stdio(&agent_id.0, port, &token, &provisional_sid);
                 // Prepend so the internal server is first in the agent's tool list.
@@ -1174,29 +1168,44 @@ impl AcpManager {
             } else {
                 (mcp_servers, None)
             };
-        gate_mcp_servers(&caps, &combined_mcp_servers)?;
 
-        let tx = self.command_tx(agent_id)?;
-        let outcome = send_command(&tx, |reply| AcpCommand::NewSession {
-            cwd,
-            mcp_servers: combined_mcp_servers,
-            stable_agent_namespace,
-            runtime_agent_id: agent_id.0.clone(),
-            project_id: context.project_id,
-            ephemeral: context.ephemeral,
-            worktree_path: context.worktree_path,
-            worktree_branch: context.worktree_branch,
-            reply,
-        })
-        .await?;
-
-        // Bind the real session_id to the plan token so the parent can emit
-        // plan_update for the right session when the agent calls termul_plan.
-        if let Some(token) = plan_token {
-            self.host_plan_server()
-                .bind_session(&token, &outcome.session_id.0);
+        let outcome = async {
+            gate_mcp_servers(&caps, &combined_mcp_servers)?;
+            let tx = self.command_tx(agent_id)?;
+            send_command(&tx, |reply| AcpCommand::NewSession {
+                cwd,
+                mcp_servers: combined_mcp_servers,
+                stable_agent_namespace,
+                runtime_agent_id: agent_id.0.clone(),
+                project_id: context.project_id,
+                ephemeral: context.ephemeral,
+                worktree_path: context.worktree_path,
+                worktree_branch: context.worktree_branch,
+                reply,
+            })
+            .await
         }
-        Ok(outcome)
+        .await;
+
+        match outcome {
+            Ok(outcome) => {
+                // Bind the real session_id to the plan token so the parent can
+                // emit plan_update for the right session when the agent calls
+                // termul_plan.
+                if let Some(token) = plan_token {
+                    self.host_plan_server.bind_session(&token, &outcome.session_id.0);
+                }
+                Ok(outcome)
+            }
+            Err(e) => {
+                // Evict the registered token on failure so it doesn't leak +
+                // the provisional id can't be reused by a later session.
+                if let Some(token) = plan_token {
+                    self.host_plan_server.unregister_by_token(&token);
+                }
+                Err(e)
+            }
+        }
     }
 
     /// Load an existing session. Gated on the agent's `loadSession` capability.
@@ -1995,8 +2004,10 @@ fn build_internal_plan_stdio(
     token: &str,
     provisional_sid: &str,
 ) -> Vec<McpServer> {
-    let exe = std::env::current_exe()
-        .unwrap_or_else(|_| std::path::PathBuf::from("termul-manager"));
+    let exe = std::env::current_exe().unwrap_or_else(|e| {
+        log::warn!("[host-mcp] current_exe() failed ({e}); falling back to PATH lookup");
+        std::path::PathBuf::from("termul-manager")
+    });
     let env = vec![
         EnvVariable::new(crate::acp::host_mcp::ENV_PORT, port.to_string()),
         EnvVariable::new(crate::acp::host_mcp::ENV_TOKEN, token.to_string()),

--- a/src-tauri/src/acp/mod.rs
+++ b/src-tauri/src/acp/mod.rs
@@ -17,6 +17,7 @@ pub mod commands;
 pub mod config;
 pub mod events;
 pub mod history_import;
+pub mod host_mcp;
 pub mod install;
 pub mod manager;
 pub mod mcp_probe;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -134,6 +134,11 @@ pub use acp::{
     AcpCatalogService, AcpInstallService, AcpManager, ChatHistoryStore, FileProjectRegistry,
     SessionPersistence, WorkspaceManifestService,
 };
+// Host-injected `termul_plan` MCP tool: the `--internal-mcp-plan-server`
+// subcommand branch in `main.rs` + `server_main.rs` reaches `host_mcp::CHILD_ARG`
+// + `host_mcp::child::run()` through this re-export (the `acp` module itself is
+// private). See `acp/host_mcp/mod.rs` + spec `spec-acp-host-todo-plan-tool.md`.
+pub use acp::host_mcp;
 pub use pty::PtyManager;
 pub use trackers::{CwdTracker, ExitCodeTracker, GitTracker, TerminalEventHub};
 // Desktop ACP event sink: wraps the Tauri `AppHandle` so the dispatcher's

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -2,6 +2,18 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
 fn main() {
+    // Self-spawned `--internal-mcp-plan-server` child: the agent spawns this
+    // binary (current_exe) as the injected `McpServer::Stdio` for the
+    // host-injected `termul_plan` tool. Branch BEFORE any Tauri/log setup so
+    // the child never initializes the app / plugins / sinks — it just runs
+    // an rmcp MCP server over stdio + forwards calls to the parent's TCP
+    // listener. See `acp::host_mcp::child` + spec `spec-acp-host-todo-plan-tool.md`.
+    if std::env::args().nth(1).as_deref()
+        == Some(termul_manager_lib::host_mcp::CHILD_ARG)
+    {
+        std::process::exit(termul_manager_lib::host_mcp::child::run());
+    }
+
     // Seed a default RUST_LOG so module-level overrides keep working, e.g.:
     //   RUST_LOG=trace npm run dev
     //   RUST_LOG=termul_manager_lib=debug npm run dev

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -8,9 +8,7 @@ fn main() {
     // the child never initializes the app / plugins / sinks — it just runs
     // an rmcp MCP server over stdio + forwards calls to the parent's TCP
     // listener. See `acp::host_mcp::child` + spec `spec-acp-host-todo-plan-tool.md`.
-    if std::env::args().nth(1).as_deref()
-        == Some(termul_manager_lib::host_mcp::CHILD_ARG)
-    {
+    if termul_manager_lib::host_mcp::is_child_invocation() {
         std::process::exit(termul_manager_lib::host_mcp::child::run());
     }
 

--- a/src-tauri/src/server_main.rs
+++ b/src-tauri/src/server_main.rs
@@ -52,10 +52,7 @@ fn main() -> ExitCode {
     // tokio/app setup (AC2) so the standalone binary never inits the server
     // stack for the child path. See `acp::host_mcp::child` + spec
     // `spec-acp-host-todo-plan-tool.md`.
-    if raw_args
-        .iter()
-        .any(|arg| arg == termul_manager_lib::host_mcp::CHILD_ARG)
-    {
+    if termul_manager_lib::host_mcp::is_child_invocation() {
         return ExitCode::from(termul_manager_lib::host_mcp::child::run() as u8);
     }
 

--- a/src-tauri/src/server_main.rs
+++ b/src-tauri/src/server_main.rs
@@ -45,6 +45,20 @@ fn main() -> ExitCode {
         return run_one_shot_update_check();
     }
 
+    // `--internal-mcp-plan-server`: self-spawned child of the host-injected
+    // `termul_plan` MCP tool. The agent spawns `current_exe()` with this flag
+    // (the injected `McpServer::Stdio`); the child runs an rmcp MCP server over
+    // stdio + forwards calls to the parent's TCP listener. Branch BEFORE any
+    // tokio/app setup (AC2) so the standalone binary never inits the server
+    // stack for the child path. See `acp::host_mcp::child` + spec
+    // `spec-acp-host-todo-plan-tool.md`.
+    if raw_args
+        .iter()
+        .any(|arg| arg == termul_manager_lib::host_mcp::CHILD_ARG)
+    {
+        return ExitCode::from(termul_manager_lib::host_mcp::child::run() as u8);
+    }
+
     // Parse CLI BEFORE any tokio / app setup (AC2).
     let cfg = match ServerConfig::from_args(raw_args) {
         Ok(cfg) => cfg,


### PR DESCRIPTION
## Summary

Termul now **auto-injects a host-side `termul_plan` MCP tool** into every ACP `session/new` so all agents can call it as a **first-class citizen** instead of their own todo tools (Claude `TodoWrite`, Codex `update_todo`, …). When the agent calls it, the host emits a synthetic `acp:plan_update` event that the existing **`PlanPanel` renders unchanged** — no translation of agents' own tools, no renderer changes, no interactive editing.

Each ACP agent ships its own todo tool that renders as a generic tool card in the chat timeline, not in the unified `PlanPanel`. The native `acp:plan_update` event + `PlanPanel` already exist but few agents emit them, so the plan UI is inconsistent across agents. Providing a host-injected tool gives every agent a first-class option it can adopt.

## Related Issue

Closes #

No related issue — direct feature request. No prior PRs attempt this; the existing `PlanPanel` (`src/renderer/components/chat/PlanPanel.tsx`) and `acp:plan_update` event were the foundation.

## Type of Change

- [x] feat: new feature
- [ ] fix: bug fix
- [ ] docs: documentation only
- [ ] style: formatting or non-functional styling changes
- [ ] refactor: internal cleanup with no behavior change
- [ ] perf: performance improvement
- [ ] test: adds or updates tests
- [ ] build: build or dependency changes
- [ ] ci: CI/CD workflow changes
- [ ] chore: maintenance or tooling
- [ ] revert: reverts a previous change

## What Changed

Stdio self-spawn (the only MCP transport every ACP agent supports; HTTP/SSE is agent-capability-gated):

- **`src-tauri/src/acp/host_mcp/parent.rs`** (new) — in-process TCP listener (`127.0.0.1:<ephemeral>`, dedicated thread, shared across sessions). Per-call frame auth via random token + provisional `session_id`; binds the real ACP `session_id` after `session/new` returns (the agent generates it during the round trip, so the host can't know it at injection time).
- **`src-tauri/src/acp/host_mcp/child.rs`** (new) — `--internal-mcp-plan-server` subcommand entrypoint (both binaries branch on it **before** Tauri/app init). Runs an rmcp MCP **server** over stdio via `#[tool_router(server_handler)]` exposing `termul_plan`; forwards each call to the parent over a fresh TCP connection. Minimal runtime: no Tauri/plugins/`AppHandle`/sinks.
- **`src-tauri/src/acp/host_mcp/mod.rs`** (new) — tool schema (`{todos:[{content,status?,priority?}]}`), `map_todos_to_plan_entries`, `emit_plan_update` → `events::fan_out(EVENT_PLAN_UPDATE)`, `PlanStore`.
- **`src-tauri/src/acp/manager.rs`** — `new_session_with_context` prepends the internal `McpServer::Stdio` (self-spawn of `current_exe()`) for non-ephemeral sessions; `bind_session(token, real_session_id)` post-response. Lazy `host_plan_server()` accessor + `build_internal_plan_stdio` helper. (No `gate_mcp_servers` change needed — stdio is already accepted unconditionally.)
- **`src-tauri/src/lib.rs`** — re-exports `host_mcp` so both binaries reach it.
- **`src-tauri/src/main.rs`** + **`src-tauri/src/server_main.rs`** — dispatch the `--internal-mcp-plan-server` subcommand before normal startup; never init Tauri/AppHandle/sinks on the child path.
- **`src-tauri/Cargo.toml`** — added `server` + `transport-io` + `macros` rmcp features (the `schemars::JsonSchema` derive for the `#[tool]` macro uses rmcp's re-export — no direct `schemars` dep). Rewrote the stale comment about the (removed) vendored ACP.

**Desktop + standalone parity:** pure `rmcp` + tokio, no `tauri-plugin-mcp-bridge` / `AppHandle` — works on both `termul-manager` and `termul-server`.

**Tool schema** (what the agent sees in `tools/list`): `name=termul_plan`, `description="Update the execution plan / todo list shown in the Termul plan panel. Call this instead of a built-in todo tool so the user sees a unified plan UI across all agents."`, `inputSchema={todos:[{content:string, status?:'pending'|'in_progress'|'completed', priority?:'high'|'medium'|'low'}]}`. Each update is a full replace (matches ACP `plan_update` semantics); empty `todos` clears the plan (`dropPlanForSession`).

## How It Was Tested

- [ ] `bun run ci` (Biome lint + format + imports, strict mode)
- [ ] `bun run typecheck`
- [ ] `bun run test`
- [x] `cargo clippy --all-targets -- -D warnings` (in src-tauri)
- [ ] `cargo test` (in src-tauri)
- [ ] Manual verification completed
- [ ] Not applicable

**15 unit + integration tests** across `host_mcp` (cover all 5 spec I/O matrix rows):
- `mod.rs` (4): `map_todos` mapping + defaults, `emit_plan_update` fires `EVENT_PLAN_UPDATE` with entries + empty-entries clears, `frame_reply` serialization.
- `parent.rs` (5): register returns port/token/provisional, unbound-call rejected before bind, token/provisional mismatch rejected, bound session emits `plan_update`, bad token rejected.
- `child.rs` (6): `parse_env` rejects missing/non-numeric/blank, accepts valid, optional `AGENT_ID`.

**Local verification (this Windows worktree):**
- `cargo check --lib` — PASSED (rmcp `#[tool_router(server_handler)]` macro, `schemars::JsonSchema` derive via `rmcp::schemars` re-export, `serve_server`, `running.waiting()` all compile).
- `cargo clippy --lib --bins --features standalone-server -- -D warnings` — PASSED (lib + desktop `termul-manager` + standalone `termul-server`).
- `cargo test` — **could not run locally** (test binary fails to LOAD with `STATUS_ENTRYPOINT_NOT_FOUND` on this Windows machine — a PRE-EXISTING environment issue; the original binary without my changes also fails to load). CI runs `cargo test` on Linux where the binary loads.
- Renderer `bun` checks — not run locally (worktree has no `node_modules`); CI runs them. No renderer files were changed.

## Screenshots or Recordings

Not applicable — no UI changes. The existing `PlanPanel` renders the host-injected plan unchanged.

## CI & Review Gate

- [ ] All CI checks pass (PR Validation, Rust Checks, Build Verification, Security Scans)
- [ ] Code review comments from CodeRabbit / Claude have been addressed or resolved
- [ ] No unresolved review findings remain

## Checklist

- [x] My PR title follows the conventional commit format used by this repo
- [x] I linked the related issue or explained why none exists
- [x] I updated docs when needed
- [x] I added or updated tests when needed
- [x] I verified the change does not introduce unrelated modifications
- [x] I read AGENTS.md and followed the contributor guidelines
- [x] A human reviewed the complete diff before submission

Spec: `_bmad-output/implementation-artifacts/spec-acp-host-todo-plan-tool.md`
