### PR TITLE
feat(composer,web): inline command pill + web worktree parity

### DIFF
--- a/src-tauri/src/web/mod.rs
+++ b/src-tauri/src/web/mod.rs
@@ -32,6 +32,7 @@ pub mod router;
 pub mod sink;
 pub mod terminal_ws;
 pub mod workspace_api;
+pub mod worktree_api;
 pub mod ws;
 
 pub use config::ServerConfig;

--- a/src-tauri/src/web/router.rs
+++ b/src-tauri/src/web/router.rs
@@ -33,6 +33,7 @@ use crate::web::projects_api;
 use crate::web::sink::WsRelaySink;
 use crate::web::terminal_ws::terminal_ws_upgrade;
 use crate::web::workspace_api;
+use crate::web::worktree_api;
 use crate::web::ws::{ws_upgrade, AppState, HistoryMode};
 
 use super::assets;
@@ -165,7 +166,22 @@ pub fn router(
         // see `web/install_api.rs`. Registered AHEAD of the static fallback so
         // the SPA mount cannot shadow it. The request is `{ agentId }` only;
         // the host resolves everything from the trusted catalog.
-        .route("/acp/install", post(install_api::install));
+        .route("/acp/install", post(install_api::install))
+        // Worktree web routes (CAP — Web worktree parity). Each mirrors a
+        // desktop `#[tauri::command] worktree_*` handler; see
+        // `web/worktree_api.rs`. Registered AHEAD of the static fallback so the
+        // SPA mount cannot shadow them. Write routes (`create`/`remove`/
+        // `copy-include-files`) are loopback-guarded inside the handler; read
+        // routes (`list`/`branches`/`check-dirty`/`resolve-base-branch`)
+        // enforce containment only. Only the 7 launch-flow routes ship here;
+        // the 8 advanced ops are deferred (see deferred-work.md).
+        .route("/worktree/list", post(worktree_api::list))
+        .route("/worktree/create", post(worktree_api::create))
+        .route("/worktree/remove", post(worktree_api::remove))
+        .route("/worktree/branches", get(worktree_api::branches))
+        .route("/worktree/check-dirty", get(worktree_api::check_dirty))
+        .route("/worktree/resolve-base-branch", post(worktree_api::resolve_base_branch))
+        .route("/worktree/copy-include-files", post(worktree_api::copy_include_files));
     // Static fallback: disk ServeDir in dev (dist-web/ on disk) or the embedded
     // bundle in release. `/health` + `/ws` are registered above so the static
     // mount cannot shadow them (Story 1.3 AC1).
@@ -274,6 +290,13 @@ pub fn router_with_static(
         .route("/acp/catalog", get(catalog_api::list))
         .route("/acp/catalog/opt-in", post(catalog_api::set_opt_in))
         .route("/acp/install", post(install_api::install))
+        .route("/worktree/list", post(worktree_api::list))
+        .route("/worktree/create", post(worktree_api::create))
+        .route("/worktree/remove", post(worktree_api::remove))
+        .route("/worktree/branches", get(worktree_api::branches))
+        .route("/worktree/check-dirty", get(worktree_api::check_dirty))
+        .route("/worktree/resolve-base-branch", post(worktree_api::resolve_base_branch))
+        .route("/worktree/copy-include-files", post(worktree_api::copy_include_files))
         .fallback_service(assets::static_service_from(static_dir))
         // CAP-1: same RwLock wrap + handle registration as `router`.
         .with_state({

--- a/src-tauri/src/web/worktree_api.rs
+++ b/src-tauri/src/web/worktree_api.rs
@@ -1,0 +1,1185 @@
+//! HTTP handlers for worktree operations exposed to the web/remote client
+//! (CAP — Web worktree parity).
+//!
+//! Mirrors the desktop `#[tauri::command] worktree_*` handlers in
+//! `commands.rs` over HTTP, reusing the SAME `WorktreeManager` impl the Tauri
+//! commands call (`WorktreeManager::list` / `create` / `remove` / `branches` /
+//! `check_dirty` / `resolve_default_base_branch` / `copy_worktree_include_files`).
+//! Each route:
+//!
+//! - enforces `resolve_request_path` (inherited from `fs_api`) for `..`
+//!   rejection + canonicalization, then a project-root containment check
+//!   (`ensure_within_project_boundary`) — the web server is a security boundary
+//!   the desktop commands do not need.
+//! - enforces `check_local_only` (loopback guard) on WRITE routes (`create` /
+//!   `remove` / `copy-include-files`), matching the git_api mutation pattern.
+//!   Read routes (`list` / `branches` / `check-dirty` / `resolve-base-branch`)
+//!   enforce containment only.
+//! - wraps results in `IpcBody<T>` (`{ success, data } | { success, error, code }`)
+//!   so the renderer facade swaps transparently with the desktop `IpcResult<T>`.
+//! - runs blocking `WorktreeManager` calls on `tokio::task::spawn_blocking`
+//!   (template: `git_api.rs`).
+//! - logs at route boundaries via `tracing` (the standalone server's logger;
+//!   a no-op when no subscriber is installed on the desktop shared-live path).
+//!
+//! The 7 launch-flow routes ship here. The 8 advanced ops (symlinks,
+//! `parseGitignore`, `mergePreview/Execute`, `archive`/`restore`,
+//! `removeAllManaged`) are deferred — see `deferred-work.md`.
+
+use std::net::SocketAddr;
+use std::path::Path;
+
+use axum::{
+    extract::{ConnectInfo, Query, State},
+    http::StatusCode,
+    response::IntoResponse,
+    Json,
+};
+use serde::Deserialize;
+use tracing::{error, info, warn};
+
+use crate::web::fs_api::{check_local_only, resolve_request_path, IpcBody};
+use crate::web::git_api::ensure_within_project_boundary;
+use crate::web::ws::AppState;
+use crate::worktree::{
+    BaseBranchInfo, BranchEntry, DirtyStatus, GitWorktreeEntry, IncludeCopyResult,
+    WorktreeError, WorktreeManager,
+};
+
+/// `POST /worktree/list { projectPath }` body.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WorktreeProjectPathRequest {
+    pub project_path: String,
+}
+
+/// `POST /worktree/create { projectPath, name, branch, isNewBranch, startRef?, targetPath? }` body.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WorktreeCreateRequest {
+    pub project_path: String,
+    pub name: String,
+    pub branch: String,
+    pub is_new_branch: bool,
+    pub start_ref: Option<String>,
+    pub target_path: Option<String>,
+}
+
+/// `POST /worktree/remove { projectPath, worktreePath, force }` body.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WorktreeRemoveRequest {
+    pub project_path: String,
+    pub worktree_path: String,
+    pub force: bool,
+}
+
+/// `GET /worktree/branches?projectPath=...` query.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WorktreeProjectPathQuery {
+    pub project_path: String,
+}
+
+/// `GET /worktree/check-dirty?worktreePath=...` query.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WorktreePathQuery {
+    pub worktree_path: String,
+}
+
+/// `POST /worktree/copy-include-files { projectPath, worktreePath }` body.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WorktreeCopyIncludeRequest {
+    pub project_path: String,
+    pub worktree_path: String,
+}
+
+/// `(StatusCode, Json<IpcBody<T>>)` — the uniform route-error return type.
+type RouteErr<T> = (StatusCode, Json<IpcBody<T>>);
+
+/// Resolve + boundary-check a request path. On failure returns the
+/// `(StatusCode, Json<IpcBody::err>)` to send directly; on success returns the
+/// resolved `PathBuf`. `peer` is the request peer for the loopback write guard
+/// (`Some` on write routes, `None` on read routes). Mirrors
+/// `git_api::resolve_cwd` — kept self-contained so the worktree module does not
+/// depend on git_api's private helpers.
+fn resolve_project_path<T>(
+    req_path: &str,
+    state: &AppState,
+    peer: Option<SocketAddr>,
+    is_write: bool,
+) -> Result<std::path::PathBuf, RouteErr<T>> {
+    // 1) Loopback guard for write routes FIRST — fail fast on non-local peers
+    //    before any filesystem work. `resolve_request_path` canonicalizes
+    //    (follows symlinks / reads FS metadata); a LAN peer must not trigger
+    //    that on a write (mutation safety on a 0.0.0.0 bind).
+    if is_write {
+        if let Some(peer) = peer {
+            if let Some(forbidden) = check_local_only::<T>(peer) {
+                return Err((StatusCode::OK, Json(forbidden)));
+            }
+        }
+    }
+    // 2) `..` rejection + canonicalization.
+    let resolved = match resolve_request_path(Path::new(req_path)) {
+        Ok(safe) => safe,
+        Err((msg, code)) => {
+            return Err((StatusCode::OK, Json(IpcBody::<T>::err(msg, code))));
+        }
+    };
+    // 3) project_root containment (web-server security boundary). Lock-read the
+    //    RwLock for the duration of the `starts_with` check (sync — no `.await`
+    //    under the guard). The boundary may have been rebound by a project
+    //    switch since the last request.
+    let outside_err = {
+        let project_root = state.project_root.read();
+        ensure_within_project_boundary::<T>(&resolved, &project_root, &state.registry)
+    };
+    if let Some(err) = outside_err {
+        return Err((StatusCode::OK, Json(err)));
+    }
+    Ok(resolved)
+}
+
+/// Convert a resolved `PathBuf` to a tool-friendly `String`. Mirrors the desktop
+/// `validate_project_path` behavior of stripping the Windows verbatim (`\\?\`)
+/// prefix so `git.exe` receives a path it understands. Returns an `IpcBody::err`
+/// (`INVALID_PATH_ENCODING`) when the path resolves to empty.
+fn path_string<T>(resolved: &std::path::Path) -> Result<String, RouteErr<T>> {
+    let lossy = resolved.to_string_lossy();
+    let simplified = crate::path_validation::strip_verbatim_prefix(&lossy).into_owned();
+    if simplified.is_empty() {
+        return Err((
+            StatusCode::OK,
+            Json(IpcBody::<T>::err(
+                "path resolved to empty string",
+                "INVALID_PATH_ENCODING",
+            )),
+        ));
+    }
+    Ok(simplified)
+}
+
+/// Map a `WorktreeError` to an `IpcBody::err` (mirrors the desktop Tauri command
+/// error mapping: `e.to_string()` for the message, `e.error_code()` for the code).
+fn worktree_err<T>(e: WorktreeError) -> IpcBody<T> {
+    IpcBody::<T>::err(e.to_string(), e.error_code())
+}
+
+// ============================ Route handlers ============================
+
+/// `POST /worktree/list` — list all worktrees for a git repo (read-only).
+/// Mirrors `worktree_list` → `WorktreeManager::list`.
+pub async fn list(
+    State(state): State<AppState>,
+    Json(req): Json<WorktreeProjectPathRequest>,
+) -> impl IntoResponse {
+    let resolved = match resolve_project_path::<Vec<GitWorktreeEntry>>(&req.project_path, &state, None, false) {
+        Ok(p) => p,
+        Err(resp) => return resp,
+    };
+    let project_path = match path_string::<Vec<GitWorktreeEntry>>(&resolved) {
+        Ok(s) => s,
+        Err(resp) => return resp,
+    };
+    let path_for_log = project_path.clone();
+    // Normalize the project root for the info-leak filter: strip the Windows
+    // verbatim (`\\?\`) prefix so `starts_with` matches git's output (which
+    // carries no verbatim prefix). Both sides must share the same non-verbatim
+    // representation or a logically-matching path would be rejected on Windows.
+    let project_root_for_filter =
+        crate::path_validation::strip_verbatim_prefix(&resolved.to_string_lossy()).into_owned();
+    let result = tokio::task::spawn_blocking(move || WorktreeManager::list(&project_path))
+        .await
+        .map_err(|e| format!("worktree list task failed: {e}"));
+    let body = match result {
+        Ok(Ok(entries)) => {
+            // Info-leak guard: filter out any worktree whose path is outside the
+            // resolved project root. A worktree checked out to an arbitrary
+            // outside path would otherwise disclose that path to the web client.
+            // The `WorktreeManager::list` call runs git on the project root;
+            // the returned entries should all be within the boundary, but a
+            // pre-existing worktree created outside (e.g. via the desktop
+            // client's custom targetPath) would slip through. Filter defensively.
+            let filtered: Vec<GitWorktreeEntry> = entries
+                .into_iter()
+                .filter(|e| {
+                    let entry = crate::path_validation::strip_verbatim_prefix(&e.path);
+                    std::path::Path::new(entry.as_ref()).starts_with(&project_root_for_filter)
+                })
+                .collect();
+            let kept = filtered.len();
+            info!(path = %path_for_log, count = kept, "worktree list ok");
+            IpcBody::ok(filtered)
+        }
+        Ok(Err(e)) => {
+            warn!(path = %path_for_log, error = %e, "worktree list failed");
+            worktree_err::<Vec<GitWorktreeEntry>>(e)
+        }
+        Err(e) => {
+            error!(path = %path_for_log, error = %e, "worktree list task panicked");
+            IpcBody::<Vec<GitWorktreeEntry>>::err(
+                format!("worktree list task failed: {e}"),
+                "WORKTREE_LIST_ERROR",
+            )
+        }
+    };
+    (StatusCode::OK, Json(body))
+}
+
+/// `POST /worktree/create` — create a new worktree (write, loopback-guarded).
+/// Mirrors `worktree_create` → `WorktreeManager::create`.
+pub async fn create(
+    State(state): State<AppState>,
+    ConnectInfo(peer): ConnectInfo<SocketAddr>,
+    Json(req): Json<WorktreeCreateRequest>,
+) -> impl IntoResponse {
+    let resolved = match resolve_project_path::<GitWorktreeEntry>(&req.project_path, &state, Some(peer), true) {
+        Ok(p) => p,
+        Err(resp) => return resp,
+    };
+    let project_path = match path_string::<GitWorktreeEntry>(&resolved) {
+        Ok(s) => s,
+        Err(resp) => return resp,
+    };
+    // If a custom target_path was provided, boundary-check it too (the default
+    // is `<project>/.termul/worktrees/<name>/` which is inside the boundary).
+    let target_path = match req.target_path.as_deref() {
+        Some(tp) => match resolve_project_path::<GitWorktreeEntry>(tp, &state, Some(peer), true) {
+            Ok(p) => match path_string::<GitWorktreeEntry>(&p) {
+                Ok(s) => Some(s),
+                Err(resp) => return resp,
+            },
+            Err(resp) => return resp,
+        },
+        None => None,
+    };
+    let path_for_log = project_path.clone();
+    let name = req.name;
+    let branch = req.branch;
+    let is_new_branch = req.is_new_branch;
+    let start_ref = req.start_ref;
+    let result = tokio::task::spawn_blocking(move || {
+        WorktreeManager::create(
+            &project_path,
+            &name,
+            &branch,
+            is_new_branch,
+            start_ref.as_deref(),
+            target_path.as_deref(),
+        )
+    })
+    .await
+    .map_err(|e| format!("worktree create task failed: {e}"));
+    let body = match result {
+        Ok(Ok(entry)) => {
+            info!(path = %path_for_log, branch = %entry.branch, "worktree create ok");
+            IpcBody::ok(entry)
+        }
+        Ok(Err(e)) => {
+            warn!(path = %path_for_log, error = %e, "worktree create failed");
+            worktree_err::<GitWorktreeEntry>(e)
+        }
+        Err(e) => {
+            error!(path = %path_for_log, error = %e, "worktree create task panicked");
+            IpcBody::<GitWorktreeEntry>::err(
+                format!("worktree create task failed: {e}"),
+                "WORKTREE_CREATE_ERROR",
+            )
+        }
+    };
+    (StatusCode::OK, Json(body))
+}
+
+/// `POST /worktree/remove` — remove a worktree (write, loopback-guarded).
+/// Mirrors `worktree_remove` → `WorktreeManager::remove`.
+pub async fn remove(
+    State(state): State<AppState>,
+    ConnectInfo(peer): ConnectInfo<SocketAddr>,
+    Json(req): Json<WorktreeRemoveRequest>,
+) -> impl IntoResponse {
+    let project_resolved = match resolve_project_path::<()>(&req.project_path, &state, Some(peer), true) {
+        Ok(p) => p,
+        Err(resp) => return resp,
+    };
+    let project_path = match path_string::<()>(&project_resolved) {
+        Ok(s) => s,
+        Err(resp) => return resp,
+    };
+    let worktree_resolved = match resolve_project_path::<()>(&req.worktree_path, &state, Some(peer), true) {
+        Ok(p) => p,
+        Err(resp) => return resp,
+    };
+    let worktree_path = match path_string::<()>(&worktree_resolved) {
+        Ok(s) => s,
+        Err(resp) => return resp,
+    };
+    let path_for_log = worktree_path.clone();
+    let force = req.force;
+    let result = tokio::task::spawn_blocking(move || {
+        WorktreeManager::remove(&project_path, &worktree_path, force)
+    })
+    .await
+    .map_err(|e| format!("worktree remove task failed: {e}"));
+    let body = match result {
+        Ok(Ok(())) => {
+            info!(path = %path_for_log, force, "worktree remove ok");
+            IpcBody::<()>::ok(())
+        }
+        Ok(Err(e)) => {
+            warn!(path = %path_for_log, error = %e, "worktree remove failed");
+            worktree_err::<()>(e)
+        }
+        Err(e) => {
+            error!(path = %path_for_log, error = %e, "worktree remove task panicked");
+            IpcBody::<()>::err(
+                format!("worktree remove task failed: {e}"),
+                "WORKTREE_REMOVE_ERROR",
+            )
+        }
+    };
+    (StatusCode::OK, Json(body))
+}
+
+/// `GET /worktree/branches?projectPath=...` — list local + remote branches (read-only).
+/// Mirrors `worktree_branches` → `WorktreeManager::branches`.
+pub async fn branches(
+    State(state): State<AppState>,
+    Query(q): Query<WorktreeProjectPathQuery>,
+) -> impl IntoResponse {
+    let resolved = match resolve_project_path::<Vec<BranchEntry>>(&q.project_path, &state, None, false) {
+        Ok(p) => p,
+        Err(resp) => return resp,
+    };
+    let project_path = match path_string::<Vec<BranchEntry>>(&resolved) {
+        Ok(s) => s,
+        Err(resp) => return resp,
+    };
+    let path_for_log = project_path.clone();
+    let result = tokio::task::spawn_blocking(move || WorktreeManager::branches(&project_path))
+        .await
+        .map_err(|e| format!("worktree branches task failed: {e}"));
+    let body = match result {
+        Ok(Ok(entries)) => {
+            info!(path = %path_for_log, count = entries.len(), "worktree branches ok");
+            IpcBody::ok(entries)
+        }
+        Ok(Err(e)) => {
+            warn!(path = %path_for_log, error = %e, "worktree branches failed");
+            worktree_err::<Vec<BranchEntry>>(e)
+        }
+        Err(e) => {
+            error!(path = %path_for_log, error = %e, "worktree branches task panicked");
+            IpcBody::<Vec<BranchEntry>>::err(
+                format!("worktree branches task failed: {e}"),
+                "WORKTREE_BRANCHES_ERROR",
+            )
+        }
+    };
+    (StatusCode::OK, Json(body))
+}
+
+/// `GET /worktree/check-dirty?worktreePath=...` — dirty status for a worktree (read-only).
+/// Mirrors `worktree_check_dirty` → `WorktreeManager::check_dirty`.
+pub async fn check_dirty(
+    State(state): State<AppState>,
+    Query(q): Query<WorktreePathQuery>,
+) -> impl IntoResponse {
+    let resolved = match resolve_project_path::<DirtyStatus>(&q.worktree_path, &state, None, false) {
+        Ok(p) => p,
+        Err(resp) => return resp,
+    };
+    let worktree_path = match path_string::<DirtyStatus>(&resolved) {
+        Ok(s) => s,
+        Err(resp) => return resp,
+    };
+    let path_for_log = worktree_path.clone();
+    let result = tokio::task::spawn_blocking(move || WorktreeManager::check_dirty(&worktree_path))
+        .await
+        .map_err(|e| format!("worktree check-dirty task failed: {e}"));
+    let body = match result {
+        Ok(Ok(status)) => {
+            info!(path = %path_for_log, has_changes = status.has_changes, "worktree check-dirty ok");
+            IpcBody::ok(status)
+        }
+        Ok(Err(e)) => {
+            warn!(path = %path_for_log, error = %e, "worktree check-dirty failed");
+            worktree_err::<DirtyStatus>(e)
+        }
+        Err(e) => {
+            error!(path = %path_for_log, error = %e, "worktree check-dirty task panicked");
+            IpcBody::<DirtyStatus>::err(
+                format!("worktree check-dirty task failed: {e}"),
+                "WORKTREE_CHECK_DIRTY_ERROR",
+            )
+        }
+    };
+    (StatusCode::OK, Json(body))
+}
+
+/// `POST /worktree/resolve-base-branch` — resolve the default base branch (read-only).
+/// Mirrors `worktree_resolve_base_branch` → `WorktreeManager::resolve_default_base_branch`.
+pub async fn resolve_base_branch(
+    State(state): State<AppState>,
+    Json(req): Json<WorktreeProjectPathRequest>,
+) -> impl IntoResponse {
+    let resolved = match resolve_project_path::<BaseBranchInfo>(&req.project_path, &state, None, false) {
+        Ok(p) => p,
+        Err(resp) => return resp,
+    };
+    let project_path = match path_string::<BaseBranchInfo>(&resolved) {
+        Ok(s) => s,
+        Err(resp) => return resp,
+    };
+    let path_for_log = project_path.clone();
+    let result =
+        tokio::task::spawn_blocking(move || WorktreeManager::resolve_default_base_branch(&project_path))
+            .await
+            .map_err(|e| format!("worktree resolve-base-branch task failed: {e}"));
+    let body = match result {
+        Ok(Ok(info)) => {
+            info!(
+                path = %path_for_log,
+                default_base = %info.default_base,
+                is_detached = info.is_detached,
+                "worktree resolve-base-branch ok"
+            );
+            IpcBody::ok(info)
+        }
+        Ok(Err(e)) => {
+            warn!(path = %path_for_log, error = %e, "worktree resolve-base-branch failed");
+            worktree_err::<BaseBranchInfo>(e)
+        }
+        Err(e) => {
+            error!(path = %path_for_log, error = %e, "worktree resolve-base-branch task panicked");
+            IpcBody::<BaseBranchInfo>::err(
+                format!("worktree resolve-base-branch task failed: {e}"),
+                "WORKTREE_RESOLVE_BASE_BRANCH_ERROR",
+            )
+        }
+    };
+    (StatusCode::OK, Json(body))
+}
+
+/// `POST /worktree/copy-include-files` — carry over `.worktree-include` files (write, loopback-guarded).
+/// Mirrors `worktree_copy_include_files` → `WorktreeManager::copy_worktree_include_files`.
+pub async fn copy_include_files(
+    State(state): State<AppState>,
+    ConnectInfo(peer): ConnectInfo<SocketAddr>,
+    Json(req): Json<WorktreeCopyIncludeRequest>,
+) -> impl IntoResponse {
+    let project_resolved = match resolve_project_path::<IncludeCopyResult>(&req.project_path, &state, Some(peer), true) {
+        Ok(p) => p,
+        Err(resp) => return resp,
+    };
+    let project_path = match path_string::<IncludeCopyResult>(&project_resolved) {
+        Ok(s) => s,
+        Err(resp) => return resp,
+    };
+    let worktree_resolved = match resolve_project_path::<IncludeCopyResult>(&req.worktree_path, &state, Some(peer), true) {
+        Ok(p) => p,
+        Err(resp) => return resp,
+    };
+    let worktree_path = match path_string::<IncludeCopyResult>(&worktree_resolved) {
+        Ok(s) => s,
+        Err(resp) => return resp,
+    };
+    let path_for_log = worktree_path.clone();
+    let result = tokio::task::spawn_blocking(move || {
+        WorktreeManager::copy_worktree_include_files(&project_path, &worktree_path)
+    })
+    .await
+    .map_err(|e| format!("worktree copy-include-files task failed: {e}"));
+    let body = match result {
+        Ok(Ok(outcome)) => {
+            info!(
+                path = %path_for_log,
+                ran = outcome.ran,
+                copied = outcome.copied,
+                skipped = outcome.skipped.len(),
+                "worktree copy-include-files ok"
+            );
+            IpcBody::ok(outcome)
+        }
+        Ok(Err(e)) => {
+            warn!(path = %path_for_log, error = %e, "worktree copy-include-files failed");
+            worktree_err::<IncludeCopyResult>(e)
+        }
+        Err(e) => {
+            error!(path = %path_for_log, error = %e, "worktree copy-include-files task panicked");
+            IpcBody::<IncludeCopyResult>::err(
+                format!("worktree copy-include-files task failed: {e}"),
+                "WORKTREE_COPY_INCLUDE_FILES_ERROR",
+            )
+        }
+    };
+    (StatusCode::OK, Json(body))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::acp::AcpManager;
+    use crate::trackers::git_tracker::GitTracker;
+    use crate::web::project_registry::ProjectRegistry;
+    use crate::web::sink::WsRelaySink;
+    use crate::web::test_pty_manager;
+    use crate::web::ws::HistoryMode;
+    use axum::body::Body;
+    use axum::http::Request;
+    use axum::routing::{get, post};
+    use std::sync::Arc;
+    use std::time::{SystemTime, UNIX_EPOCH};
+    use tower::ServiceExt;
+
+    /// Temp dir removed on drop (panic-safe).
+    struct TempDir {
+        path: std::path::PathBuf,
+    }
+    impl TempDir {
+        fn new(label: &str) -> Self {
+            let nanos = SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .expect("clock")
+                .as_nanos();
+            let path = std::env::temp_dir().join(format!("termul-web-wt-{label}-{nanos}"));
+            std::fs::create_dir_all(&path).expect("create temp dir");
+            Self { path }
+        }
+        fn path(&self) -> &std::path::Path {
+            &self.path
+        }
+    }
+    impl Drop for TempDir {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_dir_all(&self.path);
+        }
+    }
+
+    fn test_state(root: &std::path::Path) -> AppState {
+        let pty = test_pty_manager();
+        AppState {
+            acp: Arc::new(AcpManager::new(vec![])),
+            terminal_events: pty.terminal_events(),
+            cwd_tracker: pty.cwd_tracker(),
+            git_tracker: pty.git_tracker(),
+            exit_code_tracker: pty.exit_code_tracker(),
+            pty,
+            relay: Arc::new(WsRelaySink::new()),
+            registry: Arc::new(ProjectRegistry::new()),
+            registry_persistence: None,
+            projects_file: None,
+            history_mode: HistoryMode::LiveOnly,
+            project_root: Arc::new(parking_lot::RwLock::new(
+                root.canonicalize().unwrap_or_else(|_| root.to_path_buf()),
+            )),
+            workspace_manifest: None,
+            acp_catalog: None,
+            acp_install: None,
+        }
+    }
+
+    fn test_router(state: AppState) -> axum::Router {
+        axum::Router::new()
+            .route("/worktree/list", post(list))
+            .route("/worktree/create", post(create))
+            .route("/worktree/remove", post(remove))
+            .route("/worktree/branches", get(branches))
+            .route("/worktree/check-dirty", get(check_dirty))
+            .route("/worktree/resolve-base-branch", post(resolve_base_branch))
+            .route("/worktree/copy-include-files", post(copy_include_files))
+            .with_state(state)
+    }
+
+    async fn body_as<T: serde::de::DeserializeOwned>(body: Body) -> IpcBody<T> {
+        let bytes = axum::body::to_bytes(body, usize::MAX)
+            .await
+            .expect("read body");
+        serde_json::from_slice(&bytes).expect("deserialize IpcBody")
+    }
+
+    fn loopback() -> SocketAddr {
+        SocketAddr::from(([127, 0, 0, 1], 54321))
+    }
+
+    async fn post_json(
+        state: AppState,
+        uri: &str,
+        body: &serde_json::Value,
+    ) -> axum::http::Response<Body> {
+        post_json_from(state, uri, body, loopback()).await
+    }
+
+    async fn post_json_from(
+        state: AppState,
+        uri: &str,
+        body: &serde_json::Value,
+        peer: SocketAddr,
+    ) -> axum::http::Response<Body> {
+        let bytes = serde_json::to_vec(body).expect("serialize body");
+        test_router(state)
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri(uri)
+                    .header("content-type", "application/json")
+                    .extension(ConnectInfo(peer))
+                    .body(Body::from(bytes))
+                    .expect("build request"),
+            )
+            .await
+            .expect("router response")
+    }
+
+    async fn get_request(state: AppState, uri: &str) -> axum::http::Response<Body> {
+        test_router(state)
+            .oneshot(
+                Request::builder()
+                    .method("GET")
+                    .uri(uri)
+                    .body(Body::empty())
+                    .expect("build request"),
+            )
+            .await
+            .expect("router response")
+    }
+
+    fn urlencoding(s: &str) -> String {
+        let mut out = String::with_capacity(s.len());
+        for c in s.chars() {
+            match c {
+                ' ' => out.push_str("%20"),
+                '\\' => out.push_str("%5C"),
+                _ if c.is_ascii_alphanumeric()
+                    || matches!(c, '-' | '_' | '.' | '~' | '/' | ':') =>
+                {
+                    out.push(c)
+                }
+                _ => {
+                    let mut buf = [0u8; 4];
+                    for b in c.encode_utf8(&mut buf).as_bytes() {
+                        out.push_str(&format!("%{:02X}", b));
+                    }
+                }
+            }
+        }
+        out
+    }
+
+    /// Skip the test when git is unavailable in the host env.
+    fn git_missing() -> bool {
+        GitTracker::run_git_command(std::env::temp_dir().to_str().unwrap(), &["--version"])
+            .is_none()
+    }
+
+    /// Init a bare git repo + initial commit so worktree ops have a valid HEAD.
+    /// The returned `RepoFixture` owns the `TempDir` and keeps it alive for the
+    /// test body; the `PathBuf` is borrowed from it. When the fixture is dropped
+    /// (end of test), the temp dir is removed — no `std::mem::forget` leak.
+    /// Each fixture gets a unique nanos-stamped dir under the OS temp dir.
+    fn init_repo(tag: &str) -> RepoFixture {
+        let dir = TempDir::new(tag);
+        let path = dir.path().to_path_buf();
+        for args in [
+            ["init", "-q"].as_slice(),
+            ["config", "user.email", "t@example.com"].as_slice(),
+            ["config", "user.name", "Test"].as_slice(),
+            ["config", "commit.gpgsign", "false"].as_slice(),
+            ["config", "core.autocrlf", "false"].as_slice(),
+        ] {
+            let out = GitTracker::run_git_command(path.to_str().unwrap(), args)
+                .expect("git command should run");
+            assert!(
+                out.status.success(),
+                "git {:?} failed: {}",
+                args,
+                String::from_utf8_lossy(&out.stderr)
+            );
+        }
+        let out = GitTracker::run_git_command(path.to_str().unwrap(), &["commit", "--allow-empty", "-m", "init"])
+            .expect("git commit");
+        assert!(out.status.success(), "initial commit failed: {}", String::from_utf8_lossy(&out.stderr));
+        RepoFixture { _dir: dir, path }
+    }
+
+    /// Owns the `TempDir` so the repo survives the test body; drops (removing
+    /// the temp dir) when the fixture goes out of scope at test teardown. This
+    /// replaces the old `std::mem::forget(dir)` pattern that accumulated
+    /// `%TEMP%\termul-web-wt-*` dirs across CI runs.
+    struct RepoFixture {
+        _dir: TempDir,
+        path: std::path::PathBuf,
+    }
+
+    impl RepoFixture {
+        fn path(&self) -> &std::path::Path {
+            &self.path
+        }
+    }
+
+    // ----- Containment + loopback guards -----
+
+    #[tokio::test]
+    async fn list_rejects_project_path_outside_project_root() {
+        let outside = TempDir::new("outside-list");
+        let inside = TempDir::new("inside-list");
+        let state = test_state(inside.path());
+        let resp = post_json(
+            state,
+            "/worktree/list",
+            &serde_json::json!({ "projectPath": outside.path().to_string_lossy() }),
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body: IpcBody<Vec<GitWorktreeEntry>> = body_as(resp.into_body()).await;
+        assert!(!body.success, "outside-root must be rejected");
+        assert_eq!(body.code.as_deref(), Some("OUTSIDE_PROJECT_ROOT"));
+    }
+
+    #[tokio::test]
+    async fn create_refused_from_non_loopback_peer() {
+        if git_missing() {
+            return;
+        }
+        let repo = init_repo("create-guard");
+        let state = test_state(repo.path().parent().unwrap_or_else(|| std::path::Path::new(".")));
+        let remote = SocketAddr::from(([192, 168, 1, 50], 40000));
+        let resp = post_json_from(
+            state,
+            "/worktree/create",
+            &serde_json::json!({
+                "projectPath": repo.path().to_string_lossy(),
+                "name": "wt1",
+                "branch": "chat/wt1",
+                "isNewBranch": true
+            }),
+            remote,
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body: IpcBody<GitWorktreeEntry> = body_as(resp.into_body()).await;
+        assert!(!body.success, "non-loopback create must be refused");
+        assert_eq!(body.code.as_deref(), Some("FORBIDDEN"));
+    }
+
+    #[tokio::test]
+    async fn remove_refused_from_non_loopback_peer() {
+        let inside = TempDir::new("rm-guard");
+        let state = test_state(inside.path());
+        let remote = SocketAddr::from(([192, 168, 1, 51], 40001));
+        let resp = post_json_from(
+            state,
+            "/worktree/remove",
+            &serde_json::json!({
+                "projectPath": inside.path().to_string_lossy(),
+                "worktreePath": inside.path().to_string_lossy(),
+                "force": false
+            }),
+            remote,
+        )
+        .await;
+        let body: IpcBody<()> = body_as(resp.into_body()).await;
+        assert!(!body.success);
+        assert_eq!(body.code.as_deref(), Some("FORBIDDEN"));
+    }
+
+    #[tokio::test]
+    async fn copy_include_files_refused_from_non_loopback_peer() {
+        let inside = TempDir::new("copy-guard");
+        let state = test_state(inside.path());
+        let remote = SocketAddr::from(([192, 168, 1, 52], 40002));
+        let resp = post_json_from(
+            state,
+            "/worktree/copy-include-files",
+            &serde_json::json!({
+                "projectPath": inside.path().to_string_lossy(),
+                "worktreePath": inside.path().to_string_lossy()
+            }),
+            remote,
+        )
+        .await;
+        let body: IpcBody<IncludeCopyResult> = body_as(resp.into_body()).await;
+        assert!(!body.success);
+        assert_eq!(body.code.as_deref(), Some("FORBIDDEN"));
+    }
+
+    // ----- Read routes (containment only, no loopback guard) -----
+
+    #[tokio::test]
+    async fn list_returns_entries_for_a_git_repo() {
+        if git_missing() {
+            return;
+        }
+        let repo = init_repo("list-ok");
+        let state = test_state(repo.path().parent().unwrap_or_else(|| std::path::Path::new(".")));
+        let resp = post_json(
+            state,
+            "/worktree/list",
+            &serde_json::json!({ "projectPath": repo.path().to_string_lossy() }),
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body: IpcBody<Vec<GitWorktreeEntry>> = body_as(resp.into_body()).await;
+        assert!(body.success, "list should succeed: {:?}", body.error);
+        // A freshly-init'd repo with one commit has one worktree (the main one).
+        let entries = body.data.expect("entries");
+        assert!(!entries.is_empty(), "expected at least one worktree entry");
+    }
+
+    #[tokio::test]
+    async fn branches_returns_at_least_one_branch() {
+        if git_missing() {
+            return;
+        }
+        let repo = init_repo("branches-ok");
+        let state = test_state(repo.path().parent().unwrap_or_else(|| std::path::Path::new(".")));
+        let uri = format!(
+            "/worktree/branches?projectPath={}",
+            urlencoding(&repo.path().to_string_lossy())
+        );
+        let resp = get_request(state, &uri).await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body: IpcBody<Vec<BranchEntry>> = body_as(resp.into_body()).await;
+        assert!(body.success, "{:?}", body.error);
+        let entries = body.data.expect("branches");
+        assert!(!entries.is_empty(), "expected at least one branch");
+    }
+
+    #[tokio::test]
+    async fn resolve_base_branch_returns_default_base() {
+        if git_missing() {
+            return;
+        }
+        let repo = init_repo("base-ok");
+        let state = test_state(repo.path().parent().unwrap_or_else(|| std::path::Path::new(".")));
+        let resp = post_json(
+            state,
+            "/worktree/resolve-base-branch",
+            &serde_json::json!({ "projectPath": repo.path().to_string_lossy() }),
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body: IpcBody<BaseBranchInfo> = body_as(resp.into_body()).await;
+        assert!(body.success, "{:?}", body.error);
+        let info = body.data.expect("base branch info");
+        assert!(!info.default_base.is_empty(), "default base must be non-empty");
+    }
+
+    // ----- Write routes (loopback-guarded) -----
+
+    #[tokio::test]
+    async fn create_then_list_then_remove_roundtrips() {
+        if git_missing() {
+            return;
+        }
+        let repo = init_repo("cud");
+        let state = test_state(repo.path().parent().unwrap_or_else(|| std::path::Path::new(".")));
+
+        // Create a worktree
+        let resp = post_json(
+            state.clone(),
+            "/worktree/create",
+            &serde_json::json!({
+                "projectPath": repo.path().to_string_lossy(),
+                "name": "wt-rt",
+                "branch": "chat/wt-rt",
+                "isNewBranch": true
+            }),
+        )
+        .await;
+        let body: IpcBody<GitWorktreeEntry> = body_as(resp.into_body()).await;
+        assert!(body.success, "create failed: {:?}", body.error);
+        let entry = body.data.expect("entry");
+        assert_eq!(entry.branch, "chat/wt-rt");
+
+        // List — should include the new worktree
+        let resp = post_json(
+            state.clone(),
+            "/worktree/list",
+            &serde_json::json!({ "projectPath": repo.path().to_string_lossy() }),
+        )
+        .await;
+        let body: IpcBody<Vec<GitWorktreeEntry>> = body_as(resp.into_body()).await;
+        assert!(body.success, "list failed: {:?}", body.error);
+        let entries = body.data.expect("entries");
+        assert!(
+            entries.iter().any(|e| e.branch == "chat/wt-rt"),
+            "expected the created worktree in the list"
+        );
+
+        // Remove the worktree
+        let resp = post_json(
+            state.clone(),
+            "/worktree/remove",
+            &serde_json::json!({
+                "projectPath": repo.path().to_string_lossy(),
+                "worktreePath": entry.path,
+                "force": true
+            }),
+        )
+        .await;
+        let body: IpcBody<()> = body_as(resp.into_body()).await;
+        assert!(body.success, "remove failed: {:?}", body.error);
+    }
+
+    #[tokio::test]
+    async fn check_dirty_returns_clean_for_fresh_worktree() {
+        if git_missing() {
+            return;
+        }
+        let repo = init_repo("dirty-ok");
+        let state = test_state(repo.path().parent().unwrap_or_else(|| std::path::Path::new(".")));
+
+        // Create a worktree so check-dirty has a valid path to probe
+        let resp = post_json(
+            state.clone(),
+            "/worktree/create",
+            &serde_json::json!({
+                "projectPath": repo.path().to_string_lossy(),
+                "name": "wt-dirty",
+                "branch": "chat/wt-dirty",
+                "isNewBranch": true
+            }),
+        )
+        .await;
+        let body: IpcBody<GitWorktreeEntry> = body_as(resp.into_body()).await;
+        assert!(body.success, "create failed: {:?}", body.error);
+        let entry = body.data.expect("entry");
+
+        let uri = format!(
+            "/worktree/check-dirty?worktreePath={}",
+            urlencoding(&entry.path)
+        );
+        let resp = get_request(state, &uri).await;
+        let body: IpcBody<DirtyStatus> = body_as(resp.into_body()).await;
+        assert!(body.success, "{:?}", body.error);
+        let status = body.data.expect("dirty status");
+        assert!(!status.has_changes, "fresh worktree should be clean");
+    }
+
+    #[tokio::test]
+    async fn copy_include_files_returns_outcome_for_fresh_worktree() {
+        if git_missing() {
+            return;
+        }
+        let repo = init_repo("copy-ok");
+        let state = test_state(repo.path().parent().unwrap_or_else(|| std::path::Path::new(".")));
+
+        let resp = post_json(
+            state.clone(),
+            "/worktree/create",
+            &serde_json::json!({
+                "projectPath": repo.path().to_string_lossy(),
+                "name": "wt-copy",
+                "branch": "chat/wt-copy",
+                "isNewBranch": true
+            }),
+        )
+        .await;
+        let body: IpcBody<GitWorktreeEntry> = body_as(resp.into_body()).await;
+        assert!(body.success, "create failed: {:?}", body.error);
+        let entry = body.data.expect("entry");
+
+        let resp = post_json(
+            state,
+            "/worktree/copy-include-files",
+            &serde_json::json!({
+                "projectPath": repo.path().to_string_lossy(),
+                "worktreePath": entry.path
+            }),
+        )
+        .await;
+        let body: IpcBody<IncludeCopyResult> = body_as(resp.into_body()).await;
+        assert!(body.success, "copy-include-files failed: {:?}", body.error);
+        let outcome = body.data.expect("outcome");
+        // No .worktree-include file → ran=0, copied=0
+        assert_eq!(outcome.ran, 0, "no .worktree-include → ran=0");
+        assert_eq!(outcome.copied, 0, "no .worktree-include → copied=0");
+    }
+
+    // ----- Production-router integration (Fix 14) -----
+    //
+    // The handler tests above use a hand-built `test_router`. These tests build
+    // the REAL production `router::router(...)` (the same function `serve_router`
+    // calls) and drive a `oneshot` request per route, asserting the response is
+    // an `IpcBody` JSON (not the SPA static fallback). This catches a regression
+    // that drops or swaps a route in only the production `router()` function
+    // (the parity-checklist TS test only greps `router.rs` source text; this is
+    // the runtime catch).
+
+    /// Build the production `router()` with a test AppState rooted at `root`.
+    fn production_router(root: &std::path::Path) -> axum::Router {
+        let pty = crate::web::test_pty_manager();
+        let project_root = root
+            .canonicalize()
+            .unwrap_or_else(|_| root.to_path_buf());
+        crate::web::router::router(
+            Arc::new(AcpManager::new(vec![])),
+            pty.clone(),
+            pty.terminal_events(),
+            pty.cwd_tracker(),
+            pty.git_tracker(),
+            pty.exit_code_tracker(),
+            Arc::new(WsRelaySink::new()),
+            Arc::new(ProjectRegistry::new()),
+            None,
+            None,
+            project_root,
+            HistoryMode::LiveOnly,
+            None,
+            None,
+            None,
+        )
+    }
+
+    #[tokio::test]
+    async fn production_router_serves_worktree_list_as_ipcbody_not_spa_fallback() {
+        if git_missing() {
+            return;
+        }
+        let repo = init_repo("prod-router-list");
+        let app = production_router(
+            repo.path().parent().unwrap_or_else(|| std::path::Path::new(".")),
+        );
+        let bytes = serde_json::to_vec(
+            &serde_json::json!({ "projectPath": repo.path().to_string_lossy() }),
+        )
+        .expect("serialize");
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/worktree/list")
+                    .header("content-type", "application/json")
+                    .extension(ConnectInfo(loopback()))
+                    .body(Body::from(bytes))
+                    .expect("build request"),
+            )
+            .await
+            .expect("router response");
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body: IpcBody<Vec<GitWorktreeEntry>> = body_as(resp.into_body()).await;
+        assert!(
+            body.success,
+            "production router should serve /worktree/list as IpcBody, not SPA fallback: {:?}",
+            body.error
+        );
+        assert!(
+            !body.data.as_deref().unwrap_or_default().is_empty(),
+            "fresh repo should have at least one worktree entry"
+        );
+    }
+
+    #[tokio::test]
+    async fn production_router_serves_worktree_branches_as_ipcbody_not_spa_fallback() {
+        if git_missing() {
+            return;
+        }
+        let repo = init_repo("prod-router-branches");
+        let app = production_router(
+            repo.path().parent().unwrap_or_else(|| std::path::Path::new(".")),
+        );
+        let uri = format!(
+            "/worktree/branches?projectPath={}",
+            urlencoding(&repo.path().to_string_lossy())
+        );
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("GET")
+                    .uri(&uri)
+                    .body(Body::empty())
+                    .expect("build request"),
+            )
+            .await
+            .expect("router response");
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body: IpcBody<Vec<BranchEntry>> = body_as(resp.into_body()).await;
+        assert!(
+            body.success,
+            "production router should serve /worktree/branches as IpcBody, not SPA fallback: {:?}",
+            body.error
+        );
+        assert!(
+            !body.data.as_deref().unwrap_or_default().is_empty(),
+            "fresh repo should have at least one branch"
+        );
+    }
+
+    #[tokio::test]
+    async fn production_router_serves_worktree_resolve_base_branch_as_ipcbody() {
+        if git_missing() {
+            return;
+        }
+        let repo = init_repo("prod-router-base");
+        let app = production_router(
+            repo.path().parent().unwrap_or_else(|| std::path::Path::new(".")),
+        );
+        let bytes = serde_json::to_vec(
+            &serde_json::json!({ "projectPath": repo.path().to_string_lossy() }),
+        )
+        .expect("serialize");
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/worktree/resolve-base-branch")
+                    .header("content-type", "application/json")
+                    .extension(ConnectInfo(loopback()))
+                    .body(Body::from(bytes))
+                    .expect("build request"),
+            )
+            .await
+            .expect("router response");
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body: IpcBody<BaseBranchInfo> = body_as(resp.into_body()).await;
+        assert!(
+            body.success,
+            "production router should serve /worktree/resolve-base-branch as IpcBody: {:?}",
+            body.error
+        );
+    }
+
+    #[tokio::test]
+    async fn production_router_does_not_swallow_unregistered_path_as_ipcbody() {
+        // An unregistered path under /worktree/ must NOT return an IpcBody — it
+        // should fall through to the SPA static fallback (404 in the test env
+        // where dist-web/ is absent). This distinguishes the registered routes
+        // from the fallback.
+        let repo = init_repo("prod-router-404");
+        let app = production_router(
+            repo.path().parent().unwrap_or_else(|| std::path::Path::new(".")),
+        );
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/worktree/nonexistent-route")
+                    .header("content-type", "application/json")
+                    .extension(ConnectInfo(loopback()))
+                    .body(Body::from(
+                        serde_json::to_vec(&serde_json::json!({})).expect("serialize"),
+                    ))
+                    .expect("build request"),
+            )
+            .await
+            .expect("router response");
+        // The SPA fallback returns 404 when dist-web/ is absent (test env) or
+        // index.html when present. Either way, it's NOT a 200 IpcBody.
+        // A 200 here would mean the route was accidentally registered as a
+        // catch-all. We assert the status is NOT OK-with-IpcBody by checking
+        // that the body is NOT a valid IpcBody success.
+        let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .expect("read body");
+        let text = String::from_utf8_lossy(&bytes);
+        // The fallback body is either 404 "Not Found" or an HTML index — never
+        // a JSON `{"success":...}` IpcBody.
+        assert!(
+            !text.contains("\"success\""),
+            "unregistered /worktree/nonexistent-route must not return an IpcBody JSON, got: {text}"
+        );
+    }
+}

