### PR TITLE
feat(web): signal-driven adaptive keepalive and extended disconnect grace

### DIFF
--- a/src-tauri/src/web/config.rs
+++ b/src-tauri/src/web/config.rs
@@ -267,7 +267,7 @@ impl ServerConfig {
         let mut port: u16 = 8080;
         let mut event_log_capacity: usize = 4096;
         let mut permission_timeout_secs: u64 = 60;
-        let mut permission_reconnect_grace_secs: u64 = 15;
+        let mut permission_reconnect_grace_secs: u64 = 60;
         // PR-S4: when `--project-root` is absent, fall back to the env var or
         // the user's home directory via `default_project_root()`. The
         // resolved value is run through `resolve_and_validate_project_root`
@@ -682,8 +682,8 @@ mod tests {
             "default permission-timeout is 60s (Story 1.7 / FR14)"
         );
         assert_eq!(
-            cfg.permission_reconnect_grace_secs, 15,
-            "default reconnect grace is 15s"
+            cfg.permission_reconnect_grace_secs, 60,
+            "default reconnect grace is 60s (CAP-4: mobile wake + reconnect chain)"
         );
         // PR-S4: project_root defaults to $HOME / $USERPROFILE when the env var
         // is unset. The CI hosts in this repo all set $HOME, so the resolved

--- a/src-tauri/src/web/permissions.rs
+++ b/src-tauri/src/web/permissions.rs
@@ -45,8 +45,12 @@ use crate::web::sink::ClientId;
 /// Default permission timeout (60s) — the bounded rendezvous window.
 /// Expiry resolves the permission as deny (`Cancelled`). Per FR14 / NFR7-adjacent.
 pub const DEFAULT_PERMISSION_TIMEOUT: Duration = Duration::from_secs(60);
-/// Default last-subscriber reconnect grace. The ticket timeout keeps running.
-pub const DEFAULT_PERMISSION_RECONNECT_GRACE: Duration = Duration::from_secs(15);
+/// Default last-subscriber reconnect grace (CAP-4: 60s). Widened from 15s so
+/// the mobile wake + reconnect chain (3-8s desktop, 5-15s throttled mobile per
+/// prod logs) completes before pending permission tickets are denied. The
+/// per-ticket timeout keeps running throughout; only the orphan-deny grace is
+/// widened. Already overridable via `permission_reconnect_grace_secs`.
+pub const DEFAULT_PERMISSION_RECONNECT_GRACE: Duration = Duration::from_secs(60);
 
 /// Outcome of a successful [`PermissionRendezvous::try_respond`] call.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/src-tauri/src/web/ws.rs
+++ b/src-tauri/src/web/ws.rs
@@ -26,7 +26,7 @@
 //! `err.code: "not_implemented"` until Stories 1.7/1.8/Epic 4.
 
 use std::path::PathBuf;
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -474,18 +474,70 @@ const PING_INTERVAL: Duration = Duration::from_secs(20);
 /// browser's reconnect+cursor-resubscribe path can engage.
 const PONG_TIMEOUT: Duration = Duration::from_secs(75);
 
+/// Signal-gated keepalive ceiling (CAP-3): while a web client has sent a
+/// `type:"background"` control frame and not yet sent `foreground` (or any
+/// normal frame), the watchdog tolerates up to 5 minutes of inactivity so a
+/// backgrounded mobile tab (whose `setInterval` the OS throttles/pauses)
+/// survives an app-switch round-trip. `PONG_TIMEOUT` is NOT raised — the
+/// 5-min ceiling applies only while `backgrounded=true`. 5 min balances
+/// mobile battery against reconnect latency (codeg tolerates 1h; buzz 30s).
+const BACKGROUND_TIMEOUT: Duration = Duration::from_secs(300);
+
 /// Reusable Ping payload (opaque; browsers must echo it back in the Pong, but
 /// the relay does not correlate — any inbound frame resets the watchdog).
 /// Must stay under 125 bytes per RFC 6455 control-frame limits.
 const PING_PAYLOAD: &[u8] = b"keepalive";
 
 /// Pure keepalive-watchdog decision: returns true when no inbound frame
-/// (text request, Pong, or client Ping) has arrived for longer than
-/// `PONG_TIMEOUT`. Extracted from the write task so the threshold semantics
-/// (strict `>`) are unit-testable without spinning up a real socket. The write
-/// task calls this with `last_activity.load()` + `now_ms()` on each ping tick.
-fn watchdog_is_stale(last_activity_ms: u64, now_ms_value: u64) -> bool {
-    now_ms_value.saturating_sub(last_activity_ms) > PONG_TIMEOUT.as_millis() as u64
+/// (text request, Pong, or client Ping) has arrived for longer than `ceiling`
+/// — `PONG_TIMEOUT` for an active/foreground connection, or `BACKGROUND_TIMEOUT`
+/// while a `background` signal is in effect (CAP-3). Extracted from the write
+/// task so the threshold semantics (strict `>`) are unit-testable without
+/// spinning up a real socket. The write task calls this with
+/// `last_activity.load()` + `now_ms()` + the active ceiling on each tick.
+fn watchdog_is_stale(last_activity_ms: u64, now_ms_value: u64, ceiling_ms: u64) -> bool {
+    now_ms_value.saturating_sub(last_activity_ms) > ceiling_ms
+}
+
+/// Cheaply extract the `type` field of a client WS text frame (CAP-3 control
+/// signals). Returns `None` for non-JSON or frames without a string `type`.
+/// The read task uses this to recognize id-less `background`/`foreground`
+/// lifecycle frames before the strict `WsRequest` parse (which requires `id`).
+fn peer_frame_type(text: &str) -> Option<String> {
+    let value: Value = serde_json::from_str(text).ok()?;
+    value.get("type")?.as_str().map(str::to_owned)
+}
+
+/// CAP-3: consume an id-less `background`/`foreground` lifecycle control frame.
+/// Returns `true` when the frame was a lifecycle signal and the caller should
+/// skip dispatch (no reply, no `WsRequest` parse). The `backgrounded` flag is
+/// toggled ONLY when `authed` (an unauthenticated peer cannot manipulate the
+/// watchdog ceiling); an unauthenticated signal is still consumed (ignored,
+/// no dispatch, no error). Returns `false` for any other frame — the caller
+/// then resets the flag ("any normal frame resets the normal timeout") and
+/// dispatches as a normal ACP request.
+fn handle_lifecycle_signal(text: &str, authed: bool, backgrounded: &AtomicBool) -> bool {
+    if let Some(type_) = peer_frame_type(text) {
+        match type_.as_str() {
+            "background" => {
+                if authed {
+                    backgrounded.store(true, Ordering::Relaxed);
+                } else {
+                    debug!("[ws] ignoring background signal from unauthenticated connection");
+                }
+                true
+            }
+            "foreground" => {
+                if authed {
+                    backgrounded.store(false, Ordering::Relaxed);
+                }
+                true
+            }
+            _ => false,
+        }
+    } else {
+        false
+    }
 }
 
 /// Epoch-millis timestamp for the keepalive watchdog. Uses `SystemTime` (not
@@ -550,7 +602,13 @@ async fn run_relay(socket: WebSocket, state: AppState) {
     // the only way to refresh NAT/proxy/browser idle timers during silent
     // reasoning phases and to surface a dead client promptly.
     let last_activity = Arc::new(AtomicU64::new(now_ms()));
+    // CAP-3: per-connection background flag. `true` while a web client has
+    // signaled `type:"background"` (tab suspending); the watchdog then uses
+    // BACKGROUND_TIMEOUT (5min) instead of PONG_TIMEOUT (75s). Reset to
+    // false by `foreground` or any normal client frame.
+    let backgrounded = Arc::new(AtomicBool::new(false));
     let write_last_activity = Arc::clone(&last_activity);
+    let write_backgrounded = Arc::clone(&backgrounded);
 
     let write_tx = out_tx.clone();
     let mut write_task = tokio::spawn(async move {
@@ -600,10 +658,17 @@ async fn run_relay(socket: WebSocket, state: AppState) {
                     let last = write_last_activity.load(Ordering::Relaxed);
                     let now = now_ms();
                     let stale = now.saturating_sub(last);
-                    if watchdog_is_stale(last, now) {
+                    // CAP-3: a backgrounded client (sent `type:"background"`)
+                    // gets the 5-min ceiling; any other state gets 75s.
+                    let ceiling = if write_backgrounded.load(Ordering::Relaxed) {
+                        BACKGROUND_TIMEOUT
+                    } else {
+                        PONG_TIMEOUT
+                    };
+                    if watchdog_is_stale(last, now, ceiling.as_millis() as u64) {
                         warn!(
                             "[ws] keepalive: no client activity for {stale} ms \
-                             (>{PONG_TIMEOUT:?}); closing connection"
+                             (>{ceiling:?}); closing connection"
                         );
                         break;
                     }
@@ -613,6 +678,7 @@ async fn run_relay(socket: WebSocket, state: AppState) {
     });
 
     let read_last_activity = Arc::clone(&last_activity);
+    let read_backgrounded = Arc::clone(&backgrounded);
     let read_subscribed_clients = Arc::clone(&subscribed_clients);
     let read_relay = Arc::clone(&relay);
     let mut read_task = tokio::spawn(async move {
@@ -632,6 +698,19 @@ async fn run_relay(socket: WebSocket, state: AppState) {
             read_last_activity.store(now_ms(), Ordering::Relaxed);
             match msg {
                 Message::Text(t) => {
+                    // CAP-3: consume id-less `background`/`foreground`
+                    // lifecycle control frames before the strict `WsRequest`
+                    // parse (which requires `id`). These are fire-and-forget
+                    // (no reply) and toggle the keepalive ceiling; an
+                    // unauthenticated connection's signal is ignored (no flag
+                    // set, no dispatch, no error).
+                    if handle_lifecycle_signal(&t, authed, &read_backgrounded) {
+                        continue;
+                    }
+                    // Any other text frame resets the background flag (CAP-3:
+                    // "resets on foreground or any normal frame") and dispatches
+                    // as a normal ACP request.
+                    read_backgrounded.store(false, Ordering::Relaxed);
                     if !dispatch_connection_text(
                         &t,
                         &mut authed,
@@ -4532,31 +4611,94 @@ mod tests {
     #[test]
     fn watchdog_is_stale_only_past_pong_timeout() {
         // Pure threshold semantics for the keepalive watchdog: a connection is
-        // torn down only after strictly more than PONG_TIMEOUT with no inbound
-        // frame. Tests the decision the write task consults on each ping tick
-        // (the false-positive symptom behind issue: a focused tab through a
-        // proxy dropped every ~75s because Pongs didn't round-trip; a client
-        // `ping` text frame refreshes this and stays open).
+        // torn down only after strictly more than the active ceiling with no
+        // inbound frame. Tests the decision the write task consults on each
+        // ping tick (the false-positive symptom behind issue: a focused tab
+        // through a proxy dropped every ~75s because Pongs didn't round-trip;
+        // a client `ping` text frame refreshes this and stays open).
         let base = 1_000_000_u64;
         let timeout = PONG_TIMEOUT.as_millis() as u64;
         assert!(
-            !watchdog_is_stale(base, base),
+            !watchdog_is_stale(base, base, timeout),
             "fresh connection is not stale"
         );
         assert!(
-            !watchdog_is_stale(base, base + timeout),
+            !watchdog_is_stale(base, base + timeout, timeout),
             "exactly at timeout is not stale (strict >)"
         );
         assert!(
-            !watchdog_is_stale(base, base + timeout - 1),
+            !watchdog_is_stale(base, base + timeout - 1, timeout),
             "just under timeout is not stale"
         );
         assert!(
-            watchdog_is_stale(base, base + timeout + 1),
+            watchdog_is_stale(base, base + timeout + 1, timeout),
             "just past timeout is stale"
         );
         // Clock-skew safe: a future `last_activity` saturates to 0 (not stale).
-        assert!(!watchdog_is_stale(base + 10_000, base));
+        assert!(!watchdog_is_stale(base + 10_000, base, timeout));
+    }
+
+    #[test]
+    fn watchdog_backgrounded_uses_five_minute_ceiling() {
+        // CAP-3: while backgrounded, the watchdog tolerates up to
+        // BACKGROUND_TIMEOUT (5min) — 90s of inactivity must NOT close a
+        // backgrounded connection (would close under the 75s PONG_TIMEOUT).
+        let base = 1_000_000_u64;
+        let ceiling = BACKGROUND_TIMEOUT.as_millis() as u64;
+        assert!(
+            !watchdog_is_stale(base, base + 90_000, ceiling),
+            "90s idle is not stale under the 5-min background ceiling"
+        );
+        assert!(
+            watchdog_is_stale(base, base + ceiling + 1, ceiling),
+            "just past 5-min ceiling is stale"
+        );
+        // 90s idle WOULD close under the normal 75s ceiling.
+        assert!(
+            watchdog_is_stale(base, base + 90_000, PONG_TIMEOUT.as_millis() as u64),
+            "90s idle is stale under the normal 75s ceiling"
+        );
+    }
+
+    #[test]
+    fn peer_frame_type_extracts_background_and_foreground() {
+        // CAP-3: id-less lifecycle frames are recognized by `type` without a
+        // strict `WsRequest` parse (which requires `id`).
+        assert_eq!(peer_frame_type(r#"{"type":"background"}"#).as_deref(), Some("background"));
+        assert_eq!(peer_frame_type(r#"{"type":"foreground"}"#).as_deref(), Some("foreground"));
+        // Normal ACP request frames still report their type (dispatched below).
+        assert_eq!(
+            peer_frame_type(r#"{"id":"p1","type":"send_prompt","payload":{}}"#).as_deref(),
+            Some("send_prompt")
+        );
+        // Malformed / typeless frames yield None (dispatch handles the error).
+        assert!(peer_frame_type("not json").is_none());
+        assert!(peer_frame_type(r#"{"id":"x"}"#).is_none());
+    }
+
+    #[test]
+    fn handle_lifecycle_signal_toggles_background_flag() {
+        // CAP-3: a background frame sets the flag (authed); foreground clears
+        // it; an unauthed background is ignored (no flag, still consumed); a
+        // normal request frame is NOT consumed (dispatched).
+        let flag = Arc::new(AtomicBool::new(false));
+        // Unauthed background: consumed, no flag set.
+        assert!(handle_lifecycle_signal(r#"{"type":"background"}"#, false, &flag));
+        assert!(!flag.load(Ordering::Relaxed), "unauthed background does not set flag");
+        // Authed background: consumed, flag set.
+        assert!(handle_lifecycle_signal(r#"{"type":"background"}"#, true, &flag));
+        assert!(flag.load(Ordering::Relaxed), "authed background sets flag");
+        // Authed foreground: consumed, flag cleared.
+        assert!(handle_lifecycle_signal(r#"{"type":"foreground"}"#, true, &flag));
+        assert!(!flag.load(Ordering::Relaxed), "foreground clears flag");
+        // Normal request frame: NOT consumed (returns false) — dispatched.
+        assert!(!handle_lifecycle_signal(
+            r#"{"id":"p1","type":"send_prompt","payload":{}}"#,
+            true,
+            &flag,
+        ));
+        // Malformed frame: NOT consumed.
+        assert!(!handle_lifecycle_signal("not json", true, &flag));
     }
 
     #[test]

--- a/src/renderer/lib/acp-transport.test.ts
+++ b/src/renderer/lib/acp-transport.test.ts
@@ -2169,6 +2169,54 @@ describe('WsAcpTransport background/foreground lifecycle signals (CAP-3)', () =>
     dispatchVisibility('hidden')
     expect(sentType(socket, 'background')).toBe(false)
   })
+
+  it('sends a background signal when initial authentication completes while hidden', async () => {
+    vi.useFakeTimers()
+    DelayedOpenWebSocket.pending = []
+    const transport = new WsAcpTransport({
+      url: 'ws://test/ws',
+      WebSocketImpl: DelayedOpenWebSocket as unknown as typeof WebSocket
+    })
+    const connecting = transport.connect()
+    await Promise.resolve()
+    const internals = transport as unknown as TransportInternals
+    const openingSocket = internals.socket as DelayedOpenWebSocket
+
+    // Hidden BEFORE auth completes — the hide handler's background signal was
+    // a no-op (not authed). Auth-completion must re-sync the server watchdog.
+    dispatchVisibility('hidden')
+    expect(sentType(openingSocket, 'background')).toBe(false)
+
+    openingSocket.openAndAuthenticate()
+    await connecting
+    expect(sentType(openingSocket, 'background')).toBe(true)
+    transport.dispose()
+  })
+
+  it('sends a background signal when reconnection authentication completes while hidden', async () => {
+    vi.useFakeTimers()
+    const transport = new WsAcpTransport({
+      url: 'ws://test/ws',
+      WebSocketImpl: FakeWebSocket as unknown as typeof WebSocket
+    })
+    await transport.connect()
+    await transport.subscribeSession('sess-cap3b')
+    const internals = transport as unknown as TransportInternals
+    const oldSocket = internals.socket
+
+    // Tab hidden, then the server kills the socket → the reconnect's new
+    // socket authenticates while still hidden → server watchdog re-synced.
+    dispatchVisibility('hidden')
+    await vi.advanceTimersByTimeAsync(1_000)
+    oldSocket.close()
+    await vi.advanceTimersByTimeAsync(3_000)
+    await Promise.resolve()
+
+    const newSocket = internals.socket
+    expect(newSocket).not.toBe(oldSocket)
+    expect(sentType(newSocket, 'background')).toBe(true)
+    transport.dispose()
+  })
 })
 
 describe('createAcpTransport selection', () => {

--- a/src/renderer/lib/acp-transport.test.ts
+++ b/src/renderer/lib/acp-transport.test.ts
@@ -2094,6 +2094,83 @@ describe('WsAcpTransport visibility-triggered reconnect (web idle persist)', () 
   })
 })
 
+describe('WsAcpTransport background/foreground lifecycle signals (CAP-3)', () => {
+  afterEach(() => {
+    restoreVisibility()
+    _resetAcpTransportForTests(null)
+    vi.useRealTimers()
+  })
+
+  /** True if a raw frame of the given type was sent on the socket. */
+  const sentType = (sock: FakeWebSocket, type: string): boolean =>
+    sock.sent.some((raw) => {
+      try {
+        return (JSON.parse(raw) as { type?: string }).type === type
+      } catch {
+        return false
+      }
+    })
+
+  it('sends a background frame on tab hide and foreground on return', async () => {
+    vi.useFakeTimers()
+    const transport = new WsAcpTransport({
+      url: 'ws://test/ws',
+      WebSocketImpl: FakeWebSocket as unknown as typeof WebSocket
+    })
+    await transport.connect()
+    await transport.subscribeSession('sess-cap3')
+    const internals = transport as unknown as TransportInternals
+    const socket = internals.socket
+
+    dispatchVisibility('hidden')
+    await vi.advanceTimersByTimeAsync(1_000)
+    expect(sentType(socket, 'background')).toBe(true)
+
+    dispatchVisibility('visible')
+    await Promise.resolve()
+    expect(sentType(socket, 'foreground')).toBe(true)
+
+    transport.dispose()
+  })
+
+  it('does not send lifecycle signals before authentication completes', async () => {
+    vi.useFakeTimers()
+    DelayedOpenWebSocket.pending = []
+    const transport = new WsAcpTransport({
+      url: 'ws://test/ws',
+      WebSocketImpl: DelayedOpenWebSocket as unknown as typeof WebSocket
+    })
+    const connecting = transport.connect()
+    await Promise.resolve()
+    const internals = transport as unknown as TransportInternals
+    const openingSocket = internals.socket as DelayedOpenWebSocket
+
+    // While CONNECTING (not OPEN, not authed), hide must not send background.
+    dispatchVisibility('hidden')
+    expect(sentType(openingSocket, 'background')).toBe(false)
+
+    openingSocket.openAndAuthenticate()
+    await connecting
+    transport.dispose()
+  })
+
+  it('does not send lifecycle signals after dispose', async () => {
+    vi.useFakeTimers()
+    const transport = new WsAcpTransport({
+      url: 'ws://test/ws',
+      WebSocketImpl: FakeWebSocket as unknown as typeof WebSocket
+    })
+    await transport.connect()
+    await transport.subscribeSession('sess-cap3')
+    const internals = transport as unknown as TransportInternals
+    const socket = internals.socket
+    transport.dispose()
+
+    dispatchVisibility('hidden')
+    expect(sentType(socket, 'background')).toBe(false)
+  })
+})
+
 describe('createAcpTransport selection', () => {
   beforeEach(() => {
     _resetAcpTransportForTests(null)

--- a/src/renderer/lib/acp-transport.ts
+++ b/src/renderer/lib/acp-transport.ts
@@ -1073,8 +1073,17 @@ export class WsAcpTransport implements AcpTransport {
     if (!socket || socket.readyState !== WebSocket.OPEN || !this.authed) return
     try {
       socket.send(JSON.stringify({ type }))
-    } catch {
-      // Swallow: never throw out of a browser lifecycle event listener.
+    } catch (err) {
+      // Never rethrow out of a browser lifecycle event listener, but emit a
+      // durable boundary log (per AGENTS.md) so a dead/closed socket here is
+      // observable. Safe context only — no frame payload, secrets, or creds.
+      void logFrontendError({
+        level: 'warn',
+        source: 'WsAcpTransport.sendLifecycleSignal',
+        message: `failed to send a background/foreground lifecycle signal: ${
+          err instanceof Error ? err.message : String(err)
+        }`
+      })
     }
   }
 
@@ -1450,6 +1459,13 @@ export class WsAcpTransport implements AcpTransport {
         // + authed — it refreshes the server keepalive watchdog through proxies
         // that strip WS-level Ping/Pong so a focused tab stops dropping at ~75s.
         this.startHeartbeat()
+        // CAP-3: if the tab is already hidden when auth completes (e.g. a
+        // reconnect that finished while backgrounded), the hide event fired
+        // before we were authed and was a no-op. Re-sync the server's watchdog
+        // to the 5-min background ceiling now that this connection is live.
+        if (typeof document !== 'undefined' && document.visibilityState === 'hidden') {
+          this.sendLifecycleSignal('background')
+        }
       } catch (err) {
         try {
           this.socket?.close()

--- a/src/renderer/lib/acp-transport.ts
+++ b/src/renderer/lib/acp-transport.ts
@@ -1060,6 +1060,25 @@ export class WsAcpTransport implements AcpTransport {
   }
 
   /**
+   * CAP-3: send an id-less `background`/`foreground` WS control frame so the
+   * server extends (background) or resets (foreground, or any normal frame)
+   * its keepalive watchdog ceiling. Fire-and-forget — no reply, no
+   * request/reply correlation id. Guarded to a live, authenticated socket;
+   * never throws (a failed lifecycle signal is harmless — the watchdog closes
+   * a dead socket on the next ping tick and the reconnect path engages).
+   */
+  private sendLifecycleSignal(type: 'background' | 'foreground'): void {
+    if (this.disposed) return
+    const socket = this.socket
+    if (!socket || socket.readyState !== WebSocket.OPEN || !this.authed) return
+    try {
+      socket.send(JSON.stringify({ type }))
+    } catch {
+      // Swallow: never throw out of a browser lifecycle event listener.
+    }
+  }
+
+  /**
    * Attach browser lifecycle listeners so every resume signal validates the
    * application round trip instead of trusting `readyState === OPEN`.
    */
@@ -1068,8 +1087,17 @@ export class WsAcpTransport implements AcpTransport {
     const onVisibility = (): void => {
       if (document.visibilityState === 'hidden') {
         this.lastHiddenAt = Date.now()
+        // CAP-3: signal the server to extend its keepalive watchdog to the
+        // 5-min background ceiling before the tab suspends (the OS will
+        // throttle/pause this transport's timers).
+        this.sendLifecycleSignal('background')
         return
       }
+      // CAP-3: signal the server to resume the normal 75s watchdog ceiling
+      // (a no-op if the socket is already dead — sendLifecycleSignal guards on
+      // readyState === OPEN). Then CAP-2's stale-threshold branching decides
+      // whether to validate the round trip or force-reconnect.
+      this.sendLifecycleSignal('foreground')
       // CAP-2: Skip round-trip ping validation on long background returns.
       // After VISIBILITY_STALE_THRESHOLD_MS, the heartbeat is throttled and
       // the server will kill the socket within ~45s, so a ping wastes up to


### PR DESCRIPTION
## Summary

Mobile web users hit a recurring failure cycle: backgrounding the tab lets the OS throttle `setInterval`, the server's 75s keepalive watchdog kills the WebSocket, the 15s disconnect grace expires before the mobile wake + reconnect chain completes, permission tickets are denied, and the session enters a stuck state (every 15–20 min per prod logs 2026-08-14). This PR closes two server-side seams of that cycle (CAP-3 + CAP-4) so a mobile user can switch apps for up to 5 minutes and return to a still-streaming chat with no lost events and no reload.

Source: bmad spec `spec-web-streaming-persistence` story 2.

## Related Issue

No related issue. Source of truth is the bmad spec: `_bmad-output/specs/spec-web-streaming-persistence/stories/2-signal-driven-adaptive-keepalive-and-extended-disconnect-grace.md`. Searched open + closed PRs for "adaptive keepalive" / "disconnect grace" / "background foreground frame" — no duplicates (#498 relay-reliability is related but distinct).

## Type of Change

- [x] feat: new feature

## What Changed

**CAP-3 — signal-driven adaptive keepalive (`src-tauri/src/web/ws.rs`, `src/renderer/lib/acp-transport.ts`)**
- New `BACKGROUND_TIMEOUT = 300s` ceiling; the write-task watchdog uses it only while a connection has sent `type:"background"`, and resets to the normal 75s `PONG_TIMEOUT` on `foreground` or any normal frame. `PONG_TIMEOUT` is **not** raised — the ceiling is signal-gated.
- Id-less `background`/`foreground` control frames are consumed in the read task **before** the strict `WsRequest` parse (which requires `id`). The per-connection `backgrounded` flag is toggled only when authenticated; an unauthed signal is ignored (no flag, no dispatch, no error).
- Client `WsAcpTransport.onVisibility` sends `background` on hide / `foreground` on show via raw `socket.send`, guarded on open + authed + not-disposed.
- `sendLifecycleSignal` logs a non-sensitive warning via `logFrontendError` on `socket.send` failure (durable boundary log per AGENTS.md); never rethrows out of the browser lifecycle listener.
- When authentication completes while the tab is already hidden (e.g. a reconnect that finished while backgrounded — the hide event fired pre-auth and was a no-op), the client sends `background` on auth completion to re-sync the server's 5-min ceiling for the live connection.

**CAP-4 — extended disconnect grace (`src-tauri/src/web/permissions.rs`, `src-tauri/src/web/config.rs`)**
- `DEFAULT_PERMISSION_RECONNECT_GRACE` and the `permission_reconnect_grace_secs` default widened **15s → 60s**, justified by the measured mobile wake + reconnect chain (3–8s desktop, 5–15s throttled mobile). Already overridable via the existing config knob — principled, not a hardcoded bump.

Desktop Tauri behavior is unchanged (web relay path only). Rebased onto `dev` (story 1 / #636 merged mid-flight); the `onVisibility` conflict was resolved by integrating CAP-3 `foreground` with CAP-2's stale-threshold branching.

## How It Was Tested

- [x] `bun run typecheck` (tsc node/web/test) — clean
- [x] `bun run test` (Vitest) — **69/69 pass** (incl. lifecycle frame-sending + auth-completes-while-hidden, initial + reconnect)
- [x] `cargo clippy --all-targets -- -D warnings` (in src-tauri) — clean, no warnings
- [x] `cargo test` (in src-tauri) — **949 passed, 0 failed, 2 ignored** (incl. `watchdog_backgrounded_uses_five_minute_ceiling`, `handle_lifecycle_signal_toggles_background_flag`, `peer_frame_type_extracts_background_and_foreground`, `from_args_defaults` 60s)
- [ ] `bun run ci` — changed files pass `biome ci` (lint+format+imports, strict) directly; the `bun run ci` script has a pre-existing biome-config/CWD quirk in this worktree ("0 files, paths ignored" from `.`) — CI runs from the repo root where it resolves correctly.
- [ ] Manual verification completed — the spec's `done_checkpoint` requires a real mobile-browser AFK cycle (switch apps >75s, return, verify no disconnect). Pending a human/device run.

## CI & Review Gate

- [ ] All CI checks pass (PR Validation, Rust Checks, Build Verification, Security Scans)
- [ ] Code review comments from CodeRabbit / Claude have been addressed or resolved
- [ ] No unresolved review findings remain

## Checklist

- [x] My PR title follows the conventional commit format used by this repo
- [x] I linked the related issue or explained why none exists
- [ ] I updated docs when needed (n/a — code-level resilience change)
- [x] I added or updated tests when needed
- [x] I verified the change does not introduce unrelated modifications (5 files, all CAP-3/CAP-4; the local `cc6.manifest` test-runner artifact is intentionally not committed)
- [x] I read AGENTS.md and followed the contributor guidelines
- [ ] A human reviewed the complete diff before submission — **this PR is that review**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved support for backgrounded browser tabs, allowing connections to remain active longer while a tab is suspended.
  - Connections now automatically resume when returning to a visible tab.
- **Bug Fixes**
  - Increased the permission reconnect grace period from 15 to 60 seconds, reducing unnecessary interruptions during temporary disconnections.
  - Enhanced connection lifecycle handling for more reliable background and foreground transitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->