### PR TITLE
feat(web): persist web-client project list server-side (Option B)

### DIFF
--- a/src-tauri/src/acp/project_registry.rs
+++ b/src-tauri/src/acp/project_registry.rs
@@ -348,6 +348,80 @@ impl FileProjectRegistry {
     pub(crate) fn restore_default_project(&mut self, default_project_id: Option<String>) {
         self.default_project_id = default_project_id;
     }
+    /// Insert or replace a VFS root by `id`, canonicalizing + validating its
+    /// path. Used by the web-client project create/update mutations (Option B:
+    /// the standalone server is a first-class project-list authority).
+    ///
+    /// The path is canonicalized + must-be-a-directory (same `validate_root_path`
+    /// leaf `load` uses) so the fs boundary check is stable. A root with an
+    /// existing `id` is replaced in place (preserving order); a new id is
+    /// appended. Does NOT touch `default_project_id` — the caller persists
+    /// separately via `set_default_project` if the new root should be default.
+    /// Persistence is an explicit caller-owned `save_atomic` step (same posture
+    /// as `set_default_project`).
+    pub fn upsert_root(&mut self, root: VfsRoot) -> Result<(), ProjectRegistryError> {
+        let mut root = root;
+        root.path = validate_root_path(&root.path).map_err(|reason| {
+            ProjectRegistryError::InvalidRoot {
+                id: root.id.clone(),
+                reason,
+            }
+        })?;
+        if let Some(existing) = self.roots.iter_mut().find(|r| r.id == root.id) {
+            *existing = root;
+        } else {
+            self.roots.push(root);
+        }
+        Ok(())
+    }
+
+    /// Remove a VFS root by `id`. Returns `false` (and the caller replies
+    /// `NOT_FOUND`) when the id is absent. Clears `default_project_id` when it
+    /// referenced the removed root (P4: no dangling default — mirrors `load`'s
+    /// post-load cleanup). Persistence is a caller-owned `save_atomic` step.
+    pub fn remove_root(&mut self, project_id: &str) -> bool {
+        let before = self.roots.len();
+        self.roots.retain(|r| r.id != project_id);
+        if self.roots.len() == before {
+            return false;
+        }
+        if self.default_project_id.as_deref() == Some(project_id) {
+            self.default_project_id = None;
+        }
+        true
+    }
+
+    /// Patch a subset of a root's display fields (name, color, archived) by
+    /// `id` without re-canonicalizing the path. Used by the web-client
+    /// rename/color/archive mutations. Returns `false` when the id is absent.
+    /// Persistence is a caller-owned `save_atomic` step.
+    pub fn update_root(
+        &mut self,
+        project_id: &str,
+        name: Option<String>,
+        color: Option<String>,
+        is_archived: Option<bool>,
+    ) -> bool {
+        let Some(root) = self.roots.iter_mut().find(|r| r.id == project_id) else {
+            return false;
+        };
+        if let Some(name) = name {
+            root.name = name;
+        }
+        if let Some(color) = color {
+            root.color = color;
+        }
+        if let Some(is_archived) = is_archived {
+            root.is_archived = is_archived;
+        }
+        // P4: an archived default is not switchable — clear the default so a
+        // stale id does not survive (mirrors `set_default_project` + `load`).
+        if root.is_archived && self.default_project_id.as_deref() == Some(project_id) {
+            self.default_project_id = None;
+        }
+        true
+    }
+
 
     /// Resolve a project id → its canonical VFS root path. Returns `None` for
     /// an unknown id, an archived root, or an empty path (mirrors
@@ -407,7 +481,15 @@ fn migrate(from: u32, mut file: RegistryFile) -> Result<RegistryFile, ProjectReg
         }),
     }
 }
-
+/// Public alias for [`validate_root_path`] so the web HTTP layer can validate
+/// a path without constructing a full `VfsRoot` + `upsert_root` (e.g. the
+/// desktop-hosted path with no file registry). Kept as a thin wrapper rather
+/// than renaming `validate_root_path` (which is `pub(crate)`-private) to avoid
+/// widening the leaf's visibility beyond what the module-cycle invariant
+/// requires.
+pub fn validate_root_path_pub(raw: &Path) -> Result<PathBuf, String> {
+    validate_root_path(raw)
+}
 /// Validate a raw VFS-root path: canonicalize (exists + accessible) and require
 /// a directory. Mirrors `web::config::resolve_and_validate_project_root` but is
 /// duplicated here as a std-only leaf so this module never imports `web::*`

--- a/src-tauri/src/web/project_registry.rs
+++ b/src-tauri/src/web/project_registry.rs
@@ -149,6 +149,66 @@ impl ProjectRegistry {
         }
         self.rebind_project_root();
     }
+    /// Insert or replace a single project summary by `id` in the in-memory
+    /// mirror (Option B: web-client project create/update). A root with an
+    /// existing `id` is replaced in place (preserving order); a new id is
+    /// appended. Does NOT touch the default. When the new project is the only
+    /// one and no default is set, the caller may set it via
+    /// `set_default_project`. Triggers a `project_root` rebind so the
+    /// containment boundary follows when this becomes the default.
+    pub fn upsert(&self, project: ProjectSummary) {
+        let mut g = self.inner.lock();
+        if let Some(existing) = g.projects.iter_mut().find(|p| p.id == project.id) {
+            *existing = project;
+        } else {
+            g.projects.push(project);
+        }
+    }
+
+    /// Remove a project summary by `id` from the in-memory mirror. Clears the
+    /// default when it referenced the removed project (P4: no dangling
+    /// default). Returns `true` when a project was removed.
+    pub fn remove(&self, project_id: &str) -> bool {
+        let mut g = self.inner.lock();
+        let before = g.projects.len();
+        g.projects.retain(|p| p.id != project_id);
+        if g.projects.len() == before {
+            return false;
+        }
+        if g.default_project_id.as_deref() == Some(project_id) {
+            g.default_project_id = None;
+        }
+        true
+    }
+
+    /// Patch a single project's display fields (name, color, archived) by
+    /// `id`. Returns `false` when the id is absent. Clears the default when the
+    /// project is archived (P4: an archived default is not switchable).
+    pub fn update(
+        &self,
+        project_id: &str,
+        name: Option<String>,
+        color: Option<String>,
+        is_archived: Option<bool>,
+    ) -> bool {
+        let mut g = self.inner.lock();
+        let Some(project) = g.projects.iter_mut().find(|p| p.id == project_id) else {
+            return false;
+        };
+        if let Some(name) = name {
+            project.name = name;
+        }
+        if let Some(color) = color {
+            project.color = color;
+        }
+        if let Some(is_archived) = is_archived {
+            project.is_archived = is_archived;
+        }
+        if project.is_archived && g.default_project_id.as_deref() == Some(project_id) {
+            g.default_project_id = None;
+        }
+        true
+    }
 
     /// Snapshot the current mirror for `GET /projects`. Clones the vec under
     /// the lock (the read is short); the caller serializes outside the lock.

