### PR TITLE
fix(acp): recover web rate_limited turn-busy to queue on host→web switch

### DIFF
--- a/src/renderer/stores/acp-store.test.ts
+++ b/src/renderer/stores/acp-store.test.ts
@@ -1002,6 +1002,32 @@ describe('acp-store', () => {
     ])
     expect(useAcpStore.getState().messages['s1']).toHaveLength(0)
     expect(useAcpStore.getState().sessions['s1'].lastError).toBeNull()
+    expect(useAcpStore.getState().sessions['s1'].activeTurn).toBe(false)
+  })
+
+  it('queues a prompt when the WS transport rejects a concurrent turn (rate_limited)', async () => {
+    // Web/remote path: the relay returns `err.code: rate_limited` with
+    // message "a prompt turn is already in progress" (the only RateLimited
+    // emit site is the send_prompt DuplicateInFlight/Busy branch), surfaced as
+    // `AcpTransportError`. The store must recover it to the queue instead of
+    // finalizing the turn — mirrors the IPC `ACP_TURN_IN_PROGRESS` case above.
+    seedSession('s1', 'agent-1', false)
+    _setAcpTransportForTests({
+      sendPrompt: vi
+        .fn()
+        .mockRejectedValue(
+          new AcpTransportError('rate_limited', 'a prompt turn is already in progress')
+        ),
+      dispose: vi.fn()
+    } as unknown as AcpTransport)
+    await useAcpStore.getState().sendPrompt('s1', 'queued after race')
+    expect(useAcpStore.getState().promptQueues['s1']).toHaveLength(1)
+    expect(useAcpStore.getState().promptQueues['s1'][0].blocks).toEqual([
+      { type: 'text', text: 'queued after race' }
+    ])
+    expect(useAcpStore.getState().messages['s1']).toHaveLength(0)
+    expect(useAcpStore.getState().sessions['s1'].lastError).toBeNull()
+    expect(useAcpStore.getState().sessions['s1'].activeTurn).toBe(false)
   })
 
   it('flushes the next queued prompt when the turn ends', async () => {

--- a/src/renderer/stores/prompt-queue-orchestration.test.ts
+++ b/src/renderer/stores/prompt-queue-orchestration.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from 'vitest'
+import { AcpTransportError } from '@/lib/acp-transport'
 import {
   ACP_TURN_IN_PROGRESS_CODE,
   appendQueuedPrompt,
@@ -15,6 +16,23 @@ describe('prompt-queue-orchestration', () => {
     expect(isPromptTurnInProgressError(new Error(`${ACP_TURN_IN_PROGRESS_CODE}: session s1`))).toBe(
       true
     )
+    expect(isPromptTurnInProgressError(new Error('network failed'))).toBe(false)
+  })
+
+  it('matches the web/WS rate_limited turn-in-progress form', () => {
+    // The WS relay maps the same turn-busy condition to `WsErrorCode::RateLimited`
+    // and the transport surfaces it as `AcpTransportError('rate_limited', …)`.
+    // `runPromptTurn` must recover this form just like the IPC `ACP_TURN_IN_PROGRESS` string.
+    expect(
+      isPromptTurnInProgressError(
+        new AcpTransportError('rate_limited', 'a prompt turn is already in progress')
+      )
+    ).toBe(true)
+    // Unrelated transient codes must NOT be misclassified as turn-busy.
+    expect(isPromptTurnInProgressError(new AcpTransportError('closed', 'transport gone'))).toBe(
+      false
+    )
+    expect(isPromptTurnInProgressError(new AcpTransportError('timeout', 'slow link'))).toBe(false)
     expect(isPromptTurnInProgressError(new Error('network failed'))).toBe(false)
   })
 

--- a/src/renderer/stores/prompt-queue-orchestration.ts
+++ b/src/renderer/stores/prompt-queue-orchestration.ts
@@ -5,7 +5,9 @@
  * `ACP_TURN_IN_PROGRESS` error contract shared with Rust `acp_send_prompt`.
  */
 
+import { WS_ERROR_CODES } from '@shared/types/web-protocol.types'
 import type { ContentBlock, SessionId } from '@/lib/acp-api'
+import { AcpTransportError } from '@/lib/acp-transport'
 
 /** Stable code from Rust when `acp_send_prompt` rejects a concurrent turn. */
 export const ACP_TURN_IN_PROGRESS_CODE = 'ACP_TURN_IN_PROGRESS'
@@ -42,7 +44,20 @@ export interface RecoverableChatMessage {
 type PromptQueueMap = Record<SessionId, QueuedPrompt[]>
 
 export function isPromptTurnInProgressError(err: unknown): boolean {
-  return String(err).includes(ACP_TURN_IN_PROGRESS_CODE)
+  // Two surfaces report "a prompt turn is already in progress"; both must trigger
+  // `runPromptTurn`'s `recoverPromptToQueue` recovery (parity across desktop/web):
+  //  • Desktop/IPC: `acp_send_prompt` rejects with `Error('ACP_TURN_IN_PROGRESS: …')`.
+  //  • Web/WS: the relay maps the turn-busy condition to `WsErrorCode::RateLimited` via
+  //    `map_prompt_error_code` (preserving the `ACP_TURN_IN_PROGRESS: …` message) AND via
+  //    the pre-flight `TurnClaim::DuplicateInFlight | Busy` branch (message
+  //    "a prompt turn is already in progress"). Both surface as
+  //    `AcpTransportError(WS_ERROR_CODES.RATE_LIMITED, …)`.
+  // The string branch covers IPC + the WS `map_prompt_error_code` form (message keeps the
+  // code prefix); the instanceof branch covers the WS turn-claim form (different message).
+  return (
+    String(err).includes(ACP_TURN_IN_PROGRESS_CODE) ||
+    (err instanceof AcpTransportError && err.code === WS_ERROR_CODES.RATE_LIMITED)
+  )
 }
 
 /**


### PR DESCRIPTION
## Summary

The web/remote ACP chat stops streaming after a host→web/mobile switch. A reconnecting `send_prompt` hits a turn still in-flight on the host; the relay replies `err.code: rate_limited` ("a prompt turn is already in progress"), surfaced to the renderer as `AcpTransportError('rate_limited', …)`. Because `isPromptTurnInProgressError` only matched the **desktop/IPC** string `'ACP_TURN_IN_PROGRESS'`, the web/WS form fell through `runPromptTurn`'s catch into the **terminal** branch (`activeTurn=false`, `lastError` set, no retry) — the chat appears dead until a manual reload. This is a parity gap: the desktop path already recovers the same condition into the FIFO prompt queue; the web path didn't.

## Related Issue

No issue — reported directly. Supersedes the unimplemented (now-stale) draft specs `spec-fix-web-acp-retry-reliability` / `spec-fix-web-acp-active-turn-disconnect-recovery`: their headline fixes (spawn `complete_send_prompt` off the read loop; wire `record_completed`/`release_claim` via `PromptClaim::Drop`) already landed via #478 / #498 / #616 — the residual was purely the client error-classification gap. Searched open + closed PRs; no duplicate (closest open #530 is stream/rate-limit error *humanization*, a different layer; merged #478 was the heartbeat + echo-dedup fix).

## Type of Change

- [x] fix: bug fix

## What Changed

- `src/renderer/stores/prompt-queue-orchestration.ts` — `isPromptTurnInProgressError` now also matches `AcpTransportError` with code `WS_ERROR_CODES.RATE_LIMITED`. `RateLimited` is emitted **only** from the send_prompt turn-busy path (`TurnClaim::DuplicateInFlight | Busy` at `ws.rs:2909-2913` + `map_prompt_error_code`), so the match is contract-safe. The existing `recoverPromptToQueue` recovery then engages on the web surface identically to desktop — no server/wire change.
- Tests — unit (`prompt-queue-orchestration.test.ts`) + integration regression (`acp-store.test.ts`) mirroring the IPC `ACP_TURN_IN_PROGRESS` case; `activeTurn` parity assertion added to the existing desktop test.

`rate_limited` is **deliberately not** added to `isTransientAcpTransportError` — that would broaden retry to history-refresh and risk loops; the targeted queue-recovery path is correct.

## How It Was Tested

- [x] `bun run typecheck`
- [x] `bun run test` (vitest: 252 passed — 10 orchestration + 242 acp-store)
- [x] `biome check` (exit 0 at CI error-level; remaining `useLiteralKeys` infos are pre-existing file convention, non-fatal)
- [ ] `cargo clippy` / `cargo test` — N/A (no Rust changes in this PR)
- [x] Manual verification — root-cause traced from `termul.log` + `ws.rs:2909-2913` + `acp-transport.ts:86`; the literal error is a WS err reply (not logged at INFO), confirmed via the server `claim_turn` path and the transport's `rejectAllPending`.

## CI & Review Gate

- [ ] All CI checks pass (PR Validation, Rust Checks, Build Verification, Security Scans)
- [ ] CodeRabbit / review comments addressed
- [ ] No unresolved review findings remain

## Checklist

- [x] PR title follows conventional commit format (`fix(acp): …`)
- [x] Linked related issue / explained why none exists
- [x] Updated docs when needed (N/A — internal error-classification fix)
- [x] Added/updated tests
- [x] Verified no unrelated modifications
- [x] Read AGENTS.md and followed contributor guidelines
- [ ] A human reviewed the complete diff before submission


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of rate-limit errors during prompt processing.
  * Prevented interruptions when a prompt is already in progress, providing more reliable queue behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->