### PR TITLE
fix(renderer): switch native-menu hook to bubble phase so global menu opens

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -137,10 +137,11 @@ function AppEffects(): null {
   useAcpSessionResume()
   useAcpMcp()
   usePreventFileDropNavigation()
-  // P4: suppress the native browser context menu app-wide (capture phase) for
-  // web parity — portaled overlays (toasts, modals) outside
+  // Suppress the native browser context menu app-wide (BUBBLE phase) for web
+  // parity — portaled overlays (toasts, modals) outside
   // <GlobalContextMenu>'s Radix trigger subtree would show the browser's
-  // native Inspect menu. The Radix trigger still opens the global menu.
+  // native Inspect menu. Bubble — not capture — so the Radix trigger
+  // (composeEventHandlers, defaultPrevented check) still opens the global menu.
   usePreventNativeContextMenu()
 
   // Initialize notification permissions once at app startup so the OS (or

--- a/src/renderer/TauriApp.tsx
+++ b/src/renderer/TauriApp.tsx
@@ -78,11 +78,12 @@ function AppEffects(): null {
   useAcpSessionResume()
   useAcpMcp()
   usePreventFileDropNavigation()
-  // P4: suppress the native webview context menu app-wide (capture phase) so
+  // Suppress the native webview context menu app-wide (BUBBLE phase) so
   // portaled overlays (toasts, modals) outside <GlobalContextMenu>'s Radix
-  // trigger subtree don't show the native Inspect/Back menu. The Radix
-  // trigger still opens the global menu (preventDefault doesn't stop
-  // propagation). Defense-in-depth alongside <GlobalContextMenu>.
+  // trigger subtree don't show the native Inspect/Back menu. Bubble — not
+  // capture — so Radix's trigger (composeEventHandlers, defaultPrevented
+  // check) still opens the global menu. Defense-in-depth alongside
+  // <GlobalContextMenu>.
   usePreventNativeContextMenu()
   // Desktop-only: block devtools/view-source shortcuts (F12, Ctrl+Shift+I/J/C,
   // Ctrl+U) in production. Web/remote (App.tsx) must never mount this hook.

--- a/src/renderer/hooks/use-prevent-native-context-menu.test.tsx
+++ b/src/renderer/hooks/use-prevent-native-context-menu.test.tsx
@@ -1,0 +1,52 @@
+import { act, render } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import { ContextMenu, ContextMenuTrigger } from '@/components/ui/context-menu'
+import { usePreventNativeContextMenu } from '@/hooks/use-prevent-native-context-menu'
+
+/**
+ * Regression: the native-context-menu suppression hook must register its
+ * `contextmenu` listener in BUBBLE phase, not capture. Radix's
+ * `ContextMenuTrigger` opens via `composeEventHandlers` (from
+ * `@radix-ui/primitive`), which skips `handleOpen` when
+ * `event.defaultPrevented` is already true (`checkForDefaultPrevented`
+ * defaults to true). A capture-phase `preventDefault()` sets that flag
+ * before Radix's trigger handler runs, suppressing the global menu entirely
+ * (right-click shows nothing). The co-located `GlobalContextMenu.test.tsx`
+ * mocks the Radix primitive entirely, so it cannot catch this — this test
+ * drives the REAL primitive to lock the ordering invariant.
+ */
+describe('usePreventNativeContextMenu', () => {
+  it('does not block Radix ContextMenuTrigger from opening (bubble, not capture)', () => {
+    const onOpenChange = vi.fn()
+
+    function Harness() {
+      usePreventNativeContextMenu()
+      return (
+        <ContextMenu onOpenChange={onOpenChange}>
+          <ContextMenuTrigger asChild>
+            <button type="button">surface</button>
+          </ContextMenuTrigger>
+        </ContextMenu>
+      )
+    }
+
+    const { getByRole } = render(<Harness />)
+    const button = getByRole('button', { name: 'surface' })
+
+    const event = new MouseEvent('contextmenu', { bubbles: true, cancelable: true })
+    let dispatched = true
+    act(() => {
+      dispatched = button.dispatchEvent(event)
+    })
+
+    // Radix's trigger must still open the menu despite the suppression hook.
+    // (Radix's useControllableState fires onOpenChange in a deferred effect,
+    // so the dispatch must be wrapped in act() to flush it first.)
+    expect(onOpenChange).toHaveBeenCalledWith(true)
+    // The native menu is still suppressed (Radix's own preventDefault fires
+    // after handleOpen; the hook's preventDefault is redundant here).
+    expect(event.defaultPrevented).toBe(true)
+    // dispatchEvent returns false when the event was cancelled (preventDefault).
+    expect(dispatched).toBe(false)
+  })
+})

--- a/src/renderer/hooks/use-prevent-native-context-menu.ts
+++ b/src/renderer/hooks/use-prevent-native-context-menu.ts
@@ -1,17 +1,25 @@
 /**
- * Suppress the native browser/webview context menu app-wide (capture phase).
+ * Suppress the native browser/webview context menu app-wide (bubble phase).
  *
- * `preventDefault()` on the capture-phase `contextmenu` event prevents the
- * native menu (Inspect, Back, etc.) from showing on portaled overlays (toasts,
- * modals) that live outside the Radix `<GlobalContextMenu>` trigger subtree.
- * It does NOT stop propagation, so the Radix trigger still opens the global
- * menu for right-clicks inside its subtree, and custom menus
- * (FileExplorer/ProjectSidebar) still render their own UI.
+ * IMPORTANT: this listener MUST run in BUBBLE phase, not capture. Radix's
+ * `ContextMenuTrigger` opens via `composeEventHandlers` (from
+ * `@radix-ui/primitive`), which skips its `handleOpen` when
+ * `event.defaultPrevented` is already true (`checkForDefaultPrevented`
+ * defaults to true). A capture-phase `preventDefault()` here would fire
+ * before Radix's bubble-phase trigger handler, set `defaultPrevented` early,
+ * and suppress the global menu entirely — right-click would show nothing (no
+ * native menu, no Radix menu). In bubble phase, Radix's root-level listener
+ * fires first (opens the menu + its own `preventDefault`); this listener then
+ * runs redundantly inside the trigger subtree, and is the active suppression
+ * for portaled overlays outside it.
  *
- * P4 defense-in-depth alongside `<GlobalContextMenu>` — the Radix trigger's
- * own `preventDefault` only covers its subtree; this hook covers the rest of
- * the document (portals, blank areas). Mounted on BOTH surfaces (TauriApp +
- * App) for parity.
+ * P4 defense-in-depth alongside `<GlobalContextMenu>` — portals (toasts,
+ * modals) rendered outside the Radix trigger subtree still bubble to
+ * `document`, so their native menu is suppressed here. `preventDefault` does
+ * NOT stop propagation, so innermost Radix triggers (the terminal's own
+ * menu) still win via `defaultPrevented`, and custom menus
+ * (FileExplorer/ProjectSidebar) still render. Mounted on BOTH surfaces
+ * (TauriApp + App) for parity.
  */
 
 import { useEffect } from 'react'
@@ -24,7 +32,7 @@ export function usePreventNativeContextMenu(): void {
       e.preventDefault()
     }
 
-    document.addEventListener('contextmenu', handler, { capture: true })
-    return () => document.removeEventListener('contextmenu', handler, { capture: true })
+    document.addEventListener('contextmenu', handler)
+    return () => document.removeEventListener('contextmenu', handler)
   }, [])
 }


