### PR TITLE
fix(acp): web background-resume transport timeout and relay cleanup

### DIFF
--- a/src-tauri/src/acp/manager.rs
+++ b/src-tauri/src/acp/manager.rs
@@ -54,9 +54,9 @@ use crate::acp::events::{
 };
 use crate::acp::session::DriverState;
 use crate::acp::session_persistence::{
-    is_protected_title_source, normalize_title, now_millis, PersistedEventRecord,
-    PersistedSessionStatus, SessionPersistence, SessionRegistration, TitleSource,
-    SESSION_SCHEMA_VERSION,
+    is_protected_title_source, normalize_title, now_millis,
+    PersistedEventRecord, PersistedSessionStatus, SessionPersistence, SessionRegistration,
+    TitleSource, SESSION_SCHEMA_VERSION,
 };
 use crate::web::sink::CapturingEventSink;
 use crate::web::EventSink;
@@ -654,6 +654,10 @@ enum AcpCommand {
         /// `prompt_complete` for the renderer's `seenTurnIds` idempotent dedup —
         /// FR11). `None` for desktop/older clients (dedup is a no-op).
         turn_id: Option<String>,
+        /// Resolves after the driver has claimed the session turn and
+        /// registered its completion task. Callers can then process a
+        /// following cancellation without racing prompt startup.
+        accepted: oneshot::Sender<Result<(), String>>,
         reply: oneshot::Sender<Result<StopReason, String>>,
     },
     CancelPrompt {
@@ -709,6 +713,13 @@ enum AcpCommand {
     },
     /// Ask the driver thread to wind down its connection and exit.
     Shutdown,
+}
+
+pub(crate) struct StartedPrompt {
+    agent_id: AgentId,
+    session_id: SessionId,
+    first_prompt_text: String,
+    completion: oneshot::Receiver<Result<StopReason, String>>,
 }
 
 /// Result of a successful `initialize` handshake, carried back to the spawning
