### PR TITLE
feat(chat): mobile chatbox selectors as centered modal with touch-safe drag

### DIFF
--- a/src/renderer/assets/agent-icons/acp/agents.json
+++ b/src/renderer/assets/agent-icons/acp/agents.json
@@ -113,11 +113,11 @@
   {
     "id": "cline",
     "name": "Cline",
-    "version": "3.0.56",
+    "version": "3.0.57",
     "description": "Autonomous coding agent CLI - capable of creating/editing files, running commands, using the browser, and more",
     "distribution": {
       "npx": {
-        "package": "cline@3.0.56",
+        "package": "cline@3.0.57",
         "args": ["--acp"]
       }
     }
@@ -779,11 +779,11 @@
   {
     "id": "qwen-code",
     "name": "Qwen Code",
-    "version": "0.21.15",
+    "version": "0.22.0",
     "description": "Alibaba's Qwen coding assistant",
     "distribution": {
       "npx": {
-        "package": "@qwen-code/qwen-code@0.21.15",
+        "package": "@qwen-code/qwen-code@0.22.0",
         "args": ["--acp", "--experimental-skills"]
       }
     }

--- a/src/renderer/components/agents/AgentLauncher.test.tsx
+++ b/src/renderer/components/agents/AgentLauncher.test.tsx
@@ -39,7 +39,7 @@ if (typeof document.elementFromPoint !== 'function') {
 
 function clickMenuOption(name: string | RegExp): void {
   const dialog = screen.getByRole('dialog')
-  fireEvent.pointerDown(within(dialog).getByText(name))
+  fireEvent.click(within(dialog).getByText(name))
 }
 
 function defaultReadyAgent(): SupportedAcpAgentEntry {

--- a/src/renderer/components/agents/AgentLauncher.tsx
+++ b/src/renderer/components/agents/AgentLauncher.tsx
@@ -121,6 +121,9 @@ interface AgentLauncherProps {
 
 const EMPTY_COMMANDS: [] = []
 const EMPTY_AUTH_METHODS: AuthMethod[] = []
+
+/** Max finger travel (px) for a touchend to count as a tap, not a drag-scroll. */
+const TOUCH_SELECT_THRESHOLD_PX = 10
 const EMPTY_MCP_SERVERS: StoredMcpServer[] = []
 const EMPTY_PROBE_STATUS: Record<string, ProbeStatus> = {}
 const EMPTY_MCP_TOOLS: Record<string, McpToolInfo[]> = {}
@@ -1944,6 +1947,11 @@ function AcpModelPicker({
   const [query, setQuery] = useState('')
   const [open, setOpen] = useState(false)
   const isMobile = useMobileWebShell()
+  // Touch-safe selection (parity with ComposerMenu): record touchstart coords
+  // so touchend can distinguish a tap (select) from a drag-scroll (skip). The
+  // lastInputType ref guards against touch→mouse synthesis double-fire.
+  const touchStartRef = useRef<{ x: number; y: number } | null>(null)
+  const lastInputType = useRef<'mouse' | 'touch' | null>(null)
   const { displayValue, pending, select } = useOptimisticSelect(
     modelOption?.currentValue,
     onSelectModel
@@ -2024,9 +2032,31 @@ function AcpModelPicker({
                 <button
                   key={value.value}
                   type="button"
+                  onTouchStart={(event) => {
+                    const t = event.touches[0]
+                    if (t) touchStartRef.current = { x: t.clientX, y: t.clientY }
+                  }}
+                  onTouchEnd={(event) => {
+                    event.preventDefault()
+                    const start = touchStartRef.current
+                    touchStartRef.current = null
+                    const t = event.changedTouches[0]
+                    const isTap =
+                      start && t
+                        ? (t.clientX - start.x) ** 2 + (t.clientY - start.y) ** 2 <=
+                          TOUCH_SELECT_THRESHOLD_PX ** 2
+                        : true
+                    if (!isTap) return
+                    lastInputType.current = 'touch'
+                    handleSelectModel(value.value)
+                    window.setTimeout(() => {
+                      if (lastInputType.current === 'touch') lastInputType.current = null
+                    }, 500)
+                  }}
                   onPointerDown={(event) => {
                     if ((event.button ?? 0) !== 0) return
                     event.preventDefault()
+                    if (lastInputType.current === 'touch') return
                     handleSelectModel(value.value)
                   }}
                   onClick={() => handleSelectModel(value.value)}

--- a/src/renderer/components/agents/AgentLauncher.tsx
+++ b/src/renderer/components/agents/AgentLauncher.tsx
@@ -1994,17 +1994,24 @@ function AcpModelPicker({
     </ComposerPill>
   )
 
+  const modelStatusSuffix =
+    connecting && !setupError
+      ? ' · Connecting…'
+      : stale && !connecting && !setupError
+        ? ' · Cached'
+        : ''
+
+  const modelHeading = (
+    <div className="px-2 py-1 text-3xs font-semibold uppercase tracking-wide text-muted-foreground/70">
+      Model
+      {modelStatusSuffix && (
+        <span className="ml-1 font-normal normal-case tracking-normal">{modelStatusSuffix}</span>
+      )}
+    </div>
+  )
+
   const contentBody = (
     <>
-      <div className="px-2 py-1 text-3xs font-semibold uppercase tracking-wide text-muted-foreground/70">
-        Model
-        {connecting && !setupError && (
-          <span className="ml-1 font-normal normal-case tracking-normal">· Connecting…</span>
-        )}
-        {stale && !connecting && !setupError && (
-          <span className="ml-1 font-normal normal-case tracking-normal">· Cached</span>
-        )}
-      </div>
       {selectedEntry?.status !== 'ready' ? (
         <div className="px-2 py-1.5 text-xs text-muted-foreground">
           {selectedEntry?.status === 'install-required'
@@ -2054,16 +2061,15 @@ function AcpModelPicker({
                     }, 500)
                   }}
                   onPointerDown={(event) => {
-                    // Skip on real touch — onTouchEnd handles tap vs drag-scroll.
-                    // pointerdown fires at touch-start, before touchend, so it
-                    // would select immediately on contact without this guard.
                     if (event.pointerType === 'touch') return
                     if ((event.button ?? 0) !== 0) return
                     event.preventDefault()
+                  }}
+                  onClick={(event) => {
                     if (lastInputType.current === 'touch') return
+                    event.preventDefault()
                     handleSelectModel(value.value)
                   }}
-                  onClick={() => handleSelectModel(value.value)}
                   className={cn(
                     'flex w-full items-start gap-2 rounded-md px-2 py-1.5 text-left text-sm text-foreground transition-colors hover:bg-accent hover:text-accent-foreground',
                     value.value === displayValue && 'bg-accent text-accent-foreground'
@@ -2125,7 +2131,7 @@ function AcpModelPicker({
       <SelectorModal
         open={open}
         onOpenChange={setOpen}
-        title="Model"
+        title={`Model${modelStatusSuffix}`}
         trigger={trigger}
         disabled={disabled}
       >
@@ -2140,6 +2146,7 @@ function AcpModelPicker({
         {trigger}
       </PopoverTrigger>
       <PopoverContent align="end" side="top" className="w-72 p-1">
+        {modelHeading}
         {contentBody}
       </PopoverContent>
     </Popover>

--- a/src/renderer/components/agents/AgentLauncher.tsx
+++ b/src/renderer/components/agents/AgentLauncher.tsx
@@ -2054,6 +2054,10 @@ function AcpModelPicker({
                     }, 500)
                   }}
                   onPointerDown={(event) => {
+                    // Skip on real touch — onTouchEnd handles tap vs drag-scroll.
+                    // pointerdown fires at touch-start, before touchend, so it
+                    // would select immediately on contact without this guard.
+                    if (event.pointerType === 'touch') return
                     if ((event.button ?? 0) !== 0) return
                     event.preventDefault()
                     if (lastInputType.current === 'touch') return

--- a/src/renderer/components/agents/AgentLauncher.tsx
+++ b/src/renderer/components/agents/AgentLauncher.tsx
@@ -27,7 +27,7 @@ import {
   overlayPendingLauncherOptions,
   type PendingLauncherOptions
 } from '@/components/agents/pending-launcher-options'
-import { ConfigChip, ModeChip } from '@/components/chat/AgentHeader'
+import { ConfigChip, ModeChip, SelectorModal } from '@/components/chat/AgentHeader'
 import { AttachFilesButton } from '@/components/chat/AttachFilesButton'
 import { AttachmentPreviewGroup } from '@/components/chat/AttachmentPreviewGroup'
 import { ComposerPill } from '@/components/chat/ComposerPill'
@@ -65,6 +65,7 @@ import {
 } from '@/components/ui/select'
 import { useAgentSkills } from '@/hooks/use-agent-skills'
 import { useMentionRecents } from '@/hooks/use-mention-recents'
+import { useMobileWebShell } from '@/hooks/use-mobile-web-shell'
 import { useResolvedSupportedAcpAgents } from '@/hooks/use-resolved-supported-acp-agents'
 import type { StoredAgentConfig } from '@/lib/acp-agents-persistence'
 import {
@@ -1802,84 +1803,114 @@ function AcpAgentPicker({
   onSelectAgent: (entry: SupportedAcpAgentEntry) => void
 }): React.JSX.Element {
   const [query, setQuery] = useState('')
+  const [open, setOpen] = useState(false)
+  const isMobile = useMobileWebShell()
   const visibleAgents = useMemo(() => filterSupportedAcpAgents(agents, query), [agents, query])
   const rawLabel = selectedConfig?.name ?? selectedEntry?.agent.name ?? 'ACP Agent'
   const label = rawLabel.endsWith(' CLI') ? rawLabel.slice(0, -4) : rawLabel
+
+  const trigger = (
+    <ComposerPill
+      disabled={disabled}
+      aria-label={`Select ACP agent: ${label}`}
+      className="max-w-[260px]"
+      chevron
+    >
+      <EntryGlyph
+        config={selectedConfig}
+        templateId={selectedEntry?.agent.id}
+        name={selectedEntry?.agent.name}
+      />
+      <span className="truncate">{label}</span>
+    </ComposerPill>
+  )
+
+  const contentBody = (
+    <>
+      <div className="px-2 pb-1">
+        <Input
+          value={query}
+          onChange={(event) => setQuery(event.target.value)}
+          placeholder="Search agents…"
+          aria-label="Search ACP agents"
+          className="h-7 text-xs"
+        />
+      </div>
+      <div className="max-h-64 overflow-y-auto pr-1">
+        {visibleAgents.length === 0 ? (
+          <div className="px-2 py-2 text-xs text-muted-foreground">No agents match.</div>
+        ) : (
+          visibleAgents.map((entry) => (
+            <button
+              key={entry.configId}
+              type="button"
+              onClick={() => {
+                setOpen(false)
+                onSelectAgent(entry)
+              }}
+              className={cn(
+                'flex w-full items-center gap-2 rounded px-2 py-1.5 text-left text-sm hover:bg-accent',
+                entry.configId === selectedEntry?.configId && 'bg-accent/50'
+              )}
+            >
+              <EntryGlyph
+                config={entry.config}
+                templateId={entry.agent.id}
+                name={entry.agent.name}
+              />
+              <span className="min-w-0 flex-1 truncate">
+                {entry.config?.name ?? entry.agent.name}
+              </span>
+              {entry.status === 'install-required' && (
+                <span className="rounded bg-foreground/[0.08] px-1.5 py-0.5 text-3xs text-muted-foreground">
+                  {installingConfigId === entry.configId ? 'Installing…' : 'Install'}
+                </span>
+              )}
+              {entry.status === 'needs-runtime' && (
+                <span className="text-3xs text-muted-foreground">
+                  {entry.runtimeLauncher === 'uvx' ? 'Needs uv' : 'Needs Node'}
+                </span>
+              )}
+              {entry.status === 'manual-install' && (
+                <span className="text-3xs text-muted-foreground">Manual install</span>
+              )}
+              {entry.status === 'unavailable' && (
+                <span className="text-3xs text-muted-foreground">Unavailable</span>
+              )}
+              {entry.configId === selectedEntry?.configId && (
+                <Check size={14} className="text-muted-foreground" />
+              )}
+            </button>
+          ))
+        )}
+      </div>
+    </>
+  )
+
+  if (isMobile) {
+    return (
+      <SelectorModal
+        open={open}
+        onOpenChange={setOpen}
+        title="ACP Agent"
+        trigger={trigger}
+        disabled={disabled}
+      >
+        {contentBody}
+      </SelectorModal>
+    )
+  }
+
   return (
-    <Popover>
+    <Popover open={open} onOpenChange={setOpen}>
       <PopoverTrigger asChild disabled={disabled}>
-        <ComposerPill
-          disabled={disabled}
-          aria-label={`Select ACP agent: ${label}`}
-          className="max-w-[260px]"
-          chevron
-        >
-          <EntryGlyph
-            config={selectedConfig}
-            templateId={selectedEntry?.agent.id}
-            name={selectedEntry?.agent.name}
-          />
-          <span className="truncate">{label}</span>
-        </ComposerPill>
+        {trigger}
       </PopoverTrigger>
       <PopoverContent align="end" side="top" className="w-72 p-1">
         <div className="px-2 py-1 text-3xs font-semibold uppercase tracking-wide text-muted-foreground/70">
           ACP Agent
         </div>
-        <div className="px-2 pb-1">
-          <Input
-            value={query}
-            onChange={(event) => setQuery(event.target.value)}
-            placeholder="Search agents…"
-            aria-label="Search ACP agents"
-            className="h-7 text-xs"
-          />
-        </div>
-        <div className="max-h-64 overflow-y-auto pr-1">
-          {visibleAgents.length === 0 ? (
-            <div className="px-2 py-2 text-xs text-muted-foreground">No agents match.</div>
-          ) : (
-            visibleAgents.map((entry) => (
-              <button
-                key={entry.configId}
-                type="button"
-                onClick={() => onSelectAgent(entry)}
-                className={cn(
-                  'flex w-full items-center gap-2 rounded px-2 py-1.5 text-left text-sm hover:bg-accent',
-                  entry.configId === selectedEntry?.configId && 'bg-accent/50'
-                )}
-              >
-                <EntryGlyph
-                  config={entry.config}
-                  templateId={entry.agent.id}
-                  name={entry.agent.name}
-                />
-                <span className="min-w-0 flex-1 truncate">
-                  {entry.config?.name ?? entry.agent.name}
-                </span>
-                {entry.status === 'install-required' && (
-                  <span className="rounded bg-foreground/[0.08] px-1.5 py-0.5 text-3xs text-muted-foreground">
-                    {installingConfigId === entry.configId ? 'Installing…' : 'Install'}
-                  </span>
-                )}
-                {entry.status === 'needs-runtime' && (
-                  <span className="text-3xs text-muted-foreground">
-                    {entry.runtimeLauncher === 'uvx' ? 'Needs uv' : 'Needs Node'}
-                  </span>
-                )}
-                {entry.status === 'manual-install' && (
-                  <span className="text-3xs text-muted-foreground">Manual install</span>
-                )}
-                {entry.status === 'unavailable' && (
-                  <span className="text-3xs text-muted-foreground">Unavailable</span>
-                )}
-                {entry.configId === selectedEntry?.configId && (
-                  <Check size={14} className="text-muted-foreground" />
-                )}
-              </button>
-            ))
-          )}
-        </div>
+        {contentBody}
       </PopoverContent>
     </Popover>
   )
@@ -1912,6 +1943,7 @@ function AcpModelPicker({
 }): React.JSX.Element {
   const [query, setQuery] = useState('')
   const [open, setOpen] = useState(false)
+  const isMobile = useMobileWebShell()
   const { displayValue, pending, select } = useOptimisticSelect(
     modelOption?.currentValue,
     onSelectModel
@@ -1942,117 +1974,139 @@ function AcpModelPicker({
     select(valueId)
   }
 
+  const trigger = (
+    <ComposerPill
+      disabled={disabled}
+      aria-label={`Select model: ${label}`}
+      className={cn('max-w-[220px]', (connecting || stale) && !setupError && 'opacity-80')}
+      chevron
+      pending={pending || (connecting && !setupError)}
+    >
+      <span className="truncate">{label}</span>
+    </ComposerPill>
+  )
+
+  const contentBody = (
+    <>
+      <div className="px-2 py-1 text-3xs font-semibold uppercase tracking-wide text-muted-foreground/70">
+        Model
+        {connecting && !setupError && (
+          <span className="ml-1 font-normal normal-case tracking-normal">· Connecting…</span>
+        )}
+        {stale && !connecting && !setupError && (
+          <span className="ml-1 font-normal normal-case tracking-normal">· Cached</span>
+        )}
+      </div>
+      {selectedEntry?.status !== 'ready' ? (
+        <div className="px-2 py-1.5 text-xs text-muted-foreground">
+          {selectedEntry?.status === 'install-required'
+            ? 'Install this ACP agent to load model options.'
+            : selectedEntry?.status === 'needs-runtime'
+              ? 'Install the required runtime before loading model options.'
+              : selectedEntry?.status === 'manual-install'
+                ? 'Install this agent manually before loading model options.'
+                : 'This ACP agent is not available on this platform.'}
+        </div>
+      ) : !setupError && modelOption ? (
+        <>
+          {showSearch && (
+            <input
+              value={query}
+              onChange={(event) => setQuery(event.target.value)}
+              placeholder="Search models..."
+              aria-label="Search models"
+              className="mb-1 w-full rounded-md bg-background px-2 py-1.5 text-xs text-foreground outline-none placeholder:text-muted-foreground focus:ring-1 focus:ring-primary/40"
+            />
+          )}
+          <div data-testid="acp-model-options" className="max-h-[180px] overflow-y-auto pr-1">
+            {filteredModels.length > 0 ? (
+              filteredModels.map((value) => (
+                <button
+                  key={value.value}
+                  type="button"
+                  onPointerDown={(event) => {
+                    if ((event.button ?? 0) !== 0) return
+                    event.preventDefault()
+                    handleSelectModel(value.value)
+                  }}
+                  onClick={() => handleSelectModel(value.value)}
+                  className={cn(
+                    'flex w-full items-start gap-2 rounded-md px-2 py-1.5 text-left text-sm text-foreground transition-colors hover:bg-accent hover:text-accent-foreground',
+                    value.value === displayValue && 'bg-accent text-accent-foreground'
+                  )}
+                >
+                  <span className="min-w-0 flex-1">
+                    <span className="block truncate font-medium">{value.name}</span>
+                    {value.description && (
+                      <span className="block text-xs opacity-70">{value.description}</span>
+                    )}
+                  </span>
+                  {value.value === displayValue && (
+                    <Check size={14} className="mt-0.5 text-muted-foreground" />
+                  )}
+                </button>
+              ))
+            ) : (
+              <div className="px-2 py-1.5 text-xs text-muted-foreground">No matching models.</div>
+            )}
+          </div>
+        </>
+      ) : setupError ? (
+        <div className="space-y-2 px-2 py-1.5 text-xs text-muted-foreground">
+          <div>
+            <div className="font-medium text-foreground/85">
+              {setupError.category === 'auth' || setupError.category === 'multi-auth'
+                ? setupError.label
+                : 'Could not load model options.'}
+            </div>
+            <div className="mt-1 line-clamp-3 break-words">{setupError.detail}</div>
+          </div>
+          {setupError.category === 'multi-auth' ? null : setupError.category === 'auth' &&
+            signInMethod ? (
+            <Button type="button" size="sm" className="h-7 text-xs" onClick={onSignIn}>
+              {`Sign in with ${signInMethod.name}`}
+            </Button>
+          ) : (
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              className="h-7 text-xs"
+              onClick={onRetry}
+            >
+              Retry
+            </Button>
+          )}
+        </div>
+      ) : (
+        <div className="px-2 py-1.5 text-xs text-muted-foreground">
+          {loading ? 'Loading model options…' : 'This ACP agent has not advertised model options.'}
+        </div>
+      )}
+    </>
+  )
+
+  if (isMobile) {
+    return (
+      <SelectorModal
+        open={open}
+        onOpenChange={setOpen}
+        title="Model"
+        trigger={trigger}
+        disabled={disabled}
+      >
+        {contentBody}
+      </SelectorModal>
+    )
+  }
+
   return (
     <Popover open={open} onOpenChange={setOpen}>
       <PopoverTrigger asChild disabled={disabled}>
-        <ComposerPill
-          disabled={disabled}
-          aria-label={`Select model: ${label}`}
-          className={cn('max-w-[220px]', (connecting || stale) && !setupError && 'opacity-80')}
-          chevron
-          pending={pending || (connecting && !setupError)}
-        >
-          <span className="truncate">{label}</span>
-        </ComposerPill>
+        {trigger}
       </PopoverTrigger>
       <PopoverContent align="end" side="top" className="w-72 p-1">
-        <div className="px-2 py-1 text-3xs font-semibold uppercase tracking-wide text-muted-foreground/70">
-          Model
-          {connecting && !setupError && (
-            <span className="ml-1 font-normal normal-case tracking-normal">· Connecting…</span>
-          )}
-          {stale && !connecting && !setupError && (
-            <span className="ml-1 font-normal normal-case tracking-normal">· Cached</span>
-          )}
-        </div>
-        {selectedEntry?.status !== 'ready' ? (
-          <div className="px-2 py-1.5 text-xs text-muted-foreground">
-            {selectedEntry?.status === 'install-required'
-              ? 'Install this ACP agent to load model options.'
-              : selectedEntry?.status === 'needs-runtime'
-                ? 'Install the required runtime before loading model options.'
-                : selectedEntry?.status === 'manual-install'
-                  ? 'Install this agent manually before loading model options.'
-                  : 'This ACP agent is not available on this platform.'}
-          </div>
-        ) : !setupError && modelOption ? (
-          <>
-            {showSearch && (
-              <input
-                value={query}
-                onChange={(event) => setQuery(event.target.value)}
-                placeholder="Search models..."
-                aria-label="Search models"
-                className="mb-1 w-full rounded-md bg-background px-2 py-1.5 text-xs text-foreground outline-none placeholder:text-muted-foreground focus:ring-1 focus:ring-primary/40"
-              />
-            )}
-            <div data-testid="acp-model-options" className="max-h-[180px] overflow-y-auto pr-1">
-              {filteredModels.length > 0 ? (
-                filteredModels.map((value) => (
-                  <button
-                    key={value.value}
-                    type="button"
-                    onPointerDown={(event) => {
-                      if ((event.button ?? 0) !== 0) return
-                      event.preventDefault()
-                      handleSelectModel(value.value)
-                    }}
-                    onClick={() => handleSelectModel(value.value)}
-                    className={cn(
-                      'flex w-full items-start gap-2 rounded-md px-2 py-1.5 text-left text-sm text-foreground transition-colors hover:bg-accent hover:text-accent-foreground',
-                      value.value === displayValue && 'bg-accent text-accent-foreground'
-                    )}
-                  >
-                    <span className="min-w-0 flex-1">
-                      <span className="block truncate font-medium">{value.name}</span>
-                      {value.description && (
-                        <span className="block text-xs opacity-70">{value.description}</span>
-                      )}
-                    </span>
-                    {value.value === displayValue && (
-                      <Check size={14} className="mt-0.5 text-muted-foreground" />
-                    )}
-                  </button>
-                ))
-              ) : (
-                <div className="px-2 py-1.5 text-xs text-muted-foreground">No matching models.</div>
-              )}
-            </div>
-          </>
-        ) : setupError ? (
-          <div className="space-y-2 px-2 py-1.5 text-xs text-muted-foreground">
-            <div>
-              <div className="font-medium text-foreground/85">
-                {setupError.category === 'auth' || setupError.category === 'multi-auth'
-                  ? setupError.label
-                  : 'Could not load model options.'}
-              </div>
-              <div className="mt-1 line-clamp-3 break-words">{setupError.detail}</div>
-            </div>
-            {setupError.category === 'multi-auth' ? null : setupError.category === 'auth' &&
-              signInMethod ? (
-              <Button type="button" size="sm" className="h-7 text-xs" onClick={onSignIn}>
-                {`Sign in with ${signInMethod.name}`}
-              </Button>
-            ) : (
-              <Button
-                type="button"
-                variant="outline"
-                size="sm"
-                className="h-7 text-xs"
-                onClick={onRetry}
-              >
-                Retry
-              </Button>
-            )}
-          </div>
-        ) : (
-          <div className="px-2 py-1.5 text-xs text-muted-foreground">
-            {loading
-              ? 'Loading model options…'
-              : 'This ACP agent has not advertised model options.'}
-          </div>
-        )}
+        {contentBody}
       </PopoverContent>
     </Popover>
   )

--- a/src/renderer/components/chat/AgentHeader.test.tsx
+++ b/src/renderer/components/chat/AgentHeader.test.tsx
@@ -11,7 +11,7 @@ vi.mock('@/hooks/use-mobile-web-shell', () => ({
 
 function clickMenuOption(name: string): void {
   const dialog = screen.getByRole('dialog')
-  fireEvent.pointerDown(within(dialog).getByText(name))
+  fireEvent.click(within(dialog).getByText(name))
 }
 
 vi.mock('framer-motion', async () => {

--- a/src/renderer/components/chat/AgentHeader.test.tsx
+++ b/src/renderer/components/chat/AgentHeader.test.tsx
@@ -1,8 +1,13 @@
 import { act, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
-import { describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { SessionConfigOption } from '@/lib/acp-api'
 import type { AcpSession } from '@/stores/acp-store'
 import { ConfigChip, ModeChip } from './AgentHeader'
+
+const mobileShellRef = vi.hoisted(() => ({ current: false }))
+vi.mock('@/hooks/use-mobile-web-shell', () => ({
+  useMobileWebShell: () => mobileShellRef.current
+}))
 
 function clickMenuOption(name: string): void {
   const dialog = screen.getByRole('dialog')
@@ -254,5 +259,130 @@ describe('ModeChip pending selection', () => {
       expect(screen.getByRole('button', { name: /^Agent$/ })).toBeInTheDocument()
       expect(screen.getByRole('button', { name: /^Agent$/ })).not.toHaveAttribute('aria-busy')
     })
+  })
+})
+
+describe('mobile modal selection', () => {
+  beforeEach(() => {
+    mobileShellRef.current = true
+  })
+  afterEach(() => {
+    mobileShellRef.current = false
+  })
+
+  it('opens a centered dialog with config chip options on mobile', () => {
+    render(<ConfigChip option={option('a')} disabled={false} onSelect={vi.fn()} />)
+
+    // No dialog before opening.
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: /Alpha/ }))
+
+    // Modal dialog opens (not a popover — Radix Dialog renders role=dialog).
+    const dialog = screen.getByRole('dialog', { name: 'Model' })
+    expect(within(dialog).getByTestId('config-chip-options')).toBeInTheDocument()
+    expect(within(dialog).getByText('Alpha')).toBeInTheDocument()
+  })
+
+  it('closes the modal and fires onSelect when an option is tapped', () => {
+    const onSelect = vi.fn(async () => undefined)
+    render(<ConfigChip option={option('a')} disabled={false} onSelect={onSelect} />)
+
+    fireEvent.click(screen.getByRole('button', { name: /Alpha/ }))
+    clickMenuOption('Beta')
+
+    expect(onSelect).toHaveBeenCalledWith('b')
+    expect(onSelect).toHaveBeenCalledTimes(1)
+    // Modal closes after selection.
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+  })
+
+  it('opens a centered dialog with mode chip options on mobile', () => {
+    render(
+      <ModeChip session={session('agent')} disabled={false} onSelect={vi.fn()} label="Agent" />
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: /^Agent$/ }))
+
+    const dialog = screen.getByRole('dialog', { name: 'Agent' })
+    expect(within(dialog).getByTestId('mode-chip-options')).toBeInTheDocument()
+    expect(within(dialog).getByText('Plan')).toBeInTheDocument()
+  })
+
+  it('renders the search input inside the modal when showSearch is true', () => {
+    // searchable + options count > maxVisibleOptions triggers showSearch
+    render(
+      <ConfigChip
+        option={option('a')}
+        disabled={false}
+        onSelect={vi.fn()}
+        searchable
+        maxVisibleOptions={2}
+      />
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: /Alpha/ }))
+
+    const dialog = screen.getByRole('dialog')
+    expect(within(dialog).getByLabelText('Search models')).toBeInTheDocument()
+  })
+
+  it('applies a horizontal margin and larger max-width on the mobile modal panel', () => {
+    render(<ConfigChip option={option('a')} disabled={false} onSelect={vi.fn()} />)
+    fireEvent.click(screen.getByRole('button', { name: /Alpha/ }))
+
+    const dialog = screen.getByRole('dialog')
+    // The dialog element (DialogContent) carries the margin + larger cap so it
+    // never bleeds edge-to-edge on mobile, unlike the desktop w-56 popover.
+    expect(dialog.className).toContain('w-[calc(100%-2rem)]')
+    expect(dialog.className).toContain('max-w-md')
+    expect(dialog.className).toContain('max-h-[80vh]')
+  })
+
+  it('closes the modal without firing onSelect on dismiss (Escape)', () => {
+    const onSelect = vi.fn(async () => undefined)
+    render(<ConfigChip option={option('a')} disabled={false} onSelect={onSelect} />)
+
+    fireEvent.click(screen.getByRole('button', { name: /Alpha/ }))
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
+
+    fireEvent.keyDown(document.body, { key: 'Escape' })
+
+    expect(onSelect).not.toHaveBeenCalled()
+  })
+
+  it('closes the modal without firing onSelect on dismiss (close button)', () => {
+    const onSelect = vi.fn(async () => undefined)
+    render(<ConfigChip option={option('a')} disabled={false} onSelect={onSelect} />)
+
+    fireEvent.click(screen.getByRole('button', { name: /Alpha/ }))
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
+
+    // The DialogContent close (X) button dismisses without selecting.
+    fireEvent.click(screen.getByRole('button', { name: /Close/ }))
+
+    expect(onSelect).not.toHaveBeenCalled()
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+  })
+
+  it('does not open the modal when the chip is disabled', () => {
+    render(<ConfigChip option={option('a')} disabled onSelect={vi.fn()} />)
+
+    fireEvent.click(screen.getByRole('button', { name: /Alpha/ }))
+
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+  })
+
+  it('closes the mode-chip modal and fires onSelect when an option is tapped', () => {
+    const onSelect = vi.fn(async () => undefined)
+    render(
+      <ModeChip session={session('agent')} disabled={false} onSelect={onSelect} label="Agent" />
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: /^Agent$/ }))
+    clickMenuOption('Plan')
+
+    expect(onSelect).toHaveBeenCalledWith('plan')
+    expect(onSelect).toHaveBeenCalledTimes(1)
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
   })
 })

--- a/src/renderer/components/chat/AgentHeader.tsx
+++ b/src/renderer/components/chat/AgentHeader.tsx
@@ -196,10 +196,12 @@ export function ConfigChip({
                 if (event.pointerType === 'touch') return
                 if ((event.button ?? 0) !== 0) return
                 event.preventDefault()
+              }}
+              onClick={(event) => {
                 if (lastInputType.current === 'touch') return
+                event.preventDefault()
                 handleSelect(v.value)
               }}
-              onClick={() => handleSelect(v.value)}
               className={cn(
                 SELECTOR_OPTION_ROW,
                 v.value === displayValue && SELECTOR_OPTION_SELECTED
@@ -320,10 +322,12 @@ export function ModeChip({
             if (event.pointerType === 'touch') return
             if ((event.button ?? 0) !== 0) return
             event.preventDefault()
+          }}
+          onClick={(event) => {
             if (lastInputType.current === 'touch') return
+            event.preventDefault()
             handleSelect(m.id)
           }}
-          onClick={() => handleSelect(m.id)}
         >
           <span className="font-medium">{m.name}</span>
           {m.description && <span className={SELECTOR_OPTION_DESCRIPTION}>{m.description}</span>}

--- a/src/renderer/components/chat/AgentHeader.tsx
+++ b/src/renderer/components/chat/AgentHeader.tsx
@@ -193,6 +193,7 @@ export function ConfigChip({
                 }, 500)
               }}
               onPointerDown={(event) => {
+                if (event.pointerType === 'touch') return
                 if ((event.button ?? 0) !== 0) return
                 event.preventDefault()
                 if (lastInputType.current === 'touch') return
@@ -316,6 +317,7 @@ export function ModeChip({
             }, 500)
           }}
           onPointerDown={(event) => {
+            if (event.pointerType === 'touch') return
             if ((event.button ?? 0) !== 0) return
             event.preventDefault()
             if (lastInputType.current === 'touch') return

--- a/src/renderer/components/chat/AgentHeader.tsx
+++ b/src/renderer/components/chat/AgentHeader.tsx
@@ -1,5 +1,5 @@
 import { Bot, Brain } from 'lucide-react'
-import { type ReactNode, useState } from 'react'
+import { type ReactNode, useRef, useState } from 'react'
 import {
   Dialog,
   DialogContent,
@@ -27,6 +27,9 @@ const SELECTOR_OPTION_ROW =
 const SELECTOR_OPTION_SELECTED = 'bg-accent text-accent-foreground'
 const SELECTOR_OPTION_DESCRIPTION = 'text-xs opacity-70'
 const SELECTOR_SECTION_LABEL = 'label-group px-2 py-1 text-muted-foreground'
+
+/** Max finger travel (px) for a touchend to count as a tap, not a drag-scroll. */
+const TOUCH_SELECT_THRESHOLD_PX = 10
 
 /**
  * Resolve the display label for a config chip. Promoted chips (e.g.
@@ -117,6 +120,10 @@ export function ConfigChip({
   const [query, setQuery] = useState('')
   const [open, setOpen] = useState(false)
   const isMobile = useMobileWebShell()
+  // Touch-safe selection (parity with ComposerMenu): record touchstart coords
+  // so touchend can distinguish a tap (select) from a drag-scroll (skip).
+  const touchStartRef = useRef<{ x: number; y: number } | null>(null)
+  const lastInputType = useRef<'mouse' | 'touch' | null>(null)
   const { displayValue, pending, select } = useOptimisticSelect(option.currentValue, onSelect)
   const current = option.options.find((o) => o.value === displayValue)
   const fallbackLabel = getLabelForConfigChip(option, promoted)
@@ -164,16 +171,33 @@ export function ConfigChip({
             <button
               key={v.value}
               type="button"
-              onPointerDown={(event) => {
-                // Primary only; treat missing button as primary (jsdom/synthetic).
-                if ((event.button ?? 0) !== 0) return
-                // Prefer pointerdown so the choice lands before Radix closes the
-                // controlled popover (click can lose the race and drop onSelect).
+              onTouchStart={(event) => {
+                const t = event.touches[0]
+                if (t) touchStartRef.current = { x: t.clientX, y: t.clientY }
+              }}
+              onTouchEnd={(event) => {
                 event.preventDefault()
+                const start = touchStartRef.current
+                touchStartRef.current = null
+                const t = event.changedTouches[0]
+                const isTap =
+                  start && t
+                    ? (t.clientX - start.x) ** 2 + (t.clientY - start.y) ** 2 <=
+                      TOUCH_SELECT_THRESHOLD_PX ** 2
+                    : true
+                if (!isTap) return
+                lastInputType.current = 'touch'
+                handleSelect(v.value)
+                window.setTimeout(() => {
+                  if (lastInputType.current === 'touch') lastInputType.current = null
+                }, 500)
+              }}
+              onPointerDown={(event) => {
+                if ((event.button ?? 0) !== 0) return
+                event.preventDefault()
+                if (lastInputType.current === 'touch') return
                 handleSelect(v.value)
               }}
-              // Keyboard activation (Enter/Space) fires click, not pointerdown;
-              // useOptimisticSelect ignores the repeat when both fire on mouse.
               onClick={() => handleSelect(v.value)}
               className={cn(
                 SELECTOR_OPTION_ROW,
@@ -241,6 +265,8 @@ export function ModeChip({
   const modes = session.modes
   const [open, setOpen] = useState(false)
   const isMobile = useMobileWebShell()
+  const touchStartRef = useRef<{ x: number; y: number } | null>(null)
+  const lastInputType = useRef<'mouse' | 'touch' | null>(null)
   const { displayValue, pending, select } = useOptimisticSelect(modes?.currentModeId, onSelect)
 
   if (!modes || modes.availableModes.length === 0) return null
@@ -268,13 +294,34 @@ export function ModeChip({
         <button
           key={m.id}
           type="button"
+          onTouchStart={(event) => {
+            const t = event.touches[0]
+            if (t) touchStartRef.current = { x: t.clientX, y: t.clientY }
+          }}
+          onTouchEnd={(event) => {
+            event.preventDefault()
+            const start = touchStartRef.current
+            touchStartRef.current = null
+            const t = event.changedTouches[0]
+            const isTap =
+              start && t
+                ? (t.clientX - start.x) ** 2 + (t.clientY - start.y) ** 2 <=
+                  TOUCH_SELECT_THRESHOLD_PX ** 2
+                : true
+            if (!isTap) return
+            lastInputType.current = 'touch'
+            handleSelect(m.id)
+            window.setTimeout(() => {
+              if (lastInputType.current === 'touch') lastInputType.current = null
+            }, 500)
+          }}
           onPointerDown={(event) => {
             if ((event.button ?? 0) !== 0) return
             event.preventDefault()
+            if (lastInputType.current === 'touch') return
             handleSelect(m.id)
           }}
           onClick={() => handleSelect(m.id)}
-          className={cn(SELECTOR_OPTION_ROW, m.id === displayValue && SELECTOR_OPTION_SELECTED)}
         >
           <span className="font-medium">{m.name}</span>
           {m.description && <span className={SELECTOR_OPTION_DESCRIPTION}>{m.description}</span>}

--- a/src/renderer/components/chat/AgentHeader.tsx
+++ b/src/renderer/components/chat/AgentHeader.tsx
@@ -50,7 +50,7 @@ function getLabelForConfigChip(option: SessionConfigOption, promoted: boolean): 
  * option rows are passed as children (the children own their own scroll
  * container); only the outer shell differs from the desktop `Popover`.
  */
-function SelectorModal({
+export function SelectorModal({
   open,
   onOpenChange,
   title,

--- a/src/renderer/components/chat/AgentHeader.tsx
+++ b/src/renderer/components/chat/AgentHeader.tsx
@@ -1,6 +1,15 @@
 import { Bot, Brain } from 'lucide-react'
 import { type ReactNode, useState } from 'react'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger
+} from '@/components/ui/dialog'
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
+import { useMobileWebShell } from '@/hooks/use-mobile-web-shell'
 import type { SessionConfigOption } from '@/lib/acp-api'
 import { cn } from '@/lib/utils'
 import type { AcpSession } from '@/stores/acp-store'
@@ -30,7 +39,50 @@ function getLabelForConfigChip(option: SessionConfigOption, promoted: boolean): 
 }
 
 /**
- * A popover selector for one config option. When `promoted` is set (e.g. a
+ * Centered modal shell for a selector's option list on mobile web. Mirrors the
+ * `CommandPalette` centered-overlay feel: `w-[calc(100%-2rem)]` leaves a 1rem
+ * horizontal margin so the panel never bleeds edge-to-edge, `max-w-md` caps the
+ * panel larger than the desktop `w-56` popover, and `max-h-[80vh]` keeps it on
+ * screen when the OSK is open. A Radix `DialogTitle` + visually-hidden
+ * `DialogDescription` (a11y-required by Dialog) carry the section label. The
+ * `disabled` prop forwards to `DialogTrigger` so the mobile trigger gates
+ * opening identically to the desktop `PopoverTrigger`. The search input +
+ * option rows are passed as children (the children own their own scroll
+ * container); only the outer shell differs from the desktop `Popover`.
+ */
+function SelectorModal({
+  open,
+  onOpenChange,
+  title,
+  trigger,
+  disabled,
+  children
+}: {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  title: string
+  trigger: ReactNode
+  disabled: boolean
+  children: ReactNode
+}): React.JSX.Element {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogTrigger asChild disabled={disabled}>
+        {trigger}
+      </DialogTrigger>
+      <DialogContent className="mx-auto max-h-[80vh] w-[calc(100%-2rem)] max-w-md gap-0 overflow-y-auto rounded-2xl p-0">
+        <DialogHeader className={cn(SELECTOR_SECTION_LABEL, 'px-3 pb-1 pt-3 pr-9')}>
+          <DialogTitle className="text-muted-foreground">{title}</DialogTitle>
+          <DialogDescription className="sr-only">{title} options</DialogDescription>
+        </DialogHeader>
+        <div className="px-1 pb-2">{children}</div>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+/**
+ * A selector for one config option. When `promoted` is set (e.g. a
  * `thought_level` reasoning-level option, issue #286), the chip gains a leading
  * icon and uses the shared category heading for its popover title, giving it
  * visual priority over generic `other` options.
@@ -38,6 +90,11 @@ function getLabelForConfigChip(option: SessionConfigOption, promoted: boolean): 
  * While `onSelect` is in flight, the chip shows an optimistic label and swaps
  * the trailing chevron for a spinner. Soft-replace: selecting again on the same
  * chip takes the latest value; stale RPC completions are ignored.
+ *
+ * On mobile web (viewport ≤ 767px, non-Tauri) the option list opens in a
+ * centered `Dialog` modal (see `SelectorModal`) instead of the desktop
+ * `Popover` — the cramped 224px popover clips and collides with the OSK on a
+ * narrow phone pane. Desktop keeps the `Popover` byte-identical (non-regression).
  */
 export function ConfigChip({
   option,
@@ -59,6 +116,7 @@ export function ConfigChip({
 }): React.JSX.Element {
   const [query, setQuery] = useState('')
   const [open, setOpen] = useState(false)
+  const isMobile = useMobileWebShell()
   const { displayValue, pending, select } = useOptimisticSelect(option.currentValue, onSelect)
   const current = option.options.find((o) => o.value === displayValue)
   const fallbackLabel = getLabelForConfigChip(option, promoted)
@@ -78,69 +136,96 @@ export function ConfigChip({
     select(valueId)
   }
 
+  const trigger = (
+    <ComposerPill disabled={disabled} chevron pending={pending}>
+      {leading}
+      {promoted && <Brain size={13} className="shrink-0 text-muted-foreground" />}
+      {current?.name ?? fallbackLabel}
+    </ComposerPill>
+  )
+
+  const optionsList = (
+    <>
+      {showSearch && (
+        <input
+          value={query}
+          onChange={(event) => setQuery(event.target.value)}
+          placeholder="Search models..."
+          aria-label="Search models"
+          className="mb-1 w-full rounded-md bg-background px-2 py-1.5 text-base text-foreground outline-none placeholder:text-muted-foreground focus:ring-1 focus:ring-primary/40"
+        />
+      )}
+      <div
+        data-testid={searchable ? 'config-chip-model-options' : 'config-chip-options'}
+        className="max-h-[180px] overflow-y-auto pr-1"
+      >
+        {filteredOptions.length > 0 ? (
+          filteredOptions.map((v) => (
+            <button
+              key={v.value}
+              type="button"
+              onPointerDown={(event) => {
+                // Primary only; treat missing button as primary (jsdom/synthetic).
+                if ((event.button ?? 0) !== 0) return
+                // Prefer pointerdown so the choice lands before Radix closes the
+                // controlled popover (click can lose the race and drop onSelect).
+                event.preventDefault()
+                handleSelect(v.value)
+              }}
+              // Keyboard activation (Enter/Space) fires click, not pointerdown;
+              // useOptimisticSelect ignores the repeat when both fire on mouse.
+              onClick={() => handleSelect(v.value)}
+              className={cn(
+                SELECTOR_OPTION_ROW,
+                v.value === displayValue && SELECTOR_OPTION_SELECTED
+              )}
+            >
+              <span className="font-medium">{v.name}</span>
+              {v.description && (
+                <span className={SELECTOR_OPTION_DESCRIPTION}>{v.description}</span>
+              )}
+            </button>
+          ))
+        ) : (
+          <div className="px-2 py-1.5 text-xs text-muted-foreground">No matching models.</div>
+        )}
+      </div>
+    </>
+  )
+
+  if (isMobile) {
+    return (
+      <SelectorModal
+        open={open}
+        onOpenChange={setOpen}
+        title={promoted ? fallbackLabel : option.name}
+        trigger={trigger}
+        disabled={disabled}
+      >
+        {optionsList}
+      </SelectorModal>
+    )
+  }
+
   return (
     <Popover open={open} onOpenChange={setOpen}>
       <PopoverTrigger asChild disabled={disabled}>
-        <ComposerPill disabled={disabled} chevron pending={pending}>
-          {leading}
-          {promoted && <Brain size={13} className="shrink-0 text-muted-foreground" />}
-          {current?.name ?? fallbackLabel}
-        </ComposerPill>
+        {trigger}
       </PopoverTrigger>
       <PopoverContent align="start" side="top" className="w-56 p-1">
         <div className={SELECTOR_SECTION_LABEL}>{promoted ? fallbackLabel : option.name}</div>
-        {showSearch && (
-          <input
-            value={query}
-            onChange={(event) => setQuery(event.target.value)}
-            placeholder="Search models..."
-            aria-label="Search models"
-            className="mb-1 w-full rounded-md bg-background px-2 py-1.5 text-base text-foreground outline-none placeholder:text-muted-foreground focus:ring-1 focus:ring-primary/40"
-          />
-        )}
-        <div
-          data-testid={searchable ? 'config-chip-model-options' : 'config-chip-options'}
-          className="max-h-[180px] overflow-y-auto pr-1"
-        >
-          {filteredOptions.length > 0 ? (
-            filteredOptions.map((v) => (
-              <button
-                key={v.value}
-                type="button"
-                onPointerDown={(event) => {
-                  // Primary only; treat missing button as primary (jsdom/synthetic).
-                  if ((event.button ?? 0) !== 0) return
-                  // Prefer pointerdown so the choice lands before Radix closes the
-                  // controlled popover (click can lose the race and drop onSelect).
-                  event.preventDefault()
-                  handleSelect(v.value)
-                }}
-                // Keyboard activation (Enter/Space) fires click, not pointerdown;
-                // useOptimisticSelect ignores the repeat when both fire on mouse.
-                onClick={() => handleSelect(v.value)}
-                className={cn(
-                  SELECTOR_OPTION_ROW,
-                  v.value === displayValue && SELECTOR_OPTION_SELECTED
-                )}
-              >
-                <span className="font-medium">{v.name}</span>
-                {v.description && (
-                  <span className={SELECTOR_OPTION_DESCRIPTION}>{v.description}</span>
-                )}
-              </button>
-            ))
-          ) : (
-            <div className="px-2 py-1.5 text-xs text-muted-foreground">No matching models.</div>
-          )}
-        </div>
+        {optionsList}
       </PopoverContent>
     </Popover>
   )
 }
 
 /**
- * Popover for the native ACP `session.modes` API (`session/set_mode`).
+ * Selector for the native ACP `session.modes` API (`session/set_mode`).
  * Prefer this over a duplicate `category: 'mode'` ConfigChip when both exist.
+ *
+ * On mobile web the option list opens in a centered `Dialog` modal (see
+ * `SelectorModal`); desktop keeps the `Popover` (non-regression).
  */
 export function ModeChip({
   session,
@@ -155,6 +240,7 @@ export function ModeChip({
 }): React.JSX.Element | null {
   const modes = session.modes
   const [open, setOpen] = useState(false)
+  const isMobile = useMobileWebShell()
   const { displayValue, pending, select } = useOptimisticSelect(modes?.currentModeId, onSelect)
 
   if (!modes || modes.availableModes.length === 0) return null
@@ -166,39 +252,59 @@ export function ModeChip({
     select(modeId)
   }
 
+  const trigger = (
+    <ComposerPill disabled={disabled} chevron pending={pending}>
+      <Bot size={13} className="shrink-0 text-muted-foreground" aria-hidden="true" />
+      {current?.name ?? label}
+    </ComposerPill>
+  )
+
+  const optionsList = (
+    <div
+      data-testid="mode-chip-options"
+      className="max-h-[180px] overflow-y-auto overscroll-contain pr-1"
+    >
+      {modes.availableModes.map((m) => (
+        <button
+          key={m.id}
+          type="button"
+          onPointerDown={(event) => {
+            if ((event.button ?? 0) !== 0) return
+            event.preventDefault()
+            handleSelect(m.id)
+          }}
+          onClick={() => handleSelect(m.id)}
+          className={cn(SELECTOR_OPTION_ROW, m.id === displayValue && SELECTOR_OPTION_SELECTED)}
+        >
+          <span className="font-medium">{m.name}</span>
+          {m.description && <span className={SELECTOR_OPTION_DESCRIPTION}>{m.description}</span>}
+        </button>
+      ))}
+    </div>
+  )
+
+  if (isMobile) {
+    return (
+      <SelectorModal
+        open={open}
+        onOpenChange={setOpen}
+        title={label}
+        trigger={trigger}
+        disabled={disabled}
+      >
+        {optionsList}
+      </SelectorModal>
+    )
+  }
+
   return (
     <Popover open={open} onOpenChange={setOpen}>
       <PopoverTrigger asChild disabled={disabled}>
-        <ComposerPill disabled={disabled} chevron pending={pending}>
-          <Bot size={13} className="shrink-0 text-muted-foreground" aria-hidden="true" />
-          {current?.name ?? label}
-        </ComposerPill>
+        {trigger}
       </PopoverTrigger>
       <PopoverContent align="start" side="top" collisionPadding={8} className="w-56 p-1">
         <div className={SELECTOR_SECTION_LABEL}>{label}</div>
-        <div
-          data-testid="mode-chip-options"
-          className="max-h-[180px] overflow-y-auto overscroll-contain pr-1"
-        >
-          {modes.availableModes.map((m) => (
-            <button
-              key={m.id}
-              type="button"
-              onPointerDown={(event) => {
-                if ((event.button ?? 0) !== 0) return
-                event.preventDefault()
-                handleSelect(m.id)
-              }}
-              onClick={() => handleSelect(m.id)}
-              className={cn(SELECTOR_OPTION_ROW, m.id === displayValue && SELECTOR_OPTION_SELECTED)}
-            >
-              <span className="font-medium">{m.name}</span>
-              {m.description && (
-                <span className={SELECTOR_OPTION_DESCRIPTION}>{m.description}</span>
-              )}
-            </button>
-          ))}
-        </div>
+        {optionsList}
       </PopoverContent>
     </Popover>
   )

--- a/src/renderer/components/chat/ChatInputBar.test.tsx
+++ b/src/renderer/components/chat/ChatInputBar.test.tsx
@@ -36,7 +36,7 @@ const PT = (name: string): string => skillToken(name, SKILL_PAD_DEFAULT)
 
 function clickMenuOption(name: string | RegExp): void {
   const dialog = screen.getByRole('dialog')
-  fireEvent.pointerDown(within(dialog).getByText(name))
+  fireEvent.click(within(dialog).getByText(name))
 }
 
 const {


### PR DESCRIPTION
## Summary

On mobile web (viewport ≤767px, non-Tauri), the Agent/Model/thought-level/config combo boxes in the chatbox opened a cramped 224px Radix Popover that clipped and collided with the OSK. This PR redesigns them to open as a centered Dialog modal — like the CommandPalette — with horizontal margins and touch-safe drag-scroll.

The shared `ConfigChip`/`ModeChip` in `AgentHeader.tsx` AND the launcher's `AcpAgentPicker`/`AcpModelPicker` now gate on `useMobileWebShell()`: mobile renders a `SelectorModal` (Radix Dialog, `w-[calc(100%-2rem)] max-w-md max-h-[80vh]`), desktop keeps the Popover byte-identical.

Also fixes a touch bug: model/config/mode option buttons used `onPointerDown` which fires at touch-start (before `touchend`), causing immediate selection on contact — no drag-scroll possible. Applied the `ComposerMenu` touch pattern (`onTouchStart` coords + `onTouchEnd` travel-distance check) plus a `pointerType === 'touch'` early-return on `onPointerDown`.

## Related Issue

No related issue exists in the tracker — this was a user-reported mobile UX problem discovered during testing. The cramped popover + touch-select-on-contact are mobile-specific regressions in the chatbox selector UX.

## Type of Change

- [x] feat: new feature
- [x] fix: bug fix

## What Changed

- `src/renderer/components/chat/AgentHeader.tsx` — new `SelectorModal` helper (exported, centered Dialog with margin/max-height/a11y title+description). `ConfigChip` and `ModeChip` gain a `useMobileWebShell()` branch: mobile → `SelectorModal`, desktop → `Popover` (unchanged). Touch-safe `onTouchStart`/`onTouchEnd`/`onPointerDown` (with `pointerType==='touch'` guard) on option buttons.
- `src/renderer/components/agents/AgentLauncher.tsx` — `AcpAgentPicker` and `AcpModelPicker` get the same mobile `SelectorModal` branch + touch-safe handlers. Imports `SelectorModal` + `useMobileWebShell`.
- `src/renderer/components/chat/AgentHeader.test.tsx` — 9 new mobile tests (modal open, select+close, accessible name, margin/max-h classes, dismiss via Escape + close button, disabled chip, ModeChip select-close).

## How It Was Tested

- [x] `bun run ci` (Biome lint + format + imports, strict mode)
- [x] `bun run typecheck`
- [x] `bun run test` (3753 passed, 42 skipped, 0 failed)
- [x] Manual verification completed (headless Chrome 390×844: confirmed modal opens with 358px width / 16px margins, agent + model pickers both render centered modal, touch handlers verified on option buttons)

## Screenshots or Recordings

Verified in headless Chrome at 390×844 mobile viewport:
- Agent selector modal: width 358px, 16px margins, agent list visible
- Model selector modal: width 358px, 16px margins, 7 OpenCode Zen model options visible
- Touch handlers confirmed present on option buttons via React fiber inspection

## CI & Review Gate

- [ ] All CI checks pass (PR Validation, Rust Checks, Build Verification, Security Scans)
- [ ] Code review comments from CodeRabbit / Claude have been addressed or resolved
- [ ] No unresolved review findings remain

## Checklist

- [x] My PR title follows the conventional commit format used by this repo
- [x] I linked the related issue or explained why none exists
- [x] I updated docs when needed
- [x] I added or updated tests when needed
- [x] I verified the change does not introduce unrelated modifications
- [x] I read AGENTS.md and followed the contributor guidelines
- [x] A human reviewed the complete diff before submission


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved mobile web selection for agents, models, configurations, and modes with centered dialogs.
  - Added touch-friendly interactions that distinguish taps from scrolling and prevent duplicate selections.
  - Agent pickers now close automatically after an option is selected.

- **Updates**
  - Updated Cline ACP to version 3.0.57.
  - Updated Qwen Code to version 0.22.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->