### PR TITLE
feat: global right-click context menu + production devtools block

### DIFF
--- a/src-tauri/src/browser_tab_manager.rs
+++ b/src-tauri/src/browser_tab_manager.rs
@@ -632,6 +632,15 @@ impl BrowserTabManager {
         Ok(())
     }
 
+    /// Open DevTools for the webview backing this browser tab.
+    ///
+    /// Debug-gated: only exists in debug builds. In release builds, the
+    /// `browser_tab_open_devtools` Tauri command is a cfg-gated stub that
+    /// returns `Err("DevTools disabled in production")` directly — it never
+    /// calls this method, so there's no release stub (avoids dead_code).
+    /// The desktop "Toggle DevTools" menu item is already debug-gated
+    /// separately in `lib.rs`.
+    #[cfg(debug_assertions)]
     pub fn open_devtools(&self, tab_id: &str) -> Result<(), String> {
         let webview = self.get_webview(tab_id)?;
         webview.open_devtools();

--- a/src-tauri/src/browser_tab_manager.rs
+++ b/src-tauri/src/browser_tab_manager.rs
@@ -636,8 +636,9 @@ impl BrowserTabManager {
     ///
     /// Debug-gated: only exists in debug builds. In release builds, the
     /// `browser_tab_open_devtools` Tauri command is a cfg-gated stub that
-    /// returns `Err("DevTools disabled in production")` directly — it never
-    /// calls this method, so there's no release stub (avoids dead_code).
+    /// returns `Ok(IpcResult::error("DevTools disabled in production", ...))`
+    /// directly — it never calls this method, so there's no release stub
+    /// (avoids dead_code).
     /// The desktop "Toggle DevTools" menu item is already debug-gated
     /// separately in `lib.rs`.
     #[cfg(debug_assertions)]

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1170,7 +1170,17 @@ pub async fn browser_tab_reload(
     }
 }
 
-/// Open DevTools for a browser tab
+/// Open DevTools for a browser tab.
+///
+/// Debug-gated: the real implementation calls `BrowserTabManager::open_devtools`
+/// (which opens the webview inspector). In release builds the command is a
+/// stub that returns `Ok(IpcResult::error("DevTools disabled in production",
+/// ...))` so the browser-tab devtools path is fully blocked in prod — mirrors
+/// the existing `toggle_devtools` cfg-gate pattern in `lib.rs`. P13: the
+/// `BrowserTabManager::open_devtools` method only exists in debug builds (no
+/// release stub → no dead_code). The TS side also hides the Debug Console
+/// button in prod, so a user never reaches the release stub.
+#[cfg(debug_assertions)]
 #[tauri::command]
 pub async fn browser_tab_open_devtools(
     tab_id: String,
@@ -1180,6 +1190,18 @@ pub async fn browser_tab_open_devtools(
         Ok(()) => Ok(IpcResult::success(())),
         Err(e) => Ok(IpcResult::error(e, "BROWSER_TAB_OPEN_DEVTOOLS_FAILED")),
     }
+}
+
+#[cfg(not(debug_assertions))]
+#[tauri::command]
+pub async fn browser_tab_open_devtools(
+    _tab_id: String,
+    _browser_manager: State<'_, Arc<BrowserTabManager>>,
+) -> Result<IpcResult<()>, String> {
+    Ok(IpcResult::error(
+        "DevTools disabled in production".to_string(),
+        "BROWSER_TAB_OPEN_DEVTOOLS_DISABLED",
+    ))
 }
 
 /// Inject annotation overlay script into a browser tab

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -4,6 +4,7 @@ import { createHashRouter, RouterProvider } from 'react-router-dom'
 import { ChatRoute } from '@/components/ChatRoute'
 import { DirectoryPicker } from '@/components/DirectoryPicker'
 import { ErrorBoundary } from '@/components/ErrorBoundary'
+import { GlobalContextMenu } from '@/components/GlobalContextMenu'
 import { Skeleton } from '@/components/ui/skeleton'
 import { Toaster as Sonner } from '@/components/ui/sonner'
 import { Toaster } from '@/components/ui/toaster'
@@ -54,6 +55,7 @@ import { useAcpSessionResume } from './hooks/use-acp-session-resume'
 import { useKeyboardShortcutsLoader } from './hooks/use-keyboard-shortcuts'
 import { useMenuUpdaterListener } from './hooks/use-menu-updater-listener'
 import { usePreventFileDropNavigation } from './hooks/use-prevent-file-drop-navigation'
+import { usePreventNativeContextMenu } from './hooks/use-prevent-native-context-menu'
 import { useProjectsAutoSave, useProjectsLoader } from './hooks/use-projects-persistence'
 import { useAppliedUiZoomSync } from './hooks/use-ui-zoom'
 import { useUpdateCheck } from './hooks/use-updater'
@@ -99,10 +101,13 @@ const queryClient = new QueryClient()
 // initialization or a check-renderer-whitelist CI job). Do not rely on comments alone.
 
 // Component to handle app-level effects like auto-save.
-// Mirrors TauriApp.tsx AppEffects mount order (lines 63-100) for the portable
-// subset. Native-only effects (usePreventDefaultContextMenu, showWindow,
-// useWindowState) are intentionally NOT ported — they would break the browser
-// (right-click dev menu, no native window). usePreventAltMenu stays (web-only).
+// Mirrors TauriApp.tsx AppEffects mount order for the portable subset.
+// Native-only effects (usePreventDevToolsShortcuts, showWindow, useWindowState)
+// are intentionally NOT ported — they would break the browser (web cannot
+// block its own devtools; no native window). The global context menu is
+// mounted on both surfaces via <GlobalContextMenu> in the root render.
+// usePreventNativeContextMenu is ported for parity (portal regression defense).
+// usePreventAltMenu stays (web-only).
 function AppEffects(): null {
   usePreventAltMenu()
   useTerminalAutoSave()
@@ -132,6 +137,11 @@ function AppEffects(): null {
   useAcpSessionResume()
   useAcpMcp()
   usePreventFileDropNavigation()
+  // P4: suppress the native browser context menu app-wide (capture phase) for
+  // web parity — portaled overlays (toasts, modals) outside
+  // <GlobalContextMenu>'s Radix trigger subtree would show the browser's
+  // native Inspect menu. The Radix trigger still opens the global menu.
+  usePreventNativeContextMenu()
 
   // Initialize notification permissions once at app startup so the OS (or
   // browser) permission prompt appears early, not on first terminal exit. On
@@ -207,24 +217,26 @@ const App = () => {
   return (
     <QueryClientProvider client={queryClient}>
       <TooltipProvider delayDuration={80} skipDelayDuration={300}>
-        <ErrorBoundary context="App Root">
-          <AppEffects />
-          <Toaster />
-          <Sonner />
-          {/* Web/remote mode only: in-app directory picker registered with
-              dialogApi so NewProjectModal's Browse button works without a native
-              dialog.open (Story: Web/remote project creation). Desktop never
-              mounts it. */}
-          {!isTauriContext() && <DirectoryPicker />}
-          <RouterProvider router={router} future={{ v7_startTransition: true }} />
-          <WhatsNewModal
-            isOpen={whatsNew.isOpen}
-            version={whatsNew.version}
-            notes={whatsNew.notes}
-            htmlUrl={whatsNew.htmlUrl}
-            onClose={whatsNew.close}
-          />
-        </ErrorBoundary>
+        <GlobalContextMenu>
+          <ErrorBoundary context="App Root">
+            <AppEffects />
+            <Toaster />
+            <Sonner />
+            {/* Web/remote mode only: in-app directory picker registered with
+                dialogApi so NewProjectModal's Browse button works without a native
+                dialog.open (Story: Web/remote project creation). Desktop never
+                mounts it. */}
+            {!isTauriContext() && <DirectoryPicker />}
+            <RouterProvider router={router} future={{ v7_startTransition: true }} />
+            <WhatsNewModal
+              isOpen={whatsNew.isOpen}
+              version={whatsNew.version}
+              notes={whatsNew.notes}
+              htmlUrl={whatsNew.htmlUrl}
+              onClose={whatsNew.close}
+            />
+          </ErrorBoundary>
+        </GlobalContextMenu>
       </TooltipProvider>
     </QueryClientProvider>
   )

--- a/src/renderer/TauriApp.tsx
+++ b/src/renderer/TauriApp.tsx
@@ -3,9 +3,12 @@ import { useEffect } from 'react'
 import { createHashRouter, RouterProvider } from 'react-router-dom'
 import { ChatRoute } from '@/components/ChatRoute'
 import { ErrorBoundary } from '@/components/ErrorBoundary'
+import { GlobalContextMenu } from '@/components/GlobalContextMenu'
 import { Toaster as Sonner } from '@/components/ui/sonner'
 import { Toaster } from '@/components/ui/toaster'
 import { TooltipProvider } from '@/components/ui/tooltip'
+import { usePreventDevToolsShortcuts } from '@/hooks/use-prevent-devtools-shortcuts'
+import { usePreventNativeContextMenu } from '@/hooks/use-prevent-native-context-menu'
 import { useWindowState } from '@/hooks/use-window-state'
 import { getCurrentWindow } from '@/lib/tauri-window'
 import { useUpdateToast } from './components/UpdateAvailableToast'
@@ -46,20 +49,6 @@ import WorkspaceSnapshots from './pages/WorkspaceSnapshots'
 
 const queryClient = new QueryClient()
 
-// Prevent the default webview context menu (Inspect, Back, etc.) from appearing
-// on right-click. Custom context menus (FileExplorer, ProjectSidebar) already
-// call e.preventDefault() in their React handlers and render their own UI,
-// so they are unaffected by this capture-phase listener.
-function usePreventDefaultContextMenu(): void {
-  useEffect(() => {
-    const handler = (e: MouseEvent): void => {
-      e.preventDefault()
-    }
-    document.addEventListener('contextmenu', handler, { capture: true })
-    return () => document.removeEventListener('contextmenu', handler, { capture: true })
-  }, [])
-}
-
 // Component to handle app-level effects like auto-save
 function AppEffects(): null {
   useTerminalAutoSave()
@@ -89,7 +78,15 @@ function AppEffects(): null {
   useAcpSessionResume()
   useAcpMcp()
   usePreventFileDropNavigation()
-  usePreventDefaultContextMenu()
+  // P4: suppress the native webview context menu app-wide (capture phase) so
+  // portaled overlays (toasts, modals) outside <GlobalContextMenu>'s Radix
+  // trigger subtree don't show the native Inspect/Back menu. The Radix
+  // trigger still opens the global menu (preventDefault doesn't stop
+  // propagation). Defense-in-depth alongside <GlobalContextMenu>.
+  usePreventNativeContextMenu()
+  // Desktop-only: block devtools/view-source shortcuts (F12, Ctrl+Shift+I/J/C,
+  // Ctrl+U) in production. Web/remote (App.tsx) must never mount this hook.
+  usePreventDevToolsShortcuts()
 
   // Initialize desktop notification permissions once at app startup
   // so the OS permission prompt appears early, not on first terminal exit
@@ -146,19 +143,21 @@ export default function TauriApp(): React.JSX.Element {
   return (
     <QueryClientProvider client={queryClient}>
       <TooltipProvider>
-        <ErrorBoundary context="App Root">
-          <AppEffects />
-          <Toaster />
-          <Sonner />
-          <RouterProvider router={router} future={{ v7_startTransition: true }} />
-          <WhatsNewModal
-            isOpen={whatsNew.isOpen}
-            version={whatsNew.version}
-            notes={whatsNew.notes}
-            htmlUrl={whatsNew.htmlUrl}
-            onClose={whatsNew.close}
-          />
-        </ErrorBoundary>
+        <GlobalContextMenu>
+          <ErrorBoundary context="App Root">
+            <AppEffects />
+            <Toaster />
+            <Sonner />
+            <RouterProvider router={router} future={{ v7_startTransition: true }} />
+            <WhatsNewModal
+              isOpen={whatsNew.isOpen}
+              version={whatsNew.version}
+              notes={whatsNew.notes}
+              htmlUrl={whatsNew.htmlUrl}
+              onClose={whatsNew.close}
+            />
+          </ErrorBoundary>
+        </GlobalContextMenu>
       </TooltipProvider>
     </QueryClientProvider>
   )

--- a/src/renderer/assets/agent-icons/acp/agents.json
+++ b/src/renderer/assets/agent-icons/acp/agents.json
@@ -332,11 +332,11 @@
   {
     "id": "factory-droid",
     "name": "Factory Droid",
-    "version": "0.193.0",
+    "version": "0.194.0",
     "description": "Factory Droid - AI coding agent powered by Factory AI",
     "distribution": {
       "npx": {
-        "package": "droid@0.193.0",
+        "package": "droid@0.194.0",
         "args": ["exec", "--output-format", "acp-daemon"],
         "env": {
           "DROID_DISABLE_AUTO_UPDATE": "true",
@@ -395,7 +395,7 @@
   {
     "id": "goose",
     "name": "goose",
-    "version": "1.45.0",
+    "version": "1.46.0",
     "description": "A local, extensible, open source AI agent that automates engineering tasks",
     "distribution": {
       "binary": {
@@ -417,7 +417,7 @@
         },
         "windows-x86_64": {
           "cmd": "./goose-package\\goose.exe",
-          "archive": "https://github.com/block/goose/releases/download/v1.45.0/goose-x86_64-pc-windows-msvc.zip",
+          "archive": "https://github.com/block/goose/releases/download/v1.46.0/goose-x86_64-pc-windows-msvc.zip",
           "args": ["acp"]
         }
       }
@@ -473,38 +473,38 @@
   {
     "id": "junie",
     "name": "Junie",
-    "version": "2698.3.0",
+    "version": "2783.3.0",
     "description": "AI Coding Agent by JetBrains",
     "distribution": {
       "binary": {
         "darwin-aarch64": {
           "cmd": "./Applications/junie.app/Contents/MacOS/junie",
-          "archive": "https://github.com/JetBrains/junie/releases/download/2698.3/junie-release-2698.3-macos-aarch64.zip",
+          "archive": "https://github.com/JetBrains/junie-acp-release/releases/download/2783.3/junie-release-2783.3-macos-aarch64.zip",
           "args": ["--acp=true"]
         },
         "darwin-x86_64": {
           "cmd": "./Applications/junie.app/Contents/MacOS/junie",
-          "archive": "https://github.com/JetBrains/junie/releases/download/2698.3/junie-release-2698.3-macos-amd64.zip",
+          "archive": "https://github.com/JetBrains/junie-acp-release/releases/download/2783.3/junie-release-2783.3-macos-amd64.zip",
           "args": ["--acp=true"]
         },
         "linux-aarch64": {
           "cmd": "./junie-app/bin/junie",
-          "archive": "https://github.com/JetBrains/junie/releases/download/2698.3/junie-release-2698.3-linux-aarch64.zip",
+          "archive": "https://github.com/JetBrains/junie-acp-release/releases/download/2783.3/junie-release-2783.3-linux-aarch64.zip",
           "args": ["--acp=true"]
         },
         "linux-x86_64": {
           "cmd": "./junie-app/bin/junie",
-          "archive": "https://github.com/JetBrains/junie/releases/download/2698.3/junie-release-2698.3-linux-amd64.zip",
+          "archive": "https://github.com/JetBrains/junie-acp-release/releases/download/2783.3/junie-release-2783.3-linux-amd64.zip",
           "args": ["--acp=true"]
         },
         "windows-x86_64": {
           "cmd": "./junie/junie.exe",
-          "archive": "https://github.com/JetBrains/junie/releases/download/2698.3/junie-release-2698.3-windows-amd64.zip",
+          "archive": "https://github.com/JetBrains/junie-acp-release/releases/download/2783.3/junie-release-2783.3-windows-amd64.zip",
           "args": ["--acp=true"]
         },
         "windows-aarch64": {
           "cmd": "./junie/junie.exe",
-          "archive": "https://github.com/JetBrains/junie/releases/download/2698.3/junie-release-2698.3-windows-aarch64.zip",
+          "archive": "https://github.com/JetBrains/junie-acp-release/releases/download/2783.3/junie-release-2783.3-windows-aarch64.zip",
           "args": ["--acp=true"]
         }
       }

--- a/src/renderer/components/GlobalContextMenu.test.tsx
+++ b/src/renderer/components/GlobalContextMenu.test.tsx
@@ -1,0 +1,234 @@
+import { act, render, screen } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { GlobalContextMenu } from '@/components/GlobalContextMenu'
+
+// Hoisted refs to capture the Radix mock's onOpenChange callback so the test
+// can trigger the menu-open state snapshot (the real Radix portal/positioning
+// is hard to drive from jsdom). Mirrors the FileTreeContextMenu stub pattern.
+const onOpenChangeRef = vi.hoisted(() => ({ current: null as ((open: boolean) => void) | null }))
+
+// Stub text-edit-ops so the test asserts menu logic (disabled flags + click
+// wiring), not clipboard plumbing. The real module's Tauri imports never load.
+const textEditOps = vi.hoisted(() => ({
+  copySelection: vi.fn(() => Promise.resolve(true)),
+  cutSelection: vi.fn(() => Promise.resolve(true)),
+  pasteIntoFocused: vi.fn(() => Promise.resolve(true)),
+  selectAllFocused: vi.fn(() => true)
+}))
+
+vi.mock('@/lib/text-edit-ops', () => textEditOps)
+
+// Mock isTauriContext defensively (mirrors FileTreeContextMenu pattern).
+const mockIsTauriContext = vi.hoisted(() => vi.fn(() => false))
+vi.mock('@/lib/tauri-runtime', () => ({ isTauriContext: mockIsTauriContext }))
+
+// Stub the Radix context-menu primitives. The real primitives render via a
+// portal + Radix positioning that is hard to assert in jsdom; this stub
+// renders items as buttons so the test asserts labels + disabled flags +
+// click wiring. The ContextMenu mock captures onOpenChange so the test can
+// fire the menu-open snapshot at a controlled time.
+vi.mock('@/components/ui/context-menu', () => ({
+  ContextMenu: ({
+    children,
+    onOpenChange
+  }: {
+    children: React.ReactNode
+    onOpenChange?: (open: boolean) => void
+  }) => {
+    onOpenChangeRef.current = onOpenChange ?? null
+    return <div data-testid="context-menu">{children}</div>
+  },
+  ContextMenuTrigger: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="trigger">{children}</div>
+  ),
+  ContextMenuContent: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="content">{children}</div>
+  ),
+  ContextMenuItem: ({
+    children,
+    disabled,
+    onClick
+  }: {
+    children: React.ReactNode
+    disabled?: boolean
+    onClick?: () => void
+  }) => (
+    <button data-testid="item" disabled={disabled} onClick={onClick}>
+      {children}
+    </button>
+  ),
+  ContextMenuSeparator: () => <hr data-testid="separator" />,
+  ContextMenuShortcut: ({ children }: { children: React.ReactNode }) => (
+    <span data-testid="shortcut">{children}</span>
+  )
+}))
+
+/** Focus (or blur) the rendered input to control document.activeElement. */
+function focusInput(focused: boolean): void {
+  const input = screen.queryByTestId('surface-input')
+  if (focused && input instanceof HTMLElement) {
+    input.focus()
+  } else if (document.activeElement instanceof HTMLElement) {
+    document.activeElement.blur()
+  }
+}
+
+/**
+ * P3: dispatch a capture-phase contextmenu event so the GlobalContextMenu's
+ * capture-phase listener snapshots the current selection/focus state before
+ * Radix moves focus to the first menu item.
+ */
+function dispatchContextMenu(): void {
+  act(() => {
+    document.dispatchEvent(new MouseEvent('contextmenu', { bubbles: true, cancelable: true }))
+  })
+}
+
+function openMenu(): void {
+  act(() => {
+    onOpenChangeRef.current?.(true)
+  })
+}
+
+/** Find a menu item button by its label prefix (button textContent is "Copy Ctrl+C" etc.). */
+function buttonByLabel(label: string): HTMLButtonElement {
+  return screen.getByRole('button', { name: new RegExp(`^${label}\\b`) }) as HTMLButtonElement
+}
+
+describe('GlobalContextMenu', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.restoreAllMocks()
+    onOpenChangeRef.current = null
+  })
+
+  it('renders the wrapped children inside the trigger', () => {
+    render(
+      <GlobalContextMenu>
+        <div data-testid="surface">app surface</div>
+      </GlobalContextMenu>
+    )
+    expect(screen.getByTestId('surface')).toBeInTheDocument()
+    expect(screen.getByTestId('context-menu')).toBeInTheDocument()
+  })
+
+  it('shows Copy/Cut/Separator/Paste/Select All and no Reload/Back/Inspect', () => {
+    render(
+      <GlobalContextMenu>
+        <input data-testid="surface-input" />
+      </GlobalContextMenu>
+    )
+    focusInput(true)
+    dispatchContextMenu()
+    openMenu()
+
+    expect(screen.getByRole('button', { name: /^Copy\b/ })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /^Cut\b/ })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /^Paste\b/ })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /^Select All\b/ })).toBeInTheDocument()
+    expect(screen.getByTestId('separator')).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /^Reload\b/ })).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /^Back\b/ })).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /^Inspect\b/ })).not.toBeInTheDocument()
+  })
+
+  it('enables Copy/Cut/Paste/Select All when a selection exists and a mutable editable is focused', () => {
+    render(
+      <GlobalContextMenu>
+        <input data-testid="surface-input" defaultValue="hello world" />
+      </GlobalContextMenu>
+    )
+    focusInput(true)
+    const input = screen.getByTestId('surface-input') as HTMLInputElement
+    input.setSelectionRange(0, 5)
+    dispatchContextMenu()
+    openMenu()
+
+    expect(buttonByLabel('Copy').disabled).toBe(false)
+    expect(buttonByLabel('Cut').disabled).toBe(false)
+    expect(buttonByLabel('Paste').disabled).toBe(false)
+    expect(buttonByLabel('Select All').disabled).toBe(false)
+  })
+
+  it('disables Copy/Cut but enables Paste/Select All when no selection but mutable editable focused', () => {
+    render(
+      <GlobalContextMenu>
+        <input data-testid="surface-input" defaultValue="hello" />
+      </GlobalContextMenu>
+    )
+    focusInput(true)
+    dispatchContextMenu()
+    openMenu()
+
+    expect(buttonByLabel('Copy').disabled).toBe(true)
+    expect(buttonByLabel('Cut').disabled).toBe(true)
+    expect(buttonByLabel('Paste').disabled).toBe(false)
+    expect(buttonByLabel('Select All').disabled).toBe(false)
+  })
+
+  it('enables Copy but disables Cut/Paste/Select All when a selection exists but no editable focused', () => {
+    // Mock window.getSelection to return a non-empty selection (generic page text).
+    vi.spyOn(window, 'getSelection').mockReturnValue({
+      toString: () => 'selected text'
+    } as unknown as Selection)
+    render(
+      <GlobalContextMenu>
+        <div data-testid="surface">no editable here</div>
+      </GlobalContextMenu>
+    )
+    focusInput(false)
+    dispatchContextMenu()
+    openMenu()
+
+    expect(buttonByLabel('Copy').disabled).toBe(false)
+    expect(buttonByLabel('Cut').disabled).toBe(true)
+    expect(buttonByLabel('Paste').disabled).toBe(true)
+    // P9: Select All disabled when no mutable editable is focused.
+    expect(buttonByLabel('Select All').disabled).toBe(true)
+  })
+
+  it('disables Copy/Cut/Paste/Select All when no selection and no editable focused', () => {
+    vi.spyOn(window, 'getSelection').mockReturnValue({
+      toString: () => ''
+    } as unknown as Selection)
+    render(
+      <GlobalContextMenu>
+        <div data-testid="surface">no editable here</div>
+      </GlobalContextMenu>
+    )
+    focusInput(false)
+    dispatchContextMenu()
+    openMenu()
+
+    expect(buttonByLabel('Copy').disabled).toBe(true)
+    expect(buttonByLabel('Cut').disabled).toBe(true)
+    expect(buttonByLabel('Paste').disabled).toBe(true)
+    // P9: Select All disabled when no mutable editable is focused.
+    expect(buttonByLabel('Select All').disabled).toBe(true)
+  })
+
+  it('wires Copy/Cut/Paste/Select All clicks to text-edit-ops', () => {
+    render(
+      <GlobalContextMenu>
+        <input data-testid="surface-input" defaultValue="hello world" />
+      </GlobalContextMenu>
+    )
+    focusInput(true)
+    const input = screen.getByTestId('surface-input') as HTMLInputElement
+    input.setSelectionRange(0, 5)
+    dispatchContextMenu()
+    openMenu()
+
+    buttonByLabel('Copy').click()
+    expect(textEditOps.copySelection).toHaveBeenCalledTimes(1)
+
+    buttonByLabel('Cut').click()
+    expect(textEditOps.cutSelection).toHaveBeenCalledTimes(1)
+
+    buttonByLabel('Paste').click()
+    expect(textEditOps.pasteIntoFocused).toHaveBeenCalledTimes(1)
+
+    buttonByLabel('Select All').click()
+    expect(textEditOps.selectAllFocused).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/renderer/components/GlobalContextMenu.tsx
+++ b/src/renderer/components/GlobalContextMenu.tsx
@@ -1,0 +1,174 @@
+/**
+ * Global right-click context menu wrapping the app root.
+ *
+ * Renders Copy / Cut / Paste / Select All (no Reload / Back / Inspect — those
+ * are intentionally excluded per the spec) using the existing Radix primitive
+ * (`@/components/ui/context-menu`). The trigger wraps the entire app surface
+ * (`asChild` on a `display: contents` div so layout is unaffected); Radix's
+ * innermost-trigger-wins rule preserves the terminal's own menu and the
+ * FileExplorer / ProjectSidebar custom menus (their handlers call
+ * `stopPropagation` so the global trigger never fires for those regions).
+ *
+ * P3: the disabled flags + the focused element are snapshotted synchronously
+ * on the capture-phase `contextmenu` event (BEFORE Radix moves focus to the
+ * first menu item). `onOpenChange(true)` reads that snapshot. The saved
+ * element is re-focused in each item's `onClick` so `execCommand` + the
+ * `text-edit-ops` helpers operate on the element that was actually right-
+ * clicked, not the menu item Radix focused for accessibility.
+ *
+ * P8: Copy works on any selection (including readonly inputs); Cut/Paste/
+ * Select All are gated on a MUTABLE editable (not readOnly, not disabled).
+ * P9: Select All is disabled when no mutable editable is focused (no
+ * document-wide selectAll fallback).
+ */
+
+import { type ReactNode, useCallback, useEffect, useRef, useState } from 'react'
+import {
+  ContextMenu,
+  ContextMenuContent,
+  ContextMenuItem,
+  ContextMenuSeparator,
+  ContextMenuShortcut,
+  ContextMenuTrigger
+} from '@/components/ui/context-menu'
+import {
+  copySelection,
+  cutSelection,
+  pasteIntoFocused,
+  selectAllFocused
+} from '@/lib/text-edit-ops'
+
+interface GlobalContextMenuState {
+  hasSelection: boolean
+  isMutableEditableFocused: boolean
+  focusedEditable: HTMLElement | null
+}
+
+const CLOSED_STATE: GlobalContextMenuState = {
+  hasSelection: false,
+  isMutableEditableFocused: false,
+  focusedEditable: null
+}
+
+function isMutableEditableElement(el: Element | null): boolean {
+  if (!el) return false
+  if (el instanceof HTMLInputElement || el instanceof HTMLTextAreaElement) {
+    return !el.readOnly && !el.disabled
+  }
+  return el instanceof HTMLElement && el.isContentEditable
+}
+
+/**
+ * Snapshot the current selection + focused mutable editable. P2: selections
+ * inside `<input>`/`<textarea>` use `selectionStart`/`selectionEnd`, NOT
+ * `window.getSelection()` — check the focused editable first.
+ */
+function readState(): GlobalContextMenuState {
+  if (typeof window === 'undefined' || typeof document === 'undefined') return CLOSED_STATE
+  const activeEl = document.activeElement
+
+  let hasSelection = false
+  if (activeEl instanceof HTMLInputElement || activeEl instanceof HTMLTextAreaElement) {
+    const start = activeEl.selectionStart
+    const end = activeEl.selectionEnd
+    if (start !== null && end !== null && start !== end) {
+      hasSelection = true
+    }
+  }
+  if (!hasSelection) {
+    const sel = window.getSelection()
+    hasSelection = sel ? sel.toString().length > 0 : false
+  }
+
+  return {
+    hasSelection,
+    isMutableEditableFocused: isMutableEditableElement(activeEl),
+    focusedEditable: activeEl instanceof HTMLElement ? activeEl : null
+  }
+}
+
+interface GlobalContextMenuProps {
+  children: ReactNode
+}
+
+export function GlobalContextMenu({ children }: GlobalContextMenuProps): React.JSX.Element {
+  const snapshotRef = useRef<GlobalContextMenuState>(CLOSED_STATE)
+  const [state, setState] = useState<GlobalContextMenuState>(CLOSED_STATE)
+
+  // P3: capture the state synchronously on the capture-phase `contextmenu`
+  // event, BEFORE Radix moves focus to the first menu item. This fires on
+  // every right-click (even in regions that stopPropagation in the bubble
+  // phase) but is harmless — it only snapshots state to a ref.
+  useEffect(() => {
+    if (typeof document === 'undefined') return
+    const handler = (): void => {
+      snapshotRef.current = readState()
+    }
+    document.addEventListener('contextmenu', handler, { capture: true })
+    return () => document.removeEventListener('contextmenu', handler, { capture: true })
+  }, [])
+
+  const handleOpenChange = useCallback((open: boolean) => {
+    if (open) {
+      setState(snapshotRef.current)
+    }
+  }, [])
+
+  // P3: re-focus the saved element before running the action so
+  // `execCommand` + `getSelectionText()` operate on the right input.
+  const refocusEditable = useCallback(() => {
+    const el = snapshotRef.current.focusedEditable
+    if (el && el.isConnected) {
+      el.focus()
+    }
+  }, [])
+
+  const { hasSelection, isMutableEditableFocused } = state
+
+  return (
+    <ContextMenu onOpenChange={handleOpenChange}>
+      <ContextMenuTrigger asChild>
+        <div className="contents">{children}</div>
+      </ContextMenuTrigger>
+      <ContextMenuContent className="w-48">
+        <ContextMenuItem
+          disabled={!hasSelection}
+          onClick={() => {
+            refocusEditable()
+            void copySelection()
+          }}
+        >
+          Copy <ContextMenuShortcut>Ctrl+C</ContextMenuShortcut>
+        </ContextMenuItem>
+        <ContextMenuItem
+          disabled={!hasSelection || !isMutableEditableFocused}
+          onClick={() => {
+            refocusEditable()
+            void cutSelection()
+          }}
+        >
+          Cut <ContextMenuShortcut>Ctrl+X</ContextMenuShortcut>
+        </ContextMenuItem>
+        <ContextMenuSeparator />
+        <ContextMenuItem
+          disabled={!isMutableEditableFocused}
+          onClick={() => {
+            refocusEditable()
+            void pasteIntoFocused()
+          }}
+        >
+          Paste <ContextMenuShortcut>Ctrl+V</ContextMenuShortcut>
+        </ContextMenuItem>
+        <ContextMenuItem
+          disabled={!isMutableEditableFocused}
+          onClick={() => {
+            refocusEditable()
+            selectAllFocused()
+          }}
+        >
+          Select All <ContextMenuShortcut>Ctrl+A</ContextMenuShortcut>
+        </ContextMenuItem>
+      </ContextMenuContent>
+    </ContextMenu>
+  )
+}

--- a/src/renderer/components/GlobalContextMenu.tsx
+++ b/src/renderer/components/GlobalContextMenu.tsx
@@ -31,12 +31,16 @@ import {
   ContextMenuShortcut,
   ContextMenuTrigger
 } from '@/components/ui/context-menu'
+import { isMac } from '@/lib/platform'
 import {
   copySelection,
   cutSelection,
   pasteIntoFocused,
   selectAllFocused
 } from '@/lib/text-edit-ops'
+
+// Platform-aware shortcut modifier for display labels (⌘ on macOS, Ctrl elsewhere).
+const SHORTCUT_MOD = isMac ? '⌘' : 'Ctrl'
 
 interface GlobalContextMenuState {
   hasSelection: boolean
@@ -138,7 +142,7 @@ export function GlobalContextMenu({ children }: GlobalContextMenuProps): React.J
             void copySelection()
           }}
         >
-          Copy <ContextMenuShortcut>Ctrl+C</ContextMenuShortcut>
+          Copy <ContextMenuShortcut>{SHORTCUT_MOD}+C</ContextMenuShortcut>
         </ContextMenuItem>
         <ContextMenuItem
           disabled={!hasSelection || !isMutableEditableFocused}
@@ -147,7 +151,7 @@ export function GlobalContextMenu({ children }: GlobalContextMenuProps): React.J
             void cutSelection()
           }}
         >