@@ -1319,6 +1330,23 @@ impl AcpManager {
         content: Vec<ContentBlock>,
         turn_id: Option<String>,
     ) -> Result<StopReason, String> {
+        let started = self
+            .start_prompt(agent_id, session_id, content, turn_id)
+            .await?;
+        self.wait_prompt(started).await
+    }
+
+    /// Register a prompt turn with the driver without awaiting the long agent
+    /// completion. Success means the driver's single-flight marker and prompt
+    /// task are installed, so a subsequently queued cancellation cannot no-op
+    /// before the turn starts.
+    pub(crate) async fn start_prompt(
+        self: &Arc<Self>,
+        agent_id: &AgentId,
+        session_id: SessionId,
+        content: Vec<ContentBlock>,
+        turn_id: Option<String>,
+    ) -> Result<StartedPrompt, String> {
         if content.is_empty() {
             return Err("prompt content must not be empty".to_string());
         }
@@ -1327,13 +1355,40 @@ impl AcpManager {
         // prompt to a separate agent (AD-2). Never log it — only forward it.
         let first_prompt_text = extract_prompt_text(&content);
         let tx = self.command_tx(agent_id)?;
-        let stop_reason = send_command(&tx, |reply| AcpCommand::SendPrompt {
+        let (accepted_tx, accepted_rx) = oneshot::channel();
+        let (completion_tx, completion_rx) = oneshot::channel();
+        tx.send(AcpCommand::SendPrompt {
             session_id: session_id.clone(),
             content,
             turn_id,
-            reply,
+            accepted: accepted_tx,
+            reply: completion_tx,
         })
-        .await?;
+        .map_err(|_| "agent thread is no longer running".to_string())?;
+        accepted_rx
+            .await
+            .map_err(|_| "agent thread dropped the prompt acceptance".to_string())??;
+        Ok(StartedPrompt {
+            agent_id: agent_id.clone(),
+            session_id,
+            first_prompt_text,
+            completion: completion_rx,
+        })
+    }
+
+    pub(crate) async fn wait_prompt(
+        self: &Arc<Self>,
+        started: StartedPrompt,
+    ) -> Result<StopReason, String> {
+        let StartedPrompt {
+            agent_id,
+            session_id,
+            first_prompt_text,
+            completion,
+        } = started;
+        let stop_reason = completion
+            .await
+            .map_err(|_| "agent thread dropped the prompt reply".to_string())??;
 
         // Title-gen trigger: fire-and-forget, only on the first turn, only
         // when persistence says the title is still DerivedFirstMessage (no
@@ -1358,7 +1413,7 @@ impl AcpManager {
                     session_id.0
                 );
                 let manager = Arc::clone(self);
-                let user_agent_id = agent_id.clone();
+                let user_agent_id = agent_id;
                 let session_id_str = session_id.0.clone();
                 tokio::spawn(async move {
                     manager
@@ -1499,9 +1554,9 @@ impl AcpManager {
         // `session_reopen_timeout()` pattern, 60s default). The prompt embeds
         // the first user message text — never log it.
         let title_instruction = format!(
-            "Generate a concise title (max 80 characters) for a chat session based on the \
-             following user message. Reply with ONLY the title text — no quotes, no markdown, \
-             no explanation.\n\nUser message: {first_prompt}"
+            "Generate a concise title (max 48 characters) for a chat session based on the \
+             following user message. Reply with ONLY the title text on a single line — no quotes, \
+             no markdown, no greeting, no explanation.\n\nUser message: {first_prompt}"
         );
         let prompt_content = vec![ContentBlock::Text(
             agent_client_protocol::schema::v1::TextContent::new(title_instruction),
@@ -1510,24 +1565,16 @@ impl AcpManager {
         log::debug!(
             "[acp-title] background prompt sent to session {bg_session_id} (timeout {prompt_timeout:?}, user session {session_id})"
         );
-        // Send the title-gen prompt directly through the command channel,
-        // bypassing `send_prompt` (which would re-enter the title-gen trigger
-        // path — the background turn is NOT a user turn and must not fire
-        // another background gen).
-        let bg_command_tx = self.command_tx(&bg_agent_id);
-        let bg_prompt_future = match &bg_command_tx {
-            Ok(tx) => send_command(tx, |reply| AcpCommand::SendPrompt {
-                session_id: bg_session_id.clone(),
-                content: prompt_content,
-                turn_id: None,
-                reply,
-            }),
-            Err(error) => {
-                log::warn!(
-                    "[acp-title] background agent {bg_agent_id} command channel gone for session {session_id}: {error}"
-                );
-                return;
-            }
+        // Start + await directly so the background turn does not re-enter the
+        // user-turn title-generation trigger in `wait_prompt`.
+        let bg_prompt_future = async {
+            let started = self
+                .start_prompt(&bg_agent_id, bg_session_id.clone(), prompt_content, None)
+                .await?;
+            started
+                .completion
+                .await
+                .map_err(|_| "background agent dropped the prompt reply".to_string())?
         };
         let prompt_result = tokio::time::timeout(prompt_timeout, bg_prompt_future).await;
         let stop_reason = match prompt_result {
@@ -1577,7 +1624,7 @@ impl AcpManager {
         // title rather than overwriting with the fallback floor.
         if title.is_empty() || title == "Untitled Chat" {
             log::warn!(
-                "[acp-title] background gen produced empty/Untitled title for session {session_id}; keeping current title"
+                "[acp-title] background gen produced empty/boilerplate title for session {session_id}; keeping current title"
             );
             return;
         }
@@ -1888,7 +1935,10 @@ impl AcpManager {
                     AcpCommand::IsEphemeralSession { reply, .. } => {
                         let _ = reply.send(Ok(false));
                     }
-                    AcpCommand::SendPrompt { reply, .. } => {
+                    AcpCommand::SendPrompt {
+                        accepted, reply, ..
+                    } => {
+                        let _ = accepted.send(Ok(()));
                         let _ = reply.send(Ok(StopReason::EndTurn));
                     }
                     // Unhandled commands are silently dropped (same behavior
@@ -1917,6 +1967,110 @@ impl AcpManager {
                 killed: Arc::new(AtomicBool::new(false)),
             },
         );
+    }
+
+    #[cfg(test)]
+    pub(crate) fn install_test_agent_with_prompt_gate(
+        &self,
+        agent_id: AgentId,
+        sessions: std::collections::HashSet<String>,
+    ) -> (oneshot::Sender<()>, oneshot::Receiver<()>) {
+        let (release_tx, release_rx) = oneshot::channel();
+        let (entered_tx, entered_rx) = oneshot::channel();
+        let (command_tx, mut command_rx) = mpsc::unbounded_channel();
+        let sinks = self.sinks.clone();
+        let gated_agent_id = agent_id.clone();
+        tokio::spawn(async move {
+            let mut released = false;
+            let mut entered_tx = Some(entered_tx);
+            let mut release_rx = Some(release_rx);
+            let pending_cancels = Arc::new(parking_lot::Mutex::new(std::collections::HashMap::<
+                String,
+                oneshot::Sender<()>,
+            >::new()));
+            while let Some(command) = command_rx.recv().await {
+                match command {
+                    AcpCommand::OwnsSession { session_id, reply } => {
+                        let _ = reply.send(Ok(sessions.contains(&session_id.0)));
+                    }
+                    AcpCommand::IsEphemeralSession { reply, .. } => {
+                        let _ = reply.send(Ok(false));
+                    }
+                    AcpCommand::SendPrompt {
+                        session_id,
+                        turn_id,
+                        accepted,
+                        reply,
+                        ..
+                    } => {
+                        if !released {
+                            if let Some(entered_tx) = entered_tx.take() {
+                                let _ = entered_tx.send(());
+                            }
+                            let mut release_rx = release_rx.take().expect("first prompt gate");
+                            let (cancel_tx, mut cancel_rx) = oneshot::channel();
+                            pending_cancels
+                                .lock()
+                                .insert(session_id.0.clone(), cancel_tx);
+                            let prompt_sinks = sinks.clone();
+                            let prompt_agent_id = gated_agent_id.clone();
+                            let prompt_cancels = Arc::clone(&pending_cancels);
+                            let prompt_session_id = session_id.0.clone();
+                            tokio::spawn(async move {
+                                let stop_reason = tokio::select! {
+                                    _ = &mut release_rx => StopReason::EndTurn,
+                                    _ = &mut cancel_rx => StopReason::Cancelled,
+                                };
+                                prompt_cancels.lock().remove(&prompt_session_id);
+                                let event = PromptCompleteEvent {
+                                    agent_id: prompt_agent_id,
+                                    session_id: session_id.clone(),
+                                    stop_reason,
+                                    turn_id,
+                                };
+                                events::fan_out(
+                                    &prompt_sinks,
+                                    Some(&session_id.0),
+                                    events::EVENT_PROMPT_COMPLETE,
+                                    &event,
+                                );
+                                let _ = reply.send(Ok(stop_reason));
+                            });
+                            released = true;
+                        } else {
+                            let _ = reply.send(Ok(StopReason::EndTurn));
+                        }
+                        let _ = accepted.send(Ok(()));
+                    }
+                    AcpCommand::CancelPrompt { session_id, reply } => {
+                        if let Some(cancel) = pending_cancels.lock().remove(&session_id.0) {
+                            let _ = cancel.send(());
+                        }
+                        let _ = reply.send(Ok(()));
+                    }
+                    _ => {}
+                }
+            }
+        });
+        self.agents.lock().insert(
+            agent_id,
+            AgentEntry {
+                command_tx,
+                capabilities: AgentCapabilities::default(),
+                stable_namespace: None,
+                config: AgentConfig {
+                    config_id: None,
+                    name: "test-agent".to_string(),
+                    command: "test".to_string(),
+                    args: Vec::new(),
+                    env: std::collections::HashMap::new(),
+                    allow_terminal: false,
+                },
+                join_handle: None,
+                killed: Arc::new(AtomicBool::new(false)),
+            },
+        );
+        (release_tx, entered_rx)
     }
 
     /// Desktop compatibility wrapper: logs failures because app-exit callers
@@ -3244,6 +3398,7 @@ async fn run_command_loop(
                 session_id,
                 content,
                 turn_id,
+                accepted,
                 reply,
             } => {
                 // Single-flight per session: reject a second prompt while a turn
@@ -3252,10 +3407,12 @@ async fn run_command_loop(
                 let handles = driver_state.lock().try_begin_turn(&session_id.0);
                 let Some(handles) = handles else {
                     // Stable code matched by renderer `ACP_TURN_IN_PROGRESS_CODE`.
-                    let _ = reply.send(Err(format!(
+                    let error = format!(
                         "ACP_TURN_IN_PROGRESS: session {}",
                         session_id.0
-                    )));
+                    );
+                    let _ = accepted.send(Err(error.clone()));
+                    let _ = reply.send(Err(error));
                     continue;
                 };
                 let cancel_rx = handles.cancel_rx;
@@ -3419,7 +3576,11 @@ async fn run_command_loop(
                     // The connection is shutting down; clear the marker we just
                     // set and surface the real error to the caller (L5).
                     driver_state.lock().finish_turn(&turn_session.0);
-                    send_reply(&slot, Err(format!("failed to start prompt turn: {e}")));
+                    let error = format!("failed to start prompt turn: {e}");
+                    let _ = accepted.send(Err(error.clone()));
+                    send_reply(&slot, Err(error));
+                } else {
+                    let _ = accepted.send(Ok(()));
                 }
             }
 

--- a/src-tauri/src/web/permissions.rs
+++ b/src-tauri/src/web/permissions.rs
@@ -1150,38 +1150,6 @@ pub struct TurnWatermark {
     seen: Mutex<HashMap<String, std::collections::HashSet<String>>>,
 }
 
-/// Cancellation-safe ownership of an exact session turn claim.
-///
-/// Dropping the guard releases only the claim it acquired. Successful prompt
-/// completion records the turn id (when present), which also releases the
-/// claim, then disarms the guard.
-pub struct TurnClaimGuard<'a> {
-    watermark: &'a TurnWatermark,
-    session_id: String,
-    turn_id: Option<String>,
-    armed: bool,
-}
-
-impl TurnClaimGuard<'_> {
-    pub fn complete(mut self) {
-        if let Some(turn_id) = self.turn_id.as_deref() {
-            self.watermark.record_completed(&self.session_id, turn_id);
-        } else {
-            self.watermark.release_claim(&self.session_id, None);
-        }
-        self.armed = false;
-    }
-}
-
-impl Drop for TurnClaimGuard<'_> {
-    fn drop(&mut self) {
-        if self.armed {
-            self.watermark
-                .release_claim(&self.session_id, self.turn_id.as_deref());
-        }
-    }
-}
-
 impl TurnWatermark {
     /// Create an empty watermark.
     #[must_use]
@@ -1265,24 +1233,6 @@ impl TurnWatermark {
         TurnClaim::Claimed
     }
 
-    /// Claim a turn and return a guard that releases the exact claim on every
-    /// non-completed path, including future cancellation or panic unwinding.
-    pub fn claim_guard(
-        &self,
-        session_id: &str,
-        turn_id: Option<&str>,
-    ) -> Result<TurnClaimGuard<'_>, TurnClaim> {
-        match self.claim_turn(session_id, turn_id) {
-            TurnClaim::Claimed => Ok(TurnClaimGuard {
-                watermark: self,
-                session_id: session_id.to_string(),
-                turn_id: turn_id.map(str::to_string),
-                armed: true,
-            }),
-            other => Err(other),
-        }
-    }
-
     pub fn release_claim(&self, session_id: &str, turn_id: Option<&str>) {
         let expected = turn_id.unwrap_or_default();
         let mut in_flight = self.in_flight.lock();
@@ -1354,16 +1304,17 @@ mod tests {
     }
 
     #[test]
-    fn turn_claim_guard_releases_exact_claim_when_cancelled() {
+    fn turn_claim_release_releases_exact_claim_when_cancelled() {
         let watermark = TurnWatermark::new();
-        let guard = watermark
-            .claim_guard("session-1", Some("turn-1"))
-            .expect("first claim");
+        assert_eq!(
+            watermark.claim_turn("session-1", Some("turn-1")),
+            TurnClaim::Claimed
+        );
         assert_eq!(
             watermark.claim_turn("session-1", Some("turn-2")),
             TurnClaim::Busy
         );
-        drop(guard);
+        watermark.release_claim("session-1", Some("turn-1"));
         assert_eq!(
             watermark.claim_turn("session-1", Some("turn-2")),
             TurnClaim::Claimed
@@ -1371,12 +1322,13 @@ mod tests {
     }
 
     #[test]
-    fn turn_claim_guard_completion_records_stale_watermark() {
+    fn turn_claim_completion_records_stale_watermark() {
         let watermark = TurnWatermark::new();
-        watermark
-            .claim_guard("session-1", Some("turn-1"))
-            .expect("first claim")
-            .complete();
+        assert_eq!(
+            watermark.claim_turn("session-1", Some("turn-1")),
+            TurnClaim::Claimed
+        );
+        watermark.record_completed("session-1", "turn-1");
         assert_eq!(
             watermark.claim_turn("session-1", Some("turn-1")),
             TurnClaim::Completed

--- a/src-tauri/src/web/permissions.rs
+++ b/src-tauri/src/web/permissions.rs
@@ -1150,6 +1150,38 @@ pub struct TurnWatermark {
     seen: Mutex<HashMap<String, std::collections::HashSet<String>>>,
 }
 
+/// Cancellation-safe ownership of an exact session turn claim.
+///
+/// Dropping the guard releases only the claim it acquired. Successful prompt
+/// completion records the turn id (when present), which also releases the
+/// claim, then disarms the guard.
+pub struct TurnClaimGuard<'a> {
+    watermark: &'a TurnWatermark,
+    session_id: String,
+    turn_id: Option<String>,
+    armed: bool,
+}
+
+impl TurnClaimGuard<'_> {
+    pub fn complete(mut self) {
+        if let Some(turn_id) = self.turn_id.as_deref() {
+            self.watermark.record_completed(&self.session_id, turn_id);
+        } else {
+            self.watermark.release_claim(&self.session_id, None);
+        }
+        self.armed = false;
+    }
+}
+
+impl Drop for TurnClaimGuard<'_> {
+    fn drop(&mut self) {
+        if self.armed {
+            self.watermark
+                .release_claim(&self.session_id, self.turn_id.as_deref());
+        }
+    }
+}
+
 impl TurnWatermark {
     /// Create an empty watermark.
     #[must_use]
@@ -1233,6 +1265,24 @@ impl TurnWatermark {
         TurnClaim::Claimed
     }
 
+    /// Claim a turn and return a guard that releases the exact claim on every
+    /// non-completed path, including future cancellation or panic unwinding.
+    pub fn claim_guard(
+        &self,
+        session_id: &str,
+        turn_id: Option<&str>,
+    ) -> Result<TurnClaimGuard<'_>, TurnClaim> {
+        match self.claim_turn(session_id, turn_id) {
+            TurnClaim::Claimed => Ok(TurnClaimGuard {
+                watermark: self,
+                session_id: session_id.to_string(),
+                turn_id: turn_id.map(str::to_string),
+                armed: true,
+            }),
+            other => Err(other),
+        }
+    }
+
     pub fn release_claim(&self, session_id: &str, turn_id: Option<&str>) {
         let expected = turn_id.unwrap_or_default();
         let mut in_flight = self.in_flight.lock();
@@ -1301,6 +1351,40 @@ mod tests {
         assert!(!option_id_is_valid(&json!("not-an-array"), "allow"));
         assert!(!option_id_is_valid(&json!([{}]), "allow")); // no optionId field
         assert!(!option_id_is_valid(&json!(null), "allow"));
+    }
+
+    #[test]
+    fn turn_claim_guard_releases_exact_claim_when_cancelled() {
+        let watermark = TurnWatermark::new();
+        let guard = watermark
+            .claim_guard("session-1", Some("turn-1"))
+            .expect("first claim");
+        assert_eq!(
+            watermark.claim_turn("session-1", Some("turn-2")),
+            TurnClaim::Busy
+        );
+        drop(guard);
+        assert_eq!(
+            watermark.claim_turn("session-1", Some("turn-2")),
+            TurnClaim::Claimed
+        );
+    }
+
+    #[test]
+    fn turn_claim_guard_completion_records_stale_watermark() {
+        let watermark = TurnWatermark::new();
+        watermark
+            .claim_guard("session-1", Some("turn-1"))
+            .expect("first claim")
+            .complete();
+        assert_eq!(
+            watermark.claim_turn("session-1", Some("turn-1")),
+            TurnClaim::Completed
+        );
+        assert_eq!(
+            watermark.claim_turn("session-1", Some("turn-2")),
+            TurnClaim::Claimed
+        );
     }
 
     // --- Rendezvous bookkeeping tests (Story 1.7 AC3) -------------------------

--- a/src-tauri/src/web/ws.rs
+++ b/src-tauri/src/web/ws.rs
@@ -391,9 +391,9 @@ impl RuntimePolicy {
     #[must_use]
     pub fn resolved(permission_reconnect_grace: Duration) -> Self {
         let turn_timeout = crate::acp::manager::resolved_turn_timeout(); // Option
-        let turn_idle = crate::acp::manager::turn_idle_timeout();         // Option
-        // `turn_timeout_ms`: 0 = unlimited (no hard cap) sentinel; otherwise
-        // the bounded hard cap in ms.
+        let turn_idle = crate::acp::manager::turn_idle_timeout(); // Option
+                                                                  // `turn_timeout_ms`: 0 = unlimited (no hard cap) sentinel; otherwise
+                                                                  // the bounded hard cap in ms.
         let turn_timeout_ms = turn_timeout.map(|d| d.as_millis() as u64).unwrap_or(0);
         // Inactivity budget published to the client. Preserve the original
         // `hard/2` derivation when a hard cap is configured (bounded, strictly
@@ -517,7 +517,8 @@ async fn run_relay(socket: WebSocket, state: AppState) {
     // the `install_acp_agent` WS request.
     let acp_install = state.acp_install.clone();
     // Client ids registered via `subscribe` — unregistered on disconnect.
-    let mut subscribed_clients: Vec<(String, ClientId)> = Vec::new();
+    let subscribed_clients = Arc::new(tokio::sync::Mutex::new(Vec::<(String, ClientId)>::new()));
+    let cleanup = ConnectionCleanup::new(Arc::clone(&relay), Arc::clone(&subscribed_clients));
     // Per-connection tracking for `switch_project` (Ask-First resolution): the
     // last agent + session this connection used. `switch_project` reuses the
     // agent rather than auto-spawning; a cold tab (no agent yet) → `NO_AGENT`.
@@ -608,6 +609,8 @@ async fn run_relay(socket: WebSocket, state: AppState) {
     });
 
     let read_last_activity = Arc::clone(&last_activity);
+    let read_subscribed_clients = Arc::clone(&subscribed_clients);
+    let read_relay = Arc::clone(&relay);
     let mut read_task = tokio::spawn(async move {
         let mut authed = false;
         while let Some(frame) = stream.next().await {
@@ -625,16 +628,16 @@ async fn run_relay(socket: WebSocket, state: AppState) {
             read_last_activity.store(now_ms(), Ordering::Relaxed);
             match msg {
                 Message::Text(t) => {
-                    let handled = handle_request(
+                    if !dispatch_connection_text(
                         &t,
                         &mut authed,
                         &acp,
-                        &relay,
+                        &read_relay,
                         &registry,
                         registry_persistence.as_ref(),
                         projects_file.as_deref(),
                         &write_tx,
-                        &mut subscribed_clients,
+                        &read_subscribed_clients,
                         &mut current_agent,
                         &current_session,
                         &current_project,
@@ -643,8 +646,8 @@ async fn run_relay(socket: WebSocket, state: AppState) {
                         acp_catalog.as_ref(),
                         acp_install.as_ref(),
                     )
-                    .await;
-                    if write_tx.send(Outbound::Reply(handled)).is_err() {
+                    .await
+                    {
                         break; // write half closed.
                     }
                 }
@@ -664,41 +667,6 @@ async fn run_relay(socket: WebSocket, state: AppState) {
                     }
                 }
             }
-        }
-        // Cleanup subscriptions for this connection. Retain the affected
-        // session ids so last-subscriber permission grace can be scheduled.
-        let disconnected_sessions: std::collections::HashSet<String> = subscribed_clients
-            .iter()
-            .map(|(sid, _)| sid.clone())
-            .collect();
-        for (sid, cid) in subscribed_clients.drain(..) {
-            relay.unsubscribe(&sid, cid);
-        }
-        // Story 1.7: on browser disconnect, resolve every outstanding
-        // permission whose session now has zero remaining subscribers as deny
-        // (FR14: disconnect → deny). A ticket is denied only when the
-        // disconnecting client was the LAST subscriber — otherwise a remaining
-        // client can still legitimately respond. `relay.session_subscriber_count`
-        // reports the post-unsubscribe count.
-        if let Some(rdz) = relay.rendezvous() {
-            let orphan_sessions: std::collections::HashSet<String> = disconnected_sessions
-                .into_iter()
-                .filter(|sid| relay.session_subscriber_count(sid) == 0)
-                .collect();
-            for sid in orphan_sessions {
-                let relay_for_count = Arc::clone(&relay);
-                rdz.schedule_disconnect_grace(sid, move |session_id| {
-                    relay_for_count.session_subscriber_count(session_id)
-                });
-            }
-        }
-        // Issue #411: on browser disconnect, resolve every outstanding question
-        // whose session now has zero remaining subscribers as cancelled
-        // (mirrors the permission disconnect-deny above).
-        if let Some(qrdz) = relay.question_rendezvous() {
-            let relay_for_count = Arc::clone(&relay);
-            qrdz.deny_all_for_client(move |sid| relay_for_count.session_subscriber_count(sid))
-                .await;
         }
     });
 
@@ -720,6 +688,174 @@ async fn run_relay(socket: WebSocket, state: AppState) {
             // Write is the loser — await its abort to avoid orphaning.
             let _ = write_task.await;
         }
+    }
+    cleanup.run().await;
+}
+
+struct ConnectionCleanup {
+    relay: Arc<WsRelaySink>,
+    subscribed_clients: Arc<tokio::sync::Mutex<Vec<(String, ClientId)>>>,
+    state: Arc<std::sync::atomic::AtomicU8>,
+}
+
+impl ConnectionCleanup {
+    fn new(
+        relay: Arc<WsRelaySink>,
+        subscribed_clients: Arc<tokio::sync::Mutex<Vec<(String, ClientId)>>>,
+    ) -> Self {
+        Self {
+            relay,
+            subscribed_clients,
+            state: Arc::new(std::sync::atomic::AtomicU8::new(0)),
+        }
+    }
+
+    async fn run(&self) {
+        if self
+            .state
+            .compare_exchange(0, 1, Ordering::AcqRel, Ordering::Acquire)
+            .is_err()
+        {
+            return;
+        }
+        let relay = Arc::clone(&self.relay);
+        let subscribed_clients = Arc::clone(&self.subscribed_clients);
+        let state = Arc::clone(&self.state);
+        let cleanup = tokio::spawn(async move {
+            cleanup_connection_subscriptions(&relay, &subscribed_clients).await;
+            state.store(2, Ordering::Release);
+        });
+        let _ = cleanup.await;
+    }
+}
+
+impl Drop for ConnectionCleanup {
+    fn drop(&mut self) {
+        if self
+            .state
+            .compare_exchange(0, 1, Ordering::AcqRel, Ordering::Acquire)
+            .is_err()
+        {
+            return;
+        }
+        let relay = Arc::clone(&self.relay);
+        let subscribed_clients = Arc::clone(&self.subscribed_clients);
+        let state = Arc::clone(&self.state);
+        if let Ok(handle) = tokio::runtime::Handle::try_current() {
+            handle.spawn(async move {
+                cleanup_connection_subscriptions(&relay, &subscribed_clients).await;
+                state.store(2, Ordering::Release);
+            });
+        } else {
+            warn!(
+                target: "termul::web::ws",
+                "connection cleanup dropped outside a Tokio runtime"
+            );
+        }
+    }
+}
+
+fn authenticated_send_prompt(text: &str, authed: bool) -> Option<(String, Value)> {
+    if !authed {
+        return None;
+    }
+    let request: WsRequest = serde_json::from_str(text).ok()?;
+    (request.type_ == "send_prompt").then_some((request.id, request.payload))
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn dispatch_connection_text(
+    text: &str,
+    authed: &mut bool,
+    acp: &Arc<AcpManager>,
+    relay: &Arc<WsRelaySink>,
+    registry: &Arc<ProjectRegistry>,
+    registry_persistence: Option<&Arc<parking_lot::Mutex<FileProjectRegistry>>>,
+    projects_file: Option<&PathBuf>,
+    write_tx: &mpsc::UnboundedSender<Outbound>,
+    subscribed_clients: &Arc<tokio::sync::Mutex<Vec<(String, ClientId)>>>,
+    current_agent: &mut Option<AgentId>,
+    current_session: &Arc<parking_lot::Mutex<Option<SessionId>>>,
+    current_project: &Arc<parking_lot::Mutex<Option<String>>>,
+    switch_queue: &Arc<tokio::sync::Mutex<ProjectSwitchQueue>>,
+    history_mode: HistoryMode,
+    acp_catalog: Option<&Arc<crate::acp::AcpCatalogService>>,
+    acp_install: Option<&Arc<crate::acp::install::AcpInstallService>>,
+) -> bool {
+    if let Some((id, payload)) = authenticated_send_prompt(text, *authed) {
+        return match accept_send_prompt(id, &payload, acp, relay).await {
+            Ok(accepted) => {
+                let prompt_acp = Arc::clone(acp);
+                let prompt_tx = write_tx.clone();
+                tokio::spawn(async move {
+                    let reply = complete_send_prompt(accepted, &prompt_acp).await;
+                    let _ = prompt_tx.send(Outbound::Reply(reply));
+                });
+                true
+            }
+            Err(reply) => write_tx.send(Outbound::Reply(reply)).is_ok(),
+        };
+    }
+
+    let mut subscriptions = subscribed_clients.lock().await;
+    let reply = handle_request(
+        text,
+        authed,
+        acp,
+        relay,
+        registry,
+        registry_persistence,
+        projects_file,
+        write_tx,
+        &mut subscriptions,
+        current_agent,
+        current_session,
+        current_project,
+        switch_queue,
+        history_mode,
+        acp_catalog,
+        acp_install,
+    )
+    .await;
+    write_tx.send(Outbound::Reply(reply)).is_ok()
+}
+
+async fn cleanup_connection_subscriptions(
+    relay: &Arc<WsRelaySink>,
+    subscribed_clients: &Arc<tokio::sync::Mutex<Vec<(String, ClientId)>>>,
+) {
+    let subscriptions = std::mem::take(&mut *subscribed_clients.lock().await);
+    let disconnected_sessions: std::collections::HashSet<String> = subscriptions
+        .iter()
+        .map(|(session_id, _)| session_id.clone())
+        .collect();
+    for (session_id, client_id) in subscriptions {
+        relay.unsubscribe(&session_id, client_id);
+    }
+    info!(
+        target: "termul::web::ws",
+        session_count = disconnected_sessions.len(),
+        "connection subscriptions cleaned up"
+    );
+
+    if let Some(rendezvous) = relay.rendezvous() {
+        for session_id in disconnected_sessions
+            .iter()
+            .filter(|session_id| relay.session_subscriber_count(session_id) == 0)
+        {
+            let relay_for_count = Arc::clone(relay);
+            rendezvous.schedule_disconnect_grace(session_id.clone(), move |candidate| {
+                relay_for_count.session_subscriber_count(candidate)
+            });
+        }
+    }
+    if let Some(rendezvous) = relay.question_rendezvous() {
+        let relay_for_count = Arc::clone(relay);
+        rendezvous
+            .deny_all_for_client(move |session_id| {
+                relay_for_count.session_subscriber_count(session_id)
+            })
+            .await;
     }
 }
 
@@ -1148,8 +1284,26 @@ async fn handle_recover_session_snapshot(
     let (client_id, mut rx, events, watermark) =
         match relay.subscribe_snapshot(&parsed.session_id).await {
             Ok(result) => result,
-            Err(_) => {
-                return WsReply::err(id, WsErrorCode::NotFound, "session snapshot not found");
+            Err(error) => {
+                if relay.persistence().is_some_and(|persistence| {
+                    matches!(
+                        persistence.metadata(&parsed.session_id),
+                        Err(crate::acp::SessionPersistenceError::SessionNotFound)
+                    )
+                }) {
+                    return WsReply::err(id, WsErrorCode::NotFound, "session snapshot not found");
+                }
+                tracing::warn!(
+                    target: "termul::web::ws",
+                    session_id = %parsed.session_id,
+                    error = %error,
+                    "recover_session_snapshot: transient snapshot materialization failure"
+                );
+                return WsReply::err(
+                    id,
+                    WsErrorCode::AgentCrashed,
+                    "session snapshot is temporarily unavailable; retry after reconnect",
+                );
             }
         };
     subscribed_clients.retain(|(sid, client_id)| {
@@ -1232,13 +1386,13 @@ async fn handle_get_session_cursor(
         .persistence()
         .map(|persistence| {
             persistence.last_seq(&parsed.session_id).unwrap_or_else(|error| {
-                tracing::warn!(
-                    session_id = %parsed.session_id,
-                    error = ?error,
-                    "get_session_cursor: last_seq lookup failed"
-                );
-                0
-            })
+                    tracing::warn!(
+                        session_id = %parsed.session_id,
+                        error = ?error,
+                        "get_session_cursor: last_seq lookup failed"
+                    );
+                    0
+                })
         })
         .unwrap_or(0);
     tracing::debug!(
@@ -2562,94 +2716,119 @@ struct SendPromptPayload {
     turn_id: Option<String>,
 }
 
-async fn handle_send_prompt(
+struct AcceptedSendPrompt {
+    id: String,
+    started: crate::acp::manager::StartedPrompt,
+    claim: PromptClaim,
+}
+
+struct PromptClaim {
+    relay: Arc<WsRelaySink>,
+    session_id: String,
+    turn_id: Option<String>,
+    armed: bool,
+}
+
+impl PromptClaim {
+    fn complete(mut self) {
+        if let Some(turn_id) = self.turn_id.as_deref() {
+            self.relay
+                .turn_watermark()
+                .record_completed(&self.session_id, turn_id);
+        } else {
+            self.relay
+                .turn_watermark()
+                .release_claim(&self.session_id, None);
+        }
+        self.armed = false;
+    }
+}
+
+impl Drop for PromptClaim {
+    fn drop(&mut self) {
+        if self.armed {
+            self.relay
+                .turn_watermark()
+                .release_claim(&self.session_id, self.turn_id.as_deref());
+        }
+    }
+}
+
+async fn accept_send_prompt(
     id: String,
     payload: &Value,
     acp: &Arc<AcpManager>,
     relay: &Arc<WsRelaySink>,
-) -> WsReply {
-    let parsed: SendPromptPayload = match serde_json::from_value(payload.clone()) {
-        Ok(p) => p,
-        Err(e) => return WsReply::err(id, WsErrorCode::Unsupported, format!("malformed send_prompt payload (want agentId, sessionId, text|content, turnId?): {e}")),
-    };
-    // Build the content blocks: prefer explicit `content`; fall back to a
-    // single text block from `text` (mirrors the desktop store's `sendPrompt`
-    // vs `sendPromptBlocks` split — both become `Vec<ContentBlock>` for the agent).
+) -> Result<AcceptedSendPrompt, WsReply> {
+    let parsed: SendPromptPayload = serde_json::from_value(payload.clone()).map_err(|error| {
+        WsReply::err(
+            id.clone(),
+            WsErrorCode::Unsupported,
+            format!("malformed send_prompt payload (want agentId, sessionId, text|content, turnId?): {error}"),
+        )
+    })?;
     let content = match (parsed.content, parsed.text) {
         (Some(blocks), _) if !blocks.is_empty() => blocks,
-        // Story 1.8 review (EC3): reject an empty/whitespace-only text (the
-        // desktop `commands.rs` has the same guard; an empty-text turn would
-        // leak past the `content.is_empty()` check in `AcpManager::send_prompt`
-        // and poison the turn-id watermark).
         (_, Some(text)) if !text.trim().is_empty() => {
             vec![agent_client_protocol::schema::v1::ContentBlock::Text(
                 agent_client_protocol::schema::v1::TextContent::new(text),
             )]
         }
         _ => {
-            return WsReply::err(
+            return Err(WsReply::err(
                 id,
                 WsErrorCode::Unsupported,
                 "send_prompt requires non-empty `text` or `content`",
-            )
+            ))
         }
     };
 
-    // Ownership is authoritative driver state, not browser input. Reject a
-    // cross-agent session id before claiming a turn, assigning a relay seq, or
-    // writing any durable prompt record.
     match acp
         .owns_session(&parsed.agent_id, parsed.session_id.clone())
         .await
     {
         Ok(true) => {}
         Ok(false) => {
-            return WsReply::err(
+            return Err(WsReply::err(
                 id,
                 WsErrorCode::NotFound,
                 "session does not belong to the supplied live agent",
-            )
+            ))
         }
-        Err(error) => return acp_err_to_reply(id, error),
+        Err(error) => return Err(acp_err_to_reply(id, error)),
     }
 
-    // Claim before persistence so duplicate/busy turns cannot create durable
-    // prompt records. The manager still enforces its driver-thread single-flight
-    // invariant; this closes the web persistence ordering gap.
     match relay
         .turn_watermark()
         .claim_turn(parsed.session_id.0.as_str(), parsed.turn_id.as_deref())
     {
         TurnClaim::Claimed => {}
         TurnClaim::Completed => {
-            return WsReply::err(
+            return Err(WsReply::err(
                 id,
                 WsErrorCode::Stale,
                 "this turn already completed (stale turn-id)",
-            )
+            ))
         }
         TurnClaim::DuplicateInFlight | TurnClaim::Busy => {
-            return WsReply::err(
+            return Err(WsReply::err(
                 id,
                 WsErrorCode::RateLimited,
                 "a prompt turn is already in progress",
-            )
+            ))
         }
     }
-
-    let ephemeral = match acp
-        .is_ephemeral_session(&parsed.agent_id, parsed.session_id.clone())
-        .await
-    {
-        Ok(value) => value,
-        Err(error) => {
-            relay
-                .turn_watermark()
-                .release_claim(parsed.session_id.0.as_str(), parsed.turn_id.as_deref());
-            return acp_err_to_reply(id, error);
-        }
+    let claim = PromptClaim {
+        relay: Arc::clone(relay),
+        session_id: parsed.session_id.0.clone(),
+        turn_id: parsed.turn_id.clone(),
+        armed: true,
     };
 
+    let ephemeral = acp
+        .is_ephemeral_session(&parsed.agent_id, parsed.session_id.clone())
+        .await
+        .map_err(|error| acp_err_to_reply(id.clone(), error))?;
     let prompt_payload = json!({
         "agentId": parsed.agent_id.clone(),
         "sessionId": parsed.session_id.clone(),
@@ -2657,52 +2836,53 @@ async fn handle_send_prompt(
         "content": content.clone(),
     });
     if !ephemeral {
-        if let Err(error) = relay
+        relay
             .persist_user_prompt(parsed.session_id.0.as_str(), prompt_payload)
             .await
-        {
-            relay
-                .turn_watermark()
-                .release_claim(parsed.session_id.0.as_str(), parsed.turn_id.as_deref());
-            return WsReply::err(
-                id,
-                WsErrorCode::NotImplemented,
-                format!("failed to persist accepted prompt: {error}"),
-            );
-        }
+            .map_err(|error| {
+                WsReply::err(
+                    id.clone(),
+                    WsErrorCode::NotImplemented,
+                    format!("failed to persist accepted prompt: {error}"),
+                )
+            })?;
     }
 
-    match acp
-        .send_prompt(
+    let started = acp
+        .start_prompt(
             &parsed.agent_id,
-            parsed.session_id.clone(),
+            parsed.session_id,
             content,
-            parsed.turn_id.clone(),
+            parsed.turn_id,
         )
         .await
-    {
+        .map_err(|error| acp_err_to_reply(id.clone(), error))?;
+    Ok(AcceptedSendPrompt { id, started, claim })
+}
+
+async fn complete_send_prompt(
+    accepted: AcceptedSendPrompt,
+    acp: &Arc<AcpManager>,
+) -> WsReply {
+    let AcceptedSendPrompt { id, started, claim } = accepted;
+    match acp.wait_prompt(started).await {
         Ok(stop_reason) => {
-            // Story 1.8 T3.3: advance the watermark on completion so a stale
-            // `send_prompt` for the same turn-id is rejected on reconnect
-            // (FR13 last-completed-turn watermark; backs `is_completed` above).
-            // NOTE: the `seen` SET is NOT grown here (review EC2) — dedup of
-            // replayed `prompt_complete` events is client-side
-            // (`acp-transport.ts::seenTurnIds`); the server-side `seen` set has
-            // no reader and would grow unbounded. Only the high-water mark
-            // (`record_completed`) is advanced, which `is_completed` reads.
-            if let Some(turn_id) = &parsed.turn_id {
-                relay
-                    .turn_watermark()
-                    .record_completed(parsed.session_id.0.as_str(), turn_id);
-            }
+            claim.complete();
             ok_with_payload(id, &stop_reason)
         }
-        Err(e) => {
-            relay
-                .turn_watermark()
-                .release_claim(parsed.session_id.0.as_str(), parsed.turn_id.as_deref());
-            acp_err_to_reply(id, e)
-        }
+        Err(error) => acp_err_to_reply(id, error),
+    }
+}
+
+async fn handle_send_prompt(
+    id: String,
+    payload: &Value,
+    acp: &Arc<AcpManager>,
+    relay: &Arc<WsRelaySink>,
+) -> WsReply {
+    match accept_send_prompt(id, payload, acp, relay).await {
+        Ok(accepted) => complete_send_prompt(accepted, acp).await,
+        Err(reply) => reply,
     }
 }
 
@@ -3151,6 +3331,7 @@ mod tests {
     #![allow(clippy::unwrap_used, clippy::expect_used)]
     use super::*;
     use crate::acp::SpawnOutcome;
+    use crate::web::permissions::{PermissionRendezvous, QuestionRendezvous};
     use std::collections::HashSet;
 
     #[tokio::test]
@@ -3205,6 +3386,445 @@ mod tests {
         relay
             .turn_watermark()
             .release_claim("session-a", Some("turn-cross-agent"));
+        persistence.shutdown().await.unwrap();
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn authenticated_send_prompt_dispatches_only_post_auth_prompt_frames() {
+        let prompt = authenticated_send_prompt(
+            r#"{"id":"prompt-1","type":"send_prompt","payload":{"sessionId":"s1"}}"#,
+            true,
+        )
+        .expect("post-auth prompt is dispatched");
+        assert_eq!(prompt.0, "prompt-1");
+        assert_eq!(prompt.1["sessionId"], "s1");
+        assert!(
+            authenticated_send_prompt(r#"{"id":"ping-1","type":"ping","payload":{}}"#, true)
+                .is_none()
+        );
+        assert!(authenticated_send_prompt(
+            r#"{"id":"prompt-1","type":"send_prompt","payload":{}}"#,
+            false
+        )
+        .is_none());
+    }
+
+    #[tokio::test]
+    async fn connection_cleanup_unregisters_once_after_writer_first_shutdown() {
+        let relay = Arc::new(WsRelaySink::new());
+        let acp = Arc::new(AcpManager::new(vec![]));
+        let permissions = Arc::new(PermissionRendezvous::with_policy(
+            Arc::clone(&acp),
+            Duration::from_secs(60),
+            Duration::ZERO,
+        ));
+        let questions = Arc::new(QuestionRendezvous::with_timeout(
+            acp,
+            Duration::from_secs(60),
+        ));
+        relay.set_rendezvous(Arc::clone(&permissions));
+        relay.set_question_rendezvous(Arc::clone(&questions));
+        let (client_id, _rx, replay) = relay.subscribe("session-cleanup", None).await;
+        assert!(matches!(replay, ReplayResult::Ok(0)));
+        permissions.register(
+            "permission-cleanup".to_string(),
+            AgentId("agent-cleanup".to_string()),
+            "session-cleanup".to_string(),
+            json!([]),
+        );
+        questions.register(
+            "question-cleanup".to_string(),
+            AgentId("agent-cleanup".to_string()),
+            "session-cleanup".to_string(),
+            json!([]),
+        );
+        let subscribed = Arc::new(tokio::sync::Mutex::new(vec![(
+            "session-cleanup".to_string(),
+            client_id,
+        )]));
+        assert_eq!(relay.session_subscriber_count("session-cleanup"), 1);
+
+        let cleanup = ConnectionCleanup::new(Arc::clone(&relay), Arc::clone(&subscribed));
+        let cleanup_task = tokio::spawn(async move {
+            cleanup.run().await;
+            cleanup.run().await;
+        });
+        tokio::task::yield_now().await;
+        cleanup_task.abort();
+        let _ = cleanup_task.await;
+
+        assert_eq!(relay.session_subscriber_count("session-cleanup"), 0);
+        assert!(subscribed.lock().await.is_empty());
+        assert!(!questions.is_outstanding("question-cleanup"));
+        tokio::time::timeout(Duration::from_secs(1), async {
+            while permissions.is_outstanding("permission-cleanup") {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("permission disconnect policy executed");
+    }
+
+    #[tokio::test]
+    async fn connection_cleanup_runs_when_relay_future_is_cancelled() {
+        let relay = Arc::new(WsRelaySink::new());
+        let (client_id, _rx, replay) = relay.subscribe("session-cancelled-relay", None).await;
+        assert!(matches!(replay, ReplayResult::Ok(0)));
+        let subscribed = Arc::new(tokio::sync::Mutex::new(vec![(
+            "session-cancelled-relay".to_string(),
+            client_id,
+        )]));
+
+        let cleanup = ConnectionCleanup::new(Arc::clone(&relay), Arc::clone(&subscribed));
+        let relay_future = tokio::spawn(async move {
+            let _cleanup = cleanup;
+            std::future::pending::<()>().await;
+        });
+        relay_future.abort();
+        let _ = relay_future.await;
+
+        tokio::time::timeout(Duration::from_secs(1), async {
+            while relay.session_subscriber_count("session-cancelled-relay") != 0 {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("drop guard cleaned subscriptions after relay cancellation");
+        assert!(subscribed.lock().await.is_empty());
+    }
+
+    #[tokio::test]
+    async fn long_prompt_dispatch_does_not_block_ping_request() {
+        let relay = Arc::new(WsRelaySink::new());
+        let acp = Arc::new(AcpManager::new(vec![]));
+        let mut sessions = HashSet::new();
+        sessions.insert("session-long".to_string());
+        let (release, entered) =
+            acp.install_test_agent_with_prompt_gate(AgentId("agent-long".to_string()), sessions);
+        let registry = Arc::new(ProjectRegistry::new());
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        let subscriptions = Arc::new(tokio::sync::Mutex::new(Vec::new()));
+        let mut current_agent = None;
+        let current_session = Arc::new(parking_lot::Mutex::new(None));
+        let current_project = Arc::new(parking_lot::Mutex::new(None));
+        let switch_queue = Arc::new(tokio::sync::Mutex::new(ProjectSwitchQueue::default()));
+        let mut authed = true;
+        assert!(
+            dispatch_connection_text(
+                r#"{"id":"prompt-long","type":"send_prompt","payload":{"agentId":"agent-long","sessionId":"session-long","text":"long","turnId":"turn-long"}}"#,
+                &mut authed,
+                &acp,
+                &relay,
+                &registry,
+                None,
+                None,
+                &tx,
+                &subscriptions,
+                &mut current_agent,
+                &current_session,
+                &current_project,
+                &switch_queue,
+                HistoryMode::LiveOnly,
+                None,
+                None,
+            )
+            .await
+        );
+
+        tokio::time::timeout(Duration::from_secs(1), entered)
+            .await
+            .expect("prompt reached agent gate")
+            .expect("prompt gate signal");
+
+        tokio::time::timeout(Duration::from_millis(100), async {
+            dispatch_connection_text(
+                r#"{"id":"ping-1","type":"ping","payload":{}}"#,
+                &mut authed,
+                &acp,
+                &relay,
+                &registry,
+                None,
+                None,
+                &tx,
+                &subscriptions,
+                &mut current_agent,
+                &current_session,
+                &current_project,
+                &switch_queue,
+                HistoryMode::LiveOnly,
+                None,
+                None,
+            )
+            .await
+        })
+        .await
+        .expect("ping remains processable during prompt");
+        let ping = match rx.recv().await.expect("ping reply") {
+            Outbound::Reply(reply) => reply,
+            Outbound::Event(_) => panic!("expected ping reply"),
+        };
+        assert!(ping.ok);
+
+        let concurrent = handle_send_prompt(
+            "prompt-concurrent".to_string(),
+            &json!({
+                "agentId": "agent-long",
+                "sessionId": "session-long",
+                "text": "second",
+                "turnId": "turn-concurrent"
+            }),
+            &acp,
+            &relay,
+        )
+        .await;
+        assert!(!concurrent.ok);
+        assert_eq!(concurrent.err.expect("busy error").code, "rate_limited");
+
+        let _ = release.send(());
+        let completed = match rx.recv().await.expect("prompt reply") {
+            Outbound::Reply(reply) => reply,
+            Outbound::Event(_) => panic!("expected prompt reply"),
+        };
+        assert!(completed.ok);
+        assert_eq!(completed.id, "prompt-long");
+
+        let stale = handle_send_prompt(
+            "prompt-stale".to_string(),
+            &json!({
+                "agentId": "agent-long",
+                "sessionId": "session-long",
+                "text": "duplicate",
+                "turnId": "turn-long"
+            }),
+            &acp,
+            &relay,
+        )
+        .await;
+        assert!(!stale.ok);
+        assert_eq!(stale.err.expect("stale error").code, "stale");
+
+        let next = handle_send_prompt(
+            "prompt-next".to_string(),
+            &json!({
+                "agentId": "agent-long",
+                "sessionId": "session-long",
+                "text": "next",
+                "turnId": "turn-next"
+            }),
+            &acp,
+            &relay,
+        )
+        .await;
+        assert!(next.ok);
+    }
+
+    #[tokio::test]
+    async fn immediate_cancel_after_prompt_is_ordered_after_turn_acceptance() {
+        let relay = Arc::new(WsRelaySink::new());
+        let acp = Arc::new(AcpManager::new(vec![]));
+        let mut sessions = HashSet::new();
+        sessions.insert("session-ordered-cancel".to_string());
+        let (_release, entered) = acp.install_test_agent_with_prompt_gate(
+            AgentId("agent-ordered-cancel".to_string()),
+            sessions,
+        );
+        let registry = Arc::new(ProjectRegistry::new());
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        let subscriptions = Arc::new(tokio::sync::Mutex::new(Vec::new()));
+        let mut current_agent = None;
+        let current_session = Arc::new(parking_lot::Mutex::new(None));
+        let current_project = Arc::new(parking_lot::Mutex::new(None));
+        let switch_queue = Arc::new(tokio::sync::Mutex::new(ProjectSwitchQueue::default()));
+        let mut authed = true;
+
+        assert!(
+            dispatch_connection_text(
+                r#"{"id":"prompt-ordered","type":"send_prompt","payload":{"agentId":"agent-ordered-cancel","sessionId":"session-ordered-cancel","text":"start then cancel","turnId":"turn-ordered"}}"#,
+                &mut authed,
+                &acp,
+                &relay,
+                &registry,
+                None,
+                None,
+                &tx,
+                &subscriptions,
+                &mut current_agent,
+                &current_session,
+                &current_project,
+                &switch_queue,
+                HistoryMode::LiveOnly,
+                None,
+                None,
+            )
+            .await
+        );
+        assert!(
+            dispatch_connection_text(
+                r#"{"id":"cancel-ordered","type":"cancel_prompt","payload":{"agentId":"agent-ordered-cancel","sessionId":"session-ordered-cancel"}}"#,
+                &mut authed,
+                &acp,
+                &relay,
+                &registry,
+                None,
+                None,
+                &tx,
+                &subscriptions,
+                &mut current_agent,
+                &current_session,
+                &current_project,
+                &switch_queue,
+                HistoryMode::LiveOnly,
+                None,
+                None,
+            )
+            .await
+        );
+        entered.await.expect("prompt was accepted before cancellation");
+
+        let first = match rx.recv().await.expect("cancel reply") {
+            Outbound::Reply(reply) => reply,
+            Outbound::Event(_) => panic!("expected cancel reply"),
+        };
+        assert_eq!(first.id, "cancel-ordered");
+        assert!(first.ok);
+        let second = match rx.recv().await.expect("prompt completion reply") {
+            Outbound::Reply(reply) => reply,
+            Outbound::Event(_) => panic!("expected prompt reply"),
+        };
+        assert_eq!(second.id, "prompt-ordered");
+        assert!(second.ok);
+        assert_eq!(second.payload.expect("stop reason"), json!("cancelled"));
+    }
+
+    #[tokio::test]
+    async fn cancelled_prompt_handler_releases_exact_turn_claim() {
+        let relay = Arc::new(WsRelaySink::new());
+        let acp = Arc::new(AcpManager::new(vec![]));
+        let mut sessions = HashSet::new();
+        sessions.insert("session-cancel".to_string());
+        let (_release, entered) =
+            acp.install_test_agent_with_prompt_gate(AgentId("agent-cancel".to_string()), sessions);
+        let prompt_acp = Arc::clone(&acp);
+        let prompt_relay = Arc::clone(&relay);
+        let prompt = tokio::spawn(async move {
+            handle_send_prompt(
+                "prompt-cancel".to_string(),
+                &json!({
+                    "agentId": "agent-cancel",
+                    "sessionId": "session-cancel",
+                    "text": "long",
+                    "turnId": "turn-cancel"
+                }),
+                &prompt_acp,
+                &prompt_relay,
+            )
+            .await
+        });
+        tokio::time::timeout(Duration::from_secs(1), entered)
+            .await
+            .expect("prompt reached agent gate")
+            .expect("prompt gate signal");
+
+        prompt.abort();
+        let _ = prompt.await;
+        assert_eq!(
+            relay
+                .turn_watermark()
+                .claim_turn("session-cancel", Some("turn-next")),
+            TurnClaim::Claimed
+        );
+    }
+
+    #[tokio::test]
+    async fn accepted_prompt_survives_disconnect_and_persists_completion_for_reconnect() {
+        let root = std::env::temp_dir().join(format!("termul-ws-resume-{}", uuid::Uuid::new_v4()));
+        let cwd = root.join("cwd");
+        std::fs::create_dir_all(&cwd).unwrap();
+        let persistence = crate::acp::SessionPersistence::open(root.join("sessions"))
+            .await
+            .unwrap();
+        persistence
+            .register_session(crate::acp::SessionRegistration {
+                session_id: "session-resume".to_string(),
+                runtime_agent_id: Some("agent-resume".to_string()),
+                cwd,
+                ..Default::default()
+            })
+            .await
+            .unwrap();
+        let relay = Arc::new(WsRelaySink::with_persistence(8, persistence.clone()));
+        let acp = Arc::new(AcpManager::with_persistence(
+            vec![Arc::clone(&relay) as Arc<dyn crate::web::EventSink>],
+            persistence.clone(),
+        ));
+        let mut sessions = HashSet::new();
+        sessions.insert("session-resume".to_string());
+        let (release, entered) =
+            acp.install_test_agent_with_prompt_gate(AgentId("agent-resume".to_string()), sessions);
+        let (tx, rx) = mpsc::unbounded_channel();
+        let subscriptions = Arc::new(tokio::sync::Mutex::new(Vec::new()));
+        let registry = Arc::new(ProjectRegistry::new());
+        let mut current_agent = None;
+        let current_session = Arc::new(parking_lot::Mutex::new(None));
+        let current_project = Arc::new(parking_lot::Mutex::new(None));
+        let switch_queue = Arc::new(tokio::sync::Mutex::new(ProjectSwitchQueue::default()));
+        let mut authed = true;
+
+        assert!(
+            dispatch_connection_text(
+                r#"{"id":"prompt-resume","type":"send_prompt","payload":{"agentId":"agent-resume","sessionId":"session-resume","text":"continue after disconnect","turnId":"turn-resume"}}"#,
+                &mut authed,
+                &acp,
+                &relay,
+                &registry,
+                None,
+                None,
+                &tx,
+                &subscriptions,
+                &mut current_agent,
+                &current_session,
+                &current_project,
+                &switch_queue,
+                HistoryMode::Server,
+                None,
+                None,
+            )
+            .await
+        );
+        tokio::time::timeout(Duration::from_secs(1), entered)
+            .await
+            .expect("accepted prompt reached the agent gate")
+            .expect("prompt gate signal");
+
+        drop(rx);
+        drop(tx);
+        let _ = release.send(());
+        tokio::time::timeout(Duration::from_secs(1), async {
+            loop {
+                if relay
+                    .turn_watermark()
+                    .claim_turn("session-resume", Some("turn-resume"))
+                    == TurnClaim::Completed
+                {
+                    break;
+                }
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("host turn completed after reply channel disconnected");
+
+        persistence.flush_session("session-resume").await.unwrap();
+        let replay = persistence.replay_after("session-resume", 0).unwrap();
+        assert!(replay.iter().any(|event| event.type_ == "user_prompt"));
+        assert!(replay.iter().any(|event| {
+            event.type_ == "prompt_complete" && event.payload["turnId"] == "turn-resume"
+        }));
+
+        let (_client_id, _events, reconnect_replay) =
+            relay.subscribe("session-resume", Some(0)).await;
+        assert!(matches!(reconnect_replay, ReplayResult::Ok(replayed) if replayed >= 2));
         persistence.shutdown().await.unwrap();
         let _ = std::fs::remove_dir_all(root);
     }
@@ -3723,8 +4343,8 @@ mod tests {
                 &current_project,
                 &switch_queue,
                 HistoryMode::LiveOnly,
-            None,
-            None,
+                None,
+                None,
             ))
     }
 
@@ -4190,8 +4810,8 @@ mod tests {
                 &current_project,
                 &switch_queue,
                 HistoryMode::LiveOnly,
-            None,
-            None,
+                None,
+                None,
             ));
         assert!(!reply.ok);
         assert_eq!(reply.err.unwrap().code, "unsupported");
@@ -4275,8 +4895,8 @@ mod tests {
             &current_project,
             &switch_queue,
             HistoryMode::LiveOnly,
-        None,
-        None,
+            None,
+            None,
         ));
         assert!(!reply.ok);
         assert_eq!(reply.err.unwrap().code, "permission_denied");
@@ -4326,8 +4946,8 @@ mod tests {
             &current_project,
             &switch_queue,
             HistoryMode::LiveOnly,
-        None,
-        None,
+            None,
+            None,
         ));
         assert!(!reply.ok);
         assert_eq!(reply.err.unwrap().code, "not_found");
@@ -4363,8 +4983,8 @@ mod tests {
             &current_project,
             &switch_queue,
             HistoryMode::LiveOnly,
-        None,
-        None,
+            None,
+            None,
         ));
         assert!(ok_reply.ok, "first response wins: {:?}", ok_reply.err);
         // Second frame for the same requestId → stale (ticket evicted).
@@ -4383,8 +5003,8 @@ mod tests {
             &current_project,
             &switch_queue,
             HistoryMode::LiveOnly,
-        None,
-        None,
+            None,
+            None,
         ));
         assert!(!stale_reply.ok);
         assert_eq!(stale_reply.err.unwrap().code, "stale");
@@ -4419,8 +5039,8 @@ mod tests {
             &current_project,
             &switch_queue,
             HistoryMode::LiveOnly,
-        None,
-        None,
+            None,
+            None,
         ));
         assert!(!reply.ok);
         assert_eq!(reply.err.unwrap().code, "permission_denied");
@@ -4508,8 +5128,8 @@ mod tests {
             &current_project,
             &switch_queue,
             HistoryMode::LiveOnly,
-        None,
-        None,
+            None,
+            None,
         ));
         assert!(!reply.ok);
         assert_eq!(reply.err.unwrap().code, "unsupported");
@@ -4543,8 +5163,8 @@ mod tests {
             &current_project,
             &switch_queue,
             HistoryMode::LiveOnly,
-        None,
-        None,
+            None,
+            None,
         ));
         assert!(!reply.ok);
         assert_eq!(reply.err.unwrap().code, "permission_denied");
@@ -4592,8 +5212,8 @@ mod tests {
             &current_project,
             &switch_queue,
             HistoryMode::LiveOnly,
-        None,
-        None,
+            None,
+            None,
         ));
         assert!(!reply.ok);
         assert_eq!(reply.err.unwrap().code, "not_found");
@@ -4628,8 +5248,8 @@ mod tests {
             &current_project,
             &switch_queue,
             HistoryMode::LiveOnly,
-        None,
-        None,
+            None,
+            None,
         ));
         assert!(ok_reply.ok, "first answer wins: {:?}", ok_reply.err);
         let stale_reply = block_on(handle_request(
@@ -4647,8 +5267,8 @@ mod tests {
             &current_project,
             &switch_queue,
             HistoryMode::LiveOnly,
-        None,
-        None,
+            None,
+            None,
         ));
         assert!(!stale_reply.ok);
         assert_eq!(stale_reply.err.unwrap().code, "stale");
@@ -4682,8 +5302,8 @@ mod tests {
             &current_project,
             &switch_queue,
             HistoryMode::LiveOnly,
-        None,
-        None,
+            None,
+            None,
         ));
         assert!(!reply.ok);
         assert_eq!(reply.err.unwrap().code, "permission_denied");
@@ -4739,8 +5359,8 @@ mod tests {
                 &current_project,
                 &switch_queue,
                 HistoryMode::LiveOnly,
-            None,
-            None,
+                None,
+                None,
             ));
         assert!(!reply.ok);
         assert_eq!(reply.err.unwrap().code, "stale");
@@ -4766,8 +5386,8 @@ mod tests {
                 &current_project,
                 &switch_queue,
                 HistoryMode::LiveOnly,
-            None,
-            None,
+                None,
+                None,
             ));
         assert!(reply_ok.ok, "{:?}", reply_ok.err);
         assert_eq!(subs2.len(), 1);
@@ -4792,8 +5412,8 @@ mod tests {
                 &current_project,
                 &switch_queue,
                 HistoryMode::LiveOnly,
-            None,
-            None,
+                None,
+                None,
             ));
         assert!(reply_resub.ok, "{:?}", reply_resub.err);
         assert_eq!(subs2.len(), 1);
@@ -4819,8 +5439,8 @@ mod tests {
                 &current_project,
                 &switch_queue,
                 HistoryMode::LiveOnly,
-            None,
-            None,
+                None,
+                None,
             ));
         assert!(reply_live.ok, "{:?}", reply_live.err);
 
@@ -4873,8 +5493,8 @@ mod tests {
             &current_project,
             &switch_queue,
             HistoryMode::LiveOnly,
-        None,
-        None,
+            None,
+            None,
         ));
         assert!(reply.ok, "{:?}", reply.err);
         let payload = reply.payload.expect("selected payload");
@@ -4932,8 +5552,8 @@ mod tests {
             &current_project,
             &switch_queue,
             HistoryMode::LiveOnly,
-        None,
-        None,
+            None,
+            None,
         ));
         assert!(!reply.ok);
         assert_eq!(reply.err.unwrap().code, "not_found");
@@ -5048,8 +5668,8 @@ mod tests {
             &current_project,
             &switch_queue,
             HistoryMode::LiveOnly,
-        None,
-        None,
+            None,
+            None,
         ));
         assert!(!reply.ok);
         assert_eq!(reply.err.unwrap().code, "not_found");

--- a/src-tauri/src/web/ws.rs
+++ b/src-tauri/src/web/ws.rs
@@ -3454,8 +3454,18 @@ mod tests {
         cleanup_task.abort();
         let _ = cleanup_task.await;
 
-        assert_eq!(relay.session_subscriber_count("session-cleanup"), 0);
-        assert!(subscribed.lock().await.is_empty());
+        tokio::time::timeout(Duration::from_secs(1), async {
+            loop {
+                if relay.session_subscriber_count("session-cleanup") == 0
+                    && subscribed.lock().await.is_empty()
+                {
+                    break;
+                }
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("subscriptions cleaned up after connection cleanup");
         assert!(!questions.is_outstanding("question-cleanup"));
         tokio::time::timeout(Duration::from_secs(1), async {
             while permissions.is_outstanding("permission-cleanup") {

--- a/src/renderer/hooks/use-acp-history.ts
+++ b/src/renderer/hooks/use-acp-history.ts
@@ -1,6 +1,7 @@
 import { useEffect } from 'react'
 import { runHistoryWipeMigration } from '@/lib/acp-history-persistence'
 import { getAcpTransport } from '@/lib/acp-transport'
+import { logFrontendError } from '@/lib/log-api'
 import { isTauriContext } from '@/lib/tauri-runtime'
 import { useAcpStore } from '@/stores/acp-store'
 
@@ -22,9 +23,19 @@ export function useAcpHistory(): void {
         // Desktop Tauri Store migration is a no-op for server/live-only providers.
         await runHistoryWipeMigration()
       } catch (err) {
-        console.error('[acp] history wipe migration failed', err)
+        void logFrontendError({
+          level: 'warn',
+          source: 'useAcpHistory.migration',
+          message: `ACP history wipe migration failed: ${String(err)}`
+        })
       }
-      await loadSessionIndex()
+      await loadSessionIndex().catch((err) => {
+        void logFrontendError({
+          level: 'warn',
+          source: 'useAcpHistory.initialLoad',
+          message: `ACP history index refresh failed: ${String(err)}`
+        })
+      })
     })()
 
     // Web/remote: refetch the session index when the server pushes a
@@ -33,7 +44,13 @@ export function useAcpHistory(): void {
     if (isTauriContext()) return
     const transport = getAcpTransport()
     const unsubscribe = transport.onEvent('acp:chat_history_changed', () => {
-      void loadSessionIndex()
+      void loadSessionIndex().catch((err) => {
+        void logFrontendError({
+          level: 'warn',
+          source: 'useAcpHistory.chatHistoryChanged',
+          message: `ACP history index refresh failed: ${String(err)}`
+        })
+      })
     })
     return () => {
       unsubscribe()

--- a/src/renderer/lib/acp-transport.test.ts
+++ b/src/renderer/lib/acp-transport.test.ts
@@ -1,11 +1,18 @@
 import { readFileSync } from 'node:fs'
 import { resolve } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('@/lib/log-api', () => ({
+  logFrontendError: vi.fn()
+}))
+
+import { logFrontendError } from '@/lib/log-api'
 import {
   _resetAcpTransportForTests,
   _setAcpTransportForTests,
   AcpTransportError,
   createAcpTransport,
+  isTransientAcpTransportError,
   resolveWsUrl,
   toTauriEventName,
   toWsEventType,
@@ -17,6 +24,7 @@ class FakeWebSocket {
   static CONNECTING = 0
   static CLOSING = 2
   static CLOSED = 3
+  static autoOpen = true
 
   readyState = FakeWebSocket.CONNECTING
   onopen: ((ev: Event) => void) | null = null
@@ -34,6 +42,12 @@ class FakeWebSocket {
   streamOnSendPrompt = false
   /** When true, do not auto-reply to `send_prompt` (for timeout tests). */
   holdSendPrompt = false
+  /** When true, application pings remain unanswered (stale OPEN socket). */
+  holdPing = false
+  /** Session ids whose subscribe request fails. */
+  failSubscribeSessions = new Set<string>()
+  /** Per-session subscribe failures used to distinguish transient/permanent recovery. */
+  subscribeFailureCodes = new Map<string, string>()
   /** Live agent ids for spawn_agent / list_agents / kill_agent stubs. */
   liveAgents = new Set<string>()
   switchProjectReply: unknown = null
@@ -50,6 +64,7 @@ class FakeWebSocket {
     pongTimeoutMs: 75_000
   }
   snapshotEvents: unknown[] = []
+  snapshotFailureCodes = new Map<string, string>()
   /** Session payloads served by `get_session_payload`; unknown ids → not_found. */
   sessionPayloads: Record<string, unknown> = {}
   reopenOutcome: unknown = {
@@ -65,6 +80,7 @@ class FakeWebSocket {
   }
 
   constructor(public url: string) {
+    if (!(this.constructor as typeof FakeWebSocket).autoOpen) return
     queueMicrotask(() => {
       this.readyState = FakeWebSocket.OPEN
       this.onopen?.(new Event('open'))
@@ -95,11 +111,20 @@ class FakeWebSocket {
     if (req.type === 'ping') {
       // Heartbeat handler: round-trip an ok reply so the client's request
       // promise resolves (a healthy ping resets the failure counter).
-      this.emitReply({ id: req.id, ok: true, payload: {} })
+      if (!this.holdPing) this.emitReply({ id: req.id, ok: true, payload: {} })
       return
     }
     if (req.type === 'subscribe') {
       const payload = req.payload as { sessionId: string; lastSeq?: number }
+      const failureCode = this.subscribeFailureCodes.get(payload.sessionId)
+      if (this.failSubscribeSessions.has(payload.sessionId) || failureCode) {
+        this.emitReply({
+          id: req.id,
+          ok: false,
+          err: { code: failureCode ?? 'not_found', message: 'subscription failed' }
+        })
+        return
+      }
       if (payload.lastSeq === 99) {
         this.emitReply({
           id: req.id,
@@ -117,6 +142,15 @@ class FakeWebSocket {
     }
     if (req.type === 'recover_session_snapshot') {
       const payload = req.payload as { sessionId: string }
+      const failureCode = this.snapshotFailureCodes.get(payload.sessionId)
+      if (failureCode) {
+        this.emitReply({
+          id: req.id,
+          ok: false,
+          err: { code: failureCode, message: 'snapshot recovery failed' }
+        })
+        return
+      }
       this.emitReply({
         id: req.id,
         ok: true,
@@ -823,6 +857,24 @@ describe('WsAcpTransport', () => {
     transport.dispose()
   })
 
+  it('retains a stale subscription when snapshot recovery fails transiently', async () => {
+    const transport = new WsAcpTransport({
+      url: 'ws://test/ws',
+      WebSocketImpl: FakeWebSocket as unknown as typeof WebSocket
+    })
+    await transport.connect()
+    const sock = (transport as unknown as { socket: FakeWebSocket }).socket
+    sock.snapshotFailureCodes.set('s-transient-snapshot', 'agent_crashed')
+
+    await expect(transport.subscribeSession('s-transient-snapshot', 99)).rejects.toMatchObject({
+      code: 'agent_crashed'
+    })
+    const subscribed = (transport as unknown as { subscribed: Set<string> }).subscribed
+    expect(subscribed.has('s-transient-snapshot')).toBe(true)
+    expect(isTransientAcpTransportError(new AcpTransportError('agent_crashed', 'retry'))).toBe(true)
+    transport.dispose()
+  })
+
   it('reports degraded recovery in live-only mode instead of silent success', async () => {
     class LiveOnlySocket extends FakeWebSocket {
       constructor(url: string) {
@@ -1450,13 +1502,36 @@ describe('WsAcpTransport reconnect listener (Story 5.3)', () => {
 // leaving a half-open socket the client trusts and never re-establishes).
 type TransportInternals = {
   socket: FakeWebSocket
+  connecting: Promise<void> | null
+  reconnecting: boolean
   lastHiddenAt: number | null
   visibilityHandler: (() => void) | null
   focusHandler: (() => void) | null
+  pageShowHandler: (() => void) | null
+  resumeHandler: (() => void) | null
+  onlineHandler: (() => void) | null
+  resumeValidation: Promise<void> | null
   reconnectTimer: ReturnType<typeof setTimeout> | null
   reconnectAttempt: number
   lastSeq: Map<string, number>
   subscribed: Set<string>
+}
+
+class DelayedOpenWebSocket extends FakeWebSocket {
+  static autoOpen = false
+  static pending: DelayedOpenWebSocket[] = []
+
+  constructor(url: string) {
+    super(url)
+    this.readyState = FakeWebSocket.CONNECTING
+    DelayedOpenWebSocket.pending.push(this)
+  }
+
+  openAndAuthenticate(): void {
+    this.readyState = FakeWebSocket.OPEN
+    this.onopen?.(new Event('open'))
+    this.emit({ sid: null, seq: 0, type: 'auth_required', payload: {} })
+  }
 }
 
 /** Override `document.visibilityState` + dispatch `visibilitychange` (jsdom's
@@ -1500,7 +1575,7 @@ describe('WsAcpTransport visibility-triggered reconnect (web idle persist)', () 
     vi.useRealTimers()
   })
 
-  it('reconnects + re-subscribes with cursor after a long hide (> threshold)', async () => {
+  it('validates a healthy OPEN socket on visibility return without replacing it', async () => {
     vi.useFakeTimers()
     const transport = new WsAcpTransport({
       url: 'ws://test/ws',
@@ -1522,23 +1597,16 @@ describe('WsAcpTransport visibility-triggered reconnect (web idle persist)', () 
     await Promise.resolve() // flush onMessage
     expect(internals.lastSeq.get('sess-A')).toBe(1)
 
-    // Long hide (> 30s threshold) → return → proactive reconnect.
+    // Return from background validates with an application ping. A successful
+    // round trip proves the OPEN socket is still usable, so no replacement.
     dispatchVisibility('hidden')
-    await vi.advanceTimersByTimeAsync(31_000)
+    await vi.advanceTimersByTimeAsync(1_000)
     dispatchVisibility('visible')
-    // forceReconnect → scheduleReconnect fires `true` immediately.
-    expect(states[0]).toBe(true)
-
-    // Advance past the 500ms backoff → reconnect re-opens + re-subscribes.
-    await vi.advanceTimersByTimeAsync(600)
     await Promise.resolve()
 
-    expect(internals.socket).not.toBe(oldSocket) // new socket opened
-    expect(states[states.length - 1]).toBe(false) // overlay cleared
-    const sub = findSentRequest(internals.socket, 'subscribe')
-    expect(sub).toBeDefined()
-    expect(sub?.payload.sessionId).toBe('sess-A')
-    expect(sub?.payload.lastSeq).toBe(1) // cursor carried → gap replay path
+    expect(internals.socket).toBe(oldSocket)
+    expect(states).toEqual([])
+    expect(findSentRequest(oldSocket, 'ping')).toBeDefined()
 
     const timerField = transport as unknown as {
       reconnectTimer: ReturnType<typeof setTimeout> | null
@@ -1550,7 +1618,36 @@ describe('WsAcpTransport visibility-triggered reconnect (web idle persist)', () 
     transport.dispose()
   })
 
-  it('does NOT reconnect after a brief hide (< threshold) with a healthy OPEN socket', async () => {
+  it('ignores lifecycle signals while initial authentication is still in flight', async () => {
+    vi.useFakeTimers()
+    DelayedOpenWebSocket.pending = []
+    const transport = new WsAcpTransport({
+      url: 'ws://test/ws',
+      WebSocketImpl: DelayedOpenWebSocket as unknown as typeof WebSocket
+    })
+    const connecting = transport.connect()
+    await Promise.resolve()
+    const internals = transport as unknown as TransportInternals
+    const openingSocket = internals.socket as DelayedOpenWebSocket
+
+    dispatchVisibility('hidden')
+    dispatchVisibility('visible')
+    window.dispatchEvent(new Event('pageshow'))
+    document.dispatchEvent(new Event('resume'))
+    window.dispatchEvent(new Event('online'))
+
+    expect(internals.socket).toBe(openingSocket)
+    expect(internals.connecting).not.toBeNull()
+    expect(openingSocket.onclose).not.toBeNull()
+    expect(internals.reconnectTimer).toBeNull()
+
+    openingSocket.openAndAuthenticate()
+    await connecting
+    expect(internals.socket).toBe(openingSocket)
+    transport.dispose()
+  })
+
+  it('validates after a brief hide too because OPEN alone is not health proof', async () => {
     vi.useFakeTimers()
     const transport = new WsAcpTransport({
       url: 'ws://test/ws',
@@ -1564,12 +1661,13 @@ describe('WsAcpTransport visibility-triggered reconnect (web idle persist)', () 
     const socketBefore = internals.socket
 
     dispatchVisibility('hidden')
-    await vi.advanceTimersByTimeAsync(5_000) // well under the 30s threshold
+    await vi.advanceTimersByTimeAsync(1_000)
     dispatchVisibility('visible')
     await Promise.resolve()
 
-    expect(states).toEqual([]) // no reconnect transition
-    expect(internals.socket).toBe(socketBefore) // same socket, not torn down
+    expect(states).toEqual([])
+    expect(internals.socket).toBe(socketBefore)
+    expect(findSentRequest(socketBefore, 'ping')).toBeDefined()
     expect(internals.lastHiddenAt).toBeNull() // consumed
 
     const timerField = transport as unknown as {
@@ -1582,7 +1680,7 @@ describe('WsAcpTransport visibility-triggered reconnect (web idle persist)', () 
     transport.dispose()
   })
 
-  it('force-reconnects a half-open (still-OPEN) socket on return, detaching old handlers', async () => {
+  it('force-reconnects and cursor-resubscribes when an OPEN socket fails resume validation', async () => {
     vi.useFakeTimers()
     const transport = new WsAcpTransport({
       url: 'ws://test/ws',
@@ -1594,12 +1692,21 @@ describe('WsAcpTransport visibility-triggered reconnect (web idle persist)', () 
     await transport.subscribeSession('sess-A')
     const internals = transport as unknown as TransportInternals
     const oldSocket = internals.socket
+    oldSocket.emit({
+      sid: 'sess-A',
+      seq: 1,
+      type: 'message_chunk',
+      payload: { role: 'agent', content: { text: 'before background' } }
+    })
+    await Promise.resolve()
+    oldSocket.holdPing = true
     // The socket is OPEN (half-open: server gave up, client doesn't know yet).
     expect(oldSocket.readyState).toBe(FakeWebSocket.OPEN)
 
     dispatchVisibility('hidden')
-    await vi.advanceTimersByTimeAsync(31_000)
+    await vi.advanceTimersByTimeAsync(1_000)
     dispatchVisibility('visible')
+    await vi.advanceTimersByTimeAsync(5_100)
     expect(states[0]).toBe(true)
 
     await vi.advanceTimersByTimeAsync(600)
@@ -1612,6 +1719,8 @@ describe('WsAcpTransport visibility-triggered reconnect (web idle persist)', () 
     expect(oldSocket.onclose).toBeNull() // handlers detached → no double fire
     expect(states.filter((s) => s)).toHaveLength(1) // exactly one `true`
     expect(states.filter((s) => !s)).toHaveLength(1) // exactly one `false`
+    const sub = findSentRequest(internals.socket, 'subscribe')
+    expect(sub?.payload).toMatchObject({ sessionId: 'sess-A', lastSeq: 1 })
 
     const timerField = transport as unknown as {
       reconnectTimer: ReturnType<typeof setTimeout> | null
@@ -1623,7 +1732,50 @@ describe('WsAcpTransport visibility-triggered reconnect (web idle persist)', () 
     transport.dispose()
   })
 
-  it('coalesces: a `focus` following `visibilitychange` does not double-reconnect', async () => {
+  for (const signal of ['pageshow', 'resume', 'online'] as const) {
+    it(`validates an OPEN socket on isolated ${signal}`, async () => {
+      vi.useFakeTimers()
+      const transport = new WsAcpTransport({
+        url: 'ws://test/ws',
+        WebSocketImpl: FakeWebSocket as unknown as typeof WebSocket
+      })
+      await transport.connect()
+      const internals = transport as unknown as TransportInternals
+      const socket = internals.socket
+
+      if (signal === 'resume') document.dispatchEvent(new Event(signal))
+      else window.dispatchEvent(new Event(signal))
+      await Promise.resolve()
+
+      expect(findSentRequest(socket, 'ping')).toBeDefined()
+      expect(internals.socket).toBe(socket)
+      transport.dispose()
+    })
+  }
+
+  it('ignores lifecycle signals during reconnect backoff without resetting the retry', async () => {
+    vi.useFakeTimers()
+    const transport = new WsAcpTransport({
+      url: 'ws://test/ws',
+      WebSocketImpl: FakeWebSocket as unknown as typeof WebSocket
+    })
+    await transport.connect()
+    const internals = transport as unknown as TransportInternals
+    internals.socket.close()
+    const timer = internals.reconnectTimer
+    const attempt = internals.reconnectAttempt
+
+    window.dispatchEvent(new Event('pageshow'))
+    document.dispatchEvent(new Event('resume'))
+    window.dispatchEvent(new Event('online'))
+
+    expect(internals.reconnectTimer).toBe(timer)
+    expect(internals.reconnectAttempt).toBe(attempt)
+    expect(internals.reconnecting).toBe(true)
+    transport.dispose()
+  })
+
+  it('coalesces visibility, pageshow, resume, online, and focus validation signals', async () => {
     vi.useFakeTimers()
     const transport = new WsAcpTransport({
       url: 'ws://test/ws',
@@ -1633,20 +1785,23 @@ describe('WsAcpTransport visibility-triggered reconnect (web idle persist)', () 
     const states: boolean[] = []
     transport.setReconnectListener((r) => states.push(r))
     await transport.subscribeSession('sess-A')
+    const internals = transport as unknown as TransportInternals
+    const oldSocket = internals.socket
+    oldSocket.holdPing = true
 
-    // Long hide → visible triggers forceReconnect (consumes lastHiddenAt).
+    // All lifecycle signals arrive while the same bounded ping is in flight.
     dispatchVisibility('hidden')
-    await vi.advanceTimersByTimeAsync(31_000)
+    await vi.advanceTimersByTimeAsync(1_000)
     dispatchVisibility('visible')
-    expect(states[0]).toBe(true)
-
-    // A `focus` right after (the fallback path) must NOT trigger a 2nd reconnect
-    // — lastHiddenAt was consumed. Dispatched on `window` (focus is a
-    // window-level event that does not bubble to `document`).
     window.dispatchEvent(new Event('focus'))
+    window.dispatchEvent(new Event('pageshow'))
+    document.dispatchEvent(new Event('resume'))
+    window.dispatchEvent(new Event('online'))
     await Promise.resolve()
-    expect(states.filter((s) => s)).toHaveLength(1)
+    expect(oldSocket.sent.filter((raw) => JSON.parse(raw).type === 'ping')).toHaveLength(1)
 
+    await vi.advanceTimersByTimeAsync(5_100)
+    expect(states.filter((s) => s)).toHaveLength(1)
     await vi.advanceTimersByTimeAsync(600)
     await Promise.resolve()
     expect(states.filter((s) => !s)).toHaveLength(1) // one reconnect, one `false`
@@ -1671,10 +1826,89 @@ describe('WsAcpTransport visibility-triggered reconnect (web idle persist)', () 
     const internals = transport as unknown as TransportInternals
     expect(internals.visibilityHandler).not.toBeNull()
     expect(internals.focusHandler).not.toBeNull()
+    expect(internals.pageShowHandler).not.toBeNull()
+    expect(internals.resumeHandler).not.toBeNull()
+    expect(internals.onlineHandler).not.toBeNull()
 
     transport.dispose()
     expect(internals.visibilityHandler).toBeNull()
     expect(internals.focusHandler).toBeNull()
+    expect(internals.pageShowHandler).toBeNull()
+    expect(internals.resumeHandler).toBeNull()
+    expect(internals.onlineHandler).toBeNull()
+  })
+
+  it('drops a permanently obsolete not_found subscription and completes reconnect', async () => {
+    vi.useFakeTimers()
+    class ReconnectSubscribeFailureSocket extends FakeWebSocket {
+      static instances = 0
+
+      constructor(url: string) {
+        super(url)
+        ReconnectSubscribeFailureSocket.instances += 1
+        if (ReconnectSubscribeFailureSocket.instances > 1) {
+          this.failSubscribeSessions.add('sess-fail')
+        }
+      }
+    }
+    const transport = new WsAcpTransport({
+      url: 'ws://test/ws',
+      WebSocketImpl: ReconnectSubscribeFailureSocket as unknown as typeof WebSocket
+    })
+    await transport.connect()
+    await transport.subscribeSession('sess-fail')
+    const states: boolean[] = []
+    transport.setReconnectListener((state) => states.push(state))
+    const internals = transport as unknown as TransportInternals
+    internals.socket.close()
+    await vi.advanceTimersByTimeAsync(600)
+
+    expect(states).toEqual([true, false])
+    expect(internals.subscribed.has('sess-fail')).toBe(false)
+    expect(logFrontendError).toHaveBeenCalledWith(
+      expect.objectContaining({
+        source: 'WsAcpTransport.reconnect',
+        message: expect.stringContaining('Dropped obsolete')
+      })
+    )
+    transport.dispose()
+  })
+
+  it('retries a transient subscription failure with backoff and reports success after recovery', async () => {
+    vi.useFakeTimers()
+    class TransientSubscribeFailureSocket extends FakeWebSocket {
+      static instances = 0
+
+      constructor(url: string) {
+        super(url)
+        TransientSubscribeFailureSocket.instances += 1
+        if (TransientSubscribeFailureSocket.instances === 2) {
+          this.subscribeFailureCodes.set('sess-transient', 'closed')
+        }
+      }
+    }
+    const transport = new WsAcpTransport({
+      url: 'ws://test/ws',
+      WebSocketImpl: TransientSubscribeFailureSocket as unknown as typeof WebSocket
+    })
+    await transport.connect()
+    await transport.subscribeSession('sess-transient')
+    const states: boolean[] = []
+    transport.setReconnectListener((state) => states.push(state))
+    const internals = transport as unknown as TransportInternals
+    internals.socket.close()
+
+    await vi.advanceTimersByTimeAsync(600)
+    expect(states).toEqual([true])
+    expect(internals.reconnectAttempt).toBe(2)
+    expect(internals.reconnectTimer).not.toBeNull()
+
+    await vi.advanceTimersByTimeAsync(1_100)
+    await vi.waitFor(() => expect(states).toEqual([true, false]))
+    expect(states).toEqual([true, false])
+    expect(internals.reconnectAttempt).toBe(0)
+    expect(internals.subscribed.has('sess-transient')).toBe(true)
+    transport.dispose()
   })
 })
 

--- a/src/renderer/lib/acp-transport.ts
+++ b/src/renderer/lib/acp-transport.ts
@@ -52,6 +52,7 @@ import type {
   StopReason
 } from '@/lib/acp-api'
 import type { AcpRuntimeAvailability } from '@/lib/agents/supported-acp-agents'
+import { logFrontendError } from '@/lib/log-api'
 import { isTauriContext } from '@/lib/tauri-runtime'
 import { randomUUID } from '@/lib/uuid'
 import { webServerMcpProbe } from '@/lib/web-server-api'
@@ -80,6 +81,13 @@ export class AcpTransportError extends Error {
     this.name = 'AcpTransportError'
     this.code = code
   }
+}
+
+export function isTransientAcpTransportError(error: unknown): error is AcpTransportError {
+  return (
+    error instanceof AcpTransportError &&
+    (error.code === 'closed' || error.code === 'timeout' || error.code === 'agent_crashed')
+  )
 }
 
 export interface AcpTransport {
@@ -370,18 +378,8 @@ const SEND_PROMPT_GRACE_MS = 10_000
 const FALLBACK_SEND_PROMPT_INACTIVITY_MS = 3_600_000
 const RECONNECT_BASE_MS = 500
 const RECONNECT_MAX_MS = 8_000
-/**
- * How long the page must stay hidden before a return triggers a proactive
- * reconnect. Mobile browsers suspend JS in backgrounded tabs, so the server's
- * keepalive Ping goes un-ponged and the server tears the socket down at its
- * ~75s Pong-timeout (`web/ws.rs::PONG_TIMEOUT`) — but the client only learns
- * this when `onclose` is finally delivered on resume (late, or never on a
- * half-open link). 30s sits between the server's 20s Ping interval and its 75s
- * Pong-timeout: long enough to ride out a brief tab switch without a needless
- * reconnect, short enough that a real background/idle triggers recovery before
- * the user sees a dead chat. Tunable.
- */
-const VISIBILITY_STALE_THRESHOLD_MS = 30_000
+/** Bounded application round-trip check used for browser resume signals. */
+const RESUME_VALIDATION_TIMEOUT_MS = 5_000
 
 /**
  * Application-level heartbeat interval. A client-emitted `ping` text request
@@ -433,6 +431,8 @@ export class WsAcpTransport implements AcpTransport {
   private disposed = false
   private reconnectAttempt = 0
   private reconnectTimer: ReturnType<typeof setTimeout> | null = null
+  /** Prevent duplicate reconnect notifications while retries are still active. */
+  private reconnecting = false
   /** Application-level heartbeat timer (`setInterval`) — cleared on close /
    * dispose / force-reconnect. `null` while no socket is live. */
   private heartbeatTimer: ReturnType<typeof setInterval> | null = null
@@ -444,6 +444,11 @@ export class WsAcpTransport implements AcpTransport {
   /** Bound DOM-listener refs so `dispose()` can detach them. */
   private visibilityHandler: (() => void) | null = null
   private focusHandler: (() => void) | null = null
+  private pageShowHandler: (() => void) | null = null
+  private resumeHandler: (() => void) | null = null
+  private onlineHandler: (() => void) | null = null
+  /** Coalesces overlapping foreground/pageshow/resume/online health checks. */
+  private resumeValidation: Promise<void> | null = null
   private readonly pending = new Map<string, Pending>()
   private readonly listeners = new Map<string, Set<EventListener>>()
   /** Per-session last contiguous delivered seq. */
@@ -950,14 +955,17 @@ export class WsAcpTransport implements AcpTransport {
     if (this.disposed) return
     await new Promise<void>((resolve, reject) => {
       let settled = false
+      let authTimer: ReturnType<typeof setTimeout> | null = null
       const settleOk = () => {
         if (settled) return
         settled = true
+        if (authTimer) clearTimeout(authTimer)
         resolve()
       }
       const settleErr = (err: Error) => {
         if (settled) return
         settled = true
+        if (authTimer) clearTimeout(authTimer)
         reject(err)
       }
 
@@ -981,11 +989,16 @@ export class WsAcpTransport implements AcpTransport {
       }
 
       ws.onerror = () => {
+        if (this.socket !== ws) return
         this.rejectAllPending('closed', 'WebSocket error')
         settleErr(new AcpTransportError('closed', 'WebSocket error'))
       }
 
       ws.onclose = () => {
+        if (this.socket !== ws) {
+          settleErr(new AcpTransportError('closed', 'superseded WebSocket closed before auth'))
+          return
+        }
         this.socket = null
         this.authed = false
         this.clearHeartbeat()
@@ -994,7 +1007,7 @@ export class WsAcpTransport implements AcpTransport {
         settleErr(new AcpTransportError('closed', 'WebSocket closed before auth'))
       }
 
-      setTimeout(() => {
+      authTimer = setTimeout(() => {
         if (!this.authed) {
           try {
             ws.close()
@@ -1016,12 +1029,8 @@ export class WsAcpTransport implements AcpTransport {
   }
 
   /**
-   * Attach `visibilitychange` + `focus` listeners (web only) so a return from a
-   * backgrounded mobile tab proactively reconnects instead of waiting for an
-   * `onclose` the suspended browser delivers late or never. Idempotent; detached
-   * in {@link dispose}. `visibilitychange` is the primary signal (it carries
-   * hidden/visible timing); `focus` is a fallback for platforms where
-   * `visibilitychange` is unreliable.
+   * Attach browser lifecycle listeners so every resume signal validates the
+   * application round trip instead of trusting `readyState === OPEN`.
    */
   private attachVisibilityListeners(): void {
     if (this.visibilityHandler || typeof document === 'undefined') return
@@ -1030,21 +1039,27 @@ export class WsAcpTransport implements AcpTransport {
         this.lastHiddenAt = Date.now()
         return
       }
-      // visible — a backgrounded tab returning to the foreground.
-      this.maybeReconnectOnReturn()
+      this.validateOnResume('visibility return')
     }
     const onFocus = (): void => {
-      // Fallback: focus implies the window is active again. Only acts when we
-      // previously recorded a hide, so normal interaction is a no-op.
-      this.maybeReconnectOnReturn()
+      if (this.lastHiddenAt != null) this.validateOnResume('window focus')
     }
+    const onPageShow = (): void => this.validateOnResume('pageshow')
+    const onResume = (): void => this.validateOnResume('browser resume')
+    const onOnline = (): void => this.validateOnResume('network online')
     this.visibilityHandler = onVisibility
     this.focusHandler = onFocus
+    this.pageShowHandler = onPageShow
+    this.resumeHandler = onResume
+    this.onlineHandler = onOnline
     document.addEventListener('visibilitychange', onVisibility)
     // `focus`/`blur` for tab/window backgrounding are window-level events and do
     // NOT bubble — attach to `window`, not `document` (a document-level listener
     // would never fire for window focus changes, making the fallback dead code).
     window.addEventListener('focus', onFocus)
+    window.addEventListener('pageshow', onPageShow)
+    document.addEventListener('resume', onResume)
+    window.addEventListener('online', onOnline)
   }
 
   /** Detach the visibility/focus listeners (called from {@link dispose}). */
@@ -1057,27 +1072,65 @@ export class WsAcpTransport implements AcpTransport {
       window.removeEventListener('focus', this.focusHandler)
       this.focusHandler = null
     }
+    if (this.pageShowHandler && typeof window !== 'undefined') {
+      window.removeEventListener('pageshow', this.pageShowHandler)
+      this.pageShowHandler = null
+    }
+    if (this.resumeHandler && typeof document !== 'undefined') {
+      document.removeEventListener('resume', this.resumeHandler)
+      this.resumeHandler = null
+    }
+    if (this.onlineHandler && typeof window !== 'undefined') {
+      window.removeEventListener('online', this.onlineHandler)
+      this.onlineHandler = null
+    }
   }
 
-  /**
-   * On a return-to-foreground, if the page was hidden past the staleness
-   * threshold OR the socket is not OPEN, force a reconnect. The existing
-   * `reconnect()` + `subscribeSession(lastSeq)` cursor path then replays missed
-   * events from the server's per-session event log and resumes streaming — no
-   * manual page reload. Consumes `lastHiddenAt` so a `focus` following a
-   * `visibilitychange` (or vice-versa) does not double-trigger.
-   */
-  private maybeReconnectOnReturn(): void {
-    if (this.disposed) return
-    const hiddenAt = this.lastHiddenAt
+  private validateOnResume(reason: string): void {
+    if (
+      this.disposed ||
+      this.connecting ||
+      this.reconnecting ||
+      this.reconnectTimer ||
+      this.resumeValidation
+    ) {
+      return
+    }
     this.lastHiddenAt = null
-    if (hiddenAt == null) return // never recorded a hide — nothing to recover
-    const hiddenFor = Date.now() - hiddenAt
-    const socketDown = this.socket?.readyState !== WebSocket.OPEN
-    if (hiddenFor > VISIBILITY_STALE_THRESHOLD_MS || socketDown) {
-      this.forceReconnect(
-        socketDown ? 'socket closed while page was hidden' : 'visibility return after idle'
-      )
+    const validation = this.validateRoundTrip(reason).finally(() => {
+      if (this.resumeValidation === validation) this.resumeValidation = null
+    })
+    this.resumeValidation = validation
+  }
+
+  private async validateRoundTrip(reason: string): Promise<void> {
+    try {
+      if (this.socket?.readyState !== WebSocket.OPEN || !this.authed) {
+        throw new AcpTransportError('closed', 'socket is not authenticated and open')
+      }
+      await new Promise<void>((resolve, reject) => {
+        const timer = setTimeout(
+          () => reject(new AcpTransportError('timeout', 'resume health check timed out')),
+          RESUME_VALIDATION_TIMEOUT_MS
+        )
+        void this.request<void>('ping', {}).then(
+          () => {
+            clearTimeout(timer)
+            resolve()
+          },
+          (error) => {
+            clearTimeout(timer)
+            reject(error)
+          }
+        )
+      })
+    } catch (error) {
+      void logFrontendError({
+        level: 'warn',
+        source: 'WsAcpTransport.resumeValidation',
+        message: `${reason}: ACP round-trip validation failed: ${String(error)}`
+      })
+      this.forceReconnect(`${reason}: health validation failed`)
     }
   }
 
@@ -1093,18 +1146,17 @@ export class WsAcpTransport implements AcpTransport {
    * `onReconnectStateChange` machinery runs unchanged.
    */
   private forceReconnect(reason: string): void {
-    if (this.disposed) return
+    if (this.disposed || this.connecting || this.reconnecting || this.reconnectTimer) return
+    this.discardSocket(reason)
+    this.scheduleReconnect()
+  }
+
+  private discardSocket(reason: string): void {
     const old = this.socket
     this.socket = null
     this.authed = false
-    this.connecting = null
     this.rejectAllPending('closed', reason)
     this.clearHeartbeat()
-    if (this.reconnectTimer) {
-      clearTimeout(this.reconnectTimer)
-      this.reconnectTimer = null
-    }
-    this.reconnectAttempt = 0
     if (old) {
       // Detach so the old socket's close does not double-fire scheduleReconnect
       // / rejectAllPending on an already-tearing-down transport.
@@ -1117,7 +1169,6 @@ export class WsAcpTransport implements AcpTransport {
         /* ignore — already closed */
       }
     }
-    this.scheduleReconnect()
   }
 
   /**
@@ -1170,7 +1221,10 @@ export class WsAcpTransport implements AcpTransport {
     // the store can flip `transportReconnecting` immediately — the UI overlay
     // should appear as soon as the WS drop is detected, not after the backoff
     // delay. The listener is a no-op on Tauri desktop (never set).
-    this.onReconnectStateChange?.(true)
+    if (!this.reconnecting) {
+      this.reconnecting = true
+      this.onReconnectStateChange?.(true)
+    }
     this.reconnectTimer = setTimeout(() => {
       this.reconnectTimer = null
       void this.reconnect()
@@ -1180,12 +1234,13 @@ export class WsAcpTransport implements AcpTransport {
   private async reconnect(): Promise<void> {
     try {
       await this.connect()
-      this.reconnectAttempt = 0
       const prioritized = this.reconnectPriorityProvider?.() ?? []
       const ordered = [
         ...prioritized.filter((sid) => this.subscribed.has(sid)),
         ...[...this.subscribed].filter((sid) => !prioritized.includes(sid))
       ]
+      const failedSessions: string[] = []
+      const obsoleteSessions: string[] = []
       for (const sid of ordered) {
         const last = this.lastSeq.get(sid)
         // Force re-subscribe after reconnect; pass an explicit boundary.
@@ -1193,16 +1248,45 @@ export class WsAcpTransport implements AcpTransport {
         // log + continue so remaining sessions still recover.
         try {
           await this.subscribeSession(sid, last ?? 0, true)
-        } catch (err) {
-          console.error('[acp-transport] resubscribe failed for session', sid, err)
+        } catch (error) {
+          if (error instanceof AcpTransportError && error.code === WS_ERROR_CODES.NOT_FOUND) {
+            this.subscribed.delete(sid)
+            this.lastSeq.delete(sid)
+            this.seenTurnIds.delete(sid)
+            obsoleteSessions.push(sid)
+          } else {
+            failedSessions.push(sid)
+          }
         }
       }
+      if (obsoleteSessions.length > 0) {
+        void logFrontendError({
+          level: 'warn',
+          source: 'WsAcpTransport.reconnect',
+          message: `Dropped obsolete ACP subscription session ids: ${obsoleteSessions.join(', ')}`
+        })
+      }
+      if (failedSessions.length > 0) {
+        void logFrontendError({
+          level: 'warn',
+          source: 'WsAcpTransport.reconnect',
+          message: `ACP subscription recovery failed for session ids: ${failedSessions.join(', ')}`
+        })
+        throw new AcpTransportError('closed', 'required ACP subscriptions did not recover')
+      }
+      this.reconnectAttempt = 0
       // Story 5.3 (AC3): fire `false` AFTER the socket re-opens and all
       // sessions are re-subscribed so the overlay stays visible for the
       // full reconnect window (drop → backoff → reopen → resubscribe).
+      this.reconnecting = false
       this.onReconnectStateChange?.(false)
     } catch (err) {
-      console.error('[acp-transport] reconnect failed', err)
+      void logFrontendError({
+        level: 'warn',
+        source: 'WsAcpTransport.reconnect',
+        message: `ACP reconnect failed: ${String(err)}`
+      })
+      this.discardSocket('reconnect attempt failed')
       this.scheduleReconnect()
     }
   }

--- a/src/renderer/stores/acp-store.test.ts
+++ b/src/renderer/stores/acp-store.test.ts
@@ -86,7 +86,8 @@ import {
 import {
   _resetAcpTransportForTests,
   _setAcpTransportForTests,
-  type AcpTransport
+  type AcpTransport,
+  AcpTransportError
 } from '@/lib/acp-transport'
 import { logFrontendError } from '@/lib/log-api'
 import {
@@ -4074,6 +4075,176 @@ describe('acp-store', () => {
     expect(index.find((e) => e.id === 's-local')?.title).toBe('Important Title')
     // s-titled keeps the newer local title (not reverted to Untitled).
     expect(index.find((e) => e.id === 's-titled')?.title).toBe('My Title')
+  })
+
+  it('preserves then converges history across transient refresh and reconnect retry', async () => {
+    vi.useFakeTimers()
+    const current = {
+      id: 's-existing',
+      agentId: 'agent-1',
+      agentConfigId: 'cfg-1',
+      title: 'Existing Chat',
+      cwd: '/work',
+      projectId: 'p1',
+      createdAt: 1,
+      lastActivityAt: 2,
+      messageCount: 4,
+      status: 'closed' as const
+    }
+    useAcpStore.setState({ sessionIndex: [current] })
+    const recovered = { ...current, title: 'Recovered Chat', lastActivityAt: 3 }
+    vi.mocked(loadSessionIndex)
+      .mockRejectedValueOnce(new AcpTransportError('closed', 'transport recovering'))
+      .mockRejectedValueOnce(new AcpTransportError('timeout', 'reconnect race'))
+      .mockResolvedValueOnce([recovered])
+
+    await expect(useAcpStore.getState().loadSessionIndex()).rejects.toMatchObject({
+      code: 'closed'
+    })
+
+    expect(useAcpStore.getState().sessionIndex).toEqual([current])
+    expect(logFrontendError).toHaveBeenCalledWith(
+      expect.objectContaining({
+        source: 'acp-store.loadSessionIndex',
+        message: expect.stringContaining('preserving current entries')
+      })
+    )
+    let reconnectListener: ((reconnecting: boolean) => void) | undefined
+    const transport = {
+      setReconnectListener: vi.fn((listener: (reconnecting: boolean) => void) => {
+        reconnectListener = listener
+      }),
+      setReconnectPriorityProvider: vi.fn(),
+      setRecoveryHandler: vi.fn(),
+      onEvent: vi.fn(() => () => undefined),
+      dispose: vi.fn()
+    }
+    _setAcpTransportForTests(transport as unknown as AcpTransport)
+    const teardown = initAcpEventListeners()
+
+    reconnectListener?.(true)
+    expect(useAcpStore.getState().transportReconnecting).toBe(true)
+    reconnectListener?.(false)
+    await Promise.resolve()
+    expect(loadSessionIndex).toHaveBeenCalledTimes(2)
+    expect(useAcpStore.getState().sessionIndex).toEqual([current])
+
+    await vi.advanceTimersByTimeAsync(600)
+    expect(loadSessionIndex).toHaveBeenCalledTimes(3)
+    expect(useAcpStore.getState().sessionIndex).toEqual([recovered])
+
+    expect(useAcpStore.getState().transportReconnecting).toBe(false)
+    teardown()
+    vi.useRealTimers()
+  })
+
+  it('resets an exhausted history retry budget on a later reconnect cycle', async () => {
+    vi.useFakeTimers()
+    const current = {
+      id: 's-existing',
+      agentId: 'agent-1',
+      title: 'Existing Chat',
+      cwd: '/work',
+      projectId: 'p1',
+      createdAt: 1,
+      lastActivityAt: 2,
+      messageCount: 4,
+      status: 'closed' as const
+    }
+    const recovered = { ...current, title: 'Recovered Later', lastActivityAt: 8 }
+    useAcpStore.setState({ sessionIndex: [current] })
+    vi.mocked(loadSessionIndex)
+      .mockRejectedValueOnce(new AcpTransportError('closed', 'cycle one attempt one'))
+      .mockRejectedValueOnce(new AcpTransportError('timeout', 'cycle one attempt two'))
+      .mockRejectedValueOnce(new AcpTransportError('closed', 'cycle one attempt three'))
+      .mockRejectedValueOnce(new AcpTransportError('timeout', 'cycle one exhausted'))
+      .mockRejectedValueOnce(new AcpTransportError('closed', 'cycle two attempt one'))
+      .mockResolvedValueOnce([recovered])
+
+    let reconnectListener: ((reconnecting: boolean) => void) | undefined
+    const transport = {
+      setReconnectListener: vi.fn((listener: (reconnecting: boolean) => void) => {
+        reconnectListener = listener
+      }),
+      setReconnectPriorityProvider: vi.fn(),
+      setRecoveryHandler: vi.fn(),
+      onEvent: vi.fn(() => () => undefined),
+      dispose: vi.fn()
+    }
+    _setAcpTransportForTests(transport as unknown as AcpTransport)
+    const teardown = initAcpEventListeners()
+
+    reconnectListener?.(true)
+    reconnectListener?.(false)
+    await Promise.resolve()
+    await vi.advanceTimersByTimeAsync(4_000)
+    expect(loadSessionIndex).toHaveBeenCalledTimes(4)
+    expect(useAcpStore.getState().sessionIndex).toEqual([current])
+
+    reconnectListener?.(true)
+    reconnectListener?.(false)
+    await Promise.resolve()
+    expect(loadSessionIndex).toHaveBeenCalledTimes(5)
+    await vi.advanceTimersByTimeAsync(600)
+    expect(loadSessionIndex).toHaveBeenCalledTimes(6)
+    expect(useAcpStore.getState().sessionIndex).toEqual([recovered])
+
+    teardown()
+    vi.useRealTimers()
+  })
+
+  it('rejects non-transient history failures without replacing current entries', async () => {
+    const current = {
+      id: 's-existing',
+      agentId: 'agent-1',
+      title: 'Existing Chat',
+      cwd: '/work',
+      projectId: 'p1',
+      createdAt: 1,
+      lastActivityAt: 2,
+      messageCount: 4,
+      status: 'closed' as const
+    }
+    useAcpStore.setState({ sessionIndex: [current] })
+    const error = new Error('desktop schema mismatch')
+    vi.mocked(loadSessionIndex).mockRejectedValueOnce(error)
+
+    await expect(useAcpStore.getState().loadSessionIndex()).rejects.toBe(error)
+    expect(useAcpStore.getState().sessionIndex).toEqual([current])
+  })
+
+  it('allows an older valid history response to apply after a newer refresh fails', async () => {
+    const olderEntries = [
+      {
+        id: 's-valid',
+        agentId: 'agent-1',
+        title: 'Valid Host Entry',
+        cwd: '/work',
+        projectId: 'p1',
+        createdAt: 1,
+        lastActivityAt: 2,
+        messageCount: 1,
+        status: 'closed' as const
+      }
+    ]
+    let resolveOlder: ((entries: typeof olderEntries) => void) | undefined
+    vi.mocked(loadSessionIndex)
+      .mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            resolveOlder = resolve
+          })
+      )
+      .mockRejectedValueOnce(new AcpTransportError('closed', 'newer request failed'))
+
+    const older = useAcpStore.getState().loadSessionIndex()
+    await expect(useAcpStore.getState().loadSessionIndex()).rejects.toMatchObject({
+      code: 'closed'
+    })
+    resolveOlder?.(olderEntries)
+    await older
+
+    expect(useAcpStore.getState().sessionIndex).toEqual(olderEntries)
   })
 
   it('openHistorySession accepts straggler chunks of an in-progress replay after load resolves', async () => {

--- a/src/renderer/stores/acp-store.ts
+++ b/src/renderer/stores/acp-store.ts
@@ -75,7 +75,6 @@ import {
   type SessionModeState,
   type SessionReopenOutcome,
   type SessionUsage,
-  type SpawnAgentResult,
   type StopReason,
   type ToolCall,
   type ToolCallEvent,
@@ -108,7 +107,7 @@ import { decideResume } from '@/lib/acp-resume-policy'
 // store's `transportReconnecting` flag. `getAcpTransport` returns the
 // process-wide singleton (WS on web, Tauri IPC on desktop). The listener is
 // only attached on the WS transport (Tauri IPC has no `setReconnectListener`).
-import { getAcpTransport } from '@/lib/acp-transport'
+import { getAcpTransport, isTransientAcpTransportError } from '@/lib/acp-transport'
 import {
   AmbiguousAuthError,
   classifySetupError,
@@ -1648,6 +1647,7 @@ const sessionReopenGenerations = new Map<SessionId, number>()
  * generation is no longer current.
  */
 let sessionIndexLoadGeneration = 0
+let sessionIndexAppliedGeneration = 0
 
 /** Sessions with an in-flight `retryCrashedSession` (re-launch + replay + re-send).
  * Dedupes concurrent Retry clicks so only one reopen+send runs per session. */
@@ -1735,6 +1735,7 @@ export function _resetInFlightHistoryOpensForTesting(): void {
 /** Test-only: reset the index load generation counter between tests. */
 export function _resetSessionIndexLoadGenerationForTesting(): void {
   sessionIndexLoadGeneration = 0
+  sessionIndexAppliedGeneration = 0
 }
 
 type EnsureLiveAgentOptions = {
@@ -3667,8 +3668,21 @@ export const useAcpStore = create<AcpState>((set, get) => ({
     // local session/title mutation is discarded rather than overwriting the
     // newer projection.
     const generation = ++sessionIndexLoadGeneration
-    const entries = await loadSessionIndexFromDisk()
-    if (generation !== sessionIndexLoadGeneration) return
+    let entries: SessionIndexEntry[]
+    try {
+      entries = await loadSessionIndexFromDisk()
+    } catch (error) {
+      if (isTransientAcpTransportError(error)) {
+        void logFrontendError({
+          level: 'warn',
+          source: 'acp-store.loadSessionIndex',
+          message: `ACP history index refresh failed; preserving current entries: ${String(error)}`
+        })
+      }
+      throw error
+    }
+    if (generation <= sessionIndexAppliedGeneration) return
+    sessionIndexAppliedGeneration = generation
     // Continue the placeholder counter from the highest persisted suffix so a
     // restart doesn't restart at 1 and collide with existing `Untitled Chat N`.
     rebaseUntitledCounter(entries)
@@ -5361,6 +5375,34 @@ export function initAcpEventListeners(): () => void {
   // `false`. The listener is idempotent: re-registration overwrites the
   // previous callback.
   const transport = getAcpTransport()
+  let historyRetryTimer: ReturnType<typeof setTimeout> | null = null
+  let historyRetryAttempt = 0
+  const refetchHistoryAfterReconnect = (): void => {
+    const run = (): void => {
+      void useAcpStore
+        .getState()
+        .loadSessionIndex()
+        .then(() => undefined)
+        .catch((error) => {
+          if (!isTransientAcpTransportError(error) || historyRetryAttempt >= 3) {
+            void logFrontendError({
+              level: 'warn',
+              source: 'acp-store.reconnectHistoryRefresh',
+              message: `ACP history refresh after reconnect failed: ${String(error)}`
+            })
+            return
+          }
+          const delay = Math.min(500 * 2 ** historyRetryAttempt, 2_000)
+          historyRetryAttempt += 1
+          historyRetryTimer = setTimeout(() => {
+            historyRetryTimer = null
+            run()
+          }, delay)
+        })
+    }
+    if (historyRetryTimer) return
+    run()
+  }
   const connection = new AcpConnectionCoordinator(transport, {
     installRecovery: installTransportRecovery,
     pendingPermissionSessions: () => [
@@ -5372,6 +5414,14 @@ export function initAcpEventListeners(): () => void {
     ],
     setReconnecting: (reconnecting) => {
       useAcpStore.setState({ transportReconnecting: reconnecting })
+      if (!reconnecting) {
+        if (historyRetryTimer) {
+          clearTimeout(historyRetryTimer)
+          historyRetryTimer = null
+        }
+        historyRetryAttempt = 0
+        refetchHistoryAfterReconnect()
+      }
     }
   })
   connection.attach()
@@ -5505,6 +5555,10 @@ export function initAcpEventListeners(): () => void {
     )
   ]
   return () => {
+    if (historyRetryTimer) {
+      clearTimeout(historyRetryTimer)
+      historyRetryTimer = null
+    }
     teardown.forEach((fn) => {
       fn()
     })

--- a/src/renderer/stores/acp-store.ts
+++ b/src/renderer/stores/acp-store.ts
@@ -5377,13 +5377,16 @@ export function initAcpEventListeners(): () => void {
   const transport = getAcpTransport()
   let historyRetryTimer: ReturnType<typeof setTimeout> | null = null
   let historyRetryAttempt = 0
+  let historyTornDown = false
   const refetchHistoryAfterReconnect = (): void => {
     const run = (): void => {
+      if (historyTornDown) return
       void useAcpStore
         .getState()
         .loadSessionIndex()
         .then(() => undefined)
         .catch((error) => {
+          if (historyTornDown) return
           if (!isTransientAcpTransportError(error) || historyRetryAttempt >= 3) {
             void logFrontendError({
               level: 'warn',
@@ -5555,6 +5558,7 @@ export function initAcpEventListeners(): () => void {
     )
   ]
   return () => {
+    historyTornDown = true
     if (historyRetryTimer) {
       clearTimeout(historyRetryTimer)
       historyRetryTimer = null


### PR DESCRIPTION
## Summary

A Cloudflare-tunneled browser tab returning from background can hit a stale ACP WebSocket whose round-trip path is dead but \eadyState\ still reports \OPEN\. The 60-second \list_persisted_sessions\ request times out and surfaces \AcpTransportError\ while the host-owned agent and transcript remain alive. A long \send_prompt\ can also block the relay read loop, starving heartbeats and history requests, and watchdog-first socket termination can bypass subscription/permission cleanup.

This PR decouples logical ACP sessions from individual sockets: accepted prompt work continues without blocking the read loop, disconnect cleanup runs exactly once whichever half exits, the socket is validated immediately on browser resume, and history recovers after reconnection without unhandled rejections.

## Related Issue

No issue — diagnosed from local Termul logs (\	ermul.log\ line 7190: \AcpTransportError: Request list_persisted_sessions timed out\ at the Cloudflare tunnel URL, followed by watchdog closure at 77s).

Prior related PRs:
- #473 (merged): initial mobile idle/background visibility reconnect
- #478 (merged): application heartbeat + turn-id dedup
- #498 (merged): relay reliability seams (resume, long-run, stale recovery)
- #513 (merged): terminal WS reconnect on mobile AFK
- #615 (open): a prior draft from the same investigation that bundled unrelated title work — **this PR replaces it with a clean single-problem diff**

## Type of Change

- [x] fix: bug fix

## What Changed

**Server relay (\src-tauri/src/web/ws.rs\, \permissions.rs\, \manager.rs\):**
- \send_prompt\ now accepts inline (claim turn, persist prompt, start driver) and completes detached — heartbeat/history requests stay processable during long agent turns
- Exactly-once \ConnectionCleanup\ guard runs after either socket half or relay cancellation; unregisters all subscriptions and executes permission/question disconnect policy
- RAII \PromptClaim\ releases the turn watermark on drop if the detached task is aborted
- \start_prompt\ awaits driver acceptance before returning, so a following \cancel_prompt\ cannot no-op

**Browser resume (\src/renderer/lib/acp-transport.ts\):**
- \isibilitychange\ return, \pageshow\, \esume\, and \online\ signals trigger a bounded 5-second application \ping\; failure forces reconnect with cursor replay
- Coalesced to prevent backoff storms; \eadyState === OPEN\ is no longer trusted alone
- Reconnect stays active until all required subscriptions recover; obsolete \
ot_found\ sessions are dropped, transient failures retry with backoff
- \subscribe_snapshot\ failures distinguished: genuine \SessionNotFound\ → \
ot_found\; transient storage/replay errors → retryable \gent_crashed\

**History recovery (\src/renderer/stores/acp-store.ts\, \hooks/use-acp-history.ts\):**
- Transient failures preserve sidebar entries; non-transient errors still reject to callers
- Post-reconnect refetch with bounded retry; budget resets per reconnect cycle
- Generation ordering prevents stale successful responses from overwriting newer state

**Tests:**
- Rust: long-prompt concurrency, writer-first cleanup, cancelled-claim release, accepted-turn replay (80 tests)
- TypeScript: stale-OPEN validation, lifecycle coalescing, failed-subscription retry, history preservation (283 tests)

## How It Was Tested

- [x] \un run ci\ (Biome lint + format + imports, strict mode)
- [x] \un run typecheck\
- [x] \un run test\ (focused: 283 passed)
- [x] \cargo clippy --all-targets -- -D warnings\ (in src-tauri)
- [x] \cargo test\ (in src-tauri — focused WS tests: 80 passed)
- [ ] Manual verification completed (Cloudflare tunnel lifecycle check not run in this environment)

## CI & Review Gate

- [ ] All CI checks pass (PR Validation, Rust Checks, Build Verification, Security Scans)
- [ ] Code review comments from CodeRabbit / Claude have been addressed or resolved
- [ ] No unresolved review findings remain

## Checklist

- [x] My PR title follows the conventional commit format used by this repo
- [x] I linked the related issue or explained why none exists
- [x] I updated docs when needed
- [x] I added or updated tests when needed
- [x] I verified the change does not introduce unrelated modifications
- [x] I read AGENTS.md and followed the contributor guidelines
- [ ] A human reviewed the complete diff before submission

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Prompts can start and complete asynchronously, keeping other app interactions responsive.
  * Sessions recover more reliably after reconnecting or resuming the app.
  * Session subscriptions are restored automatically, while obsolete sessions are removed.

* **Bug Fixes**
  * Improved cleanup when prompts, permissions, questions, or connections are cancelled.
  * Transient connection failures no longer unnecessarily clear session history.
  * Improved handling of agent crashes, timeouts, and closed connections.
  * Generated session titles are limited to 48 characters and kept to one line.
  * Improved recovery when loading session history fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->