### PR DESCRIPTION
## Summary

The global right-click context menu shipped in #623 never appeared at runtime — right-clicking anywhere showed **nothing** on both desktop and web. This fixes it with a one-line listener-phase change plus a regression test for the exact path that let it ship undetected.

## Related Issue

Refs #623 (the merged global right-click context-menu PR whose runtime behavior this fixes). No related issue — the feature is merged but broken at runtime, so this is a follow-up fix rather than a tracked issue.

## Type of Change

- [x] fix: bug fix

## What Changed

- **Root cause:** `usePreventNativeContextMenu` registered its `contextmenu` `preventDefault()` in **capture** phase on `document`, firing *before* Radix's bubble-phase `ContextMenuTrigger` handler. Radix opens via `composeEventHandlers` (`@radix-ui/primitive`), which skips `handleOpen` when `event.defaultPrevented` is already true (`checkForDefaultPrevented` defaults to `true`). Result: the global menu was suppressed along with the native menu → right-click showed nothing.
- **Fix:** switch the listener to **bubble** phase. Radix's root-level listener now runs first (opens the menu + its own `preventDefault`); the hook then runs — redundant inside the trigger subtree, still the active suppression for portaled overlays (toasts, modals) outside it. Portal defense-in-depth (P4) is preserved.
- Updated the now-stale "capture phase" comments in `TauriApp.tsx` / `App.tsx`.
- **Regression test:** added `use-prevent-native-context-menu.test.tsx` driving the **real** Radix primitive (`ContextMenu` + `ContextMenuTrigger asChild` + the hook). The shipped `GlobalContextMenu.test.tsx` mocked the entire Radix primitive, so the real `composeEventHandlers` path was never exercised — the bug shipped undetected. The new test asserts a `contextmenu` event both opens the menu (`onOpenChange(true)`) and ends up `defaultPrevented`; verified it **fails** with the capture-phase version and **passes** with the fix.

## How It Was Tested

- [x] `bun run ci` (Biome strict) — 825 files, clean
- [x] `bun run typecheck` (node + web + test) — green
- [ ] `bun run test` — targeted suites green (`GlobalContextMenu`, `use-prevent-native-context-menu`, `parity-checklist` — 98 tests incl. the new regression). A full local run has 4 test files fail to *load* under transform thrashing (`material-icon-theme` `?raw` dynamic-chunk denial; **0 test failures**); does not reproduce in isolation and is unrelated to this change (no icon imports added). CI is the source of truth.
- N/A: `cargo clippy` / `cargo test` — no Rust changes
- N/A: manual verification — the regression test encodes the runtime behavior (fails on the bug, passes on the fix)

## CI & Review Gate

- [ ] All CI checks pass (PR Validation, Rust Checks, Build Verification, Security Scans)
- [ ] Code review comments from CodeRabbit / Claude have been addressed or resolved
- [ ] No unresolved review findings remain

## Checklist

- [x] PR title follows the conventional commit format used by this repo
- [x] I linked the related change (#623 follow-up) or explained why none exists
- [x] I updated docs when needed (code comments document the phase invariant; no user-facing behavior change beyond fixing the menu)
- [x] I added or updated tests when needed (regression test using the real Radix primitive)
- [x] I verified the change does not introduce unrelated modifications (4 files: hook + new test + 2 comment-only roots)
- [x] I read AGENTS.md and followed the contributor guidelines
- [ ] A human reviewed the complete diff before submission


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved custom context-menu behavior throughout the app.
  * Preserved context-menu interactions in supported controls while continuing to suppress the browser’s native menu where appropriate.
  * Ensured the behavior works consistently with overlays and portaled content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->