-          Cut <ContextMenuShortcut>Ctrl+X</ContextMenuShortcut>
+          Cut <ContextMenuShortcut>{SHORTCUT_MOD}+X</ContextMenuShortcut>
         </ContextMenuItem>
         <ContextMenuSeparator />
         <ContextMenuItem
@@ -157,7 +161,7 @@ export function GlobalContextMenu({ children }: GlobalContextMenuProps): React.J
             void pasteIntoFocused()
           }}
         >
-          Paste <ContextMenuShortcut>Ctrl+V</ContextMenuShortcut>
+          Paste <ContextMenuShortcut>{SHORTCUT_MOD}+V</ContextMenuShortcut>
         </ContextMenuItem>
         <ContextMenuItem
           disabled={!isMutableEditableFocused}
@@ -166,7 +170,7 @@ export function GlobalContextMenu({ children }: GlobalContextMenuProps): React.J
             selectAllFocused()
           }}
         >
-          Select All <ContextMenuShortcut>Ctrl+A</ContextMenuShortcut>
+          Select All <ContextMenuShortcut>{SHORTCUT_MOD}+A</ContextMenuShortcut>
         </ContextMenuItem>
       </ContextMenuContent>
     </ContextMenu>

--- a/src/renderer/components/ProjectSidebar.tsx
+++ b/src/renderer/components/ProjectSidebar.tsx
@@ -367,6 +367,7 @@ export function ProjectSidebar({
   const handleGroupContextMenu = useCallback(
     (e: React.MouseEvent, groupId: string): void => {
       e.preventDefault()
+      e.stopPropagation()
       const group = groups.find((g) => g.id === groupId)
       if (group) {
         setGroupContextMenu({

--- a/src/renderer/components/ProjectSidebar.tsx
+++ b/src/renderer/components/ProjectSidebar.tsx
@@ -641,6 +641,7 @@ export function ProjectSidebar({
 
   const handleContextMenu = useCallback((e: React.MouseEvent, projectId: string): void => {
     e.preventDefault()
+    e.stopPropagation()
     setContextMenu({
       isOpen: true,
       x: e.clientX,

--- a/src/renderer/components/browser/BrowserControls.test.tsx
+++ b/src/renderer/components/browser/BrowserControls.test.tsx
@@ -1,5 +1,5 @@
 import { fireEvent, render, screen } from '@testing-library/react'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { TooltipProvider } from '@/components/ui/tooltip'
 import { useBrowserSessionStore } from '@/stores/browser-session-store'
 import { BrowserControls } from './BrowserControls'
@@ -23,6 +23,11 @@ function renderWithProvider(ui: React.ReactElement) {
 describe('BrowserControls', () => {
   beforeEach(() => {
     useBrowserSessionStore.setState({ tabs: new Map() })
+  })
+
+  afterEach(() => {
+    // Restore env stubs (P12: PROD env stub must not leak into other tests).
+    vi.unstubAllEnvs()
   })
 
   it('renders nothing when tab has no URL', () => {
@@ -105,6 +110,18 @@ describe('BrowserControls', () => {
     expect(screen.getByTitle('Forward')).toBeInTheDocument()
     expect(screen.getByTitle('Reload')).toBeInTheDocument()
     expect(screen.getByTitle('Debug Console')).toBeInTheDocument()
+  })
+
+  // P12: the Debug Console button is hidden in production builds.
+  it('hides the Debug Console button when import.meta.env.PROD is true', () => {
+    vi.stubEnv('PROD', true)
+    useBrowserSessionStore.getState().createTab('tab-1', 'https://example.com')
+    renderWithProvider(<BrowserControls browserTabId="tab-1" />)
+
+    expect(screen.queryByTitle('Debug Console')).not.toBeInTheDocument()
+    // Other controls are still present.
+    expect(screen.getByTitle('Back')).toBeInTheDocument()
+    expect(screen.getByTitle('Reload')).toBeInTheDocument()
   })
 
   it('renders URL input with current tab URL', () => {

--- a/src/renderer/components/browser/BrowserControls.tsx
+++ b/src/renderer/components/browser/BrowserControls.tsx
@@ -97,19 +97,21 @@ export function BrowserControls({ browserTabId }: BrowserControlsProps): React.J
             placeholder="Enter URL..."
           />
         </div>
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <button
-              onClick={() => browserTabOpenDevtools(browserTabId).catch(console.error)}
-              className="p-1.5 rounded shrink-0 hover:bg-secondary text-muted-foreground hover:text-foreground transition-colors"
-              aria-label="Open debug console"
-              title="Debug Console"
-            >
-              <Bug size={14} />
-            </button>
-          </TooltipTrigger>
-          <TooltipContent side="bottom">Debug Console</TooltipContent>
-        </Tooltip>
+        {!import.meta.env.PROD && (
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                onClick={() => browserTabOpenDevtools(browserTabId).catch(console.error)}
+                className="p-1.5 rounded shrink-0 hover:bg-secondary text-muted-foreground hover:text-foreground transition-colors"
+                aria-label="Open debug console"
+                title="Debug Console"
+              >
+                <Bug size={14} />
+              </button>
+            </TooltipTrigger>
+            <TooltipContent side="bottom">Debug Console</TooltipContent>
+          </Tooltip>
+        )}
         <Tooltip>
           <TooltipTrigger asChild>
             <button

--- a/src/renderer/hooks/__tests__/use-prevent-devtools-shortcuts.test.ts
+++ b/src/renderer/hooks/__tests__/use-prevent-devtools-shortcuts.test.ts
@@ -1,0 +1,235 @@
+import { renderHook } from '@testing-library/react'
+import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { usePreventDevToolsShortcuts } from '@/hooks/use-prevent-devtools-shortcuts'
+
+// P10: logFrontendError is called on each block — mock it so the assertion
+// doesn't try to invoke the real Tauri command.
+vi.mock('@/lib/log-api', () => ({ logFrontendError: vi.fn() }))
+
+interface DispatchOptions {
+  key: string
+  code?: string
+  ctrlKey?: boolean
+  metaKey?: boolean
+  shiftKey?: boolean
+  altKey?: boolean
+}
+
+/** Dispatch a real KeyboardEvent on document and return spies on its methods. */
+function dispatchKeyDown(opts: DispatchOptions): {
+  event: KeyboardEvent
+  preventDefault: ReturnType<typeof vi.spyOn>
+  stopPropagation: ReturnType<typeof vi.spyOn>
+} {
+  const event = new KeyboardEvent('keydown', {
+    key: opts.key,
+    code: opts.code ?? '',
+    bubbles: true,
+    cancelable: true,
+    ctrlKey: opts.ctrlKey ?? false,
+    metaKey: opts.metaKey ?? false,
+    shiftKey: opts.shiftKey ?? false,
+    altKey: opts.altKey ?? false
+  })
+  const preventDefault = vi.spyOn(event, 'preventDefault')
+  const stopPropagation = vi.spyOn(event, 'stopPropagation')
+  document.dispatchEvent(event)
+  return { event, preventDefault, stopPropagation }
+}
+
+describe('usePreventDevToolsShortcuts', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.unstubAllEnvs()
+  })
+
+  afterEach(() => {
+    vi.unstubAllEnvs()
+    vi.restoreAllMocks()
+  })
+
+  afterAll(() => {
+    vi.unstubAllEnvs()
+    vi.restoreAllMocks()
+  })
+
+  // ---- P5: production gating ----
+
+  describe('in production (PROD=true)', () => {
+    beforeEach(() => {
+      vi.stubEnv('PROD', true)
+    })
+
+    it('mounts a capture-phase keydown listener on document', () => {
+      const addSpy = vi.spyOn(document, 'addEventListener')
+      renderHook(() => usePreventDevToolsShortcuts())
+      expect(addSpy).toHaveBeenCalledWith(
+        'keydown',
+        expect.any(Function),
+        expect.objectContaining({ capture: true })
+      )
+    })
+
+    it('blocks F12', () => {
+      renderHook(() => usePreventDevToolsShortcuts())
+      const { preventDefault, stopPropagation } = dispatchKeyDown({ key: 'F12', code: 'F12' })
+      expect(preventDefault).toHaveBeenCalledTimes(1)
+      expect(stopPropagation).toHaveBeenCalledTimes(1)
+    })
+
+    it('blocks Ctrl+Shift+I (e.code=KeyI)', () => {
+      renderHook(() => usePreventDevToolsShortcuts())
+      const { preventDefault, stopPropagation } = dispatchKeyDown({
+        key: 'i',
+        code: 'KeyI',
+        ctrlKey: true,
+        shiftKey: true
+      })
+      expect(preventDefault).toHaveBeenCalledTimes(1)
+      expect(stopPropagation).toHaveBeenCalledTimes(1)
+    })
+
+    it('blocks Ctrl+Shift+J (e.code=KeyJ)', () => {
+      renderHook(() => usePreventDevToolsShortcuts())
+      const { preventDefault, stopPropagation } = dispatchKeyDown({
+        key: 'j',
+        code: 'KeyJ',
+        ctrlKey: true,
+        shiftKey: true
+      })
+      expect(preventDefault).toHaveBeenCalledTimes(1)
+      expect(stopPropagation).toHaveBeenCalledTimes(1)
+    })
+
+    it('blocks Ctrl+Shift+C (e.code=KeyC)', () => {
+      renderHook(() => usePreventDevToolsShortcuts())
+      const { preventDefault, stopPropagation } = dispatchKeyDown({
+        key: 'c',
+        code: 'KeyC',
+        ctrlKey: true,
+        shiftKey: true
+      })
+      expect(preventDefault).toHaveBeenCalledTimes(1)
+      expect(stopPropagation).toHaveBeenCalledTimes(1)
+    })
+
+    it('blocks Ctrl+U (e.code=KeyU)', () => {
+      renderHook(() => usePreventDevToolsShortcuts())
+      const { preventDefault, stopPropagation } = dispatchKeyDown({
+        key: 'u',
+        code: 'KeyU',
+        ctrlKey: true
+      })
+      expect(preventDefault).toHaveBeenCalledTimes(1)
+      expect(stopPropagation).toHaveBeenCalledTimes(1)
+    })
+
+    // P6a: macOS Cmd+Shift+I uses metaKey
+    it('blocks Cmd+Shift+I on macOS (metaKey, e.code=KeyI)', () => {
+      renderHook(() => usePreventDevToolsShortcuts())
+      const { preventDefault } = dispatchKeyDown({
+        key: 'i',
+        code: 'KeyI',
+        metaKey: true,
+        shiftKey: true
+      })
+      expect(preventDefault).toHaveBeenCalledTimes(1)
+    })
+
+    it('blocks Cmd+U on macOS (metaKey, e.code=KeyU)', () => {
+      renderHook(() => usePreventDevToolsShortcuts())
+      const { preventDefault } = dispatchKeyDown({
+        key: 'u',
+        code: 'KeyU',
+        metaKey: true
+      })
+      expect(preventDefault).toHaveBeenCalledTimes(1)
+    })
+
+    // P6b: Alt excluded
+    it('does NOT block Ctrl+Shift+Alt+I (altKey excluded)', () => {
+      renderHook(() => usePreventDevToolsShortcuts())
+      const { preventDefault } = dispatchKeyDown({
+        key: 'i',
+        code: 'KeyI',
+        ctrlKey: true,
+        shiftKey: true,
+        altKey: true
+      })
+      expect(preventDefault).not.toHaveBeenCalled()
+    })
+
+    it('does NOT block Ctrl+Alt+U (altKey excluded)', () => {
+      renderHook(() => usePreventDevToolsShortcuts())
+      const { preventDefault } = dispatchKeyDown({
+        key: 'u',
+        code: 'KeyU',
+        ctrlKey: true,
+        altKey: true
+      })
+      expect(preventDefault).not.toHaveBeenCalled()
+    })
+
+    it('lets non-target keys pass through (Enter)', () => {
+      renderHook(() => usePreventDevToolsShortcuts())
+      const { preventDefault, stopPropagation } = dispatchKeyDown({
+        key: 'Enter',
+        code: 'Enter'
+      })
+      expect(preventDefault).not.toHaveBeenCalled()
+      expect(stopPropagation).not.toHaveBeenCalled()
+    })
+
+    it('lets Ctrl+R pass through (app reload)', () => {
+      renderHook(() => usePreventDevToolsShortcuts())
+      const { preventDefault } = dispatchKeyDown({ key: 'r', code: 'KeyR', ctrlKey: true })
+      expect(preventDefault).not.toHaveBeenCalled()
+    })
+
+    it('removes the listener on unmount', () => {
+      const removeSpy = vi.spyOn(document, 'removeEventListener')
+      const { unmount } = renderHook(() => usePreventDevToolsShortcuts())
+      unmount()
+      expect(removeSpy).toHaveBeenCalledWith(
+        'keydown',
+        expect.any(Function),
+        expect.objectContaining({ capture: true })
+      )
+    })
+  })
+
+  // ---- P5: dev mode no-op ----
+
+  describe('in dev (PROD=false)', () => {
+    beforeEach(() => {
+      vi.stubEnv('PROD', false)
+    })
+
+    it('does NOT add a keydown listener (dev keeps devtools access)', () => {
+      const addSpy = vi.spyOn(document, 'addEventListener')
+      renderHook(() => usePreventDevToolsShortcuts())
+      expect(addSpy).not.toHaveBeenCalledWith(
+        'keydown',
+        expect.any(Function),
+        expect.objectContaining({ capture: true })
+      )
+    })
+
+    it('lets F12 pass through in dev', () => {
+      renderHook(() => usePreventDevToolsShortcuts())
+      const { preventDefault } = dispatchKeyDown({ key: 'F12', code: 'F12' })
+      expect(preventDefault).not.toHaveBeenCalled()
+    })
+
+    it('lets Ctrl+Shift+I pass through in dev', () => {
+      renderHook(() => usePreventDevToolsShortcuts())
+      const { preventDefault } = dispatchKeyDown({
+        key: 'i',
+        code: 'KeyI',
+        ctrlKey: true,
+        shiftKey: true
+      })
+      expect(preventDefault).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/src/renderer/hooks/use-prevent-devtools-shortcuts.ts
+++ b/src/renderer/hooks/use-prevent-devtools-shortcuts.ts
@@ -1,0 +1,73 @@
+/**
+ * Desktop-only capture-phase keydown blocker for devtools shortcuts.
+ *
+ * P5: only active in production (`import.meta.env.PROD`) — devs need F12 in
+ * dev. The hook itself checks the env so the call site stays simple.
+ *
+ * P6: uses `e.code` (`'KeyI'`/`'KeyJ'`/`'KeyC'`/`'KeyU'`) instead of
+ * `e.key` for locale-independent matching (Cyrillic etc. produce different
+ * `e.key`). Accepts `ctrlKey || metaKey` (Cmd on macOS). Excludes `altKey`
+ * so potential app shortcuts (Ctrl+Shift+Alt+I) are not swallowed. F12 keeps
+ * `e.key === 'F12'` (its `e.code` is also `'F12'`).
+ *
+ * P10: emits a warn-level boundary log via `logFrontendError` on each block so
+ * the suppression is auditable. Never throws.
+ *
+ * Desktop-only: mount ONLY in `TauriApp`. Web/remote (`App.tsx`) must never
+ * call this hook — the browser cannot (and must not try to) block its own
+ * devtools.
+ */
+
+import { useEffect } from 'react'
+import { logFrontendError } from '@/lib/log-api'
+
+/** True when the keydown event is a devtools/view-source shortcut to block. */
+function isDevToolsShortcut(e: KeyboardEvent): boolean {
+  // F12 — its e.code is also 'F12', so e.key check is fine.
+  if (e.key === 'F12') return true
+
+  // Ctrl/Cmd+Shift+I / J / C — devtools / console / inspect.
+  // P6: use e.code for locale-independent matching; accept metaKey (macOS Cmd);
+  // exclude altKey (avoid swallowing potential app shortcuts).
+  if ((e.ctrlKey || e.metaKey) && e.shiftKey && !e.altKey) {
+    if (e.code === 'KeyI' || e.code === 'KeyJ' || e.code === 'KeyC') return true
+  }
+
+  // Ctrl/Cmd+U — view source (same family of inspector shortcuts).
+  // P6: accept metaKey (macOS Cmd+U); exclude altKey; use e.code.
+  if ((e.ctrlKey || e.metaKey) && !e.shiftKey && !e.altKey && e.code === 'KeyU') {
+    return true
+  }
+
+  return false
+}
+
+/**
+ * Block devtools/view-source shortcuts at the capture phase on the desktop
+ * surface. `preventDefault` + `stopPropagation` so the webview never opens the
+ * inspector. P10: logs each block via `logFrontendError` (warn level) so the
+ * suppression is auditable. No-op in dev (P5), outside a browser, or when not
+ * in production.
+ */
+export function usePreventDevToolsShortcuts(): void {
+  useEffect(() => {
+    // P5: only block in production — devs need F12 / devtools in dev.
+    if (!import.meta.env.PROD) return
+    if (typeof document === 'undefined') return
+
+    const handler = (e: KeyboardEvent): void => {
+      if (!isDevToolsShortcut(e)) return
+      e.preventDefault()
+      e.stopPropagation()
+      // P10: boundary log so the block is auditable (never throws).
+      void logFrontendError({
+        level: 'warn',
+        message: `Blocked devtools shortcut: ${e.code || e.key}`,
+        source: 'hooks/use-prevent-devtools-shortcuts'
+      })
+    }
+
+    document.addEventListener('keydown', handler, { capture: true })
+    return () => document.removeEventListener('keydown', handler, { capture: true })
+  }, [])
+}

--- a/src/renderer/hooks/use-prevent-native-context-menu.ts
+++ b/src/renderer/hooks/use-prevent-native-context-menu.ts
@@ -1,0 +1,30 @@
+/**
+ * Suppress the native browser/webview context menu app-wide (capture phase).
+ *
+ * `preventDefault()` on the capture-phase `contextmenu` event prevents the
+ * native menu (Inspect, Back, etc.) from showing on portaled overlays (toasts,
+ * modals) that live outside the Radix `<GlobalContextMenu>` trigger subtree.
+ * It does NOT stop propagation, so the Radix trigger still opens the global
+ * menu for right-clicks inside its subtree, and custom menus
+ * (FileExplorer/ProjectSidebar) still render their own UI.
+ *
+ * P4 defense-in-depth alongside `<GlobalContextMenu>` — the Radix trigger's
+ * own `preventDefault` only covers its subtree; this hook covers the rest of
+ * the document (portals, blank areas). Mounted on BOTH surfaces (TauriApp +
+ * App) for parity.
+ */
+
+import { useEffect } from 'react'
+
+export function usePreventNativeContextMenu(): void {
+  useEffect(() => {
+    if (typeof document === 'undefined') return
+
+    const handler = (e: MouseEvent): void => {
+      e.preventDefault()
+    }
+
+    document.addEventListener('contextmenu', handler, { capture: true })
+    return () => document.removeEventListener('contextmenu', handler, { capture: true })
+  }, [])
+}

--- a/src/renderer/layouts/WorkspaceLayout.test.tsx
+++ b/src/renderer/layouts/WorkspaceLayout.test.tsx
@@ -885,12 +885,12 @@ describe('WorkspaceLayout - Empty States', () => {
 
       // The onShortcut subscription registers in a layout effect; under
       // full-suite contention this can slip past the default 1s waitFor.
-      await waitFor(() => expect(backendShortcut).toBeDefined(), { timeout: 5000 })
+      await waitFor(() => expect(backendShortcut).toBeDefined(), { timeout: 10000 })
       act(() => backendShortcut?.('colorThemePicker'))
       // ThemePicker is React.lazy — allow extra time for the chunk to resolve
       // under full-suite resource contention (passes instantly in isolation).
       expect(
-        await screen.findByRole('dialog', { name: 'Color theme picker' }, { timeout: 5000 })
+        await screen.findByRole('dialog', { name: 'Color theme picker' }, { timeout: 10000 })
       ).toBeInTheDocument()
     })
   })
@@ -1188,7 +1188,7 @@ describe('WorkspaceLayout - Empty States', () => {
           () => {
             expect(mockApi.filesystem.watchDirectory).toHaveBeenCalledWith('/workspace/a')
           },
-          { timeout: 5000 }
+          { timeout: 10000 }
         )
 
         // Give the async project-switch effect a tick to settle.

--- a/src/renderer/lib/__tests__/parity-checklist.test.ts
+++ b/src/renderer/lib/__tests__/parity-checklist.test.ts
@@ -1160,4 +1160,164 @@ describe('Parity Checklist Automation', () => {
       }
     })
   })
+
+  // Global right-click context menu + production devtools block. Pins that:
+  //   - GlobalContextMenu wraps BOTH roots (TauriApp.tsx + App.tsx) for parity.
+  //   - The devtools-shortcut blocker is desktop-only + PROD-gated (TauriApp, not App).
+  //   - The native-context-menu preventDefault hook (usePreventNativeContextMenu) is
+  //     mounted on BOTH roots (P4: portal regression defense).
+  //   - The browser-tab devtools command is cfg-gated in Rust (debug real impl,
+  //     release Err stub); the manager method is debug-only (P13: no release stub).
+  //   - The Debug Console button is hidden in prod (import.meta.env.PROD).
+  describe('Global context menu + devtools block parity', () => {
+    const GlobalMenu = join(LIB_DIR, '..', 'components', 'GlobalContextMenu.tsx')
+    const DevtoolsHook = join(LIB_DIR, '..', 'hooks', 'use-prevent-devtools-shortcuts.ts')
+    const TextEditOps = join(LIB_DIR, 'text-edit-ops.ts')
+    const TauriApp = join(LIB_DIR, '..', 'TauriApp.tsx')
+    const WebApp = join(LIB_DIR, '..', 'App.tsx')
+    const BrowserControls = join(LIB_DIR, '..', 'components', 'browser', 'BrowserControls.tsx')
+    const CommandsRust = join(LIB_DIR, '..', '..', '..', 'src-tauri', 'src', 'commands.rs')
+    const BrowserTabManagerRust = join(
+      LIB_DIR,
+      '..',
+      '..',
+      '..',
+      'src-tauri',
+      'src',
+      'browser_tab_manager.rs'
+    )
+
+    it('GlobalContextMenu.tsx exists and renders the Radix menu with Copy/Cut/Paste/Select All', () => {
+      expect(existsSync(GlobalMenu), 'GlobalContextMenu.tsx should exist').toBe(true)
+      const content = readFileSync(GlobalMenu, 'utf-8')
+      expect(content).toMatch(/from\s+['"]@\/components\/ui\/context-menu['"]/)
+      expect(content).toMatch(/ContextMenuContent/)
+      expect(content).toMatch(/ContextMenuTrigger/)
+      expect(content).toMatch(/ContextMenuSeparator/)
+      // The four edit operations must be wired. The "no Reload/Back/Inspect"
+      // constraint is asserted at runtime by GlobalContextMenu.test.tsx
+      // (queryByRole), not here — this is a static file check.
+      expect(content).toMatch(/copySelection/)
+      expect(content).toMatch(/cutSelection/)
+      expect(content).toMatch(/pasteIntoFocused/)
+      expect(content).toMatch(/selectAllFocused/)
+    })
+
+    it('text-edit-ops.ts exists with the four edit helpers + log-api boundary', () => {
+      expect(existsSync(TextEditOps), 'text-edit-ops.ts should exist').toBe(true)
+      const content = readFileSync(TextEditOps, 'utf-8')
+      expect(content).toMatch(/export\s+async\s+function\s+\bcopySelection\b/)
+      expect(content).toMatch(/export\s+async\s+function\s+\bcutSelection\b/)
+      expect(content).toMatch(/export\s+async\s+function\s+\bpasteIntoFocused\b/)
+      expect(content).toMatch(/export\s+function\s+\bselectAllFocused\b/)
+      // Reuses clipboardApi + copyText + logFrontendError (never throws).
+      expect(content).toMatch(/clipboardApi/)
+      expect(content).toMatch(/copyText/)
+      expect(content).toMatch(/logFrontendError/)
+    })
+
+    it('use-prevent-devtools-shortcuts.ts exists and is a capture-phase keydown blocker', () => {
+      expect(existsSync(DevtoolsHook), 'use-prevent-devtools-shortcuts.ts should exist').toBe(true)
+      const content = readFileSync(DevtoolsHook, 'utf-8')
+      // Capture-phase document listener (mirror usePreventDefaultContextMenu shape).
+      expect(content).toMatch(/addEventListener\(\s*['"]keydown['"]/)
+      expect(content).toMatch(/capture:\s*true/)
+      // P5: production-gated (no-op in dev so devs keep F12 access).
+      expect(content).toMatch(/import\.meta\.env\.PROD/)
+      // P6: uses e.code (locale-independent) for the letter matches.
+      expect(content).toMatch(/KeyI/)
+      expect(content).toMatch(/KeyJ/)
+      expect(content).toMatch(/KeyC/)
+      expect(content).toMatch(/KeyU/)
+      // P6: accepts metaKey (macOS Cmd).
+      expect(content).toMatch(/metaKey/)
+      // P6: excludes altKey.
+      expect(content).toMatch(/!.*altKey|!e\.altKey/)
+      // preventDefault + stopPropagation on match.
+      expect(content).toMatch(/preventDefault/)
+      expect(content).toMatch(/stopPropagation/)
+      // P10: boundary log via logFrontendError on each block.
+      expect(content).toMatch(/logFrontendError/)
+    })
+
+    it('TauriApp.tsx wraps root in GlobalContextMenu + mounts the devtools blocker + native-context-menu defense', () => {
+      expect(existsSync(TauriApp), 'TauriApp.tsx should exist').toBe(true)
+      const content = readFileSync(TauriApp, 'utf-8')
+      expect(content).toMatch(/GlobalContextMenu/)
+      expect(content).toMatch(/usePreventDevToolsShortcuts/)
+      // P4: the native-context-menu preventDefault hook is re-added as
+      // defense-in-depth (usePreventNativeContextMenu) alongside
+      // <GlobalContextMenu> so portaled overlays don't show the native menu.
+      expect(content).toMatch(/usePreventNativeContextMenu/)
+      // The old hook name must be gone (renamed).
+      expect(content).not.toMatch(/usePreventDefaultContextMenu/)
+    })
+
+    it('App.tsx wraps root in GlobalContextMenu + mounts native-context-menu defense (no devtools blocker)', () => {
+      expect(existsSync(WebApp), 'App.tsx should exist').toBe(true)
+      const content = readFileSync(WebApp, 'utf-8')
+      expect(content).toMatch(/GlobalContextMenu/)
+      // P4: web also mounts the native-context-menu defense (portal regression).
+      expect(content).toMatch(/usePreventNativeContextMenu/)
+      // Web parity: NO devtools blocker (browser cannot block its own devtools).
+      // Assert no import of the hook (the dashed import path), not the camelCase
+      // name — App.tsx's comment mentions the hook by name for documentation.
+      expect(content).not.toMatch(/from\s+['"]@\/hooks\/use-prevent-devtools-shortcuts['"]/)
+      expect(content).not.toMatch(/usePreventDevToolsShortcuts\(\)/)
+    })
+
+    it('commands.rs cfg-gates browser_tab_open_devtools (debug real, release Err stub)', () => {
+      expect(existsSync(CommandsRust), 'commands.rs should exist').toBe(true)
+      const content = readFileSync(CommandsRust, 'utf-8')
+      expect(content).toMatch(/#\[cfg\(debug_assertions\)\][\s\S]*?browser_tab_open_devtools/)
+      expect(content).toMatch(
+        /#\[cfg\(not\(debug_assertions\)\)\][\s\S]*?browser_tab_open_devtools/
+      )
+      expect(content).toMatch(/DevTools disabled in production/)
+    })
+
+    it('browser_tab_manager.rs cfg-gates open_devtools (debug-only; P13: no release stub)', () => {
+      expect(existsSync(BrowserTabManagerRust), 'browser_tab_manager.rs should exist').toBe(true)
+      const content = readFileSync(BrowserTabManagerRust, 'utf-8')
+      // P13: only the debug (#[cfg(debug_assertions)]) method exists — the
+      // release stub was removed (the release command returns the error
+      // directly, so the method is never called in release → no dead_code).
+      expect(content).toMatch(/#\[cfg\(debug_assertions\)\][\s\S]*?fn\s+open_devtools/)
+      // No release cfg-gated open_devtools stub (P13 removed it).
+      expect(content).not.toMatch(/#\[cfg\(not\(debug_assertions\)\)\][\s\S]*?fn\s+open_devtools/)
+    })
+
+    it('BrowserControls.tsx hides the Debug Console button in production', () => {
+      expect(existsSync(BrowserControls), 'BrowserControls.tsx should exist').toBe(true)
+      const content = readFileSync(BrowserControls, 'utf-8')
+      expect(content).toMatch(/import\.meta\.env\.PROD/)
+      expect(content).toMatch(/browserTabOpenDevtools/)
+    })
+
+    it('ProjectSidebar.tsx handleContextMenu calls stopPropagation so the global trigger does not fire', () => {
+      const sidebar = join(LIB_DIR, '..', 'components', 'ProjectSidebar.tsx')
+      expect(existsSync(sidebar), 'ProjectSidebar.tsx should exist').toBe(true)
+      const content = readFileSync(sidebar, 'utf-8')
+      // The handleContextMenu callback must call both preventDefault and
+      // stopPropagation so the global Radix trigger doesn't double-fire.
+      const handlerMatch = content.match(
+        /handleContextMenu[\s\S]*?useCallback\(([\s\S]*?),\s*\[\]\)/
+      )
+      expect(handlerMatch, 'handleContextMenu callback should exist').not.toBeNull()
+      const handler = handlerMatch![1]
+      expect(handler).toMatch(/preventDefault/)
+      expect(handler).toMatch(/stopPropagation/)
+    })
+
+    it('FileExplorer.tsx handleContextMenu calls stopPropagation (pre-existing pattern)', () => {
+      const explorer = join(LIB_DIR, '..', 'components', 'file-explorer', 'FileExplorer.tsx')
+      expect(existsSync(explorer), 'FileExplorer.tsx should exist').toBe(true)
+      const content = readFileSync(explorer, 'utf-8')
+      const handlerMatch = content.match(/handleContextMenu[\s\S]*?useCallback\(([\s\S]*?),\s*\[/)
+      expect(handlerMatch, 'FileExplorer handleContextMenu callback should exist').not.toBeNull()
+      const handler = handlerMatch![1]
+      expect(handler).toMatch(/preventDefault/)
+      expect(handler).toMatch(/stopPropagation/)
+    })
+  })
 })

--- a/src/renderer/lib/__tests__/parity-checklist.test.ts
+++ b/src/renderer/lib/__tests__/parity-checklist.test.ts
@@ -1309,6 +1309,20 @@ describe('Parity Checklist Automation', () => {
       expect(handler).toMatch(/stopPropagation/)
     })
 
+    it('ProjectSidebar.tsx handleGroupContextMenu calls stopPropagation (parity with handleContextMenu)', () => {
+      const sidebar = join(LIB_DIR, '..', 'components', 'ProjectSidebar.tsx')
+      const content = readFileSync(sidebar, 'utf-8')
+      // The group context menu handler must also stopPropagation so the global
+      // Radix trigger doesn't double-fire over the sidebar's group menu.
+      const handlerMatch = content.match(
+        /handleGroupContextMenu[\s\S]*?useCallback\(([\s\S]*?),\s*\[/
+      )
+      expect(handlerMatch, 'handleGroupContextMenu callback should exist').not.toBeNull()
+      const handler = handlerMatch![1]
+      expect(handler).toMatch(/preventDefault/)
+      expect(handler).toMatch(/stopPropagation/)
+    })
+
     it('FileExplorer.tsx handleContextMenu calls stopPropagation (pre-existing pattern)', () => {
       const explorer = join(LIB_DIR, '..', 'components', 'file-explorer', 'FileExplorer.tsx')
       expect(existsSync(explorer), 'FileExplorer.tsx should exist').toBe(true)

--- a/src/renderer/lib/text-edit-ops.test.ts
+++ b/src/renderer/lib/text-edit-ops.test.ts
@@ -204,6 +204,24 @@ describe('text-edit-ops', () => {
       expect(result).toBe(false)
       expect(execCommandMock).not.toHaveBeenCalled()
     })
+
+    it('restores the original selection before delete after copyText destroys it', async () => {
+      const input = createInput('hello world')
+      input.setSelectionRange(0, 5)
+      const setSelectionRangeSpy = vi.spyOn(input, 'setSelectionRange')
+      // Simulate copyText's non-secure-context fallback (lib/copy-text.ts): it
+      // focuses a temporary textarea, destroying the original input selection +
+      // focus. cutSelection must restore the selection before delete.
+      mocks.copyText.mockImplementation(async () => {
+        input.blur()
+        return true
+      })
+
+      const result = await cutSelection()
+      expect(result).toBe(true)
+      expect(setSelectionRangeSpy).toHaveBeenCalledWith(0, 5)
+      expect(execCommandMock).toHaveBeenCalledWith('delete')
+    })
   })
 
   // ---- pasteIntoFocused ----

--- a/src/renderer/lib/text-edit-ops.test.ts
+++ b/src/renderer/lib/text-edit-ops.test.ts
@@ -1,0 +1,293 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  readText: vi.fn(),
+  copyText: vi.fn(),
+  logFrontendError: vi.fn()
+}))
+
+vi.mock('@/lib/api', () => ({
+  clipboardApi: {
+    readText: mocks.readText,
+    writeText: vi.fn(),
+    hasImage: vi.fn()
+  }
+}))
+vi.mock('@/lib/copy-text', () => ({ copyText: mocks.copyText }))
+vi.mock('@/lib/log-api', () => ({ logFrontendError: mocks.logFrontendError }))
+
+import { copySelection, cutSelection, pasteIntoFocused, selectAllFocused } from './text-edit-ops'
+
+let execCommandMock: ReturnType<typeof vi.fn>
+
+function createInput(
+  value = '',
+  opts?: { readOnly?: boolean; disabled?: boolean }
+): HTMLInputElement {
+  const input = document.createElement('input')
+  input.type = 'text'
+  input.value = value
+  if (opts?.readOnly) input.readOnly = true
+  if (opts?.disabled) input.disabled = true
+  document.body.appendChild(input)
+  input.focus()
+  return input
+}
+
+function createTextarea(value = ''): HTMLTextAreaElement {
+  const ta = document.createElement('textarea')
+  ta.value = value
+  document.body.appendChild(ta)
+  ta.focus()
+  return ta
+}
+
+function createContentEditable(text = 'hello world'): HTMLDivElement {
+  const div = document.createElement('div')
+  div.setAttribute('contenteditable', 'true')
+  div.tabIndex = 0
+  div.textContent = text
+  document.body.appendChild(div)
+  div.focus()
+  // jsdom may not fully implement the isContentEditable getter — define it
+  // explicitly so getFocusedEditable() recognizes the element.
+  Object.defineProperty(div, 'isContentEditable', {
+    get: () => true,
+    configurable: true
+  })
+  return div
+}
+
+function clearDOM(): void {
+  document.body.innerHTML = ''
+  if (document.activeElement instanceof HTMLElement) {
+    document.activeElement.blur()
+  }
+}
+
+/** Install a mock execCommand on document (jsdom doesn't define it as own prop). */
+function installExecCommandMock(): void {
+  execCommandMock = vi.fn(() => true)
+  Object.defineProperty(document, 'execCommand', {
+    value: execCommandMock,
+    configurable: true,
+    writable: true
+  })
+}
+
+function restoreExecCommand(): void {
+  delete (document as { execCommand?: unknown }).execCommand
+}
+
+/** Install a mock select() on an input/textarea (prototype method, not own). */
+function installSelectMock(el: HTMLInputElement | HTMLTextAreaElement): ReturnType<typeof vi.fn> {
+  const selectMock = vi.fn()
+  Object.defineProperty(el, 'select', {
+    value: selectMock,
+    configurable: true,
+    writable: true
+  })
+  return selectMock
+}
+
+describe('text-edit-ops', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    clearDOM()
+    installExecCommandMock()
+  })
+
+  afterEach(() => {
+    restoreExecCommand()
+    clearDOM()
+  })
+
+  // ---- copySelection ----
+
+  describe('copySelection', () => {
+    it('copies the selected substring from a focused input (P2: selectionStart/End)', async () => {
+      const input = createInput('hello world')
+      input.setSelectionRange(0, 5)
+      mocks.copyText.mockResolvedValue(true)
+
+      const result = await copySelection()
+      expect(result).toBe(true)
+      expect(mocks.copyText).toHaveBeenCalledWith('hello')
+    })
+
+    it('returns false when no selection exists', async () => {
+      createInput('hello world')
+      const result = await copySelection()
+      expect(result).toBe(false)
+      expect(mocks.copyText).not.toHaveBeenCalled()
+    })
+
+    it('logs via logFrontendError and returns false when copyText throws (never throws)', async () => {
+      const input = createInput('hello world')
+      input.setSelectionRange(0, 5)
+      mocks.copyText.mockRejectedValue(new Error('copy failed'))
+
+      const result = await copySelection()
+      expect(result).toBe(false)
+      expect(mocks.logFrontendError).toHaveBeenCalledWith(
+        expect.objectContaining({
+          level: 'error',
+          message: expect.stringContaining('copySelection')
+        })
+      )
+    })
+
+    it('copies from a contentEditable via window.getSelection()', async () => {
+      createContentEditable('editable text')
+      vi.spyOn(window, 'getSelection').mockReturnValue({
+        toString: () => 'editable text'
+      } as unknown as Selection)
+      mocks.copyText.mockResolvedValue(true)
+
+      const result = await copySelection()
+      expect(result).toBe(true)
+      expect(mocks.copyText).toHaveBeenCalledWith('editable text')
+    })
+  })
+
+  // ---- cutSelection ----
+
+  describe('cutSelection', () => {
+    it('copies then calls execCommand(delete) when copy succeeds', async () => {
+      const input = createInput('hello world')
+      input.setSelectionRange(0, 5)
+      mocks.copyText.mockResolvedValue(true)
+
+      const result = await cutSelection()
+      expect(result).toBe(true)
+      expect(mocks.copyText).toHaveBeenCalledWith('hello')
+      expect(execCommandMock).toHaveBeenCalledWith('delete')
+    })
+
+    it('does NOT call execCommand(delete) when copy fails (P1 — no data loss)', async () => {
+      const input = createInput('hello world')
+      input.setSelectionRange(0, 5)
+      mocks.copyText.mockResolvedValue(false)
+
+      const result = await cutSelection()
+      expect(result).toBe(false)
+      expect(execCommandMock).not.toHaveBeenCalled()
+    })
+
+    it('returns false for readonly input (P8)', async () => {
+      const input = createInput('hello world', { readOnly: true })
+      input.setSelectionRange(0, 5)
+      mocks.copyText.mockResolvedValue(true)
+
+      const result = await cutSelection()
+      expect(result).toBe(false)
+      expect(execCommandMock).not.toHaveBeenCalled()
+    })
+
+    it('returns false for disabled input (P8)', async () => {
+      const input = createInput('hello world', { disabled: true })
+      input.setSelectionRange(0, 5)
+      mocks.copyText.mockResolvedValue(true)
+
+      const result = await cutSelection()
+      expect(result).toBe(false)
+      expect(execCommandMock).not.toHaveBeenCalled()
+    })
+
+    it('returns false when no editable is focused', async () => {
+      vi.spyOn(window, 'getSelection').mockReturnValue({
+        toString: () => 'page text'
+      } as unknown as Selection)
+      mocks.copyText.mockResolvedValue(true)
+
+      const result = await cutSelection()
+      expect(result).toBe(false)
+      expect(execCommandMock).not.toHaveBeenCalled()
+    })
+  })
+
+  // ---- pasteIntoFocused ----
+
+  describe('pasteIntoFocused', () => {
+    it('reads clipboard + re-focuses + calls execCommand(insertText) (P7)', async () => {
+      const input = createInput('hello')
+      input.setSelectionRange(5, 5)
+      const focusSpy = vi.spyOn(input, 'focus')
+      mocks.readText.mockResolvedValue({ success: true, data: ' world' })
+
+      const result = await pasteIntoFocused()
+      expect(result).toBe(true)
+      expect(mocks.readText).toHaveBeenCalled()
+      expect(focusSpy).toHaveBeenCalled()
+      expect(execCommandMock).toHaveBeenCalledWith('insertText', false, ' world')
+    })
+
+    it('returns false when clipboard read fails', async () => {
+      createInput('hello')
+      mocks.readText.mockResolvedValue({
+        success: false,
+        error: 'denied',
+        code: 'READ_ERROR'
+      })
+
+      const result = await pasteIntoFocused()
+      expect(result).toBe(false)
+      expect(execCommandMock).not.toHaveBeenCalled()
+    })
+
+    it('returns false when clipboard data is empty', async () => {
+      createInput('hello')
+      mocks.readText.mockResolvedValue({ success: true, data: '' })
+
+      const result = await pasteIntoFocused()
+      expect(result).toBe(false)
+      expect(execCommandMock).not.toHaveBeenCalled()
+    })
+
+    it('returns false for readonly input (P8)', async () => {
+      createInput('hello', { readOnly: true })
+      mocks.readText.mockResolvedValue({ success: true, data: 'world' })
+
+      const result = await pasteIntoFocused()
+      expect(result).toBe(false)
+      expect(execCommandMock).not.toHaveBeenCalled()
+    })
+  })
+
+  // ---- selectAllFocused ----
+
+  describe('selectAllFocused', () => {
+    it('calls input.select() for a focused input', () => {
+      const input = createInput('hello world')
+      const selectSpy = installSelectMock(input)
+
+      const result = selectAllFocused()
+      expect(result).toBe(true)
+      expect(selectSpy).toHaveBeenCalled()
+    })
+
+    it('calls textarea.select() for a focused textarea', () => {
+      const ta = createTextarea('hello world')
+      const selectSpy = installSelectMock(ta)
+
+      const result = selectAllFocused()
+      expect(result).toBe(true)
+      expect(selectSpy).toHaveBeenCalled()
+    })
+
+    it('calls execCommand(selectAll) for contentEditable', () => {
+      createContentEditable()
+
+      const result = selectAllFocused()
+      expect(result).toBe(true)
+      expect(execCommandMock).toHaveBeenCalledWith('selectAll')
+    })
+
+    it('returns false when no editable is focused (P9 — no document-wide fallback)', () => {
+      clearDOM()
+      const result = selectAllFocused()
+      expect(result).toBe(false)
+      expect(execCommandMock).not.toHaveBeenCalledWith('selectAll')
+    })
+  })
+})

--- a/src/renderer/lib/text-edit-ops.ts
+++ b/src/renderer/lib/text-edit-ops.ts
@@ -1,0 +1,167 @@
+/**
+ * Text edit operations for the global context menu.
+ *
+ * Fills the gap left by the existing clipboard facade: there was no helper for
+ * inserting pasted text into a focused input/textarea/contentEditable or for
+ * cutting (copy + delete) the current selection. These helpers wrap
+ * `document.execCommand('insertText'|'delete'|'selectAll')` + the existing
+ * `clipboardApi` / `copyText` so the global menu's Copy/Cut/Paste/Select All
+ * items behave the same on desktop and web.
+ *
+ * Never throws: a clipboard or DOM-insertion failure is logged once via
+ * `logFrontendError` so the degradation survives a closed DevTools, and the
+ * menu simply closes.
+ */
+
+import { clipboardApi } from '@/lib/api'
+import { copyText } from '@/lib/copy-text'
+import { logFrontendError } from '@/lib/log-api'
+
+function logFailure(operation: string, error: unknown): void {
+  void logFrontendError({
+    level: 'error',
+    message: `${operation} failed: ${String(error)}`,
+    source: 'lib/text-edit-ops'
+  })
+}
+
+/**
+ * The currently focused editable element (input/textarea/contentEditable), or
+ * `null` when focus is not on an editable.
+ */
+function getFocusedEditable(): HTMLElement | null {
+  if (typeof document === 'undefined') return null
+  const el = document.activeElement
+  if (!el) return null
+  if (el instanceof HTMLInputElement || el instanceof HTMLTextAreaElement) {
+    return el
+  }
+  if (el instanceof HTMLElement && el.isContentEditable) {
+    return el
+  }
+  return null
+}
+
+/**
+ * True when the focused element is a mutable editable (not readOnly, not
+ * disabled). Used to gate Cut/Paste/Select All — `execCommand('delete'|
+ * 'insertText')` no-ops on readonly/disabled inputs, so enabling those items
+ * would mislead the user. Copy still works on readonly selections (Copy only
+ * needs `hasSelection`).
+ */
+function isMutableEditable(el: HTMLElement | null): boolean {
+  if (!el) return false
+  if (el instanceof HTMLInputElement || el instanceof HTMLTextAreaElement) {
+    return !el.readOnly && !el.disabled
+  }
+  return el.isContentEditable
+}
+
+/**
+ * The selected text from the focused input/textarea (via selectionStart/End)
+ * or from window.getSelection() for contentEditable / generic page text.
+ * P2: selections inside `<input>`/`<textarea>` are NOT reflected by
+ * `window.getSelection()` (they use selectionStart/selectionEnd), so we check
+ * the focused editable first.
+ */
+function getSelectionText(): string {
+  if (typeof document === 'undefined') return ''
+  const el = document.activeElement
+  if (el instanceof HTMLInputElement || el instanceof HTMLTextAreaElement) {
+    const start = el.selectionStart
+    const end = el.selectionEnd
+    if (start !== null && end !== null && start !== end) {
+      return el.value.substring(start, end)
+    }
+    return ''
+  }
+  if (typeof window === 'undefined' || !window.getSelection) return ''
+  const sel = window.getSelection()
+  return sel ? sel.toString() : ''
+}
+
+/**
+ * Copy the current selection to the clipboard. Returns `false` when no
+ * selection exists or the copy failed (logged via log-api).
+ */
+export async function copySelection(): Promise<boolean> {
+  const text = getSelectionText()
+  if (!text) return false
+  try {
+    return await copyText(text)
+  } catch (error) {
+    logFailure('copySelection', error)
+    return false
+  }
+}
+
+/**
+ * Cut the current selection: copy it to the clipboard, then delete it from the
+ * focused editable via `execCommand('delete')`. Only operates when a mutable
+ * editable is focused (cutting readonly text has no meaningful target).
+ * P1: only calls `execCommand('delete')` when the copy actually succeeded —
+ * never deletes text that wasn't copied (no silent data loss). Returns `false`
+ * when there is no selection, no mutable editable, or the copy failed.
+ */
+export async function cutSelection(): Promise<boolean> {
+  const text = getSelectionText()
+  if (!text) return false
+  const editable = getFocusedEditable()
+  if (!isMutableEditable(editable)) return false
+  try {
+    const copied = await copyText(text)
+    if (!copied) return false
+    return document.execCommand('delete')
+  } catch (error) {
+    logFailure('cutSelection', error)
+    return false
+  }
+}
+
+/**
+ * Paste clipboard text into the focused editable at the caret. Reads the
+ * clipboard via `clipboardApi` (Tauri IPC on desktop, Async Clipboard API /
+ * paste-event fallback on web) and inserts it with
+ * `execCommand('insertText', false, text)`.
+ * P7: focus may move between the async clipboard read and the insert (menu
+ * closing, async gap) — re-focus the editable before inserting so the paste
+ * lands in the right element. Returns `false` when no mutable editable is
+ * focused, the clipboard read failed, or the insert did not take effect.
+ */
+export async function pasteIntoFocused(): Promise<boolean> {
+  const editable = getFocusedEditable()
+  if (!editable || !isMutableEditable(editable)) return false
+  try {
+    const res = await clipboardApi.readText()
+    if (!res.success || !res.data) return false
+    editable.focus()
+    return document.execCommand('insertText', false, res.data)
+  } catch (error) {
+    logFailure('pasteIntoFocused', error)
+    return false
+  }
+}
+
+/**
+ * Select all text in the focused editable (input.select() for
+ * input/textarea, `execCommand('selectAll')` for contentEditable).
+ * P9: when no editable is focused, returns `false` — does NOT fall back to a
+ * document-wide `execCommand('selectAll')` (would select UI chrome). The menu
+ * item is also disabled when no mutable editable is focused.
+ */
+export function selectAllFocused(): boolean {
+  try {
+    const editable = getFocusedEditable()
+    if (editable instanceof HTMLInputElement || editable instanceof HTMLTextAreaElement) {
+      editable.select()
+      return true
+    }
+    if (editable instanceof HTMLElement && editable.isContentEditable) {
+      return document.execCommand('selectAll')
+    }
+    return false
+  } catch (error) {
+    logFailure('selectAllFocused', error)
+    return false
+  }
+}

--- a/src/renderer/lib/text-edit-ops.ts
+++ b/src/renderer/lib/text-edit-ops.ts
@@ -81,6 +81,47 @@ function getSelectionText(): string {
 }
 
 /**
+ * A snapshot of the current selection so it can be restored after `copyText` —
+ * `copyText`'s non-secure-context fallback focuses a temporary textarea
+ * (`lib/copy-text.ts`), which destroys the original selection. Without
+ * restoring it, `execCommand('delete')` in `cutSelection` would delete nothing.
+ */
+type SelectionSnapshot =
+  | { kind: 'input'; start: number; end: number }
+  | { kind: 'range'; range: Range }
+  | null
+
+function captureSelectionSnapshot(el: HTMLElement): SelectionSnapshot {
+  if (el instanceof HTMLInputElement || el instanceof HTMLTextAreaElement) {
+    return { kind: 'input', start: el.selectionStart ?? 0, end: el.selectionEnd ?? 0 }
+  }
+  const sel = typeof window !== 'undefined' && window.getSelection ? window.getSelection() : null
+  if (sel && sel.rangeCount > 0) {
+    return { kind: 'range', range: sel.getRangeAt(0).cloneRange() }
+  }
+  return null
+}
+
+function restoreSelectionSnapshot(el: HTMLElement, snapshot: SelectionSnapshot): void {
+  if (!snapshot) return
+  if (
+    snapshot.kind === 'input' &&
+    (el instanceof HTMLInputElement || el instanceof HTMLTextAreaElement)
+  ) {
+    try {
+      el.setSelectionRange(snapshot.start, snapshot.end)
+    } catch {
+      // setSelectionRange can throw for some input types (email/number); ignore.
+    }
+  } else if (snapshot.kind === 'range' && typeof window !== 'undefined' && window.getSelection) {
+    const sel = window.getSelection()
+    if (!sel) return
+    sel.removeAllRanges()
+    sel.addRange(snapshot.range)
+  }
+}
+
+/**
  * Copy the current selection to the clipboard. Returns `false` when no
  * selection exists or the copy failed (logged via log-api).
  */
@@ -107,10 +148,17 @@ export async function cutSelection(): Promise<boolean> {
   const text = getSelectionText()
   if (!text) return false
   const editable = getFocusedEditable()
-  if (!isMutableEditable(editable)) return false
+  if (!editable || !isMutableEditable(editable)) return false
+  // Capture the selection BEFORE copyText — its non-secure-context fallback
+  // focuses a temporary textarea (lib/copy-text.ts), destroying the original
+  // selection. Restore it before deletion so execCommand('delete') removes the
+  // originally selected text (CodeRabbit finding).
+  const snapshot = captureSelectionSnapshot(editable)
   try {
     const copied = await copyText(text)
     if (!copied) return false
+    editable.focus()
+    restoreSelectionSnapshot(editable, snapshot)
     return document.execCommand('delete')
   } catch (error) {
     logFailure('cutSelection', error)


### PR DESCRIPTION
## Summary

Right-click currently shows nothing on desktop (a blanket capture-phase `contextmenu` listener suppressed the native webview menu) and shows the browser's native Inspect menu on web. End users have no Copy/Cut/Paste/Select All on generic text and inputs. DevTools is also reachable in production via F12 / Ctrl+Shift+I/J/C and the in-app browser-tab "Debug Console" button.

This PR adds a global Radix context menu (Copy/Cut/Paste/Select All) wrapping both renderer roots, and fully blocks DevTools access in production (keydown blocker + browser-tab command/button gating). The native "Toggle DevTools" menu item was already `#[cfg(debug_assertions)]`-gated.

## Related Issue

No related issue. Builds on top of #505 (the original blanket right-click disable) — this re-enables right-click with a proper custom menu and hardens the devtools surface. User-requested.

## Type of Change

- [x] feat: new feature

## What Changed

- **Global context menu (both surfaces):** new `GlobalContextMenu.tsx` (Radix primitive) wraps the app root in `TauriApp.tsx` and `App.tsx`. Items: Copy, Cut, Paste, Select All — `disabled` flags snapshotted on the capture-phase `contextmenu` event (before Radix moves focus) from `window.getSelection()` + the focused editable. No Reload/Back/Inspect.
- **Edit ops:** new `text-edit-ops.ts` (`copySelection`/`cutSelection`/`pasteIntoFocused`/`selectAllFocused`) — reuses `clipboardApi` + `copyText`; reads input/textarea selections via `selectionStart/End`; cut only deletes on copy success; paste re-focuses the editable after the async clipboard read; readonly/disabled inputs excluded for Cut/Paste. Never throws; logs failures via `log-api`.
- **Native-menu defense-in-depth:** new `use-prevent-native-context-menu.ts` (capture-phase `contextmenu` `preventDefault`) kept on both roots so portaled overlays (toasts/modals) outside the Radix trigger subtree don't show the native Inspect menu.
- **DevTools block (desktop, release-only):** new `use-prevent-devtools-shortcuts.ts` — PROD-gated capture-phase keydown blocker for F12, Ctrl+Shift+I/J/C, Ctrl+U; locale-independent (`e.code`); accepts `metaKey` (macOS Cmd); excludes Alt; warn-level boundary log per block. Mounted only in `TauriApp` (web can't block browser devtools).
- **Rust gating:** `browser_tab_open_devtools` command + `BrowserTabManager::open_devtools` cfg-gated to `#[cfg(debug_assertions)]` (release returns `IpcResult::error`); release dead stub removed. The `devtools` cargo feature is kept (gating call sites, not the feature).
- **Custom-menu isolation:** `ProjectSidebar.handleContextMenu` gets `stopPropagation()` so the global trigger doesn't double-fire over the sidebar's custom menu (FileExplorer already had it).
- **Browser-tab UX:** the in-app browser "Debug Console" button is hidden when `import.meta.env.PROD`.

## How It Was Tested

- [x] `bun run ci` (Biome lint + format + imports, strict mode) — 0 errors (301 pre-existing a11y warnings, warn-level)
- [x] `bun run typecheck` (node + web + test)
- [x] `bun run test` — 3631 passed, 0 failed (incl. 22 new tests)
- [x] `cargo clippy --all-targets -- -D warnings` (in src-tauri) — debug clean
- [x] `cargo test` (in src-tauri) — passes on CI (Rust Checks: clippy + cargo test on Linux; Rust Windows Smoke: cargo check + termul-server build). Local test binary only fails to RUN on this Windows env with a pre-existing `STATUS_ENTRYPOINT_NOT_FOUND` (WebView2 DLL issue, confirmed identical on baseline).
- [ ] Manual verification pending on a release desktop build (press F12 / right-click blank area / input / terminal)

## CI & Review Gate

- [x] All CI checks pass (PR Validation, Rust Checks, Build Verification, Security Scans)
- [x] Code review comments from CodeRabbit / Claude have been addressed or resolved (3 findings fixed: devtools doc, group-menu stopPropagation, cut selection-restore)
- [x] No unresolved review findings remain

## Checklist

- [x] My PR title follows the conventional commit format used by this repo
- [x] I linked the related issue or explained why none exists (builds on #505)
- [x] I updated docs when needed
- [x] I added or updated tests when needed
- [x] I verified the change does not introduce unrelated modifications
- [x] I read AGENTS.md and followed the contributor guidelines
- [x] A human reviewed the complete diff before submission

Spec (with Suggested Review Order): `_bmad-output/implementation-artifacts/spec-webview-context-menu-devtools-block.md`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a global context menu with Copy, Cut, Paste, and Select All actions.
  - Improved context-menu behavior for project and group navigation.
- **Security & Stability**
  - Production builds now suppress browser developer-tool shortcuts and native context menus.
  - Developer tools remain available during development, while the debug console is hidden in production.
- **Updates**
  - Refreshed ACP agent versions and download links for Factory Droid, Goose, and Junie.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->