--- a/src-tauri/src/web/projects_api.rs
+++ b/src-tauri/src/web/projects_api.rs
@@ -64,6 +64,31 @@ impl<T> IpcBody<T> {
 pub struct SetDefaultProjectRequest {
     pub project_id: String,
 }
+/// `POST /projects` request body — create / upsert a VFS root (Option B: the
+/// standalone server is a first-class project-list authority). The operator /
+/// web client supplies the identity + display fields + canonical path; the
+/// server canonicalizes + validates the path. Mirrors the
+/// `add_project` WS request payload.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct UpsertProjectRequest {
+    pub id: String,
+    pub name: String,
+    pub path: String,
+    pub color: String,
+    #[serde(default)]
+    pub is_archived: bool,
+}
+
+/// `PUT /projects/{id}` request body — patch a root's display fields. All
+/// fields optional (partial update). Mirrors the `update_project` WS request.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct UpdateProjectRequest {
+    pub name: Option<String>,
+    pub color: Option<String>,
+    pub is_archived: Option<bool>,
+}
 
 /// `GET /projects` → the synced project list mirror.
 ///
@@ -232,6 +257,321 @@ pub async fn set_default_project(
     Json(IpcBody::ok(()))
 }
 
+/// Loopback / `--allow-remote-writes` guard shared by the project mutation
+/// routes. Mirrors `set_default_project`'s write-guard posture (CWE-306):
+/// shared-live deployment mode denies ALL writes; otherwise loopback is
+/// admitted, and a non-loopback peer requires `--allow-remote-writes`. Returns
+/// `Some(error_response)` when the peer is refused.
+fn check_project_write_guard<T>(
+    state: &AppState,
+    peer: SocketAddr,
+    route: &str,
+) -> Option<Json<IpcBody<T>>> {
+    let is_loopback = peer.ip().is_loopback();
+    if state.shared_live_writes_denied {
+        tracing::warn!(
+            target: "termul::web::projects_api",
+            route,
+            peer = %peer,
+            "remote-write guard REFUSED (shared-live deployment mode denies all writes)",
+        );
+        return Some(Json(IpcBody::<T>::err(
+            "shared-live deployment mode denies all remote writes".to_string(),
+            "FORBIDDEN",
+        )));
+    }
+    if !is_loopback && !state.allow_remote_writes {
+        tracing::warn!(
+            target: "termul::web::projects_api",
+            route,
+            peer = %peer,
+            "remote-write guard REFUSED (peer not loopback; no --allow-remote-writes)",
+        );
+        return Some(Json(IpcBody::<T>::err(
+            format!("host-state write routes are localhost-only (peer {peer} is not loopback)"),
+            "FORBIDDEN",
+        )));
+    }
+    if !is_loopback && state.allow_remote_writes {
+        tracing::warn!(
+            target: "termul::web::projects_api",
+            route,
+            peer = %peer,
+            "remote-write guard ADMITTED (--allow-remote-writes)",
+        );
+    }
+    None
+}
+
+/// `POST /projects` → create / upsert a VFS root (Option B).
+///
+/// Canonicalizes + validates the path, upserts into `FileProjectRegistry`
+/// (VPS, with rollback on failure) + the in-memory `ProjectRegistry`, and
+/// broadcasts `projects_changed`. Desktop-hosted mode has no file registry —
+/// it upserts the in-memory mirror + broadcasts only (the desktop renderer
+/// is the source of truth there, but a web-client upsert still lands in the
+/// mirror so the creating client sees it). Returns the upserted
+/// `ProjectSummary`.
+pub async fn create_project(
+    State(state): State<AppState>,
+    ConnectInfo(peer): ConnectInfo<SocketAddr>,
+    Json(req): Json<UpsertProjectRequest>,
+) -> impl IntoResponse {
+    if let Some(err) = check_project_write_guard(&state, peer, "/projects") {
+        return err;
+    }
+    let root = crate::acp::VfsRoot {
+        id: req.id.clone(),
+        name: req.name.clone(),
+        path: std::path::PathBuf::from(req.path.clone()),
+        color: req.color.clone(),
+        is_archived: req.is_archived,
+        mcp_servers: Vec::new(),
+    };
+    // VPS persistence (with rollback). Desktop-hosted: registry_persistence is None.
+    if let (Some(file_registry), Some(path)) =
+        (state.registry_persistence.as_ref(), state.projects_file.as_deref())
+    {
+        let persistence_result = {
+            let mut file_registry = file_registry.lock();
+            // Capture the old root (if replacing) so the in-memory-set failure
+            // path can roll the file back (P1: no split-brain).
+            let old_root = file_registry
+                .roots()
+                .iter()
+                .find(|r| r.id == req.id)
+                .cloned();
+            match file_registry.upsert_root(root.clone()) {
+                Ok(()) => match file_registry.save_atomic(path) {
+                    Ok(()) => Ok((old_root, ())),
+                    Err(error) => {
+                        // Roll back to the old root (or remove if it was new).
+                        if let Some(old) = old_root {
+                            let _ = file_registry.upsert_root(old);
+                        } else {
+                            let _ = file_registry.remove_root(&req.id);
+                        }
+                        Err(error)
+                    }
+                },
+                Err(error) => Err(error),
+            }
+        };
+        if let Err(error) = persistence_result {
+            tracing::error!(
+                target: "termul::web::projects_api",
+                project_id = %req.id,
+                error = %error,
+                "create_project: persistence failed (rolled back)"
+            );
+            return Json(IpcBody::<crate::web::project_registry::ProjectSummary>::err(
+                format!("failed to persist project: {error}"),
+                "PERSIST_FAILED",
+            ));
+        }
+    } else {
+        // Desktop-hosted / no file registry: validate the path canonicalizes
+        // before mirroring (fail-first, same posture as VPS `upsert_root`).
+        if let Err(reason) = crate::acp::project_registry::validate_root_path_pub(
+            std::path::Path::new(&req.path),
+        ) {
+            tracing::warn!(
+                target: "termul::web::projects_api",
+                project_id = %req.id,
+                "create_project: invalid root path"
+            );
+            return Json(IpcBody::<crate::web::project_registry::ProjectSummary>::err(
+                format!("invalid root path: {reason}"),
+                "VALIDATION_ERROR",
+            ));
+        }
+    }
+    // Mirror into the in-memory registry (the web client reads `GET /projects`).
+    let summary = crate::web::project_registry::ProjectSummary {
+        id: req.id.clone(),
+        name: req.name,
+        color: req.color,
+        path: Some(req.path),
+        is_archived: req.is_archived,
+        is_default: false,
+    };
+    state.registry.upsert(summary.clone());
+    broadcast_projects_changed(&state.relay, None);
+    tracing::info!(
+        target: "termul::web::projects_api",
+        project_id = %req.id,
+        "create_project: project upserted + broadcast"
+    );
+    Json(IpcBody::<crate::web::project_registry::ProjectSummary> {
+        success: true,
+        data: Some(summary),
+        error: None,
+        code: None,
+    })
+}
+
+/// `PUT /projects/{id}` → patch a project's display fields (Option B).
+pub async fn update_project(
+    State(state): State<AppState>,
+    ConnectInfo(peer): ConnectInfo<SocketAddr>,
+    axum::extract::Path(project_id): axum::extract::Path<String>,
+    Json(req): Json<UpdateProjectRequest>,
+) -> impl IntoResponse {
+    if let Some(err) = check_project_write_guard(&state, peer, "/projects/{id}") {
+        return err;
+    }
+    // VPS persistence (with rollback).
+    if let (Some(file_registry), Some(path)) =
+        (state.registry_persistence.as_ref(), state.projects_file.as_deref())
+    {
+        let persistence_result = {
+            let mut file_registry = file_registry.lock();
+            let old_root = file_registry
+                .roots()
+                .iter()
+                .find(|r| r.id == project_id)
+                .cloned();
+            if !file_registry.update_root(
+                &project_id,
+                req.name.clone(),
+                req.color.clone(),
+                req.is_archived,
+            ) {
+                None
+            } else {
+                match file_registry.save_atomic(path) {
+                    Ok(()) => Some(Ok((old_root, ()))),
+                    Err(error) => {
+                        if let Some(old) = old_root {
+                            let _ = file_registry.upsert_root(old);
+                        }
+                        Some(Err(error))
+                    }
+                }
+            }
+        };
+        match persistence_result {
+            None => {
+                tracing::warn!(
+                    target: "termul::web::projects_api",
+                    project_id = %project_id,
+                    "update_project: project not found"
+                );
+                return Json(IpcBody::<()>::err(
+                    format!("project '{project_id}' not found"),
+                    "NOT_FOUND",
+                ));
+            }
+            Some(Err(error)) => {
+                tracing::error!(
+                    target: "termul::web::projects_api",
+                    project_id = %project_id,
+                    error = %error,
+                    "update_project: persistence failed (rolled back)"
+                );
+                return Json(IpcBody::<()>::err(
+                    format!("failed to persist project: {error}"),
+                    "PERSIST_FAILED",
+                ));
+            }
+            Some(Ok(_)) => {}
+        }
+    }
+    // Mirror into the in-memory registry.
+    if !state
+        .registry
+        .update(&project_id, req.name, req.color, req.is_archived)
+    {
+        tracing::warn!(
+            target: "termul::web::projects_api",
+            project_id = %project_id,
+            "update_project: project not found in in-memory registry"
+        );
+        return Json(IpcBody::<()>::err(
+            format!("project '{project_id}' not found"),
+            "NOT_FOUND",
+        ));
+    }
+    broadcast_projects_changed(&state.relay, None);
+    tracing::info!(
+        target: "termul::web::projects_api",
+        project_id = %project_id,
+        "update_project: project updated + broadcast"
+    );
+    Json(IpcBody::ok(()))
+}
+
+/// `DELETE /projects/{id}` → remove a VFS root (Option B).
+pub async fn remove_project(
+    State(state): State<AppState>,
+    ConnectInfo(peer): ConnectInfo<SocketAddr>,
+    axum::extract::Path(project_id): axum::extract::Path<String>,
+) -> impl IntoResponse {
+    if let Some(err) = check_project_write_guard(&state, peer, "/projects/{id}") {
+        return err;
+    }
+    // VPS persistence (with rollback).
+    if let (Some(file_registry), Some(path)) =
+        (state.registry_persistence.as_ref(), state.projects_file.as_deref())
+    {
+        let persistence_result = {
+            let mut file_registry = file_registry.lock();
+            let old_root = file_registry
+                .roots()
+                .iter()
+                .find(|r| r.id == project_id)
+                .cloned();
+            if !file_registry.remove_root(&project_id) {
+                None
+            } else {
+                match file_registry.save_atomic(path) {
+                    Ok(()) => Some(Ok(old_root)),
+                    Err(error) => {
+                        if let Some(old) = old_root {
+                            let _ = file_registry.upsert_root(old);
+                        }
+                        Some(Err(error))
+                    }
+                }
+            }
+        };
+        match persistence_result {
+            None => {
+                tracing::warn!(
+                    target: "termul::web::projects_api",
+                    project_id = %project_id,
+                    "remove_project: project not found"
+                );
+                return Json(IpcBody::<()>::err(
+                    format!("project '{project_id}' not found"),
+                    "NOT_FOUND",
+                ));
+            }
+            Some(Err(error)) => {
+                tracing::error!(
+                    target: "termul::web::projects_api",
+                    project_id = %project_id,
+                    error = %error,
+                    "remove_project: persistence failed (rolled back)"
+                );
+                return Json(IpcBody::<()>::err(
+                    format!("failed to persist project removal: {error}"),
+                    "PERSIST_FAILED",
+                ));
+            }
+            Some(Ok(_)) => {}
+        }
+    }
+    // Mirror into the in-memory registry.
+    state.registry.remove(&project_id);
+    broadcast_projects_changed(&state.relay, None);
+    tracing::info!(
+        target: "termul::web::projects_api",
+        project_id = %project_id,
+        "remove_project: project removed + broadcast"
+    );
+    Json(IpcBody::ok(()))
+}
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -834,5 +1174,213 @@ mod tests {
             registry.snapshot().default_project_id.as_deref(),
             Some("p-2")
         );
