### PR TITLE
feat: persist composer selections across chat sessions

### DIFF
--- a/src/renderer/assets/agent-icons/acp/agents.json
+++ b/src/renderer/assets/agent-icons/acp/agents.json
@@ -81,11 +81,11 @@
   {
     "id": "cline",
     "name": "Cline",
-    "version": "3.0.53",
+    "version": "3.0.54",
     "description": "Autonomous coding agent CLI - capable of creating/editing files, running commands, using the browser, and more",
     "distribution": {
       "npx": {
-        "package": "cline@3.0.53",
+        "package": "cline@3.0.54",
         "args": ["--acp"]
       }
     }
@@ -332,11 +332,11 @@
   {
     "id": "factory-droid",
     "name": "Factory Droid",
-    "version": "0.194.1",
+    "version": "0.195.0",
     "description": "Factory Droid - AI coding agent powered by Factory AI",
     "distribution": {
       "npx": {
-        "package": "droid@0.194.1",
+        "package": "droid@0.195.0",
         "args": ["exec", "--output-format", "acp-daemon"],
         "env": {
           "DROID_DISABLE_AUTO_UPDATE": "true",
@@ -438,33 +438,33 @@
   {
     "id": "harn",
     "name": "Harn",
-    "version": "0.10.87",
+    "version": "0.10.88",
     "description": "Harn runs .harn agent pipelines as a native ACP coding agent over stdio.",
     "distribution": {
       "binary": {
         "darwin-aarch64": {
           "cmd": "./harn",
-          "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.87/harn-aarch64-apple-darwin.tar.gz",
+          "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.88/harn-aarch64-apple-darwin.tar.gz",
           "args": ["serve", "acp"]
         },
         "darwin-x86_64": {
           "cmd": "./harn",
-          "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.87/harn-x86_64-apple-darwin.tar.gz",
+          "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.88/harn-x86_64-apple-darwin.tar.gz",
           "args": ["serve", "acp"]
         },
         "linux-aarch64": {
           "cmd": "./harn",
-          "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.87/harn-aarch64-unknown-linux-gnu.tar.gz",
+          "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.88/harn-aarch64-unknown-linux-gnu.tar.gz",
           "args": ["serve", "acp"]
         },
         "linux-x86_64": {
           "cmd": "./harn",
-          "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.87/harn-x86_64-unknown-linux-gnu.tar.gz",
+          "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.88/harn-x86_64-unknown-linux-gnu.tar.gz",
           "args": ["serve", "acp"]
         },
         "windows-x86_64": {
           "cmd": "harn.exe",
-          "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.87/harn-x86_64-pc-windows-msvc.zip",
+          "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.88/harn-x86_64-pc-windows-msvc.zip",
           "args": ["serve", "acp"]
         }
       }
@@ -641,38 +641,38 @@
   {
     "id": "opencode",
     "name": "OpenCode",
-    "version": "1.18.17",
+    "version": "1.18.18",
     "description": "The open source coding agent",
     "distribution": {
       "binary": {
         "darwin-aarch64": {
           "cmd": "./opencode",
-          "archive": "https://github.com/anomalyco/opencode/releases/download/v1.18.17/opencode-darwin-arm64.zip",
+          "archive": "https://github.com/anomalyco/opencode/releases/download/v1.18.18/opencode-darwin-arm64.zip",
           "args": ["acp"]
         },
         "darwin-x86_64": {
           "cmd": "./opencode",
-          "archive": "https://github.com/anomalyco/opencode/releases/download/v1.18.17/opencode-darwin-x64.zip",
+          "archive": "https://github.com/anomalyco/opencode/releases/download/v1.18.18/opencode-darwin-x64.zip",
           "args": ["acp"]
         },
         "linux-aarch64": {
           "cmd": "./opencode",
-          "archive": "https://github.com/anomalyco/opencode/releases/download/v1.18.17/opencode-linux-arm64.tar.gz",
+          "archive": "https://github.com/anomalyco/opencode/releases/download/v1.18.18/opencode-linux-arm64.tar.gz",
           "args": ["acp"]
         },
         "linux-x86_64": {
           "cmd": "./opencode",
-          "archive": "https://github.com/anomalyco/opencode/releases/download/v1.18.17/opencode-linux-x64.tar.gz",
+          "archive": "https://github.com/anomalyco/opencode/releases/download/v1.18.18/opencode-linux-x64.tar.gz",
           "args": ["acp"]
         },
         "windows-aarch64": {
           "cmd": "./opencode",
-          "archive": "https://github.com/anomalyco/opencode/releases/download/v1.18.17/opencode-windows-arm64.zip",
+          "archive": "https://github.com/anomalyco/opencode/releases/download/v1.18.18/opencode-windows-arm64.zip",
           "args": ["acp"]
         },
         "windows-x86_64": {
           "cmd": "./opencode.exe",
-          "archive": "https://github.com/anomalyco/opencode/releases/download/v1.18.17/opencode-windows-x64.zip",
+          "archive": "https://github.com/anomalyco/opencode/releases/download/v1.18.18/opencode-windows-x64.zip",
           "args": ["acp"]
         }
       }
@@ -744,11 +744,11 @@
   {
     "id": "qwen-code",
     "name": "Qwen Code",
-    "version": "0.21.10",
+    "version": "0.21.11",
     "description": "Alibaba's Qwen coding assistant",
     "distribution": {
       "npx": {
-        "package": "@qwen-code/qwen-code@0.21.10",
+        "package": "@qwen-code/qwen-code@0.21.11",
         "args": ["--acp", "--experimental-skills"]
       }
     }

--- a/src/renderer/components/agents/AgentLauncher.test.tsx
+++ b/src/renderer/components/agents/AgentLauncher.test.tsx
@@ -75,6 +75,7 @@ const {
   mockHideAgentLauncher,
   mockPersistRead,
   mockPersistWrite,
+  mockPersistWriteDebounced,
   mockNavigate,
   mockRetargetWarmPool,
   mockSetSelectedAgentConfigId,
@@ -105,6 +106,7 @@ const {
   mockHideAgentLauncher: vi.fn(),
   mockPersistRead: vi.fn(),
   mockPersistWrite: vi.fn(),
+  mockPersistWriteDebounced: vi.fn(),
   mockNavigate: vi.fn(),
   mockRetargetWarmPool: vi.fn(),
   mockSetSelectedAgentConfigId: vi.fn(),
@@ -191,7 +193,11 @@ vi.mock('react-router-dom', async () => {
 })
 
 vi.mock('@/lib/api', () => ({
-  persistenceApi: { read: mockPersistRead, write: mockPersistWrite },
+  persistenceApi: {
+    read: mockPersistRead,
+    write: mockPersistWrite,
+    writeDebounced: mockPersistWriteDebounced
+  },
   filesystemApi: {
     onFileChanged: vi.fn(() => () => {}),
     onFileCreated: vi.fn(() => () => {}),
@@ -448,7 +454,8 @@ vi.mock('@/stores/acp-store', () => {
     useAcpSession,
     prepareChatKey,
     agentReuseKey,
-    hasModelRelevantOptionsCache
+    hasModelRelevantOptionsCache,
+    persistComposerOptions: vi.fn()
   }
 })
 
@@ -571,6 +578,7 @@ beforeEach(() => {
   mockSetMcpServerEnabled.mockResolvedValue(undefined)
   mockPersistRead.mockResolvedValue({ success: true, data: undefined })
   mockPersistWrite.mockResolvedValue({ success: true })
+  mockPersistWriteDebounced.mockResolvedValue({ success: true })
   mockStartChat.mockResolvedValue('session-1')
   mockClaimPreparedChat.mockReturnValue(null)
   mockCreateLaunchPlaceholder.mockReturnValue('launch-placeholder-1')

--- a/src/renderer/components/agents/AgentLauncher.tsx
+++ b/src/renderer/components/agents/AgentLauncher.tsx
@@ -1,4 +1,4 @@
-import type { LastSelectedAgent } from '@shared/types/persistence.types'
+import type { LastSelectedAgent, PersistedComposerOptions } from '@shared/types/persistence.types'
 import { PersistenceKeys } from '@shared/types/persistence.types'
 import type { Editor } from '@tiptap/core'
 import {
@@ -92,6 +92,7 @@ import {
   type AcpSession,
   agentReuseKey,
   hasModelRelevantOptionsCache,
+  persistComposerOptions,
   prepareChatKey,
   useAcpSession,
   useAcpStore
@@ -320,6 +321,23 @@ export function AgentLauncher({ paneId, className }: AgentLauncherProps): React.
     effectiveConfigOptions,
     cachedOptions?.updatedAt
   ])
+  // `persistSelection` is declared before the ACP setters below so the setters
+  // ACP setters below so the setters can close over them without a temporal-dead-zone
+  // reference (the setters are also passed into `useChatComposer` before its line).
+  const persistSelection = useCallback((configId: string) => {
+    cachedConfigId = configId
+    void persistenceApi.write<LastSelectedAgent>(PersistenceKeys.lastSelectedAgent, {
+      agentId: configId,
+      mode: 'acp'
+    })
+  }, [])
+
+  // Composer-selection persistence is delegated to the store's
+  // `persistComposerOptions` helper, which serializes per-key mutations so
+  // concurrent calls (e.g. model + mode in the same tick) can't overwrite
+  // each other. The launcher calls it without a sessionId (pre-launch, no
+  // session exists yet); the store setters call it with a sessionId (and
+  // the ephemeral-session guard skips warm-pool seeds).
   // The three ACP setters below are declared before `useChatComposer` so the
   // shared hook can pass them as `onSetConfig`/`onSetMode`/`onSetModel` without
   // a temporal-dead-zone reference (the hook captures them at call time).
@@ -330,6 +348,11 @@ export function AgentLauncher({ paneId, className }: AgentLauncherProps): React.
           ...prev,
           configValues: { ...prev.configValues, [configId]: valueId }
         }))
+        if (activeConfigId) {
+          persistComposerOptions(activeConfigId, {
+            configValues: { [configId]: valueId }
+          })
+        }
         return
       }
       try {
@@ -339,7 +362,7 @@ export function AgentLauncher({ paneId, className }: AgentLauncherProps): React.
         throw err
       }
     },
-    [preparedSessionId]
+    [preparedSessionId, activeConfigId]
   )
 
   const handleSetModel = useCallback(
@@ -347,6 +370,9 @@ export function AgentLauncher({ paneId, className }: AgentLauncherProps): React.
       if (!preparedSessionId) {
         if (modelSource === 'models') {
           setPendingOptions((prev) => ({ ...prev, modelId: valueId }))
+          if (activeConfigId) {
+            persistComposerOptions(activeConfigId, { modelId: valueId })
+          }
           return
         }
         if (!modelOption) {
@@ -357,6 +383,12 @@ export function AgentLauncher({ paneId, className }: AgentLauncherProps): React.
           modelId: valueId,
           configValues: { ...prev.configValues, [modelOption.id]: valueId }
         }))
+        if (activeConfigId) {
+          persistComposerOptions(activeConfigId, {
+            modelId: valueId,
+            configValues: { [modelOption.id]: valueId }
+          })
+        }
         return
       }
       if (modelSource === 'models') {
@@ -373,13 +405,16 @@ export function AgentLauncher({ paneId, className }: AgentLauncherProps): React.
       }
       await handleSetConfig(modelOption.id, valueId)
     },
-    [handleSetConfig, modelOption, modelSource, preparedSessionId]
+    [handleSetConfig, modelOption, modelSource, preparedSessionId, activeConfigId]
   )
 
   const handleSetMode = useCallback(
     async (modeId: string) => {
       if (!preparedSessionId) {
         setPendingOptions((prev) => ({ ...prev, modeId }))
+        if (activeConfigId) {
+          persistComposerOptions(activeConfigId, { modeId })
+        }
         return
       }
       try {
@@ -389,7 +424,7 @@ export function AgentLauncher({ paneId, className }: AgentLauncherProps): React.
         throw err
       }
     },
-    [preparedSessionId]
+    [preparedSessionId, activeConfigId]
   )
 
   const slashOpen = isSlashTriggerAny(prompt) && !composerDisabled
@@ -436,14 +471,98 @@ export function AgentLauncher({ paneId, className }: AgentLauncherProps): React.
     scheduleRestoreCaret
   })
 
-  const persistSelection = useCallback((configId: string) => {
-    cachedConfigId = configId
-    void persistenceApi.write<LastSelectedAgent>(PersistenceKeys.lastSelectedAgent, {
-      agentId: configId,
-      mode: 'acp'
-    })
-  }, [])
+  // Restore persisted composer selections for the current agent on mount and
+  // on agent change. Seeds `pendingOptions` (model/mode/config) +
+  // `isolationMode`/`baseBranch` (worktree) so the next chat starts with the
+  // user's last pick. Fallbacks: drop selections no longer advertised by the
+  // agent; fall back to 'current' when worktree is no longer available; fall
+  // back to defaultBase when baseBranch is no longer in the branch list.
+  // Runs on agent change; options may not be loaded yet on first run (cache
+  // miss + prepareChat in flight), so validation is best-effort — invalid
+  // selections are dropped silently if options are available, otherwise
+  // accepted as-is (the agent will ignore unknown values at launch).
+  // biome-ignore lint/correctness/useExhaustiveDependencies: re-run on agent change only; options/branches are read at run time, re-running on every options change would re-seed and fight user edits.
+  useEffect(() => {
+    if (!activeConfigId) return
+    let cancelled = false
+    void (async () => {
+      try {
+        const result = await persistenceApi.read<PersistedComposerOptions>(
+          PersistenceKeys.lastComposerOptions(activeConfigId)
+        )
+        if (cancelled) return
+        if (!result.success || !result.data) return
+        const saved = result.data
+        const configValues: Record<string, string> = {}
+        if (saved.configValues) {
+          for (const [cid, vid] of Object.entries(saved.configValues)) {
+            const opt = effectiveConfigOptions.find((o) => o.id === cid)
+            // Drop the value when the option is missing OR the value is no
+            // longer in the option's advertised values.
+            if (opt && opt.options.some((o) => o.value === vid)) {
+              configValues[cid] = vid
+            } else {
+              void logFrontendError({
+                level: 'warn',
+                source: 'agentLauncher.restoreComposerOptions',
+                message: `dropping persisted config — option ${cid} no longer advertised`
+              })
+            }
+          }
+        }
+        let modelId = saved.modelId
+        if (modelId) {
+          const modelOpt = resolveModelOption(
+            partitionConfigOptions(effectiveConfigOptions).model,
+            effectiveModels
+          ).option
+          if (modelOpt && !modelOpt.options.some((o) => o.value === modelId)) {
+            void logFrontendError({
+              level: 'warn',
+              source: 'agentLauncher.restoreComposerOptions',
+              message: 'dropping persisted model — no longer advertised'
+            })
+            modelId = undefined
+          }
+        }
+        let modeId = saved.modeId
+        if (modeId && effectiveModes) {
+          if (!effectiveModes.availableModes.some((m) => m.id === modeId)) {
+            void logFrontendError({
+              level: 'warn',
+              source: 'agentLauncher.restoreComposerOptions',
+              message: 'dropping persisted mode — no longer advertised'
+            })
+            modeId = undefined
+          }
+        }
+        if (modelId || modeId || Object.keys(configValues).length > 0) {
+          setPendingOptions({ modelId, modeId, configValues })
+        }
+        if (saved.isolationMode === 'worktree' && canUseWorktree && saved.baseBranch) {
+          setIsolationMode('worktree')
+          if (
+            branches.length > 0 &&
+            !branches.includes(saved.baseBranch) &&
+            baseBranchInfo?.defaultBase
+          ) {
+            setBaseBranch(baseBranchInfo.defaultBase)
+          } else {
+            setBaseBranch(saved.baseBranch)
+          }
+        }
+      } catch {
+        // Best-effort — silent failure, launcher shows agent defaults.
+      }
+    })()
+    return () => {
+      cancelled = true
+    }
+    // Re-run on agent change only. Options/branches are read at run time;
+    // re-running on every options change would re-seed and fight user edits.
+  }, [activeConfigId])
 
+  // Restore the last-selected agent on mount if no agent is selected yet.
   useEffect(() => {
     if (selectedConfigId || supportedAgents.length === 0) return
     let cancelled = false
@@ -522,6 +641,31 @@ export function AgentLauncher({ paneId, className }: AgentLauncherProps): React.
     setBaseBranch(baseBranchInfo.defaultBase)
   }, [isolationMode, baseBranch, baseBranchInfo])
 
+  // Persist worktree isolation mode + base branch changes for the current
+  // agent so the next chat starts with the same worktree preference. Only
+  // persists when worktree mode is available (`canUseWorktree`) — a non-git
+  // project falls back to 'current' and does not overwrite the persisted pick.
+  useEffect(() => {
+    if (!activeConfigId) return
+    if (!canUseWorktree) return
+    persistComposerOptions(activeConfigId, {
+      isolationMode,
+      baseBranch: isolationMode === 'worktree' ? baseBranch : null
+    })
+  }, [activeConfigId, isolationMode, baseBranch, canUseWorktree])
+
+  // Validate the restored `baseBranch` once the branch list loads. The restore
+  // effect (on `[activeConfigId]`) may set a persisted branch before
+  // `worktreeApi.branches` resolves. If the branch was deleted, fall back to
+  // the resolved default.
+  useEffect(() => {
+    if (isolationMode !== 'worktree' || !baseBranch || branches.length === 0) return
+    if (branches.includes(baseBranch)) return
+    if (baseBranchInfo?.defaultBase) {
+      setBaseBranch(baseBranchInfo.defaultBase)
+    }
+  }, [isolationMode, baseBranch, branches, baseBranchInfo])
+
   useEffect(() => {
     if (!activeConfigId || !projectRoot || selectedEntry?.status !== 'ready' || !selectedConfig)
       return
@@ -558,14 +702,25 @@ export function AgentLauncher({ paneId, className }: AgentLauncherProps): React.
 
   const handleSelectAgent = useCallback(
     (entry: SupportedAcpAgentEntry) => {
+      // No-op when re-selecting the same agent — avoids resetting
+      // worktree/pending state and overwriting the persisted record.
+      if (entry.configId === selectedConfigId) {
+        editorRef.current?.commands.focus(undefined, { scrollIntoView: false })
+        return
+      }
       setManualPath('')
       setManualInstallOverride(null)
       setPendingOptions(emptyPendingLauncherOptions())
+      // Reset worktree isolation + base branch; the restore effect on
+      // `[activeConfigId]` will re-seed them from the persisted record for
+      // the new agent (or leave them at 'current'/null if no record exists).
+      setIsolationMode('current')
+      setBaseBranch(null)
       setSelectedConfigId(entry.configId)
       persistSelection(entry.configId)
       editorRef.current?.commands.focus(undefined, { scrollIntoView: false })
     },
-    [persistSelection]
+    [persistSelection, selectedConfigId]
   )
 
   const handleInstallAgent = useCallback(
@@ -939,6 +1094,21 @@ export function AgentLauncher({ paneId, className }: AgentLauncherProps): React.
           await saveAgentConfig(configSnapshot)
         }
         persistSelection(configSnapshot.id)
+        // Persist the final composer selections snapshot (model/mode/config
+        // + worktree isolation + base branch) so the next chat starts with
+        // the user's last pick. The store setters already persisted
+        // running-chatbox changes; this catches the pre-launch pending
+        // options that never went through a store setter (no prepared session).
+        persistComposerOptions(configSnapshot.id, {
+          modelId: pendingSnapshot.modelId,
+          modeId: pendingSnapshot.modeId,
+          configValues:
+            Object.keys(pendingSnapshot.configValues).length > 0
+              ? pendingSnapshot.configValues
+              : undefined,
+          isolationMode,
+          baseBranch: isolationMode === 'worktree' ? baseBranch : null
+        })
 
         // Real send carries the WIRE text (path-framed skills, command-prefixed)
         // so the agent receives paths, not tokens.

--- a/src/renderer/stores/acp-store.test.ts
+++ b/src/renderer/stores/acp-store.test.ts
@@ -76,6 +76,21 @@ vi.mock('@/lib/web-tab-session', () => ({
   getTabFocusedSessionId: vi.fn(() => null)
 }))
 
+// Mock persistenceApi so composer-selection persistence calls are observable
+// in tests without hitting the Tauri plugin-store transport. Preserve other
+// `@/lib/api` exports via importActual so transitive imports still resolve.
+const { mockPersistenceApi } = vi.hoisted(() => ({
+  mockPersistenceApi: {
+    read: vi.fn(),
+    write: vi.fn(),
+    writeDebounced: vi.fn()
+  }
+}))
+vi.mock('@/lib/api', async (importActual) => {
+  const actual = await importActual<typeof import('@/lib/api')>()
+  return { ...actual, persistenceApi: mockPersistenceApi }
+})
+
 import { invoke } from '@tauri-apps/api/core'
 import type { PlanEntry } from '@/lib/acp-api'
 import {
@@ -92,6 +107,7 @@ import {
 } from '@/lib/acp-transport'
 import { logFrontendError } from '@/lib/log-api'
 import {
+  _addEphemeralSessionIdForTesting,
   _flushCoalescedForTesting,
   _isCoalescePendingForTesting,
   _resetAcpAuthForTesting,
@@ -262,6 +278,11 @@ describe('acp-store', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     ;(invoke as ReturnType<typeof vi.fn>).mockReset()
+    mockPersistenceApi.read.mockReset()
+    mockPersistenceApi.write.mockReset()
+    mockPersistenceApi.writeDebounced.mockReset()
+    mockPersistenceApi.read.mockResolvedValue({ success: false })
+    mockPersistenceApi.writeDebounced.mockResolvedValue({ success: true })
     _resetAcpTransportForTests(null)
     _resetInFlightHistoryOpensForTesting()
     _resetAcpAuthForTesting()
@@ -7222,5 +7243,219 @@ describe('acp provider authentication & recovery', () => {
     await useAcpStore.getState().createSession('agent-1', '/work', undefined, 'p1')
     expect(vi.mocked(invoke).mock.calls.filter(([c]) => c === 'acp_authenticate')).toHaveLength(1)
     expect(vi.mocked(invoke).mock.calls.filter(([c]) => c === 'acp_new_session')).toHaveLength(1)
+  })
+})
+
+describe('acp-store: composer-selection persistence', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    ;(invoke as ReturnType<typeof vi.fn>).mockReset()
+    mockPersistenceApi.read.mockReset()
+    mockPersistenceApi.writeDebounced.mockReset()
+    mockPersistenceApi.read.mockResolvedValue({ success: false })
+    mockPersistenceApi.writeDebounced.mockResolvedValue({ success: true })
+    _resetAcpTransportForTests(null)
+    _resetInFlightHistoryOpensForTesting()
+    _resetAcpAuthForTesting()
+    _resetInFlightPreparedForTesting()
+    _resetCoalesceForTesting()
+    _resetEphemeralSessionIdsForTesting()
+    _resetSessionIndexLoadGenerationForTesting()
+    useAcpStore.setState(FRESH)
+  })
+
+  it('setModel persists the modelId to persistenceApi (debounced)', async () => {
+    await useAcpStore
+      .getState()
+      .saveAgentConfig({ id: 'cfg-1', name: 'Gemini', command: 'gemini', args: [], env: {} })
+    seedSession('sess-persist', 'agent-9', false)
+    useAcpStore.setState((s) => ({
+      sessions: {
+        ...s.sessions,
+        'sess-persist': {
+          ...s.sessions['sess-persist'],
+          models: {
+            currentModelId: 'm1',
+            availableModels: [
+              { modelId: 'm1', name: 'Model One' },
+              { modelId: 'm2', name: 'Model Two' }
+            ]
+          }
+        }
+      },
+      configToLiveAgent: { ...s.configToLiveAgent, [agentReuseKey('cfg-1', '/work')]: 'agent-9' }
+    }))
+    ;(invoke as ReturnType<typeof vi.fn>).mockResolvedValueOnce(undefined) // set_model
+
+    await useAcpStore.getState().setModel('sess-persist', 'm2')
+    // persistComposerOptions chains on a per-key promise queue; flush the
+    // microtask before asserting.
+    await vi.waitFor(() => expect(mockPersistenceApi.writeDebounced).toHaveBeenCalled())
+
+    expect(mockPersistenceApi.writeDebounced).toHaveBeenCalledWith(
+      'agents/composer-options/cfg-1',
+      expect.objectContaining({ modelId: 'm2' })
+    )
+  })
+
+  it('setMode persists the modeId to persistenceApi (debounced)', async () => {
+    await useAcpStore
+      .getState()
+      .saveAgentConfig({ id: 'cfg-1', name: 'Gemini', command: 'gemini', args: [], env: {} })
+    seedSession('sess-persist', 'agent-9', false)
+    useAcpStore.setState((s) => ({
+      sessions: {
+        ...s.sessions,
+        'sess-persist': {
+          ...s.sessions['sess-persist'],
+          modes: {
+            currentModeId: 'agent',
+            availableModes: [
+              { id: 'agent', name: 'Agent' },
+              { id: 'plan', name: 'Plan' }
+            ]
+          }
+        }
+      },
+      configToLiveAgent: { ...s.configToLiveAgent, [agentReuseKey('cfg-1', '/work')]: 'agent-9' }
+    }))
+    ;(invoke as ReturnType<typeof vi.fn>).mockResolvedValueOnce(undefined) // set_mode
+
+    await useAcpStore.getState().setMode('sess-persist', 'plan')
+    await vi.waitFor(() => expect(mockPersistenceApi.writeDebounced).toHaveBeenCalled())
+
+    expect(mockPersistenceApi.writeDebounced).toHaveBeenCalledWith(
+      'agents/composer-options/cfg-1',
+      expect.objectContaining({ modeId: 'plan' })
+    )
+  })
+
+  it('setConfigOption persists the config value to persistenceApi (debounced)', async () => {
+    await useAcpStore
+      .getState()
+      .saveAgentConfig({ id: 'cfg-1', name: 'Gemini', command: 'gemini', args: [], env: {} })
+    seedSession('sess-persist', 'agent-9', false)
+    useAcpStore.setState((s) => ({
+      sessions: {
+        ...s.sessions,
+        'sess-persist': {
+          ...s.sessions['sess-persist'],
+          configOptions: [
+            {
+              id: 'thought_level',
+              name: 'Thinking',
+              category: 'thought_level',
+              type: 'select',
+              currentValue: 'low',
+              options: [
+                { value: 'low', name: 'Low' },
+                { value: 'high', name: 'High' }
+              ]
+            }
+          ]
+        }
+      },
+      configToLiveAgent: { ...s.configToLiveAgent, [agentReuseKey('cfg-1', '/work')]: 'agent-9' }
+    }))
+    ;(invoke as ReturnType<typeof vi.fn>).mockResolvedValueOnce([
+      {
+        id: 'thought_level',
+        name: 'Thinking',
+        category: 'thought_level',
+        type: 'select',
+        currentValue: 'high',
+        options: [
+          { value: 'low', name: 'Low' },
+          { value: 'high', name: 'High' }
+        ]
+      }
+    ]) // set_config_option
+
+    await useAcpStore.getState().setConfigOption('sess-persist', 'thought_level', 'high')
+    await vi.waitFor(() => expect(mockPersistenceApi.writeDebounced).toHaveBeenCalled())
+
+    expect(mockPersistenceApi.writeDebounced).toHaveBeenCalledWith(
+      'agents/composer-options/cfg-1',
+      expect.objectContaining({ configValues: { thought_level: 'high' } })
+    )
+  })
+
+  it('persistComposerOptions merges partial patches (does not overwrite existing fields)', async () => {
+    await useAcpStore
+      .getState()
+      .saveAgentConfig({ id: 'cfg-1', name: 'Gemini', command: 'gemini', args: [], env: {} })
+    seedSession('sess-persist', 'agent-9', false)
+    useAcpStore.setState((s) => ({
+      sessions: {
+        ...s.sessions,
+        'sess-persist': {
+          ...s.sessions['sess-persist'],
+          models: {
+            currentModelId: 'm1',
+            availableModels: [
+              { modelId: 'm1', name: 'Model One' },
+              { modelId: 'm2', name: 'Model Two' }
+            ]
+          },
+          modes: {
+            currentModeId: 'agent',
+            availableModes: [
+              { id: 'agent', name: 'Agent' },
+              { id: 'plan', name: 'Plan' }
+            ]
+          }
+        }
+      },
+      configToLiveAgent: { ...s.configToLiveAgent, [agentReuseKey('cfg-1', '/work')]: 'agent-9' }
+    }))
+    // Simulate an existing persisted record with a config value.
+    mockPersistenceApi.read.mockResolvedValue({
+      success: true,
+      data: { configValues: { thought_level: 'high' } }
+    })
+    ;(invoke as ReturnType<typeof vi.fn>).mockResolvedValueOnce(undefined) // set_model
+
+    await useAcpStore.getState().setModel('sess-persist', 'm2')
+    await vi.waitFor(() => expect(mockPersistenceApi.writeDebounced).toHaveBeenCalled())
+
+    const callArgs = vi.mocked(mockPersistenceApi.writeDebounced).mock.calls[0]
+    expect(callArgs).toBeDefined()
+    const written = callArgs![1] as Record<string, unknown>
+    // The merge preserves the existing configValues while adding modelId.
+    expect(written).toMatchObject({
+      modelId: 'm2',
+      configValues: { thought_level: 'high' }
+    })
+  })
+
+  it('skips persistence for ephemeral/warm-pool sessions', async () => {
+    await useAcpStore
+      .getState()
+      .saveAgentConfig({ id: 'cfg-1', name: 'Gemini', command: 'gemini', args: [], env: {} })
+    seedSession('sess-eph', 'agent-9', false)
+    useAcpStore.setState((s) => ({
+      sessions: {
+        ...s.sessions,
+        'sess-eph': {
+          ...s.sessions['sess-eph'],
+          models: {
+            currentModelId: 'm1',
+            availableModels: [
+              { modelId: 'm1', name: 'Model One' },
+              { modelId: 'm2', name: 'Model Two' }
+            ]
+          }
+        }
+      },
+      configToLiveAgent: { ...s.configToLiveAgent, [agentReuseKey('cfg-1', '/work')]: 'agent-9' }
+    }))
+    // Mark the session as ephemeral (warm-pool seed).
+    _addEphemeralSessionIdForTesting('sess-eph')
+    ;(invoke as ReturnType<typeof vi.fn>).mockResolvedValueOnce(undefined) // set_model
+
+    await useAcpStore.getState().setModel('sess-eph', 'm2')
+    // Ephemeral sessions skip persistence so agent defaults don't overwrite
+    // the user's real last selection.
+    expect(mockPersistenceApi.writeDebounced).not.toHaveBeenCalled()
   })
 })

--- a/src/renderer/stores/acp-store.ts
+++ b/src/renderer/stores/acp-store.ts
@@ -22,6 +22,7 @@
  * prepared-chat reaping) and is **not** a cross-tab isolation boundary.
  */
 
+import { type PersistedComposerOptions, PersistenceKeys } from '@shared/types/persistence.types'
 import type {
   ProjectSwitchCompletedEvent,
   ProjectSwitchFailedEvent,
@@ -116,6 +117,7 @@ import {
   type PrepareChatError,
   SETUP_ERROR_LABELS
 } from '@/lib/agents/acp-spawn-errors'
+import { persistenceApi } from '@/lib/api'
 import { deleteSessionTempFiles } from '@/lib/attachment-temp-cleanup'
 import { logFrontendError } from '@/lib/log-api'
 import { isTauriContext } from '@/lib/tauri-runtime'
@@ -1622,6 +1624,64 @@ function cacheOptionsFromSession(set: AcpSet, get: AcpGet, sessionId: SessionId)
   })
 }
 
+/**
+ * Persist composer selections (model/mode/config) per agent-config-id via
+ * `persistenceApi` (debounced). Called from the store setters so running-chatbox
+ * selection changes are captured regardless of which surface triggered them.
+ * Merges the patch into the existing record (not a full overwrite) so a
+ * single-field change (e.g. config) doesn't wipe the persisted model. Skips
+ * ephemeral/warm-pool sessions so agent defaults don't overwrite the user's
+ * real last selection. Best-effort — a persistence failure logs a warn and
+ * does not throw (the selection still applied to the live session).
+ *
+ * ## Concurrency: per-key serialization
+ *
+ * Each call does read-merge-write. Without serialization, two concurrent
+ * calls (e.g. setModel + setMode firing in the same tick) can both read the
+ * same prior record, then the second write overwrites the first's field. The
+ * `composerOptionQueues` map chains promises per key so each patch reads the
+ * latest in-flight record immediately before writing.
+ */
+const composerOptionQueues = new Map<string, Promise<void>>()
+
+export function persistComposerOptions(
+  configId: string,
+  patch: PersistedComposerOptions,
+  sessionId?: SessionId
+): void {
+  if (sessionId && ephemeralSessionIds.has(sessionId)) return
+  const key = PersistenceKeys.lastComposerOptions(configId)
+  const prev = composerOptionQueues.get(key) ?? Promise.resolve()
+  const next = prev.then(async () => {
+    const result = await persistenceApi.read<PersistedComposerOptions>(key)
+    const existing = result.success ? (result.data ?? {}) : {}
+    const merged: PersistedComposerOptions = { ...existing, ...patch }
+    // Deep-merge configValues so a single config change doesn't wipe
+    // sibling config values persisted from a prior selection.
+    if (existing.configValues && patch.configValues) {
+      merged.configValues = { ...existing.configValues, ...patch.configValues }
+    }
+    // Drop undefined values so the record stays compact and absent fields
+    // mean "use agent default" (not "explicitly unset to undefined").
+    for (const k of Object.keys(merged) as (keyof PersistedComposerOptions)[]) {
+      if (merged[k] === undefined) delete merged[k]
+    }
+    await persistenceApi.writeDebounced(key, merged)
+  })
+  composerOptionQueues.set(key, next)
+  next.catch((err) => {
+    void logFrontendError({
+      level: 'warn',
+      source: 'acp-store.persistComposerOptions',
+      message: `persist failed for ${configId}: ${err instanceof Error ? err.message : String(err)}`
+    })
+  })
+  // Clean up the queue entry once settled to avoid unbounded growth.
+  next.finally(() => {
+    if (composerOptionQueues.get(key) === next) composerOptionQueues.delete(key)
+  })
+}
+
 /** Best-effort tear-down for a session created by a cancelled/stale prepare. */
 function reapOrphanPreparedSession(get: AcpGet, set: AcpSet, sessionId: SessionId): void {
   // createSession may have set activeSessionId as a side effect; that must not
@@ -1752,6 +1812,11 @@ function dropEphemeralSessionState(state: AcpState, sessionId: SessionId): Parti
 export function _resetEphemeralSessionIdsForTesting(): void {
   ephemeralSessionIds.clear()
   commitMessageCollectors.clear()
+}
+
+/** Test-only: mark a session as ephemeral (warm-pool seed) for persistence-skip tests. */
+export function _addEphemeralSessionIdForTesting(sessionId: SessionId): void {
+  ephemeralSessionIds.add(sessionId)
 }
 
 /**
@@ -4639,6 +4704,7 @@ export const useAcpStore = create<AcpState>((set, get) => ({
     const agentConfigId = configIdForAgentId(get(), session.agentId)
     if (agentConfigId) {
       writeAgentOptionsCache(set, agentConfigId, { configOptions: updated })
+      persistComposerOptions(agentConfigId, { configValues: { [configId]: valueId } }, sessionId)
     }
   },
 
@@ -4660,6 +4726,10 @@ export const useAcpStore = create<AcpState>((set, get) => ({
       }
     })
     cacheOptionsFromSession(set, get, sessionId)
+    const configId = configIdForAgentId(get(), session.agentId)
+    if (configId) {
+      persistComposerOptions(configId, { modeId }, sessionId)
+    }
   },
 
   setModel: async (sessionId, modelId) => {
@@ -4680,6 +4750,10 @@ export const useAcpStore = create<AcpState>((set, get) => ({
       }
     })
     cacheOptionsFromSession(set, get, sessionId)
+    const configId = configIdForAgentId(get(), session.agentId)
+    if (configId) {
+      persistComposerOptions(configId, { modelId }, sessionId)
+    }
   },
 
   respondPermission: async (requestId, optionId) => {

--- a/src/shared/types/persistence.types.ts
+++ b/src/shared/types/persistence.types.ts
@@ -75,6 +75,11 @@ export const PersistenceKeys = {
   // GH-289: value shape is `LastSelectedAgent` ({ agentId, mode }); legacy
   // records carrying only `{ agentId }` are read as `mode: 'cli'`.
   lastSelectedAgent: 'agents/last-selected',
+  // Last composer selections (model, thinking level, config, mode, worktree
+  // isolation + base branch) per agent-config-id. Restored on launcher mount
+  // so the next chat starts with the user's last pick regardless of which
+  // surface (launcher or running chatbox) set it.
+  lastComposerOptions: (configId: string): string => `agents/composer-options/${configId}`,
   // Mobile file explorer: last folder the user navigated into, per project.
   // Restored on drawer reopen across close/reopen and page reloads (web only).
   mobileFileExplorerFolder: (projectId: string): string => `mobile-file-explorer/${projectId}`
@@ -85,6 +90,18 @@ export const PersistenceKeys = {
 export interface LastSelectedAgent {
   agentId: string
   mode: 'cli' | 'acp'
+}
+
+// Persisted composer selections per agent-config-id. Written by both the
+// launcher (pre-launch pending options + worktree isolation) and the store
+// setters (running-chatbox model/mode/config changes). Restored on launcher
+// mount. All fields optional — an absent field means "use agent default".
+export interface PersistedComposerOptions {
+  modelId?: string
+  modeId?: string
+  configValues?: Record<string, string>
+  isolationMode?: 'current' | 'worktree'
+  baseBranch?: string | null
 }
 
 // Persisted project data (stored at projects.json)


### PR DESCRIPTION
## Summary

Composer selections (model, thinking level, config, mode, worktree isolation + base branch) are now persisted per-agent-config-id across chat sessions. Selections made in **both** the AgentLauncher (pre-launch) and the running ChatInputBar (store setters) write to the same record. On launcher mount, selections are restored with fallbacks for stale/invalid values.

## Related Issue

Closes #

No related issue — this is a user-reported UX issue where composer selections were lost on the next chat.

## Type of Change

- [x] feat: new feature

## What Changed

- \src/shared/types/persistence.types.ts\ — added \lastComposerOptions(configId)\ key + \PersistedComposerOptions\ interface
- \src/renderer/stores/acp-store.ts\ — added \persistComposerOptions\ helper (deep-merge configValues, ephemeral-session guard, debounced write) + calls in \setConfigOption\/\setMode\/\setModel\ + \_addEphemeralSessionIdForTesting\
- \src/renderer/components/agents/AgentLauncher.tsx\ — restore-on-mount effect + persist-on-change in \handleSetConfig\/\handleSetModel\/\handleSetMode\ + worktree persistence effect + branch-list validation effect + launch-time snapshot persist + \handleSelectAgent\ reset
- \src/renderer/stores/acp-store.test.ts\ — 5 new persistence tests
- \src/renderer/components/agents/AgentLauncher.test.tsx\ — added \writeDebounced\ to mock

## How It Was Tested

- [x] \un run ci\ (Biome lint + format + imports, strict mode)
- [x] \un run typecheck\
- [x] \un run test\
- [ ] \cargo clippy --all-targets -- -D warnings\ (in src-tauri) — not applicable (no Rust changes)
- [ ] \cargo test\ (in src-tauri) — not applicable (no Rust changes)
- [x] Manual verification completed

## CI & Review Gate

- [ ] All CI checks pass (PR Validation, Rust Checks, Build Verification, Security Scans)
- [ ] Code review comments from CodeRabbit / Claude have been addressed or resolved
- [ ] No unresolved review findings remain

## Checklist

- [x] My PR title follows the conventional commit format used by this repo
- [x] I linked the related issue or explained why none exists
- [x] I updated docs when needed
- [x] I added or updated tests when needed
- [x] I verified the change does not introduce unrelated modifications
- [x] I read AGENTS.md and followed the contributor guidelines
- [ ] A human reviewed the complete diff before submission