### PR TITLE
fix(acp): route host plans to active session

### DIFF
--- a/src-tauri/src/acp/host_mcp/parent.rs
+++ b/src-tauri/src/acp/host_mcp/parent.rs
@@ -14,7 +14,7 @@
 //! the per-agent driver-thread model in `AcpManager`) — works on both the
 //! desktop binary and the standalone `termul-server` (no `AppHandle`).
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
 use parking_lot::Mutex;
@@ -53,6 +53,11 @@ pub struct HostPlanServer {
     sinks: Vec<Arc<dyn EventSink>>,
     /// token -> SessionAuth. One entry per registered session.
     sessions: Mutex<HashMap<String, SessionAuth>>,
+    /// Runtime agent id -> sessions with an accepted prompt currently in flight.
+    /// Some agents reuse an older session's MCP child for later sessions; this
+    /// authoritative turn registry lets `process_request` repair that stale
+    /// token binding when exactly one session for the agent is active.
+    active_turns: Mutex<HashMap<String, HashSet<String>>>,
     /// Per-session plan cache (emit-and-cache). v1 doesn't persist; this is
     /// the seam a future persistence layer reads from on resume. Updated in
     /// `process_request` (set on emit) + `unregister_*` (drop on close).
@@ -73,6 +78,7 @@ impl HostPlanServer {
             port: std::sync::OnceLock::new(),
             sinks,
             sessions: Mutex::new(HashMap::new()),
+            active_turns: Mutex::new(HashMap::new()),
             plan_store: PlanStore::new(),
         });
         let server_for_thread = Arc::clone(&server);
@@ -189,6 +195,32 @@ impl HostPlanServer {
         }
     }
 
+    /// Mark an accepted prompt turn as active before the agent can call tools.
+    pub fn begin_turn(&self, agent_id: &str, real_session_id: &str) {
+        self.active_turns
+            .lock()
+            .entry(agent_id.to_string())
+            .or_default()
+            .insert(real_session_id.to_string());
+        log::debug!(
+            "[host-mcp] registered active plan route for session {real_session_id} (agent {agent_id})"
+        );
+    }
+
+    /// Remove a completed, rejected-to-start, cancelled, or failed prompt turn.
+    pub fn end_turn(&self, agent_id: &str, real_session_id: &str) {
+        let mut active_turns = self.active_turns.lock();
+        if let Some(sessions) = active_turns.get_mut(agent_id) {
+            sessions.remove(real_session_id);
+            if sessions.is_empty() {
+                active_turns.remove(agent_id);
+            }
+        }
+        log::debug!(
+            "[host-mcp] removed active plan route for session {real_session_id} (agent {agent_id})"
+        );
+    }
+
     /// Drop a session's auth entry (on close/dispose). Scans by the bound real
     /// session_id. Best-effort — the renderer's `_onPlanUpdate` already guards
     /// closed sessions, so a stale in-flight call is harmless, but evicting
@@ -197,6 +229,12 @@ impl HostPlanServer {
         let mut sessions = self.sessions.lock();
         sessions.retain(|_, auth| auth.real_session_id.as_deref() != Some(real_session_id));
         drop(sessions);
+        let mut active_turns = self.active_turns.lock();
+        active_turns.retain(|_, sessions| {
+            sessions.remove(real_session_id);
+            !sessions.is_empty()
+        });
+        drop(active_turns);
         self.plan_store.drop_session(real_session_id);
     }
 