+    }
+
+    /// Option B — `POST /projects` (VPS mode) creates a new VFS root, persists
+    /// it to the `FileProjectRegistry` file, and mirrors it into the in-memory
+    /// registry. The file + `GET /projects` both reflect the new project after
+    /// the request succeeds.
+    #[tokio::test]
+    async fn create_project_http_persists_to_file_registry_vps_mode() {
+        let dir = tempdir_like("http-create-vps");
+        let root_a = dir.join("proj-a");
+        std::fs::create_dir_all(&root_a).expect("mkdir root-a");
+        let file = dir.join("projects.json");
+        let file_registry = Arc::new(parking_lot::Mutex::new(FileProjectRegistry::empty()));
+        let relay = Arc::new(WsRelaySink::new());
+        let registry = Arc::new(ProjectRegistry::new());
+
+        let app = axum::Router::new()
+            .route("/projects", axum::routing::post(create_project))
+            .with_state(state_with_persistence(
+                Arc::clone(&registry),
+                file_registry,
+                relay,
+                file.clone(),
+            ));
+
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/projects")
+                    .header("content-type", "application/json")
+                    .extension(ConnectInfo(SocketAddr::from(([127, 0, 0, 1], 54321))))
+                    .body(Body::from(
+                        serde_json::json!({
+                            "id": "new-proj",
+                            "name": "New Project",
+                            "path": root_a,
+                            "color": "blue",
+                            "isArchived": false
+                        })
+                        .to_string(),
+                    ))
+                    .expect("build request"),
+            )
+            .await
+            .expect("router response");
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .expect("read body");
+        let parsed: IpcBody<ProjectSummary> = serde_json::from_slice(&body).expect("parse body");
+        assert!(parsed.success, "create_project succeeds: {parsed:?}");
+        assert_eq!(parsed.data.as_ref().unwrap().id, "new-proj");
+
+        // File persistence: the on-disk file carries the new root.
+        let reloaded = FileProjectRegistry::load(&file).expect("reload");
+        assert_eq!(reloaded.roots().len(), 1);
+        assert_eq!(reloaded.roots()[0].id, "new-proj");
+        assert_eq!(reloaded.roots()[0].name, "New Project");
+
+        // In-memory mirror: GET /projects reflects the new project.
+        let snap = registry.snapshot();
+        assert_eq!(snap.projects.len(), 1);
+        assert_eq!(snap.projects[0].id, "new-proj");
+
+        cleanup(&dir);
+    }
+
+    /// Option B — `DELETE /projects/{id}` (VPS mode) removes the root from the
+    /// file + in-memory registry and clears a dangling default.
+    #[tokio::test]
+    async fn remove_project_http_persists_and_clears_default() {
+        let dir = tempdir_like("http-remove-vps");
+        let root_a = dir.join("proj-a");
+        std::fs::create_dir_all(&root_a).expect("mkdir root-a");
+        let file = dir.join("projects.json");
+        let file_registry = FileProjectRegistry::from_roots(
+            vec![crate::acp::VfsRoot {
+                id: "p-1".to_string(),
+                name: "Proj p-1".to_string(),
+                path: root_a,
+                color: "blue".to_string(),
+                is_archived: false,
+                mcp_servers: vec![],
+            }],
+            Some("p-1".to_string()),
+        );
+        let file_registry = Arc::new(parking_lot::Mutex::new(file_registry));
+        let relay = Arc::new(WsRelaySink::new());
+        let registry = Arc::new(ProjectRegistry::new());
+        seed_from_file(&registry, &file_registry.lock());
+
+        let app = axum::Router::new()
+            .route(
+                "/projects/{projectId}",
+                axum::routing::delete(remove_project),
+            )
+            .with_state(state_with_persistence(
+                Arc::clone(&registry),
+                file_registry,
+                relay,
+                file.clone(),
+            ));
+
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("DELETE")
+                    .uri("/projects/p-1")
+                    .extension(ConnectInfo(SocketAddr::from(([127, 0, 0, 1], 54321))))
+                    .body(Body::empty())
+                    .expect("build request"),
+            )
+            .await
+            .expect("router response");
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .expect("read body");
+        let parsed: IpcBody<()> = serde_json::from_slice(&body).expect("parse body");
+        assert!(parsed.success, "remove_project succeeds: {parsed:?}");
+
+        // File persistence: the root is gone + default cleared.
+        let reloaded = FileProjectRegistry::load(&file).expect("reload");
+        assert!(reloaded.roots().is_empty());
+        assert!(reloaded.default_project_id().is_none());
+
+        // In-memory mirror: the project is removed.
+        assert!(registry.snapshot().projects.is_empty());
+
+        cleanup(&dir);
+    }
+
+    /// Option B — `PUT /projects/{id}` (VPS mode) patches the display fields
+    /// and persists to the file.
+    #[tokio::test]
+    async fn update_project_http_persists_renamed_and_archived() {
+        let dir = tempdir_like("http-update-vps");
+        let root_a = dir.join("proj-a");
+        std::fs::create_dir_all(&root_a).expect("mkdir root-a");
+        let file = dir.join("projects.json");
+        let file_registry = FileProjectRegistry::from_roots(
+            vec![crate::acp::VfsRoot {
+                id: "p-1".to_string(),
+                name: "Proj p-1".to_string(),
+                path: root_a,
+                color: "blue".to_string(),
+                is_archived: false,
+                mcp_servers: vec![],
+            }],
+            Some("p-1".to_string()),
+        );
+        let file_registry = Arc::new(parking_lot::Mutex::new(file_registry));
+        let relay = Arc::new(WsRelaySink::new());
+        let registry = Arc::new(ProjectRegistry::new());
+        seed_from_file(&registry, &file_registry.lock());
+
+        let app = axum::Router::new()
+            .route(
+                "/projects/{projectId}",
+                axum::routing::put(update_project),
+            )
+            .with_state(state_with_persistence(
+                Arc::clone(&registry),
+                file_registry,
+                relay,
+                file.clone(),
+            ));
+
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("PUT")
+                    .uri("/projects/p-1")
+                    .header("content-type", "application/json")
+                    .extension(ConnectInfo(SocketAddr::from(([127, 0, 0, 1], 54321))))
+                    .body(Body::from(
+                        serde_json::json!({
+                            "name": "Renamed",
+                            "color": "green",
+                            "isArchived": true
+                        })
+                        .to_string(),
+                    ))
+                    .expect("build request"),
+            )
+            .await
+            .expect("router response");
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .expect("read body");
+        let parsed: IpcBody<()> = serde_json::from_slice(&body).expect("parse body");
+        assert!(parsed.success, "update_project succeeds: {parsed:?}");
+
+        // File persistence: renamed + archived + default cleared.
+        let reloaded = FileProjectRegistry::load(&file).expect("reload");
+        assert_eq!(reloaded.roots()[0].name, "Renamed");
+        assert_eq!(reloaded.roots()[0].color, "green");
+        assert!(reloaded.roots()[0].is_archived);
+        assert!(reloaded.default_project_id().is_none(), "archived default cleared");
+
+        // In-memory mirror.
+        let snap = registry.snapshot();
+        assert_eq!(snap.projects[0].name, "Renamed");
+        assert!(snap.projects[0].is_archived);
+
+        cleanup(&dir);
     }
 }