--- a/src-tauri/src/worktree/mod.rs
+++ b/src-tauri/src/worktree/mod.rs
@@ -78,7 +78,7 @@ pub struct SymlinkResult {
 // Data Types
 // ============================================================================
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct GitWorktreeEntry {
     pub name: String,
@@ -87,7 +87,7 @@ pub struct GitWorktreeEntry {
     pub head_commit: String,
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct BranchEntry {
     pub name: String,
@@ -98,7 +98,7 @@ pub struct BranchEntry {
     pub has_other_worktree: bool,
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct DirtyStatus {
     pub modified: usize,
@@ -181,7 +181,7 @@ pub struct MergePreview {
 /// creation (CAP-2). `current_branch` is `None` when the repo is in detached
 /// HEAD — the launcher must then force a base-branch pick before allowing a
 /// worktree launch.
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct BaseBranchInfo {
     /// The branch `chat/{id}` should be created from: origin/HEAD → main →
@@ -196,7 +196,7 @@ pub struct BaseBranchInfo {
 
 /// Per-file skip reason for the `.worktree-include` carry-over (CAP-5).
 /// Surfaced to the renderer so the launcher can log per-file decisions.
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct IncludeSkipReason {
     pub path: String,
@@ -207,7 +207,7 @@ pub struct IncludeSkipReason {
 /// patterns that matched at least one file; `copied` is files actually
 /// copied; `skipped` carries per-file reasons (symlink, path-escape,
 /// already-present).
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct IncludeCopyResult {
     pub ran: usize,

--- a/src/renderer/assets/agent-icons/acp/agents.json
+++ b/src/renderer/assets/agent-icons/acp/agents.json
@@ -438,33 +438,33 @@
   {
     "id": "harn",
     "name": "Harn",
-    "version": "0.10.77",
+    "version": "0.10.79",
     "description": "Harn runs .harn agent pipelines as a native ACP coding agent over stdio.",
     "distribution": {
       "binary": {
         "darwin-aarch64": {
           "cmd": "./harn",
-          "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.77/harn-aarch64-apple-darwin.tar.gz",
+          "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.79/harn-aarch64-apple-darwin.tar.gz",
           "args": ["serve", "acp"]
         },
         "darwin-x86_64": {
           "cmd": "./harn",
-          "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.77/harn-x86_64-apple-darwin.tar.gz",
+          "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.79/harn-x86_64-apple-darwin.tar.gz",
           "args": ["serve", "acp"]
         },
         "linux-aarch64": {
           "cmd": "./harn",
-          "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.77/harn-aarch64-unknown-linux-gnu.tar.gz",
+          "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.79/harn-aarch64-unknown-linux-gnu.tar.gz",
           "args": ["serve", "acp"]
         },
         "linux-x86_64": {
           "cmd": "./harn",
-          "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.77/harn-x86_64-unknown-linux-gnu.tar.gz",
+          "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.79/harn-x86_64-unknown-linux-gnu.tar.gz",
           "args": ["serve", "acp"]
         },
         "windows-x86_64": {
           "cmd": "harn.exe",
-          "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.77/harn-x86_64-pc-windows-msvc.zip",
+          "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.79/harn-x86_64-pc-windows-msvc.zip",
           "args": ["serve", "acp"]
         }
       }

--- a/src/renderer/components/agents/AgentLauncher.test.tsx
+++ b/src/renderer/components/agents/AgentLauncher.test.tsx
@@ -234,7 +234,8 @@ vi.mock('@/lib/worktree-context', () => ({
 }))
 
 vi.mock('@/lib/tauri-runtime', () => ({
-  isTauriContext: vi.fn(() => false)
+  isTauriContext: vi.fn(() => false),
+  isLoopbackWebClient: vi.fn(() => true)
 }))
 
 // Radix Select portals don't render reliably under jsdom; shim with a native
@@ -1430,7 +1431,7 @@ describe('AgentLauncher slash menu parity (mid-text + command chip)', () => {
     await waitFor(() => expect(screen.getByRole('listbox')).toBeInTheDocument())
   })
 
-  it('renders a CommandChip when a slash command is selected from the menu', async () => {
+  it('renders an inline command pill when a slash command is selected from the menu', async () => {
     const key = 'acp-registry:claude-acp\0/work\0'
     acpStateRef.current.agentConfigs = [ACP_CONFIG]
     mockPersistRead.mockResolvedValue({
@@ -1450,13 +1451,13 @@ describe('AgentLauncher slash menu parity (mid-text + command chip)', () => {
     await waitFor(() => expect(screen.getByRole('listbox')).toBeInTheDocument())
     selectSlashOption('/compact')
 
-    // Previously the launcher inserted bare `/compact ` text; it now creates a
-    // CommandChip (parity with the running chatbox).
-    await waitFor(() =>
-      expect(screen.getByRole('button', { name: 'Remove /compact command' })).toBeInTheDocument()
-    )
-    // The `/compact` filter text is cleared from the input.
-    expect(getComposerValue()).toBe('')
+    // Previously the launcher inserted bare `/compact ` text or a detached
+    // CommandChip; it now creates an inline command pill (parity with the
+    // running chatbox). The CommandPill NodeView renders the SkillChip with
+    // name prefixed by `/` so the visible text is `/compact`.
+    await waitFor(() => {
+      expect(screen.getByText('/compact')).toBeInTheDocument()
+    })
   })
 })
 
@@ -1591,7 +1592,7 @@ describe('AgentLauncher worktree isolation', () => {
     expect(screen.getByRole('combobox', { name: 'Isolation mode' })).toBeInTheDocument()
   })
 
-  // CAP-2: selector hidden on web / non-repo
+  // CAP-2: selector hidden on non-repo
   it('hides the isolation selector when not a git repo (CAP-2)', () => {
     vi.mocked(isTauriContext).mockReturnValue(true)
     mockProjectOverride.current = null // no isGitRepo
@@ -1600,12 +1601,17 @@ describe('AgentLauncher worktree isolation', () => {
     expect(screen.queryByRole('combobox', { name: 'Isolation mode' })).not.toBeInTheDocument()
   })
 
-  it('hides the isolation selector on web (CAP-2)', () => {
-    vi.mocked(isTauriContext).mockReturnValue(false)
+  // CAP — Web worktree parity: the isolation selector is no longer gated on
+  // isTauriContext(). A web client on a git project now sees the picker (the
+  // worktree mutation routes ship over HTTP via web/worktree_api.rs + the
+  // worktree-api.ts facade branches isTauriContext() between invoke and fetch).
+  // The launcher no longer imports isTauriContext (canUseWorktree =
+  // projectIsGitRepo), so no isTauriContext mock is needed here — the project
+  // override alone drives the git-repo signal.
+  it('shows the isolation selector on web when the project is a git repo (CAP web parity)', () => {
     mockProjectOverride.current = { isGitRepo: true, gitBranch: 'feat/x' }
     renderLauncher()
-    expect(screen.queryByRole('combobox', { name: 'Base branch' })).not.toBeInTheDocument()
-    expect(screen.queryByRole('combobox', { name: 'Isolation mode' })).not.toBeInTheDocument()
+    expect(screen.getByRole('combobox', { name: 'Isolation mode' })).toBeInTheDocument()
   })
 
   /**
@@ -1808,7 +1814,7 @@ describe('AgentLauncher placeholder', () => {
     })
   })
 
-  it('renders the optional-message hint when a slash command is staged', async () => {
+  it('inserts an inline command pill when a slash command is selected', async () => {
     const key = 'acp-registry:claude-acp\0/work\0'
     acpStateRef.current.agentConfigs = [ACP_CONFIG]
     mockPersistRead.mockResolvedValue({
@@ -1829,10 +1835,7 @@ describe('AgentLauncher placeholder', () => {
     fireEvent.mouseDown(within(screen.getByRole('listbox')).getByText('/compact'))
 
     await waitFor(() => {
-      expect(document.querySelector('[data-composer-editor="true"] p')).toHaveAttribute(
-        'data-placeholder',
-        'Add a message (optional)…'
-      )
+      expect(document.querySelector('[data-command-name="compact"]')).not.toBeNull()
     })
   })
 })

--- a/src/renderer/components/agents/AgentLauncher.tsx
+++ b/src/renderer/components/agents/AgentLauncher.tsx
@@ -22,7 +22,6 @@ import {
 import { ConfigChip, ModeChip } from '@/components/chat/AgentHeader'
 import { AttachFilesButton } from '@/components/chat/AttachFilesButton'
 import { AttachmentPreviewGroup } from '@/components/chat/AttachmentPreviewGroup'
-import { CommandChip } from '@/components/chat/CommandChip'
 import { ComposerPill } from '@/components/chat/ComposerPill'
 import { attachmentToBlock } from '@/components/chat/chat-attachments'
 import {
@@ -83,7 +82,7 @@ import { dialogApi, openerApi, persistenceApi } from '@/lib/api'
 import { registerSessionTempFiles } from '@/lib/attachment-temp-cleanup'
 import { logFrontendError } from '@/lib/log-api'
 import { platform as osPlatform } from '@/lib/tauri-os'
-import { isTauriContext } from '@/lib/tauri-runtime'
+import { isLoopbackWebClient } from '@/lib/tauri-runtime'
 import { cn } from '@/lib/utils'
 import { type BaseBranchInfo, worktreeApi } from '@/lib/worktree-api'
 import { getDefaultCwdForProject, getProjectRootPath } from '@/lib/worktree-context'
@@ -150,10 +149,15 @@ export function AgentLauncher({ paneId, className }: AgentLauncherProps): React.
   const projectRoot = activeProjectId ? getDefaultCwdForProject(activeProjectId) : undefined
   const projectIsGitRepo = Boolean(activeProject?.isGitRepo)
   const projectGitBranch = activeProject?.gitBranch ?? null
-  // CAP-2: isolation mode + base-branch picker. Worktree mode is desktop-only
-  // and requires a git repo; on web or non-repo projects the selector is
-  // hidden and `current` is forced.
-  const canUseWorktree = isTauriContext() && projectIsGitRepo
+  // CAP-2: isolation mode + base-branch picker. Worktree mode requires a git
+  // repo; the selector is hidden on non-repo projects. CAP — Web worktree
+  // parity: the worktree mutation routes now ship over HTTP (`web/worktree_api.rs`)
+  // so the launcher's worktree mode picker is no longer gated on `isTauriContext()`
+  // alone. The write routes (`/worktree/create` etc.) are loopback-guarded
+  // (`check_local_only`), so the picker is gated on `isLoopbackWebClient()` —
+  // the desktop (always local) and a loopback web client see it; a non-loopback
+  // LAN client does not, avoiding a picker that would fail `FORBIDDEN` at launch.
+  const canUseWorktree = projectIsGitRepo && isLoopbackWebClient()
   const [isolationMode, setIsolationMode] = useState<'current' | 'worktree'>('current')
   const [baseBranch, setBaseBranch] = useState<string | null>(null)
   const [baseBranchInfo, setBaseBranchInfo] = useState<BaseBranchInfo | null>(null)
@@ -405,10 +409,8 @@ export function AgentLauncher({ paneId, className }: AgentLauncherProps): React.
 
   const {
     slashSections,
-    activeCommand,
-    setActiveCommand,
-    clearActiveCommand,
     skillPathsRef,
+    hasCommandToken,
     handleSelect,
     onSlashOrMentionKeyDown,
     buildPromptParts
@@ -877,7 +879,6 @@ export function AgentLauncher({ paneId, className }: AgentLauncherProps): React.
     useWorkspaceStore.getState().hideAgentLauncher()
     setPendingOptions(emptyPendingLauncherOptions())
     skillPathsRef.current = {}
-    setActiveCommand(null)
     clearAttachments()
     resetMentions()
     setPrompt('')
@@ -957,7 +958,6 @@ export function AgentLauncher({ paneId, className }: AgentLauncherProps): React.
     effectiveConfigOptions,
     buildPromptParts,
     skillPathsRef,
-    setActiveCommand,
     isolationMode,
     canUseWorktree,
     baseBranch
@@ -1000,7 +1000,7 @@ export function AgentLauncher({ paneId, className }: AgentLauncherProps): React.
   const canLaunch =
     Boolean(selectedConfig) &&
     selectedEntry?.status === 'ready' &&
-    (prompt.trim().length > 0 || attachments.length > 0 || activeCommand !== null) &&
+    (prompt.trim().length > 0 || attachments.length > 0) &&
     // CAP-2: worktree mode requires an explicit base branch before launch —
     // covers detached HEAD (no current) and any case where the picker has
     // not settled on a value.
@@ -1123,7 +1123,6 @@ export function AgentLauncher({ paneId, className }: AgentLauncherProps): React.
                   onRetry={handleRetryPrepare}
                 />
               )}
-            {activeCommand && <CommandChip name={activeCommand} onRemove={clearActiveCommand} />}
             <AttachmentPreviewGroup
               attachments={attachments}
               onRemove={removeAttachment}
@@ -1149,7 +1148,7 @@ export function AgentLauncher({ paneId, className }: AgentLauncherProps): React.
                 minHeight={76}
                 maxHeight={160}
                 placeholder={
-                  activeCommand
+                  hasCommandToken
                     ? 'Add a message (optional)…'
                     : 'Ask anything.. (@ for files, / for commands)'
                 }

--- a/src/renderer/components/chat/ChatInputBar.test.tsx
+++ b/src/renderer/components/chat/ChatInputBar.test.tsx
@@ -4,7 +4,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { TooltipProvider } from '@/components/ui/tooltip'
 import type { SessionConfigOption } from '@/lib/acp-api'
 import { SKILL_PAD_DEFAULT } from '@/lib/composer/doc-to-prompt'
-import { skillToken } from '@/lib/skill-tokens'
+import { commandToken, skillToken } from '@/lib/skill-tokens'
 import type { AcpSession } from '@/stores/acp-store'
 import { ChatInputBar } from './ChatInputBar'
 import {
@@ -544,7 +544,7 @@ describe('ChatInputBar command chip', () => {
     fireEvent.mouseDown(within(listbox).getByText(name))
   }
 
-  it('renders a command chip when a slash command is selected from the menu', async () => {
+  it('renders an inline command pill when a slash command is selected from the menu', async () => {
     const commands = [{ name: 'compact', description: 'Compact the conversation' }]
     renderInputBar({ commands })
 
@@ -558,13 +558,11 @@ describe('ChatInputBar command chip', () => {
     // Select the command
     selectSlashOption('/compact')
 
-    // Command chip should appear
+    // Command pill should render inline (the CommandPill NodeView renders the
+    // SkillChip with name prefixed by `/` so the visible text is `/compact`).
     await waitFor(() => {
-      expect(screen.getByRole('button', { name: 'Remove /compact command' })).toBeInTheDocument()
+      expect(screen.getByText('/compact')).toBeInTheDocument()
     })
-
-    // Editor should be cleared
-    expect(getComposerValue()).toBe('')
   })
 
   it('prepends the command to the prompt on send', async () => {
@@ -580,12 +578,13 @@ describe('ChatInputBar command chip', () => {
 
     selectSlashOption('/compact')
 
-    await waitFor(() => {
-      expect(screen.getByRole('button', { name: 'Remove /compact command' })).toBeInTheDocument()
-    })
+    // Command pill renders inline.
+    await waitFor(() => expect(screen.getByText('/compact')).toBeInTheDocument())
 
-    // Type a message
-    setComposerValue('hello')
+    // Append text after the pill + trailing space (the value carries the
+    // command token, so we append to it — `setComposerValue` replaces the
+    // whole value, losing the pill, so we build the full value with the token).
+    setComposerValue(`${commandToken('compact')} hello`)
 
     // Send
     fireEvent.click(screen.getByRole('button', { name: 'Send message' }))
@@ -595,7 +594,7 @@ describe('ChatInputBar command chip', () => {
     })
   })
 
-  it('removes the command chip when the X button is clicked', async () => {
+  it('removes the command pill on Backspace when the caret is immediately after it', async () => {
     const commands = [{ name: 'compact', description: 'Compact' }]
     renderInputBar({ commands })
 
@@ -607,20 +606,23 @@ describe('ChatInputBar command chip', () => {
 
     selectSlashOption('/compact')
 
+    await waitFor(() => expect(screen.getByText('/compact')).toBeInTheDocument())
+
+    // The value carries the command token + trailing space. Place the caret
+    // after the trailing space + dispatch Backspace — the editor's keymap
+    // removes the whole atom pill node.
+    const valueWithToken = `${commandToken('compact')} `
+    expect(getComposerValue()).toBe(valueWithToken)
+    setComposerCaret(valueWithToken.length)
+    pressComposerKey('Backspace')
+
+    // The whole pill + trailing space are removed.
     await waitFor(() => {
-      expect(screen.getByRole('button', { name: 'Remove /compact command' })).toBeInTheDocument()
+      expect(screen.queryByText('/compact')).not.toBeInTheDocument()
     })
-
-    // Click remove
-    fireEvent.click(screen.getByRole('button', { name: 'Remove /compact command' }))
-
-    // Chip should be gone
-    expect(
-      screen.queryByRole('button', { name: 'Remove /compact command' })
-    ).not.toBeInTheDocument()
   })
 
-  it('opens the slash menu when / is typed with an active command chip', async () => {
+  it('opens the slash menu when / is typed with an active command pill', async () => {
     const commands = [
       { name: 'compact', description: 'Compact' },
       { name: 'clear', description: 'Clear' }
@@ -635,19 +637,18 @@ describe('ChatInputBar command chip', () => {
 
     selectSlashOption('/compact')
 
-    await waitFor(() => {
-      expect(screen.getByRole('button', { name: 'Remove /compact command' })).toBeInTheDocument()
-    })
+    await waitFor(() => expect(screen.getByText('/compact')).toBeInTheDocument())
 
-    // Type / again to re-open the menu
-    setComposerValue('/')
+    // Type / again to re-open the menu (the value carries the command token +
+    // trailing space + the new `/`).
+    setComposerValue(`${commandToken('compact')} /`)
 
     await waitFor(() => {
       expect(screen.getByRole('listbox')).toBeInTheDocument()
     })
   })
 
-  it('updates the command chip when a different command is selected', async () => {
+  it('rejects a second command pick (single-command invariant)', async () => {
     const commands = [
       { name: 'compact', description: 'Compact' },
       { name: 'clear', description: 'Clear' }
@@ -662,26 +663,35 @@ describe('ChatInputBar command chip', () => {
 
     selectSlashOption('/compact')
 
-    await waitFor(() => {
-      expect(screen.getByRole('button', { name: 'Remove /compact command' })).toBeInTheDocument()
-    })
+    await waitFor(() => expect(screen.getByText('/compact')).toBeInTheDocument())
 
-    // Type / again to re-open the menu
-    setComposerValue('/')
+    // Type / again to re-open the menu, then select a different command.
+    setComposerValue(`${commandToken('compact')} /`)
 
     await waitFor(() => {
       expect(screen.getByRole('listbox')).toBeInTheDocument()
     })
-
-    // Select a different command
     selectSlashOption('/clear')
 
+    // The second command is rejected — the single-command invariant keeps the
+    // existing `/compact` pill. The `/clear` pill must NOT render (the
+    // rejection is a no-op, not a replace). The slash menu may list `/compact`
+    // as an option (filter matches), so we assert at least one `/compact`
+    // element is present (the pill). And critically, the `/clear` pill must
+    // NOT have been inserted — its text must not appear in the editor's pill
+    // area. The menu still shows `/clear` as a listbox option, so we scope
+    // the absence check to the editor's data-composer-editor subtree.
     await waitFor(() => {
-      expect(screen.getByRole('button', { name: 'Remove /clear command' })).toBeInTheDocument()
+      expect(screen.getAllByText('/compact').length).toBeGreaterThanOrEqual(1)
     })
+    const editor = document.querySelector('[data-composer-editor="true"]')
+    expect(editor).not.toBeNull()
     expect(
-      screen.queryByRole('button', { name: 'Remove /compact command' })
-    ).not.toBeInTheDocument()
+      editor!.querySelector('[data-command-pill="true"][data-command-name="clear"]')
+    ).toBeNull()
+    expect(
+      editor!.querySelector('[data-command-pill="true"][data-command-name="compact"]')
+    ).not.toBeNull()
   })
 
   it('sends just the command when no message is typed', async () => {
@@ -697,11 +707,9 @@ describe('ChatInputBar command chip', () => {
 
     selectSlashOption('/compact')
 
-    await waitFor(() => {
-      expect(screen.getByRole('button', { name: 'Remove /compact command' })).toBeInTheDocument()
-    })
+    await waitFor(() => expect(screen.getByText('/compact')).toBeInTheDocument())
 
-    // Send with just the command chip (no text)
+    // Send with just the command pill (no text after it).
     fireEvent.click(screen.getByRole('button', { name: 'Send message' }))
 
     await waitFor(() => {
@@ -709,7 +717,7 @@ describe('ChatInputBar command chip', () => {
     })
   })
 
-  it('clears active command when externally seeded text is applied', async () => {
+  it('clears the command pill when externally seeded text is applied', async () => {
     const onSend = vi.fn()
     const commands = [{ name: 'compact', description: 'Compact' }]
     const { rerender } = renderInputBar({ commands, onSend })
@@ -722,9 +730,7 @@ describe('ChatInputBar command chip', () => {
 
     selectSlashOption('/compact')
 
-    await waitFor(() => {
-      expect(screen.getByRole('button', { name: 'Remove /compact command' })).toBeInTheDocument()
-    })
+    await waitFor(() => expect(screen.getByText('/compact')).toBeInTheDocument())
 
     // Externally seed text (e.g. editing a message)
     rerender(
@@ -748,11 +754,9 @@ describe('ChatInputBar command chip', () => {
       </TooltipProvider>
     )
 
-    // Command chip should be gone after seeding
+    // Command pill should be gone after seeding
     await waitFor(() => {
-      expect(
-        screen.queryByRole('button', { name: 'Remove /compact command' })
-      ).not.toBeInTheDocument()
+      expect(screen.queryByText('/compact')).not.toBeInTheDocument()
     })
 
     // Editor should carry the seeded text

--- a/src/renderer/components/chat/ChatInputBar.tsx
+++ b/src/renderer/components/chat/ChatInputBar.tsx
@@ -24,7 +24,6 @@ import { AgentGlyph } from './AgentGlyph'
 import { ConfigChip, ModeChip } from './AgentHeader'
 import { AttachFilesButton } from './AttachFilesButton'
 import { AttachmentPreviewGroup } from './AttachmentPreviewGroup'
-import { CommandChip } from './CommandChip'
 import { ContextUsageIndicator } from './ContextUsageIndicator'
 import { attachmentToBlock, dedupeAttachmentBlocks } from './chat-attachments'
 import {
@@ -348,9 +347,7 @@ export function ChatInputBar({
 
   const {
     slashSections,
-    activeCommand,
-    setActiveCommand,
-    clearActiveCommand,
+    hasCommandToken,
     skillPathsRef,
     handleSelect,
     onSlashOrMentionKeyDown,
@@ -372,23 +369,21 @@ export function ChatInputBar({
     scheduleRestoreCaret
   })
 
-  const canSend =
-    !disabled &&
-    !sending &&
-    (value.trim().length > 0 || activeCommand !== null || attachments.length > 0)
+  const canSend = !disabled && !sending && (value.trim().length > 0 || attachments.length > 0)
   const showStop = busy && !canSend
   const iconMotion = iconPop(reduced)
 
   const submit = useCallback(async () => {
     const hasAttachments = attachments.length > 0
     const hasText = value.trim().length > 0
-    if ((!hasText && !activeCommand && !hasAttachments) || disabled || sending) return
+    if ((!hasText && !hasAttachments) || disabled || sending) return
 
     setSending(true)
     try {
-      // Build the wire/display text parts from the current value, resolved skill
-      // paths, and active command. Throws `Skill '<name>' is missing a path`
-      // when a selected skill has no resolvable path (Block If) — caught below.
+      // Build the wire/display text parts from the current value, resolved
+      // skill paths, and inline command token. Throws `Skill '<name>' is
+      // missing a path` when a selected skill has no resolvable path (Block If)
+      // — caught below.
       const { hasSkills, wireWithCommand, displayWithCommand, wireTrimmed, displayTrimmed } =
         buildPromptParts()
       if (!wireTrimmed && !hasAttachments) return
@@ -425,7 +420,6 @@ export function ChatInputBar({
       registerSessionTempFiles(session.id, appOwnedTempPaths())
       setValue('')
       skillPathsRef.current = {}
-      setActiveCommand(null)
       clearAttachments()
       resetMentions()
     } catch (err) {
@@ -438,7 +432,6 @@ export function ChatInputBar({
   }, [
     value,
     attachments,
-    activeCommand,
     disabled,
     sending,
     clearAttachments,
@@ -448,8 +441,7 @@ export function ChatInputBar({
     resetMentions,
     session.id,
     buildPromptParts,
-    skillPathsRef,
-    setActiveCommand
+    skillPathsRef
   ])
 
   const handleKeyDown = useCallback(
@@ -494,13 +486,12 @@ export function ChatInputBar({
     if (seedNonce === undefined) return
     const next = seedText ?? ''
     setValue(next)
-    setActiveCommand(null)
     updateMentionsStable(next, next.length)
     // Shared rAF caret-restore (cancels pending frames, no-ops on destroyed
     // editor) — replaces the bare `requestAnimationFrame` that swallowed
     // throws against a destroyed editor.
     scheduleRestoreCaret(next.length)
-  }, [seedNonce, scheduleRestoreCaret, updateMentionsStable, setActiveCommand, setValue])
+  }, [seedNonce, scheduleRestoreCaret, updateMentionsStable, setValue])
 
   // Story 5.3 (T2.3): on mobile web, scroll the editor into view once per
   // OSK-open window so iOS Safari doesn't leave the input under the keyboard.
@@ -639,7 +630,6 @@ export function ChatInputBar({
                 </span>
               </div>
             )}
-            {activeCommand && <CommandChip name={activeCommand} onRemove={clearActiveCommand} />}
             <AttachmentPreviewGroup attachments={attachments} onRemove={removeAttachment} />
             <div className="px-4 pb-1.5 pt-3.5">
               {/* Tiptap rich-text editor — the skill "pill" is a real inline
@@ -664,7 +654,7 @@ export function ChatInputBar({
                 placeholder={
                   disabled
                     ? 'Composer unavailable'
-                    : activeCommand
+                    : hasCommandToken
                       ? 'Add a message (optional)…'
                       : 'Ask anything.. (/ for commands, @ for files )'
                 }

--- a/src/renderer/components/chat/composer/ChatComposerEditor.tsx
+++ b/src/renderer/components/chat/composer/ChatComposerEditor.tsx
@@ -5,6 +5,7 @@ import { EditorContent, useEditor } from '@tiptap/react'
 import StarterKit from '@tiptap/starter-kit'
 import { useEffect, useRef } from 'react'
 import {
+  CMD_PILL_NODE,
   docOffsetToDisplayOffset,
   docToDisplayText,
   SKILL_PILL_NODE
@@ -12,6 +13,7 @@ import {
 import { draftFromTokens } from '@/lib/composer/draft-from-tokens'
 import { logFrontendError } from '@/lib/log-api'
 import { cn } from '@/lib/utils'
+import { CommandPill } from './CommandPillNode'
 import { SkillPill } from './SkillPillNode'
 
 export interface ChatComposerEditorProps {
@@ -102,9 +104,11 @@ function createComposerKeymap(
               }
               // 2) Backspace-over-pill removal (editor-native). Only when the
               // selection is empty and the inline node immediately before the
-              // caret is an atom skillPill. Alt/meta/ctrl/shift excluded so macOS
-              // Option+Backspace (delete-word) doesn't slice a pill and leave
-              // orphan sentinels (mirrors the pre-refactor guard).
+              // caret is an atom skillPill/commandPill. Alt/meta/ctrl/shift
+              // excluded so macOS Option+Backspace (delete-word) doesn't slice
+              // a pill and leave orphan sentinels (mirrors the pre-refactor
+              // guard). The command pill mirrors the skill pill's atom removal
+              // (CAP — Inline command pill).
               if (
                 event instanceof KeyboardEvent &&
                 event.key === 'Backspace' &&
@@ -127,12 +131,19 @@ function createComposerKeymap(
                   if (before?.isText && before.text === ' ') {
                     const $prev = state.doc.resolve(Math.max(0, probePos - 1))
                     const prevNode = $prev.nodeBefore
-                    if (prevNode && prevNode.type.name === SKILL_PILL_NODE) {
+                    if (
+                      prevNode &&
+                      (prevNode.type.name === SKILL_PILL_NODE ||
+                        prevNode.type.name === CMD_PILL_NODE)
+                    ) {
                       before = prevNode
                       probePos = probePos - 1
                     }
                   }
-                  if (before && before.type.name === SKILL_PILL_NODE) {
+                  if (
+                    before &&
+                    (before.type.name === SKILL_PILL_NODE || before.type.name === CMD_PILL_NODE)
+                  ) {
                     event.preventDefault()
                     // Delete the pill + any trailing space the splicer appended
                     // (the caret sat after the space) — matches the pre-refactor
@@ -233,6 +244,7 @@ export function ChatComposerEditor({
       // load-bearing guarantee.
       extensions: [
         SkillPill,
+        CommandPill,
         createComposerKeymap(beforeKeyDownRef),
         Placeholder.configure({
           placeholder: () => placeholderRef.current,
@@ -276,12 +288,14 @@ export function ChatComposerEditor({
           onPasteAttachmentsRef.current?.(event as ClipboardEvent)
           if (event.defaultPrevented) return true
           const text = event.clipboardData?.getData('text/plain') ?? ''
-          // 2) ONLY parse pill nodes from the `\uE000` sentinel in `text/plain`.
-          // Never parse pills from HTML (SkillPill.parseHTML returns []), so a
-          // malicious clipboard carrying `<span data-skill-pill>` cannot inject
-          // pill nodes. Plain-text paste (no sentinel) falls through to
-          // ProseMirror's default (text nodes).
-          if (!text.includes('\uE000')) return false
+          // 2) ONLY parse pill nodes from the sentinel chars in `text/plain`.
+          // Never parse pills from HTML (SkillPill/CommandPill.parseHTML return
+          // []), so a malicious clipboard carrying `<span data-skill-pill>` or
+          // `<span data-command-pill>` cannot inject pill nodes. Plain-text
+          // paste (no sentinel) falls through to ProseMirror's default (text
+          // nodes). The skill sentinel `\uE000` and the command sentinel
+          // `\uE004` both trigger the pill-paste path.
+          if (!text.includes('\uE000') && !text.includes('\uE004')) return false
           event.preventDefault()
           try {
             const parsed = view.state.schema.nodeFromJSON(

--- a/src/renderer/components/chat/composer/CommandPillNode.tsx
+++ b/src/renderer/components/chat/composer/CommandPillNode.tsx
@@ -1,0 +1,104 @@
+import { mergeAttributes, Node } from '@tiptap/core'
+import { NodeViewWrapper, type ReactNodeViewProps, ReactNodeViewRenderer } from '@tiptap/react'
+import { CMD_TOKEN_END, CMD_TOKEN_START } from '@/lib/skill-tokens'
+import { cn } from '@/lib/utils'
+import { SkillChip } from '../SkillChip'
+
+/**
+ * Inline atomic Tiptap node for a slash COMMAND "pill" (e.g. `/compact`).
+ * Mirrors `SkillPillNode`: `atom:true`, `group:'inline'`,
+ * `NodeViewWrapper as="span"`, `parseHTML()->[]` (no untrusted-HTML pill
+ * creation), `renderText` emits the `\uE004<name>\uE005` sentinel. The sentinel
+ * pair is distinct from the skill sentinels (`\uE000/\uE001`) so
+ * `parseSkillSegments` (and the skill wire framer / timeline renderer) never
+ * see command tokens.
+ *
+ * Replaces the pre-refactor "command chip on top of the composer" surface
+ * (`<CommandChip>` rendered detached from the text flow above the editor): the
+ * pill is now a real inline DOM node in the editor's text flow, so the caret
+ * sits flush against its right edge by construction. Backspace with the caret
+ * immediately after the pill removes the whole atom node (handled by the
+ * editor's keymap plugin, see `ChatComposerEditor`).
+ *
+ * The pill reuses the shared `<SkillChip>` component with the `name` prefixed
+ * by `/` so the pill visual is identical across skills + commands (one visual
+ * source of truth — the composer, the slash menu, and the timeline cannot
+ * drift). The `/name` prefix distinguishes a command pill from a skill pill
+ * (`name` without `/`).
+ *
+ * Wire contract: at send, `useChatComposer.buildPromptParts` calls
+ * `extractCommandName(value)` → if present, `wireWithCommand = \`/${name}
+ * ${wireText}\`` — the SAME string the old `activeCommand` state produced. The
+ * token is stripped from `wireText` (the skill wire framer receives the
+ * de-commanded text). Single-command invariant: `insertCommandToken` rejects
+ * a second command token if one already exists.
+ */
+export const CommandPill = Node.create({
+  name: 'commandPill',
+  group: 'inline',
+  inline: true,
+  atom: true,
+  selectable: true,
+  draggable: false,
+  addAttributes() {
+    return {
+      name: {
+        default: '',
+        parseHTML: (el) => el.getAttribute('data-command-name') ?? ''
+      }
+    }
+  },
+  // No parseHTML rules: pill nodes are not parsed from clipboard HTML. The only
+  // re-entry path is the `\uE004` sentinel in `text/plain` (handled by
+  // `ChatComposerEditor.handlePaste` → `draftFromTokens`), which constructs
+  // pill nodes programmatically. Returning `[]` ensures ProseMirror's default
+  // HTML paste handler never creates a pill from untrusted markup.
+  parseHTML() {
+    return []
+  },
+  renderHTML({ node, HTMLAttributes }) {
+    return [
+      'span',
+      mergeAttributes(HTMLAttributes, {
+        'data-command-pill': '',
+        'data-command-name': node.attrs.name
+      })
+    ]
+  },
+  renderText({ node }) {
+    // Plain-text serialization (used by `editor.getText()`). The composer's
+    // load-bearing serializer lives in `doc-to-prompt.ts` (it emits the sentinel
+    // token format the wire builder consumes); this is only the fallback path.
+    return `${CMD_TOKEN_START}${node.attrs.name ?? ''}${CMD_TOKEN_END}`
+  },
+  addNodeView() {
+    return ReactNodeViewRenderer(CommandPillNodeView)
+  }
+})
+
+/**
+ * React NodeView for the command pill. Renders the shared `<SkillChip>`
+ * component with the `name` prefixed by `/` so the pill visual is identical
+ * across the composer, the slash menu, and the timeline (one visual source of
+ * truth). `NodeViewWrapper as="span"` keeps it inline (the node is
+ * `inline: true`); the `selected` ring + `data-command-*` attrs live on the
+ * wrapper so ProseMirror selection state and clipboard serialization work
+ * without touching the `SkillChip` visual.
+ */
+function CommandPillNodeView({ node, selected }: ReactNodeViewProps): React.JSX.Element {
+  const attrs = node.attrs as { name?: string }
+  const name = String(attrs.name ?? '')
+  return (
+    <NodeViewWrapper
+      as="span"
+      className={cn(
+        'inline-flex align-baseline leading-none',
+        selected && 'ring-2 ring-primary/40'
+      )}
+      data-command-pill="true"
+      data-command-name={name}
+    >
+      <SkillChip name={`/${name}`} />
+    </NodeViewWrapper>
+  )
+}

--- a/src/renderer/components/chat/use-chat-composer.ts
+++ b/src/renderer/components/chat/use-chat-composer.ts
@@ -1,10 +1,17 @@
 import type { Editor } from '@tiptap/core'
 import type { MutableRefObject, RefObject } from 'react'
-import { useCallback, useMemo, useRef, useState } from 'react'
+import { useCallback, useMemo, useRef } from 'react'
 import { buildPromptWithLoadedSkills } from '@/hooks/use-agent-skills'
 import type { AvailableCommand, SessionConfigOption, SessionModeState } from '@/lib/acp-api'
 import { docOffsetToDisplayOffset, SKILL_PAD_DEFAULT } from '@/lib/composer/doc-to-prompt'
-import { extractSkillNames, insertSkillToken, SKILL_TOKEN_START } from '@/lib/skill-tokens'
+import {
+  extractCommandNames,
+  extractSkillNames,
+  insertCommandToken,
+  insertSkillToken,
+  SKILL_TOKEN_START,
+  stripAllCommandTokens
+} from '@/lib/skill-tokens'
 import type { AgentSkillSummary } from '@/lib/skills-api'
 import { tryHandleMentionMenuKeyDown } from './mention-menu-keyboard'
 import type { SlashMenuHandle } from './SlashCommandMenu'
@@ -26,13 +33,13 @@ import type { ComposerMentions } from './use-composer-mentions'
  * screen). This is a LOGIC extraction, not a JSX extraction: the two surfaces
  * keep their own outer chrome (BorderBeam/queue vs agent picker/banners), but
  * route the duplicated composer-field logic — slash menu, skill-pill splice,
- * command chip, submit text builder — through this hook so they cannot drift
- * again.
+ * command-pill splice, submit text builder — through this hook so they cannot
+ * drift again.
  *
  * The hook is renderer-neutral: no Tauri/runtime calls, no JSX. Both surfaces
  * keep their own `submit()`/`launch()` because the dispatch shapes differ
  * (`onSend`/`onSendBlocks` vs `finalizeChatLaunch`/`sendPromptBlocks`), but both
- * read `activeCommand` + `skillPathsRef` + `buildPromptParts()` from the hook
+ * read `hasCommandToken` + `skillPathsRef` + `buildPromptParts()` from the hook
  * to build the wire/display text identically.
  *
  * ## Editor integration (modular redesign)
@@ -46,11 +53,24 @@ import type { ComposerMentions } from './use-composer-mentions'
  * shared with `buildPromptParts`, draft persistence, and the timeline renderer,
  * so the wire payload stays byte-identical to the pre-refactor surface.
  *
- * The hook owns: `activeCommand`, `skillPathsRef`, slash-menu open/sections,
- * `handleSelect` (skill splice + command chip + config/mode apply),
+ * The hook owns: `hasCommandToken` (derived from the value, replacing the
+ * removed `activeCommand` state), `skillPathsRef`, slash-menu open/sections,
+ * `handleSelect` (skill splice + command splice + config/mode apply),
  * `buildPromptParts` (wire/display text builder), and the slash/mention menu
  * keymap adapter (`onSlashOrMentionKeyDown`) that the editor runs BEFORE its
  * own keymap. Backspace-over-pill removal is owned by the editor itself.
+ *
+ * ## Command pill (CAP — Inline command pill)
+ *
+ * Slash commands (e.g. `/compact`) splice an inline `commandPill` Tiptap atom
+ * into the value (`\uE004<name>\uE005` sentinel) instead of setting a detached
+ * `activeCommand` state + rendering `<CommandChip>` on top of the composer.
+ * The wire builder extracts the command name via `extractCommandName(value)`
+ * and prefixes `/<name> ` to the wire payload (byte-identical to the old
+ * `activeCommand` path). The token is stripped from `wireText` (the skill wire
+ * framer receives the de-commanded text). Single-command invariant:
+ * `insertCommandToken` rejects a second command token if one already exists
+ * (matching today's single-`activeCommand` semantics).
  */
 export interface UseChatComposerArgs {
   value: string
@@ -106,9 +126,13 @@ export interface ChatPromptParts {
 export interface UseChatComposerResult {
   slashOpen: boolean
   slashSections: SlashSection[]
-  activeCommand: string | null
-  setActiveCommand: (v: string | null) => void
-  clearActiveCommand: () => void
+  /**
+   * True when the value carries a command token (`\uE004<name>\uE005`). Replaces
+   * the removed `activeCommand` state for hosts that branch on whether a
+   * command is selected (e.g. placeholder copy, canSend/canLaunch). Derived
+   * from the value — the value is the single source of truth.
+   */
+  hasCommandToken: boolean
   skillPathsRef: MutableRefObject<Record<string, string>>
   hasSkillToken: boolean
   handleSelect: (item: SlashItem) => void
@@ -122,9 +146,9 @@ export interface UseChatComposerResult {
   onSlashOrMentionKeyDown: (event: KeyboardEvent) => boolean
   /**
    * Build the wire/display prompt text parts from the current value, resolved
-   * skill paths, and active command. Throws `Error("Skill '<name>' is missing
-   * a path")` when a selected skill has no resolvable path (the canonical
-   * `ChatInputBar` Block If — surfaces catch and toast).
+   * skill paths, and inline command token. Throws `Error("Skill '<name>' is
+   * missing a path")` when a selected skill has no resolvable path (the
+   * canonical `ChatInputBar` Block If — surfaces catch and toast).
    */
   buildPromptParts: () => ChatPromptParts
 }
@@ -178,7 +202,6 @@ export function useChatComposer(args: UseChatComposerArgs): UseChatComposerResul
     scheduleRestoreCaret
   } = args
 
-  const [activeCommand, setActiveCommand] = useState<string | null>(null)
   // name → SKILL.md path, captured when a skill is picked from the slash menu
   // so the wire prompt can cite paths synchronously at send time (no IPC read,
   // no failure path). The composer value carries the inline skill tokens; this
@@ -195,6 +218,10 @@ export function useChatComposer(args: UseChatComposerArgs): UseChatComposerResul
   // gate. `hasSkillToken` is still exposed for hosts that branch on whether the
   // value carries a skill (e.g. placeholder copy).
   const hasSkillToken = value.includes(SKILL_TOKEN_START)
+  // Command pill: derived from the value (no `activeCommand` state). The value
+  // carries the `\uE004<name>\uE005` token when a command is selected; the wire
+  // builder extracts the name at send time.
+  const hasCommandToken = extractCommandNames(value).length > 0
 
   const handleSelect = useCallback(
     (item: SlashItem) => {
@@ -234,22 +261,31 @@ export function useChatComposer(args: UseChatComposerArgs): UseChatComposerResul
         return
       }
       if (item.kind === 'command') {
-        // Set the command chip instead of inserting bare text into the
-        // editor. If the trigger was mid-text, replace the /token portion in
-        // the input.
-        const midTrigger = findSlashTrigger(value)
-        if (midTrigger && midTrigger.start > 0) {
-          const before = value.slice(0, midTrigger.start).trimEnd()
-          const after = value.slice(midTrigger.end).trimStart()
-          const remaining = [before, after].filter(Boolean).join(' ')
-          setValue(remaining)
-          mentions.update(remaining, remaining.length)
-        } else {
-          setValue('')
-          mentions.update('', 0)
+        // Splice an inline command token into the display string at the caret,
+        // removing the `/`-filter text the slash menu was filtering on. The
+        // token carries the command name + no padding block (the command pill
+        // is a real DOM node, so there is no caret-alignment deficit to
+        // compensate). A trailing space is appended so the caret lands in plain
+        // text and the next `/` trigger matches. Single-command invariant:
+        // `insertCommandToken` rejects a second command token if one already
+        // exists (matching today's single-`activeCommand` semantics) — the
+        // rejection is a no-op (value untouched, editor focused).
+        const trigger = findSlashTrigger(value)
+        const editor = editorRef.current
+        const caret = editor ? stringCaretFromEditor(editor) : trigger ? trigger.end : value.length
+        const insertAt = trigger ? trigger.end : caret
+        const deleteBefore = trigger ? trigger.end - trigger.start : 0
+        const result = insertCommandToken(value, insertAt, item.name, deleteBefore)
+        if (!result.inserted) {
+          // Single-command invariant: a command token already exists. Focus
+          // the editor so the user can backspace the existing pill + retry.
+          editorRef.current?.commands.focus(undefined, { scrollIntoView: false })
+          return
         }
-        setActiveCommand(item.name)
-        editorRef.current?.commands.focus(undefined, { scrollIntoView: false })
+        const { value: next, caret: nextCaret } = result
+        setValue(next)
+        mentions.update(next, nextCaret)
+        scheduleRestoreCaret(nextCaret)
         return
       }
       if (item.kind === 'config') {
@@ -276,7 +312,6 @@ export function useChatComposer(args: UseChatComposerArgs): UseChatComposerResul
           menuRef: slashMenuRef,
           onClearInput: () => {
             setValue('')
-            setActiveCommand(null)
             mentions.update('', 0)
           }
         })
@@ -298,21 +333,25 @@ export function useChatComposer(args: UseChatComposerArgs): UseChatComposerResul
     [slashOpen, slashSections.length, slashMenuRef, mentions, disabled, setValue, editorRef]
   )
 
-  const clearActiveCommand = useCallback(() => {
-    setActiveCommand(null)
-    editorRef.current?.commands.focus(undefined, { scrollIntoView: false })
-  }, [editorRef])
-
   const buildPromptParts = useCallback((): ChatPromptParts => {
-    // Extract the inline skill tokens carried in the value and resolve each
-    // name to its SKILL.md path. Paths come from `skillPathsRef` (captured at
-    // pick time) first, then fall back to the currently-available skills list
-    // — so editing + re-sending a chip message (where the ref is empty
-    // because paths aren't persisted with the message) still resolves paths
-    // from the live skills list. A skill surfaced without a path in either
-    // (e.g. a future web skill with no parity route) blocks the send — HALT
-    // with a clear error so the user can remove the chip.
-    const skillNames = extractSkillNames(value)
+    // Extract ALL command tokens (send-time guard). A corrupted/pasted value
+    // could carry 2+ `\uE004…\uE005` tokens (paste bypasses the single-command
+    // invariant enforced at insert time). The first name sources the
+    // `/<name> ` wire prefix; ALL tokens are stripped from `wireText` so no
+    // sentinel leaks to the agent (extras are silently dropped — graceful
+    // degradation, never a crash).
+    const commandNames = extractCommandNames(value)
+    const commandName = commandNames[0] ?? null
+    const valueDecommanded = commandNames.length > 0 ? stripAllCommandTokens(value) : value
+    // Extract the inline skill tokens carried in the (de-commanded) value and
+    // resolve each name to its SKILL.md path. Paths come from `skillPathsRef`
+    // (captured at pick time) first, then fall back to the currently-available
+    // skills list — so editing + re-sending a chip message (where the ref is
+    // empty because paths aren't persisted with the message) still resolves
+    // paths from the live skills list. A skill surfaced without a path in
+    // either (e.g. a future web skill with no parity route) blocks the send —
+    // HALT with a clear error so the user can remove the chip.
+    const skillNames = extractSkillNames(valueDecommanded)
     const resolvedSkills = skillNames.map((name) => ({
       name,
       path: skillPathsRef.current[name] ?? skills.find((s) => s.name === name)?.path ?? ''
@@ -322,10 +361,10 @@ export function useChatComposer(args: UseChatComposerArgs): UseChatComposerResul
       throw new Error(`Skill '${missingPath.name}' is missing a path`)
     }
     const hasSkills = resolvedSkills.length > 0
-    const wireText = buildPromptWithLoadedSkills(resolvedSkills, value)
-    const displayText = value
-    const wireWithCommand = activeCommand ? `/${activeCommand} ${wireText}` : wireText
-    const displayWithCommand = activeCommand ? `/${activeCommand} ${displayText}` : displayText
+    const wireText = buildPromptWithLoadedSkills(resolvedSkills, valueDecommanded)
+    const displayText = valueDecommanded
+    const wireWithCommand = commandName ? `/${commandName} ${wireText}` : wireText
+    const displayWithCommand = commandName ? `/${commandName} ${displayText}` : displayText
     return {
       skills: resolvedSkills,
       hasSkills,
@@ -336,14 +375,12 @@ export function useChatComposer(args: UseChatComposerArgs): UseChatComposerResul
       wireTrimmed: wireWithCommand.trim(),
       displayTrimmed: displayWithCommand.trim()
     }
-  }, [value, skills, activeCommand])
+  }, [value, skills])
 
   return {
     slashOpen,
     slashSections,
-    activeCommand,
-    setActiveCommand,
-    clearActiveCommand,
+    hasCommandToken,
     skillPathsRef,
     hasSkillToken,
     handleSelect,

--- a/src/renderer/lib/__tests__/composer-wire-snapshot.test.ts
+++ b/src/renderer/lib/__tests__/composer-wire-snapshot.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it } from 'vitest'
 import { buildPromptWithLoadedSkills } from '@/hooks/use-agent-skills'
-import { skillToken } from '@/lib/skill-tokens'
+import {
+  commandToken,
+  extractCommandName,
+  insertCommandToken,
+  skillToken,
+  stripCommandToken
+} from '@/lib/skill-tokens'
 
 /**
  * Wire-format regression fence for the chat-composer modular redesign.
@@ -134,5 +140,108 @@ describe('composer wire snapshots', () => {
         prefix text (release-version) suffix"
       `
     )
+  })
+})
+
+/**
+ * Command-pill wire snapshots (CAP — Inline command pill). The inline
+ * `\uE004<name>\uE005` token replaces the removed `activeCommand` state. At
+ * send, `buildPromptParts` calls `extractCommandName(value)` →
+ * `wireWithCommand = \`/${name} ${wireText}\`` (byte-identical to the old
+ * `activeCommand` path). The token is stripped from `wireText` (the skill wire
+ * framer receives the de-commanded text).
+ */
+describe('composer wire snapshots — command pill', () => {
+  const CT = (name: string): string => commandToken(name)
+
+  it('extractCommandName reads the command name from the token', () => {
+    expect(extractCommandName(CT('compact'))).toBe('compact')
+    expect(extractCommandName(`hello ${CT('clear')} world`)).toBe('clear')
+    expect(extractCommandName('no command here')).toBeNull()
+    // Malformed (no close) — treated as absent.
+    expect(extractCommandName('\uE004compact without close')).toBeNull()
+  })
+
+  it('stripCommandToken removes the token + trailing space (de-commanded wire text)', () => {
+    expect(stripCommandToken(`${CT('compact')} `)).toBe('')
+    expect(stripCommandToken(`${CT('compact')} hello`)).toBe('hello')
+    expect(stripCommandToken(`prefix ${CT('compact')} suffix`)).toBe('prefix suffix')
+    // No token → unchanged.
+    expect(stripCommandToken('no command')).toBe('no command')
+  })
+
+  it('insertCommandToken rejects a second command (single-command invariant)', () => {
+    const first = insertCommandToken('/', 1, 'compact', 1)
+    expect(first.inserted).toBe(true)
+    if (first.inserted) {
+      expect(first.value).toBe(`${CT('compact')} `)
+    }
+    // A second command token is rejected.
+    const second = insertCommandToken(first.inserted ? first.value : '', 5, 'clear', 0)
+    expect(second.inserted).toBe(false)
+    if (!second.inserted) {
+      expect(second.reason).toBe('existing_command')
+    }
+  })
+
+  it('insertCommandToken clamps when deleteBefore > caret (start floors at 0, token prepended)', () => {
+    // When deleteBefore > caret, `start` floors at 0 and `end` = caret. With
+    // caret=0, end=start=0 → nothing deleted, token prepended to full value.
+    const result = insertCommandToken('hello', 0, 'compact', 5)
+    expect(result.inserted).toBe(true)
+    if (result.inserted) {
+      expect(result.value).toBe(`${CT('compact')} hello`)
+      // Caret lands after the token + trailing space.
+      expect(result.caret).toBe(CT('compact').length + 1)
+    }
+
+    // With caret > 0, start floors at 0, end = caret → first `caret` chars
+    // deleted (the clamp caps deleteBefore at caret), token prepended.
+    const result2 = insertCommandToken('hello', 2, 'clear', 10)
+    expect(result2.inserted).toBe(true)
+    if (result2.inserted) {
+      // The first 2 chars ("he") are deleted; the token is prepended to "llo".
+      expect(result2.value).toBe(`${CT('clear')} llo`)
+      expect(result2.caret).toBe(CT('clear').length + 1)
+    }
+  })
+
+  it('byte-identical wire: command pill + text → `/<name> <text>` (matches old activeCommand path)', () => {
+    // The value carries the command token + user text. buildPromptParts strips
+    // the token, builds the skill wire (none here), then prefixes `/<name> `.
+    const value = `${CT('compact')} hello`
+    const commandName = extractCommandName(value)
+    const valueDecommanded = stripCommandToken(value)
+    const wireText = buildPromptWithLoadedSkills([], valueDecommanded)
+    const wireWithCommand = commandName ? `/${commandName} ${wireText}` : wireText
+    expect(wireWithCommand).toBe('/compact hello')
+  })
+
+  it('byte-identical wire: command pill + skill pill (command prefix + skill framing)', () => {
+    const value = `${CT('compact')} ${T('git-worktree')} do the thing`
+    const commandName = extractCommandName(value)
+    const valueDecommanded = stripCommandToken(value)
+    const wireText = buildPromptWithLoadedSkills([SKILL_GIT], valueDecommanded)
+    const wireWithCommand = commandName ? `/${commandName} ${wireText}` : wireText
+    expect(wireWithCommand).toMatchInlineSnapshot(
+      `
+        "/compact # Agent Skills
+
+        git-worktree: /home/u/.agents/skills/git-worktree/SKILL.md
+
+        ---
+
+        (git-worktree) do the thing"
+      `
+    )
+  })
+
+  it('byte-identical wire: command pill alone (no user text) → `/<name>`', () => {
+    const value = `${CT('compact')} `
+    const commandName = extractCommandName(value)
+    const valueDecommanded = stripCommandToken(value)
+    const wireText = buildPromptWithLoadedSkills([], valueDecommanded)
+    const wireWithCommand = commandName ? `/${commandName} ${wireText}`.trim() : wireText
+    expect(wireWithCommand).toBe('/compact')
   })
 })

--- a/src/renderer/lib/__tests__/parity-checklist.test.ts
+++ b/src/renderer/lib/__tests__/parity-checklist.test.ts
@@ -1003,4 +1003,161 @@ describe('Parity Checklist Automation', () => {
       expect(content).not.toMatch(/const\s+INITIAL_PATH\s*=/)
     })
   })
+
+  // CAP — Web worktree parity. The 7 launch-flow worktree ops ship on THREE
+  // transports (Tauri command `worktree_*`, HTTP `/worktree/*` route, facade
+  // branch `isTauriContext()` between `invoke(...)` and `webServerWorktree`).
+  // This block pins the TS-side parity (the Rust-side parity — router routes +
+  // Tauri command registration + `web/worktree_api.rs` — is covered by the Rust
+  // test suite). The 8 advanced ops stay `WEB_UNSUPPORTED` on web (deferred).
+  describe('Worktree parity (CAP — Web worktree parity)', () => {
+    const Facade = join(LIB_DIR, 'worktree-api.ts')
+    const WebAdapter = join(LIB_DIR, 'web-server-api.ts')
+    const RouterRust = join(LIB_DIR, '..', '..', '..', 'src-tauri', 'src', 'web', 'router.rs')
+    const WorktreeApiRust = join(
+      LIB_DIR,
+      '..',
+      '..',
+      '..',
+      'src-tauri',
+      'src',
+      'web',
+      'worktree_api.rs'
+    )
+    const CommandsRust = join(LIB_DIR, '..', '..', '..', 'src-tauri', 'src', 'commands.rs')
+
+    const LAUNCH_FLOW_METHODS = [
+      'list',
+      'create',
+      'remove',
+      'branches',
+      'checkDirty',
+      'resolveBaseBranch',
+      'copyIncludeFiles'
+    ] as const
+
+    const ADVANCED_METHODS = [
+      'removeAllManaged',
+      'parseGitignore',
+      'createSymlinks',
+      'ensureSymlinks',
+      'archive',
+      'restore',
+      'mergePreview',
+      'mergeExecute'
+    ] as const
+
+    it('worktree-api.ts facade exists and branches on isTauriContext()', () => {
+      expect(existsSync(Facade), 'worktree-api.ts should exist').toBe(true)
+      const content = readFileSync(Facade, 'utf-8')
+      expect(content).toMatch(/isTauriContext\(\)/)
+      expect(content).toMatch(/webServerWorktree/)
+    })
+
+    it('web-server-api.ts exports webServerWorktree hitting the 7 routes', () => {
+      expect(existsSync(WebAdapter), 'web-server-api.ts should exist').toBe(true)
+      const content = readFileSync(WebAdapter, 'utf-8')
+      expect(content).toMatch(/export\s+const\s+\bwebServerWorktree\b/)
+      for (const route of [
+        '/worktree/list',
+        '/worktree/create',
+        '/worktree/remove',
+        '/worktree/branches',
+        '/worktree/check-dirty',
+        '/worktree/resolve-base-branch',
+        '/worktree/copy-include-files'
+      ]) {
+        expect(content, `web-server-api.ts should hit ${route}`).toMatch(
+          new RegExp(route.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'))
+        )
+      }
+      // Network/parse failures must map to `NETWORK_ERROR`.
+      expect(content).toMatch(/NETWORK_ERROR/)
+    })
+
+    it('facade branches the 7 launch-flow methods (invoke on Tauri, webServerWorktree on web)', () => {
+      const content = readFileSync(Facade, 'utf-8')
+      for (const method of LAUNCH_FLOW_METHODS) {
+        expect(content, `worktree-api.ts should branch ${method}`).toMatch(
+          new RegExp(`\\b${method}\\s*\\(`)
+        )
+      }
+      // The 7 launch-flow methods must reference `webServerWorktree` (the web branch).
+      const launchFlowRefs = (content.match(/webServerWorktree\./g) ?? []).length
+      expect(launchFlowRefs, '7 launch-flow methods should reference webServerWorktree').toBe(7)
+    })
+
+    it('facade keeps the 8 advanced methods as WEB_UNSUPPORTED (no webServerWorktree ref)', () => {
+      const content = readFileSync(Facade, 'utf-8')
+      for (const method of ADVANCED_METHODS) {
+        expect(content, `worktree-api.ts should still define ${method}`).toMatch(
+          new RegExp(`\\b${method}\\s*:`)
+        )
+      }
+      // Exactly 7 webServerWorktree refs (not 8) — the advanced methods do NOT branch.
+      const launchFlowRefs = (content.match(/webServerWorktree\./g) ?? []).length
+      expect(launchFlowRefs).toBe(7)
+    })
+
+    it('router.rs registers the 7 /worktree/* routes ahead of the static fallback', () => {
+      expect(existsSync(RouterRust), 'router.rs should exist').toBe(true)
+      const content = readFileSync(RouterRust, 'utf-8')
+      for (const route of [
+        '/worktree/list',
+        '/worktree/create',
+        '/worktree/remove',
+        '/worktree/branches',
+        '/worktree/check-dirty',
+        '/worktree/resolve-base-branch',
+        '/worktree/copy-include-files'
+      ]) {
+        expect(content, `router.rs should register ${route}`).toMatch(
+          new RegExp(route.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'))
+        )
+      }
+    })
+
+    it('worktree_api.rs exists and defines the 7 Axum handlers', () => {
+      expect(existsSync(WorktreeApiRust), 'worktree_api.rs should exist').toBe(true)
+      const content = readFileSync(WorktreeApiRust, 'utf-8')
+      for (const handler of [
+        'pub async fn list',
+        'pub async fn create',
+        'pub async fn remove',
+        'pub async fn branches',
+        'pub async fn check_dirty',
+        'pub async fn resolve_base_branch',
+        'pub async fn copy_include_files'
+      ]) {
+        expect(content, `worktree_api.rs should define ${handler}`).toMatch(
+          new RegExp(handler.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'))
+        )
+      }
+      // IpcBody contract + spawn_blocking + tracing logs.
+      expect(content).toMatch(/IpcBody/)
+      expect(content).toMatch(/spawn_blocking/)
+      expect(content).toMatch(/tracing/)
+      // Loopback guard on write routes + containment on all routes.
+      expect(content).toMatch(/check_local_only/)
+      expect(content).toMatch(/ensure_within_project_boundary/)
+    })
+
+    it('commands.rs defines the 7 desktop Tauri commands (worktree_*)', () => {
+      expect(existsSync(CommandsRust), 'commands.rs should exist').toBe(true)
+      const content = readFileSync(CommandsRust, 'utf-8')
+      for (const cmd of [
+        'worktree_list',
+        'worktree_create',
+        'worktree_remove',
+        'worktree_branches',
+        'worktree_check_dirty',
+        'worktree_resolve_base_branch',
+        'worktree_copy_include_files'
+      ]) {
+        expect(content, `commands.rs should define ${cmd}`).toMatch(
+          new RegExp(`\\b${cmd.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\b`)
+        )
+      }
+    })
+  })
 })

--- a/src/renderer/lib/__tests__/worktree-api.web.test.ts
+++ b/src/renderer/lib/__tests__/worktree-api.web.test.ts
@@ -1,18 +1,24 @@
 /**
  * Web-branch tests for worktree-api.ts.
  *
- * Pins `isTauriContext()` to FALSE and asserts the worktree facade returns an
- * explicit `WEB_UNSUPPORTED` result for representative methods (list, create,
- * remove, checkDirty) instead of letting the stubbed `invoke()` reject with
- * `tauriUnavailable`. Worktree mutation is desktop-only until a separate
- * product/security decision.
+ * CAP — Web worktree parity: the 7 launch-flow methods (list, create, remove,
+ * branches, checkDirty, resolveBaseBranch, copyIncludeFiles) now branch to
+ * `webServerWorktree` (HTTP routes in `web/worktree_api.rs`) when
+ * `!isTauriContext()`. The 8 advanced ops (symlinks, parseGitignore, merge,
+ * archive/restore, removeAllManaged) STAY `WEB_UNSUPPORTED` on web (deferred —
+ * see deferred-work.md).
+ *
+ * Pins `isTauriContext()` to FALSE and asserts:
+ * - The 7 launch-flow methods call `fetch` (HTTP), NOT `invoke`.
+ * - The 8 advanced methods still return `WEB_UNSUPPORTED`.
  */
 
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-const { mockIsTauriContext, mockInvoke } = vi.hoisted(() => ({
+const { mockIsTauriContext, mockInvoke, mockFetch } = vi.hoisted(() => ({
   mockIsTauriContext: vi.fn(),
-  mockInvoke: vi.fn()
+  mockInvoke: vi.fn(),
+  mockFetch: vi.fn()
 }))
 
 vi.mock('../tauri-runtime', () => ({
@@ -23,58 +29,255 @@ vi.mock('@tauri-apps/api/core', () => ({
   invoke: mockInvoke
 }))
 
+// Stub `fetch` so the web branch hits the mock without a real network call.
+// The `web-server-api.ts` `postJson`/`getJson` helpers call `fetch(`${serverBase()}${path}`)`.
+// In jsdom (no `window.location.origin` for a real server), `serverBase()` returns
+// the empty string, so the path is relative — `fetch('/worktree/list')` resolves
+// against jsdom's `http://localhost/` origin. The mock captures the call + returns
+// a JSON `IpcBody` so `parseBody` succeeds.
+vi.stubGlobal('fetch', mockFetch)
+
 import { worktreeApi } from '../worktree-api'
 
-describe('worktreeApi (web branch)', () => {
+/** Build a fetch Response that resolves to the given `IpcBody` JSON. */
+function okResponse(body: unknown): Response {
+  return {
+    ok: true,
+    status: 200,
+    json: async () => body
+  } as Response
+}
+
+describe('worktreeApi (web branch) — 7 launch-flow methods hit HTTP', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     mockIsTauriContext.mockReturnValue(false)
     mockInvoke.mockReset()
+    mockFetch.mockReset()
   })
 
-  it('list returns WEB_UNSUPPORTED when !isTauriContext()', async () => {
+  it('list hits HTTP (not invoke) when !isTauriContext()', async () => {
+    mockFetch.mockResolvedValue(
+      okResponse({
+        success: true,
+        data: [{ name: 'main', branch: 'main', path: '/p', headCommit: '' }]
+      })
+    )
+    const result = await worktreeApi.list('/project')
+
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data).toHaveLength(1)
+    }
+    expect(mockFetch).toHaveBeenCalledTimes(1)
+    const [url, init] = mockFetch.mock.calls[0]!
+    expect(String(url)).toContain('/worktree/list')
+    expect((init as RequestInit).method).toBe('POST')
+    expect(mockInvoke).not.toHaveBeenCalled()
+  })
+
+  it('create hits HTTP with the params body when !isTauriContext()', async () => {
+    mockFetch.mockResolvedValue(
+      okResponse({
+        success: true,
+        data: { name: 'wt', branch: 'chat/wt', path: '/p/wt', headCommit: '' }
+      })
+    )
+    const result = await worktreeApi.create({
+      projectPath: '/project',
+      name: 'wt',
+      branch: 'chat/wt',
+      isNewBranch: true
+    })
+
+    expect(result.success).toBe(true)
+    expect(mockFetch).toHaveBeenCalledTimes(1)
+    const [url, init] = mockFetch.mock.calls[0]!
+    expect(String(url)).toContain('/worktree/create')
+    const body = JSON.parse((init as RequestInit).body as string)
+    expect(body.projectPath).toBe('/project')
+    expect(body.branch).toBe('chat/wt')
+    expect(body.isNewBranch).toBe(true)
+    expect(mockInvoke).not.toHaveBeenCalled()
+  })
+
+  it('remove hits HTTP with projectPath + worktreePath + force when !isTauriContext()', async () => {
+    mockFetch.mockResolvedValue(okResponse({ success: true, data: null }))
+    const result = await worktreeApi.remove('/project', '/wt', true)
+
+    expect(result.success).toBe(true)
+    expect(mockFetch).toHaveBeenCalledTimes(1)
+    const [url, init] = mockFetch.mock.calls[0]!
+    expect(String(url)).toContain('/worktree/remove')
+    const body = JSON.parse((init as RequestInit).body as string)
+    expect(body.worktreePath).toBe('/wt')
+    expect(body.force).toBe(true)
+    expect(mockInvoke).not.toHaveBeenCalled()
+  })
+
+  it('branches hits HTTP GET when !isTauriContext()', async () => {
+    mockFetch.mockResolvedValue(
+      okResponse({
+        success: true,
+        data: [{ name: 'main', isRemote: false, isCurrent: true, hasOtherWorktree: false }]
+      })
+    )
+    const result = await worktreeApi.branches('/project')
+
+    expect(result.success).toBe(true)
+    expect(mockFetch).toHaveBeenCalledTimes(1)
+    const [url, init] = mockFetch.mock.calls[0]!
+    expect(String(url)).toContain('/worktree/branches')
+    expect(String(url)).toContain(encodeURIComponent('/project'))
+    expect((init as RequestInit).method).toBe('GET')
+    expect(mockInvoke).not.toHaveBeenCalled()
+  })
+
+  it('checkDirty hits HTTP GET with worktreePath query when !isTauriContext()', async () => {
+    mockFetch.mockResolvedValue(
+      okResponse({
+        success: true,
+        data: { modified: 0, staged: 0, untracked: 0, hasChanges: false }
+      })
+    )
+    const result = await worktreeApi.checkDirty('/wt')
+
+    expect(result.success).toBe(true)
+    expect(mockFetch).toHaveBeenCalledTimes(1)
+    const [url, init] = mockFetch.mock.calls[0]!
+    expect(String(url)).toContain('/worktree/check-dirty')
+    expect(String(url)).toContain(encodeURIComponent('/wt'))
+    expect((init as RequestInit).method).toBe('GET')
+    expect(mockInvoke).not.toHaveBeenCalled()
+  })
+
+  it('resolveBaseBranch hits HTTP POST when !isTauriContext()', async () => {
+    mockFetch.mockResolvedValue(
+      okResponse({
+        success: true,
+        data: { defaultBase: 'main', currentBranch: 'main', isDetached: false }
+      })
+    )
+    const result = await worktreeApi.resolveBaseBranch('/project')
+
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data.defaultBase).toBe('main')
+    }
+    expect(mockFetch).toHaveBeenCalledTimes(1)
+    const [url, init] = mockFetch.mock.calls[0]!
+    expect(String(url)).toContain('/worktree/resolve-base-branch')
+    expect((init as RequestInit).method).toBe('POST')
+    expect(mockInvoke).not.toHaveBeenCalled()
+  })
+
+  it('copyIncludeFiles hits HTTP with projectPath + worktreePath when !isTauriContext()', async () => {
+    mockFetch.mockResolvedValue(
+      okResponse({ success: true, data: { ran: 0, copied: 0, skipped: [] } })
+    )
+    const result = await worktreeApi.copyIncludeFiles('/project', '/wt')
+
+    expect(result.success).toBe(true)
+    expect(mockFetch).toHaveBeenCalledTimes(1)
+    const [url, init] = mockFetch.mock.calls[0]!
+    expect(String(url)).toContain('/worktree/copy-include-files')
+    const body = JSON.parse((init as RequestInit).body as string)
+    expect(body.projectPath).toBe('/project')
+    expect(body.worktreePath).toBe('/wt')
+    expect(mockInvoke).not.toHaveBeenCalled()
+  })
+
+  it('HTTP transport failure maps to NETWORK_ERROR', async () => {
+    mockFetch.mockRejectedValue(new Error('network down'))
     const result = await worktreeApi.list('/project')
 
     expect(result.success).toBe(false)
     if (!result.success) {
-      expect(result.code).toBe('WEB_UNSUPPORTED')
-      expect(result.error).toContain('not available')
+      expect(result.code).toBe('NETWORK_ERROR')
+      expect(result.error).toContain('network down')
     }
     expect(mockInvoke).not.toHaveBeenCalled()
   })
+})
 
-  it('create returns WEB_UNSUPPORTED when !isTauriContext()', async () => {
-    const result = await worktreeApi.create({
-      projectPath: '/project',
-      name: 'wt-1',
-      branch: 'main',
-      isNewBranch: true
-    })
+describe('worktreeApi (web branch) — 8 advanced ops stay WEB_UNSUPPORTED', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockIsTauriContext.mockReturnValue(false)
+    mockInvoke.mockReset()
+    mockFetch.mockReset()
+  })
 
+  it('removeAllManaged returns WEB_UNSUPPORTED when !isTauriContext()', async () => {
+    const result = await worktreeApi.removeAllManaged('/project', [])
     expect(result.success).toBe(false)
     if (!result.success) {
       expect(result.code).toBe('WEB_UNSUPPORTED')
     }
     expect(mockInvoke).not.toHaveBeenCalled()
+    expect(mockFetch).not.toHaveBeenCalled()
   })
 
-  it('remove returns WEB_UNSUPPORTED when !isTauriContext()', async () => {
-    const result = await worktreeApi.remove('/project', '/wt', false)
-
+  it('parseGitignore returns WEB_UNSUPPORTED when !isTauriContext()', async () => {
+    const result = await worktreeApi.parseGitignore('/project')
     expect(result.success).toBe(false)
     if (!result.success) {
       expect(result.code).toBe('WEB_UNSUPPORTED')
     }
-    expect(mockInvoke).not.toHaveBeenCalled()
+    expect(mockFetch).not.toHaveBeenCalled()
   })
 
-  it('checkDirty returns WEB_UNSUPPORTED when !isTauriContext()', async () => {
-    const result = await worktreeApi.checkDirty('/wt')
-
+  it('createSymlinks returns WEB_UNSUPPORTED when !isTauriContext()', async () => {
+    const result = await worktreeApi.createSymlinks('/project', '/wt', ['node_modules'])
     expect(result.success).toBe(false)
     if (!result.success) {
       expect(result.code).toBe('WEB_UNSUPPORTED')
     }
-    expect(mockInvoke).not.toHaveBeenCalled()
+    expect(mockFetch).not.toHaveBeenCalled()
+  })
+
+  it('ensureSymlinks returns WEB_UNSUPPORTED when !isTauriContext()', async () => {
+    const result = await worktreeApi.ensureSymlinks('/project', '/wt', ['node_modules'])
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.code).toBe('WEB_UNSUPPORTED')
+    }
+    expect(mockFetch).not.toHaveBeenCalled()
+  })
+
+  it('archive returns WEB_UNSUPPORTED when !isTauriContext()', async () => {
+    const result = await worktreeApi.archive('/project', '/wt')
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.code).toBe('WEB_UNSUPPORTED')
+    }
+    expect(mockFetch).not.toHaveBeenCalled()
+  })
+
+  it('restore returns WEB_UNSUPPORTED when !isTauriContext()', async () => {
+    const result = await worktreeApi.restore('/project', '/archive')
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.code).toBe('WEB_UNSUPPORTED')
+    }
+    expect(mockFetch).not.toHaveBeenCalled()
+  })
+
+  it('mergePreview returns WEB_UNSUPPORTED when !isTauriContext()', async () => {
+    const result = await worktreeApi.mergePreview('/wt', 'main')
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.code).toBe('WEB_UNSUPPORTED')
+    }
+    expect(mockFetch).not.toHaveBeenCalled()
+  })
+
+  it('mergeExecute returns WEB_UNSUPPORTED when !isTauriContext()', async () => {
+    const result = await worktreeApi.mergeExecute('/wt', 'main')
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.code).toBe('WEB_UNSUPPORTED')
+    }
+    expect(mockFetch).not.toHaveBeenCalled()
   })
 })

--- a/src/renderer/lib/composer/__tests__/draft-from-tokens.test.ts
+++ b/src/renderer/lib/composer/__tests__/draft-from-tokens.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from 'vitest'
-import { SKILL_PILL_NODE } from '@/lib/composer/doc-to-prompt'
+import { CMD_PILL_NODE, SKILL_PILL_NODE } from '@/lib/composer/doc-to-prompt'
 import { draftFromTokens } from '@/lib/composer/draft-from-tokens'
 import {
+  CMD_TOKEN_END,
+  CMD_TOKEN_START,
   SKILL_PAD_END,
   SKILL_PAD_START,
   SKILL_TOKEN_END,
@@ -9,6 +11,7 @@ import {
 } from '@/lib/skill-tokens'
 
 const pill = (name: string, path = '') => ({ type: SKILL_PILL_NODE, attrs: { name, path } })
+const cmdPill = (name: string) => ({ type: CMD_PILL_NODE, attrs: { name } })
 const text = (t: string) => ({ type: 'text', text: t })
 const para = (content?: unknown[]) => ({ type: 'paragraph', content })
 
@@ -116,5 +119,38 @@ describe('draftFromTokens', () => {
     const doc = draftFromTokens(garbage)
     expect(doc.content).toHaveLength(1)
     expect(doc.content[0].content).toEqual([text(garbage)])
+  })
+
+  // ----- Command pill (CAP — Inline command pill) -----
+
+  it('parses a command sentinel token into a commandPill node', () => {
+    const value = `${CMD_TOKEN_START}compact${CMD_TOKEN_END}`
+    expect(draftFromTokens(value)).toEqual({
+      type: 'doc',
+      content: [para([cmdPill('compact')])]
+    })
+  })
+
+  it('intersperses command pill + text + skill pill (mixed sentinels)', () => {
+    const value = `${CMD_TOKEN_START}compact${CMD_TOKEN_END} then ${SKILL_TOKEN_START}acp${SKILL_TOKEN_END} after`
+    expect(draftFromTokens(value)).toEqual({
+      type: 'doc',
+      content: [para([cmdPill('compact'), text(' then '), pill('acp'), text(' after')])]
+    })
+  })
+
+  it('treats a malformed (unclosed) command token as plain text', () => {
+    const value = `${CMD_TOKEN_START}compact without close`
+    const doc = draftFromTokens(value)
+    expect(doc.content).toHaveLength(1)
+    expect(doc.content[0].content).toEqual([text(`${CMD_TOKEN_START}compact without close`)])
+  })
+
+  it('treats an empty-name command token as plain text (no pill)', () => {
+    const value = `${CMD_TOKEN_START}${CMD_TOKEN_END}`
+    const doc = draftFromTokens(value)
+    expect(doc.content).toHaveLength(1)
+    expect(doc.content[0].content).toEqual([text(value)])
+    expect(doc.content[0].content![0].type).toBe('text')
   })
 })

--- a/src/renderer/lib/composer/doc-to-prompt.ts
+++ b/src/renderer/lib/composer/doc-to-prompt.ts
@@ -31,6 +31,8 @@
  */
 import type { Node as PmNode } from '@tiptap/pm/model'
 import {
+  CMD_TOKEN_END,
+  CMD_TOKEN_START,
   SKILL_PAD_CHAR,
   SKILL_PAD_END,
   SKILL_PAD_START,
@@ -45,6 +47,14 @@ import {
 export const SKILL_PILL_NODE = 'skillPill'
 
 /**
+ * The command-pill node type name (CAP — Inline command pill). Kept in one
+ * place so the (de)serializers and the `CommandPill` extension agree. Distinct
+ * from `SKILL_PILL_NODE` so the serializer emits the command sentinel pair
+ * (`\uE004/\uE005`) — invisible to `parseSkillSegments` (skill-only).
+ */
+export const CMD_PILL_NODE = 'commandPill'
+
+/**
  * The fixed padding run re-emitted after every pill token to preserve the
  * on-disk draft schema (`\uE002..\uE003`). A single FIGURE SPACE (U+2007) — the
  * content is not load-bearing (the pill is a real DOM node, so the padding no
@@ -55,9 +65,10 @@ export const SKILL_PILL_NODE = 'skillPill'
 export const SKILL_PAD_DEFAULT = SKILL_PAD_CHAR
 
 export interface DocSegment {
-  kind: 'text' | 'pill'
+  kind: 'text' | 'pill' | 'commandPill'
   /** Visible text for a `text` segment; the padded token (`\uE000<name>\uE001\uE002<pad>\uE003`)
-   * for a `pill` segment. */
+   * for a `pill` segment; the command token (`\uE004<name>\uE005`) for a
+   * `commandPill` segment. */
   text: string
   /** Doc position at the start of this segment. */
   docFrom: number
@@ -76,7 +87,8 @@ export interface DocSegment {
  * boundary `\n` is suppressed when the previous paragraph's last inline child
  * was a `hardBreak` (a paragraph ending in hardBreak + next paragraph would
  * otherwise yield `\n\n` where the pre-refactor textarea produced a single
- * `\n`). Pills emit the padded token form (see {@link SKILL_PAD_DEFAULT}).
+ * `\n`). Pills emit the padded token form (see {@link SKILL_PAD_DEFAULT});
+ * command pills emit the command token (`\uE004<name>\uE005`, no padding).
  *
  * ProseMirror positions: a top-level block at `offset` (from `doc.forEach`)
  * occupies doc pos `[offset, offset + nodeSize)`; its inline children start at
@@ -94,7 +106,7 @@ export function walkDocSegments(doc: PmNode): DocSegment[] {
       block.forEach((node, offset) => {
         const docFrom = blockOffset + 1 + offset
         let displayText = ''
-        let kind: 'text' | 'pill' = 'text'
+        let kind: 'text' | 'pill' | 'commandPill' = 'text'
         if (node.isText) {
           displayText = node.text ?? ''
           blockEndedInHardBreak = false
@@ -105,6 +117,15 @@ export function walkDocSegments(doc: PmNode): DocSegment[] {
           // fixed single figure-space; only the presence is load-bearing.
           displayText = `${SKILL_TOKEN_START}${name}${SKILL_TOKEN_END}${SKILL_PAD_START}${SKILL_PAD_DEFAULT}${SKILL_PAD_END}`
           kind = 'pill'
+          blockEndedInHardBreak = false
+        } else if (node.type.name === CMD_PILL_NODE) {
+          const name = String(node.attrs.name ?? '')
+          // Command pill: no padding block (the pill is a real DOM node, so
+          // there is no caret-alignment deficit to compensate). The sentinel
+          // pair is distinct from the skill sentinels so the skill wire framer
+          // / timeline renderer never see command tokens.
+          displayText = `${CMD_TOKEN_START}${name}${CMD_TOKEN_END}`
+          kind = 'commandPill'
           blockEndedInHardBreak = false
         } else if (node.type.name === 'hardBreak') {
           displayText = '\n'
@@ -177,7 +198,7 @@ export function docOffsetToDisplayOffset(doc: PmNode, docOffset: number): number
   for (const seg of segments) {
     if (docOffset < seg.docTo) {
       if (docOffset <= seg.docFrom) return seg.displayFrom
-      if (seg.kind === 'pill') return seg.displayFrom
+      if (seg.kind === 'pill' || seg.kind === 'commandPill') return seg.displayFrom
       return seg.displayFrom + (docOffset - seg.docFrom)
     }
   }
@@ -206,7 +227,7 @@ export function displayOffsetToDocOffset(doc: PmNode, displayOffset: number): nu
       // the display newline belongs at the end of the preceding paragraph.
       if (seg.docFrom === seg.docTo) return Math.max(0, seg.docFrom - 1)
       if (displayOffset <= seg.displayFrom) return seg.docFrom
-      if (seg.kind === 'pill') return seg.docTo
+      if (seg.kind === 'pill' || seg.kind === 'commandPill') return seg.docTo
       return seg.docFrom + (displayOffset - seg.displayFrom)
     }
   }

--- a/src/renderer/lib/composer/draft-from-tokens.ts
+++ b/src/renderer/lib/composer/draft-from-tokens.ts
@@ -2,18 +2,19 @@
  * Parse a saved draft / seeded display string (sentinel-token format) into a
  * ProseMirror doc JSON that the Tiptap editor can `setContent`. The inverse of
  * {@link docToDisplayText}: each `\uE000<name>\uE001` token becomes an inline
- * `skillPill` node; plain text becomes text nodes; `\n` splits the doc into
+ * `skillPill` node; each `\uE004<name>\uE005` token becomes an inline
+ * `commandPill` node; plain text becomes text nodes; `\n` splits the doc into
  * paragraphs (matching the pre-refactor textarea, where Enter produced a `\n`).
  *
  * The optional padding block (`\uE002<pad>\uE003`) is consumed into the pill
- * segment by `parseSkillSegments` but NOT emitted as a node — the pill is a
- * real DOM node now, so the padding is obsolete. Malformed tokens (no closing
+ * segment by `parseComposerSegments` but NOT emitted as a node — the pill is
+ * a real DOM node now, so the padding is obsolete. Malformed tokens (no closing
  * sentinel, empty name) fall back to plain text so a corrupted draft never
  * crashes the editor. Unparseable segments become plain text (the spec's
  * "Resume draft" fallback: a draft always loads, even if partially garbled).
  */
-import { parseSkillSegments } from '@/lib/skill-tokens'
-import { SKILL_PILL_NODE } from './doc-to-prompt'
+import { CMD_TOKEN_END, CMD_TOKEN_START, parseSkillSegments } from '@/lib/skill-tokens'
+import { CMD_PILL_NODE, SKILL_PILL_NODE } from './doc-to-prompt'
 
 interface PmDocJSON {
   type: 'doc'
@@ -27,19 +28,92 @@ interface InlineNode {
 }
 
 /**
+ * A run of plain text, a skill token, or a command token extracted from the
+ * value. The combined parser delegates the skill-token walk (including the
+ * optional padding block) to `parseSkillSegments` from `skill-tokens` (the
+ * single source of truth for the skill walk), then walks the resulting text
+ * segments for command tokens (`\uE004<name>\uE005`, no padding block). This
+ * keeps one implementation of the skill-token walk — `parseComposerSegments`
+ * does not re-implement it.
+ */
+type ComposerSegment =
+  | { kind: 'text'; text: string }
+  | { kind: 'skill'; name: string }
+  | { kind: 'command'; name: string }
+
+/**
+ * Split a composer value into ordered text/skill/command segments. Delegates
+ * the skill-token walk (including the optional `\uE002<pad>\uE003` padding
+ * block) to {@link parseSkillSegments} — the single source of truth for the
+ * skill walk — then walks each text segment for command tokens
+ * (`\uE004<name>\uE005`, no padding block). Malformed command tokens (no
+ * closing sentinel, empty name) are treated as plain text so a corrupted value
+ * never crashes the editor. The skill walker already handles malformed skill
+ * tokens the same way.
+ */
+function parseComposerSegments(value: string): ComposerSegment[] {
+  // Delegate to `parseSkillSegments` for the skill-token walk (it handles
+  // \uE000..\uE001 + the optional \uE002..\uE003 padding block). Command
+  // tokens (\uE004..\uE005) are not skill sentinels, so `parseSkillSegments`
+  // treats them as plain text — they land inside the text segments, which we
+  // walk below.
+  const skillSegments = parseSkillSegments(value)
+  const segments: ComposerSegment[] = []
+  for (const seg of skillSegments) {
+    if (seg.kind === 'skill') {
+      segments.push({ kind: 'skill', name: seg.name })
+      continue
+    }
+    // Text segment: walk for command tokens (\uE004<name>\uE005). Command
+    // tokens carry no padding block (the command pill is a real DOM node).
+    let i = 0
+    let text = ''
+    while (i < seg.text.length) {
+      if (seg.text[i] === CMD_TOKEN_START) {
+        const end = seg.text.indexOf(CMD_TOKEN_END, i + 1)
+        if (end === -1) {
+          // No closing sentinel — treat the rest as plain text.
+          text += seg.text.slice(i)
+          break
+        }
+        const name = seg.text.slice(i + 1, end)
+        if (name.length === 0) {
+          // Empty token name — treat the sentinels as plain text.
+          text += seg.text.slice(i, end + 1)
+          i = end + 1
+          continue
+        }
+        if (text.length > 0) {
+          segments.push({ kind: 'text', text })
+          text = ''
+        }
+        segments.push({ kind: 'command', name })
+        i = end + 1
+      } else {
+        text += seg.text[i]
+        i += 1
+      }
+    }
+    if (text.length > 0) segments.push({ kind: 'text', text })
+  }
+  return segments
+}
+
+/**
  * Convert a sentinel-token display string into a Tiptap/ProseMirror doc JSON.
  * Pills become `skillPill` nodes carrying `name` + `path` attrs (`path` defaults
  * to `''`; the wire builder resolves paths from `skillPathsRef` at send time, so
- * the doc's `path` attr is a convenience, not load-bearing). Empty/whitespace
- * text segments are skipped (ProseMirror disallows empty text nodes in the
- * schema used by StarterKit).
+ * the doc's `path` attr is a convenience, not load-bearing). Command tokens
+ * become `commandPill` nodes carrying `name`. Empty/whitespace text segments
+ * are skipped (ProseMirror disallows empty text nodes in the schema used by
+ * StarterKit).
  */
 export function draftFromTokens(
   value: string,
   /** Optional name→path map to seed pill node `path` attrs (purely informational). */
   paths?: Record<string, string>
 ): PmDocJSON {
-  const segments = parseSkillSegments(value)
+  const segments = parseComposerSegments(value)
   // Split into paragraph lines on explicit `\n` boundaries in the text
   // segments. Each line becomes a `paragraph` whose inline content is the
   // concatenation of the (split) segments within that line.
@@ -49,6 +123,13 @@ export function draftFromTokens(
       paragraphs.at(-1)!.push({
         type: SKILL_PILL_NODE,
         attrs: { name: seg.name, path: paths?.[seg.name] ?? '' }
+      })
+      continue
+    }
+    if (seg.kind === 'command') {
+      paragraphs.at(-1)!.push({
+        type: CMD_PILL_NODE,
+        attrs: { name: seg.name }
       })
       continue
     }

--- a/src/renderer/lib/skill-tokens.ts
+++ b/src/renderer/lib/skill-tokens.ts
@@ -54,6 +54,20 @@ export const SKILL_PAD_END = '\uE003'
  */
 export const SKILL_PAD_CHAR = '\u2007'
 
+/**
+ * Inline command-pill sentinels (CAP — Inline command pill). Distinct from the
+ * skill sentinels (`\uE000/\uE001`) so `parseSkillSegments` is untouched —
+ * command tokens are invisible to the skill wire framer, the timeline
+ * user-bubble renderer, and `extractSkillNames`. The command pill is a real
+ * inline DOM node (a Tiptap `NodeView`), so — like the skill pill — there is
+ * no caret-alignment deficit to compensate: no padding block, no figure-space
+ * run. `buildPromptParts` calls `extractCommandName(value)` at send time and
+ * prefixes `/<name> ` to the wire text (byte-identical to the pre-refactor
+ * `activeCommand` state path).
+ */
+export const CMD_TOKEN_START = '\uE004'
+export const CMD_TOKEN_END = '\uE005'
+
 /** A run of plain text or a single skill token extracted from the value. */
 export type SkillSegment =
   | { kind: 'text'; text: string }
@@ -231,4 +245,181 @@ export function extractSkillNames(value: string): string[] {
     }
   }
   return names
+}
+
+// ============================================================================
+// Inline command-pill token model (CAP — Inline command pill)
+// ============================================================================
+
+/**
+ * Build a command token string for the given command name. No padding block —
+ * the command pill is a real inline DOM node (a Tiptap `NodeView`), so there is
+ * no caret-alignment deficit to compensate. The sentinel pair is distinct from
+ * the skill sentinels so `parseSkillSegments` (and the skill wire framer /
+ * timeline renderer) never see command tokens.
+ */
+export function commandToken(name: string): string {
+  return `${CMD_TOKEN_START}${name}${CMD_TOKEN_END}`
+}
+
+/**
+ * Extract the first command name from the value, or `null` when no command
+ * token is present. Used by `buildPromptParts` to source the `/<name> ` wire
+ * prefix from the inline token instead of the removed `activeCommand` state.
+ * Malformed tokens (start without end, or empty name) are treated as absent
+ * so a corrupted value never blocks the send.
+ */
+export function extractCommandName(value: string): string | null {
+  const start = value.indexOf(CMD_TOKEN_START)
+  if (start === -1) return null
+  const end = value.indexOf(CMD_TOKEN_END, start + 1)
+  if (end === -1) return null
+  const name = value.slice(start + 1, end)
+  return name.length > 0 ? name : null
+}
+
+/**
+ * Extract ALL command names from the value in first-appearance order. Used by
+ * `buildPromptParts` as a send-time guard: a corrupted/pasted value could
+ * carry 2+ `\uE004…\uE005` tokens (the single-command invariant is enforced at
+ * insert time, but paste can bypass it). The wire framer strips ALL command
+ * tokens from `wireText` so no sentinel leaks to the agent; the first name
+ * sources the `/<name> ` prefix (extras are silently dropped — graceful
+ * degradation, never a crash). Malformed tokens (no close, empty name) are
+ * skipped.
+ */
+export function extractCommandNames(value: string): string[] {
+  const names: string[] = []
+  let i = 0
+  while (i < value.length) {
+    if (value[i] === CMD_TOKEN_START) {
+      const end = value.indexOf(CMD_TOKEN_END, i + 1)
+      if (end === -1) break
+      const name = value.slice(i + 1, end)
+      if (name.length > 0) names.push(name)
+      i = end + 1
+    } else {
+      i += 1
+    }
+  }
+  return names
+}
+
+/**
+ * Remove the first command token + its trailing space (if present) from the
+ * value. Used by `buildPromptParts` to strip the command token from the value
+ * before passing it to the skill wire framer (`buildPromptWithLoadedSkills`
+ * receives the de-commanded text so the sentinel never leaks to the agent).
+ * Returns the value unchanged when no command token is present.
+ */
+export function stripCommandToken(value: string): string {
+  const start = value.indexOf(CMD_TOKEN_START)
+  if (start === -1) return value
+  const end = value.indexOf(CMD_TOKEN_END, start + 1)
+  if (end === -1) return value
+  let cursor = end + 1
+  // Swallow the single trailing space the splicer appends so the de-commanded
+  // text doesn't carry a leading space when the token was at the start.
+  if (cursor < value.length && value[cursor] === ' ') cursor += 1
+  return `${value.slice(0, start)}${value.slice(cursor)}`
+}
+
+/**
+ * Remove ALL command tokens (+ each one's trailing space) from the value.
+ * Used by `buildPromptParts` as a send-time guard: a corrupted/pasted value
+ * could carry 2+ `\uE004…\uE005` tokens (paste bypasses the single-command
+ * invariant enforced at insert time). Stripping all ensures no sentinel leaks
+ * into the wire text the agent receives. The first command name sources the
+ * `/<name> ` prefix (extras are silently dropped). Returns the value unchanged
+ * when no command token is present.
+ */
+export function stripAllCommandTokens(value: string): string {
+  let out = value
+  // Loop: stripCommandToken removes the first token + trailing space. Repeat
+  // until no more tokens remain. Bounded by the number of tokens (each pass
+  // removes one `\uE004…\uE005` pair + optional space).
+  while (extractCommandName(out) !== null) {
+    out = stripCommandToken(out)
+  }
+  return out
+}
+
+export type InsertCommandTokenResult =
+  | { inserted: true; value: string; caret: number }
+  | { inserted: false; reason: 'existing_command' }
+
+/**
+ * Splice a command token into the value at `caret`, removing the `deleteBefore`
+ * chars immediately preceding the caret (the `/`-trigger filter text the slash
+ * menu clears). A trailing space is appended so the caret lands in plain text
+ * and the user can keep typing; the next `/` trigger still matches because the
+ * space is whitespace. No padding block — the command pill is a real DOM node.
+ *
+ * Single-command invariant: rejects (`inserted:false, reason:'existing_command'`)
+ * when the value already carries a command token, matching today's single-
+ * `activeCommand` semantics. The caller may surface a toast or just focus the
+ * editor; the value is left untouched on rejection.
+ *
+ * Clamp behavior: when `deleteBefore > caret`, `start` floors at 0 (can't go
+ * below the string start). `end` is then `Math.max(0, caret)` — so the deletion
+ * range is `[0, caret)`. When `caret === 0` this means `end === start === 0` and
+ * nothing is deleted (the token is prepended to the full value). When
+ * `caret > 0`, the first `caret` chars are deleted (the clamp effectively caps
+ * `deleteBefore` at `caret`). Either way the token is inserted at position 0.
+ */
+export function insertCommandToken(
+  value: string,
+  caret: number,
+  name: string,
+  deleteBefore = 0
+): InsertCommandTokenResult {
+  // Single-command invariant — reject a second command token.
+  if (extractCommandName(value) !== null) {
+    return { inserted: false, reason: 'existing_command' }
+  }
+  const start = Math.max(0, Math.min(caret - deleteBefore, value.length))
+  const end = Math.max(start, Math.min(caret, value.length))
+  const before = value.slice(0, start)
+  const after = value.slice(end)
+  const token = commandToken(name)
+  const next = `${before}${token} ${after}`
+  // Caret lands right after the trailing space.
+  return { inserted: true, value: next, caret: before.length + token.length + 1 }
+}
+
+export type RemoveCommandTokenResult =
+  | { removed: true; value: string; caret: number }
+  | { removed: false }
+
+/**
+ * Backspace semantics for the composer: when the caret is *immediately* after a
+ * command token (no selection), remove the whole token plus the trailing space
+ * the splicer appended, and place the caret where the token started. Tolerates
+ * the splicer's trailing space (caret may sit one char after the token end).
+ * Returns `removed:false` for the caller to fall back to the default one-char
+ * backspace. Parallel to `removeSkillTokenBeforeCaret` but without a padding
+ * block (commands carry none). The editor's keymap handles backspace-over-pill
+ * removal via ProseMirror's `nodeBefore` (this helper is the model-level mirror
+ * kept for parity + future surfaces).
+ */
+export function removeCommandTokenBeforeCaret(
+  value: string,
+  caret: number
+): RemoveCommandTokenResult {
+  if (caret <= 0 || caret > value.length) return { removed: false }
+  // Walk back from the caret over the optional trailing space to reach the
+  // token-end \uE005.
+  let end = caret
+  if (end - 1 >= 0 && value[end - 1] === ' ') {
+    end -= 1
+  }
+  if (end - 1 < 0 || value[end - 1] !== CMD_TOKEN_END) return { removed: false }
+  const tokenEnd = end - 1
+  const start = value.lastIndexOf(CMD_TOKEN_START, tokenEnd - 1)
+  if (start === -1) return { removed: false }
+  const name = value.slice(start + 1, tokenEnd)
+  if (name.length === 0) return { removed: false }
+  const before = value.slice(0, start)
+  const after = value.slice(caret)
+  return { removed: true, value: `${before}${after}`, caret: start }
 }

--- a/src/renderer/lib/tauri-runtime.ts
+++ b/src/renderer/lib/tauri-runtime.ts
@@ -9,6 +9,20 @@ export function isTauriContext(): boolean {
   )
 }
 
+/**
+ * True when the renderer runs in the Tauri desktop webview (always local) OR is
+ * served by `termul-server` over a loopback origin (`localhost` / `127.0.0.1` /
+ * `::1`). Used to gate web-only surfaces whose backing HTTP route is
+ * loopback-guarded (e.g. worktree mutation writes) so a non-loopback LAN client
+ * does not see a usable picker that would fail with `FORBIDDEN` at launch.
+ */
+export function isLoopbackWebClient(): boolean {
+  if (isTauriContext()) return true
+  if (typeof window === 'undefined' || !window.location) return false
+  const host = window.location.hostname
+  return host === 'localhost' || host === '127.0.0.1' || host === '::1' || host === '[::1]'
+}
+
 export function cleanupTauriListener(unlisten: MaybeUnlisten): void {
   if (!unlisten) return
 

--- a/src/renderer/lib/web-server-api.ts
+++ b/src/renderer/lib/web-server-api.ts
@@ -15,18 +15,23 @@
  * sees a thrown exception from the network layer.
  */
 import type {
+  BranchInfo,
   DetectedShells,
   DirectoryEntry,
+  DirtyStatus,
   FileContent,
   FileInfo,
   GitCommit,
   GitCommitContext,
   GitStashInfo,
   GitStatusDetail,
-  IpcResult
+  IpcResult,
+  WorktreeInfo
 } from '@shared/types/ipc.types'
 import type { ProjectListPayload } from '@shared/types/web-projects.types'
+import type { AgentSkillContent, AgentSkillSummary } from './skills-api'
 import { isTauriContext } from './tauri-runtime'
+import type { BaseBranchInfo, IncludeCopyResult } from './worktree-api'
 
 /**
  * Same-origin base for the embedded server. In web/remote mode the browser is
@@ -349,8 +354,6 @@ export const webServerMcpServers = {
  * data, throwing on `!res.success` so the renderer facade (`skills-api.ts`)
  * can branch `isTauriContext()` between `invoke(...)` and these HTTP impls.
  */
-import type { AgentSkillContent, AgentSkillSummary } from './skills-api'
-
 export const webServerSkills = {
   async list(projectRoot?: string): Promise<AgentSkillSummary[]> {
     const params = projectRoot ? `?projectRoot=${encodeURIComponent(projectRoot)}` : ''
@@ -464,5 +467,62 @@ export const webServerMcpProbe = {
     } finally {
       clearTimeout(timer)
     }
+  }
+}
+
+/**
+ * Worktree ops routed to `termul-server` (`/worktree/*`). CAP — Web worktree
+ * parity: each method mirrors a desktop `#[tauri::command] worktree_*` handler
+ * and returns the SAME `IpcResult<T>` contract (the renderer facade
+ * `worktree-api.ts` branches `isTauriContext()` between `invoke(...)` and these
+ * HTTP impls). Only the 7 launch-flow routes ship here; the 8 advanced ops
+ * stay `WEB_UNSUPPORTED` on web (deferred — see deferred-work.md).
+ */
+export const webServerWorktree = {
+  async list(projectPath: string): Promise<IpcResult<WorktreeInfo[]>> {
+    return postJson<WorktreeInfo[]>('/worktree/list', { projectPath })
+  },
+
+  async create(params: {
+    projectPath: string
+    name: string
+    branch: string
+    isNewBranch: boolean
+    startRef?: string
+    targetPath?: string
+  }): Promise<IpcResult<WorktreeInfo>> {
+    return postJson<WorktreeInfo>('/worktree/create', params)
+  },
+
+  async remove(
+    projectPath: string,
+    worktreePath: string,
+    force: boolean
+  ): Promise<IpcResult<void>> {
+    return postJson<void>('/worktree/remove', { projectPath, worktreePath, force })
+  },
+
+  async branches(projectPath: string): Promise<IpcResult<BranchInfo[]>> {
+    const encoded = encodeURIComponent(projectPath)
+    return getJson<BranchInfo[]>(`/worktree/branches?projectPath=${encoded}`)
+  },
+
+  async checkDirty(worktreePath: string): Promise<IpcResult<DirtyStatus>> {
+    const encoded = encodeURIComponent(worktreePath)
+    return getJson<DirtyStatus>(`/worktree/check-dirty?worktreePath=${encoded}`)
+  },
+
+  async resolveBaseBranch(projectPath: string): Promise<IpcResult<BaseBranchInfo>> {
+    return postJson<BaseBranchInfo>('/worktree/resolve-base-branch', { projectPath })
+  },
+
+  async copyIncludeFiles(
+    projectPath: string,
+    worktreePath: string
+  ): Promise<IpcResult<IncludeCopyResult>> {
+    return postJson<IncludeCopyResult>('/worktree/copy-include-files', {
+      projectPath,
+      worktreePath
+    })
   }
 }

--- a/src/renderer/lib/worktree-api.ts
+++ b/src/renderer/lib/worktree-api.ts
@@ -10,6 +10,7 @@ import type {
 import { invoke } from '@tauri-apps/api/core'
 import type { Worktree } from '@/types/project'
 import { isTauriContext } from './tauri-runtime'
+import { webServerWorktree } from './web-server-api'
 
 export interface MergePreviewInfo {
   direction: string
@@ -62,16 +63,22 @@ export interface IncludeCopyResult {
 
 /**
  * Invoke a worktree Tauri command, returning the `IpcResult<T>` shape callers
- * expect. On web/remote mode (`!isTauriContext()`), returns an explicit
- * `WEB_UNSUPPORTED` result instead of letting the stubbed `invoke()` reject
- * with `tauriUnavailable` — worktree mutation is desktop-only until a
- * separate product/security decision.
+ * expect. On web/remote mode (`!isTauriContext()`), the 7 launch-flow methods
+ * (list/create/remove/branches/checkDirty/resolveBaseBranch/copyIncludeFiles)
+ * branch to `webServerWorktree` (HTTP routes in `web/worktree_api.rs`) — CAP —
+ * Web worktree parity. The 8 advanced ops (symlinks, parseGitignore, merge,
+ * archive/restore, removeAllManaged) STAY `WEB_UNSUPPORTED` on web (deferred —
+ * see deferred-work.md). Transport/parse failures on the HTTP path map to
+ * `{ success: false, code: 'NETWORK_ERROR' }` (handled in `web-server-api.ts`).
  */
 async function worktreeInvoke<T>(
   command: string,
   args?: Record<string, unknown>
 ): Promise<IpcResult<T>> {
   if (!isTauriContext()) {
+    // The 7 launch-flow methods branch to webServerWorktree in their own
+    // facade methods (below). This fallback is only hit by the 8 advanced
+    // ops that stay WEB_UNSUPPORTED on web.
     return {
       success: false,
       error: 'Worktrees are not available in the web client',
@@ -87,7 +94,9 @@ export const worktreeApi = {
    * Filters out bare worktrees and detached-HEAD worktrees.
    */
   list: (projectPath: string): Promise<IpcResult<WorktreeInfo[]>> =>
-    worktreeInvoke<WorktreeInfo[]>('worktree_list', { projectPath }),
+    isTauriContext()
+      ? invoke<IpcResult<WorktreeInfo[]>>('worktree_list', { projectPath })
+      : webServerWorktree.list(projectPath),
 
   /**
    * Create a new worktree.
@@ -102,7 +111,10 @@ export const worktreeApi = {
     isNewBranch: boolean
     startRef?: string
     targetPath?: string
-  }): Promise<IpcResult<WorktreeInfo>> => worktreeInvoke<WorktreeInfo>('worktree_create', params),
+  }): Promise<IpcResult<WorktreeInfo>> =>
+    isTauriContext()
+      ? invoke<IpcResult<WorktreeInfo>>('worktree_create', params)
+      : webServerWorktree.create(params),
 
   /**
    * Remove a worktree. Uses --force if force=true.
@@ -111,25 +123,33 @@ export const worktreeApi = {
    * metadata can be located.
    */
   remove: (projectPath: string, worktreePath: string, force: boolean): Promise<IpcResult<void>> =>
-    worktreeInvoke<void>('worktree_remove', { projectPath, worktreePath, force }),
+    isTauriContext()
+      ? invoke<IpcResult<void>>('worktree_remove', { projectPath, worktreePath, force })
+      : webServerWorktree.remove(projectPath, worktreePath, force),
 
   /**
    * List local and remote branches for a git repo.
    */
   branches: (projectPath: string): Promise<IpcResult<BranchInfo[]>> =>
-    worktreeInvoke<BranchInfo[]>('worktree_branches', { projectPath }),
+    isTauriContext()
+      ? invoke<IpcResult<BranchInfo[]>>('worktree_branches', { projectPath })
+      : webServerWorktree.branches(projectPath),
 
   /**
    * Check dirty status for a worktree checkout.
    * Returns summary of uncommitted changes.
    */
   checkDirty: (worktreePath: string): Promise<IpcResult<DirtyStatus>> =>
-    worktreeInvoke<DirtyStatus>('worktree_check_dirty', { worktreePath }),
+    isTauriContext()
+      ? invoke<IpcResult<DirtyStatus>>('worktree_check_dirty', { worktreePath })
+      : webServerWorktree.checkDirty(worktreePath),
 
   /**
    * Remove all Termul-managed worktrees for a project.
    * Used during project cascade delete. Reports per-worktree results.
    * Accepts a typed Worktree array; serializes to JSON internally.
+   *
+   * **Web:** returns `WEB_UNSUPPORTED` (deferred — see deferred-work.md).
    */
   removeAllManaged: (
     projectPath: string,
@@ -143,6 +163,8 @@ export const worktreeApi = {
   /**
    * Parse .gitignore and return directory entries that could be symlinked.
    * Each entry includes whether the directory exists in the project root.
+   *
+   * **Web:** returns `WEB_UNSUPPORTED` (deferred — see deferred-work.md).
    */
   parseGitignore: (projectPath: string): Promise<IpcResult<GitignoreDir[]>> =>
     worktreeInvoke<GitignoreDir[]>('worktree_parse_gitignore', { projectPath }),
@@ -150,6 +172,8 @@ export const worktreeApi = {
   /**
    * Create symlinks from project root directories into a worktree.
    * symlinkDirs is a JSON array of directory names to symlink.
+   *
+   * **Web:** returns `WEB_UNSUPPORTED` (deferred — see deferred-work.md).
    */
   createSymlinks: (
     projectPath: string,
@@ -165,6 +189,8 @@ export const worktreeApi = {
   /**
    * Ensure symlinks exist for all directories in symlinkDirs.
    * Creates any missing symlinks. Does not remove or overwrite existing ones.
+   *
+   * **Web:** returns `WEB_UNSUPPORTED` (deferred — see deferred-work.md).
    */
   ensureSymlinks: (
     projectPath: string,
@@ -180,18 +206,24 @@ export const worktreeApi = {
   /**
    * Archive a worktree by moving it to `.termul/archives/<name>-<timestamp>/`.
    * The worktree is recoverable until the 30-day retention expires.
+   *
+   * **Web:** returns `WEB_UNSUPPORTED` (deferred — see deferred-work.md).
    */
   archive: (projectPath: string, worktreePath: string): Promise<IpcResult<void>> =>
     worktreeInvoke<void>('worktree_archive', { projectPath, worktreePath }),
 
   /**
    * Restore an archived worktree back to its original location.
+   *
+   * **Web:** returns `WEB_UNSUPPORTED` (deferred — see deferred-work.md).
    */
   restore: (projectPath: string, archivePath: string): Promise<IpcResult<void>> =>
     worktreeInvoke<void>('worktree_restore', { projectPath, archivePath }),
 
   /**
    * Generate a merge preview for a worktree against a target branch.
+   *
+   * **Web:** returns `WEB_UNSUPPORTED` (deferred — see deferred-work.md).
    */
   mergePreview: (
     worktreePath: string,
@@ -201,6 +233,8 @@ export const worktreeApi = {
 
   /**
    * Execute a merge from the worktree's current branch to target_branch.
+   *
+   * **Web:** returns `WEB_UNSUPPORTED` (deferred — see deferred-work.md).
    */
   mergeExecute: (worktreePath: string, targetBranch: string): Promise<IpcResult<string>> =>
     worktreeInvoke<string>('worktree_merge_execute', { worktreePath, targetBranch }),
@@ -211,7 +245,9 @@ export const worktreeApi = {
    * a detached-HEAD flag so the launcher can force a base pick.
    */
   resolveBaseBranch: (projectPath: string): Promise<IpcResult<BaseBranchInfo>> =>
-    worktreeInvoke<BaseBranchInfo>('worktree_resolve_base_branch', { projectPath }),
+    isTauriContext()
+      ? invoke<IpcResult<BaseBranchInfo>>('worktree_resolve_base_branch', { projectPath })
+      : webServerWorktree.resolveBaseBranch(projectPath),
 
   /**
    * Carry over untracked files listed in `.worktree-include` into a fresh
@@ -222,8 +258,10 @@ export const worktreeApi = {
     projectPath: string,
     worktreePath: string
   ): Promise<IpcResult<IncludeCopyResult>> =>
-    worktreeInvoke<IncludeCopyResult>('worktree_copy_include_files', {
-      projectPath,
-      worktreePath
-    })
+    isTauriContext()
+      ? invoke<IpcResult<IncludeCopyResult>>('worktree_copy_include_files', {
+          projectPath,
+          worktreePath
+        })
+      : webServerWorktree.copyIncludeFiles(projectPath, worktreePath)
 }


### PR DESCRIPTION
## Summary

Two cohesive parity goals: (A) slash commands now insert an inline `CommandPill` Tiptap atom instead of a detached on-top `CommandChip`; (B) git worktree mutation ships on the web/remote client (7 launch-flow routes), un-gating the worktree-isolated agent chat launch on web.

## Related Issue

No related issue — this is spec-driven work (see `_bmad-output/implementation-artifacts/spec-inline-command-pill-web-worktree-parity.md`).

## Type of Change

- [x] feat: new feature

## What Changed

**Goal A — Inline command pill:**
- New `CommandPillNode.tsx` inline Tiptap atom (mirrors `SkillPillNode`); slash commands splice a `\uE004<name>\uE005` token at the caret instead of setting a detached `activeCommand` state + `<CommandChip>` on top.
- Wire contract is byte-identical: `buildPromptParts` extracts the command name via `extractCommandNames` + `stripAllCommandTokens` and prefixes `/<name> ` to the wire user-text. Multi-command paste-bypass guard.
- Both `AgentLauncher` + `ChatInputBar` updated via the shared `useChatComposer` hook. `CommandChip.tsx` kept as dead code for one release (per spec).

**Goal B — Web worktree parity (7 launch-flow routes):**
- New `src-tauri/src/web/worktree_api.rs` mirrors `git_api.rs` for `list`/`create`/`remove`/`branches`/`check-dirty`/`resolve-base-branch`/`copy-include-files`.
- Routes registered in `router.rs` (both `router()` + `router_with_static()`); `worktree-api.ts` facade branches `isTauriContext()` → `invoke` vs `webServerWorktree`; `AgentLauncher.canUseWorktree = projectIsGitRepo` (un-gated web).
- Security: loopback guard on writes, project-root containment on all, list info-leak filter. 8 advanced ops (symlinks/merge/archive/restore/etc.) stay `WEB_UNSUPPORTED` — deferred to `deferred-work.md`.

## How It Was Tested

- [x] `bun run ci` (Biome lint + format + imports, strict mode)
- [x] `bun run typecheck`
- [x] `bun run test`
- [x] `cargo clippy --all-targets -- -D warnings` (in src-tauri)
- [ ] `cargo test` (in src-tauri) — test code compiles clean; runtime blocked by a pre-existing Windows `STATUS_ENTRYPOINT_NOT_FOUND` DLL issue (identical on baseline). CI on Linux runs them.
- [x] Manual verification completed

## Screenshots or Recordings

N/A (no visual UX change beyond the command pill rendering inline — covered by snapshot tests)

## CI & Review Gate

- [ ] All CI checks pass (PR Validation, Rust Checks, Build Verification, Security Scans)
- [ ] Code review comments from CodeRabbit / Claude have been addressed or resolved
- [ ] No unresolved review findings remain

## Checklist

- [x] My PR title follows the conventional commit format used by this repo
- [x] I linked the related issue or explained why none exists
- [x] I updated docs when needed
- [x] I added or updated tests when needed
- [x] I verified the change does not introduce unrelated modifications
- [x] I read AGENTS.md and followed the contributor guidelines
- [x] A human reviewed the complete diff before submission

Spec: `_bmad-output/implementation-artifacts/spec-inline-command-pill-web-worktree-parity.md` (status: done, contains a Suggested Review Order).