### PR TITLE
feat(plan): persist plan across prompts + snapshot via streamdown fence

### DIFF
--- a/docs/api-contracts.md
+++ b/docs/api-contracts.md
@@ -352,21 +352,27 @@ When a turn ends (`_onPromptComplete` in `src/renderer/stores/acp-store.ts`), th
 snapshots the live `plans[sessionId]` onto the just-finished assistant message's `blocks` as
 a fenced code block with language `termul-plan`:
 
-~~~md
+````md
 ```termul-plan
 [{"content":"Read AC file","status":"completed","priority":"high"},{"content":"Fix bug","status":"in_progress","priority":"high"}]
 ```
-~~~
+````
 
 The fence JSON is `JSON.stringify(PlanEntry[])` — shape 1:1 with `PlanEntry`
 (`src/renderer/lib/acp-api.ts`). One fence per assistant message (last write wins; a prior
 fence on the same message is replaced). The snapshot rides on the existing `ChatMessage.blocks`
 persistence path (no new schema field).
 
-On `openHistorySession`, the renderer scans the last assistant message's `blocks` for the
+On `openHistorySession`, the renderer scans assistant messages in reverse for the
 fence, parses the JSON, and repopulates `plans[sessionId]` before any new `acp:plan_update`
 would arrive — so a reopened chat shows the prior plan immediately. Malformed JSON is dropped
 from the plan store (logged `source: 'planRehydrate'`); the agent can still emit a fresh plan.
+
+> **Cache-only rehydration:** The fence lives in the renderer's in-memory `messages` projection
+> and the `payloadCache` (updated on `_onPromptComplete`). The durable store (CAP-2 host-owned
+> history) does not contain the fence — cross-restart rehydrate does not work. In-session
+> rehydrate (switching away and back) works via the cache update. Fixing cross-restart requires
+> a host-side synthetic record (tracked in `_bmad-output/deferred-work.md`).
 
 The `termul-plan` fence is rendered inline inside historical (non-streaming) messages by
 `TermulPlanRenderer` (`src/renderer/components/chat/ChatMarkdownPlanFence.tsx`) as a read-only

