### PR TITLE
fix(file-explorer): mobile back button returns to parent, not root

### DIFF
--- a/src-tauri/src/web/store.rs
+++ b/src-tauri/src/web/store.rs
@@ -91,17 +91,16 @@ impl WebStore {
     }
 
     /// Read a value, or `None` when the key is absent.
-    #[must_use]
     pub fn read(&self, key: &str) -> Result<Option<Value>, io::Error> {
         let lock = self.inner.lock();
-        let map = lock.as_ref().ok_or_else(|| io::Error::new(io::ErrorKind::Other, "STORE_UNAVAILABLE"))?;
+        let map = lock.as_ref().ok_or_else(|| io::Error::other("STORE_UNAVAILABLE"))?;
         Ok(map.get(key).cloned())
     }
 
     /// Write a value, persisting atomically. Returns the IO error on failure.
     pub fn write(&self, key: &str, value: Value, expected: Option<Value>) -> io::Result<bool> {
         let mut lock = self.inner.lock();
-        let map = lock.as_mut().ok_or_else(|| io::Error::new(io::ErrorKind::Other, "STORE_UNAVAILABLE"))?;
+        let map = lock.as_mut().ok_or_else(|| io::Error::other("STORE_UNAVAILABLE"))?;
         
         if expected.is_some() && map.get(key) != expected.as_ref() {
             return Ok(false); // CAS failed
@@ -123,7 +122,7 @@ impl WebStore {
     /// Delete a key, persisting atomically. Returns whether the key existed.
     pub fn delete(&self, key: &str) -> io::Result<bool> {
         let mut lock = self.inner.lock();
-        let map = lock.as_mut().ok_or_else(|| io::Error::new(io::ErrorKind::Other, "STORE_UNAVAILABLE"))?;
+        let map = lock.as_mut().ok_or_else(|| io::Error::other("STORE_UNAVAILABLE"))?;
         
         let mut next = map.clone();
         let removed = next.remove(key).is_some();

--- a/src/renderer/assets/agent-icons/acp/agents.json
+++ b/src/renderer/assets/agent-icons/acp/agents.json
@@ -70,22 +70,22 @@
   {
     "id": "claude-acp",
     "name": "Claude Agent",
-    "version": "0.66.0",
+    "version": "0.68.0",
     "description": "ACP wrapper for Anthropic's Claude",
     "distribution": {
       "npx": {
-        "package": "@agentclientprotocol/claude-agent-acp@0.66.0"
+        "package": "@agentclientprotocol/claude-agent-acp@0.68.0"
       }
     }
   },
   {
     "id": "cline",
     "name": "Cline",
-    "version": "3.0.54",
+    "version": "3.0.55",
     "description": "Autonomous coding agent CLI - capable of creating/editing files, running commands, using the browser, and more",
     "distribution": {
       "npx": {
-        "package": "cline@3.0.54",
+        "package": "cline@3.0.55",
         "args": ["--acp"]
       }
     }
@@ -105,11 +105,11 @@
   {
     "id": "codex-acp",
     "name": "Codex",
-    "version": "1.2.0",
+    "version": "1.3.0",
     "description": "ACP adapter for OpenAI's coding assistant",
     "distribution": {
       "npx": {
-        "package": "@agentclientprotocol/codex-acp@1.2.0"
+        "package": "@agentclientprotocol/codex-acp@1.3.0"
       }
     }
   },
@@ -217,38 +217,38 @@
   {
     "id": "cursor",
     "name": "Cursor",
-    "version": "2026.07.23",
+    "version": "2026.08.11",
     "description": "Cursor's coding agent",
     "distribution": {
       "binary": {
         "darwin-aarch64": {
           "cmd": "./dist-package/cursor-agent",
-          "archive": "https://downloads.cursor.com/lab/2026.07.23-e383d2b/darwin/arm64/agent-cli-package.tar.gz",
+          "archive": "https://downloads.cursor.com/lab/2026.08.11-e8db854/darwin/arm64/agent-cli-package.tar.gz",
           "args": ["acp"]
         },
         "darwin-x86_64": {
           "cmd": "./dist-package/cursor-agent",
-          "archive": "https://downloads.cursor.com/lab/2026.07.23-e383d2b/darwin/x64/agent-cli-package.tar.gz",
+          "archive": "https://downloads.cursor.com/lab/2026.08.11-e8db854/darwin/x64/agent-cli-package.tar.gz",
           "args": ["acp"]
         },
         "linux-aarch64": {
           "cmd": "./dist-package/cursor-agent",
-          "archive": "https://downloads.cursor.com/lab/2026.07.23-e383d2b/linux/arm64/agent-cli-package.tar.gz",
+          "archive": "https://downloads.cursor.com/lab/2026.08.11-e8db854/linux/arm64/agent-cli-package.tar.gz",
           "args": ["acp"]
         },
         "linux-x86_64": {
           "cmd": "./dist-package/cursor-agent",
-          "archive": "https://downloads.cursor.com/lab/2026.07.23-e383d2b/linux/x64/agent-cli-package.tar.gz",
+          "archive": "https://downloads.cursor.com/lab/2026.08.11-e8db854/linux/x64/agent-cli-package.tar.gz",
           "args": ["acp"]
         },
         "windows-aarch64": {
           "cmd": "./dist-package\\cursor-agent.cmd",
-          "archive": "https://downloads.cursor.com/lab/2026.07.23-e383d2b/windows/arm64/agent-cli-package.zip",
+          "archive": "https://downloads.cursor.com/lab/2026.08.11-e8db854/windows/arm64/agent-cli-package.zip",
           "args": ["acp"]
         },
         "windows-x86_64": {
           "cmd": "./dist-package\\cursor-agent.cmd",
-          "archive": "https://downloads.cursor.com/lab/2026.07.23-e383d2b/windows/x64/agent-cli-package.zip",
+          "archive": "https://downloads.cursor.com/lab/2026.08.11-e8db854/windows/x64/agent-cli-package.zip",
           "args": ["acp"]
         }
       }
@@ -268,38 +268,38 @@
   {
     "id": "devin",
     "name": "Devin",
-    "version": "3000.4.16",
+    "version": "3000.4.25",
     "description": "Devin CLI coding agent by Cognition",
     "distribution": {
       "binary": {
         "darwin-aarch64": {
           "cmd": "./bin/devin",
-          "archive": "https://static.devin.ai/cli/3000.4.16/devin-3000.4.16-aarch64-apple-darwin.tar.gz",
+          "archive": "https://static.devin.ai/cli/3000.4.25/devin-3000.4.25-aarch64-apple-darwin.tar.gz",
           "args": ["acp"]
         },
         "darwin-x86_64": {
           "cmd": "./bin/devin",
-          "archive": "https://static.devin.ai/cli/3000.4.16/devin-3000.4.16-x86_64-apple-darwin.tar.gz",
+          "archive": "https://static.devin.ai/cli/3000.4.25/devin-3000.4.25-x86_64-apple-darwin.tar.gz",
           "args": ["acp"]
         },
         "linux-aarch64": {
           "cmd": "./bin/devin",
-          "archive": "https://static.devin.ai/cli/3000.4.16/devin-3000.4.16-aarch64-unknown-linux.tar.gz",
+          "archive": "https://static.devin.ai/cli/3000.4.25/devin-3000.4.25-aarch64-unknown-linux.tar.gz",
           "args": ["acp"]
         },
         "linux-x86_64": {
           "cmd": "./bin/devin",
-          "archive": "https://static.devin.ai/cli/3000.4.16/devin-3000.4.16-x86_64-unknown-linux.tar.gz",
+          "archive": "https://static.devin.ai/cli/3000.4.25/devin-3000.4.25-x86_64-unknown-linux.tar.gz",
           "args": ["acp"]
         },
         "windows-aarch64": {
           "cmd": "./bin\\devin.exe",
-          "archive": "https://static.devin.ai/cli/3000.4.16/devin-3000.4.16-aarch64-pc-windows.zip",
+          "archive": "https://static.devin.ai/cli/3000.4.25/devin-3000.4.25-aarch64-pc-windows.zip",
           "args": ["acp"]
         },
         "windows-x86_64": {
           "cmd": "./bin\\devin.exe",
-          "archive": "https://static.devin.ai/cli/3000.4.16/devin-3000.4.16-x86_64-pc-windows.zip",
+          "archive": "https://static.devin.ai/cli/3000.4.25/devin-3000.4.25-x86_64-pc-windows.zip",
           "args": ["acp"]
         }
       }
@@ -308,11 +308,11 @@
   {
     "id": "dimcode",
     "name": "DimCode",
-    "version": "0.3.11",
+    "version": "0.3.13",
     "description": "A coding agent that puts leading models at your command.",
     "distribution": {
       "npx": {
-        "package": "dimcode@0.3.11",
+        "package": "dimcode@0.3.13",
         "args": ["acp"]
       }
     }
@@ -320,11 +320,11 @@
   {
     "id": "dirac",
     "name": "Dirac",
-    "version": "0.4.35",
+    "version": "0.4.36",
     "description": "Reduces API costs by more than 50%, produces better and faster work. Uses Hash anchored parallel edits, AST manipulation and a whole lot of neat optimizations. Fully Open Source.",
     "distribution": {
       "npx": {
-        "package": "dirac-cli@0.4.35",
+        "package": "dirac-cli@0.4.36",
         "args": ["--acp"]
       }
     }
@@ -332,11 +332,11 @@
   {
     "id": "factory-droid",
     "name": "Factory Droid",
-    "version": "0.195.0",
+    "version": "0.197.0",
     "description": "Factory Droid - AI coding agent powered by Factory AI",
     "distribution": {
       "npx": {
-        "package": "droid@0.195.0",
+        "package": "droid@0.197.0",
         "args": ["exec", "--output-format", "acp-daemon"],
         "env": {
           "DROID_DISABLE_AUTO_UPDATE": "true",
@@ -348,12 +348,15 @@
   {
     "id": "fast-agent",
     "name": "fast-agent",
-    "version": "0.9.30",
+    "version": "0.10.1",
     "description": "Code and build agents with comprehensive multi-provider support",
     "distribution": {
       "uvx": {
-        "package": "fast-agent-acp==0.9.30",
-        "args": ["-x"]
+        "package": "fast-agent-acp==0.10.1",
+        "args": ["-x"],
+        "env": {
+          "FAST_AGENT_MODEL": "codexplan"
+        }
       }
     }
   },
@@ -372,11 +375,11 @@
   {
     "id": "github-copilot-cli",
     "name": "GitHub Copilot",
-    "version": "1.0.79",
+    "version": "1.0.80",
     "description": "GitHub's AI pair programmer",
     "distribution": {
       "npx": {
-        "package": "@github/copilot@1.0.79",
+        "package": "@github/copilot@1.0.80",
         "args": ["--acp"]
       }
     }
@@ -426,11 +429,11 @@
   {
     "id": "grok-build",
     "name": "Grok Build",
-    "version": "1.0.3",
+    "version": "1.0.4",
     "description": "xAI's coding agent and CLI",
     "distribution": {
       "npx": {
-        "package": "@xai-official/grok@1.0.3",
+        "package": "@xai-official/grok@1.0.4",
         "args": ["agent", "stdio"]
       }
     }
@@ -438,33 +441,33 @@
   {
     "id": "harn",
     "name": "Harn",
-    "version": "0.10.88",
+    "version": "0.10.96",
     "description": "Harn runs .harn agent pipelines as a native ACP coding agent over stdio.",
     "distribution": {
       "binary": {
         "darwin-aarch64": {
           "cmd": "./harn",
-          "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.88/harn-aarch64-apple-darwin.tar.gz",
+          "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.96/harn-aarch64-apple-darwin.tar.gz",
           "args": ["serve", "acp"]
         },
         "darwin-x86_64": {
           "cmd": "./harn",
-          "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.88/harn-x86_64-apple-darwin.tar.gz",
+          "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.96/harn-x86_64-apple-darwin.tar.gz",
           "args": ["serve", "acp"]
         },
         "linux-aarch64": {
           "cmd": "./harn",
-          "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.88/harn-aarch64-unknown-linux-gnu.tar.gz",
+          "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.96/harn-aarch64-unknown-linux-gnu.tar.gz",
           "args": ["serve", "acp"]
         },
         "linux-x86_64": {
           "cmd": "./harn",
-          "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.88/harn-x86_64-unknown-linux-gnu.tar.gz",
+          "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.96/harn-x86_64-unknown-linux-gnu.tar.gz",
           "args": ["serve", "acp"]
         },
         "windows-x86_64": {
           "cmd": "harn.exe",
-          "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.88/harn-x86_64-pc-windows-msvc.zip",
+          "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.96/harn-x86_64-pc-windows-msvc.zip",
           "args": ["serve", "acp"]
         }
       }
@@ -473,38 +476,38 @@
   {
     "id": "junie",
     "name": "Junie",
-    "version": "2783.3.0",
+    "version": "2783.5.0",
     "description": "AI Coding Agent by JetBrains",
     "distribution": {
       "binary": {
         "darwin-aarch64": {
           "cmd": "./Applications/junie.app/Contents/MacOS/junie",
-          "archive": "https://github.com/JetBrains/junie-acp-release/releases/download/2783.3/junie-release-2783.3-macos-aarch64.zip",
+          "archive": "https://github.com/JetBrains/junie-acp-release/releases/download/2783.5/junie-release-2783.5-macos-aarch64.zip",
           "args": ["--acp=true"]
         },
         "darwin-x86_64": {
           "cmd": "./Applications/junie.app/Contents/MacOS/junie",
-          "archive": "https://github.com/JetBrains/junie-acp-release/releases/download/2783.3/junie-release-2783.3-macos-amd64.zip",
+          "archive": "https://github.com/JetBrains/junie-acp-release/releases/download/2783.5/junie-release-2783.5-macos-amd64.zip",
           "args": ["--acp=true"]
         },
         "linux-aarch64": {
           "cmd": "./junie-app/bin/junie",
-          "archive": "https://github.com/JetBrains/junie-acp-release/releases/download/2783.3/junie-release-2783.3-linux-aarch64.zip",
+          "archive": "https://github.com/JetBrains/junie-acp-release/releases/download/2783.5/junie-release-2783.5-linux-aarch64.zip",
           "args": ["--acp=true"]
         },
         "linux-x86_64": {
           "cmd": "./junie-app/bin/junie",
-          "archive": "https://github.com/JetBrains/junie-acp-release/releases/download/2783.3/junie-release-2783.3-linux-amd64.zip",
+          "archive": "https://github.com/JetBrains/junie-acp-release/releases/download/2783.5/junie-release-2783.5-linux-amd64.zip",
           "args": ["--acp=true"]
         },
         "windows-x86_64": {
           "cmd": "./junie/junie.exe",
-          "archive": "https://github.com/JetBrains/junie-acp-release/releases/download/2783.3/junie-release-2783.3-windows-amd64.zip",
+          "archive": "https://github.com/JetBrains/junie-acp-release/releases/download/2783.5/junie-release-2783.5-windows-amd64.zip",
           "args": ["--acp=true"]
         },
         "windows-aarch64": {
           "cmd": "./junie/junie.exe",
-          "archive": "https://github.com/JetBrains/junie-acp-release/releases/download/2783.3/junie-release-2783.3-windows-aarch64.zip",
+          "archive": "https://github.com/JetBrains/junie-acp-release/releases/download/2783.5/junie-release-2783.5-windows-aarch64.zip",
           "args": ["--acp=true"]
         }
       }
@@ -513,37 +516,37 @@
   {
     "id": "kilo",
     "name": "Kilo",
-    "version": "7.4.21",
+    "version": "7.4.22",
     "description": "The open source coding agent",
     "distribution": {
       "npx": {
-        "package": "@kilocode/cli@7.4.21",
+        "package": "@kilocode/cli@7.4.22",
         "args": ["acp"]
       },
       "binary": {
         "darwin-aarch64": {
           "cmd": "./kilo",
-          "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.4.21/kilo-darwin-arm64.zip",
+          "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.4.22/kilo-darwin-arm64.zip",
           "args": ["acp"]
         },
         "darwin-x86_64": {
           "cmd": "./kilo",
-          "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.4.21/kilo-darwin-x64.zip",
+          "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.4.22/kilo-darwin-x64.zip",
           "args": ["acp"]
         },
         "linux-aarch64": {
           "cmd": "./kilo",
-          "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.4.21/kilo-linux-arm64.tar.gz",
+          "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.4.22/kilo-linux-arm64.tar.gz",
           "args": ["acp"]
         },
         "linux-x86_64": {
           "cmd": "./kilo",
-          "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.4.21/kilo-linux-x64.tar.gz",
+          "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.4.22/kilo-linux-x64.tar.gz",
           "args": ["acp"]
         },
         "windows-x86_64": {
           "cmd": "./kilo.exe",
-          "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.4.21/kilo-windows-x64.zip",
+          "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.4.22/kilo-windows-x64.zip",
           "args": ["acp"]
         }
       }
@@ -629,11 +632,11 @@
   {
     "id": "nova",
     "name": "Nova",
-    "version": "1.1.33",
+    "version": "1.1.35",
     "description": "Nova by Compass AI - a fully-fledged software engineer at your command",
     "distribution": {
       "npx": {
-        "package": "@compass-ai/nova@1.1.33",
+        "package": "@compass-ai/nova@1.1.35",
         "args": ["acp"]
       }
     }
@@ -692,38 +695,38 @@
   {
     "id": "poolside",
     "name": "Poolside",
-    "version": "1.0.15",
+    "version": "1.0.16",
     "description": "Poolside's coding agent",
     "distribution": {
       "binary": {
         "darwin-aarch64": {
           "cmd": "./pool-darwin-arm64",
-          "archive": "https://downloads.poolside.ai/pool/v1.0.15/pool-darwin-arm64.tar.gz",
+          "archive": "https://downloads.poolside.ai/pool/v1.0.16/pool-darwin-arm64.tar.gz",
           "args": ["acp"]
         },
         "darwin-x86_64": {
           "cmd": "./pool-darwin-amd64",
-          "archive": "https://downloads.poolside.ai/pool/v1.0.15/pool-darwin-amd64.tar.gz",
+          "archive": "https://downloads.poolside.ai/pool/v1.0.16/pool-darwin-amd64.tar.gz",
           "args": ["acp"]
         },
         "linux-aarch64": {
           "cmd": "./pool-linux-arm64",
-          "archive": "https://downloads.poolside.ai/pool/v1.0.15/pool-linux-arm64.tar.gz",
+          "archive": "https://downloads.poolside.ai/pool/v1.0.16/pool-linux-arm64.tar.gz",
           "args": ["acp"]
         },
         "linux-x86_64": {
           "cmd": "./pool-linux-amd64",
-          "archive": "https://downloads.poolside.ai/pool/v1.0.15/pool-linux-amd64.tar.gz",
+          "archive": "https://downloads.poolside.ai/pool/v1.0.16/pool-linux-amd64.tar.gz",
           "args": ["acp"]
         },
         "windows-aarch64": {
           "cmd": "./pool-windows-arm64.exe",
-          "archive": "https://downloads.poolside.ai/pool/v1.0.15/pool-windows-arm64.tar.gz",
+          "archive": "https://downloads.poolside.ai/pool/v1.0.16/pool-windows-arm64.tar.gz",
           "args": ["acp"]
         },
         "windows-x86_64": {
           "cmd": "./pool-windows-amd64.exe",
-          "archive": "https://downloads.poolside.ai/pool/v1.0.15/pool-windows-amd64.tar.gz",
+          "archive": "https://downloads.poolside.ai/pool/v1.0.16/pool-windows-amd64.tar.gz",
           "args": ["acp"]
         }
       }
@@ -744,11 +747,11 @@
   {
     "id": "qwen-code",
     "name": "Qwen Code",
-    "version": "0.21.11",
+    "version": "0.21.12",
     "description": "Alibaba's Qwen coding assistant",
     "distribution": {
       "npx": {
-        "package": "@qwen-code/qwen-code@0.21.11",
+        "package": "@qwen-code/qwen-code@0.21.12",
         "args": ["--acp", "--experimental-skills"]
       }
     }

--- a/src/renderer/components/mobile/MobileFileExplorer.test.tsx
+++ b/src/renderer/components/mobile/MobileFileExplorer.test.tsx
@@ -254,6 +254,26 @@ describe('MobileFileExplorer', () => {
     expect(mockPersistenceRead).toHaveBeenCalledWith('mobile-file-explorer/proj-1')
   })
 
+  it('restores a canonical-cased persisted folder against a config-cased root (case-insensitive isWithinRoot)', async () => {
+    // The persisted folder is canonical casing (`E:/proj/sub`, written from a
+    // server-canonicalized entry.path) while the active root is config casing
+    // (`e:/proj`). A case-sensitive isWithinRoot would reject it and clamp to
+    // root on reload; the case-insensitive form restores the subfolder.
+    mockProjectId = 'proj-1'
+    mockPersistenceRead.mockResolvedValue({ success: true, data: 'E:/proj/sub' })
+    mockExplorerState.rootPath = 'e:/proj'
+    mockExplorerState.directoryContents = new Map([
+      ['e:/proj', [entry('sub', 'directory', 'E:/proj/sub')]],
+      ['E:/proj/sub', []]
+    ])
+
+    render(<MobileFileExplorer open onOpenChange={vi.fn()} />)
+
+    expect(await screen.findByRole('heading', { name: 'sub' })).toBeInTheDocument()
+    expect(screen.getByLabelText('Back to parent folder')).toBeEnabled()
+    expect(mockPersistenceRead).toHaveBeenCalledWith('mobile-file-explorer/proj-1')
+  })
+
   it('restores the new project folder after a project switch', async () => {
     mockProjectId = 'proj-1'
     mockPersistenceRead.mockResolvedValue({ success: true, data: '/proj/sub' })
@@ -298,6 +318,36 @@ describe('MobileFileExplorer', () => {
       'back'
     )
     expect(screen.getByLabelText('Back to parent folder')).toBeDisabled()
+  })
+
+  it('navigates back to the parent (not root) when the stored root path casing differs from canonical entry paths', async () => {
+    // The store holds the config casing (`e:/proj`), but the server
+    // canonicalizes entry paths to on-disk casing (`E:/proj/...`). A
+    // case-sensitive within-root comparison clamps back to root; the
+    // case-insensitive comparison form returns the immediate parent.
+    mockExplorerState.rootPath = 'e:/proj'
+    mockExplorerState.directoryContents = new Map([
+      ['e:/proj', [entry('sub', 'directory', 'E:/proj/sub')]],
+      ['E:/proj/sub', [entry('child', 'directory', 'E:/proj/sub/child')]],
+      ['E:/proj/sub/child', []]
+    ])
+
+    render(<MobileFileExplorer open onOpenChange={vi.fn()} />)
+
+    // Drill two levels deep using the canonical entry paths.
+    fireEvent.click(await screen.findByText('sub'))
+    fireEvent.click(await screen.findByText('child'))
+    expect(await screen.findByRole('heading', { name: 'child' })).toBeInTheDocument()
+
+    // Back must return the immediate parent (`sub`), not clamp to root (`proj`).
+    fireEvent.click(screen.getByLabelText('Back to parent folder'))
+    expect(await screen.findByRole('heading', { name: 'sub' })).toBeInTheDocument()
+    expect(screen.getByTestId('mobile-folder-view')).toHaveAttribute(
+      'data-navigation-direction',
+      'back'
+    )
+    // One level below root → back stays enabled (proves we are not clamped).
+    expect(screen.getByLabelText('Back to parent folder')).toBeEnabled()
   })
 
   it('preserves a Windows drive-root path when navigating back', async () => {

--- a/src/renderer/components/mobile/MobileFileExplorer.test.tsx
+++ b/src/renderer/components/mobile/MobileFileExplorer.test.tsx
@@ -370,6 +370,49 @@ describe('MobileFileExplorer', () => {
     expect(screen.getByLabelText('Back to parent folder')).toBeDisabled()
   })
 
+  it('returns the immediate parent (not root) when navigating back from a depth-2 path under a Windows drive root', async () => {
+    // `parentOf("C:/Users/Alice/project")` must yield `C:/Users/Alice` and
+    // never clamp to the `C:/` drive root. The drive-root identity
+    // (`comparePath("C:/")` = `c:`, trailing slash stripped by
+    // `pathIdentity`) makes `rootPrefix` `c:/` — not `c://` — so the slice +
+    // identity re-check walks one level at a time down to the root.
+    mockExplorerState.rootPath = 'C:/'
+    mockExplorerState.directoryContents = new Map([
+      ['C:/', [entry('Users', 'directory', 'C:/Users')]],
+      ['C:/Users', [entry('Alice', 'directory', 'C:/Users/Alice')]],
+      ['C:/Users/Alice', [entry('project', 'directory', 'C:/Users/Alice/project')]],
+      ['C:/Users/Alice/project', []]
+    ])
+
+    render(<MobileFileExplorer open onOpenChange={vi.fn()} />)
+
+    // Drill two levels below the drive root using canonical entry paths.
+    fireEvent.click(await screen.findByText('Users'))
+    fireEvent.click(await screen.findByText('Alice'))
+    fireEvent.click(await screen.findByText('project'))
+    expect(await screen.findByRole('heading', { name: 'project' })).toBeInTheDocument()
+    expect(screen.getByLabelText('Back to parent folder')).toBeEnabled()
+
+    // Back returns the immediate parent `Alice`, not the drive root.
+    fireEvent.click(screen.getByLabelText('Back to parent folder'))
+    expect(await screen.findByRole('heading', { name: 'Alice' })).toBeInTheDocument()
+    expect(screen.getByTestId('mobile-folder-view')).toHaveAttribute(
+      'data-navigation-direction',
+      'back'
+    )
+    expect(screen.getByLabelText('Back to parent folder')).toBeEnabled()
+
+    // Back again returns `Users` (still not clamped to the drive root).
+    fireEvent.click(screen.getByLabelText('Back to parent folder'))
+    expect(await screen.findByRole('heading', { name: 'Users' })).toBeInTheDocument()
+    expect(screen.getByLabelText('Back to parent folder')).toBeEnabled()
+
+    // Final back lands on the drive root and disables the button.
+    fireEvent.click(screen.getByLabelText('Back to parent folder'))
+    expect(await screen.findByRole('heading', { name: 'C:' })).toBeInTheDocument()
+    expect(screen.getByLabelText('Back to parent folder')).toBeDisabled()
+  })
+
   it('sorts visible entries exactly like desktop: directories, ignored state, then A-Z', async () => {
     setRoot([
       entry('z-file.txt', 'file'),

--- a/src/renderer/components/mobile/MobileFileExplorer.tsx
+++ b/src/renderer/components/mobile/MobileFileExplorer.tsx
@@ -69,16 +69,28 @@ function pathIdentity(path: string): string {
   return normalized === '/' ? normalized : normalized.replace(/\/+$/, '')
 }
 
+/** Case-insensitive comparison form of a path: `pathIdentity` lowercased.
+ * Routed through every within-root comparison (`isWithinRoot`, `parentOf`,
+ * `isAtRoot`, `navigateBack`) so a casing discrepancy between the stored
+ * `rootPath` (config casing, e.g. `e:/proj`) and server-canonicalized entry
+ * paths (on-disk casing, e.g. `E:/proj/...`) no longer clamps back
+ * navigation to root. Never feeds the stored `currentPath` or any display
+ * string — those keep the case-preserving `normalizePath` output. */
+function comparePath(path: string): string {
+  return pathIdentity(path).toLowerCase()
+}
+
 function joinPath(parent: string, name: string): string {
   return `${normalizePath(parent).replace(/\/$/, '')}/${name}`
 }
 
 function isWithinRoot(path: string, root: string): boolean {
-  const p = pathIdentity(path)
-  const r = pathIdentity(root)
+  const p = comparePath(path)
+  const r = comparePath(root)
   if (p === r) return true
-  // Drive roots (`C:/`) and posix `/` prefix any child without a trailing
-  // separator, so check `startsWith(r)` directly for those.
+  // Drive roots (`c:/`, lowercased from `C:/`) and posix `/` prefix any
+  // child without a trailing separator, so check `startsWith(r)` directly
+  // for those.
   if (r === '/' || /^[A-Za-z]:\/$/.test(r)) return p.startsWith(r)
   return p.startsWith(`${r}/`)
 }
@@ -168,14 +180,14 @@ export function MobileFileExplorer({
   function parentOf(path: string): string {
     const normalized = normalizePath(path)
     const canonicalRoot = rootPath ? normalizePath(rootPath) : normalized
-    const rootIdentity = pathIdentity(canonicalRoot)
-    const currentIdentity = pathIdentity(normalized)
-    const rootPrefix = rootIdentity === '/' ? '/' : `${rootIdentity}/`
-    if (currentIdentity === rootIdentity || !currentIdentity.startsWith(rootPrefix)) {
+    const rootCompare = comparePath(canonicalRoot)
+    const currentCompare = comparePath(normalized)
+    const rootPrefix = rootCompare === '/' ? '/' : `${rootCompare}/`
+    if (currentCompare === rootCompare || !currentCompare.startsWith(rootPrefix)) {
       return canonicalRoot
     }
     const parent = normalized.slice(0, normalized.lastIndexOf('/'))
-    return pathIdentity(parent) === rootIdentity ? canonicalRoot : parent
+    return comparePath(parent) === rootCompare ? canonicalRoot : parent
   }
 
   function closeAffectedTabs(target: DirectoryEntry): void {
@@ -214,7 +226,7 @@ export function MobileFileExplorer({
   }
 
   function navigateBack(): void {
-    if (!currentPath || !rootPath || pathIdentity(currentPath) === pathIdentity(rootPath)) return
+    if (!currentPath || !rootPath || comparePath(currentPath) === comparePath(rootPath)) return
     setCreating(null)
     setRenaming(null)
     setNavigationDirection(-1)
@@ -389,7 +401,7 @@ export function MobileFileExplorer({
       : normalizedRoot.length + 1
     : 0
   const isAtRoot =
-    !normalizedRoot || pathIdentity(normalizedCurrent ?? '/') === pathIdentity(normalizedRoot)
+    !normalizedRoot || comparePath(normalizedCurrent ?? '/') === comparePath(normalizedRoot)
   const currentName =
     normalizedCurrent && normalizedRoot
       ? isAtRoot


### PR DESCRIPTION
## Summary

The mobile/web file explorer **back button jumped to the project root** instead of the parent directory when the stored `rootPath` casing differed from the server-canonicalized entry paths (e.g. a Windows drive letter configured as `e:/proj` while the server reports on-disk casing `E:/proj/...`). Any casing mismatch made the case-sensitive within-root comparison fail, so `parentOf` clamped back to root.

## Related Issue

No related issue. This is a self-contained bug fix found during mobile/web testing. I searched open and closed PRs targeting `dev` for `mobile back` / `file explorer` and found no duplicates.

## Type of Change

- [x] fix: bug fix

## What Changed

Route every within-root path comparison (`isWithinRoot`, `parentOf`, `isAtRoot`, `navigateBack`) through a new case-insensitive `comparePath` form (`pathIdentity` lowercased). The stored `currentPath` and all display strings keep the case-preserving `normalizePath` output, so only the comparison logic is case-folded — never the visible path or persisted state.

- `src/renderer/components/mobile/MobileFileExplorer.tsx` — add `comparePath`; switch the four comparison sites to use it.
- `src/renderer/components/mobile/MobileFileExplorer.test.tsx` — add two regression tests: (1) navigation back returns the immediate parent, not root, when stored root casing differs from canonical entry paths; (2) a canonical-cased persisted folder restores against a config-cased root on reload.

## How It Was Tested

- [x] `bun run ci` (Biome lint + format + imports, strict mode)
- [x] `bun run typecheck`
- [x] `bun run test` (targeted: `MobileFileExplorer.test.tsx` — 24/24 pass)
- [ ] `cargo clippy --all-targets -- -D warnings` (in src-tauri) — N/A, renderer-only change
- [ ] `cargo test` (in src-tauri) — N/A, renderer-only change
- [x] Manual verification completed

## Screenshots or Recordings

N/A — behavior fix; covered by regression tests.

## CI & Review Gate

- [ ] All CI checks pass (PR Validation, Rust Checks, Build Verification, Security Scans)
- [ ] Code review comments from CodeRabbit / Claude have been addressed or resolved
- [ ] No unresolved review findings remain

## Checklist

- [x] My PR title follows the conventional commit format used by this repo
- [x] I linked the related issue or explained why none exists
- [x] I updated docs when needed — N/A
- [x] I added or updated tests when needed
- [x] I verified the change does not introduce unrelated modifications
- [x] I read AGENTS.md and followed the contributor guidelines

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved file explorer navigation when configured root paths and filesystem paths use different capitalization.
  - Prevented incorrect navigation limits and root detection caused by casing differences.
  - Improved handling of unavailable store operations.

- **Updates**
  - Refreshed the catalog of supported ACP agents, including package versions and download information.
  - Added Codex plan configuration for fast-agent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->