@@ -296,7 +334,7 @@ impl HostPlanServer {
         // The real session_id must be bound (post `session/new`). If not, the
         // agent called the tool before the session was created — shouldn't
         // happen, but reject defensively.
-        let real_session_id = match &auth.real_session_id {
+        let bound_session_id = match &auth.real_session_id {
             Some(sid) => sid.clone(),
             None => {
                 log::warn!(
@@ -304,6 +342,44 @@ impl HostPlanServer {
                     auth.provisional_sid
                 );
                 return FrameReply::err("session not ready");
+            }
+        };
+
+        // Agents may retain and call an MCP child created for an older session.
+        // Prefer the token's bound session when it is active. Otherwise, repair
+        // the route only when this runtime agent has exactly one active turn;
+        // multiple active sessions are ambiguous and must never cross-route.
+        let real_session_id = {
+            let active_turns = self.active_turns.lock();
+            match active_turns.get(&auth.agent_id) {
+                Some(sessions) if sessions.contains(&bound_session_id) => bound_session_id.clone(),
+                Some(sessions) if sessions.len() == 1 => {
+                    let active_session_id = sessions.iter().next().expect("len checked").clone();
+                    log::info!(
+                        "[host-mcp] rerouted stale plan binding for agent {} from session {} to active session {}",
+                        auth.agent_id,
+                        bound_session_id,
+                        active_session_id
+                    );
+                    active_session_id
+                }
+                Some(sessions) if sessions.len() > 1 => {
+                    log::warn!(
+                        "[host-mcp] rejected ambiguous stale plan binding for agent {} (bound session {}, {} active turns)",
+                        auth.agent_id,
+                        bound_session_id,
+                        sessions.len()
+                    );
+                    return FrameReply::err("ambiguous active session");
+                }
+                _ => {
+                    log::warn!(
+                        "[host-mcp] rejected plan call for agent {} with no active turn (bound session {})",
+                        auth.agent_id,
+                        bound_session_id
+                    );
+                    return FrameReply::err("no active turn");
+                }
             }
         };
 
@@ -335,13 +411,16 @@ mod tests {
 
     #[derive(Default)]
     struct CapturingSink {
-        events: StdMutex<Vec<String>>,
+        events: StdMutex<Vec<(String, serde_json::Value)>>,
     }
 
     impl EventSink for CapturingSink {
         fn emit(&self, event: &crate::web::sink::AcpEvent) {
             if event.type_ == crate::acp::events::EVENT_PLAN_UPDATE {
-                self.events.lock().unwrap().push(event.type_.to_string());
+                self.events
+                    .lock()
+                    .unwrap()
+                    .push((event.type_.to_string(), event.payload.clone()));
             }
         }
     }
@@ -412,6 +491,7 @@ mod tests {
         let server = HostPlanServer::start(vec![sink.clone()]);
         let (port, token, provisional) = server.register_session("agent-1");
         server.bind_session(&token, "sess-real");
+        server.begin_turn("agent-1", "sess-real");
 
         let runtime = Runtime::new().unwrap();
         runtime.block_on(async move {
@@ -426,9 +506,113 @@ mod tests {
             let reply = connect_and_send(port, &frame).await;
             assert_eq!(reply["ok"], true);
         });
-        // The capturing sink records plan_update event names.
         let captured = sink.events.lock().unwrap();
         assert_eq!(captured.len(), 1, "exactly one plan_update must be emitted");
+        assert_eq!(captured[0].1["sessionId"], "sess-real");
+    }
+
+    #[test]
+    fn bound_session_without_an_active_turn_is_rejected() {
+        let sink = Arc::new(CapturingSink::default());
+        let server = HostPlanServer::start(vec![sink.clone()]);
+        let (port, token, provisional) = server.register_session("agent-1");
+        server.bind_session(&token, "sess-real");
+
+        let runtime = Runtime::new().unwrap();
+        runtime.block_on(async move {
+            let frame = serde_json::json!({
+                "token": token,
+                "session_id": provisional,
+                "todos": [{"content": "late work"}],
+            });
+            let reply = connect_and_send(port, &frame).await;
+            assert_eq!(reply["ok"], false);
+            assert_eq!(reply["error"], "no active turn");
+        });
+
+        assert!(sink.events.lock().unwrap().is_empty());
+    }
+
+    #[test]
+    fn stale_binding_routes_to_the_agents_only_active_turn() {
+        let sink = Arc::new(CapturingSink::default());
+        let server = HostPlanServer::start(vec![sink.clone()]);
+        let (port, token, provisional) = server.register_session("agent-1");
+        server.bind_session(&token, "sess-old");
+        server.begin_turn("agent-1", "sess-current");
+
+        let runtime = Runtime::new().unwrap();
+        runtime.block_on(async move {
+            let frame = serde_json::json!({
+                "token": token,
+                "session_id": provisional,
+                "todos": [{"content": "current work"}],
+            });
+            let reply = connect_and_send(port, &frame).await;
+            assert_eq!(reply["ok"], true);
+        });
+
+        let captured = sink.events.lock().unwrap();
+        assert_eq!(captured.len(), 1);
+        assert_eq!(captured[0].1["sessionId"], "sess-current");
+        assert!(server.plan_store.get("sess-old").is_none());
+        assert_eq!(server.plan_store.get("sess-current").unwrap().len(), 1);
+    }
+
+    #[test]
+    fn bound_active_session_wins_when_agent_has_multiple_active_turns() {
+        let sink = Arc::new(CapturingSink::default());
+        let server = HostPlanServer::start(vec![sink.clone()]);
+        let (port, token, provisional) = server.register_session("agent-1");
+        server.bind_session(&token, "sess-bound");
+        server.begin_turn("agent-1", "sess-bound");
+        server.begin_turn("agent-1", "sess-other");
+
+        let runtime = Runtime::new().unwrap();
+        runtime.block_on(async move {
+            let frame = serde_json::json!({
+                "token": token,
+                "session_id": provisional,
+                "todos": [{"content": "bound work"}],
+            });
+            let reply = connect_and_send(port, &frame).await;
+            assert_eq!(reply["ok"], true);
+        });
+
+        let captured = sink.events.lock().unwrap();
+        assert_eq!(captured[0].1["sessionId"], "sess-bound");
+    }
+
+    #[test]
+    fn ambiguous_stale_binding_is_rejected_instead_of_cross_routed() {
+        let sink = Arc::new(CapturingSink::default());
+        let server = HostPlanServer::start(vec![sink.clone()]);
+        let (port, token, provisional) = server.register_session("agent-1");
+        server.bind_session(&token, "sess-old");
+        server.begin_turn("agent-1", "sess-a");
+        server.begin_turn("agent-1", "sess-b");
+
+        let runtime = Runtime::new().unwrap();
+        runtime.block_on(async move {
+            let frame = serde_json::json!({
+                "token": token,
+                "session_id": provisional,
+                "todos": [{"content": "ambiguous work"}],
+            });
+            let reply = connect_and_send(port, &frame).await;
+            assert_eq!(reply["ok"], false);
+            assert_eq!(reply["error"], "ambiguous active session");
+        });
+
+        assert!(sink.events.lock().unwrap().is_empty());
+    }
+
+    #[test]
+    fn end_turn_removes_routing_candidate() {
+        let server = HostPlanServer::start(vec![]);
+        server.begin_turn("agent-1", "sess-current");
+        server.end_turn("agent-1", "sess-current");
+        assert!(server.active_turns.lock().get("agent-1").is_none());
     }
 
     #[test]

--- a/src-tauri/src/acp/manager.rs
+++ b/src-tauri/src/acp/manager.rs
@@ -993,6 +993,7 @@ impl AcpManager {
         let thread_start_error = start_error.clone();
         let thread_persistence = self.persistence.clone();
         let thread_warmup_done = self.warmup_done.clone();
+        let thread_host_plan_server = self.host_plan_server.clone();
         let stable_namespace = stable_agent_namespace(&config);
 
         let join_handle = std::thread::Builder::new()
@@ -1001,6 +1002,7 @@ impl AcpManager {
                 run_agent(
                     thread_config,
                     sinks,
+                    thread_host_plan_server,
                     thread_agent_id,
                     command_rx,
                     init_tx,
@@ -2271,6 +2273,7 @@ async fn join_thread_bounded(handle: JoinHandle<()>) {
 fn run_agent(
     config: AgentConfig,
     sinks: Vec<Arc<dyn EventSink>>,
+    host_plan_server: Arc<crate::acp::host_mcp::parent::HostPlanServer>,
     agent_id: AgentId,
     command_rx: mpsc::UnboundedReceiver<AcpCommand>,
     init_tx: oneshot::Sender<Result<InitOutcome, String>>,
@@ -2306,6 +2309,7 @@ fn run_agent(
     let result = runtime.block_on(drive_connection(
         config,
         sinks.clone(),
+        host_plan_server.clone(),
         agent_id.clone(),
         command_rx,
         init_tx,
@@ -2325,6 +2329,12 @@ fn run_agent(
         let mut state = driver_state.lock();
         (state.drain_all(), state.active_session_ids())
     };
+    // A connection teardown can drop an in-flight prompt task before its normal
+    // completion cleanup runs. Remove every surviving host-plan route here so
+    // a later session cannot be mistaken for an ambiguous concurrent turn.
+    for session_id in &active_sessions {
+        host_plan_server.end_turn(&agent_id.0, session_id);
+    }
     for permission in leaked {
         let _ = permission.responder.respond(RequestPermissionResponse::new(
             RequestPermissionOutcome::Cancelled,
@@ -2440,6 +2450,7 @@ fn run_agent(
 async fn drive_connection(
     config: AgentConfig,
     sinks: Vec<Arc<dyn EventSink>>,
+    host_plan_server: Arc<crate::acp::host_mcp::parent::HostPlanServer>,
     agent_id: AgentId,
     command_rx: mpsc::UnboundedReceiver<AcpCommand>,
     init_tx: oneshot::Sender<Result<InitOutcome, String>>,
@@ -2527,6 +2538,7 @@ async fn drive_connection(
 
     // Clones moved into the command loop (`main_fn`).
     let loop_sinks = sinks.clone();
+    let loop_host_plan_server = host_plan_server;
     let loop_agent_id = agent_id.clone();
     let loop_state = driver_state.clone();
     let loop_spawned = spawned.clone();
@@ -2893,6 +2905,7 @@ async fn drive_connection(
                 command_rx,
                 init_tx,
                 loop_sinks,
+                loop_host_plan_server,
                 loop_agent_id,
                 loop_state,
                 loop_spawned,
@@ -2919,6 +2932,7 @@ async fn run_command_loop(
     mut command_rx: mpsc::UnboundedReceiver<AcpCommand>,
     init_tx: oneshot::Sender<Result<InitOutcome, String>>,
     sinks: Vec<Arc<dyn EventSink>>,
+    host_plan_server: Arc<crate::acp::host_mcp::parent::HostPlanServer>,
     agent_id: AgentId,
     driver_state: Arc<Mutex<DriverState>>,
     spawned: Arc<AtomicBool>,
@@ -3423,10 +3437,15 @@ async fn run_command_loop(
                 let turn_cx = cx.clone();
                 let turn_sinks = sinks.clone();
                 let turn_agent_id = agent_id.clone();
+                let turn_plan_server = host_plan_server.clone();
                 let turn_state = driver_state.clone();
                 let turn_persistence = persistence.clone();
                 let turn_session = session_id.clone();
                 let log_session = session_id.clone();
+                // Register before spawning so an immediate `termul_plan` call is
+                // routed to this accepted prompt's session, even when the agent
+                // reuses an MCP child created for an older session.
+                host_plan_server.begin_turn(&agent_id.0, &session_id.0);
                 // Story 1.8 T3.2: capture the client turn-id to echo on prompt_complete.
                 let turn_turn_id = turn_id.clone();
                 let spawn_result = cx.spawn(async move {
@@ -3485,9 +3504,10 @@ async fn run_command_loop(
                         }
                     }
 
-                    // Turn is over: clear the active-turn marker and resolve any
-                    // permissions that were never answered (H3 — normal
-                    // completion, not just cancel).
+                    // Turn is over: clear the host-plan routing marker and the
+                    // driver active-turn marker, then resolve permissions that
+                    // were never answered (H3 — normal completion, not just cancel).
+                    turn_plan_server.end_turn(&turn_agent_id.0, &session_id.0);
                     let pending = turn_state.lock().finish_turn(&session_id.0);
                     for permission in pending {
                         let _ = permission.responder.respond(RequestPermissionResponse::new(
@@ -3573,8 +3593,9 @@ async fn run_command_loop(
                     Ok(())
                 });
                 if let Err(e) = spawn_result {
-                    // The connection is shutting down; clear the marker we just
+                    // The connection is shutting down; clear the markers we just
                     // set and surface the real error to the caller (L5).
+                    host_plan_server.end_turn(&agent_id.0, &turn_session.0);
                     driver_state.lock().finish_turn(&turn_session.0);
                     let error = format!("failed to start prompt turn: {e}");
                     let _ = accepted.send(Err(error.clone()));

--- a/src-tauri/src/acp/manager.rs
+++ b/src-tauri/src/acp/manager.rs
@@ -2330,10 +2330,10 @@ fn run_agent(
         (state.drain_all(), state.active_session_ids())
     };
     // A connection teardown can drop an in-flight prompt task before its normal
-    // completion cleanup runs. Remove every surviving host-plan route here so
-    // a later session cannot be mistaken for an ambiguous concurrent turn.
+    // completion cleanup runs. Remove every surviving session's auth, cache,
+    // and route so stale MCP children cannot target a later session.
     for session_id in &active_sessions {
-        host_plan_server.end_turn(&agent_id.0, session_id);
+        host_plan_server.unregister_session(session_id);
     }
     for permission in leaked {
         let _ = permission.responder.respond(RequestPermissionResponse::new(
@@ -3347,6 +3347,7 @@ async fn run_command_loop(
                 let req_cx = cx.clone();
                 let req_state = driver_state.clone();
                 let req_persistence = persistence.clone();
+                let req_plan_server = host_plan_server.clone();
                 spawn_request(&cx, slot, async move {
                     let request = CloseSessionRequest::new(&session_id);
                     let result = req_cx.send_request(request).block_task().await;
@@ -3373,6 +3374,9 @@ async fn run_command_loop(
                                 "cancelled": true,
                             }));
                         }
+                        // Evict host-plan auth, cache, and any active route only
+                        // after the agent confirms the session is closed.
+                        req_plan_server.unregister_session(&session_id.0);
                     }
                     let mut result = result.map(|_| ()).map_err(|e| e.to_string());
                     if result.is_ok() {


### PR DESCRIPTION
## Summary

- Fixes the host-injected `termul_plan` tool emitting `acp:plan_update` to an older session when an ACP agent reuses a previously created MCP child.
- Tracks authoritative active prompt turns per runtime agent and reroutes a stale child binding only when exactly one active session is unambiguous.

## Related Issue

No related issue exists; this is a regression follow-up to merged PR #610.

## Type of Change

- [ ] feat: new feature
- [x] fix: bug fix
- [ ] docs: documentation only
- [ ] style: formatting or non-functional styling changes
- [ ] refactor: internal cleanup with no behavior change
- [ ] perf: performance improvement
- [x] test: adds or updates tests
- [ ] build: build or dependency changes
- [ ] ci: CI/CD workflow changes
- [ ] chore: maintenance or tooling
- [ ] revert: reverts a previous change

## What Changed

- Registers accepted prompt turns with the shared host plan server before the agent can call tools.
- Uses the token-bound session when active; otherwise reroutes only to the runtime agent's sole active session.
- Rejects ambiguous concurrent routing and late calls after a turn completes instead of cross-routing.
- Cleans plan routes on completion/failure and evicts session tokens/cache on closure and connection teardown.
- Adds focused parent-server regression tests for stale bindings, ambiguity, late calls, cache destination, and cleanup.

## How It Was Tested

- [ ] `bun run ci` (Biome lint + format + imports, strict mode)
- [x] `bun run typecheck`
- [ ] `bun run test`
- [ ] `cargo clippy --all-targets -- -D warnings` (in src-tauri)
- [ ] `cargo test` (in src-tauri)
- [ ] Manual verification completed
- [ ] Not applicable

Additional focused validation:
- `cargo check --manifest-path src-tauri/Cargo.toml --lib`
- `cargo clippy --manifest-path src-tauri/Cargo.toml --lib -- -D warnings`
- `git diff --check`
- Focused Rust tests compile but cannot start locally on Windows due to the existing `STATUS_ENTRYPOINT_NOT_FOUND (0xc0000139)` test-binary loader failure; CI executes them.

## Screenshots or Recordings

Not applicable; backend session routing fix with unchanged UI.

## CI & Review Gate

- [ ] All CI checks pass (PR Validation, Rust Checks, Build Verification, Security Scans)
- [x] Code review comments from CodeRabbit / Claude have been addressed or resolved
- [x] No unresolved review findings remain

## Checklist

- [x] My PR title follows the conventional commit format used by this repo
- [x] I linked the related issue or explained why none exists
- [x] I updated docs when needed
- [x] I added or updated tests when needed
- [x] I verified the change does not introduce unrelated modifications
- [x] I read AGENTS.md and followed the contributor guidelines
- [x] A human reviewed the complete diff before submission
