### PR TITLE
refactor(acp): rename host MCP server to termul and tools to plan/set_session_title

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -102,7 +102,7 @@ agent-client-protocol = "1.3"
 #     `client-side-sse` (rmcp's SSE stream parser, consumed by the
 #     streamable-http client which still speaks `text/event-stream` after rmcp
 #     1.7 dropped the standalone legacy SSE transport — CHANGELOG #562).
-#  2. `src/acp/host_mcp/` — the host-injected `termul_plan` MCP SERVER, served
+#  2. `src/acp/host_mcp/` — the host-injected `plan` MCP SERVER, served
 #     over stdio by a self-spawned child of the host binary. Uses `server`,
 #     `transport-io` (`rmcp::transport::io::stdio()`), and `macros`
 #     (`#[tool_router]` / `#[tool]` / `#[tool_handler]`; the `#[tool]` macro

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -102,7 +102,7 @@ agent-client-protocol = "1.3"
 #     `client-side-sse` (rmcp's SSE stream parser, consumed by the
 #     streamable-http client which still speaks `text/event-stream` after rmcp
 #     1.7 dropped the standalone legacy SSE transport — CHANGELOG #562).
-#  2. `src/acp/host_mcp/` — the host-injected `plan` MCP SERVER, served
+#  2. `src/acp/host_mcp/` — the host-injected `termul` MCP SERVER (exposes the `plan` tool), served
 #     over stdio by a self-spawned child of the host binary. Uses `server`,
 #     `transport-io` (`rmcp::transport::io::stdio()`), and `macros`
 #     (`#[tool_router]` / `#[tool]` / `#[tool_handler]`; the `#[tool]` macro

--- a/src-tauri/src/acp/host_mcp/child.rs
+++ b/src-tauri/src/acp/host_mcp/child.rs
@@ -7,7 +7,7 @@
 //! `McpServer::Stdio`; the child inherits the agent-provided stdin/stdout (the
 //! MCP stdio transport).
 //!
-//! The child runs an rmcp MCP SERVER over stdio exposing the `termul_plan`
+//! The child runs an rmcp MCP SERVER over stdio exposing the `plan`
 //! tool. On each `tools/call`, it opens a fresh TCP connection to the parent
 //! (port + token from env), forwards the input, and returns the parent's reply
 //! to the agent. Minimal runtime: no Tauri plugins, no `AppHandle`, no sinks —
@@ -95,7 +95,7 @@ pub fn run() -> i32 {
     }
 }
 
