### PR TITLE
fix(chat): drive @-mention file picker via ripgrep sidecar

### DIFF
--- a/src/renderer/components/agents/AgentLauncher.test.tsx
+++ b/src/renderer/components/agents/AgentLauncher.test.tsx
@@ -195,7 +195,11 @@ vi.mock('@/lib/api', () => ({
   filesystemApi: {
     onFileChanged: vi.fn(() => () => {}),
     onFileCreated: vi.fn(() => () => {}),
-    onFileDeleted: vi.fn(() => () => {})
+    onFileDeleted: vi.fn(() => () => {}),
+    searchFileNamesStreamStart: vi.fn(async () => ({ success: true as const })),
+    searchFileNamesStreamCancel: vi.fn(async () => ({ success: true as const })),
+    onSearchFileNamesBatch: vi.fn(() => () => {}),
+    onSearchFileNamesDone: vi.fn(() => () => {})
   }
 }))
 

--- a/src/renderer/components/chat/ChatInputBar.test.tsx
+++ b/src/renderer/components/chat/ChatInputBar.test.tsx
@@ -525,8 +525,9 @@ describe('ChatInputBar file mentions', () => {
           truncated?: boolean
         }) => void)
       | null
+    const sid = mockStreamApi.searchFileNamesStreamStart.mock.calls[0]?.[0] as string
     batch?.({
-      searchId: 'search-1',
+      searchId: sid,
       files: [{ path: 'src/auth.ts', ignored: false }]
     })
     const done = doneCb.current as unknown as
@@ -538,7 +539,7 @@ describe('ChatInputBar file mentions', () => {
           error?: string
         }) => void)
       | null
-    done?.({ searchId: 'search-1', truncated: false, totalFiles: 1 })
+    done?.({ searchId: sid, truncated: false, totalFiles: 1 })
 
     // Switch back to real timers so `waitFor` can poll for the post-select /
     // send async effects.

--- a/src/renderer/components/chat/ChatInputBar.test.tsx
+++ b/src/renderer/components/chat/ChatInputBar.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
+import { act, cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
 import type { ComponentProps } from 'react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { TooltipProvider } from '@/components/ui/tooltip'
@@ -46,37 +46,66 @@ const {
   mockMcpCount,
   mockSetMcpServerEnabled,
   mockLoadMcpTools,
-  mockReadDir,
   mockSkills,
-  mockToastError
-} = vi.hoisted(() => ({
-  mockSetConfig: vi.fn(),
-  mockSetMode: vi.fn(),
-  mockSetModel: vi.fn(),
-  // Story 1.8 review (verification-gap #8): override-able MCP server count for
-  // the read-only badge. 0 by default (badge hidden); tests set it to render.
-  mockMcpCount: { current: 0 },
-  // Stable mocks for the chatbox popover's per-server toggle + probe actions
-  // (introduced alongside the status/tools/chatbox-toggle work). Reused across
-  // renders so call assertions hold.
-  mockSetMcpServerEnabled: vi.fn(async () => {}),
-  mockLoadMcpTools: vi.fn(async () => {}),
-  mockReadDir: vi.fn(),
-  // Override-able skills list (defaults to [] — web/no-skills parity). Skill
-  // tests push entries here so useAgentSkills surfaces them in the slash menu.
-  // `path` is required so the wire prompt can cite it (desktop always has one).
-  mockSkills: {
-    current: [] as Array<{
-      name: string
-      description: string
-      scope: string
-      path: string
-    }>
-  },
-  mockToastError: vi.fn()
-}))
+  mockToastError,
+  mockIsTauri,
+  mockStreamApi,
+  batchCb,
+  doneCb
+} = vi.hoisted(() => {
+  const batch = { current: null as null | ((e: never) => void) }
+  const done = { current: null as null | ((e: never) => void) }
+  return {
+    mockSetConfig: vi.fn(),
+    mockSetMode: vi.fn(),
+    mockSetModel: vi.fn(),
+    // Story 1.8 review (verification-gap #8): override-able MCP server count for
+    // the read-only badge. 0 by default (badge hidden); tests set it to render.
+    mockMcpCount: { current: 0 },
+    // Stable mocks for the chatbox popover's per-server toggle + probe actions
+    // (introduced alongside the status/tools/chatbox-toggle work). Reused across
+    // renders so call assertions hold.
+    mockSetMcpServerEnabled: vi.fn(async () => {}),
+    mockLoadMcpTools: vi.fn(async () => {}),
+    // Override-able skills list (defaults to [] — web/no-skills parity). Skill
+    // tests push entries here so useAgentSkills surfaces them in the slash menu.
+    // `path` is required so the wire prompt can cite it (desktop always has one).
+    mockSkills: {
+      current: [] as Array<{
+        name: string
+        description: string
+        scope: string
+        path: string
+      }>
+    },
+    mockToastError: vi.fn(),
+    // Desktop/web gate for the @-mention stream. Defaults to false (web parity);
+    // the file-mentions describe flips it true to exercise the ripgrep stream.
+    mockIsTauri: vi.fn(() => false),
+    // Streaming filename-search stubs (mirror use-composer-mentions.test.tsx).
+    // Callbacks are captured into refs so tests can emit synthetic batches/done.
+    batchCb: batch,
+    doneCb: done,
+    mockStreamApi: {
+      searchFileNamesStreamStart: vi.fn(async () => ({ success: true as const })),
+      searchFileNamesStreamCancel: vi.fn(async () => ({ success: true as const })),
+      onSearchFileNamesBatch: vi.fn((cb: (e: never) => void) => {
+        batch.current = cb
+        return () => {
+          batch.current = null
+        }
+      }),
+      onSearchFileNamesDone: vi.fn((cb: (e: never) => void) => {
+        done.current = cb
+        return () => {
+          done.current = null
+        }
+      })
+    }
+  }
+})
 
