### PR TITLE
fix(acp): show worktree chats in Chats sidebar

### DIFF
--- a/src/renderer/components/agents/AgentLauncher.test.tsx
+++ b/src/renderer/components/agents/AgentLauncher.test.tsx
@@ -310,13 +310,19 @@ vi.mock('@/components/ui/select', async () => {
   }
 })
 
-const { mockWorktreeCreate, mockWorktreeCopyInclude, mockWorktreeResolveBaseBranch } = vi.hoisted(
-  () => ({
-    mockWorktreeCreate: vi.fn(),
-    mockWorktreeCopyInclude: vi.fn(),
-    mockWorktreeResolveBaseBranch: vi.fn()
-  })
-)
+const {
+  mockWorktreeCreate,
+  mockWorktreeCopyInclude,
+  mockWorktreeResolveBaseBranch,
+  mockAddWorktree,
+  mockSetActiveWorktree
+} = vi.hoisted(() => ({
+  mockWorktreeCreate: vi.fn(),
+  mockWorktreeCopyInclude: vi.fn(),
+  mockWorktreeResolveBaseBranch: vi.fn(),
+  mockAddWorktree: vi.fn(),
+  mockSetActiveWorktree: vi.fn()
+}))
 
 vi.mock('@/lib/worktree-api', () => ({
   worktreeApi: {
@@ -342,7 +348,9 @@ vi.mock('@/stores/project-store', () => {
   const baseProject = { id: 'p1', name: 'P', path: '/work', defaultShell: undefined }
   const state = {
     activeProjectId: 'p1',
-    projects: [baseProject]
+    projects: [baseProject],
+    addWorktree: mockAddWorktree,
+    setActiveWorktree: mockSetActiveWorktree
   }
   const withOverride = () => ({
     ...state,
@@ -1540,6 +1548,8 @@ describe('AgentLauncher worktree isolation', () => {
       data: { ran: 1, copied: 1, skipped: [] }
     })
     mockWorktreeResolveBaseBranch.mockReset()
+    mockAddWorktree.mockReset()
+    mockSetActiveWorktree.mockReset()
     // "Clean repo on feat/x, base auto" — no origin/HEAD, so the fallback
     // chain resolves to the current branch (feat/x).
     mockWorktreeResolveBaseBranch.mockResolvedValue({
@@ -1663,6 +1673,48 @@ describe('AgentLauncher worktree isolation', () => {
     expect(finalizeArgs.worktreeBranch).toMatch(/^chat\/[a-f0-9]+$/)
   })
 
+  // Fix: worktree chat hidden from Chats sidebar — the launcher must register
+  // the just-created worktree in the project store and activate it so the
+  // sidebar scopes to it immediately (no 60s reconciler wait) and the worktree
+  // is a first-class project citizen across restarts.
+  it('registers and activates the created worktree in the project store on launch', async () => {
+    renderLauncher()
+    await chooseWorktreeBaseBranch('feat/x')
+
+    setComposerValue('register me')
+    fireEvent.click(screen.getByLabelText('Start agent chat'))
+
+    await waitFor(() => expect(mockWorktreeCreate).toHaveBeenCalledTimes(1))
+    await waitFor(() => expect(mockAddWorktree).toHaveBeenCalledTimes(1))
+    const [projectId, worktree] = mockAddWorktree.mock.calls[0] as [
+      string,
+      { id: string; path: string; branch: string; name: string }
+    ]
+    expect(projectId).toBe('p1')
+    expect(worktree.path).toBe('/work/.termul/worktrees/abcd1234')
+    expect(worktree.branch).toMatch(/^chat\/[a-f0-9]+$/)
+    expect(worktree.name).toMatch(/^[a-f0-9]{8}$/)
+    // The same id is activated so the sidebar scopes to the new worktree.
+    await waitFor(() => expect(mockSetActiveWorktree).toHaveBeenCalledTimes(1))
+    expect(mockSetActiveWorktree).toHaveBeenCalledWith('p1', worktree.id)
+  })
+
+  it('still opens the chat when worktree registration throws (best-effort)', async () => {
+    mockAddWorktree.mockImplementation(() => {
+      throw new Error('store unavailable')
+    })
+    renderLauncher()
+    await chooseWorktreeBaseBranch('feat/x')
+
+    setComposerValue('survive failure')
+    fireEvent.click(screen.getByLabelText('Start agent chat'))
+
+    // The best-effort step threw and was swallowed; the chat still opens.
+    await waitFor(() => expect(mockWorktreeCreate).toHaveBeenCalledTimes(1))
+    await waitFor(() => expect(mockFinalizeChatLaunch).toHaveBeenCalledTimes(1))
+    expect(mockSetActiveWorktree).not.toHaveBeenCalled()
+  })
+
   // CAP-4: relaunch of a persisted-worktree session does NOT call worktreeApi.create
   it('does not call worktreeApi.create when relaunching a persisted-worktree session (CAP-4)', async () => {
     // The launcher's launch() only creates a worktree when isolationMode ===
@@ -1716,6 +1768,22 @@ describe('AgentLauncher worktree isolation', () => {
       worktreeBranch: string
     }
     expect(finalizeArgs.worktreeBranch).toBe(`${firstBranch}-2`)
+
+    // The project-store entry must reflect the RETRY worktree (name/branch
+    // matching the retry create call's inputs, not the stale original chatId),
+    // so the registered `name` matches the git worktree on disk.
+    await waitFor(() => expect(mockAddWorktree).toHaveBeenCalledTimes(1))
+    const [, registered] = mockAddWorktree.mock.calls[0] as [
+      string,
+      { name: string; branch: string; path: string }
+    ]
+    const retryCreate = mockWorktreeCreate.mock.calls[1][0] as {
+      name: string
+      branch: string
+    }
+    expect(registered.name).toBe(retryCreate.name)
+    expect(registered.branch).toBe(retryCreate.branch)
+    expect(registered.path).toBe('/work/.termul/worktrees/abcd1234-2')
   })
 
   // CAP-2: on detached HEAD, worktree mode blocks launch until a base branch

--- a/src/renderer/components/agents/AgentLauncher.tsx
+++ b/src/renderer/components/agents/AgentLauncher.tsx
@@ -66,6 +66,7 @@ import {
   type McpToolInfo,
   type ProbeStatus
 } from '@/lib/acp-api'
+import { normalizeCwdForScope } from '@/lib/acp-history-persistence'
 import type { StoredMcpServer } from '@/lib/acp-mcp-persistence'
 import type { PrepareChatError } from '@/lib/agents/acp-spawn-errors'
 import { findBundledIconByKey } from '@/lib/agents/agent-icon-catalog'
@@ -84,6 +85,7 @@ import { logFrontendError } from '@/lib/log-api'
 import { platform as osPlatform } from '@/lib/tauri-os'
 import { isLoopbackWebClient } from '@/lib/tauri-runtime'
 import { cn } from '@/lib/utils'
+import { randomUUID } from '@/lib/uuid'
 import { type BaseBranchInfo, worktreeApi } from '@/lib/worktree-api'
 import { getDefaultCwdForProject, getProjectRootPath } from '@/lib/worktree-context'
 import {
@@ -96,6 +98,7 @@ import {
 } from '@/stores/acp-store'
 import { useActiveProject, useProjectStore } from '@/stores/project-store'
 import { useWorkspaceStore } from '@/stores/workspace-store'
+import type { Worktree } from '@/types/project'
 
 interface AgentLauncherProps {
   paneId: string
@@ -762,6 +765,9 @@ export function AgentLauncher({ paneId, className }: AgentLauncherProps): React.
         let worktreePathResult: string | null =
           createResult.success && createResult.data ? createResult.data.path : null
         let worktreeBranchResult: string = branchName
+        // Track the worktree NAME actually used (the retry branch appends `-2`),
+        // so the project-store entry's `name` matches the git worktree on disk.
+        let worktreeNameResult: string = chatId
         if (!worktreePathResult) {
           const failCode = createResult.success ? 'UNKNOWN' : createResult.code
           if (failCode === 'WORKTREE_EXISTS' || failCode === 'BRANCH_ALREADY_HAS_WORKTREE') {
@@ -785,6 +791,7 @@ export function AgentLauncher({ paneId, className }: AgentLauncherProps): React.
             if (retryResult.success && retryResult.data) {
               worktreePathResult = retryResult.data.path
               worktreeBranchResult = retryBranch
+              worktreeNameResult = retryId
             } else {
               const retryErr = retryResult.success ? 'unknown' : retryResult.error
               throw new Error(`Worktree creation failed: ${retryErr}`)
@@ -825,6 +832,49 @@ export function AgentLauncher({ paneId, className }: AgentLauncherProps): React.
               level: 'warn',
               source: 'agentLauncher.worktreeInclude',
               message: `copyIncludeFiles threw: ${includeErr instanceof Error ? includeErr.message : String(includeErr)}`
+            })
+          }
+
+          // Register the just-created worktree in the project store and
+          // activate it so the Chats sidebar scopes to it immediately (no
+          // 60s reconciler wait) and the worktree survives across restarts.
+          // Dedupe by path against already-stored worktrees so the reconciler
+          // cannot add a second entry for the same path later. Best-effort:
+          // a failure logs a warn and the chat still opens below.
+          try {
+            const projectStore = useProjectStore.getState()
+            const stored = projectStore.projects.find((p) => p.id === projectIdSnapshot)
+            // Dedupe by normalized path: worktreeApi.create and an already-stored
+            // entry (from a prior launch or the reconciler's worktreeApi.list)
+            // can differ by trailing slash / verbatim prefix. Without
+            // normalization the dedup misses and addWorktree creates a duplicate
+            // the comment below claims to prevent.
+            const alreadyStored = stored?.worktrees?.find(
+              (w) => normalizeCwdForScope(w.path) === normalizeCwdForScope(worktreePathResult)
+            )
+            if (alreadyStored) {
+              projectStore.setActiveWorktree(projectIdSnapshot, alreadyStored.id)
+            } else {
+              const newWorktree: Worktree = {
+                id: randomUUID(),
+                name: worktreeNameResult,
+                branch: worktreeBranchResult,
+                path: worktreePathResult,
+                createdAt: new Date().toISOString()
+              }
+              projectStore.addWorktree(projectIdSnapshot, newWorktree)
+              projectStore.setActiveWorktree(projectIdSnapshot, newWorktree.id)
+            }
+            // Boundary log (info-level): not an error, so console.info is
+            // appropriate (logFrontendError is error/warn only).
+            console.info(
+              `[agentLauncher.worktreeRegister] activated branch=${worktreeBranchResult} path=${worktreePathResult}`
+            )
+          } catch (registerErr) {
+            void logFrontendError({
+              level: 'warn',
+              source: 'agentLauncher.worktreeRegister',
+              message: `register/activate failed: ${registerErr instanceof Error ? registerErr.message : String(registerErr)}`
             })
           }
         }

--- a/src/renderer/components/chat/ChatHistoryTab.test.tsx
+++ b/src/renderer/components/chat/ChatHistoryTab.test.tsx
@@ -123,26 +123,32 @@ describe('ChatHistoryTab scoping', () => {
     }
   })
 
-  it('shows only sessions matching active (projectId, cwd)', () => {
+  it('shows root-cwd and active-project worktree-cwd sessions from the root view', () => {
     sessionIndexRef.current = [
       entry('mine-main', { projectId: 'p1', cwd: '/work', title: 'mine-main' }),
       entry('mine-wt', { projectId: 'p1', cwd: '/work-wt', title: 'mine-wt' }),
       entry('other-main', { projectId: 'p2', cwd: '/work', title: 'other-main' })
     ]
     render(<ChatHistoryTab />)
+    // mine-main: exact-cwd match against the active project root.
     expect(screen.getByText('mine-main')).toBeInTheDocument()
-    expect(screen.queryByText('mine-wt')).not.toBeInTheDocument()
+    // mine-wt: cwd is a registered worktree path of the active project, so the
+    // worktree-inclusive scoping keeps it reachable from the root view.
+    expect(screen.getByText('mine-wt')).toBeInTheDocument()
+    // other-main: a different project — never listed.
     expect(screen.queryByText('other-main')).not.toBeInTheDocument()
   })
 
-  it('re-scopes when the active worktree changes', () => {
+  it('re-scopes to the active worktree session when the active worktree changes', () => {
     sessionIndexRef.current = [
       entry('mine-main', { projectId: 'p1', cwd: '/work', title: 'mine-main' }),
       entry('mine-wt', { projectId: 'p1', cwd: '/work-wt', title: 'mine-wt' })
     ]
     const { rerender } = render(<ChatHistoryTab />)
+    // Root view (activeWorktreeId=null): worktree-inclusive scoping lists both
+    // the root chat and the project's registered worktree chat.
     expect(screen.getByText('mine-main')).toBeInTheDocument()
-    expect(screen.queryByText('mine-wt')).not.toBeInTheDocument()
+    expect(screen.getByText('mine-wt')).toBeInTheDocument()
     // The project store creates a new record on update; mirror that so the
     // subscription notices the change.
     const prev = projectRef.current
@@ -153,6 +159,8 @@ describe('ChatHistoryTab scoping', () => {
       worktrees: prev!.worktrees
     }
     rerender(<ChatHistoryTab />)
+    // Active worktree view: scoped to the worktree cwd, the root chat is
+    // hidden while the active worktree's chat stays visible.
     expect(screen.queryByText('mine-main')).not.toBeInTheDocument()
     expect(screen.getByText('mine-wt')).toBeInTheDocument()
   })

--- a/src/renderer/components/chat/ChatHistoryTab.tsx
+++ b/src/renderer/components/chat/ChatHistoryTab.tsx
@@ -34,14 +34,25 @@ export function ChatHistoryTab({
     return wt?.path ?? activeProject.path ?? ''
   }, [activeProject])
 
+  // Active project's registered worktree paths. Passed into `scopeSessionIndex`
+  // so worktree-cwd chats stay reachable from the project root view and across
+  // restarts where `activeWorktreeId` is null (the sidebar would otherwise hide
+  // them because their cwd differs from the root). Re-derived whenever the
+  // active project record changes (covers reconciler discovery + launch adds).
+  const worktreePaths = useMemo(
+    () => activeProject?.worktrees?.map((w) => w.path) ?? [],
+    [activeProject]
+  )
+
   // ADR 0002 scoping: show only sessions whose `(projectId, cwd)` match the
   // active project + worktree/root, falling back to projectId-only matching
   // when the exact cwd yields nothing (a chat whose cwd drifted since it was
-  // created is still reachable instead of silently hidden). See
-  // `scopeSessionIndex` for the contract.
+  // created is still reachable instead of silently hidden). Worktree-inclusive
+  // reachability (above) keeps the project's worktree chats listed from the
+  // root view. See `scopeSessionIndex` for the contract.
   const scopedIndex = useMemo(
-    () => scopeSessionIndex(sessionIndex, activeProjectId, activeCwd),
-    [sessionIndex, activeProjectId, activeCwd]
+    () => scopeSessionIndex(sessionIndex, activeProjectId, activeCwd, worktreePaths),
+    [sessionIndex, activeProjectId, activeCwd, worktreePaths]
   )
 
   // Termul-created sessions only. The host-owned `discovered` flag is `false`
@@ -84,11 +95,15 @@ export function ChatHistoryTab({
     return base.slice().sort((a, b) => b.lastActivityAt - a.lastActivityAt)
   }, [mergedEntries, query])
 
-  // Reset the window when the query or active scope changes.
+  // Reset the window when the query or active scope changes. `worktreePaths`
+  // is a scoping input (worktree-inclusive reachability), so a reconciler
+  // discovery that grows the set without changing `activeCwd` must also reset
+  // the visible window — otherwise a stale "No matches"/window renders against
+  // the new scope.
   // biome-ignore lint/correctness/useExhaustiveDependencies: reset on scope/query change
   useEffect(() => {
     setVisibleCount(SIDEBAR_PAGE_SIZE)
-  }, [query, activeProjectId, activeCwd])
+  }, [query, activeProjectId, activeCwd, worktreePaths])
 
   const visible = useMemo(() => filtered.slice(0, visibleCount), [filtered, visibleCount])
   const hasMore = filtered.length > visible.length

--- a/src/renderer/hooks/use-worktree-reconciler.test.ts
+++ b/src/renderer/hooks/use-worktree-reconciler.test.ts
@@ -145,6 +145,39 @@ describe('useWorktreeReconciler', () => {
     })
   })
 
+  it('does not duplicate a worktree the launcher already registered (post-launch tick)', async () => {
+    // Post-launch state: the launcher registered the chat worktree in the
+    // store before the 60s reconciler ticked. Git now reports it too. The
+    // reconciler's `storedPaths` dedup must skip it so no second entry is
+    // created for the same path.
+    vi.mocked(worktreeApi.list).mockResolvedValue({
+      success: true,
+      data: [
+        {
+          name: 'feat-1',
+          branch: 'feat-1',
+          path: '/test/project/.termul/worktrees/feat-1',
+          headCommit: 'abc'
+        },
+        {
+          name: 'feat-2',
+          branch: 'feat-2',
+          path: '/test/project/.termul/worktrees/feat-2',
+          headCommit: 'def'
+        }
+      ]
+    })
+
+    renderHook(() => useWorktreeReconciler('proj-1'))
+
+    // Both reported worktrees are already in the store (wt-1, wt-2), so the
+    // reconciler discovers nothing and never calls addWorktree.
+    await vi.waitFor(() => {
+      expect(mocks.removeWorktree).not.toHaveBeenCalled()
+    })
+    expect(mocks.addWorktree).not.toHaveBeenCalled()
+  })
+
   it('resets active worktree if it becomes orphaned', async () => {
     // Set active worktree to the one that will be orphaned by git (only feat-1 remains)
     mocks.state.activeWorktreeId = 'wt-2'

--- a/src/renderer/lib/acp-history-persistence.test.ts
+++ b/src/renderer/lib/acp-history-persistence.test.ts
@@ -148,6 +148,97 @@ describe('pure history helpers', () => {
     expect(scopeSessionIndex(entries, '', '/a')).toEqual([])
   })
 
+  it('scopes with worktree-inclusive reachability from the root view', () => {
+    // Root view (activeWorktreeId=null): activeCwd is the project root. The
+    // sidebar must list root-cwd sessions AND the project's worktree-cwd
+    // sessions so a worktree chat stays reachable without a restart.
+    const root = entry('root', { cwd: '/project' })
+    const wtChat = entry('wt-chat', { cwd: '/project/.termul/worktrees/wt' })
+    const otherProjectWt = entry('other-wt', {
+      projectId: 'project-2',
+      cwd: '/project/.termul/worktrees/wt'
+    })
+    const entries = [root, wtChat, otherProjectWt]
+
+    expect(
+      scopeSessionIndex(entries, 'project-1', '/project', ['/project/.termul/worktrees/wt']).map(
+        ({ id }) => id
+      )
+    ).toEqual(['root', 'wt-chat'])
+  })
+
+  it('keeps the active worktree session visible while it is active', () => {
+    // activeCwd is the worktree path: exact-cwd match returns the worktree
+    // chat; the root-cwd chat is not in the worktreePath set so it is hidden,
+    // matching the prior scoped-to-active-cwd behavior.
+    const root = entry('root', { cwd: '/project' })
+    const wtChat = entry('wt-chat', { cwd: '/project/.termul/worktrees/wt' })
+    const entries = [root, wtChat]
+
+    expect(
+      scopeSessionIndex(entries, 'project-1', '/project/.termul/worktrees/wt', [
+        '/project/.termul/worktrees/wt'
+      ]).map(({ id }) => id)
+    ).toEqual(['wt-chat'])
+  })
+
+  it('does not surface another project worktree cwd and still falls back when empty', () => {
+    // A worktree path of a DIFFERENT project must not leak into the active
+    // project's scoping; and the worktree-inclusive set never duplicates an
+    // entry already matched by exact-cwd (filter, not concat).
+    const root = entry('root', { cwd: '/project' })
+    const wtChat = entry('wt-chat', { cwd: '/project/.termul/worktrees/wt' })
+    const foreignWt = entry('foreign', {
+      projectId: 'project-2',
+      cwd: '/other/.termul/worktrees/x'
+    })
+    const entries = [root, wtChat, foreignWt]
+
+    // Foreign worktree path is not in the active project's worktreePaths.
+    expect(
+      scopeSessionIndex(entries, 'project-1', '/project', ['/project/.termul/worktrees/wt']).map(
+        ({ id }) => id
+      )
+    ).toEqual(['root', 'wt-chat'])
+
+    // projectId-only fallback when the scoped set (exact + worktree) is empty.
+    expect(
+      scopeSessionIndex(entries, 'project-2', '/nowhere', ['/project/.termul/worktrees/wt']).map(
+        ({ id }) => id
+      )
+    ).toEqual(['foreign'])
+  })
+
+  it('normalizes Windows verbatim-prefix + separator forms before scoping', () => {
+    // Real runtime shapes on Windows: the host persists session cwds via Rust
+    // `Path::canonicalize` (verbatim `\\?\` prefix, backslashes), while the
+    // project store's worktree paths come from `worktreeApi.list` (forward
+    // slashes, no prefix). A raw `===`/`Set.has` would never equate them and
+    // the worktree chat would be hidden from the root view. Root sessions also
+    // appear in BOTH forms (471 unprefixed + 94 prefixed in real data).
+    const rootUnprefixed = entry('root-unprefixed', { cwd: 'E:\\project' })
+    const rootPrefixed = entry('root-prefixed', { cwd: '\\\\?\\E:\\project' })
+    const wtChat = entry('wt-chat', { cwd: '\\\\?\\E:\\project\\.termul\\worktrees\\wt' })
+    const entries = [rootUnprefixed, rootPrefixed, wtChat]
+
+    // Root view: activeCwd is the project root (store form, backslashes);
+    // worktreePaths is the store form (forward slashes, no prefix). Both root
+    // forms AND the worktree chat must be listed.
+    expect(
+      scopeSessionIndex(entries, 'project-1', 'E:\\project', ['E:/project/.termul/worktrees/wt'])
+        .map(({ id }) => id)
+        .sort()
+    ).toEqual(['root-prefixed', 'root-unprefixed', 'wt-chat'])
+
+    // Active-worktree view: activeCwd is the store worktree path (forward
+    // slashes); the prefixed-backslash session cwd must still match exactly.
+    expect(
+      scopeSessionIndex(entries, 'project-1', 'E:/project/.termul/worktrees/wt', [
+        'E:/project/.termul/worktrees/wt'
+      ]).map(({ id }) => id)
+    ).toEqual(['wt-chat'])
+  })
+
   it('preserves the existing browser summary wire shape', () => {
     expect(toPersistedSessionSummaries([entry('s-1', { status: 'initializing' })])[0]).toEqual(
       expect.objectContaining({

--- a/src/renderer/lib/acp-history-persistence.test.ts
+++ b/src/renderer/lib/acp-history-persistence.test.ts
@@ -46,6 +46,7 @@ import {
   loadSessionPayload,
   markSessionPayloadPinned,
   maxPayloadSeq,
+  normalizeCwdForScope,
   PERSISTED_TOOL_CALL_BYTE_BUDGET,
   PERSISTED_TOOL_CALLS_LIMIT,
   queueSessionPayloadDelete,
@@ -237,6 +238,23 @@ describe('pure history helpers', () => {
         'E:/project/.termul/worktrees/wt'
       ]).map(({ id }) => id)
     ).toEqual(['wt-chat'])
+  })
+
+  it('normalizes extended UNC verbatim prefix to match standard UNC paths', () => {
+    // Windows extended UNC verbatim prefix `\\?\UNC\server\share\…` and the
+    // standard UNC `\\server\share\…` must produce the same scope value so a
+    // UNC-rooted worktree chat is reachable regardless of which form the host
+    // canonicalized the cwd into.
+    const extended = '\\\\?\\UNC\\server\\share\\wt'
+    const standard = '\\\\server\\share\\wt'
+    expect(normalizeCwdForScope(extended)).toBe(normalizeCwdForScope(standard))
+
+    // Scoping matches an extended-UNC session cwd against a standard-UNC
+    // active cwd / worktree path from the root view.
+    const wtChat = entry('unc-wt', { cwd: extended })
+    expect(
+      scopeSessionIndex([wtChat], 'project-1', standard, [standard]).map(({ id }) => id)
+    ).toEqual(['unc-wt'])
   })
 
   it('preserves the existing browser summary wire shape', () => {

--- a/src/renderer/lib/acp-history-persistence.ts
+++ b/src/renderer/lib/acp-history-persistence.ts
@@ -276,11 +276,49 @@ export function groupSessionsByRecency<T extends { lastActivityAt: number }>(
 export function scopeSessionIndex(
   entries: SessionIndexEntry[],
   projectId: string,
-  cwd: string
+  cwd: string,
+  worktreePaths: string[] = []
 ): SessionIndexEntry[] {
   if (!projectId || !cwd) return []
-  const exact = entries.filter((entry) => entry.projectId === projectId && entry.cwd === cwd)
-  return exact.length > 0 ? exact : entries.filter((entry) => entry.projectId === projectId)
+  // ADR 0002 scoping with worktree-inclusive reachability: in addition to an
+  // exact-cwd match, a session whose cwd is one of the active project's
+  // registered worktree paths stays listed. This keeps a worktree chat
+  // reachable from the project root view and across restarts where
+  // `activeWorktreeId` is null (the sidebar would otherwise hide it because
+  // its cwd differs from the root). Falls back to projectId-only matching when
+  // the scoped set is empty, preserving the prior drift-tolerant behavior.
+  //
+  // `normalizeCwdForScope` is required: the host persists session cwds via Rust
+  // `Path::canonicalize`, which on Windows yields the verbatim `\\?\` prefix
+  // with backslash separators (`\\?\E:\…\wt`), while the project store's
+  // worktree paths come from `worktreeApi.list` in forward-slash form
+  // (`E:/…/wt`). A raw `===`/`Set.has` never equates the two and would
+  // silently hide worktree chats from the root view.
+  const normalizedCwd = normalizeCwdForScope(cwd)
+  const worktreePathSet =
+    worktreePaths.length > 0 ? new Set(worktreePaths.map(normalizeCwdForScope)) : null
+  const scoped = entries.filter((entry) => {
+    if (entry.projectId !== projectId) return false
+    const entryCwd = normalizeCwdForScope(entry.cwd)
+    if (entryCwd === normalizedCwd) return true
+    return worktreePathSet?.has(entryCwd) ?? false
+  })
+  return scoped.length > 0 ? scoped : entries.filter((entry) => entry.projectId === projectId)
+}
+
+// Canonicalize a cwd/path for comparison: strip the Windows verbatim `\\?\`
+// prefix, unify separators to `/`, and trim trailing slashes. Shared between
+// `scopeSessionIndex` (session cwd vs project worktree paths) and the launcher's
+// worktree-registration dedup (new worktree path vs already-stored paths), so a
+// trailing-slash or verbatim-prefix form mismatch can't defeat either check.
+// No lowercasing — preserves case-sensitive matching on POSIX where the prefix
+// and backslashes never occur (the transform is a no-op there).
+export function normalizeCwdForScope(p: string): string {
+  if (!p) return p
+  return p
+    .replace(/^\\\\\?\\/, '')
+    .replace(/\\/g, '/')
+    .replace(/\/+$/, '')
 }
 
 function historyMode(): 'server' | 'live_only' | 'tauri_store' | undefined {

--- a/src/renderer/lib/acp-history-persistence.ts
+++ b/src/renderer/lib/acp-history-persistence.ts
@@ -307,18 +307,26 @@ export function scopeSessionIndex(
 }
 
 // Canonicalize a cwd/path for comparison: strip the Windows verbatim `\\?\`
-// prefix, unify separators to `/`, and trim trailing slashes. Shared between
-// `scopeSessionIndex` (session cwd vs project worktree paths) and the launcher's
-// worktree-registration dedup (new worktree path vs already-stored paths), so a
-// trailing-slash or verbatim-prefix form mismatch can't defeat either check.
-// No lowercasing — preserves case-sensitive matching on POSIX where the prefix
-// and backslashes never occur (the transform is a no-op there).
+// prefix, collapse the extended UNC verbatim prefix `\\?\UNC\` to `//` so it
+// matches standard UNC `\\server\share`, unify separators to `/`, and trim
+// trailing slashes. Shared between `scopeSessionIndex` (session cwd vs project
+// worktree paths) and the launcher's worktree-registration dedup (new worktree
+// path vs already-stored paths), so a trailing-slash or verbatim-prefix form
+// mismatch can't defeat either check. No lowercasing — preserves case-sensitive
+// matching on POSIX where the prefix and backslashes never occur (the transform
+// is a no-op there).
 export function normalizeCwdForScope(p: string): string {
   if (!p) return p
-  return p
-    .replace(/^\\\\\?\\/, '')
-    .replace(/\\/g, '/')
-    .replace(/\/+$/, '')
+  return (
+    p
+      // Extended UNC verbatim prefix `\\?\UNC\server\share` → `//server/share`:
+      // collapse to `//` BEFORE the generic verbatim-prefix strip so extended and
+      // standard UNC (`\\server\share`) normalize identically.
+      .replace(/^\\\\\?\\UNC\\/i, '//')
+      .replace(/^\\\\\?\\/, '')
+      .replace(/\\/g, '/')
+      .replace(/\/+$/, '')
+  )
 }
 
 function historyMode(): 'server' | 'live_only' | 'tauri_store' | undefined {


### PR DESCRIPTION
## Summary

A chat launched in a fresh git worktree (`.termul/worktrees/<id>`) was persisted to the session index with correct `worktreePath`/`worktreeBranch`, but never appeared in the Chats sidebar. `AgentLauncher.launch()` created the worktree on disk and threaded the worktree fields into the ACP session without ever calling `addWorktree`/`setActiveWorktree` on the project store — registration was deferred to a 60s best-effort reconciler that never sets `activeWorktreeId`. With `activeWorktreeId=null`, the sidebar's `scopeSessionIndex` resolved `activeCwd` to the project root and, because hundreds of root-cwd sessions exist, exact-cwd matching returned only those — hiding the worktree chat (different cwd) with no fallback. The chat you just sent was durably recorded but invisible in the sidebar.

## Related Issue

No related issue — discovered via a live debugging session (the active worktree chat itself wasn't listed in the Chats sidebar). Searched open/closed PRs; no duplicate. The separate writer-race `persisted session not found` is tracked by #621 and is **not** addressed here.

## Type of Change

- [x] fix: bug fix

## What Changed

- **`AgentLauncher.launch()`** — after `worktreeApi.create` succeeds, synchronously register the worktree (`addWorktree`, path-deduped) and activate it (`setActiveWorktree`) before opening the chat, so the sidebar scopes to it immediately and the worktree survives restarts. Track `worktreeNameResult` so the collision-retry (`-2`) branch stores a `name` matching the git worktree on disk. Best-effort: a thrown registration logs a warn and the chat still opens.
- **`scopeSessionIndex`** — include sessions whose `cwd` is a registered worktree path of the active project (worktree-inclusive reachability), so worktree chats stay reachable from the project root view and across restarts where `activeWorktreeId` is null. Preserve the drift-tolerant projectId-only fallback when the scoped set is empty.
- **`normalizeCwdForScope`** — strip the Windows verbatim `\\?\` prefix and unify separators so Rust-canonicalized session cwds (`\\?\E:\…\wt`) match the project store's forward-slash worktree paths (`E:/…/wt`). Without this, raw `===`/`Set.has` never equated the two and the worktree chat stayed hidden on Windows.
- **`ChatHistoryTab`** — derive the active project's worktree paths and pass them into `scopeSessionIndex`; reset the lazy-load `visibleCount` window on `worktreePaths` change so a reconciler discovery can't leave a stale window.
- Tests: Windows verbatim-prefix normalization scoping case; launcher register+activate coverage (incl. retry-path stored name); reconciler no-duplicate-after-launch.

## How It Was Tested

- [x] `bun run ci` (Biome lint + format + imports, strict mode) — clean under `--diagnostic-level=error` (ran `biome check` directly; `bun run ci` is environmentally blocked in this worktree because it lives under `.termul/`, which biome's `vcs.useIgnoreFile`+`.gitignore` ignores → "0 files"; CI checks out at the repo root so it won't hit this)
- [x] `bun run typecheck`
- [x] `bun run test` (affected files: 115/115 pass)
- [ ] `cargo clippy` / `cargo test` — N/A (no Rust changes; `src-tauri` untouched)
- [ ] Manual verification completed — pending final reviewer check: launch a worktree chat, confirm it appears in the Chats sidebar instantly and remains visible after switching to the project root

## CI & Review Gate

- [x] All CI checks pass (PR Validation, Rust Checks, Build Verification, Security Scans)
- [x] Code review comments from CodeRabbit / Claude have been addressed or resolved (CodeRabbit review complete: 0 inline findings, 5/5 pre-merge checks pass; the auto-generated "fix failing CI" suggestion is stale — CI is green)
- [x] No unresolved review findings remain

## Checklist

- [x] My PR title follows the conventional commit format used by this repo
- [x] I linked the related issue or explained why none exists
- [x] I updated docs when needed (N/A — code-only fix)
- [x] I added or updated tests when needed
- [x] I verified the change does not introduce unrelated modifications
- [x] I read AGENTS.md and followed the contributor guidelines
- [x] A human reviewed the complete diff before submission (bmad adversarial review: Blind Hunter + Edge Case Hunter + Verification Gap; patches applied; 5 follow-ups deferred to `_bmad-output/implementation-artifacts/deferred-work.md`)

> Deferred follow-ups (out of scope for this fix): durable `info`-level boundary logs via `log-api.ts` (cross-layer); Windows case-insensitive path folding; UNC verbatim-prefix stripping; drift-tolerance fallback reconciliation; `randomUUID` migration for `chatId`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Worktree launches now automatically register and activate newly created worktrees.
  - Chats associated with worktrees remain accessible from the project’s chat history.
  - Worktree sessions are matched more reliably across Windows and POSIX path formats.

- **Bug Fixes**
  - Improved handling of duplicate worktree paths and name collisions.
  - Chat history remains available even when worktree registration encounters an issue.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->