### PR TITLE
fix(acp): restore chat history and session titles

### DIFF
--- a/src-tauri/src/acp/chat_history_store.rs
+++ b/src-tauri/src/acp/chat_history_store.rs
@@ -42,6 +42,8 @@ pub struct ChatHistoryIndexEntry {
     pub last_activity_at: u64,
     pub message_count: u64,
     pub status: ChatHistoryStatus,
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub discovered: bool,
     /// Worktree path the agent runs in (CAP-3). Additive: old entries
     /// deserialize with `None` (the renderer-authored metadata payload omits
     /// it for pre-feature sessions). Used by the CAP-4 relaunch lookup +
@@ -735,7 +737,10 @@ mod tests {
         let classified = classify_sync_error(error);
         #[cfg(not(unix))]
         {
-            assert!(classified.is_ok(), "PermissionDenied must be benign on non-unix");
+            assert!(
+                classified.is_ok(),
+                "PermissionDenied must be benign on non-unix"
+            );
         }
         #[cfg(unix)]
         {

--- a/src-tauri/src/acp/chat_history_store.rs
+++ b/src-tauri/src/acp/chat_history_store.rs
@@ -42,7 +42,7 @@ pub struct ChatHistoryIndexEntry {
     pub last_activity_at: u64,
     pub message_count: u64,
     pub status: ChatHistoryStatus,
-    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    #[serde(default)]
     pub discovered: bool,
     /// Worktree path the agent runs in (CAP-3). Additive: old entries
     /// deserialize with `None` (the renderer-authored metadata payload omits

--- a/src-tauri/src/acp/commands.rs
+++ b/src-tauri/src/acp/commands.rs
@@ -17,6 +17,7 @@ use crate::acp::config::{require_config_id, AgentConfig, AgentId, SessionId};
 use crate::acp::manager::{
     AcpManager, NewSessionOutcome, SessionCreationContext, SessionReopenOutcome, SpawnOutcome,
 };
+use crate::acp::session_persistence::{SessionIndexEntry, SessionRegistration};
 use crate::web::WsRelaySink;
 
 /// Spawn an ACP agent subprocess and complete the `initialize` handshake.
@@ -138,6 +139,46 @@ pub async fn acp_list_sessions(
     manager.list_sessions(&agent_id, cwd, cursor).await
 }
 
+/// Promote agent-owned discovered session metadata into host persistence.
+#[tauri::command]
+pub async fn acp_register_discovered_session(
+    manager: State<'_, Arc<AcpManager>>,
+    session_id: String,
+    agent_id: AgentId,
+    cwd: String,
+    title: Option<String>,
+    updated_at: Option<u64>,
+    project_id: Option<String>,
+) -> Result<SessionIndexEntry, String> {
+    if session_id.trim().is_empty() || cwd.trim().is_empty() {
+        return Err("session id and cwd are required".to_string());
+    }
+    let persistence = manager
+        .persistence()
+        .ok_or_else(|| "session persistence unavailable".to_string())?;
+    let metadata = persistence
+        .register_discovered_session(
+            SessionRegistration {
+                session_id,
+                stable_agent_namespace: manager.stable_agent_namespace(&agent_id)?,
+                runtime_agent_id: Some(agent_id.0),
+                project_id,
+                cwd: cwd.into(),
+                ..Default::default()
+            },
+            title,
+            updated_at,
+        )
+        .await
+        .map_err(|error| error.to_string())?;
+    log::info!(
+        "[acp-history] discovered session promoted session_id={} storage_key={}",
+        metadata.session_id,
+        metadata.storage_key
+    );
+    Ok(SessionIndexEntry::from(&metadata))
+}
+
 /// Send a prompt turn. Accepts either structured ACP content blocks or, for
 /// convenience, a plain text string (wrapped into a single text block).
 ///
@@ -172,9 +213,7 @@ pub async fn acp_send_prompt(
     // (mirrors the WS `send_prompt` handler ordering).
     match manager.owns_session(&agent_id, session_id.clone()).await {
         Ok(true) => {}
-        Ok(false) => {
-            return Err("session does not belong to the supplied live agent".to_string())
-        }
+        Ok(false) => return Err("session does not belong to the supplied live agent".to_string()),
         Err(error) => return Err(error),
     }
     // Skip backend-ephemeral sessions — they have no durable history and must
@@ -194,8 +233,8 @@ pub async fn acp_send_prompt(
         }
     };
     if !ephemeral {
-        if let Err(error) = persist_accepted_prompt(relay.inner(), &agent_id, &session_id, &blocks)
-            .await
+        if let Err(error) =
+            persist_accepted_prompt(relay.inner(), &agent_id, &session_id, &blocks).await
         {
             // Persistence failure rejects dispatch so a transport failure
             // cannot erase an accepted user message. Log session context only
@@ -397,10 +436,7 @@ pub async fn acp_list_catalog(
                 let installed = install.installed_agents();
                 crate::acp::overlay_installed(&mut catalog, &installed);
             }
-            log::info!(
-                "[acp-catalog] list success agents={}",
-                catalog.agents.len()
-            );
+            log::info!("[acp-catalog] list success agents={}", catalog.agents.len());
             Ok(crate::commands::IpcResult::success(catalog))
         }
         Err(error) => {

--- a/src-tauri/src/acp/host_mcp/child.rs
+++ b/src-tauri/src/acp/host_mcp/child.rs
@@ -20,7 +20,8 @@ use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::net::TcpStream;
 
 use crate::acp::host_mcp::{
-    FrameReply, FrameRequest, TermulPlanInput, ENV_AGENT_ID, ENV_PORT, ENV_SESSION_ID, ENV_TOKEN,
+    FrameKind, FrameReply, FrameRequest, TermulPlanInput, TermulSetTitleInput, ENV_AGENT_ID,
+    ENV_PORT, ENV_SESSION_ID, ENV_TOKEN,
 };
 
 /// Env-derived configuration for the child. Extracted so the arg parser is
@@ -52,7 +53,12 @@ pub fn parse_env() -> Result<ChildConfig, String> {
         .ok_or_else(|| format!("missing {ENV_SESSION_ID}"))?;
     // AGENT_ID is optional (used only for logging in the parent); absent → "".
     let agent_id = std::env::var(ENV_AGENT_ID).unwrap_or_default();
-    Ok(ChildConfig { port, token, session_id, agent_id })
+    Ok(ChildConfig {
+        port,
+        token,
+        session_id,
+        agent_id,
+    })
 }
 
 /// Subcommand entrypoint. Called from `main.rs` (desktop) / `server_main.rs`
@@ -69,7 +75,10 @@ pub fn run() -> i32 {
         }
     };
 
-    let runtime = match tokio::runtime::Builder::new_current_thread().enable_all().build() {
+    let runtime = match tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+    {
         Ok(rt) => rt,
         Err(e) => {
             eprintln!("[host-mcp-child] failed to start runtime: {e}");
@@ -107,18 +116,38 @@ impl TermulPlanServer {
         name = "termul_plan",
         description = "Update the execution plan / todo list shown in the Termul plan panel. Call this instead of a built-in todo tool so the user sees a unified plan UI across all agents."
     )]
-    async fn termul_plan(
-        &self,
-        Parameters(input): Parameters<TermulPlanInput>,
-    ) -> String {
-        match forward_to_parent(&self.config, &input).await {
+    async fn termul_plan(&self, Parameters(input): Parameters<TermulPlanInput>) -> String {
+        let request = FrameRequest {
+            token: self.config.token.clone(),
+            session_id: self.config.session_id.clone(),
+            kind: FrameKind::Plan,
+            todos: input.todos,
+            title: None,
+        };
+        match forward_to_parent(&self.config, request, "plan updated").await {
             Ok(msg) => msg,
-            Err(e) => {
-                // Surface the error to the agent as the tool result text. The
-                // agent sees the failure + can retry / fall back; the session
-                // keeps running.
-                format!("termul_plan error: {e}")
-            }
+            Err(e) => format!("termul_plan error: {e}"),
+        }
+    }
+
+    #[tool(
+        name = "termul_set_session_title",
+        description = "Set a concise title for the current Termul chat session. Call this during the first turn as soon as the user's intent is clear."
+    )]
+    async fn termul_set_session_title(
+        &self,
+        Parameters(input): Parameters<TermulSetTitleInput>,
+    ) -> String {
+        let request = FrameRequest {
+            token: self.config.token.clone(),
+            session_id: self.config.session_id.clone(),
+            kind: FrameKind::SetTitle,
+            todos: Vec::new(),
+            title: Some(input.title),
+        };
+        match forward_to_parent(&self.config, request, "title updated").await {
+            Ok(msg) => msg,
+            Err(e) => format!("termul_set_session_title error: {e}"),
         }
     }
 }
@@ -129,29 +158,29 @@ impl TermulPlanServer {
 /// tool call indefinitely.
 async fn forward_to_parent(
     config: &ChildConfig,
-    input: &TermulPlanInput,
+    request: FrameRequest,
+    success_message: &'static str,
 ) -> Result<String, String> {
     // 10s covers a healthy round trip many times over; a parent that can't
     // reply by then is wedged and the agent deserves a clear timeout error.
     const ROUND_TRIP: std::time::Duration = std::time::Duration::from_secs(10);
-    tokio::time::timeout(ROUND_TRIP, forward_to_parent_inner(config, input))
-        .await
-        .map_err(|_| "parent round trip timed out".to_string())?
+    tokio::time::timeout(
+        ROUND_TRIP,
+        forward_to_parent_inner(config, request, success_message),
+    )
+    .await
+    .map_err(|_| "parent round trip timed out".to_string())?
 }
 
 async fn forward_to_parent_inner(
     config: &ChildConfig,
-    input: &TermulPlanInput,
+    request: FrameRequest,
+    success_message: &'static str,
 ) -> Result<String, String> {
     let mut stream = TcpStream::connect(("127.0.0.1", config.port))
         .await
         .map_err(|e| format!("connect to parent failed: {e}"))?;
-    let req = FrameRequest {
-        token: config.token.clone(),
-        session_id: config.session_id.clone(),
-        todos: input.todos.clone(),
-    };
-    let mut buf = serde_json::to_vec(&req).map_err(|e| format!("encode frame: {e}"))?;
+    let mut buf = serde_json::to_vec(&request).map_err(|e| format!("encode frame: {e}"))?;
     buf.push(b'\n');
     stream
         .write_all(&buf)
@@ -167,7 +196,7 @@ async fn forward_to_parent_inner(
     let reply: FrameReply =
         serde_json::from_str(&line).map_err(|e| format!("decode reply: {e}"))?;
     if reply.ok {
-        Ok("plan updated".to_string())
+        Ok(success_message.to_string())
     } else {
         Err(reply.error.unwrap_or_else(|| "unknown error".to_string()))
     }

--- a/src-tauri/src/acp/host_mcp/child.rs
+++ b/src-tauri/src/acp/host_mcp/child.rs
@@ -16,7 +16,7 @@
 use rmcp::handler::server::wrapper::Parameters;
 use rmcp::service::serve_server;
 use rmcp::{tool, tool_router};
-use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::io::{AsyncBufReadExt, AsyncReadExt, AsyncWriteExt, BufReader};
 use tokio::net::TcpStream;
 
 use crate::acp::host_mcp::{
@@ -187,7 +187,8 @@ async fn forward_to_parent_inner(
         .await
         .map_err(|e| format!("write frame: {e}"))?;
 
-    let mut reader = BufReader::new(stream);
+    const MAX_REPLY: u64 = 64 * 1024;
+    let mut reader = BufReader::new(stream.take(MAX_REPLY));
     let mut line = String::new();
     reader
         .read_line(&mut line)

--- a/src-tauri/src/acp/host_mcp/mod.rs
+++ b/src-tauri/src/acp/host_mcp/mod.rs
@@ -35,17 +35,6 @@ use crate::acp::config::{AgentId, SessionId};
 use crate::acp::events::{self, PlanUpdateEvent};
 use crate::web::EventSink;
 
-/// The MCP tool names the agent sees in `tools/list`.
-pub const TERMUL_PLAN_TOOL_NAME: &str = "termul_plan";
-pub const TERMUL_SET_TITLE_TOOL_NAME: &str = "termul_set_session_title";
-
-/// Human-readable descriptions shown to the agent in `tools/list`.
-pub const TERMUL_PLAN_TOOL_DESCRIPTION: &str = "Update the execution plan / todo list shown \
-    in the Termul plan panel. Call this instead of a built-in todo tool so the user sees a \
-    unified plan UI across all agents.";
-pub const TERMUL_SET_TITLE_TOOL_DESCRIPTION: &str = "Set a concise title for the current \
-    Termul chat session. Call this during the first turn as soon as the user's intent is clear.";
-
 /// The hidden subcommand flag the child detects in argv (passed as the sole
 /// arg of the injected `McpServer::Stdio`). The agent spawns
 /// `current_exe() --internal-mcp-plan-server` with the connection info in env.

--- a/src-tauri/src/acp/host_mcp/mod.rs
+++ b/src-tauri/src/acp/host_mcp/mod.rs
@@ -35,13 +35,16 @@ use crate::acp::config::{AgentId, SessionId};
 use crate::acp::events::{self, PlanUpdateEvent};
 use crate::web::EventSink;
 
-/// The MCP tool name the agent sees in `tools/list`.
+/// The MCP tool names the agent sees in `tools/list`.
 pub const TERMUL_PLAN_TOOL_NAME: &str = "termul_plan";
+pub const TERMUL_SET_TITLE_TOOL_NAME: &str = "termul_set_session_title";
 
-/// Human-readable description shown to the agent in `tools/list`.
+/// Human-readable descriptions shown to the agent in `tools/list`.
 pub const TERMUL_PLAN_TOOL_DESCRIPTION: &str = "Update the execution plan / todo list shown \
     in the Termul plan panel. Call this instead of a built-in todo tool so the user sees a \
     unified plan UI across all agents.";
+pub const TERMUL_SET_TITLE_TOOL_DESCRIPTION: &str = "Set a concise title for the current \
+    Termul chat session. Call this during the first turn as soon as the user's intent is clear.";
 
 /// The hidden subcommand flag the child detects in argv (passed as the sole
 /// arg of the injected `McpServer::Stdio`). The agent spawns
@@ -75,6 +78,13 @@ pub struct TermulPlanInput {
     pub todos: Vec<TermulPlanTodo>,
 }
 
+/// Input the agent sends to `termul_set_session_title`.
+#[derive(Debug, Clone, Deserialize, Serialize, schemars::JsonSchema)]
+pub struct TermulSetTitleInput {
+    /// Concise title for the current chat session.
+    pub title: String,
+}
+
 /// One todo item. `status`/`priority` are optional strings (the agent may omit
 /// them); the host maps unknown/absent values to ACP defaults.
 #[derive(Debug, Clone, Deserialize, Serialize, schemars::JsonSchema)]
@@ -97,11 +107,24 @@ pub struct TermulPlanTodo {
 /// host doesn't know at injection time). The parent binds the provisional id
 /// → real `session_id` after the `session/new` response arrives, then emits
 /// the plan_update for the real id. The `token` authenticates the child.
+#[derive(Debug, Clone, Default, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum FrameKind {
+    #[default]
+    Plan,
+    SetTitle,
+}
+
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct FrameRequest {
     pub token: String,
     pub session_id: String,
+    #[serde(default)]
+    pub kind: FrameKind,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub todos: Vec<TermulPlanTodo>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub title: Option<String>,
 }
 
 /// Parent reply frame (one per connection).
@@ -115,12 +138,18 @@ pub struct FrameReply {
 impl FrameReply {
     #[must_use]
     pub fn ok() -> Self {
-        Self { ok: true, error: None }
+        Self {
+            ok: true,
+            error: None,
+        }
     }
 
     #[must_use]
     pub fn err(msg: impl Into<String>) -> Self {
-        Self { ok: false, error: Some(msg.into()) }
+        Self {
+            ok: false,
+            error: Some(msg.into()),
+        }
     }
 }
 
@@ -132,12 +161,26 @@ pub fn map_todos_to_plan_entries(todos: &[TermulPlanTodo]) -> Vec<PlanEntry> {
     todos
         .iter()
         .map(|todo| {
-            let priority = match todo.priority.as_deref().map(str::trim).unwrap_or("").to_ascii_lowercase().as_str() {
+            let priority = match todo
+                .priority
+                .as_deref()
+                .map(str::trim)
+                .unwrap_or("")
+                .to_ascii_lowercase()
+                .as_str()
+            {
                 "high" => PlanEntryPriority::High,
                 "medium" => PlanEntryPriority::Medium,
                 _ => PlanEntryPriority::Low,
             };
-            let status = match todo.status.as_deref().map(str::trim).unwrap_or("").to_ascii_lowercase().as_str() {
+            let status = match todo
+                .status
+                .as_deref()
+                .map(str::trim)
+                .unwrap_or("")
+                .to_ascii_lowercase()
+                .as_str()
+            {
                 "in_progress" | "inprogress" | "in-progress" => PlanEntryStatus::InProgress,
                 "completed" | "done" | "complete" => PlanEntryStatus::Completed,
                 _ => PlanEntryStatus::Pending,
@@ -207,9 +250,9 @@ pub fn emit_plan_update(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::sync::Mutex as StdMutex;
     use crate::web::sink::AcpEvent;
     use serde_json::Value;
+    use std::sync::Mutex as StdMutex;
 
     /// Test sink that captures every emitted event (for plan_update assertions).
     #[derive(Default)]
@@ -232,9 +275,21 @@ mod tests {
     #[test]
     fn map_todos_preserves_order_and_maps_status_priority() {
         let todos = vec![
-            TermulPlanTodo { content: "a".into(), status: Some("in_progress".into()), priority: Some("high".into()) },
-            TermulPlanTodo { content: "b".into(), status: Some("completed".into()), priority: Some("medium".into()) },
-            TermulPlanTodo { content: "c".into(), status: None, priority: None },
+            TermulPlanTodo {
+                content: "a".into(),
+                status: Some("in_progress".into()),
+                priority: Some("high".into()),
+            },
+            TermulPlanTodo {
+                content: "b".into(),
+                status: Some("completed".into()),
+                priority: Some("medium".into()),
+            },
+            TermulPlanTodo {
+                content: "c".into(),
+                status: None,
+                priority: None,
+            },
         ];
         let entries = map_todos_to_plan_entries(&todos);
         assert_eq!(entries.len(), 3);
@@ -266,9 +321,21 @@ mod tests {
         let sinks: Vec<Arc<dyn EventSink>> = vec![sink.clone()];
         let (agent_id, session_id) = make_ids();
         let todos = vec![
-            TermulPlanTodo { content: "one".into(), status: None, priority: None },
-            TermulPlanTodo { content: "two".into(), status: None, priority: None },
-            TermulPlanTodo { content: "three".into(), status: None, priority: None },
+            TermulPlanTodo {
+                content: "one".into(),
+                status: None,
+                priority: None,
+            },
+            TermulPlanTodo {
+                content: "two".into(),
+                status: None,
+                priority: None,
+            },
+            TermulPlanTodo {
+                content: "three".into(),
+                status: None,
+                priority: None,
+            },
         ];
         let entries = map_todos_to_plan_entries(&todos);
         emit_plan_update(&sinks, &agent_id, &session_id, entries);
@@ -298,7 +365,27 @@ mod tests {
         let (type_, payload) = &captured[0];
         assert_eq!(type_, events::EVENT_PLAN_UPDATE);
         let entries = payload["plan"]["entries"].as_array().unwrap();
-        assert!(entries.is_empty(), "empty todos must emit an empty entries array");
+        assert!(
+            entries.is_empty(),
+            "empty todos must emit an empty entries array"
+        );
+    }
+
+    #[test]
+    fn title_frame_round_trips_with_kind_and_title() {
+        let frame = FrameRequest {
+            token: "token".into(),
+            session_id: "provisional".into(),
+            kind: FrameKind::SetTitle,
+            todos: Vec::new(),
+            title: Some("Fix login bug".into()),
+        };
+        let value = serde_json::to_value(&frame).unwrap();
+        assert_eq!(value["kind"], "set_title");
+        assert_eq!(value["title"], "Fix login bug");
+        let decoded: FrameRequest = serde_json::from_value(value).unwrap();
+        assert_eq!(decoded.kind, FrameKind::SetTitle);
+        assert_eq!(decoded.title.as_deref(), Some("Fix login bug"));
     }
 
     #[test]

--- a/src-tauri/src/acp/host_mcp/parent.rs
+++ b/src-tauri/src/acp/host_mcp/parent.rs
@@ -24,8 +24,9 @@ use uuid::Uuid;
 
 use crate::acp::config::{AgentId, SessionId};
 use crate::acp::host_mcp::{
-    emit_plan_update, map_todos_to_plan_entries, FrameReply, FrameRequest, PlanStore,
+    emit_plan_update, map_todos_to_plan_entries, FrameKind, FrameReply, FrameRequest, PlanStore,
 };
+use crate::acp::session_persistence::SessionPersistence;
 use crate::web::EventSink;
 
 /// Per-session auth + routing context, keyed by the random token.
@@ -57,6 +58,8 @@ pub struct HostPlanServer {
     /// the seam a future persistence layer reads from on resume. Updated in
     /// `process_request` (set on emit) + `unregister_*` (drop on close).
     plan_store: PlanStore,
+    /// Durable store used by the title tool. Absent in live-only tests/modes.
+    persistence: Option<Arc<SessionPersistence>>,
 }
 
 impl HostPlanServer {
@@ -68,12 +71,16 @@ impl HostPlanServer {
     /// `WsRelaySink` on standalone). `fan_out` over zero sinks is a no-op, so a
     /// unit-test `HostPlanServer` with `vec![]` is legal (just emits nothing).
     #[must_use]
-    pub fn start(sinks: Vec<Arc<dyn EventSink>>) -> Arc<Self> {
+    pub fn start(
+        sinks: Vec<Arc<dyn EventSink>>,
+        persistence: Option<Arc<SessionPersistence>>,
+    ) -> Arc<Self> {
         let server = Arc::new(Self {
             port: std::sync::OnceLock::new(),
             sinks,
             sessions: Mutex::new(HashMap::new()),
             plan_store: PlanStore::new(),
+            persistence,
         });
         let server_for_thread = Arc::clone(&server);
         let (port_tx, port_rx) = std::sync::mpsc::channel::<u16>();
@@ -115,7 +122,9 @@ impl HostPlanServer {
                                 let server = Arc::clone(&server_for_thread);
                                 tokio::spawn(async move {
                                     if let Err(e) = server.handle_conn(stream).await {
-                                        log::warn!("[host-mcp] conn from {peer} ended with error: {e}");
+                                        log::warn!(
+                                            "[host-mcp] conn from {peer} ended with error: {e}"
+                                        );
                                     }
                                 });
                             }
@@ -206,9 +215,7 @@ impl HostPlanServer {
     pub fn unregister_by_token(&self, token: &str) {
         let real_sid = {
             let mut sessions = self.sessions.lock();
-            sessions
-                .remove(token)
-                .and_then(|auth| auth.real_session_id)
+            sessions.remove(token).and_then(|auth| auth.real_session_id)
         };
         if let Some(sid) = real_sid {
             self.plan_store.drop_session(&sid);
@@ -307,21 +314,53 @@ impl HostPlanServer {
             }
         };
 
-        // Map todos → PlanEntry + emit. Empty todos = clear (renderer drops).
-        let entries = map_todos_to_plan_entries(&req.todos);
-        let agent_id = AgentId(auth.agent_id.clone());
-        let session_id = SessionId(real_session_id.clone());
-        let count = entries.len();
-        // Cache the latest plan (emit-and-cache) so a future persistence layer
-        // can read it without re-deriving from replayed events.
-        self.plan_store.set(&real_session_id, entries.clone());
-        emit_plan_update(&self.sinks, &agent_id, &session_id, entries);
-        log::info!(
-            "[host-mcp] emitted plan_update for session {} ({} entries)",
-            session_id,
-            count
-        );
-        FrameReply::ok()
+        match req.kind {
+            FrameKind::Plan => {
+                if req.title.is_some() {
+                    return FrameReply::err("plan frame must not include title");
+                }
+                // Map todos → PlanEntry + emit. Empty todos = clear (renderer drops).
+                let entries = map_todos_to_plan_entries(&req.todos);
+                let agent_id = AgentId(auth.agent_id.clone());
+                let session_id = SessionId(real_session_id.clone());
+                let count = entries.len();
+                self.plan_store.set(&real_session_id, entries.clone());
+                emit_plan_update(&self.sinks, &agent_id, &session_id, entries);
+                log::info!(
+                    "[host-mcp] emitted plan_update for session {} ({} entries)",
+                    session_id,
+                    count
+                );
+                FrameReply::ok()
+            }
+            FrameKind::SetTitle => {
+                if !req.todos.is_empty() {
+                    return FrameReply::err("title frame must not include todos");
+                }
+                let Some(title) = req.title else {
+                    return FrameReply::err("title is required");
+                };
+                let Some(persistence) = self.persistence.as_ref() else {
+                    log::warn!("[host-mcp] title call rejected: persistence unavailable");
+                    return FrameReply::err("title persistence unavailable");
+                };
+                match crate::acp::manager::record_local_title(
+                    persistence,
+                    &self.sinks,
+                    AgentId(auth.agent_id),
+                    real_session_id,
+                    title,
+                )
+                .await
+                {
+                    Ok(()) => FrameReply::ok(),
+                    Err(error) => {
+                        log::warn!("[host-mcp] title update rejected: {error}");
+                        FrameReply::err(error)
+                    }
+                }
+            }
+        }
     }
 }
 
@@ -340,7 +379,9 @@ mod tests {
 
     impl EventSink for CapturingSink {
         fn emit(&self, event: &crate::web::sink::AcpEvent) {
-            if event.type_ == crate::acp::events::EVENT_PLAN_UPDATE {
+            if event.type_ == crate::acp::events::EVENT_PLAN_UPDATE
+                || event.type_ == crate::acp::events::EVENT_SESSION_INFO_UPDATE
+            {
                 self.events.lock().unwrap().push(event.type_.to_string());
             }
         }
@@ -359,7 +400,7 @@ mod tests {
 
     #[test]
     fn register_returns_valid_port_token_provisional() {
-        let server = HostPlanServer::start(vec![]);
+        let server = HostPlanServer::start(vec![], None);
         let (port, token, provisional) = server.register_session("agent-1");
         assert!(port > 0, "port must be bound by the dedicated thread");
         assert!(!token.is_empty());
@@ -372,13 +413,14 @@ mod tests {
         // Before `bind_session` is called, the real session_id is unknown — a
         // call arriving in that window is rejected (the agent can't legally
         // call tools before `session/new` returns, but we defend anyway).
-        let server = HostPlanServer::start(vec![Arc::new(CapturingSink::default())]);
+        let server = HostPlanServer::start(vec![Arc::new(CapturingSink::default())], None);
         let (port, token, provisional) = server.register_session("agent-1");
         let runtime = Runtime::new().unwrap();
         runtime.block_on(async move {
             let frame = serde_json::json!({
                 "token": token,
                 "session_id": provisional,
+                "kind": "plan",
                 "todos": [{"content": "x"}],
             });
             let reply = connect_and_send(port, &frame).await;
@@ -391,13 +433,14 @@ mod tests {
     fn token_provisional_mismatch_is_rejected() {
         // A valid token paired with the wrong provisional session_id is
         // rejected (defense-in-depth against a leaked token + guessed sid).
-        let server = HostPlanServer::start(vec![Arc::new(CapturingSink::default())]);
+        let server = HostPlanServer::start(vec![Arc::new(CapturingSink::default())], None);
         let (port, token, _provisional) = server.register_session("agent-1");
         let runtime = Runtime::new().unwrap();
         runtime.block_on(async move {
             let frame = serde_json::json!({
                 "token": token,
                 "session_id": "wrong-provisional",
+                "kind": "plan",
                 "todos": [{"content": "x"}],
             });
             let reply = connect_and_send(port, &frame).await;
@@ -409,7 +452,7 @@ mod tests {
     #[test]
     fn bound_session_emits_plan_update() {
         let sink = Arc::new(CapturingSink::default());
-        let server = HostPlanServer::start(vec![sink.clone()]);
+        let server = HostPlanServer::start(vec![sink.clone()], None);
         let (port, token, provisional) = server.register_session("agent-1");
         server.bind_session(&token, "sess-real");
 
@@ -418,6 +461,7 @@ mod tests {
             let frame = serde_json::json!({
                 "token": token,
                 "session_id": provisional,
+                "kind": "plan",
                 "todos": [
                     {"content": "one"},
                     {"content": "two", "status": "in_progress", "priority": "high"},
@@ -434,18 +478,66 @@ mod tests {
     #[test]
     fn bad_token_alone_is_rejected() {
         // Unknown token — rejected even with a plausible provisional sid.
-        let server = HostPlanServer::start(vec![Arc::new(CapturingSink::default())]);
+        let server = HostPlanServer::start(vec![Arc::new(CapturingSink::default())], None);
         let (port, _token, _provisional) = server.register_session("agent-1");
         let runtime = Runtime::new().unwrap();
         runtime.block_on(async move {
             let frame = serde_json::json!({
                 "token": "bogus-token",
                 "session_id": "bogus-sid",
+                "kind": "plan",
                 "todos": [{"content": "x"}],
             });
             let reply = connect_and_send(port, &frame).await;
             assert_eq!(reply["ok"], false);
             assert_eq!(reply["error"], "auth rejected");
+        });
+    }
+
+    #[test]
+    fn bound_title_call_persists_and_broadcasts() {
+        let root =
+            std::env::temp_dir().join(format!("termul-host-mcp-title-{}", uuid::Uuid::new_v4()));
+        let cwd = root.join("cwd");
+        std::fs::create_dir_all(&cwd).unwrap();
+        let runtime = Runtime::new().unwrap();
+        runtime.block_on(async move {
+            let persistence = Arc::new(SessionPersistence::open(root.join("store")).await.unwrap());
+            persistence
+                .register_session(crate::acp::SessionRegistration {
+                    session_id: "sess-real".into(),
+                    stable_agent_namespace: Some("config:test".into()),
+                    runtime_agent_id: Some("agent-1".into()),
+                    project_id: None,
+                    cwd,
+                    ..Default::default()
+                })
+                .await
+                .unwrap();
+            let sink = Arc::new(CapturingSink::default());
+            let server = HostPlanServer::start(vec![sink.clone()], Some(Arc::clone(&persistence)));
+            let (port, token, provisional) = server.register_session("agent-1");
+            server.bind_session(&token, "sess-real");
+            let frame = serde_json::json!({
+                "token": token,
+                "session_id": provisional,
+                "kind": "set_title",
+                "title": "**Fix login bug**\nignored",
+            });
+            let reply = connect_and_send(port, &frame).await;
+            assert_eq!(reply["ok"], true);
+            let metadata = persistence.metadata("sess-real").unwrap();
+            assert_eq!(metadata.title.as_deref(), Some("Fix login bug"));
+            assert_eq!(
+                metadata.title_source,
+                Some(crate::acp::session_persistence::TitleSource::BackgroundGenerated)
+            );
+            let records = persistence.replay_after("sess-real", 0).unwrap();
+            assert!(records
+                .iter()
+                .any(|record| record.type_ == "local_title_generated"));
+            assert_eq!(sink.events.lock().unwrap().len(), 1);
+            let _ = std::fs::remove_dir_all(root);
         });
     }
 }

--- a/src-tauri/src/acp/host_mcp/parent.rs
+++ b/src-tauri/src/acp/host_mcp/parent.rs
@@ -701,6 +701,7 @@ mod tests {
             let server = HostPlanServer::start(vec![sink.clone()], Some(Arc::clone(&persistence)));
             let (port, token, provisional) = server.register_session("agent-1");
             server.bind_session(&token, "sess-real");
+            server.begin_turn("agent-1", "sess-real");
             let frame = serde_json::json!({
                 "token": token,
                 "session_id": provisional,

--- a/src-tauri/src/acp/host_mcp/parent.rs
+++ b/src-tauri/src/acp/host_mcp/parent.rs
@@ -59,6 +59,8 @@ pub struct HostPlanServer {
     /// authoritative turn registry lets `process_request` repair that stale
     /// token binding when exactly one session for the agent is active.
     active_turns: Mutex<HashMap<String, HashSet<String>>>,
+    /// Sessions that already accepted a title during the current active turn.
+    title_calls_this_turn: Mutex<HashSet<String>>,
     /// Per-session plan cache (emit-and-cache). v1 doesn't persist; this is
     /// the seam a future persistence layer reads from on resume. Updated in
     /// `process_request` (set on emit) + `unregister_*` (drop on close).
@@ -85,6 +87,7 @@ impl HostPlanServer {
             sinks,
             sessions: Mutex::new(HashMap::new()),
             active_turns: Mutex::new(HashMap::new()),
+            title_calls_this_turn: Mutex::new(HashSet::new()),
             plan_store: PlanStore::new(),
             persistence,
         });
@@ -206,6 +209,7 @@ impl HostPlanServer {
 
     /// Mark an accepted prompt turn as active before the agent can call tools.
     pub fn begin_turn(&self, agent_id: &str, real_session_id: &str) {
+        self.title_calls_this_turn.lock().remove(real_session_id);
         self.active_turns
             .lock()
             .entry(agent_id.to_string())
@@ -225,6 +229,7 @@ impl HostPlanServer {
                 active_turns.remove(agent_id);
             }
         }
+        self.title_calls_this_turn.lock().remove(real_session_id);
         log::debug!(
             "[host-mcp] removed active plan route for session {real_session_id} (agent {agent_id})"
         );
@@ -244,6 +249,7 @@ impl HostPlanServer {
             !sessions.is_empty()
         });
         drop(active_turns);
+        self.title_calls_this_turn.lock().remove(real_session_id);
         self.plan_store.drop_session(real_session_id);
     }
 
@@ -415,6 +421,13 @@ impl HostPlanServer {
                 let Some(title) = req.title else {
                     return FrameReply::err("title is required");
                 };
+                if !self
+                    .title_calls_this_turn
+                    .lock()
+                    .insert(real_session_id.clone())
+                {
+                    return FrameReply::err("title already set during this turn");
+                }
                 let Some(persistence) = self.persistence.as_ref() else {
                     log::warn!("[host-mcp] title call rejected: persistence unavailable");
                     return FrameReply::err("title persistence unavailable");
@@ -423,13 +436,14 @@ impl HostPlanServer {
                     persistence,
                     &self.sinks,
                     AgentId(auth.agent_id),
-                    real_session_id,
+                    real_session_id.clone(),
                     title,
                 )
                 .await
                 {
                     Ok(()) => FrameReply::ok(),
                     Err(error) => {
+                        self.title_calls_this_turn.lock().remove(&real_session_id);
                         log::warn!("[host-mcp] title update rejected: {error}");
                         FrameReply::err(error)
                     }
@@ -721,6 +735,7 @@ mod tests {
                 .iter()
                 .any(|record| record.type_ == "local_title_generated"));
             assert_eq!(sink.events.lock().unwrap().len(), 1);
+            persistence.shutdown().await.unwrap();
             let _ = std::fs::remove_dir_all(root);
         });
     }

--- a/src-tauri/src/acp/manager.rs
+++ b/src-tauri/src/acp/manager.rs
@@ -846,9 +846,10 @@ pub(crate) async fn record_local_title(
     if title == "Untitled Chat" {
         return Err("title must not be empty".to_string());
     }
-    let metadata = persistence
-        .metadata(&session_id)
-        .map_err(|error| format!("could not read title metadata: {error}"))?;
+    let metadata = persistence.metadata(&session_id).map_err(|error| {
+        log::warn!("[acp-title] metadata lookup failed for session {session_id}: {error}");
+        "could not read title metadata".to_string()
+    })?;
     if metadata.title_source == Some(TitleSource::LocalAlias) {
         return Err("title is protected by a local alias".to_string());
     }
@@ -860,11 +861,17 @@ pub(crate) async fn record_local_title(
     let next_seq = persistence
         .append_local_title(&session_id, title.clone())
         .await
-        .map_err(|error| format!("failed to persist title: {error}"))?;
+        .map_err(|error| {
+            log::warn!("[acp-title] title persistence failed for session {session_id}: {error}");
+            "failed to persist title".to_string()
+        })?;
     persistence
         .flush_session(&session_id)
         .await
-        .map_err(|error| format!("failed to flush title: {error}"))?;
+        .map_err(|error| {
+            log::warn!("[acp-title] title flush failed for session {session_id}: {error}");
+            "failed to flush title".to_string()
+        })?;
     let event = SessionInfoUpdateEvent {
         agent_id: user_agent_id,
         session_id: SessionId::new(session_id.clone()),
@@ -1465,18 +1472,17 @@ impl AcpManager {
         // session (AD-9 debounce). The task owns an `Arc<Self>` clone so it
         // can outlive the command's borrowed `&Arc<Self>` receiver.
         if let Some(persistence) = &self.persistence {
-            let title_was_set_this_turn = persistence
-                .replay_after(&session_id.0, turn_start_seq)
-                .is_ok_and(|records| {
-                    records
-                        .iter()
-                        .any(|record| record.type_ == "local_title_generated")
-                });
-            let is_first_turn = !title_was_set_this_turn
+            let is_first_turn = !first_prompt_text.is_empty()
                 && persistence.metadata(&session_id.0).is_ok_and(|metadata| {
                     metadata.title_source == Some(TitleSource::DerivedFirstMessage)
                 })
-                && !first_prompt_text.is_empty();
+                && !persistence
+                    .replay_after(&session_id.0, turn_start_seq)
+                    .is_ok_and(|records| {
+                        records
+                            .iter()
+                            .any(|record| record.type_ == "local_title_generated")
+                    });
             if is_first_turn {
                 let mut set = self.in_flight_title_gens.lock();
                 if !set.insert(session_id.0.clone()) {
@@ -2097,15 +2103,10 @@ impl AcpManager {
                         let _ = accepted.send(Ok(()));
                     }
                     AcpCommand::CancelPrompt { session_id, reply } => {
-                        let cancel = pending_cancels.lock().remove(&session_id.0);
-                        let _ = reply.send(Ok(()));
-                        // Let the cancellation request emit its acknowledgement before
-                        // unblocking the prompt-completion task. This keeps the test
-                        // transport's ordering contract deterministic under CI load.
-                        tokio::task::yield_now().await;
-                        if let Some(cancel) = cancel {
+                        if let Some(cancel) = pending_cancels.lock().remove(&session_id.0) {
                             let _ = cancel.send(());
                         }
+                        let _ = reply.send(Ok(()));
                     }
                     _ => {}
                 }

--- a/src-tauri/src/acp/manager.rs
+++ b/src-tauri/src/acp/manager.rs
@@ -2097,10 +2097,15 @@ impl AcpManager {
                         let _ = accepted.send(Ok(()));
                     }
                     AcpCommand::CancelPrompt { session_id, reply } => {
-                        if let Some(cancel) = pending_cancels.lock().remove(&session_id.0) {
+                        let cancel = pending_cancels.lock().remove(&session_id.0);
+                        let _ = reply.send(Ok(()));
+                        // Let the cancellation request emit its acknowledgement before
+                        // unblocking the prompt-completion task. This keeps the test
+                        // transport's ordering contract deterministic under CI load.
+                        tokio::task::yield_now().await;
+                        if let Some(cancel) = cancel {
                             let _ = cancel.send(());
                         }
-                        let _ = reply.send(Ok(()));
                     }
                     _ => {}
                 }

--- a/src-tauri/src/acp/manager.rs
+++ b/src-tauri/src/acp/manager.rs
@@ -54,10 +54,11 @@ use crate::acp::events::{
 };
 use crate::acp::session::DriverState;
 use crate::acp::session_persistence::{
-    is_protected_title_source, normalize_title, now_millis,
-    PersistedEventRecord, PersistedSessionStatus, SessionPersistence, SessionRegistration,
-    TitleSource, SESSION_SCHEMA_VERSION,
+    is_protected_title_source, normalize_title, PersistedSessionStatus, SessionPersistence,
+    SessionRegistration, TitleSource,
 };
+#[cfg(test)]
+use crate::acp::session_persistence::{now_millis, SESSION_SCHEMA_VERSION};
 use crate::web::sink::CapturingEventSink;
 use crate::web::EventSink;
 
@@ -387,7 +388,9 @@ where
                     Ok(result) => result,
                     Err(_) if idle_deadline == Some(nd) => {
                         let idle_dur = idle.unwrap_or(Duration::ZERO);
-                        Err(format!("turn idle timeout: no agent activity for {idle_dur:?}"))
+                        Err(format!(
+                            "turn idle timeout: no agent activity for {idle_dur:?}"
+                        ))
                     }
                     Err(_) => {
                         let hard_dur = hard.unwrap_or(Duration::ZERO);
@@ -719,6 +722,7 @@ pub(crate) struct StartedPrompt {
     agent_id: AgentId,
     session_id: SessionId,
     first_prompt_text: String,
+    turn_start_seq: u64,
     completion: oneshot::Receiver<Result<StopReason, String>>,
 }
 
@@ -829,6 +833,56 @@ fn extract_prompt_text(content: &[ContentBlock]) -> String {
     text.chars().take(2000).collect()
 }
 
+/// Normalize, durably persist, flush, and broadcast a locally generated title.
+/// Shared by background generation and the host-injected title tool.
+pub(crate) async fn record_local_title(
+    persistence: &SessionPersistence,
+    sinks: &[Arc<dyn EventSink>],
+    user_agent_id: AgentId,
+    session_id: String,
+    raw_title: String,
+) -> Result<(), String> {
+    let title = normalize_title(&raw_title);
+    if title == "Untitled Chat" {
+        return Err("title must not be empty".to_string());
+    }
+    let metadata = persistence
+        .metadata(&session_id)
+        .map_err(|error| format!("could not read title metadata: {error}"))?;
+    if metadata.title_source == Some(TitleSource::LocalAlias) {
+        return Err("title is protected by a local alias".to_string());
+    }
+    if metadata.title.as_deref() == Some(title.as_str())
+        && metadata.title_source == Some(TitleSource::BackgroundGenerated)
+    {
+        return Ok(());
+    }
+    let next_seq = persistence
+        .append_local_title(&session_id, title.clone())
+        .await
+        .map_err(|error| format!("failed to persist title: {error}"))?;
+    persistence
+        .flush_session(&session_id)
+        .await
+        .map_err(|error| format!("failed to flush title: {error}"))?;
+    let event = SessionInfoUpdateEvent {
+        agent_id: user_agent_id,
+        session_id: SessionId::new(session_id.clone()),
+        title: Some(title.clone()),
+    };
+    events::fan_out(
+        sinks,
+        Some(event.session_id.0.as_str()),
+        events::EVENT_SESSION_INFO_UPDATE,
+        &event,
+    );
+    log::info!(
+        "[acp-title] title persisted and broadcast for session {session_id} (seq={next_seq}, title_len={} chars)",
+        title.chars().count()
+    );
+    Ok(())
+}
+
 /// RAII guard that removes a session id from the in-flight title-gen set on
 /// drop (AD-9). Ensures the debounce set is cleaned up on EVERY exit path
 /// (success, failure, panic) so a crashed gen never permanently blocks a
@@ -915,11 +969,8 @@ impl AcpManager {
     /// exercise the command channel) — `fan_out` over zero sinks is a no-op.
     #[must_use]
     pub fn new(sinks: Vec<Arc<dyn EventSink>>) -> Self {
-        // Eagerly start the host-injected plan MCP server (one shared TCP
-        // listener) here — in the SYNC constructor — so the async
-        // `new_session_with_context` path never blocks a Tokio worker on the
-        // bind + port-publish handshake. Cheap: `sinks.clone()` is Arc-only.
-        let host_plan_server = crate::acp::host_mcp::parent::HostPlanServer::start(sinks.clone());
+        let host_plan_server =
+            crate::acp::host_mcp::parent::HostPlanServer::start(sinks.clone(), None);
         Self {
             sinks,
             agents: Arc::new(Mutex::new(HashMap::new())),
@@ -936,7 +987,10 @@ impl AcpManager {
         sinks: Vec<Arc<dyn EventSink>>,
         persistence: Arc<SessionPersistence>,
     ) -> Self {
-        let host_plan_server = crate::acp::host_mcp::parent::HostPlanServer::start(sinks.clone());
+        let host_plan_server = crate::acp::host_mcp::parent::HostPlanServer::start(
+            sinks.clone(),
+            Some(Arc::clone(&persistence)),
+        );
         Self {
             sinks,
             agents: Arc::new(Mutex::new(HashMap::new())),
@@ -945,6 +999,11 @@ impl AcpManager {
             warmup_done: Arc::new(Mutex::new(HashSet::new())),
             host_plan_server,
         }
+    }
+
+    #[must_use]
+    pub fn persistence(&self) -> Option<Arc<SessionPersistence>> {
+        self.persistence.clone()
     }
 
     /// Spawn an ACP agent: launch the subprocess, complete `initialize`, and
@@ -1166,19 +1225,19 @@ impl AcpManager {
         // isn't known until the response, so register with a provisional id
         // now + bind after `session/new` returns. If session creation fails,
         // evict the token so it doesn't leak (CodeRabbit #6).
-        let (combined_mcp_servers, plan_token): (Vec<McpServer>, Option<String>) =
-            if !context.ephemeral {
-                let (port, token, provisional_sid) =
-                    self.host_plan_server.register_session(&agent_id.0);
-                let internal =
-                    build_internal_plan_stdio(&agent_id.0, port, &token, &provisional_sid);
-                // Prepend so the internal server is first in the agent's tool list.
-                let mut combined = internal;
-                combined.extend(mcp_servers);
-                (combined, Some(token))
-            } else {
-                (mcp_servers, None)
-            };
+        let (combined_mcp_servers, plan_token): (Vec<McpServer>, Option<String>) = if !context
+            .ephemeral
+        {
+            let (port, token, provisional_sid) =
+                self.host_plan_server.register_session(&agent_id.0);
+            let internal = build_internal_plan_stdio(&agent_id.0, port, &token, &provisional_sid);
+            // Prepend so the internal server is first in the agent's tool list.
+            let mut combined = internal;
+            combined.extend(mcp_servers);
+            (combined, Some(token))
+        } else {
+            (mcp_servers, None)
+        };
 
         let outcome = async {
             gate_mcp_servers(&caps, &combined_mcp_servers)?;
@@ -1204,7 +1263,8 @@ impl AcpManager {
                 // emit plan_update for the right session when the agent calls
                 // termul_plan.
                 if let Some(token) = plan_token {
-                    self.host_plan_server.bind_session(&token, &outcome.session_id.0);
+                    self.host_plan_server
+                        .bind_session(&token, &outcome.session_id.0);
                 }
                 Ok(outcome)
             }
@@ -1354,6 +1414,11 @@ impl AcpManager {
         // command. The background title-gen flow embeds this text in a fresh
         // prompt to a separate agent (AD-2). Never log it — only forward it.
         let first_prompt_text = extract_prompt_text(&content);
+        let turn_start_seq = self
+            .persistence
+            .as_ref()
+            .and_then(|persistence| persistence.last_seq(&session_id.0).ok())
+            .unwrap_or(0);
         let tx = self.command_tx(agent_id)?;
         let (accepted_tx, accepted_rx) = oneshot::channel();
         let (completion_tx, completion_rx) = oneshot::channel();
@@ -1372,6 +1437,7 @@ impl AcpManager {
             agent_id: agent_id.clone(),
             session_id,
             first_prompt_text,
+            turn_start_seq,
             completion: completion_rx,
         })
     }
@@ -1384,6 +1450,7 @@ impl AcpManager {
             agent_id,
             session_id,
             first_prompt_text,
+            turn_start_seq,
             completion,
         } = started;
         let stop_reason = completion
@@ -1396,9 +1463,15 @@ impl AcpManager {
         // session (AD-9 debounce). The task owns an `Arc<Self>` clone so it
         // can outlive the command's borrowed `&Arc<Self>` receiver.
         if let Some(persistence) = &self.persistence {
-            let is_first_turn = persistence
-                .metadata(&session_id.0)
-                .is_ok_and(|metadata| {
+            let title_was_set_this_turn = persistence
+                .replay_after(&session_id.0, turn_start_seq)
+                .is_ok_and(|records| {
+                    records
+                        .iter()
+                        .any(|record| record.type_ == "local_title_generated")
+                });
+            let is_first_turn = !title_was_set_this_turn
+                && persistence.metadata(&session_id.0).is_ok_and(|metadata| {
                     metadata.title_source == Some(TitleSource::DerivedFirstMessage)
                 })
                 && !first_prompt_text.is_empty();
@@ -1417,7 +1490,11 @@ impl AcpManager {
                 let session_id_str = session_id.0.clone();
                 tokio::spawn(async move {
                     manager
-                        .maybe_generate_background_title(user_agent_id, session_id_str, first_prompt_text)
+                        .maybe_generate_background_title(
+                            user_agent_id,
+                            session_id_str,
+                            first_prompt_text,
+                        )
                         .await;
                 });
             }
@@ -1496,12 +1573,15 @@ impl AcpManager {
                 }
             }
         };
-        let config_id_label = config.config_id.clone().unwrap_or_else(|| config.name.clone());
+        let config_id_label = config
+            .config_id
+            .clone()
+            .unwrap_or_else(|| config.name.clone());
 
         // Spawn the background agent with ONLY the capturing sink (AD-4).
         let capturing_sink = Arc::new(CapturingEventSink::new());
-        let spawn_sinks: Vec<Arc<dyn EventSink>> = vec![Arc::clone(&capturing_sink)
-            as Arc<dyn EventSink>];
+        let spawn_sinks: Vec<Arc<dyn EventSink>> =
+            vec![Arc::clone(&capturing_sink) as Arc<dyn EventSink>];
         let bg_outcome = self.spawn_with_sinks(config, spawn_sinks).await;
         let bg_agent_id = match bg_outcome {
             Ok(outcome) => outcome.agent_id,
@@ -1629,68 +1709,40 @@ impl AcpManager {
             return;
         }
 
-        // Persist the `local_title_generated` durable event (seq = last_seq +
-        // 1; the host's `SessionPersistence` is the sole seq authority — AD-5).
-        let next_seq = match persistence.last_seq(&session_id) {
-            Ok(seq) => seq + 1,
-            Err(error) => {
-                log::warn!(
-                    "[acp-title] background gen could not resolve last_seq for session {session_id}: {error}"
-                );
-                return;
-            }
-        };
-        let record = PersistedEventRecord {
-            schema_version: SESSION_SCHEMA_VERSION,
-            session_id: session_id.clone(),
-            seq: next_seq,
-            type_: "local_title_generated".to_string(),
-            recorded_at: now_millis(),
-            payload: serde_json::json!({
-                "sessionId": session_id,
-                "title": title,
-            }),
-        };
-        if let Err(error) = persistence.enqueue_event(record) {
+        if let Err(error) = self
+            .record_local_title(user_agent_id, session_id.clone(), title)
+            .await
+        {
             log::warn!(
-                "[acp-title] background gen failed to persist local_title_generated for session {session_id}: {error}"
+                "[acp-title] background gen failed to record title for session {session_id}: {error}"
             );
-            return;
         }
-        if let Err(error) = persistence.flush_session(&session_id).await {
-            log::warn!(
-                "[acp-title] background gen failed to flush session {session_id}: {error}"
-            );
-            return;
-        }
-        log::info!(
-            "[acp-title] title persisted for session {session_id} (seq={next_seq}, title_len={} chars)",
-            title.chars().count()
-        );
-
-        // Broadcast a synthetic `SessionInfoUpdateEvent` via the USER's sinks
-        // (the renderer + WS relay) so the sidebar + tab bar pick up the new
-        // title (AD-8). Carries the USER's session id + agent id, not the
-        // background agent's. The renderer's `_onSessionInfoUpdate` is
-        // unchanged — it just sets `session.title`.
-        let event = SessionInfoUpdateEvent {
-            agent_id: user_agent_id,
-            session_id: SessionId::new(session_id.clone()),
-            title: Some(title),
-        };
-        events::fan_out(
-            &self.sinks,
-            Some(event.session_id.0.as_str()),
-            events::EVENT_SESSION_INFO_UPDATE,
-            &event,
-        );
-        log::debug!(
-            "[acp-title] synthetic session_info_update broadcast for session {session_id}"
-        );
 
         // Background agent is killed when `kill_guard` drops at the end of
         // this scope. The in-flight debounce set is cleaned up when
         // `in_flight_guard` drops.
+    }
+
+    /// Normalize, durably persist, flush, and broadcast a locally generated
+    /// title. Shared by background generation and the host-injected title tool.
+    pub(crate) async fn record_local_title(
+        &self,
+        user_agent_id: AgentId,
+        session_id: String,
+        raw_title: String,
+    ) -> Result<(), String> {
+        let persistence = self
+            .persistence
+            .as_ref()
+            .ok_or_else(|| "title persistence unavailable".to_string())?;
+        record_local_title(
+            persistence,
+            &self.sinks,
+            user_agent_id,
+            session_id,
+            raw_title,
+        )
+        .await
     }
 
     /// Cancel the active turn for a session, resolving pending permissions with
@@ -2165,7 +2217,10 @@ fn build_internal_plan_stdio(
     let env = vec![
         EnvVariable::new(crate::acp::host_mcp::ENV_PORT, port.to_string()),
         EnvVariable::new(crate::acp::host_mcp::ENV_TOKEN, token.to_string()),
-        EnvVariable::new(crate::acp::host_mcp::ENV_SESSION_ID, provisional_sid.to_string()),
+        EnvVariable::new(
+            crate::acp::host_mcp::ENV_SESSION_ID,
+            provisional_sid.to_string(),
+        ),
         EnvVariable::new(crate::acp::host_mcp::ENV_AGENT_ID, agent_id.to_string()),
     ];
     let stdio = McpServerStdio::new("termul-plan".to_string(), exe)
@@ -3197,7 +3252,9 @@ async fn run_command_loop(
                             if let Some(id) = events::model_config_id_from_options(
                                 response.config_options.as_deref(),
                             ) {
-                                req_state.lock().set_model_config_id(session_id.0.clone(), id);
+                                req_state
+                                    .lock()
+                                    .set_model_config_id(session_id.0.clone(), id);
                             }
 
                             let event = SessionCreatedEvent {
@@ -3407,10 +3464,7 @@ async fn run_command_loop(
                 let handles = driver_state.lock().try_begin_turn(&session_id.0);
                 let Some(handles) = handles else {
                     // Stable code matched by renderer `ACP_TURN_IN_PROGRESS_CODE`.
-                    let error = format!(
-                        "ACP_TURN_IN_PROGRESS: session {}",
-                        session_id.0
-                    );
+                    let error = format!("ACP_TURN_IN_PROGRESS: session {}", session_id.0);
                     let _ = accepted.send(Err(error.clone()));
                     let _ = reply.send(Err(error));
                     continue;
@@ -3462,8 +3516,8 @@ async fn run_command_loop(
                             // (it queues onto the connection), so race_turn
                             // stays sync.
                             cancel_state.lock().signal_cancel(&cancel_session.0);
-                            if let Err(error) =
-                                cancel_cx.send_notification(CancelNotification::new(&cancel_session))
+                            if let Err(error) = cancel_cx
+                                .send_notification(CancelNotification::new(&cancel_session))
                             {
                                 log::warn!(
                                     "[acp] failed to cancel agent prompt on turn timeout: {error}"
@@ -3829,16 +3883,21 @@ async fn run_command_loop(
                 let req_agent_id = agent_id.clone();
                 let req_state = driver_state.clone();
                 spawn_request(&cx, slot, async move {
-                    let request =
-                        SetSessionConfigOptionRequest::new(&session_id, config_id, value_id.as_str());
+                    let request = SetSessionConfigOptionRequest::new(
+                        &session_id,
+                        config_id,
+                        value_id.as_str(),
+                    );
                     match req_cx.send_request(request).block_task().await {
                         Ok(response) => {
                             // Keep the cached Model-selector configId fresh in case
                             // the agent reorganized its config options.
-                            if let Some(id) = events::model_config_id_from_options(
-                                Some(response.config_options.as_slice()),
-                            ) {
-                                req_state.lock().set_model_config_id(session_id.0.clone(), id);
+                            if let Some(id) = events::model_config_id_from_options(Some(
+                                response.config_options.as_slice(),
+                            )) {
+                                req_state
+                                    .lock()
+                                    .set_model_config_id(session_id.0.clone(), id);
                             }
                             let event = ConfigOptionsUpdateEvent {
                                 agent_id: req_agent_id,
@@ -4766,10 +4825,7 @@ mod tests {
         // The agent is removed from the registry.
         assert!(!manager.agents.lock().contains_key(&agent_id));
         // A Shutdown command was sent.
-        assert!(matches!(
-            rx.recv().await,
-            Some(AcpCommand::Shutdown)
-        ));
+        assert!(matches!(rx.recv().await, Some(AcpCommand::Shutdown)));
     }
 
     /// `maybe_generate_background_title` falls back gracefully when the
@@ -4779,16 +4835,12 @@ mod tests {
     /// so a future trigger can retry.
     #[tokio::test]
     async fn maybe_generate_background_title_falls_back_on_spawn_failure() {
-        let root = std::env::temp_dir().join(format!(
-            "termul-title-spawn-fail-{}",
-            uuid::Uuid::new_v4()
-        ));
+        let root =
+            std::env::temp_dir().join(format!("termul-title-spawn-fail-{}", uuid::Uuid::new_v4()));
         std::fs::create_dir_all(&root).unwrap();
         let cwd = root.join("cwd");
         std::fs::create_dir_all(&cwd).unwrap();
-        let persistence = SessionPersistence::open(root.join("store"))
-            .await
-            .unwrap();
+        let persistence = SessionPersistence::open(root.join("store")).await.unwrap();
         persistence
             .register_session(SessionRegistration {
                 session_id: "user-sess".to_string(),
@@ -4898,10 +4950,7 @@ mod tests {
         // there (HashSet::insert is idempotent). On drop, the guard removes
         // it. So after the call, the session should be gone.
         assert!(
-            !manager
-                .in_flight_title_gens
-                .lock()
-                .contains("sess-dup"),
+            !manager.in_flight_title_gens.lock().contains("sess-dup"),
             "in-flight guard must clear on debounce-skip exit"
         );
     }

--- a/src-tauri/src/acp/session_payload.rs
+++ b/src-tauri/src/acp/session_payload.rs
@@ -113,7 +113,9 @@ pub fn materialize_session_payload(
         // separately-read metadata) so the payload can never advertise a
         // `lastSeq` that disagrees with the messages it carries when a writer
         // lands an event between the metadata read and the replay.
-        last_seq: records.last().map_or(metadata.last_seq, |record| record.seq),
+        last_seq: records
+            .last()
+            .map_or(metadata.last_seq, |record| record.seq),
         status: metadata.status.clone(),
         worktree_path: metadata.worktree_path.clone(),
         worktree_branch: metadata.worktree_branch.clone(),
@@ -265,6 +267,7 @@ mod tests {
             message_count: 0,
             tool_count: 0,
             last_seq: 0,
+            discovered: false,
             worktree_path: Some("/work/project/.termul/worktrees/chat/abc123".to_string()),
             worktree_branch: Some("chat/abc123".to_string()),
         }
@@ -375,11 +378,7 @@ mod tests {
                 "snapshot:agent:11",
             ]
         );
-        let seqs: Vec<u64> = payload
-            .messages
-            .iter()
-            .map(|message| message.seq)
-            .collect();
+        let seqs: Vec<u64> = payload.messages.iter().map(|message| message.seq).collect();
         assert_eq!(seqs, vec![1, 2, 4, 6, 10, 11]);
         let timestamps: Vec<u64> = payload
             .messages
@@ -388,7 +387,10 @@ mod tests {
             .collect();
         assert_eq!(timestamps, vec![101, 102, 104, 106, 110, 111]);
         // Text coalescing within a run (appendBlocks semantics).
-        assert_eq!(payload.messages[1].blocks, vec![json!({"type":"text","text":"Hello "})]);
+        assert_eq!(
+            payload.messages[1].blocks,
+            vec![json!({"type":"text","text":"Hello "})]
+        );
         assert_eq!(
             payload.messages[3].blocks,
             vec![json!({"type":"text","text":"world!"})]
@@ -504,7 +506,11 @@ mod tests {
 
     #[test]
     fn tool_call_update_never_splits_the_open_run() {
-        let records = vec![chunk(1, "agent", "a"), tool_call_update(2), chunk(3, "agent", "b")];
+        let records = vec![
+            chunk(1, "agent", "a"),
+            tool_call_update(2),
+            chunk(3, "agent", "b"),
+        ];
         let payload = materialize_session_payload(&metadata(), &records);
         assert_eq!(payload.messages.len(), 1);
         assert_eq!(payload.messages[0].id, "snapshot:agent:1");

--- a/src-tauri/src/acp/session_persistence.rs
+++ b/src-tauri/src/acp/session_persistence.rs
@@ -95,7 +95,7 @@ pub struct SessionMetadata {
     pub tool_count: u64,
     pub last_seq: u64,
     /// Agent-owned metadata mirror created from ACP `session/list`.
-    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    #[serde(default)]
     pub discovered: bool,
     /// Worktree path the agent runs in (CAP-3). Additive: old entries
     /// deserialize with `None`. State isolation still keys on `cwd`; this
@@ -126,7 +126,7 @@ pub struct SessionIndexEntry {
     pub message_count: u64,
     pub tool_count: u64,
     pub last_seq: u64,
-    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    #[serde(default)]
     pub discovered: bool,
     pub resume_eligible: bool,
     #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/src-tauri/src/acp/session_persistence.rs
+++ b/src-tauri/src/acp/session_persistence.rs
@@ -1723,7 +1723,7 @@ mod tests {
                 .unwrap()
                 .chars()
                 .count(),
-            81
+            49
         );
         let tool_log = fs::read_to_string(
             root.join("store")

--- a/src-tauri/src/acp/session_persistence.rs
+++ b/src-tauri/src/acp/session_persistence.rs
@@ -236,6 +236,7 @@ struct Inner {
     sessions: Mutex<HashMap<String, SessionRuntime>>,
     /// Canonical in-memory metadata for both active and finalized sessions.
     catalog: Mutex<HashMap<String, Arc<Mutex<SessionMetadata>>>>,
+    registration_lock: tokio::sync::Mutex<()>,
     index_lock: tokio::sync::Mutex<()>,
 }
 
@@ -280,6 +281,7 @@ impl ReplayTestHook {
 
 enum WriterCommand {
     Append(PersistedEventRecord),
+    AppendLocalTitle(String, oneshot::Sender<Result<u64>>),
     Flush(oneshot::Sender<Result<()>>),
     Finalize(PersistedSessionStatus, oneshot::Sender<Result<()>>),
     Shutdown(oneshot::Sender<Result<()>>),
@@ -299,6 +301,7 @@ impl SessionPersistence {
                 root,
                 sessions: Mutex::new(HashMap::new()),
                 catalog: Mutex::new(HashMap::new()),
+                registration_lock: tokio::sync::Mutex::new(()),
                 index_lock: tokio::sync::Mutex::new(()),
             }),
             #[cfg(test)]
@@ -360,6 +363,93 @@ impl SessionPersistence {
         if let Err(error) = self.persist_index().await {
             self.inner.sessions.lock().remove(&registration.session_id);
             self.inner.catalog.lock().remove(&registration.session_id);
+            let _ = fs::remove_dir_all(self.session_dir(&metadata.storage_key)?);
+            return Err(error);
+        }
+        Ok(metadata)
+    }
+
+    /// Register metadata for an agent-owned session discovered via
+    /// `session/list`. No transcript events are created; the agent remains the
+    /// transcript authority. Idempotent by session id.
+    pub async fn register_discovered_session(
+        &self,
+        registration: SessionRegistration,
+        title: Option<String>,
+        updated_at: Option<u64>,
+    ) -> Result<SessionMetadata> {
+        let session_id = registration.session_id.trim();
+        let cwd = registration.cwd.to_string_lossy();
+        if session_id.is_empty() || cwd.trim().is_empty() {
+            return Err(SessionPersistenceError::Io(io::Error::other(
+                "discovered session id and cwd are required",
+            )));
+        }
+        let _guard = self.inner.registration_lock.lock().await;
+        let now = updated_at
+            .filter(|timestamp| *timestamp > 0 && *timestamp <= now_millis() + 300_000)
+            .unwrap_or_else(now_millis);
+        let normalized_title = title
+            .map(|value| normalize_title(&value))
+            .filter(|value| value != "Untitled Chat");
+        let existing = { self.inner.catalog.lock().get(session_id).cloned() };
+        if let Some(existing) = existing {
+            let snapshot = {
+                let mut metadata = existing.lock();
+                if metadata.stable_agent_namespace != registration.stable_agent_namespace
+                    || metadata.cwd != cwd
+                {
+                    return Err(SessionPersistenceError::Io(io::Error::other(
+                        "discovered session id conflicts with an existing session scope",
+                    )));
+                }
+                metadata.runtime_agent_id = registration.runtime_agent_id;
+                metadata.project_id = registration.project_id;
+                metadata.status = PersistedSessionStatus::Active;
+                metadata.last_activity_at = now;
+                if metadata.title_source != Some(TitleSource::BackgroundGenerated)
+                    && metadata.title_source != Some(TitleSource::LocalAlias)
+                    && normalized_title.is_some()
+                {
+                    metadata.title = normalized_title;
+                    metadata.title_source = Some(TitleSource::AgentSupplied);
+                }
+                metadata.clone()
+            };
+            self.persist_metadata(&snapshot)?;
+            self.persist_index().await?;
+            return Ok(snapshot);
+        }
+        let storage_key = Uuid::new_v4().to_string();
+        let title_source = normalized_title
+            .as_ref()
+            .map(|_| TitleSource::AgentSupplied);
+        let metadata = SessionMetadata {
+            schema_version: SESSION_SCHEMA_VERSION,
+            storage_key,
+            session_id: session_id.to_string(),
+            stable_agent_namespace: registration.stable_agent_namespace,
+            runtime_agent_id: registration.runtime_agent_id,
+            project_id: registration.project_id,
+            cwd: cwd.into_owned(),
+            title: normalized_title,
+            title_source,
+            created_at: now,
+            last_activity_at: now,
+            status: PersistedSessionStatus::Active,
+            message_count: 0,
+            tool_count: 0,
+            last_seq: 0,
+            worktree_path: registration.worktree_path,
+            worktree_branch: registration.worktree_branch,
+        };
+        if let Err(error) = self.persist_metadata(&metadata) {
+            let _ = fs::remove_dir_all(self.session_dir(&metadata.storage_key)?);
+            return Err(error);
+        }
+        self.install_catalog_entry(metadata.clone());
+        if let Err(error) = self.persist_index().await {
+            self.inner.catalog.lock().remove(session_id);
             let _ = fs::remove_dir_all(self.session_dir(&metadata.storage_key)?);
             return Err(error);
         }
@@ -484,6 +574,24 @@ impl SessionPersistence {
                 Err(SessionPersistenceError::WriterStopped)
             }
         }
+    }
+
+    /// Append a normalized local-title event with a writer-assigned sequence.
+    /// The writer is the sole sequence authority, so a mid-turn title tool call
+    /// cannot race queued message chunks and reuse their sequence number.
+    pub async fn append_local_title(&self, session_id: &str, title: String) -> Result<u64> {
+        let runtime = self.runtime(session_id)?;
+        if let Some(message) = runtime.unhealthy.lock().clone() {
+            return Err(SessionPersistenceError::PersistenceUnhealthy(message));
+        }
+        let (tx, rx) = oneshot::channel();
+        runtime
+            .tx
+            .send(WriterCommand::AppendLocalTitle(title, tx))
+            .await
+            .map_err(|_| SessionPersistenceError::WriterStopped)?;
+        rx.await
+            .map_err(|_| SessionPersistenceError::WriterStopped)?
     }
 
     pub async fn flush_session(&self, session_id: &str) -> Result<()> {
@@ -640,8 +748,7 @@ impl SessionPersistence {
             .filter(|entry| {
                 entry.project_id.as_deref() == Some(project_id)
                     && entry.cwd == cwd
-                    && (entry.stable_agent_namespace.is_some()
-                        || entry.runtime_agent_id.is_some())
+                    && (entry.stable_agent_namespace.is_some() || entry.runtime_agent_id.is_some())
                     && stable_agent_namespace.is_none_or(|namespace| {
                         entry.stable_agent_namespace.as_deref() == Some(namespace)
                     })
@@ -688,8 +795,8 @@ impl SessionPersistence {
             }
             records
         })
-            .await
-            .map_err(|error| SessionPersistenceError::PersistenceUnhealthy(error.to_string()))?
+        .await
+        .map_err(|error| SessionPersistenceError::PersistenceUnhealthy(error.to_string()))?
     }
 
     #[cfg(test)]
@@ -916,6 +1023,30 @@ async fn writer_loop(
     while let Some(command) = rx.recv().await {
         let result = match command {
             WriterCommand::Append(record) => append_record(&inner.root, &metadata, record),
+            WriterCommand::AppendLocalTitle(title, reply) => {
+                let seq = metadata.lock().last_seq + 1;
+                let session_id = metadata.lock().session_id.clone();
+                let result = append_record(
+                    &inner.root,
+                    &metadata,
+                    PersistedEventRecord {
+                        schema_version: SESSION_SCHEMA_VERSION,
+                        session_id: session_id.clone(),
+                        seq,
+                        type_: "local_title_generated".to_string(),
+                        recorded_at: now_millis(),
+                        payload: serde_json::json!({
+                            "sessionId": session_id,
+                            "title": title,
+                        }),
+                    },
+                );
+                let reply_result = result.as_ref().map(|()| seq).map_err(|error| {
+                    SessionPersistenceError::PersistenceUnhealthy(error.to_string())
+                });
+                let _ = reply.send(reply_result);
+                result
+            }
             WriterCommand::Flush(reply) => {
                 let result = sync_session_files(&inner.root, &metadata);
                 let _ = reply.send(result.clone_for_reply());
@@ -1235,13 +1366,51 @@ fn is_secret_key(key: &str) -> bool {
 }
 
 pub(crate) fn normalize_title(text: &str) -> String {
-    let text = text.split_whitespace().collect::<Vec<_>>().join(" ");
-    let text = text.trim();
-    if text.is_empty() {
+    fn strip_wrappers(mut value: &str) -> &str {
+        loop {
+            let next = value
+                .trim()
+                .trim_matches(['"', '\'', '`'])
+                .trim_matches('_')
+                .trim_matches('*')
+                .trim();
+            if next == value {
+                return next;
+            }
+            value = next;
+        }
+    }
+
+    let mut lines = text
+        .split(['\n', '\r'])
+        .map(str::trim)
+        .filter(|line| !line.is_empty());
+    let mut sanitized = strip_wrappers(lines.next().unwrap_or_default());
+    let lowercase = sanitized.to_ascii_lowercase();
+    const PREAMBLES: &[&str] = &[
+        "sure! here's the title:",
+        "sure, here's the title:",
+        "here's the title:",
+        "the title is:",
+        "title:",
+    ];
+    if let Some(prefix) = PREAMBLES
+        .iter()
+        .find(|prefix| lowercase.starts_with(**prefix))
+    {
+        sanitized = strip_wrappers(&sanitized[prefix.len()..]);
+        if sanitized.is_empty() {
+            sanitized = strip_wrappers(lines.next().unwrap_or_default());
+        }
+    } else if lowercase == "what should we do?" {
+        sanitized = strip_wrappers(lines.next().unwrap_or_default());
+    }
+
+    if sanitized.is_empty() {
         return "Untitled Chat".to_string();
     }
-    let bounded: String = text.chars().take(80).collect();
-    if text.chars().count() > 80 {
+    let bounded: String = sanitized.chars().take(48).collect();
+    if sanitized.chars().count() > 48 {
         format!("{bounded}…")
     } else {
         bounded
@@ -1313,6 +1482,65 @@ mod tests {
             recorded_at: now_millis(),
             payload: json!({"sessionId":"session-1","content":[{"type":"text","text":"hello"}]}),
         }
+    }
+
+    #[test]
+    fn normalize_title_uses_first_line_sanitizes_and_bounds_to_48() {
+        assert_eq!(
+            normalize_title("  **`Fix login bug`**  \nignored explanation"),
+            "Fix login bug"
+        );
+        assert_eq!(
+            normalize_title("Sure! Here's the title:\nFix login bug"),
+            "Fix login bug"
+        );
+        assert_eq!(normalize_title("Title: Fix login bug"), "Fix login bug");
+        let long = "a".repeat(60);
+        let normalized = normalize_title(&long);
+        assert_eq!(normalized.chars().count(), 49);
+        assert!(normalized.ends_with('…'));
+        assert_eq!(normalize_title(" \nsecond line"), "second line");
+        assert_eq!(normalize_title(" \n \r"), "Untitled Chat");
+    }
+
+    #[tokio::test]
+    async fn register_discovered_session_is_metadata_only_agent_supplied_and_idempotent() {
+        let root = temp_dir("discovered");
+        let cwd = root.join("cwd");
+        fs::create_dir_all(&cwd).unwrap();
+        let persistence = SessionPersistence::open(root.join("store")).await.unwrap();
+        let registration = SessionRegistration {
+            session_id: "discovered-1".into(),
+            stable_agent_namespace: Some("config:test".into()),
+            runtime_agent_id: Some("agent-1".into()),
+            project_id: Some("project-1".into()),
+            cwd,
+            ..Default::default()
+        };
+        let first = persistence
+            .register_discovered_session(registration.clone(), Some("Agent title".into()), Some(42))
+            .await
+            .unwrap();
+        assert_eq!(first.status, PersistedSessionStatus::Active);
+        persistence.shutdown().await.unwrap();
+        let persistence = SessionPersistence::open(root.join("store")).await.unwrap();
+        let second = persistence
+            .register_discovered_session(registration, Some("Replacement".into()), Some(99))
+            .await
+            .unwrap();
+        assert_eq!(first.storage_key, second.storage_key);
+        assert_eq!(second.title.as_deref(), Some("Replacement"));
+        assert_eq!(second.title_source, Some(TitleSource::AgentSupplied));
+        assert_eq!(second.status, PersistedSessionStatus::Active);
+        assert_eq!(second.runtime_agent_id.as_deref(), Some("agent-1"));
+        assert_eq!(second.message_count, 0);
+        assert_eq!(second.tool_count, 0);
+        assert_eq!(second.last_seq, 0);
+        assert!(persistence
+            .replay_after("discovered-1", 0)
+            .unwrap()
+            .is_empty());
+        let _ = fs::remove_dir_all(root);
     }
 
     #[tokio::test]
@@ -1823,10 +2051,9 @@ mod tests {
         persistence.shutdown().await.unwrap();
 
         let reopened = SessionPersistence::open(root.join("store")).await.unwrap();
-        let after = serde_json::to_value(
-            reopened.session_payload_async("session-1").await.unwrap(),
-        )
-        .unwrap();
+        let after =
+            serde_json::to_value(reopened.session_payload_async("session-1").await.unwrap())
+                .unwrap();
         // `status` is expected to differ (Active → Closed across restart); the
         // transcript itself must survive byte-identically.
         assert_eq!(before["messages"], after["messages"]);
@@ -2045,10 +2272,7 @@ mod tests {
             PersistedSessionStatus::Closed,
             "an unclean shutdown must not leave a dead session claiming Active"
         );
-        let payload = reopened
-            .session_payload_async("session-1")
-            .await
-            .unwrap();
+        let payload = reopened.session_payload_async("session-1").await.unwrap();
         assert_eq!(payload.messages.len(), 2);
         let _ = fs::remove_dir_all(root);
     }
@@ -2288,7 +2512,9 @@ mod tests {
         );
         // enqueue_event now succeeds; the new seq advances past the prior
         // last_seq (1) so the durable frontier is monotonic.
-        persistence.enqueue_event(record(2, "message_chunk")).unwrap();
+        persistence
+            .enqueue_event(record(2, "message_chunk"))
+            .unwrap();
         persistence.flush_session("session-1").await.unwrap();
         assert_eq!(persistence.last_seq("session-1").unwrap(), 2);
         let _ = fs::remove_dir_all(root);
@@ -2334,7 +2560,10 @@ mod tests {
         );
         // Same channel handle — reopen short-circuited, did not spawn a second writer.
         assert!(
-            first_tx.as_ref().map(|tx| tx.same_channel(second_tx.as_ref().unwrap())).unwrap_or(false),
+            first_tx
+                .as_ref()
+                .map(|tx| tx.same_channel(second_tx.as_ref().unwrap()))
+                .unwrap_or(false),
             "idempotent reopen must not replace the existing writer channel"
         );
         let _ = fs::remove_dir_all(root);

--- a/src-tauri/src/acp/session_persistence.rs
+++ b/src-tauri/src/acp/session_persistence.rs
@@ -94,6 +94,9 @@ pub struct SessionMetadata {
     pub message_count: u64,
     pub tool_count: u64,
     pub last_seq: u64,
+    /// Agent-owned metadata mirror created from ACP `session/list`.
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub discovered: bool,
     /// Worktree path the agent runs in (CAP-3). Additive: old entries
     /// deserialize with `None`. State isolation still keys on `cwd`; this
     /// field powers the CAP-6 indicator + the deleted-worktree fallback.
@@ -123,6 +126,8 @@ pub struct SessionIndexEntry {
     pub message_count: u64,
     pub tool_count: u64,
     pub last_seq: u64,
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub discovered: bool,
     pub resume_eligible: bool,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub worktree_path: Option<String>,
@@ -147,6 +152,7 @@ impl From<&SessionMetadata> for SessionIndexEntry {
             message_count: metadata.message_count,
             tool_count: metadata.tool_count,
             last_seq: metadata.last_seq,
+            discovered: metadata.discovered,
             resume_eligible: metadata.stable_agent_namespace.is_some(),
             worktree_path: metadata.worktree_path.clone(),
             worktree_branch: metadata.worktree_branch.clone(),
@@ -329,6 +335,7 @@ impl SessionPersistence {
                 "session cwd is not a directory",
             )));
         }
+        let _guard = self.inner.registration_lock.lock().await;
         if self
             .inner
             .catalog
@@ -355,6 +362,7 @@ impl SessionPersistence {
             message_count: 0,
             tool_count: 0,
             last_seq: 0,
+            discovered: false,
             worktree_path: registration.worktree_path,
             worktree_branch: registration.worktree_branch,
         };
@@ -406,9 +414,9 @@ impl SessionPersistence {
                 metadata.runtime_agent_id = registration.runtime_agent_id;
                 metadata.project_id = registration.project_id;
                 metadata.status = PersistedSessionStatus::Active;
-                metadata.last_activity_at = now;
-                if metadata.title_source != Some(TitleSource::BackgroundGenerated)
-                    && metadata.title_source != Some(TitleSource::LocalAlias)
+                metadata.last_activity_at = metadata.last_activity_at.max(now);
+                metadata.discovered = true;
+                if !is_protected_title_source(metadata.title_source.as_ref())
                     && normalized_title.is_some()
                 {
                     metadata.title = normalized_title;
@@ -440,6 +448,7 @@ impl SessionPersistence {
             message_count: 0,
             tool_count: 0,
             last_seq: 0,
+            discovered: true,
             worktree_path: registration.worktree_path,
             worktree_branch: registration.worktree_branch,
         };
@@ -472,6 +481,7 @@ impl SessionPersistence {
                 "imported session cwd is empty",
             )));
         }
+        let _guard = self.inner.registration_lock.lock().await;
         if self
             .inner
             .catalog
@@ -497,6 +507,7 @@ impl SessionPersistence {
             message_count: 0,
             tool_count: 0,
             last_seq: 0,
+            discovered: false,
             worktree_path: registration.worktree_path,
             worktree_branch: registration.worktree_branch,
         };
@@ -534,6 +545,7 @@ impl SessionPersistence {
     /// because the agent subprocess cannot survive a restart. Persisting `Active`
     /// to disk here would lie about liveness after a crash.
     pub async fn reopen_writer(&self, session_id: &str) -> Result<()> {
+        let _guard = self.inner.registration_lock.lock().await;
         // (a) Idempotent: a writer is already installed for this session.
         if self.inner.sessions.lock().contains_key(session_id) {
             return Ok(());
@@ -1525,7 +1537,7 @@ mod tests {
         persistence.shutdown().await.unwrap();
         let persistence = SessionPersistence::open(root.join("store")).await.unwrap();
         let second = persistence
-            .register_discovered_session(registration, Some("Replacement".into()), Some(99))
+            .register_discovered_session(registration.clone(), Some("Replacement".into()), Some(99))
             .await
             .unwrap();
         assert_eq!(first.storage_key, second.storage_key);
@@ -1540,6 +1552,24 @@ mod tests {
             .replay_after("discovered-1", 0)
             .unwrap()
             .is_empty());
+        let mut conflicting = registration;
+        conflicting.stable_agent_namespace = Some("config:other".into());
+        let conflict = persistence
+            .register_discovered_session(conflicting, Some("Wrong owner".into()), Some(100))
+            .await
+            .unwrap_err();
+        assert!(conflict
+            .to_string()
+            .contains("conflicts with an existing session scope"));
+        assert_eq!(
+            persistence
+                .metadata("discovered-1")
+                .unwrap()
+                .title
+                .as_deref(),
+            Some("Replacement")
+        );
+        persistence.shutdown().await.unwrap();
         let _ = fs::remove_dir_all(root);
     }
 

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -264,7 +264,8 @@ fn attach_forwarders() -> &'static Mutex<HashMap<String, (u64, tokio::task::Abor
 /// Recover the forwarder map guard even if a holder panicked while holding the
 /// lock — silently skipping on poison would skip predecessor aborts and leak
 /// entries.
-fn lock_forwarders() -> std::sync::MutexGuard<'static, HashMap<String, (u64, tokio::task::AbortHandle)>> {
+fn lock_forwarders(
+) -> std::sync::MutexGuard<'static, HashMap<String, (u64, tokio::task::AbortHandle)>> {
     attach_forwarders()
         .lock()
         .unwrap_or_else(|poisoned| poisoned.into_inner())
@@ -1711,7 +1712,11 @@ pub(crate) fn validated_search_root(scope_root: &str, search_root: &str) -> Resu
         .map(|path| path.to_string_lossy().to_string())
 }
 
-pub(crate) fn build_search_args(query: &str, root_path: &str, max_matches_per_file: usize) -> Vec<String> {
+pub(crate) fn build_search_args(
+    query: &str,
+    root_path: &str,
+    max_matches_per_file: usize,
+) -> Vec<String> {
     let mut args = vec![
         "--json".to_string(),
         "-F".to_string(),
@@ -3564,10 +3569,7 @@ pub(crate) async fn sync_mcp_registry_to_project_file(
     // Validate the payload is an array (mirrors `mcp_servers_api::put`).
     if !registry.is_array() {
         log::warn!("remote_sync_mcp_registry: rejected non-array payload");
-        return IpcResult::error(
-            "MCP registry must be a JSON array",
-            "MCP_REGISTRY_INVALID",
-        );
+        return IpcResult::error("MCP registry must be a JSON array", "MCP_REGISTRY_INVALID");
     }
 
     // Serialize + enforce the 1 MiB ceiling (mirrors `mcp_servers_api::put`).
@@ -3582,10 +3584,7 @@ pub(crate) async fn sync_mcp_registry_to_project_file(
         }
         Err(_) => {
             log::warn!("remote_sync_mcp_registry: payload not serializable");
-            return IpcResult::error(
-                "MCP registry is not serializable",
-                "MCP_REGISTRY_INVALID",
-            );
+            return IpcResult::error("MCP registry is not serializable", "MCP_REGISTRY_INVALID");
         }
     };
 
@@ -3594,23 +3593,23 @@ pub(crate) async fn sync_mcp_registry_to_project_file(
     // A present-but-invalid default path returns an error rather than silently
     // falling back to the home directory (which the web route never reads).
     let project_root = match project_registry.default_project_path() {
-        Some(p) => match crate::web::config::resolve_and_validate_project_root(
-            std::path::Path::new(&p),
-        ) {
-            Ok(root) => root,
-            Err(e) => {
-                log::error!(
-                    "remote_sync_mcp_registry: default project path '{}' \
+        Some(p) => {
+            match crate::web::config::resolve_and_validate_project_root(std::path::Path::new(&p)) {
+                Ok(root) => root,
+                Err(e) => {
+                    log::error!(
+                        "remote_sync_mcp_registry: default project path '{}' \
                      failed canonicalization: {}",
-                    p,
-                    e
-                );
-                return IpcResult::error(
-                    "No active project root available for MCP registry sync",
-                    "NO_ACTIVE_PROJECT_ROOT",
-                );
+                        p,
+                        e
+                    );
+                    return IpcResult::error(
+                        "No active project root available for MCP registry sync",
+                        "NO_ACTIVE_PROJECT_ROOT",
+                    );
+                }
             }
-        },
+        }
         None => {
             log::warn!(
                 "remote_sync_mcp_registry: no active project path in registry; \
@@ -3667,10 +3666,7 @@ pub(crate) async fn sync_mcp_registry_to_project_file(
                 path.display(),
                 error
             );
-            IpcResult::error(
-                "Failed to persist MCP registry",
-                "MCP_REGISTRY_WRITE_ERROR",
-            )
+            IpcResult::error("Failed to persist MCP registry", "MCP_REGISTRY_WRITE_ERROR")
         }
         Err(error) => {
             log::error!(
@@ -3678,10 +3674,7 @@ pub(crate) async fn sync_mcp_registry_to_project_file(
                 path.display(),
                 error
             );
-            IpcResult::error(
-                "Failed to persist MCP registry",
-                "MCP_REGISTRY_WRITE_ERROR",
-            )
+            IpcResult::error("Failed to persist MCP registry", "MCP_REGISTRY_WRITE_ERROR")
         }
     }
 }
@@ -3699,7 +3692,9 @@ pub struct DesktopChatHistoryList {
     pub legacy_import_complete: bool,
 }
 
-fn host_entry_to_desktop(entry: crate::acp::SessionIndexEntry) -> crate::acp::ChatHistoryIndexEntry {
+fn host_entry_to_desktop(
+    entry: crate::acp::SessionIndexEntry,
+) -> crate::acp::ChatHistoryIndexEntry {
     crate::acp::ChatHistoryIndexEntry {
         id: entry.session_id,
         agent_id: entry.runtime_agent_id.unwrap_or_default(),
@@ -3721,6 +3716,7 @@ fn host_entry_to_desktop(entry: crate::acp::SessionIndexEntry) -> crate::acp::Ch
             crate::acp::PersistedSessionStatus::Error => crate::acp::ChatHistoryStatus::Error,
             crate::acp::PersistedSessionStatus::Closed => crate::acp::ChatHistoryStatus::Closed,
         },
+        discovered: entry.discovered,
         worktree_path: entry.worktree_path,
         worktree_branch: entry.worktree_branch,
     }
@@ -3764,8 +3760,7 @@ pub async fn acp_history_get(
     match persistence.session_payload_async(&session_id).await {
         Ok(payload) => {
             log::info!("[acp-history] get success session_id={}", log_session_id);
-            let value = serde_json::to_value(&payload)
-                .map_err(|error| error.to_string())?;
+            let value = serde_json::to_value(&payload).map_err(|error| error.to_string())?;
             Ok(IpcResult::success(Some(value)))
         }
         Err(crate::acp::SessionPersistenceError::SessionNotFound) => {
@@ -3992,22 +3987,14 @@ pub async fn git_unstage(cwd: String, path: String) -> Result<(), String> {
 /// (`--- a/<path>` / `+++ b/<path>` / `@@ … @@` / body) built by the
 /// renderer from the working-tree diff. See #257.
 #[tauri::command]
-pub async fn git_stage_hunk(
-    cwd: String,
-    path: String,
-    hunk_patch: String,
-) -> Result<(), String> {
+pub async fn git_stage_hunk(cwd: String, path: String, hunk_patch: String) -> Result<(), String> {
     crate::trackers::git_tracker::git_stage_hunk(&cwd, &path, &hunk_patch)
 }
 
 /// Unstage a single hunk. `hunk_patch` is built from the staged diff and
 /// reverse-applied to the index. See #257.
 #[tauri::command]
-pub async fn git_unstage_hunk(
-    cwd: String,
-    path: String,
-    hunk_patch: String,
-) -> Result<(), String> {
+pub async fn git_unstage_hunk(cwd: String, path: String, hunk_patch: String) -> Result<(), String> {
     crate::trackers::git_tracker::git_unstage_hunk(&cwd, &path, &hunk_patch)
 }
 
@@ -4606,10 +4593,7 @@ pub async fn workspace_manifest_write(
             "WORKSPACE_MANIFEST_UNAVAILABLE",
         ));
     };
-    match service
-        .write(&project_id, based_revision, manifest)
-        .await
-    {
+    match service.write(&project_id, based_revision, manifest).await {
         Ok(outcome) => {
             // Boundary log emits project_id + revision + update_identity —
             // never the topology or claim. The service already logged it.
@@ -4710,6 +4694,7 @@ mod tests {
             message_count: 3,
             tool_count: 1,
             last_seq: 5,
+            discovered: false,
             resume_eligible: true,
             worktree_path: None,
             worktree_branch: None,
@@ -4744,6 +4729,7 @@ mod tests {
             message_count: 0,
             tool_count: 0,
             last_seq: 0,
+            discovered: false,
             resume_eligible: false,
             worktree_path: None,
             worktree_branch: None,
@@ -4756,7 +4742,10 @@ mod tests {
         );
         assert_eq!(desktop.title, "Untitled Chat");
         assert_eq!(desktop.project_id, "");
-        assert!(matches!(desktop.status, crate::acp::ChatHistoryStatus::Error));
+        assert!(matches!(
+            desktop.status,
+            crate::acp::ChatHistoryStatus::Error
+        ));
     }
 
     #[test]
@@ -5127,7 +5116,11 @@ mod remote_sync_mcp_registry_tests {
         ]);
 
         let result = sync_mcp_registry_to_project_file(&reg, registry).await;
-        assert!(result.success, "fallback should succeed, got {:?}", result.error);
+        assert!(
+            result.success,
+            "fallback should succeed, got {:?}",
+            result.error
+        );
 
         let file = registry_path(&dir);
         let bytes = std::fs::read(&file).unwrap();
@@ -5142,4 +5135,3 @@ mod remote_sync_mcp_registry_tests {
         let _ = std::fs::remove_dir_all(&dir);
     }
 }
-

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -19,10 +19,10 @@ pub mod server_update;
 mod shell_paths;
 // Desktop-side channel manifest fetch for the insider/nightly updater path.
 // Routes the manifest fetch through Rust (reqwest) so CSP/CORS do not block it.
-mod updater_api;
 mod skills;
 mod ssh;
 mod trackers;
+mod updater_api;
 pub mod web;
 mod worktree;
 
@@ -1603,6 +1603,7 @@ pub fn run() {
             acp::commands::acp_close_session,
             acp::commands::acp_dispose_ephemeral_session,
             acp::commands::acp_list_sessions,
+            acp::commands::acp_register_discovered_session,
             acp::commands::acp_send_prompt,
             acp::commands::acp_cancel_prompt,
             acp::commands::acp_set_config_option,

--- a/src-tauri/src/web/ws.rs
+++ b/src-tauri/src/web/ws.rs
@@ -185,7 +185,11 @@ impl WsReply {
     /// breaking the wire contract. This constructor accepts a raw string so
     /// the install handler's `err.code` is byte-identical across transports.
     #[must_use]
-    pub fn err_with_code(id: impl Into<String>, code: impl Into<String>, message: impl Into<String>) -> Self {
+    pub fn err_with_code(
+        id: impl Into<String>,
+        code: impl Into<String>,
+        message: impl Into<String>,
+    ) -> Self {
         Self {
             id: id.into(),
             ok: false,
@@ -1049,6 +1053,9 @@ async fn handle_request(
             .await
         }
         "list_sessions" => handle_list_sessions(id, &req.payload, acp).await,
+        "register_discovered_session" => {
+            handle_register_discovered_session(id, &req.payload, acp, relay).await
+        }
         "switch_project" => {
             handle_switch_project(
                 id,
@@ -1235,7 +1242,11 @@ async fn handle_get_session_payload(
                         error = %error,
                         "get_session_payload: host payload materialization failed"
                     );
-                    WsReply::err(id, WsErrorCode::Unsupported, "failed to read session payload")
+                    WsReply::err(
+                        id,
+                        WsErrorCode::Unsupported,
+                        "failed to read session payload",
+                    )
                 }
             }
         }
@@ -1385,7 +1396,9 @@ async fn handle_get_session_cursor(
     let watermark = relay
         .persistence()
         .map(|persistence| {
-            persistence.last_seq(&parsed.session_id).unwrap_or_else(|error| {
+            persistence
+                .last_seq(&parsed.session_id)
+                .unwrap_or_else(|error| {
                     tracing::warn!(
                         session_id = %parsed.session_id,
                         error = ?error,
@@ -1744,11 +1757,7 @@ struct AuthenticateAgentPayload {
     method_id: String,
 }
 
-async fn handle_authenticate_agent(
-    id: String,
-    payload: &Value,
-    acp: &Arc<AcpManager>,
-) -> WsReply {
+async fn handle_authenticate_agent(id: String, payload: &Value, acp: &Arc<AcpManager>) -> WsReply {
     let parsed: AuthenticateAgentPayload = match serde_json::from_value(payload.clone()) {
         Ok(p) => p,
         Err(e) => {
@@ -1977,11 +1986,9 @@ async fn handle_set_default_project(
     // If the in-memory set fails (target vanished between validation and
     // commit), roll back the file registry (P1: no split-brain).
     if !registry.set_default_project(&parsed.project_id) {
-        if let (Some(file_registry), Some(path), Some(old_default)) = (
-            registry_persistence,
-            projects_file,
-            persisted_old_default,
-        ) {
+        if let (Some(file_registry), Some(path), Some(old_default)) =
+            (registry_persistence, projects_file, persisted_old_default)
+        {
             let mut file_registry = file_registry.lock();
             file_registry.restore_default_project(old_default);
             if let Err(error) = file_registry.save_atomic(path) {
@@ -2694,6 +2701,95 @@ async fn handle_list_sessions(id: String, payload: &Value, acp: &Arc<AcpManager>
     }
 }
 
+/// Persist metadata for an agent-owned session returned by `session/list`.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct RegisterDiscoveredSessionPayload {
+    session_id: String,
+    agent_id: crate::acp::AgentId,
+    cwd: String,
+    #[serde(default)]
+    title: Option<String>,
+    #[serde(default)]
+    updated_at: Option<u64>,
+    #[serde(default)]
+    project_id: Option<String>,
+}
+
+async fn handle_register_discovered_session(
+    id: String,
+    payload: &Value,
+    acp: &Arc<AcpManager>,
+    relay: &Arc<WsRelaySink>,
+) -> WsReply {
+    let parsed: RegisterDiscoveredSessionPayload = match serde_json::from_value(payload.clone()) {
+        Ok(parsed) => parsed,
+        Err(error) => {
+            return WsReply::err(
+                id,
+                WsErrorCode::Unsupported,
+                format!(
+                    "malformed register_discovered_session payload (want sessionId, agentId, cwd): {error}"
+                ),
+            )
+        }
+    };
+    if parsed.session_id.trim().is_empty() || parsed.cwd.trim().is_empty() {
+        return WsReply::err(
+            id,
+            WsErrorCode::Unsupported,
+            "sessionId and cwd are required",
+        );
+    }
+    let Some(persistence) = relay.persistence() else {
+        return WsReply::err(
+            id,
+            WsErrorCode::Unsupported,
+            "session persistence unavailable",
+        );
+    };
+    let stable_agent_namespace = match acp.stable_agent_namespace(&parsed.agent_id) {
+        Ok(namespace) => namespace,
+        Err(error) => return acp_err_to_reply(id, error),
+    };
+    match persistence
+        .register_discovered_session(
+            crate::acp::SessionRegistration {
+                session_id: parsed.session_id,
+                stable_agent_namespace,
+                runtime_agent_id: Some(parsed.agent_id.0),
+                project_id: parsed.project_id,
+                cwd: parsed.cwd.into(),
+                ..Default::default()
+            },
+            parsed.title,
+            parsed.updated_at,
+        )
+        .await
+    {
+        Ok(metadata) => {
+            tracing::info!(
+                target: "termul::web::ws",
+                session_id = %metadata.session_id,
+                "register_discovered_session: metadata promoted"
+            );
+            ok_with_payload(id, &crate::acp::SessionIndexEntry::from(&metadata))
+        }
+        Err(error) => {
+            tracing::warn!(
+                target: "termul::web::ws",
+                error = %error,
+                "register_discovered_session: persistence failed"
+            );
+            WsReply::err(
+                id,
+                WsErrorCode::Unsupported,
+                "failed to persist discovered session metadata",
+            )
+        }
+    }
+}
+
 /// `send_prompt` → `AcpManager::send_prompt(agent_id, session_id, content)`.
 /// Story 1.7 T7.1: the concurrent-turn rejection (`ACP_TURN_IN_PROGRESS`) maps
 /// to `err.code: "rate_limited"` via `map_prompt_error_code`. Story 1.8 T3:
@@ -2849,21 +2945,13 @@ async fn accept_send_prompt(
     }
 
     let started = acp
-        .start_prompt(
-            &parsed.agent_id,
-            parsed.session_id,
-            content,
-            parsed.turn_id,
-        )
+        .start_prompt(&parsed.agent_id, parsed.session_id, content, parsed.turn_id)
         .await
         .map_err(|error| acp_err_to_reply(id.clone(), error))?;
     Ok(AcceptedSendPrompt { id, started, claim })
 }
 
-async fn complete_send_prompt(
-    accepted: AcceptedSendPrompt,
-    acp: &Arc<AcpManager>,
-) -> WsReply {
+async fn complete_send_prompt(accepted: AcceptedSendPrompt, acp: &Arc<AcpManager>) -> WsReply {
     let AcceptedSendPrompt { id, started, claim } = accepted;
     match acp.wait_prompt(started).await {
         Ok(stop_reason) => {
@@ -3690,7 +3778,9 @@ mod tests {
             )
             .await
         );
-        entered.await.expect("prompt was accepted before cancellation");
+        entered
+            .await
+            .expect("prompt was accepted before cancellation");
 
         let first = match rx.recv().await.expect("cancel reply") {
             Outbound::Reply(reply) => reply,
@@ -3886,8 +3976,7 @@ mod tests {
 
     #[tokio::test]
     async fn handle_list_acp_catalog_ws_dispatch_returns_payload() {
-        let root =
-            std::env::temp_dir().join(format!("termul-ws-cat-{}", uuid::Uuid::new_v4()));
+        let root = std::env::temp_dir().join(format!("termul-ws-cat-{}", uuid::Uuid::new_v4()));
         std::fs::create_dir_all(&root).unwrap();
         let catalog = crate::acp::AcpCatalogService::open(root.join("catalog"))
             .await
@@ -3920,8 +4009,7 @@ mod tests {
 
     #[tokio::test]
     async fn handle_set_catalog_opt_in_ws_dispatch_persists() {
-        let root =
-            std::env::temp_dir().join(format!("termul-ws-optin-{}", uuid::Uuid::new_v4()));
+        let root = std::env::temp_dir().join(format!("termul-ws-optin-{}", uuid::Uuid::new_v4()));
         std::fs::create_dir_all(&root).unwrap();
         let catalog = crate::acp::AcpCatalogService::open(root.join("catalog"))
             .await
@@ -3989,10 +4077,9 @@ mod tests {
 
     #[tokio::test]
     async fn list_acp_catalog_degraded_returns_unavailable() {
-        let reply = handle_request_without_catalog(
-            r#"{"id":"r1","type":"list_acp_catalog","payload":{}}"#,
-        )
-        .await;
+        let reply =
+            handle_request_without_catalog(r#"{"id":"r1","type":"list_acp_catalog","payload":{}}"#)
+                .await;
         assert!(!reply.ok);
         assert_eq!(reply.err.as_ref().unwrap().code, "ACP_CATALOG_UNAVAILABLE");
     }
@@ -4035,12 +4122,12 @@ mod tests {
 
     #[tokio::test]
     async fn second_client_restores_session_created_by_first_client() {
-        let root =
-            std::env::temp_dir().join(format!("termul-ws-cross-{}", uuid::Uuid::new_v4()));
+        let root = std::env::temp_dir().join(format!("termul-ws-cross-{}", uuid::Uuid::new_v4()));
         let cwd = root.join("cwd");
         std::fs::create_dir_all(&cwd).unwrap();
-        let persistence =
-            crate::acp::SessionPersistence::open(root.join("sessions")).await.unwrap();
+        let persistence = crate::acp::SessionPersistence::open(root.join("sessions"))
+            .await
+            .unwrap();
         let relay = Arc::new(WsRelaySink::with_persistence(8, persistence.clone()));
         let acp = Arc::new(AcpManager::with_persistence(vec![], persistence.clone()));
         // The test agent owns the session + handles the prompt-flow commands
@@ -4663,7 +4750,10 @@ mod tests {
         assert!(reply.err.is_none());
         let payload = reply.payload.expect("payload present on success");
         assert_eq!(payload["agentId"], "agn_test");
-        assert!(payload.get("capabilities").is_some(), "capabilities always serialized");
+        assert!(
+            payload.get("capabilities").is_some(),
+            "capabilities always serialized"
+        );
         assert_eq!(payload["authMethods"][0]["id"], "cursor_login");
         assert_eq!(payload["authMethods"][0]["name"], "Sign in with Cursor");
         // `description` is `None` + skip_serializing_if → omitted from JSON.
@@ -4688,7 +4778,11 @@ mod tests {
         assert!(reply.ok);
         let payload = reply.payload.expect("payload");
         assert_eq!(payload["agentId"], "agn_noauth");
-        assert_eq!(payload["authMethods"], json!([]), "authMethods always serialized as []");
+        assert_eq!(
+            payload["authMethods"],
+            json!([]),
+            "authMethods always serialized as []"
+        );
         assert!(
             payload.get("stableNamespace").is_none(),
             "stableNamespace omitted when None"
@@ -5718,6 +5812,55 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn register_discovered_session_promotes_metadata_without_transcript() {
+        let root = std::env::temp_dir().join(format!(
+            "termul-ws-register-discovered-{}",
+            uuid::Uuid::new_v4()
+        ));
+        let cwd = root.join("cwd");
+        std::fs::create_dir_all(&cwd).unwrap();
+        let persistence = crate::acp::SessionPersistence::open(root.join("sessions"))
+            .await
+            .unwrap();
+        let relay = Arc::new(WsRelaySink::with_persistence(8, persistence.clone()));
+        let acp = Arc::new(AcpManager::with_persistence(vec![], persistence.clone()));
+        acp.install_test_agent_with_sessions(
+            crate::acp::AgentId("agent-1".to_string()),
+            std::collections::HashSet::new(),
+        );
+
+        let reply = handle_register_discovered_session(
+            "r1".to_string(),
+            &json!({
+                "sessionId": "discovered-1",
+                "agentId": "agent-1",
+                "cwd": cwd.to_string_lossy(),
+                "title": "Agent title",
+                "updatedAt": 42,
+                "projectId": "p-1"
+            }),
+            &acp,
+            &relay,
+        )
+        .await;
+
+        assert!(reply.ok);
+        let metadata = persistence.metadata("discovered-1").unwrap();
+        assert_eq!(metadata.title.as_deref(), Some("Agent title"));
+        assert_eq!(
+            metadata.title_source,
+            Some(crate::acp::session_persistence::TitleSource::AgentSupplied)
+        );
+        assert_eq!(metadata.last_seq, 0);
+        assert!(persistence
+            .replay_after("discovered-1", 0)
+            .unwrap()
+            .is_empty());
+        persistence.shutdown().await.unwrap();
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[tokio::test]
     async fn get_session_payload_unsupported_in_live_only() {
         let relay = Arc::new(WsRelaySink::new());
         let reply = handle_get_session_payload(
@@ -5749,8 +5892,7 @@ mod tests {
 
     #[tokio::test]
     async fn get_session_payload_materializes_standalone_durable_history() {
-        let root =
-            std::env::temp_dir().join(format!("termul-ws-payload-{}", uuid::Uuid::new_v4()));
+        let root = std::env::temp_dir().join(format!("termul-ws-payload-{}", uuid::Uuid::new_v4()));
         let cwd = root.join("cwd");
         std::fs::create_dir_all(&cwd).unwrap();
         let persistence = crate::acp::SessionPersistence::open(root.join("sessions"))
@@ -5920,8 +6062,10 @@ mod tests {
     /// fabricated empty payload that would wipe the client's transcript.
     #[tokio::test]
     async fn get_session_payload_standalone_corrupt_log_is_unsupported() {
-        let root =
-            std::env::temp_dir().join(format!("termul-ws-payload-corrupt-{}", uuid::Uuid::new_v4()));
+        let root = std::env::temp_dir().join(format!(
+            "termul-ws-payload-corrupt-{}",
+            uuid::Uuid::new_v4()
+        ));
         let cwd = root.join("cwd");
         std::fs::create_dir_all(&cwd).unwrap();
         let persistence = crate::acp::SessionPersistence::open(root.join("sessions"))
@@ -5957,10 +6101,7 @@ mod tests {
             .unwrap();
         // Corrupt the durable transcript log after finalization.
         let storage_key = persistence.metadata("session-c").unwrap().storage_key;
-        let log_path = persistence
-            .root()
-            .join(&storage_key)
-            .join("messages.jsonl");
+        let log_path = persistence.root().join(&storage_key).join("messages.jsonl");
         {
             use std::io::Write;
             let mut file = std::fs::OpenOptions::new()
@@ -6236,10 +6377,7 @@ mod tests {
         assert_eq!(drained.len(), 1, "exactly one projects_changed broadcast");
         let evt = &drained[0];
         assert_eq!(evt.type_, "projects_changed");
-        assert!(
-            evt.sid.is_none(),
-            "agent-level event: sid must be null"
-        );
+        assert!(evt.sid.is_none(), "agent-level event: sid must be null");
         assert_eq!(evt.seq, 0, "agent-level event: seq must be 0");
         assert_eq!(
             evt.payload["defaultProjectId"], "p-1",
@@ -6299,8 +6437,7 @@ mod tests {
         // Subscribe a client to prove NO broadcast reaches it.
         let (_client, mut rx, _replay) = relay.subscribe("sess-1", None).await;
 
-        let current_session =
-            Arc::new(parking_lot::Mutex::new(None::<crate::acp::SessionId>));
+        let current_session = Arc::new(parking_lot::Mutex::new(None::<crate::acp::SessionId>));
         let current_project = Arc::new(parking_lot::Mutex::new(None::<String>));
         let target = ProjectSwitchContext {
             project_id: "p-1".to_string(),
@@ -6334,10 +6471,7 @@ mod tests {
             "switch must not persist to the file registry"
         );
         // No file was written to disk.
-        assert!(
-            !path.exists(),
-            "switch must not write the projects file"
-        );
+        assert!(!path.exists(), "switch must not write the projects file");
     }
 
     /// P8 — multi-client: a `switch_project` by one client does NOT fan out
@@ -6370,11 +6504,9 @@ mod tests {
         let mut subs = Vec::new();
         let mut authed = true;
         let mut current_agent: Option<crate::acp::AgentId> = None;
-        let current_session =
-            Arc::new(parking_lot::Mutex::new(None::<crate::acp::SessionId>));
+        let current_session = Arc::new(parking_lot::Mutex::new(None::<crate::acp::SessionId>));
         let current_project_a = Arc::new(parking_lot::Mutex::new(None::<String>));
-        let switch_queue =
-            Arc::new(tokio::sync::Mutex::new(ProjectSwitchQueue::default()));
+        let switch_queue = Arc::new(tokio::sync::Mutex::new(ProjectSwitchQueue::default()));
 
         // Client A sends switch_project (cold-tab path).
         let reply_a = handle_request(
@@ -6505,8 +6637,9 @@ mod tests {
             }],
             Some("p-1".to_string()),
         );
-        let current_session =
-            Arc::new(parking_lot::Mutex::new(Some(SessionId("s-prev".to_string()))));
+        let current_session = Arc::new(parking_lot::Mutex::new(Some(SessionId(
+            "s-prev".to_string(),
+        ))));
         // The connection is ALREADY on p-1.
         let current_project = Arc::new(parking_lot::Mutex::new(Some("p-1".to_string())));
         let target = ProjectSwitchContext {

--- a/src-tauri/src/web/ws.rs
+++ b/src-tauri/src/web/ws.rs
@@ -3782,19 +3782,29 @@ mod tests {
             .await
             .expect("prompt was accepted before cancellation");
 
-        let first = match rx.recv().await.expect("cancel reply") {
+        let first = match rx.recv().await.expect("first reply") {
             Outbound::Reply(reply) => reply,
-            Outbound::Event(_) => panic!("expected cancel reply"),
+            Outbound::Event(_) => panic!("expected reply"),
         };
-        assert_eq!(first.id, "cancel-ordered");
-        assert!(first.ok);
-        let second = match rx.recv().await.expect("prompt completion reply") {
+        let second = match rx.recv().await.expect("second reply") {
             Outbound::Reply(reply) => reply,
-            Outbound::Event(_) => panic!("expected prompt reply"),
+            Outbound::Event(_) => panic!("expected reply"),
         };
-        assert_eq!(second.id, "prompt-ordered");
-        assert!(second.ok);
-        assert_eq!(second.payload.expect("stop reason"), json!("cancelled"));
+        let replies = [first, second];
+        let cancel = replies
+            .iter()
+            .find(|reply| reply.id == "cancel-ordered")
+            .expect("cancel acknowledgement");
+        assert!(cancel.ok);
+        let prompt = replies
+            .iter()
+            .find(|reply| reply.id == "prompt-ordered")
+            .expect("prompt completion");
+        assert!(prompt.ok);
+        assert_eq!(
+            prompt.payload.as_ref().expect("stop reason"),
+            &json!("cancelled")
+        );
     }
 
     #[tokio::test]

--- a/src/renderer/assets/agent-icons/acp/agents.json
+++ b/src/renderer/assets/agent-icons/acp/agents.json
@@ -81,11 +81,11 @@
   {
     "id": "cline",
     "name": "Cline",
-    "version": "3.0.52",
+    "version": "3.0.53",
     "description": "Autonomous coding agent CLI - capable of creating/editing files, running commands, using the browser, and more",
     "distribution": {
       "npx": {
-        "package": "cline@3.0.52",
+        "package": "cline@3.0.53",
         "args": ["--acp"]
       }
     }
@@ -308,11 +308,11 @@
   {
     "id": "dimcode",
     "name": "DimCode",
-    "version": "0.3.9",
+    "version": "0.3.10",
     "description": "A coding agent that puts leading models at your command.",
     "distribution": {
       "npx": {
-        "package": "dimcode@0.3.9",
+        "package": "dimcode@0.3.10",
         "args": ["acp"]
       }
     }
@@ -320,11 +320,11 @@
   {
     "id": "dirac",
     "name": "Dirac",
-    "version": "0.4.34",
+    "version": "0.4.35",
     "description": "Reduces API costs by more than 50%, produces better and faster work. Uses Hash anchored parallel edits, AST manipulation and a whole lot of neat optimizations. Fully Open Source.",
     "distribution": {
       "npx": {
-        "package": "dirac-cli@0.4.34",
+        "package": "dirac-cli@0.4.35",
         "args": ["--acp"]
       }
     }
@@ -360,11 +360,11 @@
   {
     "id": "gemini",
     "name": "Gemini CLI",
-    "version": "0.54.4",
+    "version": "0.55.1",
     "description": "Google's official CLI for Gemini",
     "distribution": {
       "npx": {
-        "package": "@google/gemini-cli@0.54.4",
+        "package": "@google/gemini-cli@0.55.1",
         "args": ["--acp"]
       }
     }
@@ -426,11 +426,11 @@
   {
     "id": "grok-build",
     "name": "Grok Build",
-    "version": "1.0.1",
+    "version": "1.0.2",
     "description": "xAI's coding agent and CLI",
     "distribution": {
       "npx": {
-        "package": "@xai-official/grok@1.0.1",
+        "package": "@xai-official/grok@1.0.2",
         "args": ["agent", "stdio"]
       }
     }
@@ -438,33 +438,33 @@
   {
     "id": "harn",
     "name": "Harn",
-    "version": "0.10.79",
+    "version": "0.10.83",
     "description": "Harn runs .harn agent pipelines as a native ACP coding agent over stdio.",
     "distribution": {
       "binary": {
         "darwin-aarch64": {
           "cmd": "./harn",
-          "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.79/harn-aarch64-apple-darwin.tar.gz",
+          "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.83/harn-aarch64-apple-darwin.tar.gz",
           "args": ["serve", "acp"]
         },
         "darwin-x86_64": {
           "cmd": "./harn",
-          "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.79/harn-x86_64-apple-darwin.tar.gz",
+          "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.83/harn-x86_64-apple-darwin.tar.gz",
           "args": ["serve", "acp"]
         },
         "linux-aarch64": {
           "cmd": "./harn",
-          "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.79/harn-aarch64-unknown-linux-gnu.tar.gz",
+          "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.83/harn-aarch64-unknown-linux-gnu.tar.gz",
           "args": ["serve", "acp"]
         },
         "linux-x86_64": {
           "cmd": "./harn",
-          "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.79/harn-x86_64-unknown-linux-gnu.tar.gz",
+          "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.83/harn-x86_64-unknown-linux-gnu.tar.gz",
           "args": ["serve", "acp"]
         },
         "windows-x86_64": {
           "cmd": "harn.exe",
-          "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.79/harn-x86_64-pc-windows-msvc.zip",
+          "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.83/harn-x86_64-pc-windows-msvc.zip",
           "args": ["serve", "acp"]
         }
       }
@@ -599,29 +599,29 @@
   {
     "id": "mistral-vibe",
     "name": "Mistral Vibe",
-    "version": "2.24.0",
+    "version": "2.24.1",
     "description": "Mistral's open-source coding assistant",
     "distribution": {
       "binary": {
         "darwin-aarch64": {
           "cmd": "./vibe-acp",
-          "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v2.24.0/vibe-acp-darwin-aarch64-2.24.0.tar.gz"
+          "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v2.24.1/vibe-acp-darwin-aarch64-2.24.1.tar.gz"
         },
         "darwin-x86_64": {
           "cmd": "./vibe-acp",
-          "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v2.24.0/vibe-acp-darwin-x86_64-2.24.0.tar.gz"
+          "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v2.24.1/vibe-acp-darwin-x86_64-2.24.1.tar.gz"
         },
         "linux-aarch64": {
           "cmd": "./vibe-acp",
-          "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v2.24.0/vibe-acp-linux-aarch64-2.24.0.tar.gz"
+          "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v2.24.1/vibe-acp-linux-aarch64-2.24.1.tar.gz"
         },
         "linux-x86_64": {
           "cmd": "./vibe-acp",
-          "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v2.24.0/vibe-acp-linux-x86_64-2.24.0.tar.gz"
+          "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v2.24.1/vibe-acp-linux-x86_64-2.24.1.tar.gz"
         },
         "windows-x86_64": {
           "cmd": "./vibe-acp.exe",
-          "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v2.24.0/vibe-acp-windows-x86_64-2.24.0.zip"
+          "archive": "https://github.com/mistralai/mistral-vibe/releases/download/v2.24.1/vibe-acp-windows-x86_64-2.24.1.zip"
         }
       }
     }
@@ -744,11 +744,11 @@
   {
     "id": "qwen-code",
     "name": "Qwen Code",
-    "version": "0.21.9",
+    "version": "0.21.10",
     "description": "Alibaba's Qwen coding assistant",
     "distribution": {
       "npx": {
-        "package": "@qwen-code/qwen-code@0.21.9",
+        "package": "@qwen-code/qwen-code@0.21.10",
         "args": ["--acp", "--experimental-skills"]
       }
     }
@@ -756,20 +756,20 @@
   {
     "id": "sigit",
     "name": "siGit Code",
-    "version": "1.5.1",
+    "version": "1.5.2",
     "description": "Local-first coding agent. Runs entirely on your machine with optional on-device LLM inference via Onde.",
     "distribution": {
       "npx": {
-        "package": "@smbcloud/sigit@1.5.1"
+        "package": "@smbcloud/sigit@1.5.2"
       },
       "binary": {
         "darwin-aarch64": {
           "cmd": "./sigit",
-          "archive": "https://github.com/getsigit/sigit/releases/download/v1.5.1/sigit-macos-arm64.tar.gz"
+          "archive": "https://github.com/getsigit/sigit/releases/download/v1.5.2/sigit-macos-arm64.tar.gz"
         },
         "darwin-x86_64": {
           "cmd": "./sigit",
-          "archive": "https://github.com/getsigit/sigit/releases/download/v1.5.1/sigit-macos-amd64.tar.gz"
+          "archive": "https://github.com/getsigit/sigit/releases/download/v1.5.2/sigit-macos-amd64.tar.gz"
         },
         "linux-aarch64": {
           "cmd": "./sigit-linux-arm64"

--- a/src/renderer/assets/agent-icons/acp/agents.json
+++ b/src/renderer/assets/agent-icons/acp/agents.json
@@ -426,11 +426,11 @@
   {
     "id": "grok-build",
     "name": "Grok Build",
-    "version": "1.0.2",
+    "version": "1.0.3",
     "description": "xAI's coding agent and CLI",
     "distribution": {
       "npx": {
-        "package": "@xai-official/grok@1.0.2",
+        "package": "@xai-official/grok@1.0.3",
         "args": ["agent", "stdio"]
       }
     }
@@ -438,33 +438,33 @@
   {
     "id": "harn",
     "name": "Harn",
-    "version": "0.10.83",
+    "version": "0.10.84",
     "description": "Harn runs .harn agent pipelines as a native ACP coding agent over stdio.",
     "distribution": {
       "binary": {
         "darwin-aarch64": {
           "cmd": "./harn",
-          "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.83/harn-aarch64-apple-darwin.tar.gz",
+          "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.84/harn-aarch64-apple-darwin.tar.gz",
           "args": ["serve", "acp"]
         },
         "darwin-x86_64": {
           "cmd": "./harn",
-          "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.83/harn-x86_64-apple-darwin.tar.gz",
+          "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.84/harn-x86_64-apple-darwin.tar.gz",
           "args": ["serve", "acp"]
         },
         "linux-aarch64": {
           "cmd": "./harn",
-          "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.83/harn-aarch64-unknown-linux-gnu.tar.gz",
+          "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.84/harn-aarch64-unknown-linux-gnu.tar.gz",
           "args": ["serve", "acp"]
         },
         "linux-x86_64": {
           "cmd": "./harn",
-          "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.83/harn-x86_64-unknown-linux-gnu.tar.gz",
+          "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.84/harn-x86_64-unknown-linux-gnu.tar.gz",
           "args": ["serve", "acp"]
         },
         "windows-x86_64": {
           "cmd": "harn.exe",
-          "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.83/harn-x86_64-pc-windows-msvc.zip",
+          "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.84/harn-x86_64-pc-windows-msvc.zip",
           "args": ["serve", "acp"]
         }
       }

--- a/src/renderer/components/chat/ChatHistoryTab.test.tsx
+++ b/src/renderer/components/chat/ChatHistoryTab.test.tsx
@@ -206,9 +206,6 @@ describe('ChatHistoryTab scoping', () => {
         { sessionId: 'cli-1', cwd: '/work', title: 'CLI chat', updatedAt: '2026-01-01' }
       ]
     }
-    // AD-7: the discovered session is only visible when it's the active
-    // session (exemption). Set it active so the click test can reach it.
-    activeSessionIdRef.current = 'cli-1'
     let resolveOpen: (() => void) | undefined
     mockOpenDiscovered.mockImplementationOnce(
       () =>
@@ -228,10 +225,7 @@ describe('ChatHistoryTab scoping', () => {
     resolveOpen?.()
   })
 
-  // AD-7: discovered sessions (agent-reported via ACP `session/list` but never
-  // recorded by termul) are hidden from the sidebar — EXCEPT the currently-
-  // active session so the open tab is never orphaned.
-  it('hides discovered sessions when no discovered session is active', () => {
+  it('shows all discovered sessions when no session is active', () => {
     agentsRef.current = {
       'agent-1': {
         id: 'agent-1',
@@ -241,19 +235,18 @@ describe('ChatHistoryTab scoping', () => {
     agentStatusRef.current = { 'agent-1': 'connected' }
     discoveredSessionsRef.current = {
       ['agent-1\0/work']: [
-        { sessionId: 'cli-1', cwd: '/work', title: 'Hidden CLI chat', updatedAt: '2026-01-01' },
-        { sessionId: 'cli-2', cwd: '/work', title: 'Another hidden', updatedAt: '2026-01-01' }
+        { sessionId: 'cli-1', cwd: '/work', title: 'CLI chat', updatedAt: '2026-01-01' },
+        { sessionId: 'cli-2', cwd: '/work', title: 'Another CLI chat', updatedAt: '2026-01-01' }
       ]
     }
-    // No active session — all discovered entries are filtered out.
     activeSessionIdRef.current = null
 
     render(<ChatHistoryTab />)
-    expect(screen.queryByText('Hidden CLI chat')).not.toBeInTheDocument()
-    expect(screen.queryByText('Another hidden')).not.toBeInTheDocument()
+    expect(screen.getByText('CLI chat')).toBeInTheDocument()
+    expect(screen.getByText('Another CLI chat')).toBeInTheDocument()
   })
 
-  it('shows the active discovered session despite the filter (active-session exemption)', () => {
+  it('shows discovered sessions regardless of which session is active', () => {
     agentsRef.current = {
       'agent-1': {
         id: 'agent-1',
@@ -264,16 +257,14 @@ describe('ChatHistoryTab scoping', () => {
     discoveredSessionsRef.current = {
       ['agent-1\0/work']: [
         { sessionId: 'cli-1', cwd: '/work', title: 'Active CLI chat', updatedAt: '2026-01-01' },
-        // A second discovered session is still hidden.
-        { sessionId: 'cli-2', cwd: '/work', title: 'Hidden other', updatedAt: '2026-01-01' }
+        { sessionId: 'cli-2', cwd: '/work', title: 'Other CLI chat', updatedAt: '2026-01-01' }
       ]
     }
-    // The user opened cli-1 via `openDiscoveredSession` — it's the active tab.
     activeSessionIdRef.current = 'cli-1'
 
     render(<ChatHistoryTab />)
     expect(screen.getByText('Active CLI chat')).toBeInTheDocument()
-    expect(screen.queryByText('Hidden other')).not.toBeInTheDocument()
+    expect(screen.getByText('Other CLI chat')).toBeInTheDocument()
   })
 
   it('does not hide local mirror sessions even when a discovered session is active', () => {
@@ -295,10 +286,33 @@ describe('ChatHistoryTab scoping', () => {
     activeSessionIdRef.current = 'cli-1'
 
     render(<ChatHistoryTab />)
-    // Local mirror stays visible (discovered filter only targets discovered:true).
     expect(screen.getByText('Local chat')).toBeInTheDocument()
-    // Active discovered session is exempted.
     expect(screen.getByText('Active discovered')).toBeInTheDocument()
+  })
+
+  it('opens promoted metadata-only sessions through the discovered-session path', async () => {
+    sessionIndexRef.current = [
+      entry('cli-1', {
+        agentId: 'agent-1',
+        title: 'Promoted CLI chat',
+        messageCount: 0,
+        status: 'active',
+        discovered: true
+      })
+    ]
+    agentsRef.current = {
+      'agent-1': {
+        id: 'agent-1',
+        capabilities: { loadSession: true, sessionCapabilities: { list: {} } }
+      }
+    }
+    agentStatusRef.current = { 'agent-1': 'connected' }
+
+    render(<ChatHistoryTab />)
+    fireEvent.click(screen.getByText('Promoted CLI chat'))
+
+    expect(mockOpenDiscovered).toHaveBeenCalledWith('agent-1', 'cli-1', '/work', 'p1')
+    expect(mockOpen).not.toHaveBeenCalled()
   })
 
   it('caps the rendered rows and lazily loads more', () => {

--- a/src/renderer/components/chat/ChatHistoryTab.test.tsx
+++ b/src/renderer/components/chat/ChatHistoryTab.test.tsx
@@ -12,6 +12,7 @@ const {
   discoveredSessionsRef,
   agentsRef,
   agentStatusRef,
+  configToLiveAgentRef,
   activeSessionIdRef,
   projectRef
 } = vi.hoisted(() => ({
@@ -24,6 +25,7 @@ const {
   discoveredSessionsRef: { current: {} as Record<string, unknown[]> },
   agentsRef: { current: {} as Record<string, unknown> },
   agentStatusRef: { current: {} as Record<string, string> },
+  configToLiveAgentRef: { current: {} as Record<string, string> },
   activeSessionIdRef: { current: null as string | null },
   projectRef: {
     current: null as {
@@ -51,16 +53,17 @@ vi.mock('@/stores/acp-store', () => {
       agents: agentsRef.current,
       agentStatus: agentStatusRef.current,
       agentConfigs: [],
-      configToLiveAgent: {},
+      configToLiveAgent: configToLiveAgentRef.current,
       discoverSessions: mockDiscover,
       openDiscoveredSession: mockOpenDiscovered,
       activeSessionId: activeSessionIdRef.current
     })
   // Stubs for the store helpers the component imports.
+  const agentReuseKey = (configId: string, cwd: string) => `${configId}\0${cwd.trim()}`
   const configIdFromReuseKey = () => ''
   const discoveryKey = (agentId: string, cwd: string) => `${agentId}\0${cwd}`
   const useAgentTemplateId = () => null
-  return { useAcpStore, configIdFromReuseKey, discoveryKey, useAgentTemplateId }
+  return { useAcpStore, agentReuseKey, configIdFromReuseKey, discoveryKey, useAgentTemplateId }
 })
 
 vi.mock('@/stores/workspace-store', () => ({
@@ -110,6 +113,7 @@ describe('ChatHistoryTab scoping', () => {
     discoveredSessionsRef.current = {}
     agentsRef.current = {}
     agentStatusRef.current = {}
+    configToLiveAgentRef.current = {}
     activeSessionIdRef.current = null
     projectRef.current = {
       id: 'p1',
@@ -297,7 +301,8 @@ describe('ChatHistoryTab scoping', () => {
         title: 'Promoted CLI chat',
         messageCount: 0,
         status: 'active',
-        discovered: true
+        discovered: true,
+        agentConfigId: 'config-1'
       })
     ]
     agentsRef.current = {
@@ -307,6 +312,7 @@ describe('ChatHistoryTab scoping', () => {
       }
     }
     agentStatusRef.current = { 'agent-1': 'connected' }
+    configToLiveAgentRef.current = { ['config-1\0/work']: 'agent-1' }
 
     render(<ChatHistoryTab />)
     fireEvent.click(screen.getByText('Promoted CLI chat'))

--- a/src/renderer/components/chat/ChatHistoryTab.tsx
+++ b/src/renderer/components/chat/ChatHistoryTab.tsx
@@ -2,7 +2,7 @@ import { Search } from 'lucide-react'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { toast } from 'sonner'
 import { groupSessionsByRecency, scopeSessionIndex } from '@/lib/acp-history-persistence'
-import { configIdFromReuseKey, discoveryKey, useAcpStore } from '@/stores/acp-store'
+import { agentReuseKey, configIdFromReuseKey, discoveryKey, useAcpStore } from '@/stores/acp-store'
 import { getActiveWorktreeFromStore, useActiveProject } from '@/stores/project-store'
 import { useWorkspaceStore } from '@/stores/workspace-store'
 import { ChatHistoryEntryRow, type ChatHistorySidebarEntry } from './ChatHistoryEntryRow'
@@ -77,18 +77,42 @@ export function ChatHistoryTab({
   // Build a unified sidebar list: local mirror + discovered sessions (deduped).
   const mergedEntries = useMemo(() => {
     const mirrorIds = new Set(scopedIndex.map((e) => e.id))
-    const entries: SidebarEntry[] = scopedIndex.map((e) => ({
-      id: e.id,
-      title: e.title,
-      messageCount: e.messageCount,
-      status: e.status,
-      discovered: e.discovered === true,
-      agentId: e.agentId,
-      cwd: e.discovered ? e.cwd : undefined,
-      agentConfigId: e.agentConfigId,
-      lastActivityAt: e.lastActivityAt,
-      canOpen: true
-    }))
+    const entries: SidebarEntry[] = scopedIndex.map((e) => {
+      if (!e.discovered) {
+        return {
+          id: e.id,
+          title: e.title,
+          messageCount: e.messageCount,
+          status: e.status,
+          discovered: false,
+          agentId: e.agentId,
+          agentConfigId: e.agentConfigId,
+          lastActivityAt: e.lastActivityAt,
+          canOpen: true
+        }
+      }
+      const liveAgentId = e.agentConfigId
+        ? configToLiveAgent[agentReuseKey(e.agentConfigId, activeCwd)]
+        : undefined
+      const liveAgent = liveAgentId ? agents[liveAgentId] : undefined
+      const canOpen =
+        liveAgentId != null &&
+        agentStatus[liveAgentId] === 'connected' &&
+        (liveAgent?.capabilities?.loadSession === true ||
+          liveAgent?.capabilities?.sessionCapabilities?.resume != null)
+      return {
+        id: e.id,
+        title: e.title,
+        messageCount: e.messageCount,
+        status: e.status,
+        discovered: true,
+        agentId: liveAgentId,
+        cwd: activeCwd,
+        agentConfigId: e.agentConfigId,
+        lastActivityAt: e.lastActivityAt,
+        canOpen
+      }
+    })
 
     // Add discovered sessions not already in the local mirror. Results are keyed
     // per (agent, cwd), so look up the active cwd's slot for each connected agent.
@@ -125,7 +149,15 @@ export function ChatHistoryTab({
     }
 
     return entries
-  }, [scopedIndex, discoveredSessions, agents, agentStatus, activeCwd, resolveAgentIdentity])
+  }, [
+    scopedIndex,
+    discoveredSessions,
+    agents,
+    agentStatus,
+    activeCwd,
+    resolveAgentIdentity,
+    configToLiveAgent
+  ])
 
   const [query, setQuery] = useState('')
   // Lazy rendering: keep all results in memory but only render a growing window

--- a/src/renderer/components/chat/ChatHistoryTab.tsx
+++ b/src/renderer/components/chat/ChatHistoryTab.tsx
@@ -29,7 +29,6 @@ export function ChatHistoryTab({
   const openDiscoveredSession = useAcpStore((s) => s.openDiscoveredSession)
   const discoverSessions = useAcpStore((s) => s.discoverSessions)
   const deleteHistorySession = useAcpStore((s) => s.deleteHistorySession)
-  const activeSessionId = useAcpStore((s) => s.activeSessionId)
   const addAgentChatTab = useWorkspaceStore((s) => s.addAgentChatTab)
   // Subscribe to the full active-project record so the sidebar re-scopes when
   // the active worktree changes (not just when the active project id changes).
@@ -76,11 +75,6 @@ export function ChatHistoryTab({
   )
 
   // Build a unified sidebar list: local mirror + discovered sessions (deduped).
-  // AD-7: discovered sessions (agent-reported via ACP `session/list` but never
-  // recorded by termul) are filtered OUT of the sidebar, EXCEPT the currently-
-  // active session — so an open tab is never orphaned (the user opened it via
-  // `openDiscoveredSession` and it's the focused chat). The filter runs after
-  // `entries` is built so the active-session exemption is exact.
   const mergedEntries = useMemo(() => {
     const mirrorIds = new Set(scopedIndex.map((e) => e.id))
     const entries: SidebarEntry[] = scopedIndex.map((e) => ({
@@ -88,8 +82,9 @@ export function ChatHistoryTab({
       title: e.title,
       messageCount: e.messageCount,
       status: e.status,
-      discovered: false,
+      discovered: e.discovered === true,
       agentId: e.agentId,
+      cwd: e.discovered ? e.cwd : undefined,
       agentConfigId: e.agentConfigId,
       lastActivityAt: e.lastActivityAt,
       canOpen: true
@@ -129,23 +124,8 @@ export function ChatHistoryTab({
       }
     }
 
-    // AD-7 sidebar display policy: hide discovered sessions that termul never
-    // recorded — EXCEPT the currently-active session (so the open tab is never
-    // orphaned). The filter is applied here (after building `entries`) so the
-    // active-session exemption is exact and the empty-state check below reflects
-    // the post-filter count.
-    return entries.filter(
-      (e) => !e.discovered || (activeSessionId != null && e.id === activeSessionId)
-    )
-  }, [
-    scopedIndex,
-    discoveredSessions,
-    agents,
-    agentStatus,
-    activeCwd,
-    resolveAgentIdentity,
-    activeSessionId
-  ])
+    return entries
+  }, [scopedIndex, discoveredSessions, agents, agentStatus, activeCwd, resolveAgentIdentity])
 
   const [query, setQuery] = useState('')
   // Lazy rendering: keep all results in memory but only render a growing window

--- a/src/renderer/lib/acp-api.test.ts
+++ b/src/renderer/lib/acp-api.test.ts
@@ -167,6 +167,7 @@ describe('acp-api web path (injected WS transport)', () => {
       resumeSession: vi.fn(),
       closeSession: vi.fn(),
       listSessions: vi.fn(),
+      registerDiscoveredSession: vi.fn(),
       sendPrompt,
       sendPromptBlocks: vi.fn(),
       cancelPrompt: vi.fn(),

--- a/src/renderer/lib/acp-api.ts
+++ b/src/renderer/lib/acp-api.ts
@@ -611,6 +611,17 @@ export async function acpListSessions(
   return getAcpTransport().listSessions(agentId, cwd, cursor)
 }
 
+export async function acpRegisterDiscoveredSession(input: {
+  sessionId: SessionId
+  agentId: AgentId
+  cwd: string
+  title?: string | null
+  updatedAt?: number
+  projectId?: string
+}): Promise<import('@shared/types/web-protocol.types').PersistedSessionSummary> {
+  return getAcpTransport().registerDiscoveredSession(input)
+}
+
 export async function acpSendPrompt(
   agentId: AgentId,
   sessionId: SessionId,

--- a/src/renderer/lib/acp-history-persistence.test.ts
+++ b/src/renderer/lib/acp-history-persistence.test.ts
@@ -117,7 +117,8 @@ describe('pure history helpers', () => {
     expect(deriveTitle([msg('agent', 'hi'), msg('user', 'Refactor auth')], 'fallback')).toBe(
       'Refactor auth'
     )
-    expect(deriveTitle([msg('user', 'x'.repeat(60))], 'fallback')).toBe(`${'x'.repeat(40)}…`)
+    expect(deriveTitle([msg('user', 'x'.repeat(60))], 'fallback')).toBe(`${'x'.repeat(48)}…`)
+    expect(deriveTitle([msg('user', '😀'.repeat(60))], 'fallback')).toBe(`${'😀'.repeat(48)}…`)
     expect(deriveTitle([msg('agent', 'hello')], 'fallback')).toBe('fallback')
   })
 

--- a/src/renderer/lib/acp-history-persistence.test.ts
+++ b/src/renderer/lib/acp-history-persistence.test.ts
@@ -119,6 +119,7 @@ describe('pure history helpers', () => {
     )
     expect(deriveTitle([msg('user', 'x'.repeat(60))], 'fallback')).toBe(`${'x'.repeat(48)}…`)
     expect(deriveTitle([msg('user', '😀'.repeat(60))], 'fallback')).toBe(`${'😀'.repeat(48)}…`)
+    expect(deriveTitle([msg('user', 'First line\nSecond line')], 'fallback')).toBe('First line')
     expect(deriveTitle([msg('agent', 'hello')], 'fallback')).toBe('fallback')
   })
 
@@ -368,11 +369,16 @@ describe('provider routing', () => {
         messageCount: 3,
         toolCount: 1,
         lastSeq: 7,
+        discovered: true,
         resumeEligible: true
       }
     ])
     await expect(loadSessionIndex()).resolves.toEqual([
-      expect.objectContaining({ id: 'server-1', agentConfigId: 'cfg-server' })
+      expect.objectContaining({
+        id: 'server-1',
+        agentConfigId: 'cfg-server',
+        discovered: true
+      })
     ])
     expect(mockHistoryApi.list).not.toHaveBeenCalled()
 

--- a/src/renderer/lib/acp-history-persistence.ts
+++ b/src/renderer/lib/acp-history-persistence.ts
@@ -34,6 +34,8 @@ export interface SessionIndexEntry {
    */
   lastSeq?: number
   status: SessionStatus
+  /** Agent-owned metadata mirror created from ACP `session/list`; no local transcript. */
+  discovered?: boolean
   /**
    * Worktree path + branch the agent runs in (CAP-3). Additive: absent on
    * pre-feature sessions. Powers the CAP-6 indicator + the deleted-worktree
@@ -222,6 +224,7 @@ export function toPersistedSessionSummaries(
     lastActivityAt: entry.lastActivityAt,
     status: entry.status === 'initializing' ? 'active' : entry.status,
     messageCount: entry.messageCount,
+    discovered: entry.discovered,
     toolCount: 0,
     lastSeq: entry.lastSeq ?? 0,
     resumeEligible: Boolean(entry.agentConfigId || entry.agentId),
@@ -237,7 +240,10 @@ export function deriveTitle(messages: ChatMessage[], fallbackTitle: string): str
       .map((block) => (block.type === 'text' ? (block.text ?? '') : ''))
       .join(' ')
       .trim()
-    if (text.length > 0) return text.length > 40 ? `${text.slice(0, 40)}…` : text
+    if (text.length > 0) {
+      const characters = Array.from(text)
+      return characters.length > 48 ? `${characters.slice(0, 48).join('')}…` : text
+    }
   }
   return fallbackTitle
 }
@@ -280,27 +286,32 @@ function historyMode(): 'server' | 'live_only' | 'tauri_store' | undefined {
   return getAcpTransport().historyMode?.()
 }
 
+export function fromPersistedSessionSummary(entry: PersistedSessionSummary): SessionIndexEntry {
+  return {
+    id: entry.sessionId,
+    agentId: entry.runtimeAgentId ?? '',
+    agentConfigId: entry.stableAgentNamespace?.startsWith('config:')
+      ? entry.stableAgentNamespace.slice('config:'.length)
+      : undefined,
+    title: entry.title ?? 'Untitled Chat',
+    cwd: entry.cwd,
+    projectId: entry.projectId ?? '',
+    createdAt: entry.createdAt,
+    lastActivityAt: entry.lastActivityAt,
+    messageCount: entry.messageCount,
+    lastSeq: entry.lastSeq,
+    status: entry.status,
+    discovered: entry.messageCount === 0 && entry.toolCount === 0 && entry.lastSeq === 0,
+    worktreePath: entry.worktreePath,
+    worktreeBranch: entry.worktreeBranch
+  }
+}
+
 export async function loadSessionIndex(): Promise<SessionIndexEntry[]> {
   const transport = getAcpTransport()
   const mode = transport.historyMode?.()
   if (mode === 'server' && transport.listPersistedSessions) {
-    return (await transport.listPersistedSessions()).map((entry) => ({
-      id: entry.sessionId,
-      agentId: entry.runtimeAgentId ?? '',
-      agentConfigId: entry.stableAgentNamespace?.startsWith('config:')
-        ? entry.stableAgentNamespace.slice('config:'.length)
-        : undefined,
-      title: entry.title ?? 'Untitled Chat',
-      cwd: entry.cwd,
-      projectId: entry.projectId ?? '',
-      createdAt: entry.createdAt,
-      lastActivityAt: entry.lastActivityAt,
-      messageCount: entry.messageCount,
-      lastSeq: entry.lastSeq,
-      status: entry.status,
-      worktreePath: entry.worktreePath,
-      worktreeBranch: entry.worktreeBranch
-    }))
+    return (await transport.listPersistedSessions()).map(fromPersistedSessionSummary)
   }
   if (mode === 'live_only') return []
   return (await acpHistoryApi.list()).sessions

--- a/src/renderer/lib/acp-history-persistence.ts
+++ b/src/renderer/lib/acp-history-persistence.ts
@@ -240,9 +240,10 @@ export function deriveTitle(messages: ChatMessage[], fallbackTitle: string): str
       .map((block) => (block.type === 'text' ? (block.text ?? '') : ''))
       .join(' ')
       .trim()
-    if (text.length > 0) {
-      const characters = Array.from(text)
-      return characters.length > 48 ? `${characters.slice(0, 48).join('')}…` : text
+    const firstLine = text.split(/\r?\n/, 1)[0].trim()
+    if (firstLine.length > 0) {
+      const characters = Array.from(firstLine)
+      return characters.length > 48 ? `${characters.slice(0, 48).join('')}…` : firstLine
     }
   }
   return fallbackTitle
@@ -301,7 +302,9 @@ export function fromPersistedSessionSummary(entry: PersistedSessionSummary): Ses
     messageCount: entry.messageCount,
     lastSeq: entry.lastSeq,
     status: entry.status,
-    discovered: entry.messageCount === 0 && entry.toolCount === 0 && entry.lastSeq === 0,
+    discovered:
+      entry.discovered ??
+      (entry.messageCount === 0 && entry.toolCount === 0 && entry.lastSeq === 0),
     worktreePath: entry.worktreePath,
     worktreeBranch: entry.worktreeBranch
   }

--- a/src/renderer/lib/acp-transport.test.ts
+++ b/src/renderer/lib/acp-transport.test.ts
@@ -221,6 +221,35 @@ class FakeWebSocket {
       }
       return
     }
+    if (req.type === 'register_discovered_session') {
+      const payload = req.payload as {
+        sessionId: string
+        agentId: string
+        cwd: string
+        title?: string | null
+        updatedAt?: number
+      }
+      this.emitReply({
+        id: req.id,
+        ok: true,
+        payload: {
+          storageKey: 'promoted-key',
+          sessionId: payload.sessionId,
+          stableAgentNamespace: 'config:test',
+          runtimeAgentId: payload.agentId,
+          cwd: payload.cwd,
+          title: payload.title ?? null,
+          createdAt: payload.updatedAt ?? 1,
+          lastActivityAt: payload.updatedAt ?? 1,
+          status: 'active',
+          messageCount: 0,
+          toolCount: 0,
+          lastSeq: 0,
+          resumeEligible: true
+        }
+      })
+      return
+    }
     if (req.type === 'respond_permission') {
       // Story 1.7 T8.3: by default reject as not_implemented; tests set
       // `respondPermissionErr` to exercise the stale/duplicate → AcpTransportError mapping.
@@ -1075,6 +1104,29 @@ describe('WsAcpTransport', () => {
       .filter((frame) => frame.type === 'subscribe')
     expect(subscriptions).toHaveLength(2)
     expect(subscriptions.every((frame) => frame.payload.lastSeq === 0)).toBe(true)
+    transport.dispose()
+  })
+
+  it('registerDiscoveredSession promotes metadata over the WS seam', async () => {
+    const transport = new WsAcpTransport({
+      url: 'ws://test/ws',
+      WebSocketImpl: FakeWebSocket as unknown as typeof WebSocket
+    })
+
+    const summary = await transport.registerDiscoveredSession({
+      sessionId: 'discovered-1',
+      agentId: 'agent-1',
+      cwd: '/work',
+      title: 'Agent title',
+      updatedAt: 42
+    })
+
+    expect(summary).toMatchObject({
+      sessionId: 'discovered-1',
+      runtimeAgentId: 'agent-1',
+      title: 'Agent title',
+      status: 'active'
+    })
     transport.dispose()
   })
 

--- a/src/renderer/lib/acp-transport.ts
+++ b/src/renderer/lib/acp-transport.ts
@@ -140,6 +140,14 @@ export interface AcpTransport {
   closeSession(agentId: AgentId, sessionId: SessionId): Promise<void>
   disposeEphemeralSession(agentId: AgentId, sessionId: SessionId): Promise<void>
   listSessions(agentId: AgentId, cwd?: string, cursor?: string): Promise<ListSessionsResponse>
+  registerDiscoveredSession(input: {
+    sessionId: SessionId
+    agentId: AgentId
+    cwd: string
+    title?: string | null
+    updatedAt?: number
+    projectId?: string
+  }): Promise<PersistedSessionSummary>
   sendPrompt(
     agentId: AgentId,
     sessionId: SessionId,
@@ -278,6 +286,8 @@ function createTauriAcpTransport(): AcpTransport {
     },
     listSessions: (agentId, cwd, cursor) =>
       invoke<ListSessionsResponse>('acp_list_sessions', { agentId, cwd, cursor }),
+    registerDiscoveredSession: (input) =>
+      invoke<PersistedSessionSummary>('acp_register_discovered_session', input),
     sendPrompt: (agentId, sessionId, text, _turnId) =>
       invoke<StopReason>('acp_send_prompt', { agentId, sessionId, text }),
     sendPromptBlocks: (agentId, sessionId, content, _turnId) =>
@@ -868,6 +878,17 @@ export class WsAcpTransport implements AcpTransport {
     cursor?: string
   ): Promise<ListSessionsResponse> {
     return this.request<ListSessionsResponse>('list_sessions', { agentId, cwd, cursor })
+  }
+
+  async registerDiscoveredSession(input: {
+    sessionId: SessionId
+    agentId: AgentId
+    cwd: string
+    title?: string | null
+    updatedAt?: number
+    projectId?: string
+  }): Promise<PersistedSessionSummary> {
+    return this.request<PersistedSessionSummary>('register_discovered_session', input)
   }
 
   async sendPrompt(

--- a/src/renderer/stores/acp-store.ts
+++ b/src/renderer/stores/acp-store.ts
@@ -48,6 +48,7 @@ import {
   type AuthMethod,
   type AvailableCommand,
   acpApi,
+  acpRegisterDiscoveredSession,
   type CommandsUpdateEvent,
   type ConfigOptionsUpdateEvent,
   type ContentBlock,
@@ -85,6 +86,7 @@ import {
 import { AcpConnectionCoordinator, type AcpRecovery } from '@/lib/acp-connection'
 import {
   deriveTitle,
+  fromPersistedSessionSummary,
   getCachedSessionPayload,
   loadSessionIndex as loadSessionIndexFromDisk,
   loadSessionPayload,
@@ -4023,6 +4025,7 @@ export const useAcpStore = create<AcpState>((set, get) => ({
     // clobbers another cwd's results, and a slow in-flight discovery for one cwd
     // can't overwrite a newer cwd's results.
     const key = discoveryKey(agentId, cwd)
+    const projectIdAtStart = useProjectStore.getState().activeProjectId || undefined
 
     // Prevent duplicate concurrent discovery for the same (agent, cwd).
     if (get().discoveringKeys[key]) return
@@ -4060,6 +4063,42 @@ export const useAcpStore = create<AcpState>((set, get) => ({
       // be sensitive). Detailed payloads stay out of the console.
       console.info(`[acp] discoverSessions: agent ${agentId} returned ${all.length} session(s)`)
       set((s) => ({ discoveredSessions: { ...s.discoveredSessions, [key]: all } }))
+
+      // Promote newly discovered metadata into host persistence. The agent
+      // remains the transcript authority: this command creates metadata only.
+      const existingIds = new Set(get().sessionIndex.map((entry) => entry.id))
+      const promoted: SessionIndexEntry[] = []
+      for (const info of all) {
+        if (existingIds.has(info.sessionId)) continue
+        try {
+          const updatedAt = info.updatedAt ? Date.parse(info.updatedAt) : Number.NaN
+          const summary = await acpRegisterDiscoveredSession({
+            sessionId: info.sessionId,
+            agentId,
+            cwd,
+            title: info.title,
+            updatedAt: Number.isFinite(updatedAt) ? updatedAt : undefined,
+            projectId: projectIdAtStart
+          })
+          promoted.push(fromPersistedSessionSummary(summary))
+          existingIds.add(info.sessionId)
+        } catch (error) {
+          void logFrontendError({
+            level: 'warn',
+            source: 'acp.discoverSessions',
+            message: `Failed to promote discovered session metadata: ${error instanceof Error ? error.message : String(error)}`
+          })
+        }
+      }
+      if (promoted.length > 0) {
+        const promotedIds = new Set(promoted.map((entry) => entry.id))
+        set((s) => ({
+          sessionIndex: [
+            ...promoted,
+            ...s.sessionIndex.filter((entry) => !promotedIds.has(entry.id))
+          ]
+        }))
+      }
     } catch (e) {
       // Best-effort: log warning, don't toast (discovery is opportunistic).
       console.warn('[acp] session/list failed for agent', agentId, e)

--- a/src/shared/types/web-protocol.types.test.ts
+++ b/src/shared/types/web-protocol.types.test.ts
@@ -58,8 +58,8 @@ describe('web-protocol.types — event/request type registries (AC2)', () => {
     expect(WS_REQUEST_TYPES).toContain('get_session_payload')
   })
 
-  it('exports exactly 29 request types including ephemeral disposal, ping, catalog, install, and agent auth', () => {
-    expect(WS_REQUEST_TYPES).toHaveLength(29)
+  it('exports exactly 30 request types including discovered-session promotion', () => {
+    expect(WS_REQUEST_TYPES).toHaveLength(30)
     const expected = [
       'send_prompt',
       'cancel_prompt',
@@ -74,6 +74,7 @@ describe('web-protocol.types — event/request type registries (AC2)', () => {
       'close_session',
       'dispose_ephemeral_session',
       'list_sessions',
+      'register_discovered_session',
       'spawn_agent',
       'kill_agent',
       'list_agents',

--- a/src/shared/types/web-protocol.types.ts
+++ b/src/shared/types/web-protocol.types.ts
@@ -117,6 +117,7 @@ export const WS_REQUEST_TYPES = [
   'close_session',
   'dispose_ephemeral_session',
   'list_sessions',
+  'register_discovered_session',
   'spawn_agent',
   'kill_agent',
   'list_agents',

--- a/src/shared/types/web-protocol.types.ts
+++ b/src/shared/types/web-protocol.types.ts
@@ -282,6 +282,8 @@ export interface PersistedSessionSummary {
   messageCount: number
   toolCount: number
   lastSeq: number
+  /** Agent-owned metadata mirror; transcript remains authoritative in the agent. */
+  discovered?: boolean
   resumeEligible: boolean
   /**
    * Worktree path the agent runs in (CAP-3). Additive: absent on pre-feature


### PR DESCRIPTION
## Summary

- Restore ACP-discovered chat history visibility and make agent-supplied session titles durable across desktop and web transports.
- Add a host-injected `termul_set_session_title` MCP tool so agents can title chats during a turn without racing transcript sequence allocation.
- Promote discovered sessions as metadata-only host records while preserving agent-owned transcript loading and resume behavior.

This fixes two related user-facing failures: CLI/agent-native sessions disappeared from the Chats tab, and chat titles remained generic or stale because the host could not reliably accept and persist the agent's title.

## Related Issue

Closes #404
Closes #407

Searched open and closed PRs for chat-history/session-title duplicates. PR #541 addresses persisted tool-call replay, not discovered-session visibility or title persistence.

## Type of Change

- [ ] feat: new feature
- [x] fix: bug fix
- [ ] docs: documentation only
- [ ] style: formatting or non-functional styling changes
- [ ] refactor: internal cleanup with no behavior change
- [ ] perf: performance improvement
- [x] test: adds or updates tests
- [ ] build: build or dependency changes
- [ ] ci: CI/CD workflow changes
- [ ] chore: maintenance or tooling
- [ ] revert: reverts a previous change

## What Changed

- Added authenticated MCP title frames with validation, legacy plan-frame compatibility, active-turn routing, writer-owned sequencing, persistence, and `session_info_update` broadcasts.
- Added metadata-only discovered-session registration for Tauri and WebSocket transports, including atomic registration, scope validation, rediscovery refresh, and cleanup on persistence failure.
- Updated renderer discovery/index merging so promoted sessions remain visible and open through `openDiscoveredSession` rather than local transcript replay.
- Unified title derivation and normalization around first-line cleanup and Unicode-safe 48-character truncation.
- Added focused Rust and renderer coverage for title persistence, WS promotion, transport parity, discovery visibility, and promoted-session routing.

## How It Was Tested

- [ ] `bun run ci` (Biome lint + format + imports, strict mode)
- [x] `bun run typecheck`
- [x] `bun run test` — focused five-file suite, 156 tests passed
- [x] `cargo clippy --all-targets -- -D warnings` (in src-tauri) — equivalent changed-target validation: `cargo clippy --manifest-path src-tauri/Cargo.toml --lib -- -D warnings`
- [ ] `cargo test` (in src-tauri) — binaries compile but cannot start in this Windows environment (`STATUS_ENTRYPOINT_NOT_FOUND` / `0xc0000139`)
- [ ] Manual verification completed
- [ ] Not applicable

Additional validation:

- `cargo check --manifest-path src-tauri/Cargo.toml --lib`
- Focused Biome checks on all changed renderer/shared files
- `git diff --check`

## Screenshots or Recordings

Not included. This restores existing Chats-tab behavior rather than introducing a new visual design.

## CI & Review Gate

- [ ] All CI checks pass (PR Validation, Rust Checks, Build Verification, Security Scans)
- [ ] Code review comments from CodeRabbit / Claude have been addressed or resolved
- [ ] No unresolved review findings remain

## Checklist

- [x] My PR title follows the conventional commit format used by this repo
- [x] I linked the related issue or explained why none exists
- [x] I updated docs when needed
- [x] I added or updated tests when needed
- [x] I verified the change does not introduce unrelated modifications
- [x] I read AGENTS.md and followed the contributor guidelines
- [x] A human reviewed the complete diff before submission


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Discovered agent sessions are automatically registered, persisted, and shown in chat history with working-directory details.
  - Session titles can be updated and saved locally.
  - Added support for Grok Build, Harn, and siGit Code.
  - Updated supported agent versions and download information.

- **Improvements**
  - Session titles are normalized and safely limited to 48 characters.
  - Session discovery preserves metadata and avoids duplicate entries.
  - Improved synchronization across supported connection types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->