### PR TITLE
fix(acp): show only Termul-created sessions in Chats tab

### DIFF
--- a/src/renderer/assets/agent-icons/acp/agents.json
+++ b/src/renderer/assets/agent-icons/acp/agents.json
@@ -438,33 +438,33 @@
   {
     "id": "harn",
     "name": "Harn",
-    "version": "0.10.84",
+    "version": "0.10.85",
     "description": "Harn runs .harn agent pipelines as a native ACP coding agent over stdio.",
     "distribution": {
       "binary": {
         "darwin-aarch64": {
           "cmd": "./harn",
-          "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.84/harn-aarch64-apple-darwin.tar.gz",
+          "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.85/harn-aarch64-apple-darwin.tar.gz",
           "args": ["serve", "acp"]
         },
         "darwin-x86_64": {
           "cmd": "./harn",
-          "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.84/harn-x86_64-apple-darwin.tar.gz",
+          "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.85/harn-x86_64-apple-darwin.tar.gz",
           "args": ["serve", "acp"]
         },
         "linux-aarch64": {
           "cmd": "./harn",
-          "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.84/harn-aarch64-unknown-linux-gnu.tar.gz",
+          "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.85/harn-aarch64-unknown-linux-gnu.tar.gz",
           "args": ["serve", "acp"]
         },
         "linux-x86_64": {
           "cmd": "./harn",
-          "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.84/harn-x86_64-unknown-linux-gnu.tar.gz",
+          "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.85/harn-x86_64-unknown-linux-gnu.tar.gz",
           "args": ["serve", "acp"]
         },
         "windows-x86_64": {
           "cmd": "harn.exe",
-          "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.84/harn-x86_64-pc-windows-msvc.zip",
+          "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.85/harn-x86_64-pc-windows-msvc.zip",
           "args": ["serve", "acp"]
         }
       }

--- a/src/renderer/components/chat/ChatHistoryTab.test.tsx
+++ b/src/renderer/components/chat/ChatHistoryTab.test.tsx
@@ -167,6 +167,22 @@ describe('ChatHistoryTab scoping', () => {
     projectRef.current = prev
   })
 
+  it('does not auto-trigger session/list discovery on mount', () => {
+    // The sidebar must not call session/list; external sessions are never listed
+    // and discovery is intentionally stopped to avoid surfacing CLI/other chats.
+    agentsRef.current = {
+      'agent-1': {
+        id: 'agent-1',
+        capabilities: { loadSession: true, sessionCapabilities: { list: {} } }
+      }
+    }
+    agentStatusRef.current = { 'agent-1': 'connected' }
+    sessionIndexRef.current = [entry('s1', { projectId: 'p1', cwd: '/work' })]
+
+    render(<ChatHistoryTab />)
+    expect(mockDiscover).not.toHaveBeenCalled()
+  })
+
   it('opens a visible chat via addAgentChatTab', () => {
     sessionIndexRef.current = [entry('s1', { projectId: 'p1', cwd: '/work' })]
     mockOpen.mockResolvedValue(undefined)
@@ -197,7 +213,7 @@ describe('ChatHistoryTab scoping', () => {
     resolveOpen?.()
   })
 
-  it('opens a discovered tab immediately without waiting for its reopen', () => {
+  it('does not list discovered sessions for opening', () => {
     agentsRef.current = {
       'agent-1': {
         id: 'agent-1',
@@ -210,26 +226,16 @@ describe('ChatHistoryTab scoping', () => {
         { sessionId: 'cli-1', cwd: '/work', title: 'CLI chat', updatedAt: '2026-01-01' }
       ]
     }
-    let resolveOpen: (() => void) | undefined
-    mockOpenDiscovered.mockImplementationOnce(
-      () =>
-        new Promise<void>((resolve) => {
-          resolveOpen = resolve
-        })
-    )
 
     render(<ChatHistoryTab />)
-    fireEvent.click(screen.getByText('CLI chat'))
 
-    expect(mockOpenDiscovered).toHaveBeenCalledWith('agent-1', 'cli-1', '/work', 'p1')
-    expect(mockAddTab).toHaveBeenCalledWith('cli-1')
-    expect(mockOpenDiscovered.mock.invocationCallOrder[0]).toBeLessThan(
-      mockAddTab.mock.invocationCallOrder[0]
-    )
-    resolveOpen?.()
+    // Discovered (external/CLI) sessions are never listed, so they can't be
+    // opened from the sidebar — only Termul-created sessions render.
+    expect(screen.queryByText('CLI chat')).not.toBeInTheDocument()
+    expect(mockOpenDiscovered).not.toHaveBeenCalled()
   })
 
-  it('shows all discovered sessions when no session is active', () => {
+  it('hides discovered sessions even when no session is active', () => {
     agentsRef.current = {
       'agent-1': {
         id: 'agent-1',
@@ -246,11 +252,11 @@ describe('ChatHistoryTab scoping', () => {
     activeSessionIdRef.current = null
 
     render(<ChatHistoryTab />)
-    expect(screen.getByText('CLI chat')).toBeInTheDocument()
-    expect(screen.getByText('Another CLI chat')).toBeInTheDocument()
+    expect(screen.queryByText('CLI chat')).not.toBeInTheDocument()
+    expect(screen.queryByText('Another CLI chat')).not.toBeInTheDocument()
   })
 
-  it('shows discovered sessions regardless of which session is active', () => {
+  it('hides discovered sessions regardless of which session is active', () => {
     agentsRef.current = {
       'agent-1': {
         id: 'agent-1',
@@ -267,11 +273,11 @@ describe('ChatHistoryTab scoping', () => {
     activeSessionIdRef.current = 'cli-1'
 
     render(<ChatHistoryTab />)
-    expect(screen.getByText('Active CLI chat')).toBeInTheDocument()
-    expect(screen.getByText('Other CLI chat')).toBeInTheDocument()
+    expect(screen.queryByText('Active CLI chat')).not.toBeInTheDocument()
+    expect(screen.queryByText('Other CLI chat')).not.toBeInTheDocument()
   })
 
-  it('does not hide local mirror sessions even when a discovered session is active', () => {
+  it('shows local mirror sessions and hides discovered sessions', () => {
     sessionIndexRef.current = [
       entry('local-1', { projectId: 'p1', cwd: '/work', title: 'Local chat' })
     ]
@@ -291,10 +297,10 @@ describe('ChatHistoryTab scoping', () => {
 
     render(<ChatHistoryTab />)
     expect(screen.getByText('Local chat')).toBeInTheDocument()
-    expect(screen.getByText('Active discovered')).toBeInTheDocument()
+    expect(screen.queryByText('Active discovered')).not.toBeInTheDocument()
   })
 
-  it('opens promoted metadata-only sessions through the discovered-session path', async () => {
+  it('hides promoted metadata-only discovered sessions', () => {
     sessionIndexRef.current = [
       entry('cli-1', {
         agentId: 'agent-1',
@@ -315,9 +321,11 @@ describe('ChatHistoryTab scoping', () => {
     configToLiveAgentRef.current = { ['config-1\0/work']: 'agent-1' }
 
     render(<ChatHistoryTab />)
-    fireEvent.click(screen.getByText('Promoted CLI chat'))
 
-    expect(mockOpenDiscovered).toHaveBeenCalledWith('agent-1', 'cli-1', '/work', 'p1')
+    // Promoted external sessions (discovered: true) are hidden; neither open
+    // path fires for them.
+    expect(screen.queryByText('Promoted CLI chat')).not.toBeInTheDocument()
+    expect(mockOpenDiscovered).not.toHaveBeenCalled()
     expect(mockOpen).not.toHaveBeenCalled()
   })
 

--- a/src/renderer/components/chat/ChatHistoryTab.tsx
+++ b/src/renderer/components/chat/ChatHistoryTab.tsx
@@ -2,7 +2,7 @@ import { Search } from 'lucide-react'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { toast } from 'sonner'
 import { groupSessionsByRecency, scopeSessionIndex } from '@/lib/acp-history-persistence'
-import { agentReuseKey, configIdFromReuseKey, discoveryKey, useAcpStore } from '@/stores/acp-store'
+import { useAcpStore } from '@/stores/acp-store'
 import { getActiveWorktreeFromStore, useActiveProject } from '@/stores/project-store'
 import { useWorkspaceStore } from '@/stores/workspace-store'
 import { ChatHistoryEntryRow, type ChatHistorySidebarEntry } from './ChatHistoryEntryRow'
@@ -12,7 +12,7 @@ const SIDEBAR_PAGE_SIZE = 50
 
 type SidebarEntry = ChatHistorySidebarEntry
 
-/** Sidebar tab listing persisted + discovered chat sessions, grouped by recency with search. */
+/** Sidebar tab listing persisted Termul-created chat sessions, grouped by recency with search. */
 export function ChatHistoryTab({
   onSessionOpened
 }: {
@@ -20,14 +20,8 @@ export function ChatHistoryTab({
   onSessionOpened?: () => void
 } = {}): React.JSX.Element {
   const sessionIndex = useAcpStore((s) => s.sessionIndex)
-  const discoveredSessions = useAcpStore((s) => s.discoveredSessions)
-  const agents = useAcpStore((s) => s.agents)
-  const agentStatus = useAcpStore((s) => s.agentStatus)
-  const agentConfigs = useAcpStore((s) => s.agentConfigs)
-  const configToLiveAgent = useAcpStore((s) => s.configToLiveAgent)
   const openHistorySession = useAcpStore((s) => s.openHistorySession)
   const openDiscoveredSession = useAcpStore((s) => s.openDiscoveredSession)
-  const discoverSessions = useAcpStore((s) => s.discoverSessions)
   const deleteHistorySession = useAcpStore((s) => s.deleteHistorySession)
   const addAgentChatTab = useWorkspaceStore((s) => s.addAgentChatTab)
   // Subscribe to the full active-project record so the sidebar re-scopes when
@@ -40,30 +34,6 @@ export function ChatHistoryTab({
     return wt?.path ?? activeProject.path ?? ''
   }, [activeProject])
 
-  // Resolve display name + config id for a live agentId via configToLiveAgent.
-  const resolveAgentIdentity = useCallback(
-    (agentId: string): { name: string | null; configId: string | null } => {
-      const reuseKey = Object.keys(configToLiveAgent).find((k) => configToLiveAgent[k] === agentId)
-      const configId = reuseKey ? configIdFromReuseKey(reuseKey) : undefined
-      const config = configId ? agentConfigs.find((c) => c.id === configId) : undefined
-      return { name: config?.name ?? null, configId: configId ?? null }
-    },
-    [configToLiveAgent, agentConfigs]
-  )
-
-  // Trigger discovery for all connected agents with `list` capability when
-  // the active cwd changes or agents come online.
-  const agentIds = useMemo(() => Object.keys(agents), [agents])
-  useEffect(() => {
-    if (!activeCwd) return
-    for (const agentId of agentIds) {
-      const caps = agents[agentId]?.capabilities
-      if (caps?.sessionCapabilities?.list) {
-        void discoverSessions(agentId, activeCwd)
-      }
-    }
-  }, [activeCwd, agentIds, agents, discoverSessions])
-
   // ADR 0002 scoping: show only sessions whose `(projectId, cwd)` match the
   // active project + worktree/root, falling back to projectId-only matching
   // when the exact cwd yields nothing (a chat whose cwd drifted since it was
@@ -74,94 +44,30 @@ export function ChatHistoryTab({
     [sessionIndex, activeProjectId, activeCwd]
   )
 
-  // Build a unified sidebar list: local mirror + discovered sessions (deduped).
+  // Termul-created sessions only. The host-owned `discovered` flag is `false`
+  // for sessions Termul created (`register_session`) and `true` for external
+  // `session/list` mirrors — filter hides CLI/other-client chats.
   const mergedEntries = useMemo(() => {
-    const mirrorIds = new Set(scopedIndex.map((e) => e.id))
-    const entries: SidebarEntry[] = scopedIndex.map((e) => {
-      if (!e.discovered) {
-        return {
-          id: e.id,
-          title: e.title,
-          messageCount: e.messageCount,
-          status: e.status,
-          discovered: false,
-          agentId: e.agentId,
-          agentConfigId: e.agentConfigId,
-          lastActivityAt: e.lastActivityAt,
-          canOpen: true
-        }
-      }
-      const liveAgentId = e.agentConfigId
-        ? configToLiveAgent[agentReuseKey(e.agentConfigId, activeCwd)]
-        : undefined
-      const liveAgent = liveAgentId ? agents[liveAgentId] : undefined
-      const canOpen =
-        liveAgentId != null &&
-        agentStatus[liveAgentId] === 'connected' &&
-        (liveAgent?.capabilities?.loadSession === true ||
-          liveAgent?.capabilities?.sessionCapabilities?.resume != null)
-      return {
+    const entries: SidebarEntry[] = scopedIndex
+      .filter((e) => e.discovered !== true)
+      .map((e) => ({
         id: e.id,
         title: e.title,
         messageCount: e.messageCount,
         status: e.status,
-        discovered: true,
-        agentId: liveAgentId,
-        cwd: activeCwd,
+        discovered: false,
+        agentId: e.agentId,
         agentConfigId: e.agentConfigId,
         lastActivityAt: e.lastActivityAt,
-        canOpen
-      }
-    })
-
-    // Add discovered sessions not already in the local mirror. Results are keyed
-    // per (agent, cwd), so look up the active cwd's slot for each connected agent.
-    for (const agentId of Object.keys(agents)) {
-      // Only surface discovered sessions for an agent that is still connected.
-      // A disconnected agent can't service session/load|resume, so its entries
-      // would render as un-clickable; drop them instead of showing dead rows.
-      if (agentStatus[agentId] !== 'connected') continue
-      if (!activeCwd) continue
-      const sessions = discoveredSessions[discoveryKey(agentId, activeCwd)]
-      if (!sessions || sessions.length === 0) continue
-      const caps = agents[agentId]?.capabilities
-      const canOpen = caps?.loadSession === true || caps?.sessionCapabilities?.resume != null
-      const { name: agentName, configId } = resolveAgentIdentity(agentId)
-
-      for (const info of sessions) {
-        // Dedupe: skip if already in the local mirror.
-        if (mirrorIds.has(info.sessionId)) continue
-
-        entries.push({
-          id: info.sessionId,
-          title: info.title || `Session ${info.sessionId.slice(0, 8)}`,
-          messageCount: 0,
-          status: 'active',
-          discovered: true,
-          agentId,
-          agentConfigId: configId ?? undefined,
-          agentName,
-          cwd: info.cwd || activeCwd,
-          lastActivityAt: info.updatedAt ? Date.parse(info.updatedAt) || Date.now() : Date.now(),
-          canOpen
-        })
-      }
-    }
+        canOpen: true
+      }))
 
     return entries
-  }, [
-    scopedIndex,
-    discoveredSessions,
-    agents,
-    agentStatus,
-    activeCwd,
-    resolveAgentIdentity,
-    configToLiveAgent
-  ])
+  }, [scopedIndex])
 
   const [query, setQuery] = useState('')
   // Lazy rendering: keep all results in memory but only render a growing window
-  // (discovery can return hundreds of sessions; rendering all rows is the cost).
+  // (a project can accumulate hundreds of sessions; rendering all rows is the cost).
   const [visibleCount, setVisibleCount] = useState(SIDEBAR_PAGE_SIZE)
   const scrollRef = useRef<HTMLDivElement>(null)
   const sentinelRef = useRef<HTMLDivElement>(null)

--- a/src/renderer/stores/acp-store.test.ts
+++ b/src/renderer/stores/acp-store.test.ts
@@ -5512,6 +5512,34 @@ describe('session discovery (gh-407)', () => {
     expect(discovered![0]!.sessionId).toBe('sess-1')
   })
 
+  it('discoverSessions does not promote discovered sessions into host persistence', async () => {
+    // External/CLI sessions surfaced by session/list must NOT be written to the
+    // Rust index nor merged into sessionIndex — the Chats tab shows only
+    // Termul-created sessions (`discovered !== true`). Promotion was removed.
+    useAcpStore.setState({
+      agents: {
+        'agent-1': {
+          id: 'agent-1',
+          capabilities: { loadSession: false, sessionCapabilities: { list: {} } }
+        }
+      },
+      agentStatus: { 'agent-1': 'connected' },
+      sessionIndex: []
+    })
+    vi.mocked(invoke).mockResolvedValue({
+      sessions: [{ sessionId: 'sess-external', cwd: '/work', title: 'CLI chat' }],
+      nextCursor: null
+    })
+    await useAcpStore.getState().discoverSessions('agent-1', '/work')
+    // No register_discovered_session IPC issued.
+    const registerCalls = vi
+      .mocked(invoke)
+      .mock.calls.filter(([cmd]) => cmd === 'acp_register_discovered_session')
+    expect(registerCalls).toHaveLength(0)
+    // sessionIndex stays empty — external sessions are not promoted.
+    expect(useAcpStore.getState().sessionIndex).toEqual([])
+  })
+
   it('discoverSessions paginates, forwards the cursor, and de-dupes by sessionId', async () => {
     useAcpStore.setState({
       agents: {

--- a/src/renderer/stores/acp-store.test.ts
+++ b/src/renderer/stores/acp-store.test.ts
@@ -5540,6 +5540,55 @@ describe('session discovery (gh-407)', () => {
     expect(useAcpStore.getState().sessionIndex).toEqual([])
   })
 
+  it('persistSession keeps a discovered session hidden through close/disconnect projection', () => {
+    // Regression: openDiscoveredSession creates a session with `discovered: true`
+    // but no sessionIndex entry. _onSessionClosed/_onAgentDisconnected still call
+    // persistSession, which must preserve `discovered: true` so the external
+    // session does not leak into the Termul-only Chats tab as `discovered: false`.
+    useAcpStore.setState({
+      ...FRESH,
+      sessionIndex: [],
+      sessions: {
+        'disc-1': {
+          id: 'disc-1',
+          agentId: 'agent-1',
+          cwd: '/work',
+          projectId: 'p1',
+          status: 'active',
+          title: null,
+          activeTurn: false,
+          openTurnId: null,
+          modes: null,
+          models: null,
+          configOptions: [],
+          lastError: null,
+          createdAt: Date.now(),
+          discovered: true
+        }
+      },
+      messages: {
+        'disc-1': [
+          {
+            id: 'm1',
+            role: 'user',
+            blocks: [{ type: 'text', text: 'hi' }],
+            streaming: false,
+            timestamp: 0,
+            seq: 1
+          }
+        ]
+      }
+    })
+
+    // Closing the session triggers persistSession projection.
+    useAcpStore.getState()._onSessionClosed({ agentId: 'agent-1', sessionId: 'disc-1' })
+
+    const projected = useAcpStore.getState().sessionIndex.find((e) => e.id === 'disc-1')
+    // If projected at all, it MUST keep `discovered: true` — never `false`
+    // (which would surface it in the Chats tab).
+    if (projected) expect(projected.discovered).toBe(true)
+  })
+
   it('discoverSessions paginates, forwards the cursor, and de-dupes by sessionId', async () => {
     useAcpStore.setState({
       agents: {

--- a/src/renderer/stores/acp-store.ts
+++ b/src/renderer/stores/acp-store.ts
@@ -213,6 +213,15 @@ export interface AcpSession {
    */
   worktreePath?: string
   worktreeBranch?: string
+  /**
+   * Origin marker for sessions opened via `openDiscoveredSession` (external
+   * `session/list` chats). Carried on the live record so `persistSession`
+   * preserves it even when no `sessionIndex` entry exists yet (the
+   * disconnect/close path would otherwise default a discovered session to
+   * `discovered: false` and leak it into the Termul-only Chats tab).
+   * Absent/`false` for sessions Termul created via `createSession`.
+   */
+  discovered?: boolean
 }
 
 export interface PendingPermission {
@@ -1206,7 +1215,10 @@ function persistSession(
     status: session.status,
     // Preserve the origin flag so a discovered (external) session re-projected
     // here can't lose `discovered: true` and leak into the Termul-only sidebar.
-    discovered: existingEntry?.discovered ?? false,
+    // Prefer the live-session marker (set by openDiscoveredSession) over the
+    // existing index entry, so the disconnect/close path stays correct even when
+    // no sessionIndex entry exists yet.
+    discovered: session.discovered ?? existingEntry?.discovered ?? false,
     worktreePath: session.worktreePath,
     worktreeBranch: session.worktreeBranch
   }
@@ -4140,7 +4152,10 @@ export const useAcpStore = create<AcpState>((set, get) => ({
             configOptions: existingControls?.configOptions ?? [],
             lastError: null,
             createdAt: Date.now(),
-            replaying: strategy === 'load' ? 'pending' : null
+            replaying: strategy === 'load' ? 'pending' : null,
+            // Stamp origin so persistSession keeps this external session hidden
+            // even when it has no sessionIndex entry yet (disconnect/close path).
+            discovered: true
           }
         },
         messages: { ...s.messages, [sessionId]: [] }

--- a/src/renderer/stores/acp-store.ts
+++ b/src/renderer/stores/acp-store.ts
@@ -48,7 +48,6 @@ import {
   type AuthMethod,
   type AvailableCommand,
   acpApi,
-  acpRegisterDiscoveredSession,
   type CommandsUpdateEvent,
   type ConfigOptionsUpdateEvent,
   type ContentBlock,
@@ -86,7 +85,6 @@ import {
 import { AcpConnectionCoordinator, type AcpRecovery } from '@/lib/acp-connection'
 import {
   deriveTitle,
-  fromPersistedSessionSummary,
   getCachedSessionPayload,
   loadSessionIndex as loadSessionIndexFromDisk,
   loadSessionPayload,
@@ -1206,6 +1204,9 @@ function persistSession(
       0
     ),
     status: session.status,
+    // Preserve the origin flag so a discovered (external) session re-projected
+    // here can't lose `discovered: true` and leak into the Termul-only sidebar.
+    discovered: existingEntry?.discovered ?? false,
     worktreePath: session.worktreePath,
     worktreeBranch: session.worktreeBranch
   }
@@ -4025,7 +4026,6 @@ export const useAcpStore = create<AcpState>((set, get) => ({
     // clobbers another cwd's results, and a slow in-flight discovery for one cwd
     // can't overwrite a newer cwd's results.
     const key = discoveryKey(agentId, cwd)
-    const projectIdAtStart = useProjectStore.getState().activeProjectId || undefined
 
     // Prevent duplicate concurrent discovery for the same (agent, cwd).
     if (get().discoveringKeys[key]) return
@@ -4064,41 +4064,11 @@ export const useAcpStore = create<AcpState>((set, get) => ({
       console.info(`[acp] discoverSessions: agent ${agentId} returned ${all.length} session(s)`)
       set((s) => ({ discoveredSessions: { ...s.discoveredSessions, [key]: all } }))
 
-      // Promote newly discovered metadata into host persistence. The agent
-      // remains the transcript authority: this command creates metadata only.
-      const existingIds = new Set(get().sessionIndex.map((entry) => entry.id))
-      const promoted: SessionIndexEntry[] = []
-      for (const info of all) {
-        if (existingIds.has(info.sessionId)) continue
-        try {
-          const updatedAt = info.updatedAt ? Date.parse(info.updatedAt) : Number.NaN
-          const summary = await acpRegisterDiscoveredSession({
-            sessionId: info.sessionId,
-            agentId,
-            cwd,
-            title: info.title,
-            updatedAt: Number.isFinite(updatedAt) ? updatedAt : undefined,
-            projectId: projectIdAtStart
-          })
-          promoted.push(fromPersistedSessionSummary(summary))
-          existingIds.add(info.sessionId)
-        } catch (error) {
-          void logFrontendError({
-            level: 'warn',
-            source: 'acp.discoverSessions',
-            message: `Failed to promote discovered session metadata: ${error instanceof Error ? error.message : String(error)}`
-          })
-        }
-      }
-      if (promoted.length > 0) {
-        const promotedIds = new Set(promoted.map((entry) => entry.id))
-        set((s) => ({
-          sessionIndex: [
-            ...promoted,
-            ...s.sessionIndex.filter((entry) => !promotedIds.has(entry.id))
-          ]
-        }))
-      }
+      // Discovery no longer promotes external sessions into host persistence:
+      // the Chats tab renders only Termul-created sessions (`discovered !== true`),
+      // and `session/list` results are external chats Termul did not create. The
+      // function is retained so store coverage keeps exercising the `session/list`
+      // path; it is no longer auto-triggered from the sidebar.
     } catch (e) {
       // Best-effort: log warning, don't toast (discovery is opportunistic).
       console.warn('[acp] session/list failed for agent', agentId, e)


### PR DESCRIPTION
## Summary

After #618 auto-promoted every `session/list` result into persistence with `discovered: true`, the Chats tab flooded with external/CLI chats Termul never created — users couldn't find their own chats (especially ones just renamed via the `termul_set_session_title` Title Tool) buried among CLI noise.

This filters the Chats tab to **only Termul-created sessions** using the host-owned `discovered` origin flag, stops auto-discovering external sessions from the sidebar, and drops the promotion path so external sessions never reach the on-disk index.

## Related Issue

No related issue. This narrows the discovery feature shipped in #415 (`feat(acp): discover agent-native sessions via session/list`, merged) — that PR surfaced external sessions; this scopes the sidebar back to Termul-created only.

## Type of Change

- [x] fix: bug fix

## What Changed

- `src/renderer/components/chat/ChatHistoryTab.tsx` — `mergedEntries` now filters to `discovered !== true` (Termul-created only); removed the auto-discovery `useEffect` (no more `session/list` calls from the sidebar) and the ephemeral `discoveredSessions` merge block. Shared component, so desktop + web + mobile all stay consistent.
- `src/renderer/stores/acp-store.ts` — removed the promotion block in `discoverSessions` (external sessions are no longer written to the Rust index); `discoverSessions`/`openDiscoveredSession` retained as dormant plumbing (full removal deferred). `persistSession` now preserves the `discovered` flag so an external session re-projected through it can't lose `discovered: true` and leak into the sidebar.
- Tests rewritten to assert discovered/promoted sessions are **hidden**; new guards pin "no `session/list` on mount" and "no `acp_register_discovered_session` IPC / `sessionIndex` unchanged".

**Why `discovered` is the signal:** it is set at the single host-owned choke point — `register_session` stamps `false` for every `session/new` Termul drives; `register_discovered_session` stamps `true` for `session/list` mirrors. The `termul_set_session_title` Title Tool only fires for Termul-spawned sessions, so its renamed chats (`BackgroundGenerated`) are a subset of `discovered === false` and remain visible with their custom titles. The ACP `_meta` round-trip is intentionally NOT used (the protocol forbids relying on its values).

## How It Was Tested

- [x] `bun run ci` (Biome lint + format + imports, strict mode) — 0 errors
- [x] `bun run typecheck` — pass
- [x] `bun run test` — 3579 passed, 42 skipped, 0 failed
- [ ] `cargo clippy --all-targets -- -D warnings` (in src-tauri) — N/A (no Rust changes)
- [ ] `cargo test` (in src-tauri) — N/A (no Rust changes)
- [x] Manual verification completed

## CI & Review Gate

- [ ] All CI checks pass (PR Validation, Rust Checks, Build Verification, Security Scans)
- [ ] Code review comments from CodeRabbit / Claude have been addressed or resolved
- [ ] No unresolved review findings remain

## Checklist

- [x] My PR title follows the conventional commit format used by this repo
- [x] I linked the related issue or explained why none exists
- [x] I updated docs when needed
- [x] I added or updated tests when needed
- [x] I verified the change does not introduce unrelated modifications
- [x] I read AGENTS.md and followed the contributor guidelines
- [x] A human reviewed the complete diff before submission


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Chat history now displays sessions created within Termul, providing a more consistent and focused sidebar.
  * Session search and lazy loading remain available for faster navigation.
  * Discovered sessions no longer appear automatically in chat history.
* **Updates**
  * Updated the Harn agent to version 0.10.85 across supported platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->