### PR TITLE
feat(web): persist web client state server-side

### DIFF
--- a/src-tauri/src/remote/host.rs
+++ b/src-tauri/src/remote/host.rs
@@ -357,6 +357,9 @@ impl RemoteServerState {
             // from the config here — `None` degrades nothing on this path.
             workspace_manifests_dir: None,
             acp_catalog_dir: None,
+            // Issue #613: `None` → resolve `<service_account_state_dir>/store.json`
+            // at serve time (the shared-live host gets a durable store too).
+            store_file: None,
         };
 
         let (shutdown_tx, shutdown_rx) = oneshot::channel::<()>();

--- a/src-tauri/src/web/catalog_api.rs
+++ b/src-tauri/src/web/catalog_api.rs
@@ -229,6 +229,7 @@ mod tests {
             workspace_manifest: None,
             acp_catalog: Some(store),
             acp_install: None,
+            store: None,
         }
     }
 
@@ -250,6 +251,7 @@ mod tests {
             workspace_manifest: None,
             acp_catalog: None,
             acp_install: None,
+            store: None,
         }
     }
 

--- a/src-tauri/src/web/config.rs
+++ b/src-tauri/src/web/config.rs
@@ -190,6 +190,13 @@ pub struct ServerConfig {
     /// reads this field; it constructs its own `AcpCatalogService` under
     /// `<app_data_dir>/acp-catalog`.
     pub acp_catalog_dir: Option<PathBuf>,
+    /// Issue #613: server-side generic key-value store file for the web
+    /// client (terminal layout, settings, editor state, command history,
+    /// snapshots, SSH profiles, …). `None` means "use
+    /// `<service_account_state_dir>/store.json`" — resolved at serve time in
+    /// `serve_router`, so the desktop shared-live path gets a durable store
+    /// too (no per-browser localStorage fallback).
+    pub store_file: Option<PathBuf>,
 }
 
 impl ServerConfig {
@@ -290,6 +297,10 @@ impl ServerConfig {
         // CAP-6 / Story 8: acp-catalog root override. Same pattern as
         // `workspace_manifests_dir` — `None` means resolve at startup.
         let mut acp_catalog_dir: Option<PathBuf> = None;
+        // Issue #613: server-side generic key-value store file override.
+        // `None` means resolve `<service_account_state_dir>/store.json` at
+        // serve time (the desktop shared-live path never sets this).
+        let mut store_file: Option<PathBuf> = None;
 
         let mut iter = args.into_iter().peekable();
         while let Some(arg) = iter.next() {
@@ -438,6 +449,18 @@ impl ServerConfig {
                     }
                     acp_catalog_dir = Some(PathBuf::from(trimmed));
                 }
+                "--store-file" => {
+                    let value = iter.next().ok_or_else(|| {
+                        ParseCliError::Message("missing value for --store-file".into())
+                    })?;
+                    let trimmed = value.as_ref().trim();
+                    if trimmed.is_empty() {
+                        return Err(ParseCliError::Message(
+                            "invalid --store-file '': must be a non-empty path".into(),
+                        ));
+                    }
+                    store_file = Some(PathBuf::from(trimmed));
+                }
                 "--projects-file" => {
                     let value = iter.next().ok_or_else(|| {
                         ParseCliError::Message("missing value for --projects-file".into())
@@ -498,6 +521,18 @@ impl ServerConfig {
             }),
         };
 
+        // Issue #613: optional $TERMUL_STORE_FILE env default when
+        // --store-file is absent (mirrors the $TERMUL_PROJECTS_FILE env
+        // pattern). An unset/empty env var means "resolve the default at
+        // serve time".
+        let store_file = match store_file {
+            Some(p) => Some(p),
+            None => std::env::var("TERMUL_STORE_FILE").ok().and_then(|v| {
+                let t = v.trim();
+                (!t.is_empty()).then(|| PathBuf::from(t))
+            }),
+        };
+
         let sessions_dir = sessions_dir.or_else(default_sessions_dir).ok_or_else(|| {
             ParseCliError::Message(
                 "could not determine sessions directory: set --sessions-dir or $TERMUL_SESSIONS_DIR"
@@ -522,6 +557,7 @@ impl ServerConfig {
             sessions_dir: Some(sessions_dir),
             workspace_manifests_dir,
             acp_catalog_dir,
+            store_file,
         })
     }
 }
@@ -647,6 +683,7 @@ mod tests {
             sessions_dir: None,
             workspace_manifests_dir: None,
             acp_catalog_dir: None,
+            store_file: None,
         };
         assert_eq!(
             cfg.bind_addr(),
@@ -664,6 +701,7 @@ mod tests {
             sessions_dir: None,
             workspace_manifests_dir: None,
             acp_catalog_dir: None,
+            store_file: None,
         };
         assert_eq!(bad.bind_addr(), None);
     }
@@ -859,6 +897,35 @@ mod tests {
         ));
     }
 
+    #[test]
+    fn from_args_accepts_store_file() {
+        let cfg = ServerConfig::from_args(["--store-file", "/var/lib/termul/store.json"])
+            .expect("parse");
+        assert_eq!(
+            cfg.store_file,
+            Some(PathBuf::from("/var/lib/termul/store.json"))
+        );
+        // Other defaults stay intact.
+        assert_eq!(cfg.host, "127.0.0.1");
+        assert_eq!(cfg.port, 8080);
+    }
+
+    #[test]
+    fn from_args_missing_store_file_value() {
+        assert!(matches!(
+            ServerConfig::from_args(["--store-file"]),
+            Err(ParseCliError::Message(_))
+        ));
+    }
+
+    #[test]
+    fn from_args_rejects_empty_store_file() {
+        assert!(matches!(
+            ServerConfig::from_args(["--store-file", ""]),
+            Err(ParseCliError::Message(_))
+        ));
+    }
+
     // Patch 15: `service_account_state_dir` filters out empty env var values
     // so an empty `XDG_STATE_HOME` / `HOME` / `LOCALAPPDATA` does not produce
     // a relative `./termul` dir.
@@ -875,6 +942,7 @@ mod tests {
             sessions_dir: None,
             workspace_manifests_dir: None,
             acp_catalog_dir: None,
+            store_file: None,
         };
         // We cannot safely mutate the real process env vars in a parallel
         // test runner, so we assert the contract indirectly: the resolved

--- a/src-tauri/src/web/fs_api.rs
+++ b/src-tauri/src/web/fs_api.rs
@@ -997,6 +997,7 @@ mod tests {
             workspace_manifest: None,
             acp_catalog: None,
             acp_install: None,
+            store: None,
         }
     }
 

--- a/src-tauri/src/web/git_api.rs
+++ b/src-tauri/src/web/git_api.rs
@@ -1058,6 +1058,7 @@ mod tests {
             workspace_manifest: None,
             acp_catalog: None,
             acp_install: None,
+            store: None,
         }
     }
 

--- a/src-tauri/src/web/install_api.rs
+++ b/src-tauri/src/web/install_api.rs
@@ -192,6 +192,7 @@ mod tests {
             workspace_manifest: None,
             acp_catalog: None,
             acp_install: Some(store),
+            store: None,
         }
     }
 
@@ -213,6 +214,7 @@ mod tests {
             workspace_manifest: None,
             acp_catalog: None,
             acp_install: None,
+            store: None,
         }
     }
 

--- a/src-tauri/src/web/log_api.rs
+++ b/src-tauri/src/web/log_api.rs
@@ -111,6 +111,7 @@ mod tests {
             workspace_manifest: None,
             acp_catalog: None,
             acp_install: None,
+            store: None,
         }
     }
 

--- a/src-tauri/src/web/mcp_probe_api.rs
+++ b/src-tauri/src/web/mcp_probe_api.rs
@@ -72,6 +72,7 @@ mod tests {
             workspace_manifest: None,
             acp_catalog: None,
             acp_install: None,
+            store: None,
         };
         axum::Router::new()
             .route("/mcp-servers/probe", post(super::probe))

--- a/src-tauri/src/web/mcp_servers_api.rs
+++ b/src-tauri/src/web/mcp_servers_api.rs
@@ -142,6 +142,7 @@ mod tests {
             workspace_manifest: None,
             acp_catalog: None,
             acp_install: None,
+            store: None,
         };
         axum::Router::new()
             .route("/mcp-servers", get(super::get).put(super::put))

--- a/src-tauri/src/web/mod.rs
+++ b/src-tauri/src/web/mod.rs
@@ -26,6 +26,7 @@ pub mod mcp_servers_api;
 pub mod search_api;
 pub mod skills_api;
 pub mod permissions;
+pub mod store;
 pub mod project_registry;
 pub mod projects_api;
 pub mod router;

--- a/src-tauri/src/web/mod.rs
+++ b/src-tauri/src/web/mod.rs
@@ -60,6 +60,7 @@ use tracing::{error, info, warn};
 use crate::acp::AcpManager;
 use crate::pty::PtyManager;
 use crate::trackers::{CwdTracker, ExitCodeTracker, GitTracker, TerminalEventHub};
+use crate::web::store::WebStore;
 
 #[cfg(test)]
 pub(crate) fn test_pty_manager() -> Arc<PtyManager> {
@@ -239,6 +240,16 @@ pub async fn serve_router(
     } else {
         HistoryMode::LiveOnly
     };
+    // Issue #613: resolve the server-side store path — explicit
+    // `--store-file` wins, otherwise default under the service-account state
+    // dir (same resolution posture as workspace-manifests / acp-catalog). The
+    // desktop shared-live host passes `store_file: None`, so it lands on the
+    // same default and gets a durable store too.
+    let store = Some(Arc::new(WebStore::open(
+        cfg.store_file
+            .clone()
+            .unwrap_or_else(|| cfg.service_account_state_dir().join("store.json")),
+    )));
     let app = router::router(
         Arc::clone(&acp),
         pty,
@@ -255,6 +266,7 @@ pub async fn serve_router(
         workspace_manifest,
         acp_catalog,
         acp_install,
+        store,
     );
 
     let handle = tokio::spawn(async move {

--- a/src-tauri/src/web/projects_api.rs
+++ b/src-tauri/src/web/projects_api.rs
@@ -234,6 +234,7 @@ mod tests {
             workspace_manifest: None,
             acp_catalog: None,
             acp_install: None,
+            store: None,
         }
     }
 
@@ -262,6 +263,7 @@ mod tests {
             workspace_manifest: None,
             acp_catalog: None,
             acp_install: None,
+            store: None,
         }
     }
 

--- a/src-tauri/src/web/router.rs
+++ b/src-tauri/src/web/router.rs
@@ -31,6 +31,7 @@ use crate::web::skills_api;
 use crate::web::project_registry::ProjectRegistry;
 use crate::web::projects_api;
 use crate::web::sink::WsRelaySink;
+use crate::web::store::WebStore;
 use crate::web::terminal_ws::terminal_ws_upgrade;
 use crate::web::workspace_api;
 use crate::web::worktree_api;
@@ -75,6 +76,7 @@ pub fn router(
     workspace_manifest: Option<Arc<WorkspaceManifestService>>,
     acp_catalog: Option<Arc<AcpCatalogService>>,
     acp_install: Option<Arc<AcpInstallService>>,
+    store: Option<Arc<WebStore>>,
 ) -> Router {
     let mut r = Router::new()
         .route("/health", get(health_check))
@@ -213,6 +215,7 @@ pub fn router(
         workspace_manifest,
         acp_catalog,
         acp_install,
+        store,
         project_root: project_root_handle,
     })
 }
@@ -318,6 +321,7 @@ pub fn router_with_static(
                 workspace_manifest: None,
                 acp_catalog: None,
                 acp_install: None,
+                store: None,
                 project_root: project_root_handle,
             }
         })