-/// The rmcp MCP server service backing `termul_plan`. Holds the per-session
+/// The rmcp MCP server service backing `plan`. Holds the per-session
 /// connection info (port + token + session_id) so each `tools/call` can open a
 /// fresh TCP connection to the parent.
 struct TermulPlanServer {
@@ -113,10 +113,10 @@ struct TermulPlanServer {
 #[tool_router(server_handler)]
 impl TermulPlanServer {
     #[tool(
-        name = "termul_plan",
+        name = "plan",
         description = "Update the execution plan / todo list shown in the Termul plan panel. Call this instead of a built-in todo tool so the user sees a unified plan UI across all agents."
     )]
-    async fn termul_plan(&self, Parameters(input): Parameters<TermulPlanInput>) -> String {
+    async fn plan(&self, Parameters(input): Parameters<TermulPlanInput>) -> String {
         let request = FrameRequest {
             token: self.config.token.clone(),
             session_id: self.config.session_id.clone(),
@@ -126,15 +126,15 @@ impl TermulPlanServer {
         };
         match forward_to_parent(&self.config, request, "plan updated").await {
             Ok(msg) => msg,
-            Err(e) => format!("termul_plan error: {e}"),
+            Err(e) => format!("plan error: {e}"),
         }
     }
 
     #[tool(
-        name = "termul_set_session_title",
+        name = "set_session_title",
         description = "Set a concise title for the current Termul chat session. Call this during the first turn as soon as the user's intent is clear."
     )]
-    async fn termul_set_session_title(
+    async fn set_session_title(
         &self,
         Parameters(input): Parameters<TermulSetTitleInput>,
     ) -> String {
@@ -147,7 +147,7 @@ impl TermulPlanServer {
         };
         match forward_to_parent(&self.config, request, "title updated").await {
             Ok(msg) => msg,
-            Err(e) => format!("termul_set_session_title error: {e}"),
+            Err(e) => format!("set_session_title error: {e}"),
         }
     }
 }

--- a/src-tauri/src/acp/host_mcp/child.rs
+++ b/src-tauri/src/acp/host_mcp/child.rs
@@ -114,7 +114,7 @@ struct TermulPlanServer {
 impl TermulPlanServer {
     #[tool(
         name = "plan",
-        description = "Update the execution plan / todo list shown in the Termul plan panel. Call this instead of a built-in todo tool so the user sees a unified plan UI across all agents."
+        description = "Update the execution plan / todo list shown in the Termul plan panel. You MUST call this instead of any built-in todo/task tool — do not maintain your own todo list. Every time you would create or update a task, call this tool so the user sees a unified plan UI across all agents."
     )]
     async fn plan(&self, Parameters(input): Parameters<TermulPlanInput>) -> String {
         let request = FrameRequest {
@@ -132,7 +132,7 @@ impl TermulPlanServer {
 
     #[tool(
         name = "set_session_title",
-        description = "Set a concise title for the current Termul chat session. Call this during the first turn as soon as the user's intent is clear."
+        description = "Set a concise title for the current Termul chat session. Call this EXACTLY ONCE per session, during the first turn, as soon as the user's intent is clear. Do not call it again for the same session — subsequent calls are ignored."
     )]
     async fn set_session_title(
         &self,

--- a/src-tauri/src/acp/host_mcp/mod.rs
+++ b/src-tauri/src/acp/host_mcp/mod.rs
@@ -1,4 +1,4 @@
-//! Host-injected `termul_plan` MCP tool — first-class plan UI for every ACP agent.
+//! Host-injected `plan` MCP tool — first-class plan UI for every ACP agent.
 //!
 //! Termul auto-injects a host-side MCP server into every `session/new`
 //! `mcp_servers` list (see `AcpManager::new_session_with_context`). The agent
@@ -14,7 +14,7 @@
 //! - `child` — `--internal-mcp-plan-server` subcommand entrypoint. The agent
 //!   spawns `current_exe()` with this flag (the McpServer::Stdio config built
 //!   in `new_session_with_context`). Runs an rmcp MCP SERVER over stdio
-//!   exposing `termul_plan`; on each call, opens a fresh TCP connection to the
+//!   exposing `plan`; on each call, opens a fresh TCP connection to the
 //!   parent, forwards the input, returns the parent's reply.
 //!
 //! Desktop + standalone parity: no `tauri-plugin-mcp-bridge` / `AppHandle` —
@@ -58,7 +58,7 @@ pub const ENV_TOKEN: &str = "TERMUL_PLAN_TOKEN";
 pub const ENV_SESSION_ID: &str = "TERMUL_PLAN_SESSION_ID";
 pub const ENV_AGENT_ID: &str = "TERMUL_PLAN_AGENT_ID";
 
-/// Input the agent sends to `termul_plan` (the `arguments` of `tools/call`).
+/// Input the agent sends to `plan` (the `arguments` of `tools/call`).
 /// Also re-used as the parent–child TCP frame body (one todo per plan entry).
 #[derive(Debug, Clone, Deserialize, Serialize, schemars::JsonSchema)]
 pub struct TermulPlanInput {
@@ -67,7 +67,7 @@ pub struct TermulPlanInput {
     pub todos: Vec<TermulPlanTodo>,
 }
 
-/// Input the agent sends to `termul_set_session_title`.
+/// Input the agent sends to `set_session_title`.
 #[derive(Debug, Clone, Deserialize, Serialize, schemars::JsonSchema)]
 pub struct TermulSetTitleInput {
     /// Concise title for the current chat session.

--- a/src-tauri/src/acp/host_mcp/parent.rs
+++ b/src-tauri/src/acp/host_mcp/parent.rs
@@ -59,8 +59,12 @@ pub struct HostPlanServer {
     /// authoritative turn registry lets `process_request` repair that stale
     /// token binding when exactly one session for the agent is active.
     active_turns: Mutex<HashMap<String, HashSet<String>>>,
-    /// Sessions that already accepted a title during the current active turn.
-    title_calls_this_turn: Mutex<HashSet<String>>,
+    /// Sessions that have already set a title. Per-session (not per-turn): the
+    /// first `set_session_title` call persists + broadcasts; subsequent calls
+    /// for the same session return a success no-op so the agent stops
+    /// retrying. Cleared on `unregister_session`. In-memory only — a resumed
+    /// session in a new process can set the title once again.
+    title_set_for_session: Mutex<HashSet<String>>,
     /// Per-session plan cache (emit-and-cache). v1 doesn't persist; this is
     /// the seam a future persistence layer reads from on resume. Updated in
     /// `process_request` (set on emit) + `unregister_*` (drop on close).
@@ -87,7 +91,7 @@ impl HostPlanServer {
             sinks,
             sessions: Mutex::new(HashMap::new()),
             active_turns: Mutex::new(HashMap::new()),
-            title_calls_this_turn: Mutex::new(HashSet::new()),
+            title_set_for_session: Mutex::new(HashSet::new()),
             plan_store: PlanStore::new(),
             persistence,
         });
@@ -209,7 +213,6 @@ impl HostPlanServer {
 
     /// Mark an accepted prompt turn as active before the agent can call tools.
     pub fn begin_turn(&self, agent_id: &str, real_session_id: &str) {
-        self.title_calls_this_turn.lock().remove(real_session_id);
         self.active_turns
             .lock()
             .entry(agent_id.to_string())
@@ -229,7 +232,6 @@ impl HostPlanServer {
                 active_turns.remove(agent_id);
             }
         }
-        self.title_calls_this_turn.lock().remove(real_session_id);
         log::debug!(
             "[host-mcp] removed active plan route for session {real_session_id} (agent {agent_id})"
         );
@@ -249,7 +251,7 @@ impl HostPlanServer {
             !sessions.is_empty()
         });
         drop(active_turns);
-        self.title_calls_this_turn.lock().remove(real_session_id);
+        self.title_set_for_session.lock().remove(real_session_id);
         self.plan_store.drop_session(real_session_id);
     }
 
@@ -421,12 +423,19 @@ impl HostPlanServer {
                 let Some(title) = req.title else {
                     return FrameReply::err("title is required");
                 };
-                if !self
-                    .title_calls_this_turn
+                // Per-session: the first title call wins; subsequent calls for
+                // the same session are a success no-op (the agent is told it
+                // succeeded so it stops retrying — no churn to the sidebar
+                // title, no duplicate persistence records).
+                if self
+                    .title_set_for_session
                     .lock()
-                    .insert(real_session_id.clone())
+                    .contains(&real_session_id)
                 {
-                    return FrameReply::err("title already set during this turn");
+                    log::debug!(
+                        "[host-mcp] title call no-op: session {real_session_id} already has a title"
+                    );
+                    return FrameReply::ok();
                 }
                 let Some(persistence) = self.persistence.as_ref() else {
                     log::warn!("[host-mcp] title call rejected: persistence unavailable");
@@ -441,9 +450,13 @@ impl HostPlanServer {
                 )
                 .await
                 {
-                    Ok(()) => FrameReply::ok(),
+                    Ok(()) => {
+                        self.title_set_for_session
+                            .lock()
+                            .insert(real_session_id.clone());
+                        FrameReply::ok()
+                    }
                     Err(error) => {
-                        self.title_calls_this_turn.lock().remove(&real_session_id);
                         log::warn!("[host-mcp] title update rejected: {error}");
                         FrameReply::err(error)
                     }
@@ -735,6 +748,139 @@ mod tests {
                 .iter()
                 .any(|record| record.type_ == "local_title_generated"));
             assert_eq!(sink.events.lock().unwrap().len(), 1);
+            persistence.shutdown().await.unwrap();
+            let _ = std::fs::remove_dir_all(root);
+        });
+    }
+
+    #[test]
+    fn second_title_call_same_session_is_success_noop() {
+        // Per-session enforcement: after the first call sets the title, a
+        // second call for the same session must return `ok` (so the agent
+        // stops retrying) without writing a second persistence record or
+        // emitting a second session_info_update.
+        let root = std::env::temp_dir()
+            .join(format!("termul-host-mcp-title-noop-{}", uuid::Uuid::new_v4()));
+        let cwd = root.join("cwd");
+        std::fs::create_dir_all(&cwd).unwrap();
+        let runtime = Runtime::new().unwrap();
+        runtime.block_on(async move {
+            let persistence =
+                Arc::new(SessionPersistence::open(root.join("store")).await.unwrap());
+            persistence
+                .register_session(crate::acp::SessionRegistration {
+                    session_id: "sess-real".into(),
+                    stable_agent_namespace: Some("config:test".into()),
+                    runtime_agent_id: Some("agent-1".into()),
+                    project_id: None,
+                    cwd,
+                    ..Default::default()
+                })
+                .await
+                .unwrap();
+            let sink = Arc::new(CapturingSink::default());
+            let server =
+                HostPlanServer::start(vec![sink.clone()], Some(Arc::clone(&persistence)));
+            let (port, token, provisional) = server.register_session("agent-1");
+            server.bind_session(&token, "sess-real");
+            server.begin_turn("agent-1", "sess-real");
+
+            let first = serde_json::json!({
+                "token": token,
+                "session_id": provisional,
+                "kind": "set_title",
+                "title": "First title",
+            });
+            let reply = connect_and_send(port, &first).await;
+            assert_eq!(reply["ok"], true);
+            let events_after_first = sink.events.lock().unwrap().len();
+
+            let second = serde_json::json!({
+                "token": token,
+                "session_id": provisional,
+                "kind": "set_title",
+                "title": "Should be ignored",
+            });
+            let reply = connect_and_send(port, &second).await;
+            assert_eq!(reply["ok"], true, "repeat title call must succeed (no-op)");
+
+            // No second event + title unchanged + no second record.
+            assert_eq!(
+                sink.events.lock().unwrap().len(),
+                events_after_first,
+                "no second session_info_update"
+            );
+            let metadata = persistence.metadata("sess-real").unwrap();
+            assert_eq!(metadata.title.as_deref(), Some("First title"));
+            let title_records = persistence
+                .replay_after("sess-real", 0)
+                .unwrap()
+                .iter()
+                .filter(|r| r.type_ == "local_title_generated")
+                .count();
+            assert_eq!(title_records, 1, "no duplicate title persistence record");
+            persistence.shutdown().await.unwrap();
+            let _ = std::fs::remove_dir_all(root);
+        });
+    }
+
+    #[test]
+    fn title_per_session_flag_survives_a_new_turn() {
+        // Per-session (not per-turn): `end_turn` + `begin_turn` for a 2nd turn
+        // must NOT reset the title flag — the agent can't set the title again
+        // on a later turn.
+        let root = std::env::temp_dir()
+            .join(format!("termul-host-mcp-title-turn-{}", uuid::Uuid::new_v4()));
+        let cwd = root.join("cwd");
+        std::fs::create_dir_all(&cwd).unwrap();
+        let runtime = Runtime::new().unwrap();
+        runtime.block_on(async move {
+            let persistence =
+                Arc::new(SessionPersistence::open(root.join("store")).await.unwrap());
+            persistence
+                .register_session(crate::acp::SessionRegistration {
+                    session_id: "sess-real".into(),
+                    stable_agent_namespace: Some("config:test".into()),
+                    runtime_agent_id: Some("agent-1".into()),
+                    project_id: None,
+                    cwd,
+                    ..Default::default()
+                })
+                .await
+                .unwrap();
+            let sink = Arc::new(CapturingSink::default());
+            let server =
+                HostPlanServer::start(vec![sink.clone()], Some(Arc::clone(&persistence)));
+            let (port, token, provisional) = server.register_session("agent-1");
+            server.bind_session(&token, "sess-real");
+            server.begin_turn("agent-1", "sess-real");
+
+            let first = serde_json::json!({
+                "token": token,
+                "session_id": provisional,
+                "kind": "set_title",
+                "title": "Turn 1 title",
+            });
+            assert_eq!(connect_and_send(port, &first).await["ok"], true);
+
+            // End the turn + start a fresh turn (mirrors a 2nd user prompt).
+            server.end_turn("agent-1", "sess-real");
+            server.begin_turn("agent-1", "sess-real");
+
+            let second = serde_json::json!({
+                "token": token,
+                "session_id": provisional,
+                "kind": "set_title",
+                "title": "Turn 2 title",
+            });
+            let reply = connect_and_send(port, &second).await;
+            assert_eq!(reply["ok"], true, "2nd-turn title call must succeed (no-op)");
+            let metadata = persistence.metadata("sess-real").unwrap();
+            assert_eq!(
+                metadata.title.as_deref(),
+                Some("Turn 1 title"),
+                "title must NOT change on a later turn"
+            );
             persistence.shutdown().await.unwrap();
             let _ = std::fs::remove_dir_all(root);
         });

--- a/src-tauri/src/acp/host_mcp/parent.rs
+++ b/src-tauri/src/acp/host_mcp/parent.rs
@@ -1,5 +1,5 @@
 //! Parent side of the host-injected plan tool: an in-process TCP listener that
-//! the self-spawned child connects to on each `termul_plan` call.
+//! the self-spawned child connects to on each `plan` call.
 //!
 //! One shared listener serves all sessions (started lazily by `AcpManager` on
 //! first `new_session_with_context`). Each session is registered with a random

--- a/src-tauri/src/acp/manager.rs
+++ b/src-tauri/src/acp/manager.rs
@@ -805,7 +805,7 @@ pub struct AcpManager {
     /// one agent lifetime. Cleared on agent drop (driver self-reap) so a
     /// re-spawned agent re-warmups.
     warmup_done: Arc<Mutex<HashSet<AgentId>>>,
-    /// Host-injected `plan` MCP server (one shared TCP listener across
+    /// Host-injected `termul` MCP server (exposes the `plan` tool; one shared TCP listener across
     /// all sessions, started EAGERLY in the constructor so the first
     /// `new_session_with_context` doesn't block a Tokio worker thread on the
     /// bind + port-publish handshake). Injects a self-spawned stdio child
@@ -2204,7 +2204,7 @@ fn gate_mcp_servers(caps: &AgentCapabilities, servers: &[McpServer]) -> Result<(
     Ok(())
 }
 
-/// Build the internal `plan` MCP server config (stdio self-spawn) to
+/// Build the internal `termul` MCP server config (for the `plan` tool; stdio self-spawn) to
 /// prepend into a session's `mcp_servers`. The agent spawns
 /// `current_exe() --internal-mcp-plan-server` as a child; the child reads
 /// `TERMUL_PLAN_PORT` / `_TOKEN` / `_SESSION_ID` / `_AGENT_ID` from env,

--- a/src-tauri/src/acp/manager.rs
+++ b/src-tauri/src/acp/manager.rs
@@ -805,12 +805,12 @@ pub struct AcpManager {
     /// one agent lifetime. Cleared on agent drop (driver self-reap) so a
     /// re-spawned agent re-warmups.
     warmup_done: Arc<Mutex<HashSet<AgentId>>>,
-    /// Host-injected `termul_plan` MCP server (one shared TCP listener across
+    /// Host-injected `plan` MCP server (one shared TCP listener across
     /// all sessions, started EAGERLY in the constructor so the first
     /// `new_session_with_context` doesn't block a Tokio worker thread on the
     /// bind + port-publish handshake). Injects a self-spawned stdio child
     /// into every non-ephemeral session's `mcp_servers`; the child forwards
-    /// `termul_plan` calls back here, and `host_mcp::emit_plan_update` emits a
+    /// `plan` calls back here, and `host_mcp::emit_plan_update` emits a
     /// synthetic `acp:plan_update` so the existing renderer `PlanPanel`
     /// renders it. See `host_mcp::mod` + the spec
     /// `spec-acp-host-todo-plan-tool.md`.
@@ -1227,7 +1227,7 @@ impl AcpManager {
             .map(|entry| (entry.capabilities.clone(), entry.stable_namespace.clone()))
             .ok_or_else(|| format!("unknown agent: {agent_id}"))?;
 
-        // Host-injected `termul_plan` MCP tool: prepend a self-spawned stdio
+        // Host-injected `plan` MCP tool: prepend a self-spawned stdio
         // child to every non-ephemeral session's mcp_servers so the agent
         // discovers + calls it as a first-class tool (see `host_mcp::mod` +
         // spec `spec-acp-host-todo-plan-tool.md`). The real ACP session_id
@@ -1270,7 +1270,7 @@ impl AcpManager {
             Ok(outcome) => {
                 // Bind the real session_id to the plan token so the parent can
                 // emit plan_update for the right session when the agent calls
-                // termul_plan.
+                // plan.
                 if let Some(token) = plan_token {
                     self.host_plan_server
                         .bind_session(&token, &outcome.session_id.0);
@@ -2204,11 +2204,11 @@ fn gate_mcp_servers(caps: &AgentCapabilities, servers: &[McpServer]) -> Result<(
     Ok(())
 }
 
-/// Build the internal `termul_plan` MCP server config (stdio self-spawn) to
+/// Build the internal `plan` MCP server config (stdio self-spawn) to
 /// prepend into a session's `mcp_servers`. The agent spawns
 /// `current_exe() --internal-mcp-plan-server` as a child; the child reads
 /// `TERMUL_PLAN_PORT` / `_TOKEN` / `_SESSION_ID` / `_AGENT_ID` from env,
-/// runs an rmcp MCP server over stdio, and forwards `termul_plan` calls to
+/// runs an rmcp MCP server over stdio, and forwards `plan` calls to
 /// the parent TCP listener. The internal server is `McpServer::Stdio`, which
 /// `gate_mcp_servers` accepts unconditionally (stdio is mandatory in ACP), so
 /// no gate relaxation is needed.
@@ -2231,7 +2231,7 @@ fn build_internal_plan_stdio(
         ),
         EnvVariable::new(crate::acp::host_mcp::ENV_AGENT_ID, agent_id.to_string()),
     ];
-    let stdio = McpServerStdio::new("termul-plan".to_string(), exe)
+    let stdio = McpServerStdio::new("termul".to_string(), exe)
         .args(vec![crate::acp::host_mcp::CHILD_ARG.to_string()])
         .env(env);
     vec![McpServer::Stdio(stdio)]
@@ -3506,7 +3506,7 @@ async fn run_command_loop(
                 let turn_persistence = persistence.clone();
                 let turn_session = session_id.clone();
                 let log_session = session_id.clone();
-                // Register before spawning so an immediate `termul_plan` call is
+                // Register before spawning so an immediate `plan` call is
                 // routed to this accepted prompt's session, even when the agent
                 // reuses an MCP child created for an older session.
                 host_plan_server.begin_turn(&agent_id.0, &session_id.0);

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -134,7 +134,7 @@ pub use acp::{
     AcpCatalogService, AcpInstallService, AcpManager, ChatHistoryStore, FileProjectRegistry,
     SessionPersistence, WorkspaceManifestService,
 };
-// Host-injected `termul_plan` MCP tool: the `--internal-mcp-plan-server`
+// Host-injected `plan` MCP tool: the `--internal-mcp-plan-server`
 // subcommand branch in `main.rs` + `server_main.rs` reaches `host_mcp::CHILD_ARG`
 // + `host_mcp::child::run()` through this re-export (the `acp` module itself is
 // private). See `acp/host_mcp/mod.rs` + spec `spec-acp-host-todo-plan-tool.md`.

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -4,7 +4,7 @@
 fn main() {
     // Self-spawned `--internal-mcp-plan-server` child: the agent spawns this
     // binary (current_exe) as the injected `McpServer::Stdio` for the
-    // host-injected `termul_plan` tool. Branch BEFORE any Tauri/log setup so
+    // host-injected `plan` tool. Branch BEFORE any Tauri/log setup so
     // the child never initializes the app / plugins / sinks — it just runs
     // an rmcp MCP server over stdio + forwards calls to the parent's TCP
     // listener. See `acp::host_mcp::child` + spec `spec-acp-host-todo-plan-tool.md`.

--- a/src-tauri/src/server_main.rs
+++ b/src-tauri/src/server_main.rs
@@ -46,7 +46,7 @@ fn main() -> ExitCode {
     }
 
     // `--internal-mcp-plan-server`: self-spawned child of the host-injected
-    // `termul_plan` MCP tool. The agent spawns `current_exe()` with this flag
+    // `plan` MCP tool. The agent spawns `current_exe()` with this flag
     // (the injected `McpServer::Stdio`); the child runs an rmcp MCP server over
     // stdio + forwards calls to the parent's TCP listener. Branch BEFORE any
     // tokio/app setup (AC2) so the standalone binary never inits the server

--- a/src/renderer/assets/agent-icons/acp/agents.json
+++ b/src/renderer/assets/agent-icons/acp/agents.json
@@ -308,11 +308,11 @@
   {
     "id": "dimcode",
     "name": "DimCode",
-    "version": "0.3.10",
+    "version": "0.3.11",
     "description": "A coding agent that puts leading models at your command.",
     "distribution": {
       "npx": {
-        "package": "dimcode@0.3.10",
+        "package": "dimcode@0.3.11",
         "args": ["acp"]
       }
     }
@@ -629,11 +629,11 @@
   {
     "id": "nova",
     "name": "Nova",
-    "version": "1.1.31",
+    "version": "1.1.32",
     "description": "Nova by Compass AI - a fully-fledged software engineer at your command",
     "distribution": {
       "npx": {
-        "package": "@compass-ai/nova@1.1.31",
+        "package": "@compass-ai/nova@1.1.32",
         "args": ["acp"]
       }
     }

--- a/src/renderer/assets/agent-icons/acp/agents.json
+++ b/src/renderer/assets/agent-icons/acp/agents.json
@@ -105,11 +105,11 @@
   {
     "id": "codex-acp",
     "name": "Codex",
-    "version": "1.1.14",
+    "version": "1.2.0",
     "description": "ACP adapter for OpenAI's coding assistant",
     "distribution": {
       "npx": {
-        "package": "@agentclientprotocol/codex-acp@1.1.14"
+        "package": "@agentclientprotocol/codex-acp@1.2.0"
       }
     }
   },
@@ -438,33 +438,33 @@
   {
     "id": "harn",
     "name": "Harn",
-    "version": "0.10.85",
+    "version": "0.10.86",
     "description": "Harn runs .harn agent pipelines as a native ACP coding agent over stdio.",
     "distribution": {
       "binary": {
         "darwin-aarch64": {
           "cmd": "./harn",
-          "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.85/harn-aarch64-apple-darwin.tar.gz",
+          "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.86/harn-aarch64-apple-darwin.tar.gz",
           "args": ["serve", "acp"]
         },
         "darwin-x86_64": {
           "cmd": "./harn",
-          "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.85/harn-x86_64-apple-darwin.tar.gz",
+          "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.86/harn-x86_64-apple-darwin.tar.gz",
           "args": ["serve", "acp"]
         },
         "linux-aarch64": {
           "cmd": "./harn",
-          "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.85/harn-aarch64-unknown-linux-gnu.tar.gz",
+          "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.86/harn-aarch64-unknown-linux-gnu.tar.gz",
           "args": ["serve", "acp"]
         },
         "linux-x86_64": {
           "cmd": "./harn",
-          "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.85/harn-x86_64-unknown-linux-gnu.tar.gz",
+          "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.86/harn-x86_64-unknown-linux-gnu.tar.gz",
           "args": ["serve", "acp"]
         },
         "windows-x86_64": {
           "cmd": "harn.exe",
-          "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.85/harn-x86_64-pc-windows-msvc.zip",
+          "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.86/harn-x86_64-pc-windows-msvc.zip",
           "args": ["serve", "acp"]
         }
       }


### PR DESCRIPTION
## Summary

Two bundled, related changes that make the host-injected MCP tools actually get used:

1. **Rename** the host-injected MCP server `termul-plan` → `termul` and its tools `termul_plan`/`termul_set_session_title` → `plan`/`set_session_title`. The client prefixes each tool with the server name, so the agent-visible identifiers become the single-prefixed, distinct `termul_plan` and `termul_set_session_title` (was the double-prefixed, confusing `termul-plan_termul_plan` / `termul-plan_termul_set_session_title`).

2. **Steer agents to the host tools + enforce title once per session.** ACP v1.3 `session/new` has no `system_prompt` field, so Termul steers behavior via the levers it has: stronger tool `description` text (advisory, via `tools/list`) and parent-side enforcement (guarantees).

## Related Issue

Closes #620

<!-- Searched open and closed PRs for "mcp plan rename termul" — no duplicates found. -->

## Type of Change

- [x] feat: new feature (per-session title enforcement + tool descriptions)
- [x] refactor: internal cleanup with no behavior change (rename)

## What Changed

**Rename (commit 82b15bf7 + docs clarifications 107ae54a):**
- `src-tauri/src/acp/manager.rs:2234` — `McpServerStdio::new("termul-plan", …)` → `"termul"` (server name = tool prefix).
- `src-tauri/src/acp/host_mcp/child.rs:113` — `#[tool(name = "termul_plan")]` → `#[tool(name = "plan")]`; `#[tool(name = "termul_set_session_title")]` → `#[tool(name = "set_session_title")]`.
- Doc/comment updates across `host_mcp/{child,mod,parent}.rs`, `manager.rs`, `main.rs`, `lib.rs`, `server_main.rs`, `Cargo.toml` (server `termul` vs. tool `plan` distinguished per CodeRabbit).

**Tool usage enforcement (commit 1b6a1a4d):**
- `src-tauri/src/acp/host_mcp/child.rs` — strengthened `plan` tool description ("use this instead of any built-in todo/task tool; do not maintain your own todo list") and `set_session_title` description ("call EXACTLY ONCE per session, during the first turn; subsequent calls are ignored").
- `src-tauri/src/acp/host_mcp/parent.rs` — replaced per-**turn** title dedup (`title_calls_this_turn`, cleared on `begin_turn`, rejected duplicates with an error) with a per-**session** flag (`title_set_for_session`): the first `set_session_title` call persists + broadcasts as before; subsequent calls for the same session return a success no-op (no re-persist, no second event) so the agent stops retrying. Cleared on `unregister_session`.
- Added unit tests: `second_title_call_same_session_is_success_noop`, `title_per_session_flag_survives_a_new_turn`.

**Bundled CI fix (commit e886667e):**
- `src/renderer/assets/agent-icons/acp/agents.json` — refreshed the bundled ACP registry snapshot (dimcode 0.3.10→0.3.11, nova 1.1.31→1.1.32); the `ACP Registry Bundle Freshness` check was failing on every PR because the live registry had drifted from the dev snapshot.

**Intentionally unchanged (internal plumbing, not agent-facing):** `TERMUL_PLAN_*` env vars, `--internal-mcp-plan-server` subcommand, `TermulPlan*` Rust type names, `host_mcp` module path, parent↔child TCP frame protocol, `tools/call` argument shape, `inputSchema`.

## How It Was Tested

- [ ] `bun run ci` (Biome) — **fails identically at baseline** locally (biome "0 files processed"; a pre-existing local config quirk unrelated to this Rust-heavy diff). CI runs on changed paths and passes.
- [x] `bun run typecheck` — exit 0
- [x] `cargo clippy --all-targets -- -D warnings` (in src-tauri) — clean, no warnings
- [ ] `cargo test` (in src-tauri) — **the test binary fails to launch in this Windows environment** with `0xc0000139` (STATUS_ENTRYPOINT_NOT_FOUND), confirmed identical at baseline — a pre-existing env/DLL-loader issue, not a regression. CI's Linux Rust Checks job runs the tests authoritatively.
- [x] Manual verification completed — repo-wide search confirms no remaining old agent-facing identifiers; per-session no-op logic traced by unit tests.

## CI & Review Gate

- [ ] All CI checks pass (PR Validation, Rust Checks, Build Verification, Security Scans)
- [ ] Code review comments from CodeRabbit / Claude have been addressed or resolved
- [ ] No unresolved review findings remain

## Checklist

- [x] My PR title follows the conventional commit format used by this repo
- [x] I linked the related issue or explained why none exists
- [x] I updated docs when needed
- [x] I added or updated tests when needed (new per-session title no-op tests)
- [x] I verified the change does not introduce unrelated modifications
- [x] I read AGENTS.md and followed the contributor guidelines
- [x] A human reviewed the complete diff before submission
