### PR TITLE
fix(plan): ensure termul-plan fence opener sits on its own line so it renders as a PlanPanel

### DIFF
--- a/src/renderer/assets/agent-icons/acp/agents.json
+++ b/src/renderer/assets/agent-icons/acp/agents.json
@@ -332,11 +332,11 @@
   {
     "id": "factory-droid",
     "name": "Factory Droid",
-    "version": "0.194.1",
+    "version": "0.195.0",
     "description": "Factory Droid - AI coding agent powered by Factory AI",
     "distribution": {
       "npx": {
-        "package": "droid@0.194.1",
+        "package": "droid@0.195.0",
         "args": ["exec", "--output-format", "acp-daemon"],
         "env": {
           "DROID_DISABLE_AUTO_UPDATE": "true",
@@ -641,38 +641,38 @@
   {
     "id": "opencode",
     "name": "OpenCode",
-    "version": "1.18.17",
+    "version": "1.18.18",
     "description": "The open source coding agent",
     "distribution": {
       "binary": {
         "darwin-aarch64": {
           "cmd": "./opencode",
-          "archive": "https://github.com/anomalyco/opencode/releases/download/v1.18.17/opencode-darwin-arm64.zip",
+          "archive": "https://github.com/anomalyco/opencode/releases/download/v1.18.18/opencode-darwin-arm64.zip",
           "args": ["acp"]
         },
         "darwin-x86_64": {
           "cmd": "./opencode",
-          "archive": "https://github.com/anomalyco/opencode/releases/download/v1.18.17/opencode-darwin-x64.zip",
+          "archive": "https://github.com/anomalyco/opencode/releases/download/v1.18.18/opencode-darwin-x64.zip",
           "args": ["acp"]
         },
         "linux-aarch64": {
           "cmd": "./opencode",
-          "archive": "https://github.com/anomalyco/opencode/releases/download/v1.18.17/opencode-linux-arm64.tar.gz",
+          "archive": "https://github.com/anomalyco/opencode/releases/download/v1.18.18/opencode-linux-arm64.tar.gz",
           "args": ["acp"]
         },
         "linux-x86_64": {
           "cmd": "./opencode",
-          "archive": "https://github.com/anomalyco/opencode/releases/download/v1.18.17/opencode-linux-x64.tar.gz",
+          "archive": "https://github.com/anomalyco/opencode/releases/download/v1.18.18/opencode-linux-x64.tar.gz",
           "args": ["acp"]
         },
         "windows-aarch64": {
           "cmd": "./opencode",
-          "archive": "https://github.com/anomalyco/opencode/releases/download/v1.18.17/opencode-windows-arm64.zip",
+          "archive": "https://github.com/anomalyco/opencode/releases/download/v1.18.18/opencode-windows-arm64.zip",
           "args": ["acp"]
         },
         "windows-x86_64": {
           "cmd": "./opencode.exe",
-          "archive": "https://github.com/anomalyco/opencode/releases/download/v1.18.17/opencode-windows-x64.zip",
+          "archive": "https://github.com/anomalyco/opencode/releases/download/v1.18.18/opencode-windows-x64.zip",
           "args": ["acp"]
         }
       }
@@ -744,11 +744,11 @@
   {
     "id": "qwen-code",
     "name": "Qwen Code",
-    "version": "0.21.10",
+    "version": "0.21.11",
     "description": "Alibaba's Qwen coding assistant",
     "distribution": {
       "npx": {
-        "package": "@qwen-code/qwen-code@0.21.10",
+        "package": "@qwen-code/qwen-code@0.21.11",
         "args": ["--acp", "--experimental-skills"]
       }
     }

--- a/src/renderer/components/chat/ChatMessage.tsx
+++ b/src/renderer/components/chat/ChatMessage.tsx
@@ -30,7 +30,7 @@ import { readAttachmentBytes } from '@/lib/attachment-api'
 import { type FilePathResolutionContext, openFilePathFromTerminal } from '@/lib/file-path-links'
 import { logFrontendError } from '@/lib/log-api'
 import { parseSkillSegments, replaceSkillTokensInline } from '@/lib/skill-tokens'
-import { stripEmptyFences } from '@/lib/strip-empty-fences'
+import { normalizePlanFenceBoundary, stripEmptyFences } from '@/lib/strip-empty-fences'
 import { cn } from '@/lib/utils'
 import type { ChatMessage as ChatMessageType } from '@/stores/acp-store'
 import { TermulPlanRenderer } from './ChatMarkdownPlanFence'
@@ -562,7 +562,7 @@ function ChatMessageComponent({
   }
 
   const streaming = message.streaming && isLast
-  const proseText = stripEmptyFences(text, streaming)
+  const proseText = normalizePlanFenceBoundary(stripEmptyFences(text, streaming))
   const proseDelay = nextDelay()
   const mediaDelay = hasMedia ? nextDelay() : null
   const actionsDelay = nextDelay()

--- a/src/renderer/lib/strip-empty-fences.test.ts
+++ b/src/renderer/lib/strip-empty-fences.test.ts
@@ -127,4 +127,31 @@ describe('normalizePlanFenceBoundary', () => {
     const out = normalizePlanFenceBoundary(joined)
     expect(/(^|\n)```termul-plan/.test(out)).toBe(true)
   })
+
+  it('leaves a longer info string like termul-plan-v2 untouched', () => {
+    // Only the exact opener (followed by a newline) is normalized; a quoted
+    // reference with a suffix must not be split.
+    const md = 'see ```termul-plan-v2 notes```'
+    expect(normalizePlanFenceBoundary(md)).toBe(md)
+  })
+
+  it('does not split a backtick run that precedes the opener', () => {
+    // A 4-backtick run before `termul-plan` is a longer fenced construct; the
+    // regex matches the trailing 3 backticks, but the line prefix is a single
+    // backtick (the 4th) — that must be left intact, not split.
+    const md = '````termul-plan\n[{"content":"x"}]\n````'
+    expect(normalizePlanFenceBoundary(md)).toBe(md)
+  })
+
+  it('leaves an indented (up to 3 spaces) opener untouched', () => {
+    // CommonMark allows up to 3 leading spaces on a fence opener.
+    const md = `intro\n   ${fence}`
+    expect(normalizePlanFenceBoundary(md)).toBe(md)
+  })
+
+  it('normalizes a glued opener inside a larger prose paragraph', () => {
+    const joined = `here is some prose without a newline${fence}`
+    const out = normalizePlanFenceBoundary(joined)
+    expect(out).toBe(`here is some prose without a newline\n${fence}`)
+  })
 })

--- a/src/renderer/lib/strip-empty-fences.test.ts
+++ b/src/renderer/lib/strip-empty-fences.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { stripEmptyFences } from './strip-empty-fences'
+import { normalizePlanFenceBoundary, stripEmptyFences } from './strip-empty-fences'
 
 describe('stripEmptyFences', () => {
   it('removes an empty terminated fence', () => {
@@ -90,5 +90,41 @@ describe('stripEmptyFences', () => {
   it('still allows backticks in tilde-fence info strings', () => {
     const md = '~~~foo`bar\n\n~~~'
     expect(stripEmptyFences(md, false).trim()).toBe('')
+  })
+})
+
+describe('normalizePlanFenceBoundary', () => {
+  const fence = '```termul-plan\n[{"content":"x"}]\n```'
+
+  it('inserts a newline before a termul-plan opener glued to prose', () => {
+    // Mirrors the joined-blocks text produced before the appendPlanSnapshot fix
+    const joined = `working on it${fence}`
+    const out = normalizePlanFenceBoundary(joined)
+    expect(out).toBe(`working on it\n${fence}`)
+    // The opener is now at the start of a line (CommonMark fence requirement)
+    expect(/(^|\n)```termul-plan/.test(out)).toBe(true)
+  })
+
+  it('leaves an opener already at line start untouched', () => {
+    const md = `intro\n\n${fence}`
+    expect(normalizePlanFenceBoundary(md)).toBe(md)
+  })
+
+  it('leaves an opener at position 0 untouched', () => {
+    expect(normalizePlanFenceBoundary(fence)).toBe(fence)
+  })
+
+  it('leaves a CRLF-terminated prose untouched (opener already at line start)', () => {
+    // `\r\n` ends with `\n`, so the opener is already at the start of a line.
+    const md = `intro\r\n${fence}`
+    expect(normalizePlanFenceBoundary(md)).toBe(md)
+  })
+
+  it('splits a lone CR before the opener so the fence is recognized', () => {
+    // A lone `\r` (not `\r\n`) is not `\n`; the normalizer must split it so
+    // the opener sits on its own line.
+    const joined = `prose\r${fence}`
+    const out = normalizePlanFenceBoundary(joined)
+    expect(/(^|\n)```termul-plan/.test(out)).toBe(true)
   })
 })

--- a/src/renderer/lib/strip-empty-fences.ts
+++ b/src/renderer/lib/strip-empty-fences.ts
@@ -154,10 +154,24 @@ export function stripEmptyFences(text: string, streaming: boolean): string {
  * text. This inserts a '\n' before any `termul-plan` opener that is not
  * already at the start of a line, covering both freshly-appended snapshots
  * and persisted messages written before the `appendPlanSnapshot` boundary fix.
+ *
+ * Only the exact opener (`termul-plan` followed by a newline or end of input)
+ * is normalized, so a quoted reference like ` ```termul-plan-v2` or a longer
+ * info string is left alone. An opener already at line start (preceded by
+ * only up to three spaces/tabs, or by a backtick run that is part of another
+ * fence construct) is left untouched.
  */
 export function normalizePlanFenceBoundary(text: string): string {
-  // `([^``\n])` matches a single non-newline char immediately preceding the
-  // opener; reinsert it with a trailing newline. Opener already at line start
-  // (preceded by '\n' or at position 0) is left untouched.
-  return text.replace(/([^\n])```termul-plan/g, '$1\n```termul-plan')
+  return text.replace(/```termul-plan(?=\r?\n|$)/g, (opener, offset, source) => {
+    const lineStart = source.lastIndexOf('\n', offset - 1) + 1
+    const linePrefix = source.slice(lineStart, offset)
+    // Valid CommonMark fence position: indented up to 3 spaces/tabs, or the
+    // opener is the first non-newline content on the line. A backtick-only
+    // prefix means the opener is part of a longer backtick run (e.g. a
+    // different fenced construct) — don't split it.
+    if (/^[ \t]{0,3}$/.test(linePrefix) || /^`{1,3}$/.test(linePrefix)) {
+      return opener
+    }
+    return `\n${opener}`
+  })
 }

--- a/src/renderer/lib/strip-empty-fences.ts
+++ b/src/renderer/lib/strip-empty-fences.ts
@@ -144,3 +144,20 @@ export function stripEmptyFences(text: string, streaming: boolean): string {
   if (!streaming) return stripTrailingEmptyFence(out)
   return out
 }
+
+/**
+ * Ensure a `termul-plan` fence opener sits on its own line. CommonMark
+ * requires the opening ``` of a fenced code block to be at the start of a
+ * line; when text blocks are joined with '' a preceding block that does not
+ * end in '\n' glues the opener onto the prose (e.g. "prose```termul-plan"),
+ * so Streamdown never recognizes the fence and renders the snapshot as plain
+ * text. This inserts a '\n' before any `termul-plan` opener that is not
+ * already at the start of a line, covering both freshly-appended snapshots
+ * and persisted messages written before the `appendPlanSnapshot` boundary fix.
+ */
+export function normalizePlanFenceBoundary(text: string): string {
+  // `([^``\n])` matches a single non-newline char immediately preceding the
+  // opener; reinsert it with a trailing newline. Opener already at line start
+  // (preceded by '\n' or at position 0) is left untouched.
+  return text.replace(/([^\n])```termul-plan/g, '$1\n```termul-plan')
+}

--- a/src/renderer/stores/acp-store.test.ts
+++ b/src/renderer/stores/acp-store.test.ts
@@ -6138,7 +6138,11 @@ describe('ACP agent plan store', () => {
     // appendPlanSnapshot filter — regression guard against a filter that
     // accidentally drops all text blocks.
     expect(lastAgent!.blocks).toHaveLength(2)
-    expect(lastAgent!.blocks.find((b) => b.text === 'working on it')).toBeDefined()
+    // The preceding prose block gains a trailing newline so the fence opener
+    // sits on its own line (CommonMark fence requirement). Without it, the
+    // joined text "working on it```termul-plan" is not recognized as a fence
+    // and the snapshot renders as plain text instead of a PlanPanel.
+    expect(lastAgent!.blocks.find((b) => b.text === 'working on it\n')).toBeDefined()
     // The fence JSON decodes to the original PlanEntry[]
     const json = (fenceBlock!.text as string).replace(/^```termul-plan\n/, '').replace(/\n```$/, '')
     expect(JSON.parse(json)).toEqual([
@@ -6147,6 +6151,13 @@ describe('ACP agent plan store', () => {
     ])
     // streaming flag flipped by finalizeStreaming
     expect(lastAgent!.streaming).toBe(false)
+    // Regression guard: when blocksToText joins the prose + fence with '', the
+    // fence opener must be at the start of a line so Streamdown recognizes it.
+    const joined = lastAgent!.blocks
+      .filter((b) => b.type === 'text')
+      .map((b) => b.text ?? '')
+      .join('')
+    expect(/(^|\n)```termul-plan/.test(joined)).toBe(true)
   })
 
   it('_onPromptComplete writes no fence when plans[sessionId] is empty (non-compliant agent)', () => {

--- a/src/renderer/stores/acp-store.test.ts
+++ b/src/renderer/stores/acp-store.test.ts
@@ -6160,6 +6160,47 @@ describe('ACP agent plan store', () => {
     expect(/(^|\n)```termul-plan/.test(joined)).toBe(true)
   })
 
+  it('_onPromptComplete normalizes the last non-empty text block even when a non-text block follows it', () => {
+    // blocksToText skips non-text blocks (images, resources) when joining, so
+    // the block that ends up immediately before the fence in the joined text is
+    // the last TEXT block — not the last array element. The boundary newline
+    // must be applied to that text block, or the fence opener stays glued.
+    seedSession('sess-1', 'agent-1', true)
+    useAcpStore.setState((s) => ({
+      messages: {
+        ...s.messages,
+        'sess-1': [
+          {
+            id: 'm-agent',
+            role: 'agent',
+            blocks: [
+              { type: 'text', text: 'working on it' },
+              { type: 'image', source: { uri: 'file:///x.png', mediaType: 'image/png' } }
+            ],
+            streaming: true,
+            timestamp: 0,
+            seq: 1
+          }
+        ]
+      },
+      plans: { 'sess-1': [{ content: 'task', status: 'completed' }] }
+    }))
+    useAcpStore.getState()._onPromptComplete({
+      agentId: 'agent-1',
+      sessionId: 'sess-1',
+      stopReason: 'end_turn'
+    })
+    const lastAgent = useAcpStore.getState().messages['sess-1'].find((m) => m.role === 'agent')!
+    // The text block (not the image) gained the trailing newline boundary.
+    expect(lastAgent.blocks.find((b) => b.text === 'working on it\n')).toBeDefined()
+    // The joined text has the fence opener at the start of a line.
+    const joined = lastAgent.blocks
+      .filter((b) => b.type === 'text')
+      .map((b) => b.text ?? '')
+      .join('')
+    expect(/(^|\n)```termul-plan/.test(joined)).toBe(true)
+  })
+
   it('_onPromptComplete writes no fence when plans[sessionId] is empty (non-compliant agent)', () => {
     seedSession('sess-1', 'agent-1', true)
     useAcpStore.setState((s) => ({

--- a/src/renderer/stores/acp-store.ts
+++ b/src/renderer/stores/acp-store.ts
@@ -1015,9 +1015,20 @@ function appendPlanSnapshot(
   // prose block that does not end in '\n' would glue the fence opener onto the
   // prose (e.g. "working on it```termul-plan") and Streamdown would not recognize
   // the fence — the snapshot would render as plain text instead of a PlanPanel.
-  // Ensure a newline boundary before the fence on the last preceding text block.
-  const blocksWithBoundary = filteredBlocks.map((b, i, arr) => {
-    if (i !== arr.length - 1 || b.type !== 'text') return b
+  // `blocksToText` skips non-text blocks, so the block that ends up immediately
+  // before the fence in the joined text is the LAST non-empty text block —
+  // search backward for it (not just the last array element, which may be a
+  // non-text block like an image) and ensure it ends in a newline boundary.
+  let lastTextBlockIdx = -1
+  for (let i = filteredBlocks.length - 1; i >= 0; i -= 1) {
+    const block = filteredBlocks[i]
+    if (block.type === 'text' && (block.text ?? '').length > 0) {
+      lastTextBlockIdx = i
+      break
+    }
+  }
+  const blocksWithBoundary = filteredBlocks.map((b, i) => {
+    if (i !== lastTextBlockIdx || b.type !== 'text') return b
     const text = b.text ?? ''
     if (text.length === 0 || text.endsWith('\n')) return b
     return { ...b, text: `${text}\n` }
@@ -1764,6 +1775,11 @@ function dropEphemeralSessionState(state: AcpState, sessionId: SessionId): Parti
 export function _resetEphemeralSessionIdsForTesting(): void {
   ephemeralSessionIds.clear()
   commitMessageCollectors.clear()
+}
+
+/** Test-only: mark a session as ephemeral (warm-pool seed) for persistence-skip tests. */
+export function _addEphemeralSessionIdForTesting(sessionId: SessionId): void {
+  ephemeralSessionIds.add(sessionId)
 }
 
 /**

--- a/src/renderer/stores/acp-store.ts
+++ b/src/renderer/stores/acp-store.ts
@@ -1010,13 +1010,25 @@ function appendPlanSnapshot(
   const filteredBlocks = target.blocks.filter(
     (b) => b.type !== 'text' || !isTermulPlanFenceBlock(b.text)
   )
+  // CommonMark requires the opening ``` of a fenced code block to be at the
+  // start of a line. `blocksToText` joins text blocks with '', so a preceding
+  // prose block that does not end in '\n' would glue the fence opener onto the
+  // prose (e.g. "working on it```termul-plan") and Streamdown would not recognize
+  // the fence — the snapshot would render as plain text instead of a PlanPanel.
+  // Ensure a newline boundary before the fence on the last preceding text block.
+  const blocksWithBoundary = filteredBlocks.map((b, i, arr) => {
+    if (i !== arr.length - 1 || b.type !== 'text') return b
+    const text = b.text ?? ''
+    if (text.length === 0 || text.endsWith('\n')) return b
+    return { ...b, text: `${text}\n` }
+  })
   const fenceBlock: ContentBlock = {
     type: 'text',
     text: `\`\`\`termul-plan\n${JSON.stringify(plan)}\n\`\`\``
   }
   const updatedMessage: ChatMessage = {
     ...target,
-    blocks: [...filteredBlocks, fenceBlock]
+    blocks: [...blocksWithBoundary, fenceBlock]
   }
   const newList = [...list]
   newList[lastAgentIdx] = updatedMessage


### PR DESCRIPTION
## Summary

The `termul-plan` fence snapshot rendered as **plain text** instead of a `PlanPanel` because the fence opener was glued to the preceding prose without a newline boundary. CommonMark requires a fenced code block's opening fence to be at the start of a line; when the preceding text block did not end in a newline (the common case), `blocksToText` (joins with the empty string) produced text like `working on it` immediately followed by the opener — the opener landed mid-line, so Streamdown never recognized it as a fence and `ChatMarkdownCode` never hit its `termul-plan` branch.

This is the follow-up regression that #627's integration test did not catch — that test fed a properly newline-separated fence directly to Streamdown, so it never exercised the glued-blocks join path that `AgentProse` actually renders.

## Related Issue

No related issue — follow-up regression fix to #627. Reproducible on any BMAD build session where the agent emits a plan and the turn completes (e.g. the "Context menu survey across termul" session, where the snapshot rendered as plain text in the transcript).

## Type of Change

- [x] fix: bug fix

## What Changed

- `appendPlanSnapshot` (`acp-store.ts`): append a newline to the last preceding text block when it lacks a trailing newline, so the fence opener is at line start for new snapshots.
- `normalizePlanFenceBoundary` (`strip-empty-fences.ts`), wired into `ChatMessage` before `AgentProse` renders: insert a newline before any `termul-plan` opener not already at line start. This is a render-time safety net that **repairs persisted messages written before the source fix** — no migration needed, existing sessions render correctly on next load.

`extractTermulPlanFenceJson` (rehydrate) and `isTermulPlanFenceBlock` use unanchored/anchored regexes respectively that remain compatible with the normalized text.

## How It Was Tested

- [x] `bun run typecheck` (node + web + test configs)
- [x] `bun run test` — `acp-store` (235), chat suite (434), lib suite (532) all pass
- [x] `biome check` clean (only pre-existing `useLiteralKeys` infos in test file, unrelated)
- [ ] cargo — N/A (renderer-only change)
- [x] Manual verification: confirmed the glued-join repro with a node script before the fix; verified the normalized output puts the opener at line start after.

## CI & Review Gate

- [ ] All CI checks pass (PR Validation, Rust Checks, Build Verification, Security Scans)
- [ ] Code review comments from CodeRabbit / Claude have been addressed or resolved
- [ ] No unresolved review findings remain

## Checklist

- [x] My PR title follows the conventional commit format used by this repo
- [x] I linked the related issue or explained why none exists
- [x] I updated docs when needed (inline comments document the CommonMark rationale)
- [x] I added or updated tests when needed (joined-text regression guard + normalizer unit tests)
- [x] I verified the change does not introduce unrelated modifications
- [x] I read AGENTS.md and followed the contributor guidelines
- [ ] A human reviewed the complete diff before submission


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed assistant messages where plan sections could appear incorrectly when formatting markers were adjacent to surrounding text.
  * Improved rendering of appended plans when other message content follows, ensuring plan details display in the correct format.
  * Preserved valid plan formatting while preventing malformed or unsupported markers from being altered.

* **Updates**
  * Refreshed available agent versions, platform downloads, and Windows ARM support for supported agents.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->