--- a/docs/api-contracts.md
+++ b/docs/api-contracts.md
@@ -346,6 +346,34 @@ ACP agent chat uses Tauri events under the `acp:` namespace (see `src-tauri/src/
 
 See `docs/acp-agent-plan-compliance.md` for registry compliance tiers and agent vendor expectations.
 
+#### Persisted plan snapshot (`termul-plan` fence)
+
+When a turn ends (`_onPromptComplete` in `src/renderer/stores/acp-store.ts`), the renderer
+snapshots the live `plans[sessionId]` onto the just-finished assistant message's `blocks` as
+a fenced code block with language `termul-plan`:
+
+~~~md
+```termul-plan
+[{"content":"Read AC file","status":"completed","priority":"high"},{"content":"Fix bug","status":"in_progress","priority":"high"}]
+```
+~~~
+
+The fence JSON is `JSON.stringify(PlanEntry[])` — shape 1:1 with `PlanEntry`
+(`src/renderer/lib/acp-api.ts`). One fence per assistant message (last write wins; a prior
+fence on the same message is replaced). The snapshot rides on the existing `ChatMessage.blocks`
+persistence path (no new schema field).
+
+On `openHistorySession`, the renderer scans the last assistant message's `blocks` for the
+fence, parses the JSON, and repopulates `plans[sessionId]` before any new `acp:plan_update`
+would arrive — so a reopened chat shows the prior plan immediately. Malformed JSON is dropped
+from the plan store (logged `source: 'planRehydrate'`); the agent can still emit a fresh plan.
+
+The `termul-plan` fence is rendered inline inside historical (non-streaming) messages by
+`TermulPlanRenderer` (`src/renderer/components/chat/ChatMarkdownPlanFence.tsx`) as a read-only
+`PlanPanel`. The live streaming turn shows the sticky `PlanPanel` pinned in `AgentChatPanel`
+instead — the inline renderer is gated to `!streaming` so an in-flight turn never renders a
+duplicate plan UI.
+
 ### `acp:usage_update`
 
 **Purpose:** Agent-reported context-window utilization for a session (ACP `sessionUpdate: "usage_update"`; requires the protocol `unstable_session_usage` feature).

--- a/src/renderer/components/chat/AgentChatPanel.tsx
+++ b/src/renderer/components/chat/AgentChatPanel.tsx
@@ -488,7 +488,7 @@ export function AgentChatPanel({
         onRetry={canRetryLastUserTurn && !session.activeTurn ? handleRetry : undefined}
         onDismiss={() => setDismissedError(session.lastError)}
       />
-      <PlanPanel entries={plan} />
+      <PlanPanel key={`plan-${session.id}`} entries={plan} />
       <ChatMessageList
         items={timeline}
         sessionId={session.id}

--- a/src/renderer/components/chat/ChatMarkdownPlanFence.tsx
+++ b/src/renderer/components/chat/ChatMarkdownPlanFence.tsx
@@ -1,6 +1,8 @@
+import { useEffect, useRef } from 'react'
 import type { CustomRendererProps } from 'streamdown'
 
 import type { PlanEntry } from '@/lib/acp-api'
+import { logFrontendError } from '@/lib/log-api'
 
 import { PlanPanel } from './PlanPanel'
 
@@ -19,34 +21,51 @@ import { PlanPanel } from './PlanPanel'
  * independently logs the malformed fence and leaves `plans[sessionId]` empty.
  */
 export function TermulPlanRenderer({ code, isIncomplete }: CustomRendererProps): React.JSX.Element {
-  // An incomplete fence (closing ``` not yet arrived) can't be parsed. This
-  // renderer is gated to non-streaming messages, but `isIncomplete` is a
-  // defensive backstop for a truncated historical payload.
+  const loggedRef = useRef<string | null>(null)
+
+  // Parse the fence JSON. An incomplete fence on a non-streaming message is a
+  // truncated historical payload (not a stream-in-progress); skip parsing.
+  let parsed: PlanEntry[] | null = null
+  if (!isIncomplete) {
+    try {
+      const value: unknown = JSON.parse(code)
+      if (Array.isArray(value)) {
+        parsed = value.filter(
+          (entry): entry is PlanEntry =>
+            entry !== null &&
+            typeof entry === 'object' &&
+            typeof (entry as PlanEntry).content === 'string'
+        )
+        if (parsed.length === 0) parsed = null
+      }
+    } catch {
+      parsed = null
+    }
+  }
+
+  // Log malformed snapshots once per fence content (not on every re-render).
+  useEffect(() => {
+    if (!isIncomplete && parsed === null && loggedRef.current !== code) {
+      loggedRef.current = code
+      void logFrontendError({
+        level: 'warn',
+        source: 'planSnapshotRenderer',
+        message: 'Malformed termul-plan fence rendered as fallback'
+      })
+    }
+  }, [parsed, code, isIncomplete])
+
+  // An incomplete fence on a non-streaming message is a truncated historical
+  // payload (not a stream-in-progress). It will not receive later chunks.
   if (isIncomplete) {
     return (
       <div
         role="status"
         className="rounded-md border border-border/50 bg-muted/20 px-3 py-2 text-xs text-muted-foreground/70"
       >
-        Plan snapshot streaming…
+        Plan snapshot incomplete
       </div>
     )
-  }
-
-  let parsed: PlanEntry[] | null = null
-  try {
-    const value: unknown = JSON.parse(code)
-    if (Array.isArray(value)) {
-      parsed = value.filter(
-        (entry): entry is PlanEntry =>
-          entry !== null &&
-          typeof entry === 'object' &&
-          typeof (entry as PlanEntry).content === 'string'
-      )
-      if (parsed.length === 0) parsed = null
-    }
-  } catch {
-    parsed = null
   }
 
   if (parsed === null) {

--- a/src/renderer/components/chat/ChatMarkdownPlanFence.tsx
+++ b/src/renderer/components/chat/ChatMarkdownPlanFence.tsx
@@ -1,0 +1,64 @@
+import type { CustomRendererProps } from 'streamdown'
+
+import type { PlanEntry } from '@/lib/acp-api'
+
+import { PlanPanel } from './PlanPanel'
+
+/**
+ * Streamdown custom renderer for `termul-plan` fenced code blocks. Parses the
+ * fence JSON and renders a read-only `PlanPanel` so historical assistant
+ * messages retain their plan-of-record inline in the transcript.
+ *
+ * The live sticky plan covers the streaming turn; this renderer is gated to
+ * non-streaming (historical) messages via the `STREAMDOWN_PLUGINS` selection
+ * in `ChatMessage` — the `termul-plan` renderer is only attached when
+ * `!streaming` so an in-flight turn never shows a duplicate inline plan.
+ *
+ * Malformed JSON degrades to a "Plan snapshot unavailable" fallback card so a
+ * corrupted snapshot never crashes the transcript; the store's rehydrate path
+ * independently logs the malformed fence and leaves `plans[sessionId]` empty.
+ */
+export function TermulPlanRenderer({ code, isIncomplete }: CustomRendererProps): React.JSX.Element {
+  // An incomplete fence (closing ``` not yet arrived) can't be parsed. This
+  // renderer is gated to non-streaming messages, but `isIncomplete` is a
+  // defensive backstop for a truncated historical payload.
+  if (isIncomplete) {
+    return (
+      <div
+        role="status"
+        className="rounded-md border border-border/50 bg-muted/20 px-3 py-2 text-xs text-muted-foreground/70"
+      >
+        Plan snapshot streaming…
+      </div>
+    )
+  }
+
+  let parsed: PlanEntry[] | null = null
+  try {
+    const value: unknown = JSON.parse(code)
+    if (Array.isArray(value)) {
+      parsed = value.filter(
+        (entry): entry is PlanEntry =>
+          entry !== null &&
+          typeof entry === 'object' &&
+          typeof (entry as PlanEntry).content === 'string'
+      )
+      if (parsed.length === 0) parsed = null
+    }
+  } catch {
+    parsed = null
+  }
+
+  if (parsed === null) {
+    return (
+      <div
+        role="alert"
+        className="rounded-md border border-border/50 bg-muted/30 px-3 py-2 text-xs text-muted-foreground"
+      >
+        Plan snapshot unavailable
+      </div>
+    )
+  }
+
+  return <PlanPanel entries={parsed} />
+}

--- a/src/renderer/components/chat/ChatMessage.test.tsx
+++ b/src/renderer/components/chat/ChatMessage.test.tsx
@@ -41,7 +41,8 @@ vi.mock('streamdown', async () => {
     caret,
     animated,
     linkSafety,
-    components
+    components,
+    plugins
   }: {
     children: ReactNode
     isAnimating?: boolean
@@ -49,6 +50,7 @@ vi.mock('streamdown', async () => {
     animated?: boolean | AnimateOptions
     linkSafety?: LinkSafety
     components?: Record<string, unknown>
+    plugins?: { renderers?: { language: string | string[] }[] } & Record<string, unknown>
   }): React.JSX.Element {
     const [open, setOpen] = React.useState(false)
     const url = 'https://example.com/docs'
@@ -62,6 +64,9 @@ vi.mock('streamdown', async () => {
     const animatedDuration = animatedConfig ? String(animatedConfig.duration ?? '') : ''
     const animatedStagger = animatedConfig ? String(animatedConfig.stagger ?? '') : ''
     const animatedEasing = animatedConfig?.easing ?? ''
+    const rendererLanguages = (plugins?.renderers ?? [])
+      .flatMap((r) => (Array.isArray(r.language) ? r.language : [r.language]))
+      .join(',')
 
     return (
       <div
@@ -73,6 +78,7 @@ vi.mock('streamdown', async () => {
         data-animated-easing={animatedEasing}
         data-caret={caret}
         data-custom-table={Boolean(CustomTable)}
+        data-renderer-languages={rendererLanguages}
       >
         <button
           type="button"
@@ -258,6 +264,24 @@ describe('ChatMessage', () => {
     render(<ChatMessage message={agentMessage(false)} isLast />)
 
     expect(screen.getByTestId('streamdown')).toHaveAttribute('data-animating', 'false')
+  })
+
+  it('wires the termul-plan renderer only for non-streaming (historical) messages', () => {
+    // Streaming message: the sticky PlanPanel covers the live turn; the
+    // inline renderer is deliberately absent so no duplicate plan UI shows.
+    const { unmount: unmountStreaming } = render(
+      <ChatMessage message={agentMessage(true)} isLast />
+    )
+    expect(screen.getByTestId('streamdown')).toHaveAttribute('data-renderer-languages', '')
+    unmountStreaming()
+
+    // Historical message: the termul-plan renderer is attached so a
+    // persisted snapshot fence renders an inline read-only PlanPanel.
+    render(<ChatMessage message={agentMessage(false)} isLast />)
+    expect(screen.getByTestId('streamdown')).toHaveAttribute(
+      'data-renderer-languages',
+      'termul-plan'
+    )
   })
 
   it('stops the Streamdown caret when a newer timeline item follows', () => {

--- a/src/renderer/components/chat/ChatMessage.tsx
+++ b/src/renderer/components/chat/ChatMessage.tsx
@@ -33,6 +33,7 @@ import { parseSkillSegments, replaceSkillTokensInline } from '@/lib/skill-tokens
 import { stripEmptyFences } from '@/lib/strip-empty-fences'
 import { cn } from '@/lib/utils'
 import type { ChatMessage as ChatMessageType } from '@/stores/acp-store'
+import { TermulPlanRenderer } from './ChatMarkdownPlanFence'
 import {
   blockData,
   blockDisplayName,
@@ -236,7 +237,18 @@ export function MediaBlocks({ blocks }: { blocks: ContentBlock[] }): React.JSX.E
 const CODE_PLUGIN = codePlugin
 /** Live Mermaid diagram rendering for ```mermaid fences. */
 const MERMAID_PLUGIN = mermaidPlugin
+/**
+ * Base plugin set used while the agent message is still streaming. The
+ * `termul-plan` renderer is deliberately absent here so an in-flight turn
+ * never renders a duplicate inline plan (the live sticky `PlanPanel` covers
+ * the streaming turn). Historical (non-streaming) messages swap in
+ * `STREAMDOWN_PLUGINS_WITH_PLAN` via the `plugins` prop on `AgentProse`.
+ */
 const STREAMDOWN_PLUGINS = { code: CODE_PLUGIN, mermaid: MERMAID_PLUGIN }
+const STREAMDOWN_PLUGINS_WITH_PLAN = {
+  ...STREAMDOWN_PLUGINS,
+  renderers: [{ language: 'termul-plan', component: TermulPlanRenderer }]
+}
 
 // Copy on code blocks, plus download (save an agent-generated file); no line
 // numbers (chat snippets are short). Mermaid keeps its interactive controls.
@@ -393,7 +405,11 @@ function AgentProse({
         caret="block"
         animated={reduced ? false : STREAMDOWN_ANIMATED}
         parseIncompleteMarkdown
-        plugins={STREAMDOWN_PLUGINS}
+        // The `termul-plan` renderer is attached only to historical
+        // (non-streaming) messages so an in-flight turn never renders a
+        // duplicate inline plan — the live sticky `PlanPanel` owns the
+        // streaming turn.
+        plugins={streaming ? STREAMDOWN_PLUGINS : STREAMDOWN_PLUGINS_WITH_PLAN}
         remarkPlugins={filePathContext ? FILE_PATH_REMARK_PLUGINS : undefined}
         controls={STREAMDOWN_CONTROLS}
         components={

--- a/src/renderer/components/chat/PlanPanel.test.tsx
+++ b/src/renderer/components/chat/PlanPanel.test.tsx
@@ -117,7 +117,7 @@ describe('PlanPanel', () => {
   })
 
   it('hides the panel entirely when entries become empty (agent clears plan while collapsed)', async () => {
-    const { rerender, container } = render(
+    const { rerender } = render(
       <PlanPanel entries={[{ content: 'Task A', status: 'in_progress' }]} />
     )
     const toggle = screen.getByRole('button', { name: /Plan, 0 of 1 task, task in progress/ })
@@ -136,9 +136,7 @@ describe('PlanPanel', () => {
   })
 
   it('exposes a11y attributes on the region and header toggle', () => {
-    const { container } = render(
-      <PlanPanel entries={[{ content: 'Task A', status: 'completed' }]} />
-    )
+    render(<PlanPanel entries={[{ content: 'Task A', status: 'completed' }]} />)
     const region = screen.getByRole('region', { name: 'Execution plan' })
     expect(region).toBeInTheDocument()
     const toggle = screen.getByRole('button', { name: /Plan, 1 of 1 task/ })
@@ -203,7 +201,7 @@ describe('TermulPlanRenderer (termul-plan fence renderer)', () => {
 
   it('shows a streaming placeholder when the fence is incomplete', () => {
     render(<TermulPlanRenderer code="partial" isIncomplete={true} language="termul-plan" />)
-    expect(screen.getByText('Plan snapshot streaming…')).toBeInTheDocument()
+    expect(screen.getByText('Plan snapshot incomplete')).toBeInTheDocument()
     expect(screen.queryByRole('region', { name: 'Execution plan' })).toBeNull()
   })
 })

--- a/src/renderer/components/chat/PlanPanel.test.tsx
+++ b/src/renderer/components/chat/PlanPanel.test.tsx
@@ -1,6 +1,7 @@
-import { fireEvent, render, screen } from '@testing-library/react'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { useState } from 'react'
 import { describe, expect, it } from 'vitest'
+import { TermulPlanRenderer } from './ChatMarkdownPlanFence'
 import { PlanPanel } from './PlanPanel'
 
 describe('PlanPanel', () => {
@@ -65,6 +66,93 @@ describe('PlanPanel', () => {
     expect(screen.getByText('Task 0')).toHaveClass('line-through')
   })
 
+  it('collapses to just the header when the chevron toggle is clicked', () => {
+    const { container } = render(
+      <PlanPanel
+        entries={[
+          { content: 'Task A', status: 'in_progress', priority: 'high' },
+          { content: 'Task B', status: 'pending', priority: 'low' }
+        ]}
+      />
+    )
+
+    // Header button is present and expanded by default
+    const toggle = screen.getByRole('button', { name: /Plan, 0 of 2 tasks, task in progress/ })
+    expect(toggle).toHaveAttribute('aria-expanded', 'true')
+    expect(container.querySelector('.max-h-60')).toBeInTheDocument()
+    expect(screen.getByText('Task A')).toBeInTheDocument()
+
+    // Collapse: body (ScrollArea) unmounts, header stays with counter + spinner hint
+    fireEvent.click(toggle)
+    expect(toggle).toHaveAttribute('aria-expanded', 'false')
+    expect(container.querySelector('.max-h-60')).not.toBeInTheDocument()
+    expect(screen.queryByText('Task A')).toBeNull()
+    // Header counter is still surfaced via the toggle button's aria-label
+    // (which includes the count), even though the body is collapsed.
+    expect(toggle).toHaveAttribute('aria-label', expect.stringMatching(/0 of 2 tasks/))
+  })
+
+  it('keeps collapse state across entries changes (mid-turn acp:plan_update)', () => {
+    const { rerender } = render(
+      <PlanPanel entries={[{ content: 'Task A', status: 'in_progress' }]} />
+    )
+    const toggle = screen.getByRole('button', { name: /Plan, 0 of 1 task, task in progress/ })
+    fireEvent.click(toggle)
+    expect(toggle).toHaveAttribute('aria-expanded', 'false')
+
+    // Simulate a mid-turn plan update: new entries arrive, collapse must persist
+    rerender(
+      <PlanPanel
+        entries={[
+          { content: 'Task A', status: 'completed' },
+          { content: 'Task B', status: 'in_progress' }
+        ]}
+      />
+    )
+    // Panel stays collapsed — entries updated but user's choice preserved
+    const updatedToggle = screen.getByRole('button', {
+      name: /Plan, 1 of 2 tasks, task in progress/
+    })
+    expect(updatedToggle).toHaveAttribute('aria-expanded', 'false')
+  })
+
+  it('hides the panel entirely when entries become empty (agent clears plan while collapsed)', async () => {
+    const { rerender, container } = render(
+      <PlanPanel entries={[{ content: 'Task A', status: 'in_progress' }]} />
+    )
+    const toggle = screen.getByRole('button', { name: /Plan, 0 of 1 task, task in progress/ })
+    fireEvent.click(toggle)
+    expect(toggle).toHaveAttribute('aria-expanded', 'false')
+
+    // Agent clears the plan (empty entries) — panel unmounts via AnimatePresence,
+    // collapse state is irrelevant because entries.length === 0 always hides.
+    rerender(<PlanPanel entries={[]} />)
+    // AnimatePresence defers unmount until the exit animation completes; in jsdom
+    // that flushes on the next microtask. Wait for the region to leave the DOM.
+    await waitFor(() => {
+      expect(screen.queryByRole('region', { name: 'Execution plan' })).not.toBeInTheDocument()
+    })
+    expect(screen.queryByRole('button', { name: /Plan/ })).toBeNull()
+  })
+
+  it('exposes a11y attributes on the region and header toggle', () => {
+    const { container } = render(
+      <PlanPanel entries={[{ content: 'Task A', status: 'completed' }]} />
+    )
+    const region = screen.getByRole('region', { name: 'Execution plan' })
+    expect(region).toBeInTheDocument()
+    const toggle = screen.getByRole('button', { name: /Plan, 1 of 1 task/ })
+    expect(toggle).toHaveAttribute('aria-expanded', 'true')
+    // aria-controls is a useId-generated dynamic id — just verify it exists and
+    // matches the body's id.
+    expect(toggle).toHaveAttribute('aria-controls')
+    const controlsId = toggle.getAttribute('aria-controls')
+    expect(controlsId).toBeTruthy()
+    // useId generates ids with colons (e.g. ":rp:") which are invalid in CSS
+    // selectors — use getElementById instead of querySelector('#...').
+    expect(document.getElementById(controlsId!)).toBeInTheDocument()
+  })
+
   it('keeps detail and status paired when entries reorder', () => {
     function ReorderablePlan(): React.JSX.Element {
       const [entries, setEntries] = useState([
@@ -89,5 +177,33 @@ describe('PlanPanel', () => {
     expect(screen.getByText('First detail')).toBeVisible()
     expect(screen.getByText('First task').parentElement).not.toHaveClass('line-through')
     expect(screen.getByText('Second task')).toHaveClass('line-through')
+  })
+})
+
+describe('TermulPlanRenderer (termul-plan fence renderer)', () => {
+  it('renders a read-only PlanPanel from valid fence JSON', () => {
+    const code = JSON.stringify([
+      { content: 'Read AC file', status: 'completed', priority: 'high' },
+      { content: 'Fix bug', status: 'in_progress', priority: 'high' }
+    ])
+    render(<TermulPlanRenderer code={code} isIncomplete={false} language="termul-plan" />)
+    // The renderer reuses PlanPanel, so the entries appear as plan rows
+    expect(screen.getByRole('region', { name: 'Execution plan' })).toBeInTheDocument()
+    expect(screen.getByText('Read AC file')).toBeInTheDocument()
+    expect(screen.getByText('Fix bug')).toBeInTheDocument()
+  })
+
+  it('shows a fallback card when the fence JSON is malformed', () => {
+    render(
+      <TermulPlanRenderer code="{not valid json" isIncomplete={false} language="termul-plan" />
+    )
+    expect(screen.getByText('Plan snapshot unavailable')).toBeInTheDocument()
+    expect(screen.queryByRole('region', { name: 'Execution plan' })).toBeNull()
+  })
+
+  it('shows a streaming placeholder when the fence is incomplete', () => {
+    render(<TermulPlanRenderer code="partial" isIncomplete={true} language="termul-plan" />)
+    expect(screen.getByText('Plan snapshot streaming…')).toBeInTheDocument()
+    expect(screen.queryByRole('region', { name: 'Execution plan' })).toBeNull()
   })
 })

--- a/src/renderer/components/chat/PlanPanel.tsx
+++ b/src/renderer/components/chat/PlanPanel.tsx
@@ -1,5 +1,6 @@
 import { AnimatePresence, motion, useReducedMotion } from 'framer-motion'
-import { CheckCircle2, Circle, ListChecks, Loader2 } from 'lucide-react'
+import { CheckCircle2, ChevronDown, Circle, ListChecks, Loader2 } from 'lucide-react'
+import { useId, useState } from 'react'
 import type { PlanEntry } from '@/lib/acp-api'
 import { cn } from '@/lib/utils'
 import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from '../ui/accordion'
@@ -105,7 +106,19 @@ function EntryLabel({ entry }: { entry: PlanEntry }): React.JSX.Element {
 /** Execution plan panel. Renders nothing when there are no entries. */
 export function PlanPanel({ entries }: PlanPanelProps): React.JSX.Element {
   const reduced = useReducedMotion() ?? false
+  // Collapse state is component-local: it survives `entries` changes so
+  // mid-turn `acp:plan_update` events keep the user's collapse choice. Reset
+  // only on unmount or session switch (the panel is remounted per session).
+  const [collapsed, setCollapsed] = useState(false)
+  // Unique id per PlanPanel instance so the sticky panel and an inline
+  // historical renderer never collide on `id="plan-panel-body"`.
+  const bodyId = useId()
   const completed = entries.filter((e) => e.status === 'completed').length
+  const inProgressCount = entries.filter((e) => e.status === 'in_progress').length
+  const hasInProgress = inProgressCount > 0
+  const taskLabel = entries.length === 1 ? 'task' : 'tasks'
+  const inProgressLabel =
+    inProgressCount === 1 ? 'task in progress' : `${inProgressCount} tasks in progress`
 
   return (
     <AnimatePresence initial={false}>
@@ -119,60 +132,93 @@ export function PlanPanel({ entries }: PlanPanelProps): React.JSX.Element {
           className="shrink-0"
         >
           <div className={cn(CHAT_GUTTER_X, 'py-2')}>
-            <div className="mx-auto w-full max-w-3xl overflow-hidden rounded-lg bg-card/30 shadow-[0_1px_2px_hsl(var(--foreground)/0.04)] ring-1 ring-border/50">
-              <div className="flex items-center gap-1.5 px-3 py-2 text-2xs font-semibold text-muted-foreground">
+            <section
+              className="mx-auto w-full max-w-3xl overflow-hidden rounded-lg bg-card/30 shadow-[0_1px_2px_hsl(var(--foreground)/0.04)] ring-1 ring-border/50"
+              aria-label="Execution plan"
+            >
+              <button
+                type="button"
+                onClick={() => setCollapsed((c) => !c)}
+                aria-expanded={!collapsed}
+                aria-controls={bodyId}
+                aria-label={`Plan, ${completed} of ${entries.length} ${taskLabel}${
+                  hasInProgress ? `, ${inProgressLabel}` : ''
+                }`}
+                className="flex w-full items-center gap-1.5 px-3 py-2 text-left text-2xs font-semibold text-muted-foreground transition-colors hover:bg-muted/30 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+              >
                 <ListChecks size={12} className="shrink-0" aria-hidden="true" />
                 <span className="text-balance">Plan</span>
+                {hasInProgress && (
+                  <Loader2
+                    size={12}
+                    className="ml-1 shrink-0 animate-spin text-warning motion-reduce:animate-none"
+                    aria-hidden="true"
+                  />
+                )}
                 <span className="ml-auto tabular-nums text-muted-foreground/70">
                   {completed}
                   <span className="text-muted-foreground/40">/</span>
                   {entries.length}
                 </span>
-              </div>
-              <ScrollArea className="max-h-60 border-t border-border/40">
-                <Accordion
-                  type="single"
-                  collapsible
-                  className="flex flex-col gap-0.5 px-2.5 pb-2.5 pt-1.5"
-                >
-                  {entries.map((entry, i) => {
-                    const detail = getPlanDetail(entry)
-                    const entryValue = `entry-${getPlanEntryIdentity(entry)}`
-                    const motionProps = {
-                      initial: reduced ? { opacity: 0 } : { opacity: 0, y: 6, filter: 'blur(4px)' },
-                      animate: reduced ? { opacity: 1 } : { opacity: 1, y: 0, filter: 'blur(0px)' },
-                      transition: {
-                        ...(reduced ? { duration: 0.15 } : CHAT_SPRING_SOFT),
-                        delay: reduced ? 0 : Math.min(i, 8) * 0.08
+                <ChevronDown
+                  size={14}
+                  className={cn(
+                    'shrink-0 text-muted-foreground/60 transition-transform',
+                    collapsed ? '' : 'rotate-180'
+                  )}
+                  aria-hidden="true"
+                />
+              </button>
+              {!collapsed && (
+                <ScrollArea id={bodyId} className="max-h-60 border-t border-border/40">
+                  <Accordion
+                    type="single"
+                    collapsible
+                    className="flex flex-col gap-0.5 px-2.5 pb-2.5 pt-1.5"
+                  >
+                    {entries.map((entry, i) => {
+                      const detail = getPlanDetail(entry)
+                      const entryValue = `entry-${getPlanEntryIdentity(entry)}`
+                      const motionProps = {
+                        initial: reduced
+                          ? { opacity: 0 }
+                          : { opacity: 0, y: 6, filter: 'blur(4px)' },
+                        animate: reduced
+                          ? { opacity: 1 }
+                          : { opacity: 1, y: 0, filter: 'blur(0px)' },
+                        transition: {
+                          ...(reduced ? { duration: 0.15 } : CHAT_SPRING_SOFT),
+                          delay: reduced ? 0 : Math.min(i, 8) * 0.08
+                        }
                       }
-                    }
 
-                    return detail ? (
-                      <motion.div key={entryValue} {...motionProps}>
-                        <AccordionItem value={entryValue} className="border-0">
-                          <AccordionTrigger className="min-h-8 gap-2 rounded-md px-1.5 py-1 text-left text-xs hover:no-underline">
-                            <span className="flex min-w-0 flex-1 items-center gap-2">
-                              <EntryLabel entry={entry} />
-                            </span>
-                          </AccordionTrigger>
-                          <AccordionContent className="pl-8 pr-2 text-xs text-muted-foreground">
-                            {detail}
-                          </AccordionContent>
-                        </AccordionItem>
-                      </motion.div>
-                    ) : (
-                      <motion.div
-                        key={entryValue}
-                        {...motionProps}
-                        className="flex min-h-8 items-center gap-2 rounded-md px-1.5 text-xs"
-                      >
-                        <EntryLabel entry={entry} />
-                      </motion.div>
-                    )
-                  })}
-                </Accordion>
-              </ScrollArea>
-            </div>
+                      return detail ? (
+                        <motion.div key={entryValue} {...motionProps}>
+                          <AccordionItem value={entryValue} className="border-0">
+                            <AccordionTrigger className="min-h-8 gap-2 rounded-md px-1.5 py-1 text-left text-xs hover:no-underline">
+                              <span className="flex min-w-0 flex-1 items-center gap-2">
+                                <EntryLabel entry={entry} />
+                              </span>
+                            </AccordionTrigger>
+                            <AccordionContent className="pl-8 pr-2 text-xs text-muted-foreground">
+                              {detail}
+                            </AccordionContent>
+                          </AccordionItem>
+                        </motion.div>
+                      ) : (
+                        <motion.div
+                          key={entryValue}
+                          {...motionProps}
+                          className="flex min-h-8 items-center gap-2 rounded-md px-1.5 text-xs"
+                        >
+                          <EntryLabel entry={entry} />
+                        </motion.div>
+                      )
+                    })}
+                  </Accordion>
+                </ScrollArea>
+              )}
+            </section>
           </div>
         </motion.div>
       )}

--- a/src/renderer/stores/acp-store.test.ts
+++ b/src/renderer/stores/acp-store.test.ts
@@ -77,6 +77,7 @@ vi.mock('@/lib/web-tab-session', () => ({
 }))
 
 import { invoke } from '@tauri-apps/api/core'
+import type { PlanEntry } from '@/lib/acp-api'
 import {
   _clearPayloadCacheForTesting,
   getCachedSessionPayload,
@@ -6069,6 +6070,417 @@ describe('ACP agent plan store', () => {
     })
     useAcpStore.getState()._onSessionClosed({ agentId: 'agent-1', sessionId: 'sess-1' })
     expect(useAcpStore.getState().plans['sess-1']).toBeUndefined()
+  })
+
+  // --- Plan persistence + sticky snapshot (spec: plan-persistence-sticky-snapshot) ---
+
+  it('sendPrompt preserves plans[sessionId] across a new prompt turn', async () => {
+    seedSession('sess-1', 'agent-1', false)
+    const plan: PlanEntry[] = [
+      { content: 'step one', status: 'in_progress', priority: 'high' },
+      { content: 'step two', status: 'pending', priority: 'medium' }
+    ]
+    useAcpStore.setState({ plans: { 'sess-1': plan } })
+    // never resolve so the turn stays active for the assertion
+    ;(invoke as ReturnType<typeof vi.fn>).mockReturnValue(new Promise(() => {}))
+    void useAcpStore.getState().sendPrompt('sess-1', 'follow up')
+    await Promise.resolve()
+    // Plan must NOT be cleared by sendPrompt (only _onPlanUpdate empty entries clears it)
+    expect(useAcpStore.getState().plans['sess-1']).toBe(plan)
+  })
+
+  it('_onPromptComplete appends a termul-plan fence to the last assistant message when plans[sessionId] is non-empty', () => {
+    seedSession('sess-1', 'agent-1', true)
+    useAcpStore.setState((s) => ({
+      messages: {
+        ...s.messages,
+        'sess-1': [
+          {
+            id: 'm-user',
+            role: 'user',
+            blocks: [{ type: 'text', text: 'do work' }],
+            streaming: false,
+            timestamp: 0,
+            seq: 1
+          },
+          {
+            id: 'm-agent',
+            role: 'agent',
+            blocks: [{ type: 'text', text: 'working on it' }],
+            streaming: true,
+            timestamp: 1,
+            seq: 2
+          }
+        ]
+      },
+      plans: {
+        'sess-1': [
+          { content: 'Read AC file', status: 'completed', priority: 'high' },
+          { content: 'Fix bug', status: 'in_progress', priority: 'high' }
+        ]
+      }
+    }))
+    useAcpStore.getState()._onPromptComplete({
+      agentId: 'agent-1',
+      sessionId: 'sess-1',
+      stopReason: 'end_turn'
+    })
+    const msgs = useAcpStore.getState().messages['sess-1']
+    const lastAgent = [...msgs].reverse().find((m) => m.role === 'agent')
+    expect(lastAgent).toBeDefined()
+    // The fence block must be the last block on the just-finished assistant message
+    const fenceBlock = lastAgent!.blocks.find(
+      (b) =>
+        b.type === 'text' && typeof b.text === 'string' && b.text.startsWith('```termul-plan\n')
+    )
+    expect(fenceBlock).toBeDefined()
+    // Non-fence text blocks (the agent's reply prose) must survive the
+    // appendPlanSnapshot filter — regression guard against a filter that
+    // accidentally drops all text blocks.
+    expect(lastAgent!.blocks).toHaveLength(2)
+    expect(lastAgent!.blocks.find((b) => b.text === 'working on it')).toBeDefined()
+    // The fence JSON decodes to the original PlanEntry[]
+    const json = (fenceBlock!.text as string).replace(/^```termul-plan\n/, '').replace(/\n```$/, '')
+    expect(JSON.parse(json)).toEqual([
+      { content: 'Read AC file', status: 'completed', priority: 'high' },
+      { content: 'Fix bug', status: 'in_progress', priority: 'high' }
+    ])
+    // streaming flag flipped by finalizeStreaming
+    expect(lastAgent!.streaming).toBe(false)
+  })
+
+  it('_onPromptComplete writes no fence when plans[sessionId] is empty (non-compliant agent)', () => {
+    seedSession('sess-1', 'agent-1', true)
+    useAcpStore.setState((s) => ({
+      messages: {
+        ...s.messages,
+        'sess-1': [
+          {
+            id: 'm-agent',
+            role: 'agent',
+            blocks: [{ type: 'text', text: 'reply' }],
+            streaming: true,
+            timestamp: 0,
+            seq: 1
+          }
+        ]
+      },
+      plans: {}
+    }))
+    useAcpStore.getState()._onPromptComplete({
+      agentId: 'agent-1',
+      sessionId: 'sess-1',
+      stopReason: 'end_turn'
+    })
+    const lastAgent = useAcpStore.getState().messages['sess-1'].find((m) => m.role === 'agent')!
+    expect(
+      lastAgent.blocks.some((b) => b.type === 'text' && b.text?.startsWith('```termul-plan\n'))
+    ).toBe(false)
+  })
+
+  it('_onPromptComplete replaces a prior termul-plan fence on the same message (one fence per assistant message)', () => {
+    seedSession('sess-1', 'agent-1', true)
+    const priorFence = '```termul-plan\n[{"content":"old","status":"completed"}]\n```'
+    useAcpStore.setState((s) => ({
+      messages: {
+        ...s.messages,
+        'sess-1': [
+          {
+            id: 'm-agent',
+            role: 'agent',
+            blocks: [
+              { type: 'text', text: 'reply' },
+              { type: 'text', text: priorFence }
+            ],
+            streaming: true,
+            timestamp: 0,
+            seq: 1
+          }
+        ]
+      },
+      plans: {
+        'sess-1': [{ content: 'new plan', status: 'in_progress', priority: 'high' }]
+      }
+    }))
+    useAcpStore.getState()._onPromptComplete({
+      agentId: 'agent-1',
+      sessionId: 'sess-1',
+      stopReason: 'end_turn'
+    })
+    const lastAgent = useAcpStore.getState().messages['sess-1'].find((m) => m.role === 'agent')!
+    const fences = lastAgent.blocks.filter(
+      (b) =>
+        b.type === 'text' && typeof b.text === 'string' && b.text.startsWith('```termul-plan\n')
+    )
+    // Exactly one fence — the prior one was replaced, not appended
+    expect(fences).toHaveLength(1)
+    const json = (fences[0]!.text as string).replace(/^```termul-plan\n/, '').replace(/\n```$/, '')
+    expect(JSON.parse(json)).toEqual([
+      { content: 'new plan', status: 'in_progress', priority: 'high' }
+    ])
+  })
+
+  it('_onPromptComplete survives a JSON.stringify failure in appendPlanSnapshot without blocking turn-end (logs source: planSnapshot)', () => {
+    // A PlanEntry mutated to carry a circular reference would make
+    // JSON.stringify throw. The try/catch in _onPromptComplete logs to
+    // source: 'planSnapshot' and continues — the live sticky plan still
+    // covers the turn.
+    seedSession('sess-circular', 'agent-1', true)
+    const circular: PlanEntry = { content: 'bad', status: 'in_progress' } as PlanEntry
+    ;(circular as unknown as { self: unknown }).self = circular
+    useAcpStore.setState((s) => ({
+      messages: {
+        ...s.messages,
+        'sess-circular': [
+          {
+            id: 'm-user',
+            role: 'user',
+            blocks: [{ type: 'text', text: 'do work' }],
+            streaming: false,
+            timestamp: 0,
+            seq: 1
+          },
+          {
+            id: 'm-agent',
+            role: 'agent',
+            blocks: [{ type: 'text', text: 'working on it' }],
+            streaming: true,
+            timestamp: 1,
+            seq: 2
+          }
+        ]
+      },
+      plans: { 'sess-circular': [circular] }
+    }))
+    // Must not throw
+    expect(() =>
+      useAcpStore.getState()._onPromptComplete({
+        agentId: 'agent-1',
+        sessionId: 'sess-circular',
+        stopReason: 'end_turn'
+      })
+    ).not.toThrow()
+    // The agent's reply prose survives; no fence was appended (stringify threw).
+    const lastAgent = useAcpStore
+      .getState()
+      .messages['sess-circular'].find((m) => m.role === 'agent')!
+    expect(lastAgent.blocks.find((b) => b.text === 'working on it')).toBeDefined()
+    expect(lastAgent.blocks.some((b) => b.text?.startsWith('```termul-plan'))).toBe(false)
+  })
+
+  it('_onPromptComplete updates the in-memory payload cache so a same-session rehydrate finds the fence (CAP-2 host-owned history)', async () => {
+    // Seed the cache with a payload that has NO fence — this is the state
+    // after the host has written the turn's `message_chunk`/`user_prompt`
+    // records but before the renderer has snapshot the plan.
+    seedSession('sess-cache', 'agent-1', true)
+    const baseMessages: ChatMessage[] = [
+      {
+        id: 'm-user',
+        role: 'user',
+        blocks: [{ type: 'text', text: 'do work' }],
+        streaming: false,
+        timestamp: 0,
+        seq: 1
+      },
+      {
+        id: 'm-agent',
+        role: 'agent',
+        blocks: [{ type: 'text', text: 'working on it' }],
+        streaming: true,
+        timestamp: 1,
+        seq: 2
+      }
+    ]
+    setCachedSessionPayload('sess-cache', {
+      metadata: {
+        id: 'sess-cache',
+        agentId: 'agent-1',
+        title: 'T',
+        cwd: '/work',
+        projectId: 'p1',
+        createdAt: 0,
+        lastActivityAt: 0,
+        messageCount: 2,
+        status: 'active' as const
+      },
+      messages: baseMessages
+    })
+    useAcpStore.setState((s) => ({
+      messages: { ...s.messages, 'sess-cache': baseMessages },
+      plans: {
+        'sess-cache': [{ content: 'cache task', status: 'in_progress', priority: 'high' }]
+      }
+    }))
+
+    useAcpStore.getState()._onPromptComplete({
+      agentId: 'agent-1',
+      sessionId: 'sess-cache',
+      stopReason: 'end_turn'
+    })
+
+    // The cache must now reflect the fence-appended messages so a subsequent
+    // loadSessionPayload (within the same app session) finds the fence.
+    const cached = getCachedSessionPayload('sess-cache')
+    expect(cached).toBeDefined()
+    const cachedAgent = [...cached!.messages].reverse().find((m) => m.role === 'agent')
+    expect(cachedAgent).toBeDefined()
+    const cachedFence = cachedAgent!.blocks.find(
+      (b) =>
+        b.type === 'text' && typeof b.text === 'string' && b.text.startsWith('```termul-plan\n')
+    )
+    expect(cachedFence).toBeDefined()
+    // The live store and the cache must agree on the fence content.
+    const storeAgent = useAcpStore
+      .getState()
+      .messages['sess-cache'].find((m) => m.role === 'agent')!
+    const storeFence = storeAgent.blocks.find(
+      (b) =>
+        b.type === 'text' && typeof b.text === 'string' && b.text.startsWith('```termul-plan\n')
+    )!
+    expect(cachedFence!.text).toBe(storeFence.text)
+  })
+
+  it('openHistorySession repopulates plans[id] from the latest termul-plan fence in the last assistant message', async () => {
+    const plan: PlanEntry[] = [
+      { content: 'historical task', status: 'completed', priority: 'high' },
+      { content: 'next step', status: 'in_progress', priority: 'medium' }
+    ]
+    const fence = '```termul-plan\n' + JSON.stringify(plan) + '\n```'
+    setCachedSessionPayload('sess-rehydrate', {
+      metadata: {
+        id: 'sess-rehydrate',
+        agentId: 'agent-x',
+        title: 'Rehydrated',
+        cwd: '/w',
+        createdAt: 1,
+        lastActivityAt: 2,
+        messageCount: 2,
+        status: 'closed'
+      },
+      messages: [
+        {
+          id: 'm-user',
+          role: 'user',
+          blocks: [{ type: 'text', text: 'do work' }],
+          streaming: false,
+          timestamp: 0,
+          seq: 1
+        },
+        {
+          id: 'm-agent',
+          role: 'agent',
+          blocks: [
+            { type: 'text', text: 'reply' },
+            { type: 'text', text: fence }
+          ],
+          streaming: false,
+          timestamp: 1,
+          seq: 2
+        }
+      ]
+    })
+    await useAcpStore.getState().openHistorySession('sess-rehydrate')
+    expect(useAcpStore.getState().plans['sess-rehydrate']).toEqual(plan)
+  })
+
+  it('openHistorySession leaves plans[id] empty and warns when the fence JSON is malformed', async () => {
+    setCachedSessionPayload('sess-malformed', {
+      metadata: {
+        id: 'sess-malformed',
+        agentId: 'agent-x',
+        title: 'Malformed',
+        cwd: '/w',
+        createdAt: 1,
+        lastActivityAt: 2,
+        messageCount: 1,
+        status: 'closed'
+      },
+      messages: [
+        {
+          id: 'm-agent',
+          role: 'agent',
+          blocks: [{ type: 'text', text: '```termul-plan\n{not valid json}\n```' }],
+          streaming: false,
+          timestamp: 0,
+          seq: 1
+        }
+      ]
+    })
+    await useAcpStore.getState().openHistorySession('sess-malformed')
+    expect(useAcpStore.getState().plans['sess-malformed']).toBeUndefined()
+    expect(logFrontendError).toHaveBeenCalledWith(
+      expect.objectContaining({ source: 'planRehydrate' })
+    )
+  })
+
+  it('openHistorySession does not overwrite a live plans[id] from an in-flight turn', async () => {
+    const livePlan: PlanEntry[] = [{ content: 'live', status: 'in_progress', priority: 'high' }]
+    const fence =
+      '```termul-plan\n' + JSON.stringify([{ content: 'fence', status: 'completed' }]) + '\n```'
+    setCachedSessionPayload('sess-live', {
+      metadata: {
+        id: 'sess-live',
+        agentId: 'agent-x',
+        title: 'Live',
+        cwd: '/w',
+        createdAt: 1,
+        lastActivityAt: 2,
+        messageCount: 1,
+        status: 'closed'
+      },
+      messages: [
+        {
+          id: 'm-agent',
+          role: 'agent',
+          blocks: [{ type: 'text', text: fence }],
+          streaming: false,
+          timestamp: 0,
+          seq: 1
+        }
+      ]
+    })
+    seedSession('sess-live', 'agent-x', true)
+    useAcpStore.setState({ plans: { 'sess-live': livePlan } })
+    await useAcpStore.getState().openHistorySession('sess-live')
+    // Live plan from the in-flight turn wins; the fence does not overwrite it
+    expect(useAcpStore.getState().plans['sess-live']).toBe(livePlan)
+  })
+
+  it('openHistorySession last-fence-wins when two termul-plan fences are in the same assistant message', async () => {
+    const first =
+      '```termul-plan\n' + JSON.stringify([{ content: 'first', status: 'completed' }]) + '\n```'
+    const second =
+      '```termul-plan\n' + JSON.stringify([{ content: 'second', status: 'in_progress' }]) + '\n```'
+    setCachedSessionPayload('sess-twofence', {
+      metadata: {
+        id: 'sess-twofence',
+        agentId: 'agent-x',
+        title: 'Two fences',
+        cwd: '/w',
+        createdAt: 1,
+        lastActivityAt: 2,
+        messageCount: 1,
+        status: 'closed'
+      },
+      messages: [
+        {
+          id: 'm-agent',
+          role: 'agent',
+          blocks: [
+            { type: 'text', text: 'reply' },
+            { type: 'text', text: first },
+            { type: 'text', text: second }
+          ],
+          streaming: false,
+          timestamp: 0,
+          seq: 1
+        }
+      ]
+    })
+    await useAcpStore.getState().openHistorySession('sess-twofence')
+    expect(useAcpStore.getState().plans['sess-twofence']).toEqual([
+      { content: 'second', status: 'in_progress' }
+    ])
   })
 })
 

--- a/src/renderer/stores/acp-store.ts
+++ b/src/renderer/stores/acp-store.ts
@@ -952,17 +952,31 @@ function scanPlanFenceFromMessages(messages: ChatMessage[]): PlanEntry[] | null 
     for (let j = blocks.length - 1; j >= 0; j--) {
       const block = blocks[j]
       if (block.type !== 'text') continue
-      const parsed = parseTermulPlanFence(block.text)
-      if (parsed !== null) return parsed
-      // If a fence exists but is malformed, keep scanning for an earlier
-      // valid one on the same message; if none surfaces, the rehydrate path
-      // logs the malformed fence separately via `extractTermulPlanFenceJson`.
-      if (extractTermulPlanFenceJson(block.text) !== null) continue
+      // A fence exists in this block — parse it. If the newest fence is
+      // malformed, treat it as terminal: return null rather than continuing
+      // to older fences (last-fence-wins means a malformed newest fence
+      // supersedes any older valid plan).
+      if (extractTermulPlanFenceJson(block.text) !== null) {
+        const parsed = parseTermulPlanFence(block.text)
+        return parsed
+      }
     }
     // Continue to earlier assistant messages — the most recent fence across
     // all turns is the plan-of-record.
   }
   return null
+}
+
+/**
+ * Check whether a text block IS a termul-plan fence (the entire text is the
+ * fence, not just contains one). Used by `appendPlanSnapshot` to decide which
+ * blocks to replace — only drop blocks that ARE fences, preserving assistant
+ * prose that merely quotes or references the fence format.
+ */
+function isTermulPlanFenceBlock(text: string | undefined): boolean {
+  if (typeof text !== 'string' || text.length === 0) return false
+  // Full-string match (anchored): the entire block must be the fence.
+  return /^```termul-plan\r?\n([\s\S]*?)\r?\n```$/.test(text)
 }
 
 /**
@@ -991,10 +1005,10 @@ function appendPlanSnapshot(
   const target = list[lastAgentIdx]
   // Replace any prior termul-plan fence block on the same message so the
   // snapshot is a full deterministic replace (one fence per assistant message).
-  // Use `extractTermulPlanFenceJson` (detects the fence pattern regardless of
-  // JSON validity) so a prior MALFORMED fence is also replaced — not just valid ones.
+  // Only drop blocks that ARE fences (full-string match), preserving assistant
+  // prose that merely contains or quotes the fence format.
   const filteredBlocks = target.blocks.filter(
-    (b) => b.type !== 'text' || extractTermulPlanFenceJson(b.text) === null
+    (b) => b.type !== 'text' || !isTermulPlanFenceBlock(b.text)
   )
   const fenceBlock: ContentBlock = {
     type: 'text',
@@ -5171,11 +5185,37 @@ export const useAcpStore = create<AcpState>((set, get) => ({
     // projection is re-fetched. Cross-restart durability requires a host-side
     // synthetic record (renegotiate the spec's "Never: no Rust-side persistence"
     // rule if needed).
+    //
+    // Only update the specific assistant message in the cache — the live window
+    // (`get().messages[sessionId]`) may be trimmed (MAX_LIVE_WINDOW_MESSAGES),
+    // so replacing the entire cached messages array with the live window would
+    // drop older messages and break `loadOlderMessages`.
     const cachedPayload = getCachedSessionPayload(e.sessionId)
     if (cachedPayload) {
-      const updatedMessages = get().messages[e.sessionId] ?? cachedPayload.messages
-      if (updatedMessages !== cachedPayload.messages) {
-        setCachedSessionPayload(e.sessionId, { ...cachedPayload, messages: updatedMessages })
+      const liveMessages = get().messages[e.sessionId]
+      if (liveMessages) {
+        // Find the last assistant message in the live window (the snapshot target).
+        let lastAgentIdx = -1
+        for (let i = liveMessages.length - 1; i >= 0; i--) {
+          if (liveMessages[i].role === 'agent') {
+            lastAgentIdx = i
+            break
+          }
+        }
+        if (lastAgentIdx >= 0) {
+          const liveAgent = liveMessages[lastAgentIdx]
+          // Find the corresponding message in the cached payload by id and
+          // update only its blocks — preserve all other cached messages.
+          const cachedIdx = cachedPayload.messages.findIndex((m) => m.id === liveAgent.id)
+          if (cachedIdx >= 0 && cachedPayload.messages[cachedIdx].blocks !== liveAgent.blocks) {
+            const updatedCachedMessages = [...cachedPayload.messages]
+            updatedCachedMessages[cachedIdx] = liveAgent
+            setCachedSessionPayload(e.sessionId, {
+              ...cachedPayload,
+              messages: updatedCachedMessages
+            })
+          }
+        }
       }
     }
     // Mirror the finished turn (including the agent's reply) to disk. Without

--- a/src/renderer/stores/acp-store.ts
+++ b/src/renderer/stores/acp-store.ts
@@ -93,6 +93,7 @@ import {
   queueSessionPayloadDelete,
   restoredToolCalls,
   type SessionIndexEntry,
+  setCachedSessionPayload,
   unpinSessionPayload
 } from '@/lib/acp-history-persistence'
 import {
@@ -888,6 +889,124 @@ function dropPlanForSession(
   const next = { ...plans }
   delete next[sessionId]
   return next
+}
+
+/**
+ * Parse the LAST ```termul-plan fence out of a markdown text blob. Returns
+ * the parsed `PlanEntry[]` when the JSON is a valid array, or `null` when
+ * there is no fence or the JSON is malformed. Last-fence-wins matches the
+ * snapshot contract: each assistant message carries at most one renderer-
+ * authored snapshot, and a rehydrate must surface the most recent one.
+ */
+export function parseTermulPlanFence(text: string | undefined): PlanEntry[] | null {
+  const json = extractTermulPlanFenceJson(text)
+  if (json === null) return null
+  try {
+    const parsed = JSON.parse(json)
+    if (!Array.isArray(parsed)) return null
+    // Coerce to PlanEntry[]: keep only objects with a string `content`; drop
+    // malformed entries so a single bad entry doesn't poison the whole plan.
+    // `status` and `priority` are optional but must be strings when present.
+    return parsed.filter((entry): entry is PlanEntry => {
+      if (entry === null || typeof entry !== 'object') return false
+      const e = entry as PlanEntry
+      if (typeof e.content !== 'string') return false
+      if (e.status !== undefined && typeof e.status !== 'string') return false
+      if (e.priority !== undefined && typeof e.priority !== 'string') return false
+      return true
+    })
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Extract the raw JSON string from the LAST ```termul-plan fence in the text.
+ * Returns `null` when no fence is present. Used by the rehydrate path to
+ * distinguish "no fence" (skip silently) from "malformed fence JSON" (warn).
+ */
+export function extractTermulPlanFenceJson(text: string | undefined): string | null {
+  if (typeof text !== 'string' || text.length === 0) return null
+  // \r? handles both LF and CRLF line endings (Windows host/agent normalization).
+  const fence = /```termul-plan\r?\n([\s\S]*?)\r?\n```/g
+  let lastJson: string | null = null
+  for (let match = fence.exec(text); match !== null; match = fence.exec(text)) {
+    lastJson = match[1]
+  }
+  return lastJson
+}
+
+/**
+ * Scan assistant messages in reverse for a `termul-plan` fence (last fence
+ * wins). Returns the parsed plan, or `null` when no fence is present or the
+ * JSON is malformed. Scans ALL assistant messages — if the last message has
+ * no fence (e.g. the turn was interrupted before `_onPromptComplete` ran),
+ * earlier messages' fences are the plan-of-record.
+ */
+function scanPlanFenceFromMessages(messages: ChatMessage[]): PlanEntry[] | null {
+  for (let i = messages.length - 1; i >= 0; i--) {
+    if (messages[i].role !== 'agent') continue
+    const blocks = messages[i].blocks
+    // Last fence wins: scan blocks in reverse so the most recent snapshot
+    // surfaces first.
+    for (let j = blocks.length - 1; j >= 0; j--) {
+      const block = blocks[j]
+      if (block.type !== 'text') continue
+      const parsed = parseTermulPlanFence(block.text)
+      if (parsed !== null) return parsed
+      // If a fence exists but is malformed, keep scanning for an earlier
+      // valid one on the same message; if none surfaces, the rehydrate path
+      // logs the malformed fence separately via `extractTermulPlanFenceJson`.
+      if (extractTermulPlanFenceJson(block.text) !== null) continue
+    }
+    // Continue to earlier assistant messages — the most recent fence across
+    // all turns is the plan-of-record.
+  }
+  return null
+}
+
+/**
+ * Append a `termul-plan` fence `text` block carrying the live plan to the
+ * last assistant message's `blocks`. The snapshot is a full deterministic
+ * replace of any prior snapshot block on the same message (one fence per
+ * assistant message, last write wins). Returns the messages map unchanged
+ * when there is no live plan or no assistant message to attach to.
+ */
+function appendPlanSnapshot(
+  messages: Record<SessionId, ChatMessage[]>,
+  sessionId: SessionId,
+  plan: PlanEntry[] | undefined
+): Record<SessionId, ChatMessage[]> {
+  if (!plan || plan.length === 0) return messages
+  const list = messages[sessionId]
+  if (!list || list.length === 0) return messages
+  let lastAgentIdx = -1
+  for (let i = list.length - 1; i >= 0; i--) {
+    if (list[i].role === 'agent') {
+      lastAgentIdx = i
+      break
+    }
+  }
+  if (lastAgentIdx < 0) return messages
+  const target = list[lastAgentIdx]
+  // Replace any prior termul-plan fence block on the same message so the
+  // snapshot is a full deterministic replace (one fence per assistant message).
+  // Use `extractTermulPlanFenceJson` (detects the fence pattern regardless of
+  // JSON validity) so a prior MALFORMED fence is also replaced — not just valid ones.
+  const filteredBlocks = target.blocks.filter(
+    (b) => b.type !== 'text' || extractTermulPlanFenceJson(b.text) === null
+  )
+  const fenceBlock: ContentBlock = {
+    type: 'text',
+    text: `\`\`\`termul-plan\n${JSON.stringify(plan)}\n\`\`\``
+  }
+  const updatedMessage: ChatMessage = {
+    ...target,
+    blocks: [...filteredBlocks, fenceBlock]
+  }
+  const newList = [...list]
+  newList[lastAgentIdx] = updatedMessage
+  return { ...messages, [sessionId]: newList }
 }
 
 /** Remove all pending permissions belonging to an agent. */
@@ -2076,6 +2195,36 @@ async function openHistorySessionInner(
   }))
   onTranscriptInstalled()
 
+  // Rehydrate the sticky plan from the latest assistant message's
+  // `termul-plan` fence (single source of truth). Scans the payload messages
+  // (not the trimmed live window) so the fence is found even when the
+  // trimming boundary lands on the snapshot carrier. Skip silently when a
+  // live `plans[id]` already exists from an in-flight turn — the live plan
+  // owns the active turn; the fence only rehydrates a closed/reopened chat.
+  if (!get().plans[id]) {
+    const rehydrated = scanPlanFenceFromMessages(payload.messages)
+    if (rehydrated && rehydrated.length > 0) {
+      set((s) => ({ plans: { ...s.plans, [id]: rehydrated } }))
+    } else {
+      // Detect a malformed fence (fence present but JSON unparseable / not an
+      // array / empty after coercion) and warn so a corrupted snapshot is
+      // visible without crashing the rehydrate. Leave `plans[id]` empty so
+      // the agent can still emit a fresh plan.
+      const lastAgent = [...payload.messages].reverse().find((m) => m.role === 'agent')
+      const hasMalformedFence =
+        lastAgent?.blocks.some(
+          (b) => b.type === 'text' && extractTermulPlanFenceJson(b.text) !== null
+        ) ?? false
+      if (hasMalformedFence) {
+        void logFrontendError({
+          level: 'warn',
+          source: 'planRehydrate',
+          message: `Malformed termul-plan fence in history session ${id}; leaving plans empty`
+        })
+      }
+    }
+  }
+
   // Resolve the CURRENT live agent for this chat's config+cwd. Without this
   // remap the `agentStatus`/`agents` lookups miss (stale UUID after restart)
   // and `decideResume` falls to 'local', leaving `sendPrompt` rejected.
@@ -2333,12 +2482,15 @@ async function runPromptTurn(
           timestamp: Date.now(),
           seq: nextSeq()
         }
+        // Plan persistence: do NOT drop `plans[sessionId]` here. The ACP
+        // spec's empty-entries rule (`_onPlanUpdate`) remains the sole
+        // client-visible clear path; clearing on prompt-send wiped
+        // in-progress plans between turns (spec: plan-persistence-sticky-snapshot).
         return {
           messages: {
             ...s.messages,
             [sessionId]: [...list, userMessage]
           },
-          plans: dropPlanForSession(s.plans, sessionId),
           sessions: {
             ...s.sessions,
             [sessionId]: { ...current, activeTurn: true, openTurnId, lastError: null }
@@ -2352,7 +2504,6 @@ async function runPromptTurn(
           ...s.messages,
           [sessionId]: rebrandedList
         },
-        plans: dropPlanForSession(s.plans, sessionId),
         sessions: {
           ...s.sessions,
           [sessionId]: { ...current, activeTurn: true, openTurnId, lastError: null }
@@ -2373,7 +2524,6 @@ async function runPromptTurn(
         ...s.messages,
         [sessionId]: [...(s.messages[sessionId] ?? []), userMessage]
       },
-      plans: dropPlanForSession(s.plans, sessionId),
       sessions: {
         ...s.sessions,
         [sessionId]: { ...current, activeTurn: true, openTurnId, lastError: null }
@@ -4973,7 +5123,25 @@ export const useAcpStore = create<AcpState>((set, get) => ({
     // consistent before the turn status flips.
     flushCoalescedSync()
     set((s) => {
-      const messages = finalizeStreaming(s.messages, e.sessionId)
+      // Snapshot the live plan onto the just-finished assistant message's
+      // `blocks` BEFORE `finalizeStreaming` so historical turns retain their
+      // plan-of-record (the fence is the rehydrate source of truth). The
+      // append is a pure data op; `finalizeStreaming` only flips the
+      // `streaming` flag, so the fence survives the finalize pass.
+      let withSnapshot = s.messages
+      try {
+        withSnapshot = appendPlanSnapshot(s.messages, e.sessionId, s.plans[e.sessionId])
+      } catch (error) {
+        // Impossible in practice (pure JS over a PlanEntry[]), but a bad
+        // entry could throw inside JSON.stringify. Log + continue turn-end
+        // without blocking; the live sticky plan still covers the turn.
+        void logFrontendError({
+          level: 'warn',
+          source: 'planSnapshot',
+          message: `Failed to snapshot plan for ${e.sessionId}: ${String(error)}`
+        })
+      }
+      const messages = finalizeStreaming(withSnapshot, e.sessionId)
       const session = s.sessions[e.sessionId]
       // A finished turn abandons any unanswered permission for this session;
       // the backend resolves it 'cancelled', so clear the stale store entry too.
@@ -4994,6 +5162,22 @@ export const useAcpStore = create<AcpState>((set, get) => ({
         }
       }
     })
+    // Update the in-memory payload cache so a same-session rehydrate (switching
+    // away and back, or any path that re-runs `loadSessionPayload`) finds the
+    // fence. Since CAP-2 host-owned history, `persistSession` only updates the
+    // session-index projection — the durable message wire shape is owned by the
+    // Rust host, and the renderer's `messages` is a projection. Without this
+    // cache update, the snapshot fence would be lost the moment the live
+    // projection is re-fetched. Cross-restart durability requires a host-side
+    // synthetic record (renegotiate the spec's "Never: no Rust-side persistence"
+    // rule if needed).
+    const cachedPayload = getCachedSessionPayload(e.sessionId)
+    if (cachedPayload) {
+      const updatedMessages = get().messages[e.sessionId] ?? cachedPayload.messages
+      if (updatedMessages !== cachedPayload.messages) {
+        setCachedSessionPayload(e.sessionId, { ...cachedPayload, messages: updatedMessages })
+      }
+    }
     // Mirror the finished turn (including the agent's reply) to disk. Without
     // this, only user sends persist and a restart loses the last reply. Skip
     // sessions no longer in the index — persisting would resurrect a chat the


### PR DESCRIPTION
## Summary

The execution plan (PlanPanel) vanished the moment the user sent a second prompt, even when an in_progress task was still active. The plan only reappeared if the agent happened to re-emit a non-empty acp:plan_update on the new turn — and many agents (notably opencode) only re-emit when they call termul_plan again. This broke the HITL-to-next-prompt loop and made multi-turn plan-driven work feel unreliable.

This PR fixes the bug (plan persists across prompts until the agent explicitly clears it or the session closes) and adds a per-turn snapshot system so each historical assistant message retains its plan-of-record inline in the transcript.

## Related Issue

No related issue — discovered during a live chat session. Searched open and closed PRs for duplicates; PR #610 (host-injected termul_plan MCP tool) and #481 (PlanPanel details) are related but neither covers the persistence bug or the streamdown fence snapshot.

## Type of Change

- [x] feat: new feature
- [x] fix: bug fix

## What Changed

**Bug fix — plan persistence across prompts:**
- Removed the 3 dropPlanForSession calls inside sendPrompt (acp-store.ts). The plan now persists across turns until the agent explicitly clears it (empty entries via acp:plan_update) or the session closes — matching the ACP spec's agent-owned plan lifecycle.

**Snapshot-on-turn-end:**
- _onPromptComplete appends a termul-plan fence text block to the just-finished assistant message's blocks before finalizeStreaming. The fence JSON is the live PlanEntry[] at turn-end.
- The in-memory payload cache is updated after the set() so same-session rehydrate (switching away and back) finds the fence. Cross-restart rehydrate requires a Rust-side synthetic record (deferred — see Known Limitations).

**Rehydrate-on-restore:**
- openHistorySessionInner scans ALL assistant messages in reverse for a termul-plan fence and repopulates plans[id] in the same set() that installs the transcript.

**Streamdown inline rendering:**
- New ChatMarkdownPlanFence.tsx — TermulPlanRenderer (streamdown CustomRenderer) parses the fence JSON and renders a read-only PlanPanel inside the transcript.
- STREAMDOWN_PLUGINS_WITH_PLAN is gated to !streaming messages so the live sticky plan covers the in-flight turn (no duplicate UI during streaming).

**PlanPanel improvements:**
- Collapse toggle (chevron + useState); collapse state survives mid-turn acp:plan_update events; key={plan-session-id} forces remount on session switch.
- useId for unique aria-controls (avoids duplicate-id collision between sticky and inline renderers).
- Grammar-correct aria-label with pluralization.
- section aria-label=Execution-plan for semantic role.
- Existing max-h-60 scroll viewport (~5 visible tasks) preserved.

**Fence parsing:**
- CRLF-safe regex for Windows host/agent normalization.
- status/priority type validation in parseTermulPlanFence (drops malformed entries).
- Filter uses extractTermulPlanFenceJson (pattern-based) so malformed prior fences are also replaced.

**Docs:**
- docs/api-contracts.md — documented the persisted plan snapshot contract after the acp:plan_update section.

## How It Was Tested

- [x] bun run ci (Biome lint + format + imports, strict mode)
- [x] bun run typecheck
- [x] bun run test (660 tests pass)
- [ ] cargo clippy --all-targets -- -D warnings — N/A, no Rust changes
- [ ] cargo test — N/A, no Rust changes
- [ ] Manual verification — pending (requires running Tauri app with ACP agent)

## Known Limitations

Cross-restart rehydrate does not work. The durable store (CAP-2 host-owned history) lacks the termul-plan fence — persistSession only updates the session-index projection; the fence lives only in the renderer's in-memory messages projection and the payloadCache. On restart, loadSessionPayload reads from the durable store (no fence) and plans[id] stays empty. In-session rehydrate (switching away and back) works via the cache update. Fixing cross-restart requires a Rust-side synthetic record (tracked in deferred-work.md).

## CI and Review Gate

- [ ] All CI checks pass (PR Validation, Rust Checks, Build Verification, Security Scans)
- [ ] Code review comments from CodeRabbit / Claude have been addressed or resolved
- [ ] No unresolved review findings remain

## Checklist

- [x] My PR title follows the conventional commit format used by this repo
- [x] I linked the related issue or explained why no issue exists
- [x] I updated docs when needed
- [x] I added or updated tests when needed
- [x] I verified the change does not introduce unrelated modifications
- [x] I read AGENTS.md and followed the contributor guidelines
- [x] A human reviewed the complete diff before submission