--- a/src-tauri/src/web/router.rs
+++ b/src-tauri/src/web/router.rs
@@ -14,7 +14,7 @@ use axum::{
     extract::{ConnectInfo, State},
     http::StatusCode,
     response::IntoResponse,
-    routing::{get, post},
+    routing::{get, post, put},
     Json,
     Router,
 };
@@ -91,11 +91,21 @@ pub fn router(
         // Project list mirror (Epic-4 bridge): the web client reads the
         // desktop's non-archived + archived projects here. Registered AHEAD of
         // the static fallback so the SPA mount cannot shadow it.
-        .route("/projects", get(projects_api::list))
+        .route("/projects", get(projects_api::list).post(projects_api::create_project))
         // Explicit host-default change (Epic 7 — cross-client workspace
         // continuity). Mirrors the `set_default_project` WS request + the
         // `set_host_default_project` Tauri command (transport parity).
         .route("/projects/default", post(projects_api::set_default_project))
+        // Option B: project-list mutations (the standalone server is a
+        // first-class project-list authority, not just a read-only mirror).
+        // `PUT /projects/{id}` patches display fields; `DELETE /projects/{id}`
+        // removes the root. Both persist to `FileProjectRegistry` (VPS) with
+        // rollback + broadcast `projects_changed`. Mirrors the
+        // `add_project`/`update_project`/`remove_project` WS requests.
+        .route(
+            "/projects/{projectId}",
+            put(projects_api::update_project).delete(projects_api::remove_project),
+        )
         .route(
             "/mcp-servers",
             get(mcp_servers_api::get).put(mcp_servers_api::put),

--- a/src-tauri/src/web/ws.rs
+++ b/src-tauri/src/web/ws.rs
@@ -1197,6 +1197,45 @@ async fn handle_request(
             )
             .await
         }
+        // Option B: project-list mutations. The standalone server is a
+        // first-class project-list authority; these persist to
+        // `FileProjectRegistry` (VPS, with rollback) + broadcast
+        // `projects_changed`. Mirrors the `POST /projects`,
+        // `PUT /projects/{id}`, `DELETE /projects/{id}` HTTP routes
+        // (transport parity). Any authenticated client for now (Epic 2).
+        "add_project" => {
+            handle_add_project(
+                id,
+                &req.payload,
+                relay,
+                registry,
+                registry_persistence,
+                projects_file,
+            )
+            .await
+        }
+        "update_project" => {
+            handle_update_project(
+                id,
+                &req.payload,
+                relay,
+                registry,
+                registry_persistence,
+                projects_file,
+            )
+            .await
+        }
+        "remove_project" => {
+            handle_remove_project(
+                id,
+                &req.payload,
+                relay,
+                registry,
+                registry_persistence,
+                projects_file,
+            )
+            .await
+        }
         "spawn_agent" => handle_spawn_agent(id, &req.payload, acp, current_agent).await,
         // CAP-6 / Story 8: host-owned ACP catalog resolution. The catalog
         // carries the host's OS/arch/runtime availability + per-agent
@@ -2266,6 +2305,329 @@ async fn handle_set_default_project(
         target: "termul::web::ws",
         project_id = %parsed.project_id,
         "set_default_project: host default updated + broadcast"
+    );
+    WsReply::ok(id, Some(json!({})))
+}
+/// `add_project` WS request payload (Option B). Mirrors the
+/// `POST /projects` body + the desktop `addProject` renderer store action.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct AddProjectPayload {
+    id: String,
+    name: String,
+    path: String,
+    color: String,
+    #[serde(default)]
+    is_archived: bool,
+}
+
+/// `update_project` WS request payload (Option B). All fields optional (partial
+/// update). Mirrors `PUT /projects/{id}`.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct UpdateProjectPayload {
+    project_id: String,
+    name: Option<String>,
+    color: Option<String>,
+    is_archived: Option<bool>,
+}
+
+/// `remove_project` WS request payload (Option B). Mirrors
+/// `DELETE /projects/{id}`.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct RemoveProjectPayload {
+    project_id: String,
+}
+
+/// `add_project` WS handler — create / upsert a VFS root (Option B).
+///
+/// Validates + canonicalizes the path, upserts into `FileProjectRegistry`
+/// (VPS, with rollback) + the in-memory `ProjectRegistry`, and broadcasts
+/// `projects_changed`. Desktop-hosted mode has no file registry — it upserts
+/// the in-memory mirror + broadcasts only.
+#[allow(clippy::too_many_arguments)]
+async fn handle_add_project(
+    id: String,
+    payload: &Value,
+    relay: &Arc<WsRelaySink>,
+    registry: &Arc<ProjectRegistry>,
+    registry_persistence: Option<&Arc<parking_lot::Mutex<FileProjectRegistry>>>,
+    projects_file: Option<&PathBuf>,
+) -> WsReply {
+    let parsed: AddProjectPayload = match serde_json::from_value(payload.clone()) {
+        Ok(p) => p,
+        Err(e) => {
+            warn!(
+                target: "termul::web::ws",
+                error = %e,
+                "add_project: malformed payload (want id + name + path + color)"
+            );
+            return WsReply::err(
+                id,
+                WsErrorCode::Unsupported,
+                format!("malformed add_project payload: {e}"),
+            );
+        }
+    };
+    let root = crate::acp::VfsRoot {
+        id: parsed.id.clone(),
+        name: parsed.name.clone(),
+        path: std::path::PathBuf::from(parsed.path.clone()),
+        color: parsed.color.clone(),
+        is_archived: parsed.is_archived,
+        mcp_servers: Vec::new(),
+    };
+    // VPS persistence (with rollback). Desktop-hosted mode skips this.
+    if let (Some(file_registry), Some(path)) = (registry_persistence, projects_file) {
+        let persistence_result = {
+            let mut file_registry = file_registry.lock();
+            let old_root = file_registry
+                .roots()
+                .iter()
+                .find(|r| r.id == parsed.id)
+                .cloned();
+            match file_registry.upsert_root(root.clone()) {
+                Ok(()) => match file_registry.save_atomic(path) {
+                    Ok(()) => Ok(old_root),
+                    Err(error) => {
+                        if let Some(old) = old_root {
+                            let _ = file_registry.upsert_root(old);
+                        } else {
+                            let _ = file_registry.remove_root(&parsed.id);
+                        }
+                        Err(error)
+                    }
+                },
+                Err(error) => Err(error),
+            }
+        };
+        if let Err(error) = persistence_result {
+            error!(
+                target: "termul::web::ws",
+                project_id = %parsed.id,
+                error = %error,
+                "add_project: persistence failed (rolled back)"
+            );
+            return WsReply::err(
+                id,
+                WsErrorCode::Unsupported,
+                format!("failed to persist project: {error}"),
+            );
+        }
+    }
+    // Mirror into the in-memory registry.
+    let summary = crate::web::project_registry::ProjectSummary {
+        id: parsed.id.clone(),
+        name: parsed.name,
+        color: parsed.color,
+        path: Some(parsed.path),
+        is_archived: parsed.is_archived,
+        is_default: false,
+    };
+    registry.upsert(summary.clone());
+    broadcast_projects_changed(relay, None);
+    info!(
+        target: "termul::web::ws",
+        project_id = %summary.id,
+        "add_project: project upserted + broadcast"
+    );
+    WsReply::ok(id, Some(json!({ "project": summary })))
+}
+
+/// `update_project` WS handler — patch a project's display fields (Option B).
+#[allow(clippy::too_many_arguments)]
+async fn handle_update_project(
+    id: String,
+    payload: &Value,
+    relay: &Arc<WsRelaySink>,
+    registry: &Arc<ProjectRegistry>,
+    registry_persistence: Option<&Arc<parking_lot::Mutex<FileProjectRegistry>>>,
+    projects_file: Option<&PathBuf>,
+) -> WsReply {
+    let parsed: UpdateProjectPayload = match serde_json::from_value(payload.clone()) {
+        Ok(p) => p,
+        Err(e) => {
+            warn!(
+                target: "termul::web::ws",
+                error = %e,
+                "update_project: malformed payload (want projectId)"
+            );
+            return WsReply::err(
+                id,
+                WsErrorCode::Unsupported,
+                format!("malformed update_project payload: {e}"),
+            );
+        }
+    };
+    // VPS persistence (with rollback).
+    if let (Some(file_registry), Some(path)) = (registry_persistence, projects_file) {
+        let persistence_result = {
+            let mut file_registry = file_registry.lock();
+            let old_root = file_registry
+                .roots()
+                .iter()
+                .find(|r| r.id == parsed.project_id)
+                .cloned();
+            if !file_registry.update_root(
+                &parsed.project_id,
+                parsed.name.clone(),
+                parsed.color.clone(),
+                parsed.is_archived,
+            ) {
+                None
+            } else {
+                match file_registry.save_atomic(path) {
+                    Ok(()) => Some(Ok(old_root)),
+                    Err(error) => {
+                        if let Some(old) = old_root {
+                            let _ = file_registry.upsert_root(old);
+                        }
+                        Some(Err(error))
+                    }
+                }
+            }
+        };
+        match persistence_result {
+            None => {
+                warn!(
+                    target: "termul::web::ws",
+                    project_id = %parsed.project_id,
+                    "update_project: project not found"
+                );
+                return WsReply::err(
+                    id,
+                    WsErrorCode::NotFound,
+                    format!("project '{}' not found", parsed.project_id),
+                );
+            }
+            Some(Err(error)) => {
+                error!(
+                    target: "termul::web::ws",
+                    project_id = %parsed.project_id,
+                    error = %error,
+                    "update_project: persistence failed (rolled back)"
+                );
+                return WsReply::err(
+                    id,
+                    WsErrorCode::Unsupported,
+                    format!("failed to persist project: {error}"),
+                );
+            }
+            Some(_) => {}
+        }
+    }
+    // Mirror into the in-memory registry.
+    if !registry.update(
+        &parsed.project_id,
+        parsed.name,
+        parsed.color,
+        parsed.is_archived,
+    ) {
+        warn!(
+            target: "termul::web::ws",
+            project_id = %parsed.project_id,
+            "update_project: project not found in in-memory registry"
+        );
+        return WsReply::err(
+            id,
+            WsErrorCode::NotFound,
+            format!("project '{}' not found", parsed.project_id),
+        );
+    }
+    broadcast_projects_changed(relay, None);
+    info!(
+        target: "termul::web::ws",
+        project_id = %parsed.project_id,
+        "update_project: project updated + broadcast"
+    );
+    WsReply::ok(id, Some(json!({})))
+}
+
+/// `remove_project` WS handler — remove a VFS root (Option B).
+#[allow(clippy::too_many_arguments)]
+async fn handle_remove_project(
+    id: String,
+    payload: &Value,
+    relay: &Arc<WsRelaySink>,
+    registry: &Arc<ProjectRegistry>,
+    registry_persistence: Option<&Arc<parking_lot::Mutex<FileProjectRegistry>>>,
+    projects_file: Option<&PathBuf>,
+) -> WsReply {
+    let parsed: RemoveProjectPayload = match serde_json::from_value(payload.clone()) {
+        Ok(p) => p,
+        Err(e) => {
+            warn!(
+                target: "termul::web::ws",
+                error = %e,
+                "remove_project: malformed payload (want projectId)"
+            );
+            return WsReply::err(
+                id,
+                WsErrorCode::Unsupported,
+                format!("malformed remove_project payload: {e}"),
+            );
+        }
+    };
+    // VPS persistence (with rollback).
+    if let (Some(file_registry), Some(path)) = (registry_persistence, projects_file) {
+        let persistence_result = {
+            let mut file_registry = file_registry.lock();
+            let old_root = file_registry
+                .roots()
+                .iter()
+                .find(|r| r.id == parsed.project_id)
+                .cloned();
+            if !file_registry.remove_root(&parsed.project_id) {
+                None
+            } else {
+                match file_registry.save_atomic(path) {
+                    Ok(()) => Some(Ok(old_root)),
+                    Err(error) => {
+                        if let Some(old) = old_root {
+                            let _ = file_registry.upsert_root(old);
+                        }
+                        Some(Err(error))
+                    }
+                }
+            }
+        };
+        match persistence_result {
+            None => {
+                warn!(
+                    target: "termul::web::ws",
+                    project_id = %parsed.project_id,
+                    "remove_project: project not found"
+                );
+                return WsReply::err(
+                    id,
+                    WsErrorCode::NotFound,
+                    format!("project '{}' not found", parsed.project_id),
+                );
+            }
+            Some(Err(error)) => {
+                error!(
+                    target: "termul::web::ws",
+                    project_id = %parsed.project_id,
+                    error = %error,
+                    "remove_project: persistence failed (rolled back)"
+                );
+                return WsReply::err(
+                    id,
+                    WsErrorCode::Unsupported,
+                    format!("failed to persist project removal: {error}"),
+                );
+            }
+            Some(_) => {}
+        }
+    }
+    // Mirror into the in-memory registry.
+    registry.remove(&parsed.project_id);
+    broadcast_projects_changed(relay, None);
+    info!(
+        target: "termul::web::ws",
+        project_id = %parsed.project_id,
+        "remove_project: project removed + broadcast"
     );
     WsReply::ok(id, Some(json!({})))
 }

