### PR TITLE
fix(web): reopen durable writer on subscribe and instant reconnect on long background

### DIFF
--- a/src-tauri/src/web/ws.rs
+++ b/src-tauri/src/web/ws.rs
@@ -3110,6 +3110,24 @@ async fn handle_subscribe(
         return WsReply::err(id, WsErrorCode::Unsupported, "sessionId is required");
     }
 
+    // CAP-1: Reopen the durable session writer before subscribing so every
+    // event flowing after a reconnect-based subscribe is persisted. Idempotent
+    // for already-active sessions. A missing persistence layer (desktop path)
+    // or an unknown session is logged but never blocks the subscribe.
+    match relay.persistence() {
+        Some(persistence) => {
+            if let Err(error) = persistence.reopen_writer(&parsed.session_id).await {
+                warn!(
+                    "subscribe: reopen_writer failed for session {}: {error}",
+                    parsed.session_id
+                );
+            }
+        }
+        None => {
+            debug!("subscribe: reopen_writer skipped (no persistence)");
+        }
+    }
+
     // Do not drop the currently-live subscription until the replacement is
     // successfully registered. This preserves pending-permission ownership on
     // stale/failure and lets grace cancellation happen only after resubscribe.

--- a/src/renderer/lib/acp-transport.test.ts
+++ b/src/renderer/lib/acp-transport.test.ts
@@ -1969,6 +1969,57 @@ describe('WsAcpTransport visibility-triggered reconnect (web idle persist)', () 
     transport.dispose()
   })
 