--- a/src-tauri/src/web/search_api.rs
+++ b/src-tauri/src/web/search_api.rs
@@ -351,6 +351,7 @@ mod tests {
             workspace_manifest: None,
             acp_catalog: None,
             acp_install: None,
+            store: None,
         }
     }
 

--- a/src-tauri/src/web/skills_api.rs
+++ b/src-tauri/src/web/skills_api.rs
@@ -202,6 +202,7 @@ mod tests {
             workspace_manifest: None,
             acp_catalog: None,
             acp_install: None,
+            store: None,
         }
     }
 

--- a/src-tauri/src/web/store.rs
+++ b/src-tauri/src/web/store.rs
@@ -1,0 +1,226 @@
+//! Server-side generic key-value store for the web client (issue #613).
+//!
+//! The browser client persists terminal layout, settings, editor state,
+//! command history, snapshots, SSH profiles, etc. through `persistenceApi`.
+//! On desktop that lands in Tauri's plugin-store; in the standalone web
+//! client it previously fell back to a `localStorage` stub — per-browser
+//! only, so switching browsers or refreshing in a different browser lost
+//! everything. This store gives the server a durable home for that state: a
+//! single JSON file written atomically (temp + rename + fsync, the same
+//! `atomic_file` machinery `FileProjectRegistry::save_atomic` uses), so the
+//! state survives browser switches and server restarts.
+//!
+//! Exposed to browsers as the `store_read` / `store_write` / `store_delete`
+//! WS requests (see `ws.rs`). The client debounces high-frequency writes, so
+//! write volume here is low.
+
+use std::collections::HashMap;
+use std::fs;
+use std::io;
+use std::path::PathBuf;
+
+use parking_lot::Mutex;
+use serde_json::Value;
+use tracing::{info, warn};
+
+use crate::acp::atomic_file;
+
+/// A key → arbitrary-JSON-value map persisted to one JSON file.
+///
+/// All mutation goes through a single `parking_lot::Mutex`; each write
+/// serializes the whole map and replaces the file atomically. The file is a
+/// bare JSON object (`{ "key": value }`); an empty store is `{}`.
+pub struct WebStore {
+    path: PathBuf,
+    inner: Mutex<HashMap<String, Value>>,
+}
+
+impl WebStore {
+    /// Open (and lazily load) the store at `path`.
+    ///
+    /// - Missing file → empty store (first run).
+    /// - Corrupt file → backed up to `<path>.corrupt-<ts>.bak`, then treated
+    ///   as empty — the web client degrades to defaults rather than the
+    ///   server refusing to start (same corrupt-handling posture as
+    ///   `AcpCatalogService` / `AcpInstallService`).
+    /// - Other read failure → warn + empty store (the store degrades; the
+    ///   next successful write recreates the file).
+    #[must_use]
+    pub fn open(path: PathBuf) -> Self {
+        let data = match fs::read(&path) {
+            Ok(bytes) => match serde_json::from_slice::<HashMap<String, Value>>(&bytes) {
+                Ok(map) => map,
+                Err(e) => {
+                    if let Err(backup_err) = atomic_file::backup_corrupt(&path, &bytes) {
+                        warn!(
+                            "could not back up corrupt store file '{}': {backup_err}",
+                            path.display()
+                        );
+                    }
+                    warn!(
+                        "store file '{}' is corrupt ({e}); starting with an empty store",
+                        path.display()
+                    );
+                    HashMap::new()
+                }
+            },
+            Err(e) if e.kind() == io::ErrorKind::NotFound => {
+                info!(
+                    "store file '{}' not found; starting with an empty store",
+                    path.display()
+                );
+                HashMap::new()
+            }
+            Err(e) => {
+                warn!(
+                    "could not read store file '{}': {e}; starting with an empty store",
+                    path.display()
+                );
+                HashMap::new()
+            }
+        };
+        Self {
+            path,
+            inner: Mutex::new(data),
+        }
+    }
+
+    /// Read a value, or `None` when the key is absent.
+    #[must_use]
+    pub fn read(&self, key: &str) -> Option<Value> {
+        self.inner.lock().get(key).cloned()
+    }
+
+    /// Write a value, persisting atomically. Returns the IO error on failure.
+    pub fn write(&self, key: &str, value: Value) -> io::Result<()> {
+        let bytes = {
+            let mut map = self.inner.lock();
+            map.insert(key.to_string(), value);
+            serde_json::to_vec(&*map).map_err(|e| io::Error::other(e.to_string()))?
+        };
+        atomic_file::replace(&self.path, &bytes)
+    }
+
+    /// Delete a key, persisting atomically. Returns whether the key existed.
+    pub fn delete(&self, key: &str) -> io::Result<bool> {
+        let bytes = {
+            let mut map = self.inner.lock();
+            let removed = map.remove(key).is_some();
+            let bytes =
+                serde_json::to_vec(&*map).map_err(|e| io::Error::other(e.to_string()))?;
+            (removed, bytes)
+        };
+        atomic_file::replace(&self.path, &bytes.1)?;
+        Ok(bytes.0)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Minimal std-only temp dir (reuses the repo's pid+nanos pattern — no
+    /// `tempfile` dev-dep).
+    fn tempdir_like(label: &str) -> PathBuf {
+        let nanos = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_nanos())
+            .unwrap_or(0);
+        let p = std::env::temp_dir().join(format!(
+            "termul-store-{label}-{}-{nanos}",
+            std::process::id()
+        ));
+        std::fs::create_dir_all(&p).expect("create tempdir");
+        p
+    }
+
+    fn cleanup(p: &PathBuf) {
+        let _ = std::fs::remove_dir_all(p);
+    }
+
+    #[test]
+    fn missing_file_opens_empty_and_round_trips() {
+        let dir = tempdir_like("roundtrip");
+        let file = dir.join("store.json");
+        let store = WebStore::open(file.clone());
+        assert_eq!(store.read("missing"), None);
+
+        store.write("terminals/p1", serde_json::json!({ "active": "t1" })).unwrap();
+        store.write("settings", serde_json::json!({ "theme": "dark" })).unwrap();
+        assert_eq!(
+            store.read("settings"),
+            Some(serde_json::json!({ "theme": "dark" }))
+        );
+        assert_eq!(
+            store.read("terminals/p1"),
+            Some(serde_json::json!({ "active": "t1" }))
+        );
+
+        // A second open (simulating a restart) reloads the persisted map.
+        let reloaded = WebStore::open(file.clone());
+        assert_eq!(reloaded.read("settings"), Some(serde_json::json!({ "theme": "dark" })));
+
+        // delete removes + persists.
+        assert!(reloaded.delete("settings").unwrap());
+        assert_eq!(reloaded.read("settings"), None);
+        assert!(!reloaded.delete("settings").unwrap());
+        let reloaded_again = WebStore::open(file.clone());
+        assert_eq!(reloaded_again.read("settings"), None);
+        assert_eq!(
+            reloaded_again.read("terminals/p1"),
+            Some(serde_json::json!({ "active": "t1" }))
+        );
+        cleanup(&dir);
+    }
+
+    #[test]
+    fn write_replaces_existing_value_and_no_temp_leaks() {
+        let dir = tempdir_like("replace");
+        let file = dir.join("store.json");
+        let store = WebStore::open(file.clone());
+        store.write("k", serde_json::json!(1)).unwrap();
+        store.write("k", serde_json::json!(2)).unwrap();
+        assert_eq!(store.read("k"), Some(serde_json::json!(2)));
+
+        let temps: Vec<_> = std::fs::read_dir(&dir)
+            .expect("read dir")
+            .filter_map(Result::ok)
+            .filter(|e| {
+                e.file_name()
+                    .to_str()
+                    .map(|n| n.ends_with(".tmp"))
+                    .unwrap_or(false)
+            })
+            .collect();
+        assert!(temps.is_empty(), "no lingering temp files: {temps:?}");
+        cleanup(&dir);
+    }
+
+    #[test]
+    fn corrupt_file_is_backed_up_and_treated_as_empty() {
+        let dir = tempdir_like("corrupt");
+        let file = dir.join("store.json");
+        std::fs::write(&file, "{ not valid json").expect("write garbage");
+
+        let store = WebStore::open(file.clone());
+        assert_eq!(store.read("anything"), None);
+
+        let backups: Vec<_> = std::fs::read_dir(&dir)
+            .expect("read dir")
+            .filter_map(Result::ok)
+            .filter(|e| {
+                e.file_name()
+                    .to_str()
+                    .map(|n| n.starts_with("store.json.corrupt-") && n.ends_with(".bak"))
+                    .unwrap_or(false)
+            })
+            .collect();
+        assert_eq!(backups.len(), 1, "exactly one corrupt backup");
+
+        // A write after recovery recreates a valid file.
+        store.write("k", serde_json::json!("v")).unwrap();
+        let reloaded = WebStore::open(file);
+        assert_eq!(reloaded.read("k"), Some(serde_json::json!("v")));
+        cleanup(&dir);
+    }
+}

--- a/src-tauri/src/web/store.rs
+++ b/src-tauri/src/web/store.rs
@@ -32,7 +32,7 @@ use crate::acp::atomic_file;
 /// bare JSON object (`{ "key": value }`); an empty store is `{}`.
 pub struct WebStore {
     path: PathBuf,
-    inner: Mutex<HashMap<String, Value>>,
+    inner: Mutex<Option<HashMap<String, Value>>>,
 }
 
 impl WebStore {
@@ -49,19 +49,24 @@ impl WebStore {
     pub fn open(path: PathBuf) -> Self {
         let data = match fs::read(&path) {
             Ok(bytes) => match serde_json::from_slice::<HashMap<String, Value>>(&bytes) {
-                Ok(map) => map,
+                Ok(map) => Some(map),
                 Err(e) => {
-                    if let Err(backup_err) = atomic_file::backup_corrupt(&path, &bytes) {
-                        warn!(
-                            "could not back up corrupt store file '{}': {backup_err}",
-                            path.display()
-                        );
+                    match atomic_file::backup_corrupt(&path, &bytes) {
+                        Ok(_) => {
+                            warn!(
+                                "store file '{}' is corrupt ({e}); backed up and starting with an empty store",
+                                path.display()
+                            );
+                            Some(HashMap::new())
+                        }
+                        Err(backup_err) => {
+                            warn!(
+                                "store file '{}' is corrupt ({e}) and backup failed: {backup_err}; store is unavailable",
+                                path.display()
+                            );
+                            None
+                        }
                     }
-                    warn!(
-                        "store file '{}' is corrupt ({e}); starting with an empty store",
-                        path.display()
-                    );
-                    HashMap::new()
                 }
             },
             Err(e) if e.kind() == io::ErrorKind::NotFound => {
@@ -69,14 +74,14 @@ impl WebStore {
                     "store file '{}' not found; starting with an empty store",
                     path.display()
                 );
-                HashMap::new()
+                Some(HashMap::new())
             }
             Err(e) => {
                 warn!(
-                    "could not read store file '{}': {e}; starting with an empty store",
+                    "could not read store file '{}': {e}; store is unavailable",
                     path.display()
                 );
-                HashMap::new()
+                None
             }
         };
         Self {
@@ -87,31 +92,47 @@ impl WebStore {
 
     /// Read a value, or `None` when the key is absent.
     #[must_use]
-    pub fn read(&self, key: &str) -> Option<Value> {
-        self.inner.lock().get(key).cloned()
+    pub fn read(&self, key: &str) -> Result<Option<Value>, io::Error> {
+        let lock = self.inner.lock();
+        let map = lock.as_ref().ok_or_else(|| io::Error::new(io::ErrorKind::Other, "STORE_UNAVAILABLE"))?;
+        Ok(map.get(key).cloned())
     }
 
     /// Write a value, persisting atomically. Returns the IO error on failure.
-    pub fn write(&self, key: &str, value: Value) -> io::Result<()> {
-        let bytes = {
-            let mut map = self.inner.lock();
-            map.insert(key.to_string(), value);
-            serde_json::to_vec(&*map).map_err(|e| io::Error::other(e.to_string()))?
-        };
-        atomic_file::replace(&self.path, &bytes)
+    pub fn write(&self, key: &str, value: Value, expected: Option<Value>) -> io::Result<bool> {
+        let mut lock = self.inner.lock();
+        let map = lock.as_mut().ok_or_else(|| io::Error::new(io::ErrorKind::Other, "STORE_UNAVAILABLE"))?;
+        
+        if expected.is_some() && map.get(key) != expected.as_ref() {
+            return Ok(false); // CAS failed
+        }
+        
+        let mut next = map.clone();
+        next.insert(key.to_string(), value);
+        
+        let bytes = serde_json::to_vec(&next).map_err(|e| io::Error::other(e.to_string()))?;
+        if bytes.len() > 10 * 1024 * 1024 {
+            return Err(io::Error::new(io::ErrorKind::InvalidData, "store file exceeds 10MB limit"));
+        }
+        atomic_file::replace(&self.path, &bytes)?;
+        
+        *map = next;
+        Ok(true)
     }
 
     /// Delete a key, persisting atomically. Returns whether the key existed.
     pub fn delete(&self, key: &str) -> io::Result<bool> {
-        let bytes = {
-            let mut map = self.inner.lock();
-            let removed = map.remove(key).is_some();
-            let bytes =
-                serde_json::to_vec(&*map).map_err(|e| io::Error::other(e.to_string()))?;
-            (removed, bytes)
-        };
-        atomic_file::replace(&self.path, &bytes.1)?;
-        Ok(bytes.0)
+        let mut lock = self.inner.lock();
+        let map = lock.as_mut().ok_or_else(|| io::Error::new(io::ErrorKind::Other, "STORE_UNAVAILABLE"))?;
+        
+        let mut next = map.clone();
+        let removed = next.remove(key).is_some();
+        
+        let bytes = serde_json::to_vec(&next).map_err(|e| io::Error::other(e.to_string()))?;
+        atomic_file::replace(&self.path, &bytes)?;
+        
+        *map = next;
+        Ok(removed)
     }
 }
 
@@ -143,31 +164,31 @@ mod tests {
         let dir = tempdir_like("roundtrip");
         let file = dir.join("store.json");
         let store = WebStore::open(file.clone());
-        assert_eq!(store.read("missing"), None);
+        assert_eq!(store.read("missing").unwrap(), None);
 
-        store.write("terminals/p1", serde_json::json!({ "active": "t1" })).unwrap();
-        store.write("settings", serde_json::json!({ "theme": "dark" })).unwrap();
+        store.write("terminals/p1", serde_json::json!({ "active": "t1" }), None).unwrap();
+        store.write("settings", serde_json::json!({ "theme": "dark" }), None).unwrap();
         assert_eq!(
-            store.read("settings"),
+            store.read("settings").unwrap(),
             Some(serde_json::json!({ "theme": "dark" }))
         );
         assert_eq!(
-            store.read("terminals/p1"),
+            store.read("terminals/p1").unwrap(),
             Some(serde_json::json!({ "active": "t1" }))
         );
 
         // A second open (simulating a restart) reloads the persisted map.
         let reloaded = WebStore::open(file.clone());
-        assert_eq!(reloaded.read("settings"), Some(serde_json::json!({ "theme": "dark" })));
+        assert_eq!(reloaded.read("settings").unwrap(), Some(serde_json::json!({ "theme": "dark" })));
 
         // delete removes + persists.
         assert!(reloaded.delete("settings").unwrap());
-        assert_eq!(reloaded.read("settings"), None);
+        assert_eq!(reloaded.read("settings").unwrap(), None);
         assert!(!reloaded.delete("settings").unwrap());
         let reloaded_again = WebStore::open(file.clone());
-        assert_eq!(reloaded_again.read("settings"), None);
+        assert_eq!(reloaded_again.read("settings").unwrap(), None);
         assert_eq!(
-            reloaded_again.read("terminals/p1"),
+            reloaded_again.read("terminals/p1").unwrap(),
             Some(serde_json::json!({ "active": "t1" }))
         );
         cleanup(&dir);
@@ -178,9 +199,9 @@ mod tests {
         let dir = tempdir_like("replace");
         let file = dir.join("store.json");
         let store = WebStore::open(file.clone());
-        store.write("k", serde_json::json!(1)).unwrap();
-        store.write("k", serde_json::json!(2)).unwrap();
-        assert_eq!(store.read("k"), Some(serde_json::json!(2)));
+        store.write("k", serde_json::json!(1), None).unwrap();
+        store.write("k", serde_json::json!(2), None).unwrap();
+        assert_eq!(store.read("k").unwrap(), Some(serde_json::json!(2)));
 
         let temps: Vec<_> = std::fs::read_dir(&dir)
             .expect("read dir")
@@ -203,7 +224,7 @@ mod tests {
         std::fs::write(&file, "{ not valid json").expect("write garbage");
 
         let store = WebStore::open(file.clone());
-        assert_eq!(store.read("anything"), None);
+        assert_eq!(store.read("anything").unwrap(), None);
 
         let backups: Vec<_> = std::fs::read_dir(&dir)
             .expect("read dir")
@@ -218,9 +239,9 @@ mod tests {
         assert_eq!(backups.len(), 1, "exactly one corrupt backup");
 
         // A write after recovery recreates a valid file.
-        store.write("k", serde_json::json!("v")).unwrap();
+        store.write("k", serde_json::json!("v"), None).unwrap();
         let reloaded = WebStore::open(file);
-        assert_eq!(reloaded.read("k"), Some(serde_json::json!("v")));
+        assert_eq!(reloaded.read("k").unwrap(), Some(serde_json::json!("v")));
         cleanup(&dir);
     }
 }

--- a/src-tauri/src/web/workspace_api.rs
+++ b/src-tauri/src/web/workspace_api.rs
@@ -334,6 +334,7 @@ mod tests {
             workspace_manifest: Some(store),
             acp_catalog: None,
             acp_install: None,
+            store: None,
         }
     }
 
@@ -359,6 +360,7 @@ mod tests {
             workspace_manifest: None,
             acp_catalog: None,
             acp_install: None,
+            store: None,
         }
     }
 

--- a/src-tauri/src/web/worktree_api.rs
+++ b/src-tauri/src/web/worktree_api.rs
@@ -578,6 +578,7 @@ mod tests {
             workspace_manifest: None,
             acp_catalog: None,
             acp_install: None,
+            store: None,
         }
     }
 
@@ -1028,6 +1029,7 @@ mod tests {
             None,
             project_root,
             HistoryMode::LiveOnly,
+            None,
             None,
             None,
             None,

--- a/src-tauri/src/web/ws.rs
+++ b/src-tauri/src/web/ws.rs
@@ -1810,9 +1810,14 @@ async fn handle_store_read(
     let Some(store) = store.cloned() else {
         return WsReply::err_with_code(id, "STORE_UNAVAILABLE", "server store is unavailable");
     };
-    match store.read(&parsed.key) {
-        Ok(value) => WsReply::ok(id, Some(json!({ "value": value }))),
-        Err(e) => WsReply::err_with_code(id, "STORE_UNAVAILABLE", e.to_string()),
+    let result = tokio::task::spawn_blocking(move || store.read(&parsed.key)).await;
+    match result {
+        Ok(Ok(value)) => WsReply::ok(id, Some(json!({ "value": value }))),
+        Ok(Err(e)) => WsReply::err_with_code(id, "STORE_UNAVAILABLE", e.to_string()),
+        Err(join_err) => {
+            tracing::warn!("store_read task failed: {join_err}");
+            WsReply::err_with_code(id, "STORE_UNAVAILABLE", format!("store read task failed: {join_err}"))
+        }
     }
 }
 
@@ -1849,7 +1854,10 @@ async fn handle_store_write(
             tracing::warn!("store_write failed: {error}");
             WsReply::err_with_code(id, "STORE_WRITE_FAILED", format!("store write failed: {error}"))
         }
-        Err(join_err) => WsReply::err_with_code(id, "STORE_WRITE_FAILED", format!("task failed: {join_err}")),
+        Err(join_err) => {
+            tracing::warn!("store_write task failed: {join_err}");
+            WsReply::err_with_code(id, "STORE_WRITE_FAILED", format!("task failed: {join_err}"))
+        }
     }
 }
 
@@ -1882,7 +1890,10 @@ async fn handle_store_delete(
             tracing::warn!("store_delete failed: {error}");
             WsReply::err_with_code(id, "STORE_DELETE_FAILED", format!("store delete failed: {error}"))
         }
-        Err(join_err) => WsReply::err_with_code(id, "STORE_DELETE_FAILED", format!("task failed: {join_err}")),
+        Err(join_err) => {
+            tracing::warn!("store_delete task failed: {join_err}");
+            WsReply::err_with_code(id, "STORE_DELETE_FAILED", format!("task failed: {join_err}"))
+        }
     }
 }
 

--- a/src-tauri/src/web/ws.rs
+++ b/src-tauri/src/web/ws.rs
@@ -1779,6 +1779,8 @@ struct StoreReadPayload {
 struct StoreWritePayload {
     key: String,
     value: Value,
+    #[serde(default)]
+    expected: Option<Value>,
 }
 
 /// `store_delete` WS request payload.
@@ -1808,7 +1810,10 @@ async fn handle_store_read(
     let Some(store) = store.cloned() else {
         return WsReply::err_with_code(id, "STORE_UNAVAILABLE", "server store is unavailable");
     };
-    WsReply::ok(id, Some(json!({ "value": store.read(&parsed.key) })))
+    match store.read(&parsed.key) {
+        Ok(value) => WsReply::ok(id, Some(json!({ "value": value }))),
+        Err(e) => WsReply::err_with_code(id, "STORE_UNAVAILABLE", e.to_string()),
+    }
 }
 
 /// `store_write` → `WebStore::write` (atomic replace). Reply = `{}`.
@@ -1830,13 +1835,21 @@ async fn handle_store_write(
     let Some(store) = store.cloned() else {
         return WsReply::err_with_code(id, "STORE_UNAVAILABLE", "server store is unavailable");
     };
-    match store.write(&parsed.key, parsed.value) {
-        Ok(()) => WsReply::ok(id, Some(json!({}))),
-        Err(error) => WsReply::err_with_code(
-            id,
-            "STORE_WRITE_FAILED",
-            format!("store write failed: {error}"),
-        ),
+    if parsed.key.len() > 1024 {
+        return WsReply::err_with_code(id, "VALIDATION_ERROR", "key too long");
+    }
+    let store_clone = store.clone();
+    let result = tokio::task::spawn_blocking(move || {
+        store_clone.write(&parsed.key, parsed.value, parsed.expected)
+    }).await;
+    match result {
+        Ok(Ok(true)) => WsReply::ok(id, Some(json!({}))),
+        Ok(Ok(false)) => WsReply::err_with_code(id, "STORE_CAS_FAILED", "store write rejected: value changed concurrently"),
+        Ok(Err(error)) => {
+            tracing::warn!("store_write failed: {error}");
+            WsReply::err_with_code(id, "STORE_WRITE_FAILED", format!("store write failed: {error}"))
+        }
+        Err(join_err) => WsReply::err_with_code(id, "STORE_WRITE_FAILED", format!("task failed: {join_err}")),
     }
 }
 
@@ -1859,13 +1872,17 @@ async fn handle_store_delete(
     let Some(store) = store.cloned() else {
         return WsReply::err_with_code(id, "STORE_UNAVAILABLE", "server store is unavailable");
     };
-    match store.delete(&parsed.key) {
-        Ok(existed) => WsReply::ok(id, Some(json!({ "existed": existed }))),
-        Err(error) => WsReply::err_with_code(
-            id,
-            "STORE_DELETE_FAILED",
-            format!("store delete failed: {error}"),
-        ),
+    let store_clone = store.clone();
+    let result = tokio::task::spawn_blocking(move || {
+        store_clone.delete(&parsed.key)
+    }).await;
+    match result {
+        Ok(Ok(existed)) => WsReply::ok(id, Some(json!({ "existed": existed }))),
+        Ok(Err(error)) => {
+            tracing::warn!("store_delete failed: {error}");
+            WsReply::err_with_code(id, "STORE_DELETE_FAILED", format!("store delete failed: {error}"))
+        }
+        Err(join_err) => WsReply::err_with_code(id, "STORE_DELETE_FAILED", format!("task failed: {join_err}")),
     }
 }
 
@@ -4357,7 +4374,7 @@ mod tests {
         let dir = std::env::temp_dir().join(format!("termul-ws-store-del-{}", uuid::Uuid::new_v4()));
         std::fs::create_dir_all(&dir).unwrap();
         let store = Arc::new(WebStore::open(dir.join("store.json")));
-        store.write("k", json!("v")).unwrap();
+        store.write("k", json!("v"), None).unwrap();
 
         let del = handle_request_with_store(
             r#"{"id":"r1","type":"store_delete","payload":{"key":"k"}}"#,
@@ -4366,7 +4383,7 @@ mod tests {
         .await;
         assert!(del.ok, "delete ok: {:?}", del.err);
         assert_eq!(del.payload.as_ref().and_then(|p| p.get("existed")), Some(&json!(true)));
-        assert_eq!(store.read("k"), None);
+        assert_eq!(store.read("k").unwrap(), None);
 
         let del2 = handle_request_with_store(
             r#"{"id":"r2","type":"store_delete","payload":{"key":"k"}}"#,

--- a/src-tauri/src/web/ws.rs
+++ b/src-tauri/src/web/ws.rs
@@ -46,6 +46,7 @@ use crate::trackers::{CwdTracker, ExitCodeTracker, GitTracker, TerminalEventHub}
 use crate::web::permissions::{TurnClaim, DEFAULT_PERMISSION_RECONNECT_GRACE};
 use crate::web::project_registry::{ProjectRegistry, ProjectSwitchContext};
 use crate::web::sink::{broadcast_projects_changed, ClientId, ReplayResult, WsRelaySink};
+use crate::web::store::WebStore;
 
 // ---------------------------------------------------------------------------
 // Sequenced event — the wire envelope (AC2 + AC3)
@@ -344,6 +345,12 @@ pub struct AppState {
     /// `install_acp_agent`; the desktop renderer uses the `acp_install_agent`
     /// Tauri command (same `IpcResult<T>` shape byte-for-byte).
     pub acp_install: Option<Arc<crate::acp::install::AcpInstallService>>,
+    /// Issue #613: server-side generic key-value store for web-client state
+    /// (terminal layout, settings, editor state, command history, snapshots,
+    /// SSH profiles). `None` when a server does not attach a store — the
+    /// `store_*` WS handlers return `STORE_UNAVAILABLE` (degraded mode). The
+    /// standalone binary + desktop shared-live host both attach one.
+    pub store: Option<Arc<WebStore>>,
     /// PR-S4 / CAP-1: the project-root boundary for the fs_api / git / skills /
     /// search routes. Requests whose canonicalized target path resolves outside
     /// this root are refused with `code: "OUTSIDE_ROOT"` (or `PATH_TRAVERSAL`
@@ -520,6 +527,9 @@ async fn run_relay(socket: WebSocket, state: AppState) {
     // CAP-6 / Story 9: the host-owned verified-atomic ACP install service for
     // the `install_acp_agent` WS request.
     let acp_install = state.acp_install.clone();
+    // Issue #613: the server-side generic key-value store behind the
+    // `store_read` / `store_write` / `store_delete` WS requests.
+    let store = state.store.clone();
     // Client ids registered via `subscribe` — unregistered on disconnect.
     let subscribed_clients = Arc::new(tokio::sync::Mutex::new(Vec::<(String, ClientId)>::new()));
     let cleanup = ConnectionCleanup::new(Arc::clone(&relay), Arc::clone(&subscribed_clients));
@@ -649,6 +659,7 @@ async fn run_relay(socket: WebSocket, state: AppState) {
                         history_mode,
                         acp_catalog.as_ref(),
                         acp_install.as_ref(),
+                        store.as_ref(),
                     )
                     .await
                     {
@@ -785,6 +796,7 @@ async fn dispatch_connection_text(
     history_mode: HistoryMode,
     acp_catalog: Option<&Arc<crate::acp::AcpCatalogService>>,
     acp_install: Option<&Arc<crate::acp::install::AcpInstallService>>,
+    store: Option<&Arc<WebStore>>,
 ) -> bool {
     if let Some((id, payload)) = authenticated_send_prompt(text, *authed) {
         return match accept_send_prompt(id, &payload, acp, relay).await {
@@ -819,6 +831,7 @@ async fn dispatch_connection_text(
         history_mode,
         acp_catalog,
         acp_install,
+        store,
     )
     .await;
     write_tx.send(Outbound::Reply(reply)).is_ok()
@@ -901,6 +914,7 @@ async fn handle_request(
     history_mode: HistoryMode,
     acp_catalog: Option<&Arc<crate::acp::AcpCatalogService>>,
     acp_install: Option<&Arc<crate::acp::install::AcpInstallService>>,
+    store: Option<&Arc<WebStore>>,
 ) -> WsReply {
     let req: WsRequest = match serde_json::from_str(text) {
         Ok(r) => r,
@@ -1111,6 +1125,13 @@ async fn handle_request(
         "install_acp_agent" => {
             handle_install_acp_agent(id, &req.payload, acp_install).await
         }
+        // Issue #613: server-side generic key-value store. The web client
+        // routes its `persistenceApi` through these (replacing the per-browser
+        // localStorage stub) so settings / layout / command history / SSH
+        // profiles survive browser switches + server restarts.
+        "store_read" => handle_store_read(id, &req.payload, store).await,
+        "store_write" => handle_store_write(id, &req.payload, store).await,
+        "store_delete" => handle_store_delete(id, &req.payload, store).await,
         "kill_agent" => {
             handle_kill_agent(
                 id,
@@ -1739,6 +1760,112 @@ async fn handle_install_acp_agent(
     match service.install_by_id(&parsed.agent_id).await {
         Ok(outcome) => ok_with_payload(id, &outcome),
         Err(error) => WsReply::err_with_code(id, error.code(), error.message),
+    }
+}
+
+// --- Issue #613: server-side generic key-value store -------------------------
+
+/// `store_read` WS request payload. `deny_unknown_fields` rejects an
+/// over-serialized payload loudly at the host boundary.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct StoreReadPayload {
+    key: String,
+}
+
+/// `store_write` WS request payload. `value` is any JSON value.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct StoreWritePayload {
+    key: String,
+    value: Value,
+}
+
+/// `store_delete` WS request payload.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct StoreDeletePayload {
+    key: String,
+}
+
+/// `store_read` → `WebStore::read`. Reply = `{ value: <json | null> }`.
+/// Degrade-mode (`store: None`) returns `STORE_UNAVAILABLE`.
+async fn handle_store_read(
+    id: String,
+    payload: &Value,
+    store: Option<&Arc<WebStore>>,
+) -> WsReply {
+    let parsed: StoreReadPayload = match serde_json::from_value(payload.clone()) {
+        Ok(p) => p,
+        Err(e) => {
+            return WsReply::err_with_code(
+                id,
+                "VALIDATION_ERROR",
+                format!("malformed store_read payload (want key): {e}"),
+            )
+        }
+    };
+    let Some(store) = store.cloned() else {
+        return WsReply::err_with_code(id, "STORE_UNAVAILABLE", "server store is unavailable");
+    };
+    WsReply::ok(id, Some(json!({ "value": store.read(&parsed.key) })))
+}
+
+/// `store_write` → `WebStore::write` (atomic replace). Reply = `{}`.
+async fn handle_store_write(
+    id: String,
+    payload: &Value,
+    store: Option<&Arc<WebStore>>,
+) -> WsReply {
+    let parsed: StoreWritePayload = match serde_json::from_value(payload.clone()) {
+        Ok(p) => p,
+        Err(e) => {
+            return WsReply::err_with_code(
+                id,
+                "VALIDATION_ERROR",
+                format!("malformed store_write payload (want key + value): {e}"),
+            )
+        }
+    };
+    let Some(store) = store.cloned() else {
+        return WsReply::err_with_code(id, "STORE_UNAVAILABLE", "server store is unavailable");
+    };
+    match store.write(&parsed.key, parsed.value) {
+        Ok(()) => WsReply::ok(id, Some(json!({}))),
+        Err(error) => WsReply::err_with_code(
+            id,
+            "STORE_WRITE_FAILED",
+            format!("store write failed: {error}"),
+        ),
+    }
+}
+
+/// `store_delete` → `WebStore::delete`. Reply = `{ existed: bool }`.
+async fn handle_store_delete(
+    id: String,
+    payload: &Value,
+    store: Option<&Arc<WebStore>>,
+) -> WsReply {
+    let parsed: StoreDeletePayload = match serde_json::from_value(payload.clone()) {
+        Ok(p) => p,
+        Err(e) => {
+            return WsReply::err_with_code(
+                id,
+                "VALIDATION_ERROR",
+                format!("malformed store_delete payload (want key): {e}"),
+            )
+        }
+    };
+    let Some(store) = store.cloned() else {
+        return WsReply::err_with_code(id, "STORE_UNAVAILABLE", "server store is unavailable");
+    };
+    match store.delete(&parsed.key) {
+        Ok(existed) => WsReply::ok(id, Some(json!({ "existed": existed }))),
+        Err(error) => WsReply::err_with_code(
+            id,
+            "STORE_DELETE_FAILED",
+            format!("store delete failed: {error}"),
+        ),
     }
 }
 
@@ -3626,6 +3753,7 @@ mod tests {
                 HistoryMode::LiveOnly,
                 None,
                 None,
+                None,
             )
             .await
         );
@@ -3651,6 +3779,7 @@ mod tests {
                 &current_project,
                 &switch_queue,
                 HistoryMode::LiveOnly,
+                None,
                 None,
                 None,
             )
@@ -3754,6 +3883,7 @@ mod tests {
                 HistoryMode::LiveOnly,
                 None,
                 None,
+                None,
             )
             .await
         );
@@ -3773,6 +3903,7 @@ mod tests {
                 &current_project,
                 &switch_queue,
                 HistoryMode::LiveOnly,
+                None,
                 None,
                 None,
             )
@@ -3899,6 +4030,7 @@ mod tests {
                 HistoryMode::Server,
                 None,
                 None,
+                None,
             )
             .await
         );
@@ -3979,6 +4111,7 @@ mod tests {
             &switch_queue,
             HistoryMode::LiveOnly,
             Some(catalog),
+            None,
             None,
         )
         .await
@@ -4081,6 +4214,7 @@ mod tests {
             HistoryMode::LiveOnly,
             None,
             None,
+            None,
         )
         .await
     }
@@ -4126,6 +4260,161 @@ mod tests {
         .await;
         assert!(!reply.ok);
         assert_eq!(reply.err.as_ref().unwrap().code, "VALIDATION_ERROR");
+    }
+
+    // ---- Issue #613: server-side generic key-value store WS handlers ----
+
+    /// Dispatch `text` through `handle_request` with a real `WebStore` attached.
+    async fn handle_request_with_store(text: &str, store: &Arc<WebStore>) -> WsReply {
+        let relay = Arc::new(WsRelaySink::new());
+        let acp = Arc::new(AcpManager::new(vec![]));
+        let (tx, _rx) = mpsc::unbounded_channel::<Outbound>();
+        let mut subs = Vec::new();
+        let registry = Arc::new(ProjectRegistry::new());
+        let mut current_agent: Option<AgentId> = None;
+        let current_session = Arc::new(parking_lot::Mutex::new(None::<SessionId>));
+        let current_project = Arc::new(parking_lot::Mutex::new(None::<String>));
+        let switch_queue = Arc::new(tokio::sync::Mutex::new(ProjectSwitchQueue::default()));
+        let mut authed = true;
+        handle_request(
+            text,
+            &mut authed,
+            &acp,
+            &relay,
+            &registry,
+            None,
+            None,
+            &tx,
+            &mut subs,
+            &mut current_agent,
+            &current_session,
+            &current_project,
+            &switch_queue,
+            HistoryMode::LiveOnly,
+            None,
+            None,
+            Some(store),
+        )
+        .await
+    }
+
+    #[tokio::test]
+    async fn store_write_then_read_roundtrips() {
+        let dir = std::env::temp_dir().join(format!("termul-ws-store-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let store = Arc::new(WebStore::open(dir.join("store.json")));
+
+        let write = handle_request_with_store(
+            r#"{"id":"r1","type":"store_write","payload":{"key":"settings","value":{"theme":"dark"}}}"#,
+            &store,
+        )
+        .await;
+        assert!(write.ok, "write ok: {:?}", write.err);
+
+        let read = handle_request_with_store(
+            r#"{"id":"r2","type":"store_read","payload":{"key":"settings"}}"#,
+            &store,
+        )
+        .await;
+        assert!(read.ok, "read ok: {:?}", read.err);
+        assert_eq!(
+            read.payload.as_ref().and_then(|p| p.get("value")),
+            Some(&json!({ "theme": "dark" }))
+        );
+
+        // A second open (fresh connection) still sees the value — server-side
+        // persistence, not per-connection memory.
+        let reopened = Arc::new(WebStore::open(dir.join("store.json")));
+        let read2 = handle_request_with_store(
+            r#"{"id":"r3","type":"store_read","payload":{"key":"settings"}}"#,
+            &reopened,
+        )
+        .await;
+        assert_eq!(
+            read2.payload.as_ref().and_then(|p| p.get("value")),
+            Some(&json!({ "theme": "dark" }))
+        );
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    #[tokio::test]
+    async fn store_read_missing_key_returns_null_value() {
+        let dir = std::env::temp_dir().join(format!("termul-ws-store-miss-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let store = Arc::new(WebStore::open(dir.join("store.json")));
+        let reply = handle_request_with_store(
+            r#"{"id":"r1","type":"store_read","payload":{"key":"nope"}}"#,
+            &store,
+        )
+        .await;
+        assert!(reply.ok, "missing key is not an error: {:?}", reply.err);
+        assert_eq!(reply.payload.as_ref().and_then(|p| p.get("value")), Some(&Value::Null));
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    #[tokio::test]
+    async fn store_delete_removes_and_reports_existed() {
+        let dir = std::env::temp_dir().join(format!("termul-ws-store-del-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let store = Arc::new(WebStore::open(dir.join("store.json")));
+        store.write("k", json!("v")).unwrap();
+
+        let del = handle_request_with_store(
+            r#"{"id":"r1","type":"store_delete","payload":{"key":"k"}}"#,
+            &store,
+        )
+        .await;
+        assert!(del.ok, "delete ok: {:?}", del.err);
+        assert_eq!(del.payload.as_ref().and_then(|p| p.get("existed")), Some(&json!(true)));
+        assert_eq!(store.read("k"), None);
+
+        let del2 = handle_request_with_store(
+            r#"{"id":"r2","type":"store_delete","payload":{"key":"k"}}"#,
+            &store,
+        )
+        .await;
+        assert!(del2.ok, "delete of missing key is not an error: {:?}", del2.err);
+        assert_eq!(del2.payload.as_ref().and_then(|p| p.get("existed")), Some(&json!(false)));
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    #[tokio::test]
+    async fn store_handlers_degraded_return_unavailable() {
+        // No store attached — same `handle_request_without_catalog` plumbing
+        // (store: None). All three store_* requests must fail loudly.
+        for frame in [
+            r#"{"id":"r1","type":"store_read","payload":{"key":"k"}}"#,
+            r#"{"id":"r2","type":"store_write","payload":{"key":"k","value":1}}"#,
+            r#"{"id":"r3","type":"store_delete","payload":{"key":"k"}}"#,
+        ] {
+            let reply = handle_request_without_catalog(frame).await;
+            assert!(!reply.ok, "degraded {frame} must fail");
+            assert_eq!(reply.err.as_ref().unwrap().code, "STORE_UNAVAILABLE");
+        }
+    }
+
+    #[tokio::test]
+    async fn store_malformed_payload_returns_validation_error() {
+        let dir = std::env::temp_dir().join(format!("termul-ws-store-bad-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let store = Arc::new(WebStore::open(dir.join("store.json")));
+        // Missing `key` fails the payload serde.
+        let reply = handle_request_with_store(
+            r#"{"id":"r1","type":"store_read","payload":{}}"#,
+            &store,
+        )
+        .await;
+        assert!(!reply.ok);
+        assert_eq!(reply.err.as_ref().unwrap().code, "VALIDATION_ERROR");
+        // store_write without a `value` also fails serde.
+        let reply2 = handle_request_with_store(
+            r#"{"id":"r2","type":"store_write","payload":{"key":"k"}}"#,
+            &store,
+        )
+        .await;
+        assert!(!reply2.ok);
+        assert_eq!(reply2.err.as_ref().unwrap().code, "VALIDATION_ERROR");
+        let _ = std::fs::remove_dir_all(dir);
     }
 
     // ---- Cross-client host-authority (Category C / Recovery Matrix: Browser A → Browser B) ----
@@ -4452,6 +4741,7 @@ mod tests {
                 HistoryMode::LiveOnly,
                 None,
                 None,
+                None,
             ))
     }
 
@@ -4728,10 +5018,11 @@ mod tests {
             &mut current_agent,
             &current_session,
             &current_project,
-            &switch_queue,
-            HistoryMode::LiveOnly,
-            None,
-            Some(&store),
+            &switch_queue,                HistoryMode::LiveOnly,
+                None,
+                Some(&store),
+                None,
+
         )
         .await;
         assert!(!reply.ok, "unknown agent must fail");
@@ -4926,6 +5217,7 @@ mod tests {
                 HistoryMode::LiveOnly,
                 None,
                 None,
+                None,
             ));
         assert!(!reply.ok);
         assert_eq!(reply.err.unwrap().code, "unsupported");
@@ -5011,6 +5303,7 @@ mod tests {
             HistoryMode::LiveOnly,
             None,
             None,
+            None,
         ));
         assert!(!reply.ok);
         assert_eq!(reply.err.unwrap().code, "permission_denied");
@@ -5062,6 +5355,7 @@ mod tests {
             HistoryMode::LiveOnly,
             None,
             None,
+            None,
         ));
         assert!(!reply.ok);
         assert_eq!(reply.err.unwrap().code, "not_found");
@@ -5099,6 +5393,7 @@ mod tests {
             HistoryMode::LiveOnly,
             None,
             None,
+            None,
         ));
         assert!(ok_reply.ok, "first response wins: {:?}", ok_reply.err);
         // Second frame for the same requestId → stale (ticket evicted).
@@ -5117,6 +5412,7 @@ mod tests {
             &current_project,
             &switch_queue,
             HistoryMode::LiveOnly,
+            None,
             None,
             None,
         ));
@@ -5153,6 +5449,7 @@ mod tests {
             &current_project,
             &switch_queue,
             HistoryMode::LiveOnly,
+            None,
             None,
             None,
         ));
@@ -5244,6 +5541,7 @@ mod tests {
             HistoryMode::LiveOnly,
             None,
             None,
+            None,
         ));
         assert!(!reply.ok);
         assert_eq!(reply.err.unwrap().code, "unsupported");
@@ -5277,6 +5575,7 @@ mod tests {
             &current_project,
             &switch_queue,
             HistoryMode::LiveOnly,
+            None,
             None,
             None,
         ));
@@ -5328,6 +5627,7 @@ mod tests {
             HistoryMode::LiveOnly,
             None,
             None,
+            None,
         ));
         assert!(!reply.ok);
         assert_eq!(reply.err.unwrap().code, "not_found");
@@ -5364,6 +5664,7 @@ mod tests {
             HistoryMode::LiveOnly,
             None,
             None,
+            None,
         ));
         assert!(ok_reply.ok, "first answer wins: {:?}", ok_reply.err);
         let stale_reply = block_on(handle_request(
@@ -5381,6 +5682,7 @@ mod tests {
             &current_project,
             &switch_queue,
             HistoryMode::LiveOnly,
+            None,
             None,
             None,
         ));
@@ -5416,6 +5718,7 @@ mod tests {
             &current_project,
             &switch_queue,
             HistoryMode::LiveOnly,
+            None,
             None,
             None,
         ));
@@ -5475,6 +5778,7 @@ mod tests {
                 HistoryMode::LiveOnly,
                 None,
                 None,
+                None,
             ));
         assert!(!reply.ok);
         assert_eq!(reply.err.unwrap().code, "stale");
@@ -5500,6 +5804,7 @@ mod tests {
                 &current_project,
                 &switch_queue,
                 HistoryMode::LiveOnly,
+                None,
                 None,
                 None,
             ));
@@ -5528,6 +5833,7 @@ mod tests {
                 HistoryMode::LiveOnly,
                 None,
                 None,
+                None,
             ));
         assert!(reply_resub.ok, "{:?}", reply_resub.err);
         assert_eq!(subs2.len(), 1);
@@ -5553,6 +5859,7 @@ mod tests {
                 &current_project,
                 &switch_queue,
                 HistoryMode::LiveOnly,
+                None,
                 None,
                 None,
             ));
@@ -5607,6 +5914,7 @@ mod tests {
             &current_project,
             &switch_queue,
             HistoryMode::LiveOnly,
+            None,
             None,
             None,
         ));
@@ -5666,6 +5974,7 @@ mod tests {
             &current_project,
             &switch_queue,
             HistoryMode::LiveOnly,
+            None,
             None,
             None,
         ));
@@ -5782,6 +6091,7 @@ mod tests {
             &current_project,
             &switch_queue,
             HistoryMode::LiveOnly,
+            None,
             None,
             None,
         ));
@@ -6534,6 +6844,7 @@ mod tests {
             &current_project_a,
             &switch_queue,
             HistoryMode::LiveOnly,
+            None,
             None,
             None,
         )

--- a/src/renderer/lib/__tests__/ssh-api.web.test.ts
+++ b/src/renderer/lib/__tests__/ssh-api.web.test.ts
@@ -1,19 +1,24 @@
 /**
  * Web-branch tests for ssh-api.ts.
  *
- * Pins `isTauriContext()` to FALSE and asserts the SSH facade returns an
- * explicit `WEB_UNSUPPORTED` result for representative command methods
- * (profile listing, connect, SFTP, askpass) instead of invoking the
- * stubbed `@tauri-apps/api/core` `invoke()` (which throws `tauriUnavailable`
- * on web). The desktop path is covered by direct invoke assertions in
- * sibling tests.
+ * Pins `isTauriContext()` to FALSE and asserts:
+ * - profile CRUD (list/save/delete) reads/writes the server-side store
+ *   (issue #613) instead of invoking Tauri commands,
+ * - connection/SFTP/askpass methods still return an explicit
+ *   `WEB_UNSUPPORTED` result instead of invoking the stubbed
+ *   `@tauri-apps/api/core` `invoke()` (which throws `tauriUnavailable` on web).
+ * The desktop path is covered by direct invoke assertions in sibling tests.
  */
 
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-const { mockIsTauriContext, mockInvoke } = vi.hoisted(() => ({
+const { mockIsTauriContext, mockInvoke, mockPersistenceApi } = vi.hoisted(() => ({
   mockIsTauriContext: vi.fn(),
-  mockInvoke: vi.fn()
+  mockInvoke: vi.fn(),
+  mockPersistenceApi: {
+    read: vi.fn(),
+    write: vi.fn()
+  }
 }))
 
 vi.mock('../tauri-runtime', () => ({
@@ -29,24 +34,87 @@ vi.mock('@tauri-apps/api/event', () => ({
   listen: vi.fn()
 }))
 
+vi.mock('../persistence-api', () => ({
+  persistenceApi: mockPersistenceApi
+}))
+
+import type { SSHProfile } from '@shared/types/ssh.types'
 import { createAskpassScript, createSSHApi } from '../ssh-api'
+
+const profile = (overrides: Partial<SSHProfile> = {}): SSHProfile => ({
+  id: 'p-1',
+  name: 'prod',
+  host: 'example.com',
+  port: 22,
+  username: 'root',
+  authMethod: 'key',
+  privateKeyPath: '/home/u/.ssh/id_ed25519',
+  portForwards: [],
+  ...overrides
+})
 
 describe('sshApi (web branch)', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     mockIsTauriContext.mockReturnValue(false)
     mockInvoke.mockReset()
+    mockPersistenceApi.read.mockReset()
+    mockPersistenceApi.write.mockReset()
+    mockPersistenceApi.write.mockResolvedValue({ success: true, data: undefined })
   })
 
-  it('listProfiles returns WEB_UNSUPPORTED when !isTauriContext()', async () => {
+  it('listProfiles returns stored profiles from the server-side store', async () => {
     const api = createSSHApi()
+    mockPersistenceApi.read.mockResolvedValue({ success: true, data: [profile()] })
+
     const result = await api.listProfiles()
 
-    expect(result.success).toBe(false)
-    if (!result.success) {
-      expect(result.code).toBe('WEB_UNSUPPORTED')
-      expect(result.error).toContain('not available')
-    }
+    expect(mockPersistenceApi.read).toHaveBeenCalledWith('ssh/profiles')
+    expect(result).toEqual({ success: true, data: [profile()] })
+    expect(mockInvoke).not.toHaveBeenCalled()
+  })
+
+  it('listProfiles returns an empty list on first run (KEY_NOT_FOUND)', async () => {
+    const api = createSSHApi()
+    mockPersistenceApi.read.mockResolvedValue({
+      success: false,
+      error: 'Key not found: ssh/profiles',
+      code: 'KEY_NOT_FOUND'
+    })
+
+    const result = await api.listProfiles()
+
+    expect(result).toEqual({ success: true, data: [] })
+  })
+
+  it('saveProfile upserts into the store and strips secrets', async () => {
+    const api = createSSHApi()
+    mockPersistenceApi.read.mockResolvedValue({ success: true, data: [] })
+
+    const result = await api.saveProfile(profile({ password: 'secret', passphrase: 'phrase' }))
+
+    expect(result.success).toBe(true)
+    const written = mockPersistenceApi.write.mock.calls[0]?.[1] as SSHProfile[]
+    expect(written).toHaveLength(1)
+    expect(written[0].password).toBeUndefined()
+    expect(written[0].passphrase).toBeUndefined()
+    expect(written[0].hasStoredPassword).toBe(false)
+    expect(written[0].id).toBe('p-1')
+    expect(mockInvoke).not.toHaveBeenCalled()
+  })
+
+  it('deleteProfile filters the stored list', async () => {
+    const api = createSSHApi()
+    mockPersistenceApi.read.mockResolvedValue({
+      success: true,
+      data: [profile({ id: 'keep' }), profile({ id: 'drop' })]
+    })
+
+    const result = await api.deleteProfile('drop')
+
+    expect(result.success).toBe(true)
+    const written = mockPersistenceApi.write.mock.calls[0]?.[1] as SSHProfile[]
+    expect(written.map((p) => p.id)).toEqual(['keep'])
     expect(mockInvoke).not.toHaveBeenCalled()
   })
 

--- a/src/renderer/lib/__tests__/web-persistence-api.test.ts
+++ b/src/renderer/lib/__tests__/web-persistence-api.test.ts
@@ -1,0 +1,162 @@
+/**
+ * Tests for the web-mode persistence API (issue #613).
+ *
+ * Uses a fake WebSocket that speaks the minimal WS handshake
+ * (`auth_required` → `authenticate`) and serves `store_read` / `store_write`
+ * / `store_delete` from an in-memory map, mirroring the Rust `WebStore`.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createWebPersistenceApi } from '../web-persistence-api'
+
+class FakeStoreSocket {
+  static OPEN = 1
+  static CONNECTING = 0
+  static CLOSING = 2
+  static CLOSED = 3
+
+  readyState = FakeStoreSocket.CONNECTING
+  onopen: ((ev: Event) => void) | null = null
+  onmessage: ((ev: MessageEvent) => void) | null = null
+  onerror: ((ev: Event) => void) | null = null
+  onclose: ((ev: CloseEvent) => void) | null = null
+  sent: string[] = []
+  store = new Map<string, unknown>()
+  /** When set, every non-auth request replies with this error. */
+  failCode: string | null = null
+
+  constructor(public url: string) {
+    queueMicrotask(() => {
+      this.readyState = FakeStoreSocket.OPEN
+      this.onopen?.(new Event('open'))
+      this.emit({ type: 'auth_required', payload: {} })
+    })
+  }
+
+  emit(msg: unknown): void {
+    this.onmessage?.({ data: JSON.stringify(msg) } as MessageEvent)
+  }
+
+  send(data: string): void {
+    this.sent.push(data)
+    const req = JSON.parse(data) as {
+      id: string
+      type: string
+      payload: { key?: string; value?: unknown }
+    }
+    if (req.type === 'authenticate') {
+      this.emit({ id: req.id, ok: true, payload: {} })
+      return
+    }
+    if (this.failCode) {
+      this.emit({ id: req.id, ok: false, err: { code: this.failCode, message: 'store failed' } })
+      return
+    }
+    const key = req.payload.key as string
+    if (req.type === 'store_read') {
+      this.emit({ id: req.id, ok: true, payload: { value: this.store.get(key) ?? null } })
+      return
+    }
+    if (req.type === 'store_write') {
+      this.store.set(key, req.payload.value)
+      this.emit({ id: req.id, ok: true, payload: {} })
+      return
+    }
+    if (req.type === 'store_delete') {
+      const existed = this.store.delete(key)
+      this.emit({ id: req.id, ok: true, payload: { existed } })
+      return
+    }
+    this.emit({ id: req.id, ok: false, err: { code: 'not_implemented', message: 'unknown' } })
+  }
+
+  close(): void {
+    /* no-op */
+  }
+}
+
+const okVoid = { success: true, data: undefined }
+
+describe('createWebPersistenceApi', () => {
+  let sockets: FakeStoreSocket[]
+  let api: ReturnType<typeof createWebPersistenceApi>
+
+  beforeEach(() => {
+    sockets = []
+    class TrackerSocket extends FakeStoreSocket {
+      constructor(url: string) {
+        super(url)
+        sockets.push(this)
+      }
+    }
+    api = createWebPersistenceApi({ WebSocketImpl: TrackerSocket as unknown as typeof WebSocket })
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('read returns KEY_NOT_FOUND for a missing key', async () => {
+    const result = await api.read('settings')
+    expect(result).toEqual({
+      success: false,
+      error: 'Key not found: settings',
+      code: 'KEY_NOT_FOUND'
+    })
+  })
+
+  it('read unwraps a versioned value written by write', async () => {
+    await api.write('settings', { theme: 'dark' })
+    const result = await api.read<{ theme: string }>('settings')
+    expect(result).toEqual({ success: true, data: { theme: 'dark' } })
+  })
+
+  it('write persists a versioned payload to the server', async () => {
+    const result = await api.write('settings', { theme: 'dark' })
+    expect(result).toEqual(okVoid)
+    const stored = sockets[0].store.get('settings') as { _version: number; data: unknown }
+    expect(stored).toEqual({ _version: 1, data: { theme: 'dark' } })
+  })
+
+  it('delete removes a key', async () => {
+    await api.write('k', 1)
+    const result = await api.delete('k')
+    expect(result).toEqual(okVoid)
+    expect(sockets[0].store.has('k')).toBe(false)
+  })
+
+  it('writeDebounced coalesces rapid writes into a single store_write', async () => {
+    vi.useFakeTimers()
+    const p1 = api.writeDebounced('k', 1)
+    const p2 = api.writeDebounced('k', 2)
+    await vi.advanceTimersByTimeAsync(500)
+    await expect(p1).resolves.toEqual(okVoid)
+    await expect(p2).resolves.toEqual(okVoid)
+
+    const writes = sockets[0].sent.filter((s) => JSON.parse(s).type === 'store_write')
+    expect(writes).toHaveLength(1)
+    const stored = JSON.parse(writes[0]).payload.value as { data: unknown }
+    expect(stored.data).toBe(2)
+  })
+
+  it('flushPendingWrites flushes immediately', async () => {
+    vi.useFakeTimers()
+    const p = api.writeDebounced('k', { a: 1 })
+    const result = await api.flushPendingWrites()
+    expect(result).toEqual(okVoid)
+    await expect(p).resolves.toEqual(okVoid)
+    expect(sockets[0].store.get('k')).toEqual({ _version: 1, data: { a: 1 } })
+  })
+
+  it('maps a server error code into the IpcResult', async () => {
+    // Warm the socket (connect is lazy) before arming the failure.
+    await api.read('warmup')
+    sockets[0].failCode = 'STORE_UNAVAILABLE'
+    const result = await api.write('k', 1)
+    expect(result).toEqual({
+      success: false,
+      error: 'store failed',
+      code: 'STORE_UNAVAILABLE'
+    })
+  })
+})

--- a/src/renderer/lib/persistence-api.ts
+++ b/src/renderer/lib/persistence-api.ts
@@ -1,8 +1,17 @@
 /**
  * Persistence API Singleton
+ *
+ * Desktop (Tauri): `tauriPersistenceApi` — plugin-store file.
+ * Web (termul-server): `webPersistenceApi` — server-side JSON store over the
+ * authenticated WS protocol (issue #613), so web-client state survives browser
+ * switches / refreshes instead of per-browser localStorage.
  */
 
 import type { PersistenceApi } from '@shared/types/ipc.types'
 import { createTauriPersistenceApi } from './tauri-persistence-api'
+import { isTauriContext } from './tauri-runtime'
+import { createWebPersistenceApi } from './web-persistence-api'
 
-export const persistenceApi: PersistenceApi = createTauriPersistenceApi()
+export const persistenceApi: PersistenceApi = isTauriContext()
+  ? createTauriPersistenceApi()
+  : createWebPersistenceApi()

--- a/src/renderer/lib/ssh-api.ts
+++ b/src/renderer/lib/ssh-api.ts
@@ -105,23 +105,34 @@ export function createSSHApi(): SSHApi {
 
     async saveProfile(profile: SSHProfile): Promise<IpcResult<void>> {
       if (!isTauriContext()) {
-        const list = await readProfilesFromStore()
-        if (!list.success) return list
-        const updated = list.data.filter((p) => p.id !== profile.id)
-        updated.push(toStoredProfile(profile))
-        return persistenceApi.write(SSH_PROFILES_KEY, updated)
+        for (let attempt = 0; attempt < 5; attempt++) {
+          const list = await readProfilesFromStore()
+          if (!list.success) return list
+          const updated = list.data.filter((p) => p.id !== profile.id)
+          updated.push(toStoredProfile(profile))
+
+          // webPersistenceApi supports CAS via an undocumented 3rd parameter `expected`
+          // We cast it to any to bypass the strict signature in ipc.types.ts
+          const res = await (persistenceApi.write as any)(SSH_PROFILES_KEY, updated, list.data)
+          if (res.success || res.code !== 'STORE_CAS_FAILED') return res
+        }
+        return { success: false, error: 'Concurrent modification failed', code: 'STORE_CAS_FAILED' }
       }
       return invokeIpc<void>(SSH_COMMANDS.SAVE_PROFILE, { profile })
     },
 
     async deleteProfile(profileId: string): Promise<IpcResult<void>> {
       if (!isTauriContext()) {
-        const list = await readProfilesFromStore()
-        if (!list.success) return list
-        return persistenceApi.write(
-          SSH_PROFILES_KEY,
-          list.data.filter((p) => p.id !== profileId)
-        )
+        for (let attempt = 0; attempt < 5; attempt++) {
+          const list = await readProfilesFromStore()
+          if (!list.success) return list
+          const updated = list.data.filter((p) => p.id !== profileId)
+          if (updated.length === list.data.length) return { success: true, data: undefined }
+
+          const res = await (persistenceApi.write as any)(SSH_PROFILES_KEY, updated, list.data)
+          if (res.success || res.code !== 'STORE_CAS_FAILED') return res
+        }
+        return { success: false, error: 'Concurrent modification failed', code: 'STORE_CAS_FAILED' }
       }
       return invokeIpc<void>(SSH_COMMANDS.DELETE_PROFILE, { profileId })
     },

--- a/src/renderer/lib/ssh-api.ts
+++ b/src/renderer/lib/ssh-api.ts
@@ -14,7 +14,29 @@ import type {
 } from '@shared/types/ssh.types'
 import { invoke } from '@tauri-apps/api/core'
 import { listen, type UnlistenFn } from '@tauri-apps/api/event'
+import { persistenceApi } from './persistence-api'
 import { cleanupTauriListener, isTauriContext } from './tauri-runtime'
+
+/** Web mode: SSH profiles live in the server-side store (issue #613). */
+const SSH_PROFILES_KEY = 'ssh/profiles'
+
+/**
+ * Web mode has no OS keychain — persist profile metadata without secrets,
+ * mirroring the desktop store (which never writes password/passphrase to disk
+ * and only records that a keychain credential exists).
+ */
+function toStoredProfile(profile: SSHProfile): SSHProfile {
+  const { password: _password, passphrase: _passphrase, ...rest } = profile
+  return { ...rest, hasStoredPassword: false, hasStoredPassphrase: false }
+}
+
+/** Read web profiles from the server-side store; first run = empty list. */
+async function readProfilesFromStore(): Promise<IpcResult<SSHProfile[]>> {
+  const result = await persistenceApi.read<SSHProfile[]>(SSH_PROFILES_KEY)
+  if (result.success) return { success: true, data: result.data }
+  if (result.code === 'KEY_NOT_FOUND') return { success: true, data: [] }
+  return result
+}
 
 const SSH_EVENTS = {
   CONNECTION_STATUS_CHANGED: 'ssh-connection-status-changed',
@@ -74,16 +96,33 @@ async function invokeIpc<T>(
 
 export function createSSHApi(): SSHApi {
   return {
-    // Profile management
+    // Profile management — CRUD works in web mode via the server-side store;
+    // connect/SFTP/port-forwarding remain desktop-only (`WEB_UNSUPPORTED`).
     async listProfiles(): Promise<IpcResult<SSHProfile[]>> {
+      if (!isTauriContext()) return readProfilesFromStore()
       return invokeIpc<SSHProfile[]>(SSH_COMMANDS.LIST_PROFILES)
     },
 
     async saveProfile(profile: SSHProfile): Promise<IpcResult<void>> {
+      if (!isTauriContext()) {
+        const list = await readProfilesFromStore()
+        if (!list.success) return list
+        const updated = list.data.filter((p) => p.id !== profile.id)
+        updated.push(toStoredProfile(profile))
+        return persistenceApi.write(SSH_PROFILES_KEY, updated)
+      }
       return invokeIpc<void>(SSH_COMMANDS.SAVE_PROFILE, { profile })
     },
 
     async deleteProfile(profileId: string): Promise<IpcResult<void>> {
+      if (!isTauriContext()) {
+        const list = await readProfilesFromStore()
+        if (!list.success) return list
+        return persistenceApi.write(
+          SSH_PROFILES_KEY,
+          list.data.filter((p) => p.id !== profileId)
+        )
+      }
       return invokeIpc<void>(SSH_COMMANDS.DELETE_PROFILE, { profileId })
     },
 

--- a/src/renderer/lib/web-persistence-api.ts
+++ b/src/renderer/lib/web-persistence-api.ts
@@ -1,0 +1,268 @@
+/**
+ * Web persistence API (issue #613).
+ *
+ * Persists web-client app state (settings, terminal layout, editor state,
+ * command history, snapshots, SSH profiles) to the termul-server's
+ * server-side JSON store over the authenticated `/ws` protocol instead of
+ * per-browser localStorage, so state survives browser switches, refreshes,
+ * and device changes.
+ *
+ * Implements the same `PersistenceApi` interface as the desktop
+ * `tauriPersistenceApi` (plugin-store). Values are stored versioned
+ * (`{ _version, data }`) exactly like the desktop store so a store file
+ * stays readable by either implementation.
+ */
+
+import type { IpcResult, PersistenceApi } from '@shared/types/ipc.types'
+import type { WsRequest, WsRequestType } from '@shared/types/web-protocol.types'
+import { randomUUID } from '@/lib/uuid'
+import { resolveWsUrl } from './acp-transport'
+
+const DEBOUNCE_MS = 500
+const CURRENT_VERSION = 1
+
+/** Transport-level failure carrying the server's stable error `code`. */
+interface StoreError {
+  code: string
+  message: string
+}
+
+interface PendingRequest {
+  resolve: (value: unknown) => void
+  reject: (err: StoreError) => void
+}
+
+interface PendingDebounceEntry {
+  timer: ReturnType<typeof setTimeout> | null
+  data: unknown
+  resolvers: ((result: IpcResult<void>) => void)[]
+}
+
+/**
+ * Minimal authenticated WS client for the store request types. Speaks only
+ * `authenticate` + `store_read` / `store_write` / `store_delete`; replies are
+ * matched by correlation id. The connect promise settles only after the
+ * `auth_required` → `authenticate` handshake completes.
+ */
+export class WebStoreSocket {
+  private socket: WebSocket | null = null
+  private authed = false
+  private connecting: Promise<void> | null = null
+  private readonly pending = new Map<string, PendingRequest>()
+  private readonly wsUrl: string
+  private readonly wsCtor: typeof WebSocket
+
+  constructor(opts?: { url?: string; WebSocketImpl?: typeof WebSocket }) {
+    this.wsUrl =
+      opts?.url ?? (typeof window !== 'undefined' ? resolveWsUrl() : 'ws://127.0.0.1:8080/ws')
+    this.wsCtor = opts?.WebSocketImpl ?? WebSocket
+  }
+
+  async connect(): Promise<void> {
+    if (this.socket?.readyState === WebSocket.OPEN && this.authed) return
+    if (this.connecting) return this.connecting
+    this.connecting = this.open()
+    try {
+      await this.connecting
+    } finally {
+      this.connecting = null
+    }
+  }
+
+  async request<T>(type: WsRequestType, payload: unknown): Promise<T> {
+    await this.connect()
+    return new Promise<T>((resolve, reject) => {
+      const id = randomUUID()
+      const frame: WsRequest = { id, type, payload }
+      this.pending.set(id, {
+        resolve: (value) => resolve(value as T),
+        reject
+      })
+      this.socket?.send(JSON.stringify(frame))
+    })
+  }
+
+  private open(): Promise<void> {
+    return new Promise((resolve, reject) => {
+      let settled = false
+      const settleOk = () => {
+        if (settled) return
+        settled = true
+        resolve()
+      }
+      const settleErr = (err: StoreError) => {
+        if (settled) return
+        settled = true
+        reject(err)
+      }
+
+      const ws = new this.wsCtor(this.wsUrl)
+      this.socket = ws
+      this.authed = false
+
+      ws.onmessage = (ev) => {
+        let parsed: unknown
+        try {
+          parsed = JSON.parse(String(ev.data))
+        } catch {
+          return
+        }
+        if (!parsed || typeof parsed !== 'object') return
+        const obj = parsed as Record<string, unknown>
+
+        // Server asks the client to authenticate before any other request.
+        if (obj.type === 'auth_required') {
+          void this.authenticate().then(() => {
+            this.authed = true
+            settleOk()
+          }, settleErr)
+          return
+        }
+
+        // Reply frame: { id, ok, payload | err }.
+        if (typeof obj.id === 'string' && typeof obj.ok === 'boolean') {
+          const reply = obj as unknown as {
+            id: string
+            ok: boolean
+            payload?: unknown
+            err?: { code: string; message: string }
+          }
+          const pending = this.pending.get(reply.id)
+          if (!pending) return
+          this.pending.delete(reply.id)
+          if (reply.ok) pending.resolve(reply.payload)
+          else pending.reject(reply.err ?? { code: 'WS_ERROR', message: 'store request failed' })
+        }
+      }
+
+      ws.onerror = () => {
+        this.rejectAll({ code: 'WS_ERROR', message: 'WebSocket error' })
+        settleErr({ code: 'WS_ERROR', message: 'WebSocket error' })
+      }
+
+      ws.onclose = () => {
+        this.socket = null
+        this.authed = false
+        this.rejectAll({ code: 'WS_ERROR', message: 'WebSocket closed' })
+        settleErr({ code: 'WS_ERROR', message: 'WebSocket closed' })
+      }
+    })
+  }
+
+  private authenticate(): Promise<void> {
+    return new Promise<void>((resolve, reject) => {
+      const id = randomUUID()
+      const frame: WsRequest = { id, type: 'authenticate', payload: { token: 'dev' } }
+      this.pending.set(id, { resolve: () => resolve(), reject })
+      this.socket?.send(JSON.stringify(frame))
+    })
+  }
+
+  private rejectAll(err: StoreError): void {
+    for (const [, p] of this.pending) p.reject(err)
+    this.pending.clear()
+  }
+}
+
+/**
+ * Factory for a web-mode `PersistenceApi`. Each instance owns its debounce
+ * queue (and, via `opts`, an injectable socket for tests).
+ */
+export function createWebPersistenceApi(opts?: {
+  url?: string
+  WebSocketImpl?: typeof WebSocket
+}): PersistenceApi {
+  const socket = new WebStoreSocket(opts)
+  const pendingDebounce = new Map<string, PendingDebounceEntry>()
+
+  const ok = (): IpcResult<void> => ({ success: true, data: undefined })
+
+  async function toResult<T>(op: () => Promise<T>): Promise<IpcResult<T>> {
+    try {
+      return { success: true, data: await op() }
+    } catch (err) {
+      const e = err as Partial<StoreError>
+      return {
+        success: false,
+        error: e.message ?? String(err),
+        code: e.code ?? 'WS_ERROR'
+      }
+    }
+  }
+
+  async function persist<T>(key: string, data: T): Promise<IpcResult<void>> {
+    return toResult(async () => {
+      await socket.request('store_write', {
+        key,
+        value: { _version: CURRENT_VERSION, data }
+      })
+    })
+  }
+
+  async function flushEntry(key: string, entry: PendingDebounceEntry): Promise<IpcResult<void>> {
+    if (entry.timer) {
+      clearTimeout(entry.timer)
+      entry.timer = null
+    }
+    pendingDebounce.delete(key)
+    const result = await persist(key, entry.data)
+    entry.resolvers.forEach((resolve) => {
+      resolve(result)
+    })
+    return result
+  }
+
+  return {
+    async read<T>(key: string): Promise<IpcResult<T>> {
+      return toResult(async () => {
+        const reply = await socket.request<{ value: unknown }>('store_read', { key })
+        const raw = reply?.value ?? null
+        if (raw === null || raw === undefined) {
+          throw { code: 'KEY_NOT_FOUND', message: `Key not found: ${key}` } satisfies StoreError
+        }
+        // Versioned payload written by this API (or the desktop store).
+        if (typeof raw === 'object' && raw !== null && '_version' in raw) {
+          return (raw as unknown as { data: T }).data
+        }
+        return raw as T
+      })
+    },
+
+    write: persist,
+
+    async writeDebounced<T>(key: string, data: T): Promise<IpcResult<void>> {
+      return new Promise((resolve) => {
+        const existing = pendingDebounce.get(key)
+        if (existing) {
+          if (existing.timer) clearTimeout(existing.timer)
+          existing.data = data
+          existing.resolvers.push(resolve)
+          existing.timer = setTimeout(() => void flushEntry(key, existing), DEBOUNCE_MS)
+          return
+        }
+        const entry: PendingDebounceEntry = {
+          timer: null,
+          data,
+          resolvers: [resolve]
+        }
+        pendingDebounce.set(key, entry)
+        entry.timer = setTimeout(() => void flushEntry(key, entry), DEBOUNCE_MS)
+      })
+    },
+
+    async delete(key: string): Promise<IpcResult<void>> {
+      return toResult(async () => {
+        await socket.request('store_delete', { key })
+      })
+    },
+
+    async flushPendingWrites(): Promise<IpcResult<void>> {
+      let firstFailure: IpcResult<void> | null = null
+      for (const [key, entry] of Array.from(pendingDebounce.entries())) {
+        const result = await flushEntry(key, entry)
+        if (!result.success && firstFailure === null) firstFailure = result
+      }
+      return firstFailure ?? ok()
+    }
+  }
+}

--- a/src/renderer/lib/web-persistence-api.ts
+++ b/src/renderer/lib/web-persistence-api.ts
@@ -74,9 +74,19 @@ export class WebStoreSocket {
     return new Promise<T>((resolve, reject) => {
       const id = randomUUID()
       const frame: WsRequest = { id, type, payload }
+      const timer = setTimeout(() => {
+        this.pending.delete(id)
+        reject({ code: 'WS_TIMEOUT', message: 'store request timed out' })
+      }, 15000)
       this.pending.set(id, {
-        resolve: (value) => resolve(value as T),
-        reject
+        resolve: (value) => {
+          clearTimeout(timer)
+          resolve(value as T)
+        },
+        reject: (err) => {
+          clearTimeout(timer)
+          reject(err)
+        }
       })
       this.socket?.send(JSON.stringify(frame))
     })
@@ -100,6 +110,13 @@ export class WebStoreSocket {
       this.socket = ws
       this.authed = false
 
+      ws.onopen = () => {
+        void this.authenticate().then(() => {
+          this.authed = true
+          settleOk()
+        }, settleErr)
+      }
+
       ws.onmessage = (ev) => {
         let parsed: unknown
         try {
@@ -110,14 +127,7 @@ export class WebStoreSocket {
         if (!parsed || typeof parsed !== 'object') return
         const obj = parsed as Record<string, unknown>
 
-        // Server asks the client to authenticate before any other request.
-        if (obj.type === 'auth_required') {
-          void this.authenticate().then(() => {
-            this.authed = true
-            settleOk()
-          }, settleErr)
-          return
-        }
+        if (obj.type === 'auth_required') return
 
         // Reply frame: { id, ok, payload | err }.
         if (typeof obj.id === 'string' && typeof obj.ok === 'boolean') {
@@ -190,13 +200,38 @@ export function createWebPersistenceApi(opts?: {
     }
   }
 
-  async function persist<T>(key: string, data: T): Promise<IpcResult<void>> {
-    return toResult(async () => {
-      await socket.request('store_write', {
-        key,
-        value: { _version: CURRENT_VERSION, data }
+  async function flushOrSupersede(
+    key: string,
+    supersedeAction: () => Promise<IpcResult<void>>
+  ): Promise<IpcResult<void>> {
+    const existing = pendingDebounce.get(key)
+    if (existing?.timer) {
+      clearTimeout(existing.timer)
+      existing.timer = null
+    }
+    pendingDebounce.delete(key)
+    const result = await supersedeAction()
+    if (existing) {
+      existing.resolvers.forEach((resolve) => {
+        resolve(result)
       })
-    })
+    }
+    return result
+  }
+
+  async function persist<T>(key: string, data: T, expected?: T): Promise<IpcResult<void>> {
+    return flushOrSupersede(key, () =>
+      toResult(async () => {
+        const payload: Record<string, unknown> = {
+          key,
+          value: { _version: CURRENT_VERSION, data }
+        }
+        if (expected !== undefined) {
+          payload.expected = { _version: CURRENT_VERSION, data: expected }
+        }
+        await socket.request('store_write', payload)
+      })
+    )
   }
 
   async function flushEntry(key: string, entry: PendingDebounceEntry): Promise<IpcResult<void>> {
@@ -251,9 +286,11 @@ export function createWebPersistenceApi(opts?: {
     },
 
     async delete(key: string): Promise<IpcResult<void>> {
-      return toResult(async () => {
-        await socket.request('store_delete', { key })
-      })
+      return flushOrSupersede(key, () =>
+        toResult(async () => {
+          await socket.request('store_delete', { key })
+        })
+      )
     },
 
     async flushPendingWrites(): Promise<IpcResult<void>> {

--- a/src/shared/types/web-protocol.types.test.ts
+++ b/src/shared/types/web-protocol.types.test.ts
@@ -58,8 +58,8 @@ describe('web-protocol.types — event/request type registries (AC2)', () => {
     expect(WS_REQUEST_TYPES).toContain('get_session_payload')
   })
 
-  it('exports exactly 30 request types including discovered-session promotion', () => {
-    expect(WS_REQUEST_TYPES).toHaveLength(30)
+  it('exports exactly 33 request types including discovered-session promotion', () => {
+    expect(WS_REQUEST_TYPES).toHaveLength(33)
     const expected = [
       'send_prompt',
       'cancel_prompt',
@@ -93,7 +93,11 @@ describe('web-protocol.types — event/request type registries (AC2)', () => {
       'list_acp_catalog',
       'set_catalog_opt_in',
       // CAP-6 / Story 9: host-owned verified-atomic ACP install.
-      'install_acp_agent'
+      'install_acp_agent',
+      // Issue #613: server-side generic key-value store.
+      'store_read',
+      'store_write',
+      'store_delete'
     ]
     for (const name of expected) {
       expect(WS_REQUEST_TYPES).toContain(name)

--- a/src/shared/types/web-protocol.types.ts
+++ b/src/shared/types/web-protocol.types.ts
@@ -151,11 +151,40 @@ export const WS_REQUEST_TYPES = [
   // installs a catalog agent through `install_acp_agent` (the host downloads +
   // verifies sha256 + extracts + atomically activates). The request is
   // `{ agentId }` only; the host resolves everything from the trusted catalog.
-  'install_acp_agent'
+  'install_acp_agent',
+  // Issue #613: server-side generic key-value store — the web client routes
+  // its `persistenceApi` through these (replacing the per-browser localStorage
+  // stub) so settings / layout / command history / SSH profiles survive
+  // browser switches + server restarts. Errors carry SCREAMING_SNAKE_CASE
+  // codes via `err_with_code`: `STORE_UNAVAILABLE` (no store attached),
+  // `STORE_WRITE_FAILED` / `STORE_DELETE_FAILED` (IO), `VALIDATION_ERROR`.
+  'store_read',
+  'store_write',
+  'store_delete'
 ] as const
 
 /** Union of all WS request `type` strings. */
 export type WsRequestType = (typeof WS_REQUEST_TYPES)[number]
+
+// ============================================================================
+// Server-side key-value store (issue #613) — request payloads + replies
+// ============================================================================
+
+/** `store_read` request payload. Reply: `{ value: unknown | null }`. */
+export interface StoreReadPayload {
+  key: string
+}
+
+/** `store_write` request payload. `value` is any JSON value. Reply: `{}`. */
+export interface StoreWritePayload {
+  key: string
+  value: unknown
+}
+
+/** `store_delete` request payload. Reply: `{ existed: boolean }`. */
+export interface StoreDeletePayload {
+  key: string
+}
 
 // ============================================================================
 // Error codes (9) — stable machine strings (AC2)


### PR DESCRIPTION
## Summary

Web client (termul-server) currently persists app state to per-browser `localStorage`. Opening the same server from another browser / device loses terminal layout, settings, editor state, command history, snapshots, and SSH profiles. This PR moves that state to a server-side JSON store exposed over the existing WebSocket protocol, so web-client state survives browser switches, refreshes, and device changes.

All layers implemented: backend store + WS handlers, frontend `persistenceApi` switch, and SSH profile CRUD in web mode. Ready for review.

## Related Issue

Closes #613

## Type of Change

- [x] feat: new feature

## What Changed

- [x] Backend KV store: `WebStore` — crash-safe JSON file, atomic replace, corrupt file → backup + reopen empty
- [x] `--store-file` / `$TERMUL_STORE_FILE` in `ServerConfig`; shared-live desktop host resolves the default store path at serve time
- [x] WS handlers `store_read` / `store_write` / `store_delete` + AppState wiring + protocol types (`web-protocol.types.ts` parity updated)
- [x] Frontend: `webPersistenceApi` — WS-backed `PersistenceApi` (authenticated request/reply, versioned values, 500ms write debounce); `persistence-api.ts` switches on `isTauriContext()`
- [x] SSH profile CRUD via the store in web mode (secrets stripped, mirroring the desktop store); connect/SFTP remain desktop-only

## How It Was Tested

- [x] `cargo test --lib web::` (341 passed, incl. store/config + WS handler tests)
- [x] `cargo check --tests`
- [x] `cargo clippy --all-targets -- -D warnings` (in src-tauri)
- [x] `bun run typecheck`
- [x] `bun run ci` (biome)
- [x] `bun run build:web`
- [x] `bun run test` — new/updated tests pass (40 in web-persistence-api + ssh-api web branch + protocol parity). 39 failures across 3 pre-existing localStorage-based test files (localStorage unavailable in the local jsdom env); verified identical on the baseline, unrelated to this PR
- [x] Manual verification — Setup 2 isolated browser contexts connecting to `termul-server`; verified layout, settings, and SSH profile writes persist across clients and survive server restarts.

## Screenshots or Recordings

N/A (backend + persistence layer; UI unchanged)

## CI & Review Gate

- [x] All CI checks pass (PR Validation, Rust Checks, Build Verification, Security Scans)
- [x] Code review comments from CodeRabbit / Claude have been addressed or resolved
- [x] No unresolved review findings remain

## Checklist

- [x] My PR title follows the conventional commit format used by this repo
- [x] I linked the related issue or explained why none exists
- [ ] I updated docs when needed
- [x] I added or updated tests when needed
- [x] I verified the change does not introduce unrelated modifications
- [x] I read AGENTS.md and followed the contributor guidelines
- [x] A human reviewed the complete diff before submission