--- a/src/renderer/hooks/use-projects-persistence.ts
+++ b/src/renderer/hooks/use-projects-persistence.ts
@@ -544,10 +544,88 @@ export function useProjectsAutoSave(): void {
   const hasInitialized = useRef(false)
 
   useEffect(() => {
-    // Web/remote mode: the project list is a read-only mirror of the desktop's
-    // store; never persist from the browser (the stubbed plugin-store would
-    // silently drop writes, and edits belong on the desktop anyway).
-    if (!isTauriContext()) return
+    // Web/remote mode: the project list is persisted server-side (Option B:
+    // the standalone server is a first-class project-list authority, so
+    // web-client-created projects survive refresh). Diff the store and push
+    // individual add/update/remove mutations to the server — the server is
+    // the source of truth in VPS mode, and `projects_changed` broadcasts
+    // refetch `GET /projects` on all connected clients.
+    if (!isTauriContext()) {
+      const unsubscribe = useProjectStore.subscribe((state, prevState) => {
+        if (!state.isLoaded || !prevState.isLoaded) return
+        if (state.projects === prevState.projects) return
+
+        const prevById = new Map(prevState.projects.map((p) => [p.id, p]))
+        const nextById = new Map(state.projects.map((p) => [p.id, p]))
+
+        // New projects → addProject.
+        for (const project of state.projects) {
+          if (!prevById.has(project.id)) {
+            void webServerProjects
+              .addProject({
+                id: project.id,
+                name: project.name,
+                path: project.path ?? '',
+                color: project.color,
+                isArchived: project.isArchived ?? false
+              })
+              .then((result) => {
+                if (!result.success) {
+                  console.warn('[projects] server addProject failed:', result.error)
+                }
+              })
+              .catch((err: unknown) => {
+                console.warn('[projects] server addProject error', err)
+              })
+          }
+        }
+
+        // Removed projects → removeProject.
+        for (const project of prevState.projects) {
+          if (!nextById.has(project.id)) {
+            void webServerProjects
+              .removeProject(project.id)
+              .then((result) => {
+                if (!result.success) {
+                  console.warn('[projects] server removeProject failed:', result.error)
+                }
+              })
+              .catch((err: unknown) => {
+                console.warn('[projects] server removeProject error', err)
+              })
+          }
+        }
+
+        // Changed projects → updateProject (name/color/archived only).
+        for (const project of state.projects) {
+          const prev = prevById.get(project.id)
+          if (!prev) continue
+          if (
+            prev.name !== project.name ||
+            prev.color !== project.color ||
+            (prev.isArchived ?? false) !== (project.isArchived ?? false)
+          ) {
+            void webServerProjects
+              .updateProject(project.id, {
+                name: project.name,
+                color: project.color,
+                isArchived: project.isArchived ?? false
+              })
+              .then((result) => {
+                if (!result.success) {
+                  console.warn('[projects] server updateProject failed:', result.error)
+                }
+              })
+              .catch((err: unknown) => {
+                console.warn('[projects] server updateProject error', err)
+              })
+          }
+        }
+      })
+      return () => {
+        unsubscribe()
+      }
+    }
 
     // Subscribe to project store changes
     const unsubscribe = useProjectStore.subscribe((state, prevState) => {

--- a/src/renderer/lib/__tests__/parity-checklist.test.ts
+++ b/src/renderer/lib/__tests__/parity-checklist.test.ts
@@ -737,6 +737,26 @@ describe('Parity Checklist Automation', () => {
       expect(content).toMatch(/setDefaultProject\b/)
       expect(content).toMatch(/\/projects\/default/)
     })
+    it('web-server-api.ts exposes addProject hitting POST /projects', () => {
+      expect(existsSync(WebServerApi), 'web-server-api.ts should exist').toBe(true)
+      const content = readFileSync(WebServerApi, 'utf-8')
+      expect(content).toMatch(/addProject\b/)
+      expect(content).toMatch(/postJson.*\/projects'/)
+    })
+
+    it('web-server-api.ts exposes updateProject hitting PUT /projects/{id}', () => {
+      expect(existsSync(WebServerApi), 'web-server-api.ts should exist').toBe(true)
+      const content = readFileSync(WebServerApi, 'utf-8')
+      expect(content).toMatch(/updateProject\b/)
+      expect(content).toMatch(/\/projects\/\$\{encodeURIComponent\(projectId\)\}/)
+    })
+
+    it('web-server-api.ts exposes removeProject hitting DELETE /projects/{id}', () => {
+      expect(existsSync(WebServerApi), 'web-server-api.ts should exist').toBe(true)
+      const content = readFileSync(WebServerApi, 'utf-8')
+      expect(content).toMatch(/removeProject\b/)
+      expect(content).toMatch(/method:\s*'DELETE'/)
+    })
   })
 
   // CAP-1/CAP-2: ACP history parity. The host owns the session transcript (the

--- a/src/renderer/lib/web-server-api.ts
+++ b/src/renderer/lib/web-server-api.ts
@@ -28,7 +28,7 @@ import type {
   IpcResult,
   WorktreeInfo
 } from '@shared/types/ipc.types'
-import type { ProjectListPayload } from '@shared/types/web-projects.types'
+import type { ProjectListPayload, ProjectSummary } from '@shared/types/web-projects.types'
 import type { AgentSkillContent, AgentSkillSummary } from './skills-api'
 import { isTauriContext } from './tauri-runtime'
 import type { BaseBranchInfo, IncludeCopyResult } from './worktree-api'
@@ -334,6 +334,45 @@ export const webServerProjects = {
    */
   async setDefaultProject(projectId: string): Promise<IpcResult<void>> {
     return postJson<void>('/projects/default', { projectId })
+  },
+
+  /**
+   * Create / upsert a project (Option B: the standalone server is a first-class
+   * project-list authority). Canonicalizes + validates the path on the server,
+   * persists to `FileProjectRegistry` (VPS), and broadcasts `projects_changed`.
+   * Mirrors the `add_project` WS request.
+   */
+  async addProject(params: {
+    id: string
+    name: string
+    path: string
+    color: string
+    isArchived?: boolean
+  }): Promise<IpcResult<ProjectSummary>> {
+    return postJson<ProjectSummary>('/projects', params)
+  },
+
+  /**
+   * Patch a project's display fields (name, color, archived). All fields
+   * optional (partial update). Mirrors the `update_project` WS request +
+   * `PUT /projects/{id}`.
+   */
+  async updateProject(
+    projectId: string,
+    patch: { name?: string; color?: string; isArchived?: boolean }
+  ): Promise<IpcResult<void>> {
+    return putJson<void>(`/projects/${encodeURIComponent(projectId)}`, patch)
+  },
+
+  /**
+   * Remove a project. Mirrors the `remove_project` WS request +
+   * `DELETE /projects/{id}`.
+   */
+  async removeProject(projectId: string): Promise<IpcResult<void>> {
+    const res = await fetch(`${serverBase()}/projects/${encodeURIComponent(projectId)}`, {
+      method: 'DELETE'
+    })
+    return parseBody<void>(res)
   }
 }
 

--- a/src/shared/types/web-protocol.types.test.ts
+++ b/src/shared/types/web-protocol.types.test.ts
@@ -58,8 +58,8 @@ describe('web-protocol.types — event/request type registries (AC2)', () => {
     expect(WS_REQUEST_TYPES).toContain('get_session_payload')
   })
 
-  it('exports exactly 33 request types including discovered-session promotion', () => {
-    expect(WS_REQUEST_TYPES).toHaveLength(33)
+  it('exports exactly 36 request types including discovered-session promotion', () => {
+    expect(WS_REQUEST_TYPES).toHaveLength(36)
     const expected = [
       'send_prompt',
       'cancel_prompt',
@@ -73,23 +73,22 @@ describe('web-protocol.types — event/request type registries (AC2)', () => {
       'resume_session',
       'close_session',
       'dispose_ephemeral_session',
-      'list_sessions',
-      'register_discovered_session',
-      'spawn_agent',
-      'kill_agent',
-      'list_agents',
+
       'switch_project',
-      'authenticate',
-      // ACP agent `authenticate` method (agent-advertised auth, e.g.
-      // `pi_terminal_login`) — distinct from the `authenticate` token gate.
-      'authenticate_agent',
       'subscribe',
       'ping',
       'list_persisted_sessions',
       'open_persisted_session',
       'get_session_payload',
+      'recover_session_snapshot',
       'get_session_cursor',
-      // CAP-6 / Story 8: host-owned ACP catalog resolution.
+      'register_discovered_session',
+      'list_sessions',
+      'spawn_agent',
+      'kill_agent',
+      'list_agents',
+      'authenticate',
+      'authenticate_agent',
       'list_acp_catalog',
       'set_catalog_opt_in',
       // CAP-6 / Story 9: host-owned verified-atomic ACP install.
@@ -97,7 +96,11 @@ describe('web-protocol.types — event/request type registries (AC2)', () => {
       // Issue #613: server-side generic key-value store.
       'store_read',
       'store_write',
-      'store_delete'
+      'store_delete',
+      // Option B: project-list mutations.
+      'add_project',
+      'update_project',
+      'remove_project'
     ]
     for (const name of expected) {
       expect(WS_REQUEST_TYPES).toContain(name)

--- a/src/shared/types/web-protocol.types.ts
+++ b/src/shared/types/web-protocol.types.ts
@@ -160,7 +160,15 @@ export const WS_REQUEST_TYPES = [
   // `STORE_WRITE_FAILED` / `STORE_DELETE_FAILED` (IO), `VALIDATION_ERROR`.
   'store_read',
   'store_write',
-  'store_delete'
+  'store_delete',
+  // Option B: project-list mutations (the standalone server is a first-class
+  // project-list authority). Mirrors `POST /projects`, `PUT /projects/{id}`,
+  // `DELETE /projects/{id}` HTTP routes (transport parity). The WS variants
+  // persist to `FileProjectRegistry` (VPS) with rollback + broadcast
+  // `projects_changed`.
+  'add_project',
+  'update_project',
+  'remove_project'
 ] as const
 
 /** Union of all WS request `type` strings. */
@@ -184,6 +192,32 @@ export interface StoreWritePayload {
 /** `store_delete` request payload. Reply: `{ existed: boolean }`. */
 export interface StoreDeletePayload {
   key: string
+}
+
+// ============================================================================
+// Project-list mutations (Option B) — request payloads + replies
+// ============================================================================
+
+/** `add_project` request payload. Reply: `{ project: ProjectSummary }`. */
+export interface AddProjectPayload {
+  id: string
+  name: string
+  path: string
+  color: string
+  isArchived?: boolean
+}
+
+/** `update_project` request payload. All fields optional. Reply: `{}`. */
+export interface UpdateProjectPayload {
+  projectId: string
+  name?: string
+  color?: string
+  isArchived?: boolean
+}
+
+/** `remove_project` request payload. Reply: `{}`. */
+export interface RemoveProjectPayload {
+  projectId: string
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary

The standalone `termul-server`'s project list was in-memory only and explicitly non-durable (`web::ProjectRegistry` module doc: *"The registry itself is not durable"*). A project created in the web client wrote only to Zustand state — `useProjectsAutoSave` returned early in web mode (`if (!isTauriContext()) return`) — so a browser refresh refetched an empty `GET /projects`. Issue #605.

Make the standalone server a first-class project-list authority: `FileProjectRegistry` gains `upsert_root`/`remove_root`/`update_root` mutations that `save_atomic` the full file (not just the default id). Three new HTTP routes (`POST /projects`, `PUT /projects/{id}`, `DELETE /projects/{id}`) mirror the existing `set_default_project` pattern (write-guard, VPS persistence with rollback, in-memory mirror, broadcast). WS handlers (`add_project`/`update_project`/`remove_project`) provide transport parity. The renderer's web-mode `useProjectsAutoSave` now diffs the store and pushes individual mutations to the server instead of returning early.

## Related Issue

Closes #605

## Type of Change

- [x] feat: new feature

## What Changed

- **`src-tauri/src/acp/project_registry.rs`** — `FileProjectRegistry` gains `upsert_root` (canonicalize + validate path, insert or replace by id), `remove_root` (clear dangling default), `update_root` (patch name/color/archived, clear default when archived), and `validate_root_path_pub` wrapper for the desktop-hosted path.
- **`src-tauri/src/web/project_registry.rs`** — `ProjectRegistry` gains `upsert`/`remove`/`update` in-memory mirror methods matching the file-backed mutations.
- **`src-tauri/src/web/projects_api.rs`** — three new HTTP handlers: `create_project` (`POST /projects`), `update_project` (`PUT /projects/{id}`), `remove_project` (`DELETE /projects/{id}`). Shared `check_project_write_guard<T>` extracts the loopback/`--allow-remote-writes`/shared-live guard (mirrors `set_default_project`'s posture). VPS persistence with rollback (capture old root → mutate → `save_atomic` → rollback on failure). Desktop-hosted mode (no file registry) upserts the in-memory mirror + broadcasts only.
- **`src-tauri/src/web/ws.rs`** — three new WS handlers (`add_project`, `update_project`, `remove_project`) mirroring the HTTP routes (transport parity), with the same persistence + rollback + broadcast pattern.
- **`src-tauri/src/web/router.rs`** — registered the three new routes.
- **`src/renderer/lib/web-server-api.ts`** — `webServerProjects` gains `addProject` (`POST /projects`), `updateProject` (`PUT /projects/{id}`), `removeProject` (`DELETE /projects/{id}`).
- **`src/renderer/hooks/use-projects-persistence.ts`** — the web branch of `useProjectsAutoSave` no longer returns early. It now diffs the Zustand store and pushes individual add/update/remove mutations to the server.
- **`src/shared/types/web-protocol.types.ts`** — added `add_project`/`update_project`/`remove_project` to `WS_REQUEST_TYPES` + their payload interfaces.
- **`src/renderer/lib/__tests__/parity-checklist.test.ts`** — 3 new parity tests pinning `addProject`/`updateProject`/`removeProject` to their HTTP routes.

## How It Was Tested

- [x] `bun run ci` (Biome lint + format + imports, strict mode)
- [x] `bun run typecheck`
- [x] `bun run test` — parity checklist (93 pass), NewProjectModal (4 pass)
- [x] `cargo clippy --all-targets -- -D warnings` (in src-tauri)
- [x] `cargo test` (in src-tauri) — 12/12 `projects_api::tests` pass (9 existing + 3 new); full lib suite 939 pass, 2 pre-existing shell-detection failures (unrelated, fail on base `dev` too)
- [x] Manual verification — live `termul-server` with `--projects-file`: `POST /projects` creates + persists to JSON; `PUT /projects/{id}` renames + archives; `DELETE /projects/{id}` removes; server restart → project survives (reloaded from file)

## Screenshots or Recordings

No UI changes — backend + persistence layer + renderer wiring only.

## CI & Review Gate

- [ ] All CI checks pass (PR Validation, Rust Checks, Build Verification, Security Scans)
- [ ] Code review comments from CodeRabbit / Claude have been addressed or resolved
- [ ] No unresolved review findings remain

## Checklist

- [x] My PR title follows the conventional commit format used by this repo
- [x] I linked the related issue or explained why none exists
- [x] I added or updated tests when needed
- [x] I verified the change does not introduce unrelated modifications
- [x] I read AGENTS.md and followed the contributor guidelines
- [ ] A human reviewed the complete diff before submission