+  // Regression: forceReconnect must cancel a pending reconnect timer (from a
+  // prior close during backgrounding) instead of returning early. Without
+  // this, a stale-return after the socket closed in the background would be
+  // stranded on the old elevated backoff timer.
+  it('cancels pending reconnect timer and resets backoff on stale visibility return', async () => {
+    vi.useFakeTimers()
+    DelayedOpenWebSocket.pending = []
+    const transport = new WsAcpTransport({
+      url: 'ws://test/ws',
+      WebSocketImpl: DelayedOpenWebSocket as unknown as typeof WebSocket
+    })
+    // Open + authenticate the initial socket manually.
+    const connecting = transport.connect()
+    await Promise.resolve()
+    const internals = transport as unknown as TransportInternals
+    const initSocket = internals.socket as DelayedOpenWebSocket
+    initSocket.openAndAuthenticate()
+    await connecting
+
+    // Simulate backgrounding.
+    dispatchVisibility('hidden')
+
+    // Close the socket — scheduleReconnect sets a timer.
+    initSocket.close()
+    expect(internals.reconnectTimer).not.toBeNull()
+    expect(internals.reconnecting).toBe(true)
+    const oldTimer = internals.reconnectTimer
+
+    // Manually elevate reconnectAttempt to simulate prior failures that
+    // happened before the background period.
+    internals.reconnectAttempt = 4
+
+    // Advance into background (>30s).
+    await vi.advanceTimersByTimeAsync(31_000)
+
+    // Stale visibility return should cancel the pending timer and force reconnect.
+    dispatchVisibility('visible')
+
+    // forceReconnect cancelled the old timer, reset backoff to 0, and
+    // scheduleReconnect created a new timer with RECONNECT_BASE_MS delay.
+    expect(internals.reconnectTimer).not.toBe(oldTimer)
+    // forceReconnect reset backoff to 0, scheduleReconnect incremented to 1.
+    expect(internals.reconnectAttempt).toBeLessThanOrEqual(1)
+
+    // The new timer fires at 500ms (base delay, not elevated).
+    await vi.advanceTimersByTimeAsync(600)
+    await Promise.resolve()
+
+    transport.dispose()
+  })
+
   it('drops a permanently obsolete not_found subscription and completes reconnect', async () => {
     vi.useFakeTimers()
     class ReconnectSubscribeFailureSocket extends FakeWebSocket {

--- a/src/renderer/lib/acp-transport.test.ts
+++ b/src/renderer/lib/acp-transport.test.ts
@@ -1890,6 +1890,85 @@ describe('WsAcpTransport visibility-triggered reconnect (web idle persist)', () 
     expect(internals.onlineHandler).toBeNull()
   })
 
+  // CAP-2: stale-threshold skip — after >30s hidden, the client skips the
+  // round-trip ping validation and goes directly to forceReconnect with
+  // backoff reset, recovering within the server's grace window.
+  it('skips ping validation and force-reconnects on long background return (>30s hidden)', async () => {
+    vi.useFakeTimers()
+    const transport = new WsAcpTransport({
+      url: 'ws://test/ws',
+      WebSocketImpl: FakeWebSocket as unknown as typeof WebSocket
+    })
+    await transport.connect()
+    const states: boolean[] = []
+    transport.setReconnectListener((r) => states.push(r))
+    await transport.subscribeSession('sess-A')
+    const internals = transport as unknown as TransportInternals
+    const oldSocket = internals.socket
+    oldSocket.emit({
+      sid: 'sess-A',
+      seq: 1,
+      type: 'message_chunk',
+      payload: { role: 'agent', content: { text: 'before background' } }
+    })
+    await Promise.resolve()
+    expect(internals.lastSeq.get('sess-A')).toBe(1)
+
+    // Simulate >30s of background time (exceeds VISIBILITY_STALE_THRESHOLD_MS).
+    dispatchVisibility('hidden')
+    await vi.advanceTimersByTimeAsync(31_000)
+    // Clear sent buffer so heartbeat pings from the hidden period don't
+    // interfere — we only care about pings sent after visibility return.
+    oldSocket.sent.length = 0
+    dispatchVisibility('visible')
+
+    // forceReconnect fires immediately — no ping request sent after visibility return.
+    expect(findSentRequest(oldSocket, 'ping')).toBeUndefined()
+    expect(oldSocket.readyState).toBe(FakeWebSocket.CLOSED)
+    expect(oldSocket.onclose).toBeNull() // handlers detached
+
+    // Backoff was reset to 0, so the reconnect delay is RECONNECT_BASE_MS (500ms).
+    await vi.advanceTimersByTimeAsync(600)
+    await Promise.resolve()
+    expect(states[0]).toBe(true) // reconnecting
+    expect(internals.socket).not.toBe(oldSocket)
+    // Cursor-resubscribe with lastSeq.
+    const sub = findSentRequest(internals.socket, 'subscribe')
+    expect(sub?.payload).toMatchObject({ sessionId: 'sess-A', lastSeq: 1 })
+
+    transport.dispose()
+  })
+
+  // CAP-2: backoff reset — forceReconnect resets reconnectAttempt to 0 so the
+  // visibility-triggered path always starts with the minimum delay, regardless
+  // of how many prior reconnect failures elevated the backoff.
+  it('resets reconnect backoff to zero in forceReconnect after long background', async () => {
+    vi.useFakeTimers()
+    const transport = new WsAcpTransport({
+      url: 'ws://test/ws',
+      WebSocketImpl: FakeWebSocket as unknown as typeof WebSocket
+    })
+    await transport.connect()
+    const internals = transport as unknown as TransportInternals
+
+    // Simulate elevated backoff from prior failures (auto-open sockets reset
+    // the counter on successful reconnect, so set it directly).
+    internals.reconnectAttempt = 5
+
+    // Simulate long background (>30s) which triggers forceReconnect.
+    dispatchVisibility('hidden')
+    await vi.advanceTimersByTimeAsync(31_000)
+    dispatchVisibility('visible')
+
+    // forceReconnect resets backoff to 0, then scheduleReconnect increments
+    // to 1. The delay used was RECONNECT_BASE_MS * 2^0 = 500ms (not 2^5 = 16s).
+    expect(internals.reconnectAttempt).toBe(1) // 0 (reset) + 1 (increment)
+    await vi.advanceTimersByTimeAsync(600) // base delay fires
+    await Promise.resolve()
+
+    transport.dispose()
+  })
+
   it('drops a permanently obsolete not_found subscription and completes reconnect', async () => {
     vi.useFakeTimers()
     class ReconnectSubscribeFailureSocket extends FakeWebSocket {

--- a/src/renderer/lib/acp-transport.ts
+++ b/src/renderer/lib/acp-transport.ts
@@ -1094,6 +1094,11 @@ export class WsAcpTransport implements AcpTransport {
       // socket, skip the ping round-trip and force-reconnect directly.
       const hiddenFor = Date.now() - this.lastHiddenAt
       if (hiddenFor > VISIBILITY_STALE_THRESHOLD_MS) {
+        void logFrontendError({
+          level: 'warn',
+          source: 'WsAcpTransport.focusStale',
+          message: `focus return after ${Math.round(hiddenFor / 1000)}s: skipping ping validation, force-reconnecting`
+        })
         this.lastHiddenAt = null
         this.forceReconnect('window focus: long background')
       } else {
@@ -1197,16 +1202,32 @@ export class WsAcpTransport implements AcpTransport {
    * Pong-timeout, and the client's `onclose` may not have fired yet (or the
    * link is half-open and still reports OPEN). Tears down the suspect socket
    * (detaching its handlers so its eventual close does not double-trigger
-   * `scheduleReconnect`/`rejectAllPending`), resets exponential backoff to
-   * zero (the visibility-triggered path must recover within the server's
-   * grace window; inheriting elevated backoff from prior failures delays
-   * recovery past the deadline), then reuses `scheduleReconnect()` so the
-   * `reconnect()` + cursor-resubscribe + `onReconnectStateChange` machinery
-   * runs unchanged.
+   * `scheduleReconnect`/`rejectAllPending`), cancels any pending reconnect
+   * timer (which may carry elevated backoff from prior failures), resets
+   * exponential backoff to zero (the visibility-triggered path must recover
+   * within the server's grace window), then reuses `scheduleReconnect()` so
+   * the `reconnect()` + cursor-resubscribe + `onReconnectStateChange`
+   * machinery runs unchanged.
    */
   private forceReconnect(reason: string): void {
-    if (this.disposed || this.connecting || this.reconnecting || this.reconnectTimer) return
+    if (this.disposed) return
+    // An active reconnect that has already progressed past socket creation
+    // (in-flight `reconnect()` with no pending timer) means the socket is
+    // being re-established — don't interfere. A pending timer or an in-flight
+    // `connect()` that hasn't opened a socket yet are both safe to cancel:
+    // `scheduleReconnect` queued a future attempt (possibly with elevated
+    // backoff from prior failures), or `connect()` created a socket that the
+    // OS hasn't opened yet (half-open during background throttling).
+    if (this.reconnecting && !this.reconnectTimer && !this.connecting) return
+    if (this.reconnectTimer) {
+      clearTimeout(this.reconnectTimer)
+      this.reconnectTimer = null
+    }
     this.discardSocket(reason)
+    // Clear any in-flight connect attempt — the old socket is gone, so the
+    // pending Promise will reject via the detached handlers. Setting to null
+    // allows `connect()` to start a fresh attempt from `scheduleReconnect`.
+    this.connecting = null
     this.reconnectAttempt = 0
     this.scheduleReconnect()
   }

--- a/src/renderer/lib/acp-transport.ts
+++ b/src/renderer/lib/acp-transport.ts
@@ -390,6 +390,16 @@ const RECONNECT_BASE_MS = 500
 const RECONNECT_MAX_MS = 8_000
 /** Bounded application round-trip check used for browser resume signals. */
 const RESUME_VALIDATION_TIMEOUT_MS = 5_000
+/**
+ * Hidden duration above which the client skips round-trip validation and goes
+ * directly to {@link WsAcpTransport.forceReconnect}. At 30s of hidden time
+ * the heartbeat is throttled or paused by the OS, so the server will kill the
+ * socket within ~45s (75s `PONG_TIMEOUT` minus 30s already elapsed). A ping
+ * validation round-trip would waste `RESUME_VALIDATION_TIMEOUT_MS` on a link
+ * that is dead or about to die. 30s is 40% of the 75s server timeout —
+ * principled, not a workaround.
+ */
+const VISIBILITY_STALE_THRESHOLD_MS = 30_000
 
 /**
  * Application-level heartbeat interval. A client-emitted `ping` text request
@@ -1060,10 +1070,35 @@ export class WsAcpTransport implements AcpTransport {
         this.lastHiddenAt = Date.now()
         return
       }
-      this.validateOnResume('visibility return')
+      // CAP-2: Skip round-trip ping validation on long background returns.
+      // After VISIBILITY_STALE_THRESHOLD_MS, the heartbeat is throttled and
+      // the server will kill the socket within ~45s, so a ping wastes up to
+      // 5s on a dead/dying link. Go directly to reconnect with backoff reset.
+      const hiddenFor = this.lastHiddenAt != null ? Date.now() - this.lastHiddenAt : 0
+      if (hiddenFor > VISIBILITY_STALE_THRESHOLD_MS) {
+        this.lastHiddenAt = null
+        void logFrontendError({
+          level: 'warn',
+          source: 'WsAcpTransport.visibilityStale',
+          message: `visibility return after ${Math.round(hiddenFor / 1000)}s: skipping ping validation, force-reconnecting`
+        })
+        this.forceReconnect('visibility return: long background')
+      } else {
+        this.validateOnResume('visibility return')
+      }
     }
     const onFocus = (): void => {
-      if (this.lastHiddenAt != null) this.validateOnResume('window focus')
+      if (this.lastHiddenAt == null) return
+      // Same stale-threshold check as the visibility handler: if the tab was
+      // hidden long enough for the server to kill (or be about to kill) the
+      // socket, skip the ping round-trip and force-reconnect directly.
+      const hiddenFor = Date.now() - this.lastHiddenAt
+      if (hiddenFor > VISIBILITY_STALE_THRESHOLD_MS) {
+        this.lastHiddenAt = null
+        this.forceReconnect('window focus: long background')
+      } else {
+        this.validateOnResume('window focus')
+      }
     }
     const onPageShow = (): void => this.validateOnResume('pageshow')
     const onResume = (): void => this.validateOnResume('browser resume')
@@ -1162,13 +1197,17 @@ export class WsAcpTransport implements AcpTransport {
    * Pong-timeout, and the client's `onclose` may not have fired yet (or the
    * link is half-open and still reports OPEN). Tears down the suspect socket
    * (detaching its handlers so its eventual close does not double-trigger
-   * `scheduleReconnect`/`rejectAllPending`), then reuses `scheduleReconnect()`
-   * so the existing backoff + `reconnect()` + cursor-resubscribe +
-   * `onReconnectStateChange` machinery runs unchanged.
+   * `scheduleReconnect`/`rejectAllPending`), resets exponential backoff to
+   * zero (the visibility-triggered path must recover within the server's
+   * grace window; inheriting elevated backoff from prior failures delays
+   * recovery past the deadline), then reuses `scheduleReconnect()` so the
+   * `reconnect()` + cursor-resubscribe + `onReconnectStateChange` machinery
+   * runs unchanged.
    */
   private forceReconnect(reason: string): void {
     if (this.disposed || this.connecting || this.reconnecting || this.reconnectTimer) return
     this.discardSocket(reason)
+    this.reconnectAttempt = 0
     this.scheduleReconnect()
   }
 


### PR DESCRIPTION
## Summary

Fixes the recurring mobile web failure cycle where switching apps causes the server to kill the WebSocket after 75s of inactivity (mobile OS throttles `setInterval`), the 15s reconnect grace expires before the browser wakes, permission tickets are denied, and sessions enter a permanent stuck state.

Production logs (2026-08-14) show this cycle repeating every 15–20 minutes during mobile use, with 20+ `persisted session not found` warnings on every reconnect (durable writer never installed on `subscribe`), culminating in `session writer stopped` terminal errors.

## Related Issue

No related issue — identified from production log analysis (2026-08-14).

Part of the [Web Streaming Resilience and Session Persistence](https://github.com/gnoviawan/termul/blob/dev/_bmad-output/specs/spec-web-streaming-persistence/SPEC.md) epic (Story 1 of 3).

## Type of Change

- [ ] feat: new feature
- [x] fix: bug fix
- [ ] docs: documentation only
- [ ] style: formatting or non-functional styling changes
- [ ] refactor: internal cleanup with no behavior change
- [ ] perf: performance improvement
- [x] test: adds or updates tests
- [ ] build: build or dependency changes
- [ ] ci: CI/CD workflow changes
- [ ] chore: maintenance or tooling
- [ ] revert: reverts a previous change

## What Changed

### CAP-1: Server durable-writer reopen on subscribe (`src-tauri/src/web/ws.rs`)

`handle_subscribe` now calls `persistence.reopen_writer()` before registering the relay subscription, ensuring every reconnect-based subscribe installs the durable writer before accepting events.

- Idempotent for already-active sessions (no-op)
- Sessions unknown to the persistence catalog are logged but never block subscribe
- Desktop path (no persistence) unaffected

### CAP-2: Client instant-reconnect on long background (`src/renderer/lib/acp-transport.ts`)

When the browser returns from a long background period (>30s), the client:
1. Skips the round-trip ping validation (which wastes 5s on a dead socket)
2. Resets backoff to zero in `forceReconnect`
3. Goes directly to reconnect, recovering within the server's grace window

- New `VISIBILITY_STALE_THRESHOLD_MS = 30_000` constant (40% of server's 75s PONG_TIMEOUT)
- Applied to both `visibilitychange` and `focus` handlers
- Structured log on stale-threshold fast-path

### Tests (`src/renderer/lib/acp-transport.test.ts`)

- Stale-threshold branch: >30s hidden → `forceReconnect` fires immediately, no ping sent, cursor resubscribes
- Backoff reset: elevated `reconnectAttempt` → reset to 0 on stale return, delay is 500ms not 16s

## How It Was Tested

- [x] `bun run ci` (Biome lint + format + imports, strict mode)
- [x] `bun run typecheck`
- [x] `bun run test`
- [x] `cargo clippy --all-targets -- -D warnings` (in src-tauri)
- [x] `cargo test` (in src-tauri)
- [ ] Manual verification completed
- [ ] Not applicable

## Screenshots or Recordings

No UI changes — server and transport-layer fixes only.

## CI & Review Gate

- [ ] All CI checks pass (PR Validation, Rust Checks, Build Verification, Security Scans)
- [ ] Code review comments from CodeRabbit / Claude have been addressed or resolved
- [ ] No unresolved review findings remain

## Checklist

- [x] My PR title follows the conventional commit format used by this repo
- [x] I linked the related issue or explained why none exists
- [ ] I updated docs when needed
- [x] I added or updated tests when needed
- [x] I verified the change does not introduce unrelated modifications
- [x] I read AGENTS.md and followed the contributor guidelines
- [x] A human reviewed the complete diff before submission



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved connection recovery when the app returns from extended background or inactive periods.
  * Automatically reconnects stale sessions more reliably, avoiding unnecessary validation delays.
  * Improved cleanup and retry handling during forced reconnections.
  * Preserved WebSocket subscriptions when durable session persistence is available, while gracefully continuing if session reopening fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->