-vi.mock('@tauri-apps/plugin-fs', () => ({ readDir: mockReadDir }))
+vi.mock('@/lib/tauri-runtime', () => ({ isTauriContext: mockIsTauri }))
 
 vi.mock('sonner', () => ({
   toast: { error: mockToastError, success: vi.fn() }
@@ -153,7 +182,11 @@ const { persistenceStore, fakePersistenceApi } = vi.hoisted(() => {
 
 vi.mock('@/lib/api', async () => {
   const actual = await vi.importActual<typeof import('@/lib/api')>('@/lib/api')
-  return { ...actual, persistenceApi: fakePersistenceApi }
+  return {
+    ...actual,
+    persistenceApi: fakePersistenceApi,
+    filesystemApi: { ...actual.filesystemApi, ...mockStreamApi }
+  }
 })
 
 beforeEach(() => {
@@ -459,11 +492,19 @@ describe('ChatInputBar placeholder', () => {
 describe('ChatInputBar file mentions', () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    mockReadDir.mockImplementation(async (path: string) => {
-      if (path === '/work') return [{ name: 'src', isDirectory: true }]
-      if (path === '/work/src') return [{ name: 'auth.ts', isDirectory: false }]
-      return []
-    })
+    vi.useFakeTimers()
+    mockIsTauri.mockReturnValue(true)
+    mockStreamApi.searchFileNamesStreamStart.mockResolvedValue({ success: true as const })
+    mockStreamApi.searchFileNamesStreamCancel.mockResolvedValue({ success: true as const })
+    mockStreamApi.onSearchFileNamesBatch.mockClear()
+    mockStreamApi.onSearchFileNamesDone.mockClear()
+    batchCb.current = null
+    doneCb.current = null
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    mockIsTauri.mockReturnValue(false)
   })
 
   it('stages a selected @ file and sends it as a resource link block', async () => {
@@ -472,7 +513,39 @@ describe('ChatInputBar file mentions', () => {
 
     setComposerValue('fix @auth')
 
-    const option = await screen.findByRole('option', { name: /auth\.ts/ })
+    // Debounce (90ms for >=3-char query) then the ripgrep stream starts.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(90)
+    })
+
+    const batch = batchCb.current as unknown as
+      | ((e: {
+          searchId: string
+          files: Array<{ path: string; ignored: boolean }>
+          truncated?: boolean
+        }) => void)
+      | null
+    batch?.({
+      searchId: 'search-1',
+      files: [{ path: 'src/auth.ts', ignored: false }]
+    })
+    const done = doneCb.current as unknown as
+      | ((e: {
+          searchId: string
+          truncated: boolean
+          totalFiles: number
+          code?: string
+          error?: string
+        }) => void)
+      | null
+    done?.({ searchId: 'search-1', truncated: false, totalFiles: 1 })
+
+    // Switch back to real timers so `waitFor` can poll for the post-select /
+    // send async effects.
+    vi.useRealTimers()
+    await act(async () => {})
+
+    const option = screen.getByRole('option', { name: /auth\.ts/ })
     fireEvent.mouseDown(option)
 
     await waitFor(() => expect(getComposerValue()).toBe('fix '))

--- a/src/renderer/components/chat/use-composer-mentions.test.tsx
+++ b/src/renderer/components/chat/use-composer-mentions.test.tsx
@@ -3,36 +3,40 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { MentionMatch } from './mention-menu-model'
 import { useComposerMentions } from './use-composer-mentions'
 
-const { mockApi, batchCb, doneCb, mockIsTauri, mockLog } = vi.hoisted(() => {
-  const batch = { current: null as null | ((e: never) => void) }
-  const done = { current: null as null | ((e: never) => void) }
+const { mockApi, batchCbs, doneCbs, mockIsTauri, mockLog, mockUuid } = vi.hoisted(() => {
+  const batch: Array<(e: never) => void> = []
+  const done: Array<(e: never) => void> = []
   return {
-    batchCb: batch,
-    doneCb: done,
+    batchCbs: batch,
+    doneCbs: done,
     mockApi: {
       searchFileNamesStreamStart: vi.fn(),
       searchFileNamesStreamCancel: vi.fn(async () => ({ success: true as const })),
       onSearchFileNamesBatch: vi.fn((cb: (e: never) => void) => {
-        batch.current = cb
+        batch.push(cb)
         return () => {
-          batch.current = null
+          const i = batch.indexOf(cb)
+          if (i >= 0) batch.splice(i, 1)
         }
       }),
       onSearchFileNamesDone: vi.fn((cb: (e: never) => void) => {
-        done.current = cb
+        done.push(cb)
         return () => {
-          done.current = null
+          const i = done.indexOf(cb)
+          if (i >= 0) done.splice(i, 1)
         }
       })
     },
     mockIsTauri: vi.fn(() => true),
-    mockLog: vi.fn(async () => {})
+    mockLog: vi.fn(async () => {}),
+    mockUuid: vi.fn(() => 'inst')
   }
 })
 
 vi.mock('@/lib/api', () => ({ filesystemApi: mockApi }))
 vi.mock('@/lib/tauri-runtime', () => ({ isTauriContext: mockIsTauri }))
 vi.mock('@/lib/log-api', () => ({ logFrontendError: mockLog }))
+vi.mock('@/lib/uuid', () => ({ randomUUID: mockUuid }))
 
 interface BatchEvent {
   searchId: string
@@ -49,11 +53,11 @@ interface DoneEvent {
 
 const emitBatch = (e: BatchEvent) =>
   act(() => {
-    ;(batchCb.current as unknown as ((e: BatchEvent) => void) | null)?.(e)
+    for (const cb of [...batchCbs]) (cb as (e: BatchEvent) => void)(e)
   })
 const emitDone = (e: DoneEvent) =>
   act(() => {
-    ;(doneCb.current as unknown as ((e: DoneEvent) => void) | null)?.(e)
+    for (const cb of [...doneCbs]) (cb as (e: DoneEvent) => void)(e)
   })
 const advance = (ms: number) =>
   act(async () => {
@@ -90,12 +94,14 @@ describe('useComposerMentions', () => {
     mockApi.searchFileNamesStreamCancel.mockResolvedValue({ success: true as const })
     mockApi.onSearchFileNamesBatch.mockClear()
     mockApi.onSearchFileNamesDone.mockClear()
-    batchCb.current = null
-    doneCb.current = null
+    batchCbs.length = 0
+    doneCbs.length = 0
     mockIsTauri.mockReset()
     mockIsTauri.mockReturnValue(true)
     mockLog.mockReset()
     mockLog.mockResolvedValue(undefined)
+    mockUuid.mockReset()
+    mockUuid.mockReturnValue('inst')
   })
 
   afterEach(() => {
@@ -107,8 +113,8 @@ describe('useComposerMentions', () => {
     expect(mockApi.onSearchFileNamesBatch).toHaveBeenCalledTimes(1)
     expect(mockApi.onSearchFileNamesDone).toHaveBeenCalledTimes(1)
     unmount()
-    expect(batchCb.current).toBeNull()
-    expect(doneCb.current).toBeNull()
+    expect(batchCbs).toHaveLength(0)
+    expect(doneCbs).toHaveLength(0)
   })
 
   it('fires a debounced stream on @query and maps SearchFileHit -> MentionMatch', async () => {
@@ -122,7 +128,7 @@ describe('useComposerMentions', () => {
 
     await advance(90)
     expect(mockApi.searchFileNamesStreamStart).toHaveBeenCalledWith(
-      'search-1',
+      'search-inst-1',
       '/work',
       '/work',
       'rea',
@@ -131,7 +137,7 @@ describe('useComposerMentions', () => {
     expect(result.current.loading).toBe(true)
 
     emitBatch({
-      searchId: 'search-1',
+      searchId: 'search-inst-1',
       files: [
         { path: 'src/auth.ts', ignored: false },
         { path: 'build/x.ts', ignored: true }
@@ -147,7 +153,7 @@ describe('useComposerMentions', () => {
     expect(items[1].label).toBe('x.ts')
     expect(items[1].ignored).toBe(true)
 
-    emitDone({ searchId: 'search-1', truncated: false, totalFiles: 2 })
+    emitDone({ searchId: 'search-inst-1', truncated: false, totalFiles: 2 })
     expect(result.current.loading).toBe(false)
   })
 
@@ -159,7 +165,7 @@ describe('useComposerMentions', () => {
       path: `f${i}.ts`,
       ignored: false
     }))
-    emitBatch({ searchId: 'search-1', files })
+    emitBatch({ searchId: 'search-inst-1', files })
     expect(result.current.sections[0].items).toHaveLength(100)
   })
 
@@ -190,7 +196,7 @@ describe('useComposerMentions', () => {
     // r -> re -> rea
     act(() => result.current.update('@r', 2))
     await advance(180)
-    const firstSid = 'search-1'
+    const firstSid = 'search-inst-1'
     expect(mockApi.searchFileNamesStreamStart).toHaveBeenLastCalledWith(
       firstSid,
       '/work',
@@ -203,7 +209,7 @@ describe('useComposerMentions', () => {
     // New keystroke cancels the in-flight stream before scheduling the next.
     expect(mockApi.searchFileNamesStreamCancel).toHaveBeenCalledWith(firstSid)
     await advance(180)
-    const secondSid = 'search-2'
+    const secondSid = 'search-inst-2'
     expect(mockApi.searchFileNamesStreamStart).toHaveBeenLastCalledWith(
       secondSid,
       '/work',
@@ -215,7 +221,7 @@ describe('useComposerMentions', () => {
     act(() => result.current.update('@rea', 4))
     expect(mockApi.searchFileNamesStreamCancel).toHaveBeenCalledWith(secondSid)
     await advance(90)
-    const thirdSid = 'search-3'
+    const thirdSid = 'search-inst-3'
     expect(mockApi.searchFileNamesStreamStart).toHaveBeenLastCalledWith(
       thirdSid,
       '/work',
@@ -251,14 +257,14 @@ describe('useComposerMentions', () => {
     act(() => result.current.update('@rea', 4))
     await advance(90)
     // A late done for the cancelled search must not drop loading of the active one.
-    emitDone({ searchId: 'search-1', truncated: false, totalFiles: 0 })
+    emitDone({ searchId: 'search-inst-1', truncated: false, totalFiles: 0 })
     expect(result.current.loading).toBe(true)
     emitBatch({
-      searchId: 'search-2',
+      searchId: 'search-inst-2',
       files: [{ path: 'real.ts', ignored: false }]
     })
     expect(result.current.sections).toHaveLength(1)
-    emitDone({ searchId: 'search-2', truncated: false, totalFiles: 1 })
+    emitDone({ searchId: 'search-inst-2', truncated: false, totalFiles: 1 })
     expect(result.current.loading).toBe(false)
   })
 
@@ -305,12 +311,12 @@ describe('useComposerMentions', () => {
     act(() => result.current.update('@rea', 4))
     await advance(90)
     emitBatch({
-      searchId: 'search-1',
+      searchId: 'search-inst-1',
       files: [{ path: 'src/auth.ts', ignored: false }]
     })
     expect(result.current.sections).toHaveLength(1)
     emitDone({
-      searchId: 'search-1',
+      searchId: 'search-inst-1',
       truncated: false,
       totalFiles: 1,
       code: 'RG_SPAWN_FAILED',
@@ -331,7 +337,7 @@ describe('useComposerMentions', () => {
     act(() => result.current.update('@rea', 4))
     await advance(90)
     emitBatch({
-      searchId: 'search-1',
+      searchId: 'search-inst-1',
       files: [{ path: 'src/auth.ts', ignored: false }]
     })
     const picked = match('src/auth.ts')
@@ -350,6 +356,33 @@ describe('useComposerMentions', () => {
     await advance(90)
     expect(result.current.loading).toBe(true)
     unmount()
-    expect(mockApi.searchFileNamesStreamCancel).toHaveBeenCalledWith('search-1')
+    expect(mockApi.searchFileNamesStreamCancel).toHaveBeenCalledWith('search-inst-1')
+  })
+
+  it('uses instance-unique search ids so two hook instances never collide', async () => {
+    // Distinct per-instance prefixes (randomUUID) keep the composer's
+    // `search-<inst>-<n>` namespace disjoint from another hook instance and
+    // from the file-explorer store's `search-<n>` namespace, so broadcast
+    // batch/done events cannot update the wrong consumer.
+    mockUuid.mockReturnValueOnce('a').mockReturnValueOnce('b')
+    const first = renderMentions()
+    act(() => first.result.current.update('@rea', 4))
+    await advance(90)
+    const firstSid = mockApi.searchFileNamesStreamStart.mock.calls[0][0] as string
+
+    const second = renderMentions()
+    act(() => second.result.current.update('@rea', 4))
+    await advance(90)
+    const secondSid = mockApi.searchFileNamesStreamStart.mock.calls[1][0] as string
+
+    expect(firstSid).not.toBe(secondSid)
+    expect(firstSid).toBe('search-a-1')
+    expect(secondSid).toBe('search-b-1')
+    // A batch for the first instance must not land in the second.
+    emitBatch({ searchId: firstSid, files: [{ path: 'a.ts', ignored: false }] })
+    expect(first.result.current.sections).toHaveLength(1)
+    expect(second.result.current.sections).toHaveLength(0)
+    first.unmount()
+    second.unmount()
   })
 })

--- a/src/renderer/components/chat/use-composer-mentions.test.tsx
+++ b/src/renderer/components/chat/use-composer-mentions.test.tsx
@@ -1,41 +1,64 @@
-import { act, renderHook, waitFor } from '@testing-library/react'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { act, renderHook } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { MentionMatch } from './mention-menu-model'
-import { __resetMentionFileCache, useComposerMentions } from './use-composer-mentions'
+import { useComposerMentions } from './use-composer-mentions'
 
-const { mockReadDir, mockChangeCb, mockApi } = vi.hoisted(() => {
-  const changeCb = { current: null as null | ((event: { path: string }) => void) }
+const { mockApi, batchCb, doneCb, mockIsTauri, mockLog } = vi.hoisted(() => {
+  const batch = { current: null as null | ((e: never) => void) }
+  const done = { current: null as null | ((e: never) => void) }
   return {
-    mockReadDir: vi.fn(),
-    mockChangeCb: changeCb,
+    batchCb: batch,
+    doneCb: done,
     mockApi: {
-      onFileChanged: vi.fn((cb: (event: { path: string }) => void) => {
-        changeCb.current = cb
-        return () => {}
+      searchFileNamesStreamStart: vi.fn(),
+      searchFileNamesStreamCancel: vi.fn(async () => ({ success: true as const })),
+      onSearchFileNamesBatch: vi.fn((cb: (e: never) => void) => {
+        batch.current = cb
+        return () => {
+          batch.current = null
+        }
       }),
-      onFileCreated: vi.fn(() => () => {}),
-      onFileDeleted: vi.fn(() => () => {})
-    }
+      onSearchFileNamesDone: vi.fn((cb: (e: never) => void) => {
+        done.current = cb
+        return () => {
+          done.current = null
+        }
+      })
+    },
+    mockIsTauri: vi.fn(() => true),
+    mockLog: vi.fn(async () => {})
   }
 })
 
-vi.mock('@tauri-apps/plugin-fs', () => ({ readDir: mockReadDir }))
 vi.mock('@/lib/api', () => ({ filesystemApi: mockApi }))
+vi.mock('@/lib/tauri-runtime', () => ({ isTauriContext: mockIsTauri }))
+vi.mock('@/lib/log-api', () => ({ logFrontendError: mockLog }))
 
-// Minimal fake project tree. `node_modules` is present at the root to verify
-// the walk skips it (never enqueued, so readDir is never called for it).
-const TREE: Record<string, Array<{ name: string; isDirectory: boolean }>> = {
-  '/work': [
-    { name: 'src', isDirectory: true },
-    { name: 'a.ts', isDirectory: false },
-    { name: 'node_modules', isDirectory: true }
-  ],
-  '/work/src': [
-    { name: 'auth.ts', isDirectory: false },
-    { name: 'chat', isDirectory: true }
-  ],
-  '/work/src/chat': [{ name: 'ChatInputBar.tsx', isDirectory: false }]
+interface BatchEvent {
+  searchId: string
+  files: Array<{ path: string; ignored: boolean }>
+  truncated?: boolean
 }
+interface DoneEvent {
+  searchId: string
+  truncated: boolean
+  totalFiles: number
+  code?: string
+  error?: string
+}
+
+const emitBatch = (e: BatchEvent) =>
+  act(() => {
+    ;(batchCb.current as unknown as ((e: BatchEvent) => void) | null)?.(e)
+  })
+const emitDone = (e: DoneEvent) =>
+  act(() => {
+    ;(doneCb.current as unknown as ((e: DoneEvent) => void) | null)?.(e)
+  })
+const advance = (ms: number) =>
+  act(async () => {
+    await vi.advanceTimersByTimeAsync(ms)
+  })
 
 const match = (relPath: string, ignored = false): MentionMatch => ({
   relPath,
@@ -60,122 +83,273 @@ function renderMentions(overrides: Partial<Parameters<typeof useComposerMentions
 
 describe('useComposerMentions', () => {
   beforeEach(() => {
-    mockReadDir.mockReset()
-    mockReadDir.mockImplementation(async (dir: string) => TREE[dir] ?? [])
-    mockApi.onFileChanged.mockClear()
-    mockApi.onFileCreated.mockClear()
-    mockApi.onFileDeleted.mockClear()
-    mockChangeCb.current = null
-    __resetMentionFileCache()
+    vi.useFakeTimers()
+    mockApi.searchFileNamesStreamStart.mockReset()
+    mockApi.searchFileNamesStreamStart.mockResolvedValue({ success: true as const })
+    mockApi.searchFileNamesStreamCancel.mockReset()
+    mockApi.searchFileNamesStreamCancel.mockResolvedValue({ success: true as const })
+    mockApi.onSearchFileNamesBatch.mockClear()
+    mockApi.onSearchFileNamesDone.mockClear()
+    batchCb.current = null
+    doneCb.current = null
+    mockIsTauri.mockReset()
+    mockIsTauri.mockReturnValue(true)
+    mockLog.mockReset()
+    mockLog.mockResolvedValue(undefined)
   })
 
-  it('walks the project tree and filters by basename on a non-empty @filter', async () => {
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('subscribes once per mount and unlistens on unmount', () => {
+    const { unmount } = renderMentions()
+    expect(mockApi.onSearchFileNamesBatch).toHaveBeenCalledTimes(1)
+    expect(mockApi.onSearchFileNamesDone).toHaveBeenCalledTimes(1)
+    unmount()
+    expect(batchCb.current).toBeNull()
+    expect(doneCb.current).toBeNull()
+  })
+
+  it('fires a debounced stream on @query and maps SearchFileHit -> MentionMatch', async () => {
     const { result } = renderMentions()
-    act(() => result.current.update('@auth', 5))
+    act(() => result.current.update('@rea', 4))
     expect(result.current.menuOpen).toBe(true)
-    expect(result.current.filter).toBe('auth')
-    await waitFor(() => expect(result.current.sections).toHaveLength(1))
+    expect(result.current.filter).toBe('rea')
+    // During the debounce window no search has started yet.
+    expect(mockApi.searchFileNamesStreamStart).not.toHaveBeenCalled()
+    expect(result.current.loading).toBe(false)
+
+    await advance(90)
+    expect(mockApi.searchFileNamesStreamStart).toHaveBeenCalledWith(
+      'search-1',
+      '/work',
+      '/work',
+      'rea',
+      false
+    )
+    expect(result.current.loading).toBe(true)
+
+    emitBatch({
+      searchId: 'search-1',
+      files: [
+        { path: 'src/auth.ts', ignored: false },
+        { path: 'build/x.ts', ignored: true }
+      ]
+    })
+    expect(result.current.sections).toHaveLength(1)
     const items = result.current.sections[0].items
-    expect(items).toHaveLength(1)
+    expect(items).toHaveLength(2)
     expect(items[0].label).toBe('auth.ts')
     expect(items[0].description).toBe('src/auth.ts')
+    expect(items[0].payload.absPath).toBe('/work/src/auth.ts')
+    expect(items[0].ignored).toBe(false)
+    expect(items[1].label).toBe('x.ts')
+    expect(items[1].ignored).toBe(true)
+
+    emitDone({ searchId: 'search-1', truncated: false, totalFiles: 2 })
+    expect(result.current.loading).toBe(false)
   })
 
-  it('skips commonly-ignored directories during the walk', async () => {
+  it('caps accumulated matches at MAX_RESULTS=100', async () => {
     const { result } = renderMentions()
-    act(() => result.current.update('@auth', 5))
-    await waitFor(() => expect(result.current.sections).toHaveLength(1))
-    // node_modules is listed under /work but must never be walked into.
-    expect(mockReadDir).not.toHaveBeenCalledWith('/work/node_modules')
+    act(() => result.current.update('@rea', 4))
+    await advance(90)
+    const files = Array.from({ length: 150 }, (_, i) => ({
+      path: `f${i}.ts`,
+      ignored: false
+    }))
+    emitBatch({ searchId: 'search-1', files })
+    expect(result.current.sections[0].items).toHaveLength(100)
   })
 
-  it('shows recents on a bare @ with empty filter', () => {
+  it('fires no search on a bare @ (empty filter) and renders Recents', () => {
     const { result } = renderMentions({
       recents: [match('src/recent.ts'), match('README.md')]
     })
     act(() => result.current.update('@', 1))
     expect(result.current.menuOpen).toBe(true)
+    expect(result.current.filter).toBe('')
+    expect(mockApi.searchFileNamesStreamStart).not.toHaveBeenCalled()
+    expect(result.current.loading).toBe(false)
     expect(result.current.sections).toHaveLength(1)
     expect(result.current.sections[0].id).toBe('recents')
     expect(result.current.sections[0].items).toHaveLength(2)
   })
 
-  it('does not walk when disabled', () => {
+  it('does not search when disabled', async () => {
     const { result } = renderMentions({ disabled: true })
-    act(() => result.current.update('@auth', 5))
-    expect(mockReadDir).not.toHaveBeenCalled()
+    act(() => result.current.update('@rea', 4))
+    await advance(90)
+    expect(mockApi.searchFileNamesStreamStart).not.toHaveBeenCalled()
+    expect(result.current.loading).toBe(false)
   })
 
-  it('select splices the @token, stages the file-ref, and closes the menu', () => {
+  it('cancels the previous stream and id-gates stale batches on rapid typing', async () => {
+    const { result } = renderMentions()
+    // r -> re -> rea
+    act(() => result.current.update('@r', 2))
+    await advance(180)
+    const firstSid = 'search-1'
+    expect(mockApi.searchFileNamesStreamStart).toHaveBeenLastCalledWith(
+      firstSid,
+      '/work',
+      '/work',
+      'r',
+      false
+    )
+
+    act(() => result.current.update('@re', 3))
+    // New keystroke cancels the in-flight stream before scheduling the next.
+    expect(mockApi.searchFileNamesStreamCancel).toHaveBeenCalledWith(firstSid)
+    await advance(180)
+    const secondSid = 'search-2'
+    expect(mockApi.searchFileNamesStreamStart).toHaveBeenLastCalledWith(
+      secondSid,
+      '/work',
+      '/work',
+      're',
+      false
+    )
+
+    act(() => result.current.update('@rea', 4))
+    expect(mockApi.searchFileNamesStreamCancel).toHaveBeenCalledWith(secondSid)
+    await advance(90)
+    const thirdSid = 'search-3'
+    expect(mockApi.searchFileNamesStreamStart).toHaveBeenLastCalledWith(
+      thirdSid,
+      '/work',
+      '/work',
+      'rea',
+      false
+    )
+
+    // Stale batch from the cancelled second search must be ignored.
+    emitBatch({
+      searchId: secondSid,
+      files: [{ path: 'stale.ts', ignored: false }]
+    })
+    expect(result.current.sections).toHaveLength(0)
+
+    // Current batch is accepted.
+    emitBatch({
+      searchId: thirdSid,
+      files: [{ path: 'src/real.ts', ignored: false }]
+    })
+    expect(result.current.sections).toHaveLength(1)
+    expect(result.current.sections[0].items[0].label).toBe('real.ts')
+
+    emitDone({ searchId: thirdSid, truncated: false, totalFiles: 1 })
+    expect(result.current.loading).toBe(false)
+  })
+
+  it('ignores stale done events from a cancelled search', async () => {
+    const { result } = renderMentions()
+    act(() => result.current.update('@re', 3))
+    await advance(180)
+    // Cancel by typing a new query.
+    act(() => result.current.update('@rea', 4))
+    await advance(90)
+    // A late done for the cancelled search must not drop loading of the active one.
+    emitDone({ searchId: 'search-1', truncated: false, totalFiles: 0 })
+    expect(result.current.loading).toBe(true)
+    emitBatch({
+      searchId: 'search-2',
+      files: [{ path: 'real.ts', ignored: false }]
+    })
+    expect(result.current.sections).toHaveLength(1)
+    emitDone({ searchId: 'search-2', truncated: false, totalFiles: 1 })
+    expect(result.current.loading).toBe(false)
+  })
+
+  it('skips search entirely on web (!isTauriContext) and shows Recents', async () => {
+    mockIsTauri.mockReturnValue(false)
+    const { result } = renderMentions({
+      recents: [match('src/recent.ts')]
+    })
+    // No subscription attempted on web.
+    expect(mockApi.onSearchFileNamesBatch).not.toHaveBeenCalled()
+    expect(mockApi.onSearchFileNamesDone).not.toHaveBeenCalled()
+    act(() => result.current.update('@rea', 4))
+    await advance(90)
+    expect(mockApi.searchFileNamesStreamStart).not.toHaveBeenCalled()
+    expect(result.current.loading).toBe(false)
+    // Bare @ still shows recents on web.
+    act(() => result.current.update('@', 1))
+    expect(result.current.sections).toHaveLength(1)
+    expect(result.current.sections[0].id).toBe('recents')
+  })
+
+  it('drops loading synchronously and logs when the stream start fails', async () => {
+    mockApi.searchFileNamesStreamStart.mockResolvedValue({
+      success: false as const,
+      code: 'SEARCH_FILENAMES_STREAM_ERROR',
+      error: 'boom'
+    })
+    const { result } = renderMentions()
+    act(() => result.current.update('@rea', 4))
+    await advance(90)
+    expect(mockLog).toHaveBeenCalledTimes(1)
+    expect(result.current.loading).toBe(false)
+    expect(result.current.sections).toHaveLength(0)
+    expect(mockLog).toHaveBeenCalledWith(
+      expect.objectContaining({
+        source: 'useComposerMentions',
+        message: expect.stringContaining('SEARCH_FILENAMES_STREAM_ERROR')
+      })
+    )
+  })
+
+  it('drops loading and logs when done carries an error code (e.g. RG_SPAWN_FAILED)', async () => {
+    const { result } = renderMentions()
+    act(() => result.current.update('@rea', 4))
+    await advance(90)
+    emitBatch({
+      searchId: 'search-1',
+      files: [{ path: 'src/auth.ts', ignored: false }]
+    })
+    expect(result.current.sections).toHaveLength(1)
+    emitDone({
+      searchId: 'search-1',
+      truncated: false,
+      totalFiles: 1,
+      code: 'RG_SPAWN_FAILED',
+      error: 'rg missing'
+    })
+    expect(result.current.loading).toBe(false)
+    expect(result.current.sections).toHaveLength(0)
+    expect(mockLog).toHaveBeenCalledWith(
+      expect.objectContaining({
+        source: 'useComposerMentions',
+        message: expect.stringContaining('RG_SPAWN_FAILED')
+      })
+    )
+  })
+
+  it('select splices the @token, stages the file-ref, and closes the menu', async () => {
     const { result, onStageFileRef } = renderMentions()
-    act(() => result.current.update('@auth', 5))
+    act(() => result.current.update('@rea', 4))
+    await advance(90)
+    emitBatch({
+      searchId: 'search-1',
+      files: [{ path: 'src/auth.ts', ignored: false }]
+    })
     const picked = match('src/auth.ts')
     let outcome: { value: string; caret: number } | null = null
     act(() => {
-      outcome = result.current.select('@auth', 5, picked)
+      outcome = result.current.select('@rea', 4, picked)
     })
     expect(outcome).toEqual({ value: '', caret: 0 })
     expect(onStageFileRef).toHaveBeenCalledWith(picked)
     expect(result.current.menuOpen).toBe(false)
   })
 
-  it('reuses the cache on a second menu open (no re-walk)', async () => {
-    const { result } = renderMentions()
-    act(() => result.current.update('@auth', 5))
-    await waitFor(() => expect(result.current.sections).toHaveLength(1))
-    const callsAfterFirst = mockReadDir.mock.calls.length
-    expect(callsAfterFirst).toBeGreaterThan(0)
-
-    act(() => result.current.reset())
-    act(() => result.current.update('@chat', 5))
-    await waitFor(() => expect(result.current.sections).toHaveLength(1))
-    expect(mockReadDir.mock.calls.length).toBe(callsAfterFirst)
-    const items = result.current.sections[0].items
-    expect(items.some((i) => i.label === 'ChatInputBar.tsx')).toBe(true)
-  })
-
-  it('re-walks after a file-change invalidation', async () => {
-    const { result } = renderMentions()
-    act(() => result.current.update('@auth', 5))
-    await waitFor(() => expect(result.current.sections).toHaveLength(1))
-    const callsAfterFirst = mockReadDir.mock.calls.length
-
-    act(() => mockChangeCb.current?.({ path: '/work/new.ts' }))
-    act(() => result.current.update('@auth', 5))
-    await waitFor(() => expect(mockReadDir.mock.calls.length).toBeGreaterThan(callsAfterFirst))
-  })
-
-  it('ignores file-change events outside the project root', async () => {
-    const { result } = renderMentions()
-    act(() => result.current.update('@auth', 5))
-    await waitFor(() => expect(result.current.sections).toHaveLength(1))
-    const callsAfterFirst = mockReadDir.mock.calls.length
-
-    act(() => mockChangeCb.current?.({ path: '/other/x.ts' }))
-    act(() => result.current.update('@auth', 5))
-    // Event was outside /work, so the cache stays warm and no re-walk happens.
-    expect(mockReadDir.mock.calls.length).toBe(callsAfterFirst)
-  })
-
-  it('re-walks when a change lands during an in-flight walk', async () => {
-    let resolveFirst: () => void = () => {}
-    mockReadDir.mockReset()
-    mockReadDir.mockImplementationOnce(
-      () =>
-        new Promise<Array<{ name: string; isDirectory: boolean }>>((resolve) => {
-          resolveFirst = () => resolve(TREE['/work'] ?? [])
-        })
-    )
-    mockReadDir.mockImplementation(async (dir: string) => TREE[dir] ?? [])
-
-    const { result } = renderMentions()
-    act(() => result.current.update('@auth', 5))
-    // Walk is in flight (readDir for /work pending). Fire a change under /work
-    // before it resolves — the result is stale and must be discarded.
-    act(() => mockChangeCb.current?.({ path: '/work/new.ts' }))
-    act(() => resolveFirst())
-    await waitFor(() => expect(result.current.sections).toHaveLength(1))
-    const workCalls = mockReadDir.mock.calls.filter((c) => c[0] === '/work').length
-    expect(workCalls).toBeGreaterThanOrEqual(2)
+  it('cancels an in-flight stream on unmount', async () => {
+    const { result, unmount } = renderMentions()
+    act(() => result.current.update('@rea', 4))
+    await advance(90)
+    expect(result.current.loading).toBe(true)
+    unmount()
+    expect(mockApi.searchFileNamesStreamCancel).toHaveBeenCalledWith('search-1')
   })
 })

--- a/src/renderer/components/chat/use-composer-mentions.ts
+++ b/src/renderer/components/chat/use-composer-mentions.ts
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useRef, useState } from 'react'
 import { filesystemApi } from '@/lib/api'
 import { logFrontendError } from '@/lib/log-api'
 import { isTauriContext } from '@/lib/tauri-runtime'
+import { randomUUID } from '@/lib/uuid'
 import { basename } from './chat-attachments'
 import type { FileMentionMenuHandle } from './FileMentionMenu'
 import {
@@ -77,6 +78,12 @@ export function useComposerMentions(opts: UseComposerMentionsOptions): ComposerM
 
   const reqIdRef = useRef(0)
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  // Per-hook-instance prefix so search ids never collide with another
+  // `useComposerMentions` instance or the file-explorer store's `search-N`
+  // namespace — broadcast batch/done events only reach this listener.
+  // Lazy-init so `randomUUID()` runs once per instance, not every render.
+  const instanceIdRef = useRef<string>('')
+  if (instanceIdRef.current === '') instanceIdRef.current = randomUUID()
   // The search id (`search-${reqId}`) whose batch/done events are currently
   // accepted. Stale events from a cancelled stream mismatch and are ignored.
   const activeSearchIdRef = useRef<string | null>(null)
@@ -160,7 +167,7 @@ export function useComposerMentions(opts: UseComposerMentionsOptions): ComposerM
     }
 
     const id = ++reqIdRef.current
-    const sid = `search-${id}`
+    const sid = `search-${instanceIdRef.current}-${id}`
     accumRef.current = []
     timerRef.current = setTimeout(
       () => {

--- a/src/renderer/components/chat/use-composer-mentions.ts
+++ b/src/renderer/components/chat/use-composer-mentions.ts
@@ -1,8 +1,9 @@
-import type { FileChangeEvent } from '@shared/types/ipc.types'
+import type { SearchFileHit } from '@shared/types/ipc.types'
 import type { RefObject } from 'react'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { filesystemApi } from '@/lib/api'
-import { readDir } from '@/lib/tauri-fs'
+import { logFrontendError } from '@/lib/log-api'
+import { isTauriContext } from '@/lib/tauri-runtime'
 import { basename } from './chat-attachments'
 import type { FileMentionMenuHandle } from './FileMentionMenu'
 import {
@@ -14,81 +15,24 @@ import {
 } from './mention-menu-model'
 
 const MAX_RESULTS = 100
-/** Max projects kept in the module-level file cache (LRU-bounded). */
-const CACHE_MAX = 8
 
 /**
- * Directory basenames (and a few cruft files) skipped during the project file
- * walk. Mirrors the backend `COMMONLY_IGNORED_NAMES` so the mention picker
- * only surfaces source files — matching the file-explorer search — instead of
- * `node_modules` / `.git` / build artifacts. See ADR 0003.
+ * Debounce window in ms before firing a filename-search stream. Matches the
+ * file-explorer recipe: shorter queries (1-2 chars) get the longer window so
+ * rapid typing does not spawn a stream per keystroke; >=3 chars feel instant.
  */
-const SKIP_NAMES = new Set([
-  'node_modules',
-  '.git',
-  '.next',
-  '.cache',
-  '.turbo',
-  'dist',
-  'build',
-  '.output',
-  '.nuxt',
-  '.svelte-kit',
-  '__pycache__',
-  '.pytest_cache',
-  'venv',
-  'coverage',
-  '.nyc_output',
-  '.env',
-  'Thumbs.db',
-  'desktop.ini',
-  '.DS_Store'
-])
+const DEBOUNCE_SHORT = 90
+const DEBOUNCE_LONG = 180
+/** Queries of at least this many chars use the short debounce window. */
+const SHORT_QUERY_MIN = 3
 
-/**
- * Module-level cache: `rootPath` -> forward-slash-relative file paths. Walked
- * lazily once per project on the first @-mention, then filtered in-memory per
- * keystroke. Invalidated on file-change events (piggybacking whatever watcher
- * the file-explorer has active) so newly added files appear on the next open.
- */
-const fileCache = new Map<string, string[]>()
-
-/** @internal Reset the project-file cache between tests. */
-export function __resetMentionFileCache(): void {
-  fileCache.clear()
-}
-
-/** Recursively walk `rootPath` via `readDir`, returning forward-slash-relative paths. */
-async function collectProjectFiles(rootPath: string): Promise<string[]> {
-  const root = rootPath.replace(/\\/g, '/').replace(/\/$/, '')
-  const files: string[] = []
-  const queue: string[] = [root]
-  while (queue.length > 0) {
-    const dir = queue.shift()
-    if (!dir) continue
-    let entries: Awaited<ReturnType<typeof readDir>>
-    try {
-      entries = await readDir(dir)
-    } catch {
-      continue
-    }
-    for (const entry of entries) {
-      if (SKIP_NAMES.has(entry.name)) continue
-      const full = `${dir}/${entry.name}`.replace(/\/+/g, '/')
-      if (entry.isDirectory) queue.push(full)
-      else files.push(full.slice(root.length + 1))
-    }
-  }
-  return files
-}
-
-/** Build a {@link MentionMatch} from a relative path + the search root. */
-function toMentionMatch(relPath: string, rootPath: string): MentionMatch {
+/** Build a {@link MentionMatch} from a ripgrep `SearchFileHit` + search root. */
+function toMentionMatch(hit: SearchFileHit, root: string): MentionMatch {
   return {
-    relPath,
-    absPath: `${rootPath}/${relPath}`,
-    name: basename(relPath),
-    ignored: false
+    relPath: hit.path,
+    absPath: `${root}/${hit.path}`,
+    name: basename(hit.path),
+    ignored: hit.ignored
   }
 }
 
@@ -106,7 +50,7 @@ export interface ComposerMentions {
   /** The active @token query (empty for a bare `@`). */
   filter: string
   sections: MentionSection[]
-  /** True while the project file list is being walked (first open / re-walk). */
+  /** True while a filename-search stream is in flight for the current query. */
   loading: boolean
   menuRef: RefObject<FileMentionMenuHandle>
   /** Call on textarea input + selection change. */
@@ -127,104 +71,130 @@ export function useComposerMentions(opts: UseComposerMentionsOptions): ComposerM
   const [filter, setFilter] = useState('')
   const [matches, setMatches] = useState<MentionMatch[]>([])
   const [loading, setLoading] = useState(false)
-  const [cacheReady, setCacheReady] = useState(false)
   const menuRef = useRef<FileMentionMenuHandle>(null)
   const onStageRef = useRef(onStageFileRef)
   onStageRef.current = onStageFileRef
-  // True when a file-change landed during an in-flight walk — the walk must
-  // discard its stale result and re-walk before caching.
-  const dirtyRef = useRef(false)
 
-  // Invalidate the cache when files under `rootPath` change so the next menu
-  // open re-walks. Events fire globally for every watched dir, so filter by
-  // path prefix to avoid dropping the cache on unrelated projects' changes.
+  const reqIdRef = useRef(0)
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  // The search id (`search-${reqId}`) whose batch/done events are currently
+  // accepted. Stale events from a cancelled stream mismatch and are ignored.
+  const activeSearchIdRef = useRef<string | null>(null)
+  // Accumulator for the in-flight search's batches, capped at MAX_RESULTS.
+  const accumRef = useRef<MentionMatch[]>([])
+  const rootPathRef = useRef(rootPath)
+  rootPathRef.current = rootPath
+
+  // Subscribe to the filename-stream events once per mount (desktop only).
+  // Web (`!isTauriContext()`) never starts a stream and these return no-ops.
   useEffect(() => {
-    if (!rootPath) return
-    const root = rootPath.replace(/\\/g, '/')
-    const invalidate = (event: FileChangeEvent) => {
-      if (!event.path.replace(/\\/g, '/').startsWith(root)) return
-      if (fileCache.delete(rootPath)) {
-        setCacheReady((r) => (r ? false : r))
-      } else {
-        // Cache not populated yet — flag the in-flight walk as stale so it
-        // re-walks before caching its (now-out-of-date) result.
-        dirtyRef.current = true
+    if (!isTauriContext()) return
+    const unsubBatch = filesystemApi.onSearchFileNamesBatch((event) => {
+      if (event.searchId !== activeSearchIdRef.current) return
+      const root = rootPathRef.current?.replace(/\\/g, '/').replace(/\/$/, '') ?? ''
+      const next = accumRef.current
+        .concat(event.files.map((f) => toMentionMatch(f, root)))
+        .slice(0, MAX_RESULTS)
+      accumRef.current = next
+      setMatches(next)
+    })
+    const unsubDone = filesystemApi.onSearchFileNamesDone((event) => {
+      if (event.searchId !== activeSearchIdRef.current) return
+      activeSearchIdRef.current = null
+      setLoading(false)
+      if (event.code || event.error) {
+        logFrontendError({
+          level: 'warn',
+          message:
+            `composer mention search done with error: code=${event.code ?? 'n/a'}` +
+            ` error=${event.error ?? 'n/a'}`,
+          source: 'useComposerMentions'
+        })
+        setMatches([])
       }
-    }
-    const u1 = filesystemApi.onFileChanged(invalidate)
-    const u2 = filesystemApi.onFileCreated(invalidate)
-    const u3 = filesystemApi.onFileDeleted(invalidate)
+    })
     return () => {
-      u1()
-      u2()
-      u3()
-    }
-  }, [rootPath])
-
-  // Walk the project tree lazily when the menu opens and the cache is empty.
-  // Re-walks after an invalidation (cacheReady flips back to false) while the
-  // menu is still open. Does NOT depend on `filter`, so typing does not cancel
-  // an in-flight walk. The module cache is LRU-bounded (CACHE_MAX) so opening
-  // many distinct projects does not grow memory unbounded.
-  useEffect(() => {
-    if (!menuOpen || !rootPath || disabled) return
-    if (fileCache.has(rootPath)) {
-      // Refresh LRU recency on hit (Map.set on an existing key keeps order).
-      const cached = fileCache.get(rootPath)
-      if (cached) {
-        fileCache.delete(rootPath)
-        fileCache.set(rootPath, cached)
+      unsubBatch()
+      unsubDone()
+      if (timerRef.current) {
+        clearTimeout(timerRef.current)
+        timerRef.current = null
       }
-      if (!cacheReady) setCacheReady(true)
-      return
-    }
-    let cancelled = false
-    setLoading(true)
-    const finish = (files: string[]) => {
-      if (cancelled) return
-      if (dirtyRef.current) {
-        // A change landed while this walk was in flight — discard the stale
-        // result and re-walk before caching.
-        dirtyRef.current = false
-        void collectProjectFiles(rootPath).then(finish)
-        return
-      }
-      fileCache.set(rootPath, files)
-      if (fileCache.size > CACHE_MAX) {
-        const oldest = fileCache.keys().next().value
-        if (oldest !== undefined && oldest !== rootPath) fileCache.delete(oldest)
+      const sid = activeSearchIdRef.current
+      if (sid) {
+        activeSearchIdRef.current = null
+        filesystemApi.searchFileNamesStreamCancel(sid).catch(() => {})
       }
       setLoading(false)
-      setCacheReady(true)
     }
-    void collectProjectFiles(rootPath).then(finish)
-    return () => {
-      cancelled = true
-    }
-  }, [menuOpen, rootPath, disabled, cacheReady])
+  }, [])
 
-  // Filter the cached file list in-memory per keystroke. The basename-contains
-  // match mirrors the old `rg --iglob **/*query*` behavior without the round-trip.
+  // Debounced per-keystroke stream: cancel any in-flight stream, bump the
+  // request id, and schedule a new start. Batches whose searchId != active
+  // are dropped by the listeners above. Mirrors `file-explorer-store.ts`.
   useEffect(() => {
-    if (!menuOpen || disabled || !rootPath || !cacheReady) {
+    if (timerRef.current) {
+      clearTimeout(timerRef.current)
+      timerRef.current = null
+    }
+    // Cancel any in-flight stream before considering a new one.
+    const prevSid = activeSearchIdRef.current
+    if (prevSid) {
+      activeSearchIdRef.current = null
+      filesystemApi.searchFileNamesStreamCancel(prevSid).catch(() => {})
+    }
+
+    if (!menuOpen || disabled || !rootPath || !isTauriContext()) {
+      accumRef.current = []
       setMatches([])
+      setLoading(false)
       return
     }
     const f = filter.trim()
     if (f === '') {
+      // Bare `@`: no search, Recents render.
+      accumRef.current = []
       setMatches([])
+      setLoading(false)
       return
     }
-    const root = rootPath.replace(/\\/g, '/').replace(/\/$/, '')
-    const cached = fileCache.get(rootPath) ?? []
-    const lower = f.toLowerCase()
-    setMatches(
-      cached
-        .filter((p) => basename(p).toLowerCase().includes(lower))
-        .slice(0, MAX_RESULTS)
-        .map((p) => toMentionMatch(p, root))
+
+    const id = ++reqIdRef.current
+    const sid = `search-${id}`
+    accumRef.current = []
+    timerRef.current = setTimeout(
+      () => {
+        timerRef.current = null
+        activeSearchIdRef.current = sid
+        const root = rootPathRef.current?.replace(/\\/g, '/').replace(/\/$/, '') ?? ''
+        setLoading(true)
+        void filesystemApi.searchFileNamesStreamStart(sid, root, root, f, false).then((res) => {
+          if (res.success) return
+          // Failed start: no stream will emit done — drop loading now and
+          // surface the failure so it is never silently swallowed.
+          if (activeSearchIdRef.current === sid) {
+            activeSearchIdRef.current = null
+            setLoading(false)
+            setMatches([])
+          }
+          logFrontendError({
+            level: 'warn',
+            message:
+              `composer mention search start failed: code=${res.code ?? 'n/a'}` +
+              ` error=${res.error ?? 'n/a'}`,
+            source: 'useComposerMentions'
+          })
+        })
+      },
+      f.length >= SHORT_QUERY_MIN ? DEBOUNCE_SHORT : DEBOUNCE_LONG
     )
-  }, [menuOpen, filter, rootPath, disabled, cacheReady])
+    return () => {
+      if (timerRef.current) {
+        clearTimeout(timerRef.current)
+        timerRef.current = null
+      }
+    }
+  }, [menuOpen, filter, rootPath, disabled])
 
   const update = useCallback((value: string, caret: number) => {
     const token = activeMentionToken(value, caret)

--- a/src/renderer/components/chat/use-composer-mentions.ts
+++ b/src/renderer/components/chat/use-composer-mentions.ts
@@ -27,6 +27,37 @@ const DEBOUNCE_LONG = 180
 /** Queries of at least this many chars use the short debounce window. */
 const SHORT_QUERY_MIN = 3
 
+/** Normalize a search root to forward slashes without a trailing separator. */
+function normalizeRoot(root: string | null | undefined): string {
+  return root?.replace(/\\/g, '/').replace(/\/$/, '') ?? ''
+}
+
+/**
+ * Cancel an in-flight filename search stream and surface failures. The facade
+ * resolves `{ success: false }` on cancel failure (and may reject on a
+ * transport fault); both are logged so the boundary is never silently swallowed
+ * (AGENTS.md logging rule).
+ */
+function cancelSearchStream(sid: string): void {
+  void filesystemApi
+    .searchFileNamesStreamCancel(sid)
+    .then((res) => {
+      if (res.success) return
+      logFrontendError({
+        level: 'warn',
+        message: `composer mention search cancel failed: code=${res.code ?? 'n/a'} error=${res.error ?? 'n/a'}`,
+        source: 'useComposerMentions'
+      })
+    })
+    .catch((err) => {
+      logFrontendError({
+        level: 'warn',
+        message: `composer mention search cancel rejected: ${err instanceof Error ? err.message : String(err)}`,
+        source: 'useComposerMentions'
+      })
+    })
+}
+
 /** Build a {@link MentionMatch} from a ripgrep `SearchFileHit` + search root. */
 function toMentionMatch(hit: SearchFileHit, root: string): MentionMatch {
   return {
@@ -89,8 +120,13 @@ export function useComposerMentions(opts: UseComposerMentionsOptions): ComposerM
   const activeSearchIdRef = useRef<string | null>(null)
   // Accumulator for the in-flight search's batches, capped at MAX_RESULTS.
   const accumRef = useRef<MentionMatch[]>([])
+  // The mount-scoped batch listener can't close over `rootPath` (its effect has
+  // no deps), so it reads the current root through this ref. Updated in an
+  // effect, not during render, so the write can't leak from an uncommitted render.
   const rootPathRef = useRef(rootPath)
-  rootPathRef.current = rootPath
+  useEffect(() => {
+    rootPathRef.current = rootPath
+  }, [rootPath])
 
   // Subscribe to the filename-stream events once per mount (desktop only).
   // Web (`!isTauriContext()`) never starts a stream and these return no-ops.
@@ -98,7 +134,7 @@ export function useComposerMentions(opts: UseComposerMentionsOptions): ComposerM
     if (!isTauriContext()) return
     const unsubBatch = filesystemApi.onSearchFileNamesBatch((event) => {
       if (event.searchId !== activeSearchIdRef.current) return
-      const root = rootPathRef.current?.replace(/\\/g, '/').replace(/\/$/, '') ?? ''
+      const root = normalizeRoot(rootPathRef.current)
       const next = accumRef.current
         .concat(event.files.map((f) => toMentionMatch(f, root)))
         .slice(0, MAX_RESULTS)
@@ -130,7 +166,7 @@ export function useComposerMentions(opts: UseComposerMentionsOptions): ComposerM
       const sid = activeSearchIdRef.current
       if (sid) {
         activeSearchIdRef.current = null
-        filesystemApi.searchFileNamesStreamCancel(sid).catch(() => {})
+        cancelSearchStream(sid)
       }
       setLoading(false)
     }
@@ -148,7 +184,7 @@ export function useComposerMentions(opts: UseComposerMentionsOptions): ComposerM
     const prevSid = activeSearchIdRef.current
     if (prevSid) {
       activeSearchIdRef.current = null
-      filesystemApi.searchFileNamesStreamCancel(prevSid).catch(() => {})
+      cancelSearchStream(prevSid)
     }
 
     if (!menuOpen || disabled || !rootPath || !isTauriContext()) {
@@ -169,29 +205,48 @@ export function useComposerMentions(opts: UseComposerMentionsOptions): ComposerM
     const id = ++reqIdRef.current
     const sid = `search-${instanceIdRef.current}-${id}`
     accumRef.current = []
+    // Drop stale matches from the previous query so they don't flash during
+    // the debounce window before the first batch lands.
+    setMatches([])
     timerRef.current = setTimeout(
       () => {
         timerRef.current = null
         activeSearchIdRef.current = sid
-        const root = rootPathRef.current?.replace(/\\/g, '/').replace(/\/$/, '') ?? ''
+        const root = normalizeRoot(rootPath)
         setLoading(true)
-        void filesystemApi.searchFileNamesStreamStart(sid, root, root, f, false).then((res) => {
-          if (res.success) return
-          // Failed start: no stream will emit done — drop loading now and
-          // surface the failure so it is never silently swallowed.
-          if (activeSearchIdRef.current === sid) {
-            activeSearchIdRef.current = null
-            setLoading(false)
-            setMatches([])
-          }
-          logFrontendError({
-            level: 'warn',
-            message:
-              `composer mention search start failed: code=${res.code ?? 'n/a'}` +
-              ` error=${res.error ?? 'n/a'}`,
-            source: 'useComposerMentions'
+        void filesystemApi
+          .searchFileNamesStreamStart(sid, root, root, f, false)
+          .then((res) => {
+            if (res.success) return
+            // Failed start: no stream will emit done — drop loading now and
+            // surface the failure so it is never silently swallowed.
+            if (activeSearchIdRef.current === sid) {
+              activeSearchIdRef.current = null
+              setLoading(false)
+              setMatches([])
+            }
+            logFrontendError({
+              level: 'warn',
+              message:
+                `composer mention search start failed: code=${res.code ?? 'n/a'}` +
+                ` error=${res.error ?? 'n/a'}`,
+              source: 'useComposerMentions'
+            })
           })
-        })
+          .catch((err) => {
+            // Defense-in-depth: the facade resolves even on invoke failure, but
+            // a transport fault rejecting the promise must not pin `loading`.
+            if (activeSearchIdRef.current === sid) {
+              activeSearchIdRef.current = null
+              setLoading(false)
+              setMatches([])
+            }
+            logFrontendError({
+              level: 'warn',
+              message: `composer mention search start rejected: ${err instanceof Error ? err.message : String(err)}`,
+              source: 'useComposerMentions'
+            })
+          })
       },
       f.length >= SHORT_QUERY_MIN ? DEBOUNCE_SHORT : DEBOUNCE_LONG
     )


### PR DESCRIPTION
## Summary

The chat composer's `@`-file mention picker walked the project tree via `readDir` (one IPC round-trip per directory) into a renderer module cache. On first open of a non-cached project the recursive walk is slow, so the menu sat on "Searching files…" with no results — appearing broken. This rewrites `use-composer-mentions.ts` to drive the existing ripgrep `search_file_names_stream` sidecar (the same one the file-explorer already uses successfully), so `@`-mention results stream within ~100ms per keystroke.

## Related Issue

No related issue. Searched open and closed PRs — no duplicate for the `@`-mention ripgrep rewrite.

## Type of Change

- [x] fix: bug fix
- [x] perf: performance improvement

## What Changed

- `src/renderer/components/chat/use-composer-mentions.ts` — REWRITE. Dropped the module file cache, `readDir` walk, `SKIP_NAMES`, and `onFileChanged/Created/Deleted` subscriptions. Added a debounced (90ms >=3 chars / 180ms <3) `search_file_names_stream` driver via `filesystemApi.searchFileNamesStreamStart/Cancel` + `onSearchFileNamesBatch/Done` (subscribe-once-per-mount, id-gated on `search-${reqId}`, cancel-on-new-request, cancel-on-unmount). Maps `SearchFileHit`->`MentionMatch` (`absPath=root/relPath`, `name=basename`, `ignored` passthrough). Web (`!isTauriContext()`) skips search entirely (Recents show). Failed start drops `loading` synchronously + logs; `done` with `code`/`error` drops loading, clears matches, + logs. `MAX_RESULTS=100` and the public `ComposerMentions`/`UseComposerMentionsOptions` API are unchanged.
- `src/renderer/components/chat/use-composer-mentions.test.tsx` — rewrote tests (12) covering the streaming contract: debounce, `SearchFileHit`->`MentionMatch` mapping incl. `ignored`, MAX_RESULTS cap, bare-`@` no-search + Recents, disabled, rapid-typing cancel + stale-batch/stale-done id-gating, web no-search, failed-start, done-error `RG_SPAWN_FAILED`, select splice, unmount cancel.
- `src/renderer/components/chat/ChatInputBar.test.tsx` — updated mocks: removed the dead `readDir` mock; added `isTauriContext` + streaming-API stubs; rewrote the `@`-file test to drive the stream (emit batch/done) instead of the removed walk.
- `src/renderer/components/agents/AgentLauncher.test.tsx` — added the four streaming stubs to the `filesystemApi` mock so the rewritten hook mounts in the worktree-isolation tests.

No Rust changes, no new Tauri command, no web route — the sidecar and its web no-op behavior already exist and power the file-explorer.

## How It Was Tested

- [x] `bun run ci` equivalent — `bun x biome check` on changed files clean (worktree path is Biome-excluded by `!**/.termul`; changed files checked explicitly)
- [x] `bun run typecheck` — `typecheck:web` exit 0; `typecheck:test` exit 0
- [x] `bun run test` — hook tests 12/12; consumer tests 80/80 (ChatInputBar 35 + AgentLauncher 45)
- [x] `cargo clippy --all-targets -- -D warnings` (in src-tauri) — N/A, no Rust edits
- [x] `cargo test` (in src-tauri) — N/A, no Rust edits
- [ ] Manual verification completed — manual desktop check (`@rea` streams within ~100ms) recommended before merge

## CI & Review Gate

- [ ] All CI checks pass (PR Validation, Rust Checks, Build Verification, Security Scans)
- [ ] Code review comments from CodeRabbit / Claude have been addressed or resolved
- [ ] No unresolved review findings remain

## Checklist

- [x] My PR title follows the conventional commit format used by this repo
- [x] I linked the related issue or explained why none exists
- [x] I updated docs when needed
- [x] I added or updated tests when needed
- [x] I verified the change does not introduce unrelated modifications
- [x] I read AGENTS.md and followed the contributor guidelines
- [x] A human reviewed the complete diff before submission


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved file mention search with faster, streamed results.
  * Search results now update more reliably as queries change, while outdated results are prevented from appearing.
  * Ongoing searches are automatically stopped when no longer needed, reducing unnecessary activity.
* **Bug Fixes**
  * Improved loading-state accuracy and handling of search completion or failure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->