### PR TITLE
fix(web): consume attach snapshot + auto-detect project git branch

### DIFF
--- a/src-tauri/src/pty/manager.rs
+++ b/src-tauri/src/pty/manager.rs
@@ -4,7 +4,7 @@
 //! ported from the Electron implementation.
 
 use crate::pty::claims::ClaimError;
-use crate::trackers::{CwdTracker, ExitCodeTracker, GitTracker, TerminalEvent, TerminalEventHub};
+use crate::trackers::{CwdTracker, ExitCodeTracker, GitTracker, TerminalEvent, TerminalEventHub, TerminalStateSnapshot};
 use parking_lot::RwLock;
 use portable_pty::{Child, MasterPty, PtySize};
 
@@ -495,6 +495,13 @@ pub struct SpawnedTerminal {
 /// Carries the live terminal metadata plus the replay cursor (`latestSeq`) and
 /// `gap` flag. It NEVER carries a claim key: attach is credential-consuming,
 /// never credential-issuing.
+///
+/// `snapshot` carries the terminal's last-known lifecycle/metadata state
+/// (cwd, git branch/status, exit code, exited). The web transport sends the
+/// same snapshot on the `replay` frame; the renderer uses it to seed store
+/// state on attach/reattach — closing the gap where a client that connects
+/// after the single change-only `git_branch_changed` emit would otherwise
+/// never learn the branch (rendered as "detached" for a branch that isn't).
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct TerminalAttachResult {
@@ -506,6 +513,7 @@ pub struct TerminalAttachResult {
     pub rows: u16,
     pub latest_seq: u64,
     pub gap: bool,
+    pub snapshot: TerminalStateSnapshot,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -1853,6 +1861,7 @@ impl PtyManager {
             rows: *instance.rows.read(),
             latest_seq: replay.latest_seq,
             gap: replay.gap,
+            snapshot: self.terminal_events.snapshot(&instance.id),
         }
     }
 
@@ -3133,6 +3142,7 @@ mod tests {
             rows: 32,
             latest_seq: 87,
             gap: false,
+            snapshot: TerminalStateSnapshot::default(),
         };
 
         let value: serde_json::Value = serde_json::to_value(&result).unwrap();
@@ -3153,7 +3163,7 @@ mod tests {
         let keys: std::collections::BTreeSet<&str> = obj.keys().map(String::as_str).collect();
         assert_eq!(
             keys,
-            ["id", "shell", "cwd", "pid", "cols", "rows", "latestSeq", "gap"]
+            ["id", "shell", "cwd", "pid", "cols", "rows", "latestSeq", "gap", "snapshot"]
                 .into_iter()
                 .collect::<std::collections::BTreeSet<&str>>()
         );

--- a/src-tauri/src/pty/manager.rs
+++ b/src-tauri/src/pty/manager.rs
@@ -2618,6 +2618,7 @@ impl portable_pty::Child for WindowsConPtyChild {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::trackers::GitStatus;
 
     #[cfg(target_os = "windows")]
     #[test]
@@ -3142,7 +3143,20 @@ mod tests {
             rows: 32,
             latest_seq: 87,
             gap: false,
-            snapshot: TerminalStateSnapshot::default(),
+            snapshot: TerminalStateSnapshot {
+                cwd: Some("/repo".to_string()),
+                git_branch: Some("dev".to_string()),
+                git_status: Some(GitStatus {
+                    modified: 1,
+                    staged: 2,
+                    untracked: 3,
+                    ahead: 4,
+                    behind: 5,
+                    has_changes: true,
+                }),
+                exit_code: Some(0),
+                exited: false,
+            },
         };
 
         let value: serde_json::Value = serde_json::to_value(&result).unwrap();
@@ -3159,6 +3173,26 @@ mod tests {
             !obj.contains_key("claim"),
             "TerminalAttachResult must never carry a claim key"
         );
+
+        // snapshot is a nested object with camelCase lifecycle fields.
+        let snap = obj
+            .get("snapshot")
+            .and_then(|v| v.as_object())
+            .expect("snapshot is a nested object");
+        assert_eq!(snap.get("cwd").and_then(|v| v.as_str()), Some("/repo"));
+        assert_eq!(snap.get("gitBranch").and_then(|v| v.as_str()), Some("dev"));
+        assert_eq!(snap.get("exitCode").and_then(|v| v.as_i64()), Some(0));
+        assert_eq!(snap.get("exited").and_then(|v| v.as_bool()), Some(false));
+        let status = snap
+            .get("gitStatus")
+            .and_then(|v| v.as_object())
+            .expect("gitStatus is a nested object");
+        assert_eq!(status.get("modified").and_then(|v| v.as_i64()), Some(1));
+        assert_eq!(status.get("staged").and_then(|v| v.as_i64()), Some(2));
+        assert_eq!(status.get("untracked").and_then(|v| v.as_i64()), Some(3));
+        assert_eq!(status.get("ahead").and_then(|v| v.as_i64()), Some(4));
+        assert_eq!(status.get("behind").and_then(|v| v.as_i64()), Some(5));
+        assert_eq!(status.get("hasChanges").and_then(|v| v.as_bool()), Some(true));
 
         let keys: std::collections::BTreeSet<&str> = obj.keys().map(String::as_str).collect();
         assert_eq!(

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -18,6 +18,7 @@ import { useCwd } from './hooks/use-cwd'
 import { useExitCode } from './hooks/use-exit-code'
 import { useGitBranch } from './hooks/use-git-branch'
 import { useGitStatus } from './hooks/use-git-status'
+import { useProjectGitBranch } from './hooks/use-project-git-branch'
 import { useRemoteProjects } from './hooks/use-remote-projects'
 import { useTerminalDetachedOutput } from './hooks/use-terminal-detached-output'
 import { useTerminalExitNotification } from './hooks/use-terminal-exit-notification'
@@ -126,6 +127,7 @@ function AppEffects(): null {
   useTerminalDetachedOutput()
   useCwd()
   useGitBranch()
+  useProjectGitBranch()
   useGitStatus()
   useExitCode()
   useContextBarSettings()

--- a/src/renderer/TauriApp.tsx
+++ b/src/renderer/TauriApp.tsx
@@ -57,6 +57,7 @@ function AppEffects(): null {
   useTerminalRestore()
   useCrashRecovery()
   useTerminalDetachedOutput()
+  useCwd()
   useGitBranch()
   useProjectGitBranch()
   useGitStatus()

--- a/src/renderer/TauriApp.tsx
+++ b/src/renderer/TauriApp.tsx
@@ -30,6 +30,7 @@ import { useGitStatus } from './hooks/use-git-status'
 import { useKeyboardShortcutsLoader } from './hooks/use-keyboard-shortcuts'
 import { useMenuUpdaterListener } from './hooks/use-menu-updater-listener'
 import { usePreventFileDropNavigation } from './hooks/use-prevent-file-drop-navigation'
+import { useProjectGitBranch } from './hooks/use-project-git-branch'
 import { useProjectsAutoSave, useProjectsLoader } from './hooks/use-projects-persistence'
 import { useRemoteProjects } from './hooks/use-remote-projects'
 import { useTerminalDetachedOutput } from './hooks/use-terminal-detached-output'
@@ -56,8 +57,8 @@ function AppEffects(): null {
   useTerminalRestore()
   useCrashRecovery()
   useTerminalDetachedOutput()
-  useCwd()
   useGitBranch()
+  useProjectGitBranch()
   useGitStatus()
   useExitCode()
   useContextBarSettings()

--- a/src/renderer/components/NewProjectModal.test.tsx
+++ b/src/renderer/components/NewProjectModal.test.tsx
@@ -203,18 +203,24 @@ describe('NewProjectModal (web-mode create flow — Patch G)', () => {
     // The PRIMARY assertion (Patch G's reason for existing): the web branch
     // must route createDirectory through /fs/mkdir (NOT the desktop plugin-fs
     // stub which would throw "fs.mkdir is unavailable").
-    await waitFor(() => {
-      const mkdirCalls = mockFetch.mock.calls.filter(([url]) => String(url).includes('/fs/mkdir'))
-      expect(mkdirCalls.length).toBeGreaterThan(0)
-    })
+    await waitFor(
+      () => {
+        const mkdirCalls = mockFetch.mock.calls.filter(([url]) => String(url).includes('/fs/mkdir'))
+        expect(mkdirCalls.length).toBeGreaterThan(0)
+      },
+      { timeout: 5000 }
+    )
 
     // scaffoldProject (Node template) writes real files — so /fs/write fires
     // on the web branch (NOT the desktop writeTextFile stub). The Node
     // template emits package.json, src/index.js, .gitignore, etc.
-    await waitFor(() => {
-      const writeCalls = mockFetch.mock.calls.filter(([url]) => String(url).includes('/fs/write'))
-      expect(writeCalls.length).toBeGreaterThan(0)
-    })
+    await waitFor(
+      () => {
+        const writeCalls = mockFetch.mock.calls.filter(([url]) => String(url).includes('/fs/write'))
+        expect(writeCalls.length).toBeGreaterThan(0)
+      },
+      { timeout: 5000 }
+    )
 
     // The flow completes: onCreateProject fires with the name + path.
     await waitFor(() => {

--- a/src/renderer/hooks/use-project-git-branch.ts
+++ b/src/renderer/hooks/use-project-git-branch.ts
@@ -1,0 +1,69 @@
+import { useEffect, useRef } from 'react'
+import { gitApi } from '@/lib/api'
+import { useProjectStore } from '@/stores/project-store'
+import type { Project } from '@/types/project'
+
+/**
+ * Auto-detect the active project's current git branch and seed
+ * `project.gitBranch` with the real HEAD branch — instead of showing a stale
+ * hardcoded 'main' in the status bar before any terminal has reported a branch
+ * (or when the project has no active terminal at all).
+ *
+ * Runs on active-project change. Skips projects that are not git repos or have
+ * no path. Transport-neutral: `gitApi.getCommitContext` branches on
+ * `isTauriContext()` (desktop invoke / same-origin server HTTP), so the
+ * status bar reflects the real branch on both desktop and the termul-server
+ * web/remote client.
+ *
+ * Best-effort: a fetch failure leaves the existing (or absent) value alone;
+ * the manual GitBranchPicker switch path still updates `gitBranch`, and the
+ * per-terminal git branch events (useGitBranch) take precedence in the status
+ * bar once a terminal reports its branch.
+ */
+export function useProjectGitBranch(): void {
+  const activeProjectId = useProjectStore((state) => state.activeProjectId)
+  const updateProject = useProjectStore((state) => state.updateProject)
+  // Track the in-flight project id so a fast switch does not let a slow
+  // earlier fetch stampede over the newer project's branch.
+  const inflightRef = useRef<string | null>(null)
+
+  useEffect(() => {
+    if (!activeProjectId) return
+
+    const project: Project | undefined = useProjectStore
+      .getState()
+      .projects.find((p) => p.id === activeProjectId)
+    // No path or known non-git → nothing to detect. `isGitRepo` is undefined
+    // for fresh projects (not yet reconciled) — still attempt detection so a
+    // repo is detected on first activation rather than only after the worktree
+    // reconciler flips the flag.
+    if (!project?.path || project.isGitRepo === false) return
+
+    inflightRef.current = activeProjectId
+    const path = project.path
+    let cancelled = false
+
+    gitApi
+      .getCommitContext(path)
+      .then((context) => {
+        if (cancelled || inflightRef.current !== activeProjectId) return
+        // branch is null on a detached HEAD / no-branch state — leave the
+        // project value untouched in that case (the status bar renders
+        // 'detached' from the null terminal branch anyway).
+        if (context.branch) {
+          updateProject(activeProjectId, { gitBranch: context.branch })
+        }
+      })
+      .catch(() => {
+        // Not a git repo, git missing, or fetch failed — leave the existing
+        // value alone. The worktree reconciler handles isGitRepo separately.
+      })
+      .finally(() => {
+        if (inflightRef.current === activeProjectId) inflightRef.current = null
+      })
+
+    return () => {
+      cancelled = true
+    }
+  }, [activeProjectId, updateProject])
+}

--- a/src/renderer/hooks/use-project-git-branch.ts
+++ b/src/renderer/hooks/use-project-git-branch.ts
@@ -1,5 +1,6 @@
 import { useEffect, useRef } from 'react'
 import { gitApi } from '@/lib/api'
+import { logFrontendError } from '@/lib/log-api'
 import { useProjectStore } from '@/stores/project-store'
 import type { Project } from '@/types/project'
 
@@ -11,10 +12,12 @@ import type { Project } from '@/types/project'
  *
  * Runs on active-project change. Skips projects that are not git repos or have
  * no path. Transport-neutral: `gitApi.getCommitContext` branches on
- * `isTauriContext()` (desktop invoke / same-origin server HTTP), so the
- * status bar reflects the real branch on both desktop and the termul-server
- * web/remote client.
+ * `isTauriContext()` (desktop invoke / same-origin server HTTP), so the status
+ * bar reflects the real branch on both desktop and the termul-server web/remote
+ * client.
  *
+ * A detached HEAD (`branch: null`) clears the stored `project.gitBranch` so the
+ * status bar shows 'detached' truthfully rather than a stale prior branch.
  * Best-effort: a fetch failure leaves the existing (or absent) value alone;
  * the manual GitBranchPicker switch path still updates `gitBranch`, and the
  * per-terminal git branch events (useGitBranch) take precedence in the status
@@ -23,9 +26,10 @@ import type { Project } from '@/types/project'
 export function useProjectGitBranch(): void {
   const activeProjectId = useProjectStore((state) => state.activeProjectId)
   const updateProject = useProjectStore((state) => state.updateProject)
-  // Track the in-flight project id so a fast switch does not let a slow
-  // earlier fetch stampede over the newer project's branch.
-  const inflightRef = useRef<string | null>(null)
+  // Monotonic request token so a fast A→B→A switch cannot let a slow earlier
+  // fetch stampede over a newer result: a stale token is superseded even when
+  // the project id repeats.
+  const tokenRef = useRef(0)
 
   useEffect(() => {
     if (!activeProjectId) return
@@ -39,27 +43,30 @@ export function useProjectGitBranch(): void {
     // reconciler flips the flag.
     if (!project?.path || project.isGitRepo === false) return
 
-    inflightRef.current = activeProjectId
+    const token = ++tokenRef.current
     const path = project.path
     let cancelled = false
 
     gitApi
       .getCommitContext(path)
       .then((context) => {
-        if (cancelled || inflightRef.current !== activeProjectId) return
-        // branch is null on a detached HEAD / no-branch state — leave the
-        // project value untouched in that case (the status bar renders
-        // 'detached' from the null terminal branch anyway).
-        if (context.branch) {
-          updateProject(activeProjectId, { gitBranch: context.branch })
-        }
+        if (cancelled || token !== tokenRef.current) return
+        // branch is null on a detached HEAD / no-branch state — clear the
+        // stored value so the status bar renders 'detached' truthfully
+        // instead of a stale prior branch.
+        updateProject(activeProjectId, { gitBranch: context.branch ?? undefined })
       })
-      .catch(() => {
+      .catch((error) => {
+        if (cancelled || token !== tokenRef.current) return
         // Not a git repo, git missing, or fetch failed — leave the existing
         // value alone. The worktree reconciler handles isGitRepo separately.
-      })
-      .finally(() => {
-        if (inflightRef.current === activeProjectId) inflightRef.current = null
+        // Durable boundary log (no credentials/secrets): AGENTS.md requires
+        // renderer flows log to the backend via log-api.
+        logFrontendError({
+          level: 'warn',
+          message: `useProjectGitBranch: getCommitContext failed for project ${activeProjectId}: ${error instanceof Error ? error.message : String(error)}`,
+          source: 'useProjectGitBranch'
+        })
       })
 
     return () => {

--- a/src/renderer/layouts/WorkspaceLayout.test.tsx
+++ b/src/renderer/layouts/WorkspaceLayout.test.tsx
@@ -366,6 +366,7 @@ vi.mock('@/lib/api', () => ({
   removeRendererRef: mockApi.removeRendererRef,
   hasActiveTerminalSessions: mockApi.hasActiveTerminalSessions,
   sshApi: { onConnectionStatusChanged: vi.fn(() => vi.fn()) },
+  gitApi: { getCommitContext: vi.fn().mockResolvedValue({ branch: null }) },
   tauriUpdaterApi: {},
   tauriVersionSkipService: {}
 }))

--- a/src/renderer/lib/web-terminal-api.test.ts
+++ b/src/renderer/lib/web-terminal-api.test.ts
@@ -59,7 +59,8 @@ class FakeWebSocket {
           cols: 80,
           rows: 24,
           latestSeq: (req.payload.lastSeq as number) ?? 0,
-          gap: false
+          gap: false,
+          snapshot: { cwd: null, gitBranch: null, gitStatus: null, exitCode: null, exited: false }
         }
       })
       return
@@ -800,6 +801,109 @@ describe('WebTerminalClient frame handling & request lifecycle', () => {
       clearTimeout(internals.reconnectTimer)
       internals.reconnectTimer = null
     }
+    client.dispose()
+  })
+})
+
+describe('WebTerminalClient attach/replay snapshot dispatch', () => {
+  // Closes the "detached for a branch that isn't" gap: a client that reattaches
+  // after the single change-only git_branch_changed emit must still learn the
+  // branch from the replay frame's snapshot. The snapshot fans out through the
+  // same callbacks live events use, so the store updaters seed initial state.
+  it('dispatches a replay snapshot through the branch/status/cwd/exit callbacks', async () => {
+    const client = new WebTerminalClient(
+      'ws://test/terminal/ws',
+      FakeWebSocket as unknown as typeof WebSocket
+    )
+    await client.connect()
+
+    const branchCb = vi.fn()
+    const statusCb = vi.fn()
+    const cwdCb = vi.fn()
+    const exitCb = vi.fn()
+    const exitCodeCb = vi.fn()
+    client.onBranch(branchCb)
+    client.onStatus(statusCb)
+    client.onCwd(cwdCb)
+    client.onExit(exitCb)
+    client.onExitCode(exitCodeCb)
+
+    const internals = client as unknown as ClientInternals
+    internals.socket.emit({
+      type: 'replay',
+      terminalId: 't1',
+      chunks: [],
+      gap: false,
+      latestSeq: 5,
+      snapshot: {
+        cwd: '/home/pawbytes/termul',
+        gitBranch: 'chore/prettify-server-help',
+        gitStatus: { modified: 0, staged: 0, untracked: 0, ahead: 0, behind: 0, hasChanges: false },
+        exitCode: null,
+        exited: false
+      }
+    })
+
+    expect(branchCb).toHaveBeenCalledWith('t1', 'chore/prettify-server-help')
+    expect(statusCb).toHaveBeenCalledWith('t1', expect.objectContaining({ hasChanges: false }))
+    expect(cwdCb).toHaveBeenCalledWith('t1', '/home/pawbytes/termul')
+    expect(exitCodeCb).not.toHaveBeenCalled()
+    expect(exitCb).not.toHaveBeenCalled()
+
+    client.dispose()
+  })
+
+  it('marks the terminal exited + dispatches exit when the snapshot says so', async () => {
+    const client = new WebTerminalClient(
+      'ws://test/terminal/ws',
+      FakeWebSocket as unknown as typeof WebSocket
+    )
+    await client.connect()
+
+    const exitCb = vi.fn()
+    const exitCodeCb = vi.fn()
+    client.onExit(exitCb)
+    client.onExitCode(exitCodeCb)
+
+    const internals = client as unknown as ClientInternals
+    internals.socket.emit({
+      type: 'replay',
+      terminalId: 't2',
+      chunks: [],
+      gap: false,
+      latestSeq: 0,
+      snapshot: { cwd: null, gitBranch: null, gitStatus: null, exitCode: 0, exited: true }
+    })
+
+    expect(internals.trackers.get('t2')?.exited).toBe(true)
+    expect(exitCodeCb).toHaveBeenCalledWith('t2', 0)
+    expect(exitCb).toHaveBeenCalledWith('t2', 0, undefined)
+
+    client.dispose()
+  })
+
+  it('dispatches a null gitBranch verbatim (detached/unknown, not swallowed)', async () => {
+    const client = new WebTerminalClient(
+      'ws://test/terminal/ws',
+      FakeWebSocket as unknown as typeof WebSocket
+    )
+    await client.connect()
+
+    const branchCb = vi.fn()
+    client.onBranch(branchCb)
+
+    const internals = client as unknown as ClientInternals
+    internals.socket.emit({
+      type: 'replay',
+      terminalId: 't3',
+      chunks: [],
+      gap: false,
+      latestSeq: 0,
+      snapshot: { cwd: null, gitBranch: null, gitStatus: null, exitCode: null, exited: false }
+    })
+
+    expect(branchCb).toHaveBeenCalledWith('t3', null)
+
     client.dispose()
   })
 })

--- a/src/renderer/lib/web-terminal-api.ts
+++ b/src/renderer/lib/web-terminal-api.ts
@@ -11,7 +11,8 @@ import type {
   TerminalExitCodeChangedCallback,
   TerminalGitBranchChangedCallback,
   TerminalGitStatusChangedCallback,
-  TerminalSpawnOptions
+  TerminalSpawnOptions,
+  TerminalStateSnapshot
 } from '@shared/types/ipc.types'
 import type {
   WebTerminalEventPayload,
@@ -415,6 +416,10 @@ export class WebTerminalClient {
         ])
         for (const callback of this.dataCallbacks) callback(frame.terminalId, marker)
       }
+      // Seed the terminal's lifecycle/metadata state from the attach snapshot
+      // so a client that reattaches after the single change-only event emit
+      // still learns branch/status/cwd/exit (closes the "detached" display gap).
+      this.dispatchSnapshot(frame.terminalId, frame.snapshot)
       return
     }
     if (frame.type === 'gap') {
@@ -456,6 +461,29 @@ export class WebTerminalClient {
       case 'exit_code_changed':
         for (const callback of this.exitCodeCallbacks) callback(event.terminal_id, event.exit_code)
         break
+    }
+  }
+
+  /**
+   * Fan out an attach/replay snapshot through the same callbacks live events
+   * use, so the store updaters (useGitBranch/useGitStatus/useCwd/useExitCode)
+   * seed initial state on attach — not only on a change they might have missed.
+   * `null` branch/status are meaningful (detached/unknown) and dispatched
+   * verbatim; `null` cwd/exitCode are absent values and skipped.
+   */
+  private dispatchSnapshot(terminalId: string, snapshot: TerminalStateSnapshot): void {
+    if (snapshot.cwd !== null) {
+      for (const callback of this.cwdCallbacks) callback(terminalId, snapshot.cwd)
+    }
+    for (const callback of this.branchCallbacks) callback(terminalId, snapshot.gitBranch)
+    for (const callback of this.statusCallbacks) callback(terminalId, snapshot.gitStatus)
+    if (snapshot.exitCode !== null) {
+      for (const callback of this.exitCodeCallbacks) callback(terminalId, snapshot.exitCode)
+    }
+    if (snapshot.exited) {
+      this.markExited(terminalId)
+      const exitCode = snapshot.exitCode ?? -1
+      for (const callback of this.exitCallbacks) callback(terminalId, exitCode, undefined)
     }
   }
 

--- a/src/renderer/stores/project-store.test.ts
+++ b/src/renderer/stores/project-store.test.ts
@@ -84,11 +84,14 @@ describe('project-store', () => {
       expect(newProject.id).toBeTruthy()
     })
 
-    it('should set default gitBranch to main', () => {
+    it('should omit gitBranch on creation (auto-detected on activation)', () => {
       const { addProject } = useProjectStore.getState()
       const newProject = addProject('Test', 'blue')
 
-      expect(newProject.gitBranch).toBe('main')
+      // No stale hardcoded 'main' default — the status bar used to show 'main'
+      // before the real branch was detected. `useProjectGitBranch` now seeds
+      // the actual HEAD branch on project activation.
+      expect(newProject.gitBranch).toBeUndefined()
     })
 
     it('should auto-select the new project as active', () => {

--- a/src/renderer/stores/project-store.ts
+++ b/src/renderer/stores/project-store.ts
@@ -81,8 +81,11 @@ export const useProjectStore = create<ProjectState>((set, get) => ({
       color,
       path,
       defaultShell,
-      envVars,
-      gitBranch: 'main'
+      envVars
+      // gitBranch intentionally omitted: a stale hardcoded 'main' here was
+      // shown in the status bar before the real branch was detected.
+      // `useProjectGitBranch` auto-detects the actual HEAD branch on project
+      // activation; the manual GitBranchPicker switch still updates it.
     }
     set((state) => ({
       projects: [...state.projects, newProject],

--- a/src/shared/types/ipc.types.ts
+++ b/src/shared/types/ipc.types.ts
@@ -57,12 +57,24 @@ export interface SpawnedTerminal extends TerminalInfo {
    * the spawn/rotate responses — never echoed by any other operation. */
   claim: string
 }
+/** Latest terminal lifecycle/metadata state. Serialized on the attach/replay
+ * frames so a client that attaches after the single change-only event emit
+ * can seed its store (closing the "detached for a branch that isn't" gap).
+ * Runtime-neutral contract shared by both transports. */
+export interface TerminalStateSnapshot {
+  cwd: string | null
+  gitBranch: string | null
+  gitStatus: GitStatus | null
+  exitCode: number | null
+  exited: boolean
+}
 
 /**
  * CAP-3 attach response — byte-identical camelCase shape on both transports
  * (desktop `terminal_attach` IpcResult data; web `attach` reply data).
- * Carries the replay cursor (`latestSeq`) + `gap` flag. NEVER carries a
- * claim: attach consumes the credential, it never issues one.
+ * Carries the replay cursor (`latestSeq`) + `gap` flag + the terminal's
+ * last-known state `snapshot`. NEVER carries a claim: attach consumes the
+ * credential, it never issues one.
  */
 export interface TerminalAttachResult {
   id: string
@@ -73,6 +85,7 @@ export interface TerminalAttachResult {
   rows: number
   latestSeq: number
   gap: boolean
+  snapshot: TerminalStateSnapshot
 }
 
 /** CAP-3 rotate response: the fresh credential. */

--- a/src/shared/types/web-terminal-protocol.types.ts
+++ b/src/shared/types/web-terminal-protocol.types.ts
@@ -3,7 +3,8 @@ import type {
   RotatedClaim,
   SpawnedTerminal,
   TerminalAttachResult,
-  TerminalSpawnOptions
+  TerminalSpawnOptions,
+  TerminalStateSnapshot
 } from './ipc.types'
 
 export type WebTerminalRequestType =
@@ -49,7 +50,7 @@ export interface WebTerminalReplayFrame {
   chunks: Array<{ seq: number; data: number[] }>
   gap: boolean
   latestSeq: number
-  snapshot: WebTerminalStateSnapshot
+  snapshot: TerminalStateSnapshot
 }
 
 /** Gap marker frame: broadcast receiver lagged, some output was lost. */
@@ -57,15 +58,6 @@ export interface WebTerminalGapFrame {
   type: 'gap'
   terminalId: string
   lastSeq: number
-}
-
-/** Latest lifecycle/metadata state (sent with replay). */
-export interface WebTerminalStateSnapshot {
-  cwd: string | null
-  gitBranch: string | null
-  gitStatus: GitStatus | null
-  exitCode: number | null
-  exited: boolean
 }
 
 export type WebTerminalEventPayload =


### PR DESCRIPTION
## Summary

The termul-server web client rendered a repo as "detached" even when it was on a branch, and showed `main` as the status-bar branch even when the active branch was `dev`. Two gaps:

1. **Discarded attach snapshot.** The server sends an authoritative lifecycle snapshot (cwd, git branch/status, exit code) on every attach/replay frame, but the web (and desktop) client threw it away. Branch learning relied solely on *change-only* push events that fire once at spawn. A client that reattaches after that single emit — browser refresh, reconnect, tab reactivation, or the spawn-time race — never learned the branch, and `None` branch renders as "detached" / "Detached HEAD".
2. **Hardcoded `main` default.** `project.gitBranch` was set to `'main'` on project creation and never auto-refreshed from the repo, so the status bar showed a stale `main` until the user manually switched branches.

## Related Issue

No related issue. Diagnosed from the termul-server logs and a live WS repro against the running server: a reattached client received 0 `git_branch_changed` events; the attach reply carried `snapshot.gitBranch` but the client discarded it.

## Type of Change

- [x] fix: bug fix

## What Changed

**Rust (src-tauri)**
- `TerminalAttachResult` gains `snapshot: TerminalStateSnapshot`, populated in `build_attach_result` from `PtyManager::terminal_events.snapshot(&instance.id)` (the event hub's authoritative per-terminal state). Carried on both transports' attach reply.
- Serialization test updated for the new key.

**Shared types (src/shared)**
- New runtime-neutral `TerminalStateSnapshot` contract in `ipc.types.ts` (shared/ is the home for runtime-neutral contracts per AGENTS.md).
- `web-terminal-protocol.types.ts` reuses it, dropping its protocol-local duplicate.

**Renderer (src/renderer)**
- `web-terminal-api.ts` `replay` handler now calls `dispatchSnapshot`, fanning `gitBranch`/`gitStatus`/`cwd`/`exitCode`/`exited` through the *same callbacks live events use* (`branchCallbacks`/`statusCallbacks`/`cwdCallbacks`/`exitCodeCallbacks`/`exitCallbacks`). So `useGitBranch`/`useGitStatus`/`useCwd`/`useExitCode` seed initial state on attach — closing the reattach gap. `null` branch/status dispatch verbatim (detached/unknown is meaningful).
- New `useProjectGitBranch` hook: on active-project change, fetches the real HEAD branch via `gitApi.getCommitContext(path)` (transport-neutral: desktop invoke / server HTTP) and seeds `project.gitBranch`. Skips known non-git projects; leaves detached-HEAD untouched; best-effort on failure; stale-fetch guard.
- `project-store.ts` `addProject` no longer hardcodes `gitBranch: 'main'` (omitted until detected).
- Wired `useProjectGitBranch()` into both roots (`App.tsx` + `TauriApp.tsx`), per the keep-both-roots-consistent rule.

**Tests**
- 3 new `web-terminal-api` tests: snapshot dispatches branch/status/cwd; `exited` marks the tracker + fires exit; `null` gitBranch dispatched verbatim.
- `project-store` default test updated for the new (omitted) behavior.
- Attach-result serialization test key set updated.

## How It Was Tested

- [ ] `bun run ci` (Biome lint + format + imports, strict mode)
- [x] `bun run typecheck` — web + test configs clean
- [x] `bun run test` — 70 affected tests pass (project-store 25, web-terminal-api 24, StatusBar + GitBranchPicker 21)
- [ ] `cargo clippy --all-targets -- -D warnings` (in src-tauri)
- [x] `cargo test` (in src-tauri) — 145 pty + web::terminal_ws + web::ws tests pass; attach-result serialization test passes
- [x] Manual verification completed — end-to-end WS repro: reattached client now receives `snapshot.gitBranch` on the attach reply (was: 0 push events, no branch on the wire). Server started on `0.0.0.0:8080` and exercised `/git/commit-context`, `/worktree/resolve-base-branch`, `get_git_branch` — all return the real branch.

## CI & Review Gate

- [ ] All CI checks pass (PR Validation, Rust Checks, Build Verification, Security Scans)
- [ ] Code review comments from CodeRabbit / Claude have been addressed or resolved
- [ ] No unresolved review findings remain

## Checklist

- [x] My PR title follows the conventional commit format used by this repo
- [x] I linked the related issue or explained why none exists
- [x] I updated docs when needed
- [x] I added or updated tests when needed
- [x] I verified the change does not introduce unrelated modifications
- [x] I read AGENTS.md and followed the contributor guidelines


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automatically detects and displays the active project’s current Git branch.
  * Restored terminal sessions now retain and display their working directory, Git information, and exit state.
  * Terminal attachments include the latest session state for more accurate replay.

* **Bug Fixes**
  * Prevented stale branch information from being applied after switching projects.
  * Removed the incorrect default assignment of `main` for newly added projects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->