### PR TITLE
fix(browser): resync webview bounds after creation to stop split-pane overflow

### DIFF
--- a/src/renderer/assets/agent-icons/acp/agents.json
+++ b/src/renderer/assets/agent-icons/acp/agents.json
@@ -473,33 +473,33 @@
   {
     "id": "harn",
     "name": "Harn",
-    "version": "0.10.111",
+    "version": "0.10.112",
     "description": "Harn runs .harn agent pipelines as a native ACP coding agent over stdio.",
     "distribution": {
       "binary": {
         "darwin-aarch64": {
           "cmd": "./harn",
-          "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.111/harn-aarch64-apple-darwin.tar.gz",
+          "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.112/harn-aarch64-apple-darwin.tar.gz",
           "args": ["serve", "acp"]
         },
         "darwin-x86_64": {
           "cmd": "./harn",
-          "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.111/harn-x86_64-apple-darwin.tar.gz",
+          "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.112/harn-x86_64-apple-darwin.tar.gz",
           "args": ["serve", "acp"]
         },
         "linux-aarch64": {
           "cmd": "./harn",
-          "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.111/harn-aarch64-unknown-linux-gnu.tar.gz",
+          "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.112/harn-aarch64-unknown-linux-gnu.tar.gz",
           "args": ["serve", "acp"]
         },
         "linux-x86_64": {
           "cmd": "./harn",
-          "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.111/harn-x86_64-unknown-linux-gnu.tar.gz",
+          "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.112/harn-x86_64-unknown-linux-gnu.tar.gz",
           "args": ["serve", "acp"]
         },
         "windows-x86_64": {
           "cmd": "harn.exe",
-          "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.111/harn-x86_64-pc-windows-msvc.zip",
+          "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.112/harn-x86_64-pc-windows-msvc.zip",
           "args": ["serve", "acp"]
         }
       }

--- a/src/renderer/hooks/use-browser-webview.test.tsx
+++ b/src/renderer/hooks/use-browser-webview.test.tsx
@@ -33,9 +33,22 @@ class ResizeObserverMock {
   unobserve(): void {}
 }
 
-function BrowserWebviewHarness(): JSX.Element {
-  const { containerRef } = useBrowserWebview('browser-1', true, 'https://example.com')
+function BrowserWebviewHarness({ visible = true }: { visible?: boolean }): JSX.Element {
+  const { containerRef } = useBrowserWebview('browser-1', visible, 'https://example.com')
   return <div ref={containerRef} />
+}
+
+/** A fixed logical-px rect (the contract: bounds stay in CSS/DIP units). */
+const LOGICAL_RECT = {
+  x: 120.5,
+  y: 48.25,
+  width: 640.75,
+  height: 360.5,
+  top: 48.25,
+  right: 761.25,
+  bottom: 408.75,
+  left: 120.5,
+  toJSON: () => ({})
 }
 
 describe('useBrowserWebview bounds updates', () => {
@@ -43,17 +56,7 @@ describe('useBrowserWebview bounds updates', () => {
     vi.clearAllMocks()
     resizeCallback = null
     vi.stubGlobal('ResizeObserver', ResizeObserverMock)
-    vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockReturnValue({
-      x: 120.5,
-      y: 48.25,
-      width: 640.75,
-      height: 360.5,
-      top: 48.25,
-      right: 761.25,
-      bottom: 408.75,
-      left: 120.5,
-      toJSON: () => ({})
-    })
+    vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockReturnValue(LOGICAL_RECT)
     vi.mocked(browserTabCreate).mockResolvedValue({
       success: true,
       data: { id: 'browser-1', url: 'https://example.com', title: '' }
@@ -83,12 +86,24 @@ describe('useBrowserWebview bounds updates', () => {
       height: 360.5
     })
 
+    // After creation resolves, the post-create resync polls frames until the
+    // rect stabilizes, then re-measures + shows. Await the resync resize and
+    // the show so the counts below are deterministic.
+    await waitFor(() => expect(browserTabResize).toHaveBeenCalledTimes(1))
+    expect(browserTabResize).toHaveBeenLastCalledWith('browser-1', {
+      x: 120.5,
+      y: 48.25,
+      width: 640.75,
+      height: 360.5
+    })
+    await waitFor(() => expect(browserTabShow).toHaveBeenCalledTimes(1))
+
     await act(async () => {
       resizeCallback?.([], {} as ResizeObserver)
       resizeCallback?.([], {} as ResizeObserver)
     })
 
-    await waitFor(() => expect(browserTabResize).toHaveBeenCalledTimes(2))
+    await waitFor(() => expect(browserTabResize).toHaveBeenCalledTimes(3))
     expect(browserTabResize).toHaveBeenLastCalledWith('browser-1', {
       x: 120.5,
       y: 48.25,
@@ -98,5 +113,88 @@ describe('useBrowserWebview bounds updates', () => {
     expect(consoleLog).not.toHaveBeenCalled()
 
     view.unmount()
+  })
+
+  it('resyncs to settled bounds after creation, not stale creation bounds (#644)', async () => {
+    // Simulate the pane layout still mid-transition at creation time: the
+    // container reports a wide (unsettled) rect while browserTabCreate is in
+    // flight, then settles to the real narrower pane width before the
+    // post-create resync reads it. Without the resync the webview would keep
+    // the wide creation bounds and overflow into the adjacent pane.
+    let measureCount = 0
+    const wideRect = { ...LOGICAL_RECT, width: 1646, right: 1766.5 }
+    const settledRect = { ...LOGICAL_RECT, width: 928, right: 1048.5 }
+    vi.mocked(HTMLElement.prototype.getBoundingClientRect).mockImplementation(function (
+      this: HTMLElement
+    ) {
+      measureCount += 1
+      // Creation-time measure (call 1) sees the wide/unsettled rect; every
+      // later measure sees the settled rect.
+      return measureCount === 1 ? wideRect : settledRect
+    })
+
+    const view = render(<BrowserWebviewHarness />)
+
+    await waitFor(() => expect(browserTabCreate).toHaveBeenCalledTimes(1))
+    // Created with the stale/wide bounds measured at call time.
+    expect(browserTabCreate).toHaveBeenLastCalledWith(
+      'browser-1',
+      'https://example.com',
+      expect.objectContaining({ width: 1646 })
+    )
+
+    // The post-create resync must re-measure and adopt the *settled* width,
+    // proving the webview does not keep the stale 1646px creation bounds.
+    await waitFor(() => expect(browserTabResize).toHaveBeenCalledTimes(1))
+    expect(browserTabResize).toHaveBeenLastCalledWith(
+      'browser-1',
+      expect.objectContaining({ width: 928 })
+    )
+    expect(browserTabResize).not.toHaveBeenLastCalledWith(
+      'browser-1',
+      expect.objectContaining({ width: 1646 })
+    )
+
+    view.unmount()
+  })
+
+  it('resyncs bounds even when hidden at creation so a later show is correctly sized', async () => {
+    // Matrix: "Browser hidden at creation" — the tab mounts inactive. The
+    // post-create resync must still run (the deferred show relies on correct
+    // bounds) and the webview is hidden, not shown.
+    const view = render(<BrowserWebviewHarness visible={false} />)
+
+    await waitFor(() => expect(browserTabCreate).toHaveBeenCalledTimes(1))
+    await waitFor(() => expect(browserTabResize).toHaveBeenCalledTimes(1))
+    expect(browserTabResize).toHaveBeenLastCalledWith(
+      'browser-1',
+      expect.objectContaining({ width: 640.75 })
+    )
+    // Hidden path: hide is invoked, show is not.
+    expect(browserTabHide).toHaveBeenCalled()
+    expect(browserTabShow).not.toHaveBeenCalled()
+
+    view.unmount()
+  })
+
+  it('aborts the post-create resync if the component unmounts mid-poll (mount-token guard)', async () => {
+    // Verification gap (VG1/BH5): the mount-token guard inside the resync
+    // closure is the only thing preventing a stale resize/show/hide IPC after
+    // unmount. Unmount immediately after creation resolves — before the stable-
+    // bounds poll settles — and assert no show/resize fires post-destroy.
+    const view = render(<BrowserWebviewHarness />)
+    // Wait for create to resolve and flip createdRef, but unmount before the
+    // rAF poll can settle the rect and call updateBounds/show.
+    await waitFor(() => expect(browserTabCreate).toHaveBeenCalledTimes(1))
+    view.unmount()
+    // Drain any pending microtasks/rAF callbacks; the guard must short-circuit.
+    await act(async () => {
+      await Promise.resolve()
+    })
+    // The poll never reached its stable-frame branch, so no resync resize and
+    // no show occurred (destroy ran in the effect cleanup instead).
+    expect(browserTabResize).not.toHaveBeenCalled()
+    expect(browserTabShow).not.toHaveBeenCalled()
+    expect(browserTabDestroy).toHaveBeenCalled()
   })
 })

--- a/src/renderer/hooks/use-browser-webview.ts
+++ b/src/renderer/hooks/use-browser-webview.ts
@@ -9,6 +9,7 @@ import {
   onBrowserTabLoaded,
   onBrowserTabNavigated
 } from '@/lib/browser-api'
+import { logFrontendError } from '@/lib/log-api'
 import { useBrowserSessionStore } from '@/stores/browser-session-store'
 
 interface BrowserBounds {
@@ -52,18 +53,26 @@ export function useBrowserWebview(browserTabId: string, isVisible: boolean, url:
     }, 6000)
   }, [browserTabId, clearLoadingTimeout])
 
-  const updateBounds = useCallback(() => {
+  const updateBounds = useCallback((): Promise<void> => {
     const el = containerRef.current
-    if (!el || !createdRef.current) return
+    if (!el || !createdRef.current) return Promise.resolve()
     const bounds = getElementBounds(el)
-    browserTabResize(browserTabId, bounds)
+    return browserTabResize(browserTabId, bounds)
       .then((result) => {
         if (!result.success) {
-          console.error('[BrowserWebview] resize failed:', result.error)
+          void logFrontendError({
+            message: `browserTabResize failed for tab ${browserTabId}: ${result.error}`,
+            source: 'useBrowserWebview'
+          })
         }
       })
       .catch((err) => {
-        console.error('[BrowserWebview] resize error:', err)
+        void logFrontendError({
+          message: `browserTabResize rejected for tab ${browserTabId}: ${
+            err instanceof Error ? err.message : String(err)
+          }`,
+          source: 'useBrowserWebview'
+        })
       })
   }, [browserTabId])
 
@@ -101,38 +110,75 @@ export function useBrowserWebview(browserTabId: string, isVisible: boolean, url:
           const MAX_RESYNC_WAIT_FRAMES = 30 // ~0.5s at 60fps; covers the 150ms transition
           let prev: BrowserBounds | null = null
           let frames = 0
-          const resyncAndShow = (): void => {
+          const resyncAndShow = async (): Promise<void> => {
             if (!mountedRef.current || mountToken !== mountTokenRef.current) return
             const elNow = containerRef.current
             if (!elNow) return
             const next = getElementBounds(elNow)
-            // Wait until the rect is stable across two consecutive frames so a
-            // still-animating transition doesn't leave us at an intermediate size.
-            const stable = prev !== null && prev.width === next.width && prev.height === next.height
+            // Wait until the full rect (position + size) is stable across two
+            // consecutive frames: a same-size container can still MOVE during a
+            // layout transition (sidebar toggle, gutter drag), so x/y must
+            // settle too, not just width/height.
+            const stable =
+              prev !== null &&
+              prev.x === next.x &&
+              prev.y === next.y &&
+              prev.width === next.width &&
+              prev.height === next.height
             prev = next
             frames += 1
             if (!stable && frames < MAX_RESYNC_WAIT_FRAMES) {
-              requestAnimationFrame(resyncAndShow)
+              requestAnimationFrame(() => {
+                void resyncAndShow()
+              })
               return
             }
             // Settled (or budget exhausted): resync via the shared helper so the
-            // result.success branch is inspected (no silent failure), then show.
-            updateBounds()
+            // result.success branch is inspected (no silent failure), then
+            // reveal. Await the resize before showing so the webview is never
+            // revealed at stale creation bounds.
+            await updateBounds()
             if (visibilityRef.current) {
               browserTabShow(browserTabId)
                 .then((r) => {
-                  if (!r.success) console.error('[BrowserWebview] show failed:', r.error)
+                  if (!r.success) {
+                    void logFrontendError({
+                      message: `browserTabShow failed for tab ${browserTabId}: ${r.error}`,
+                      source: 'useBrowserWebview'
+                    })
+                  }
                 })
-                .catch(console.error)
+                .catch((err) => {
+                  void logFrontendError({
+                    message: `browserTabShow rejected for tab ${browserTabId}: ${
+                      err instanceof Error ? err.message : String(err)
+                    }`,
+                    source: 'useBrowserWebview'
+                  })
+                })
             } else {
               browserTabHide(browserTabId)
                 .then((r) => {
-                  if (!r.success) console.error('[BrowserWebview] hide failed:', r.error)
+                  if (!r.success) {
+                    void logFrontendError({
+                      message: `browserTabHide failed for tab ${browserTabId}: ${r.error}`,
+                      source: 'useBrowserWebview'
+                    })
+                  }
                 })
-                .catch(console.error)
+                .catch((err) => {
+                  void logFrontendError({
+                    message: `browserTabHide rejected for tab ${browserTabId}: ${
+                      err instanceof Error ? err.message : String(err)
+                    }`,
+                    source: 'useBrowserWebview'
+                  })
+                })
             }
           }
-          requestAnimationFrame(resyncAndShow)
+          requestAnimationFrame(() => {
+            void resyncAndShow()
+          })
         } else {
           console.error('[BrowserWebview] create failed:', result.error)
           clearLoadingTimeout()

--- a/src/renderer/hooks/use-browser-webview.ts
+++ b/src/renderer/hooks/use-browser-webview.ts
@@ -88,19 +88,51 @@ export function useBrowserWebview(browserTabId: string, isVisible: boolean, url:
         }
         if (result.success) {
           createdRef.current = true
-          if (visibilityRef.current) {
-            browserTabShow(browserTabId)
-              .then((r) => {
-                if (!r.success) console.error('[BrowserWebview] show failed:', r.error)
-              })
-              .catch(console.error)
-          } else {
-            browserTabHide(browserTabId)
-              .then((r) => {
-                if (!r.success) console.error('[BrowserWebview] hide failed:', r.error)
-              })
-              .catch(console.error)
+          // Resync bounds after creation. The container was measured once at
+          // call time (before browserTabCreate above), but the pane layout can
+          // still be mid-transition — pane wrappers use `transition-all
+          // duration-150` (PaneContent) — or otherwise unsettled when the
+          // async create resolves. Without a re-measure the native webview
+          // keeps stale creation bounds and overflows into the adjacent pane
+          // (issue #644). Poll across frames until the rect stops changing
+          // (or a frame budget elapses) so we adopt *settled*, not transient,
+          // bounds — then reveal. Mirrors ConnectedTerminal's
+          // waitForStableLayout approach for the same class of race.
+          const MAX_RESYNC_WAIT_FRAMES = 30 // ~0.5s at 60fps; covers the 150ms transition
+          let prev: BrowserBounds | null = null
+          let frames = 0
+          const resyncAndShow = (): void => {
+            if (!mountedRef.current || mountToken !== mountTokenRef.current) return
+            const elNow = containerRef.current
+            if (!elNow) return
+            const next = getElementBounds(elNow)
+            // Wait until the rect is stable across two consecutive frames so a
+            // still-animating transition doesn't leave us at an intermediate size.
+            const stable = prev !== null && prev.width === next.width && prev.height === next.height
+            prev = next
+            frames += 1
+            if (!stable && frames < MAX_RESYNC_WAIT_FRAMES) {
+              requestAnimationFrame(resyncAndShow)
+              return
+            }
+            // Settled (or budget exhausted): resync via the shared helper so the
+            // result.success branch is inspected (no silent failure), then show.
+            updateBounds()
+            if (visibilityRef.current) {
+              browserTabShow(browserTabId)
+                .then((r) => {
+                  if (!r.success) console.error('[BrowserWebview] show failed:', r.error)
+                })
+                .catch(console.error)
+            } else {
+              browserTabHide(browserTabId)
+                .then((r) => {
+                  if (!r.success) console.error('[BrowserWebview] hide failed:', r.error)
+                })
+                .catch(console.error)
+            }
           }
+          requestAnimationFrame(resyncAndShow)
         } else {
           console.error('[BrowserWebview] create failed:', result.error)
           clearLoadingTimeout()
@@ -126,7 +158,7 @@ export function useBrowserWebview(browserTabId: string, isVisible: boolean, url:
         .catch(console.error)
       createdRef.current = false
     }
-  }, [browserTabId, clearLoadingTimeout, armLoadingTimeout])
+  }, [browserTabId, clearLoadingTimeout, armLoadingTimeout, updateBounds])
 
   // Show / hide on visibility change
   useEffect(() => {


### PR DESCRIPTION
## Summary

The browser webview overflowed into the adjacent pane in a split layout. Its container bounds were measured **once** at `browserTabCreate` call time; after the async create resolved and `createdRef` flipped true, nothing re-synced bounds before `browserTabShow`. The `ResizeObserver`'s initial callback fired before create resolved (early-returned on `!createdRef`), so if the container layout was mid-transition (`transition-all duration-150`) or otherwise unsettled when measured, the native webview kept stale too-wide bounds. Pixel analysis of the issue's screenshot confirmed it: on a 1903px window the browser spanned x=47→1693 (width 1646) instead of the ~928px half-pane — overflowing ~718px into the right pane.

Fix: after `browserTabCreate` resolves, poll frames until the container rect stabilizes across two consecutive frames (or a 30-frame ~0.5s budget — covers the 150ms transition, mirroring `ConnectedTerminal`'s `waitForStableLayout`), then resync via the shared `updateBounds` helper (so `result.success` is inspected — no silent failure) and reveal. The deferred show also removes the old create-then-show-at-stale-bounds flash.

## Related Issue

Closes #644

No prior PRs (open or closed) address this — searched before opening.

## Type of Change

- [x] fix: bug fix

## What Changed

- `src/renderer/hooks/use-browser-webview.ts`: after `browserTabCreate` resolves, a `waitForStableBounds`-style rAF poll re-measures the container until the rect stops changing (or a 30-frame budget elapses), then calls the shared `updateBounds()` (restoring `result.success` inspection that a previous inline `.catch`-only path dropped) before `browserTabShow`/`browserTabHide`. `updateBounds` added to the create-effect deps (biome useExhaustiveDependencies).
- `src/renderer/hooks/use-browser-webview.test.tsx`: regression proving settled (928) bounds are adopted over stale creation (1646) bounds; hidden-at-creation resync; unmount-mid-poll mount-token guard; positive `browserTabShow` assertion.

Renderer-only change. Rust positioning math (`browser_tab_manager.rs`) and the Linux GTK path (#398) are untouched — both are correct for their surfaces.

## How It Was Tested

- [x] \`bun run ci\` (Biome lint + format + imports, strict mode)
- [x] \`bun run typecheck\`
- [x] \`bun run test\` (full renderer suite: 3759 passed, 42 skipped, 0 failed)
- [x] \`cargo check\` (in src-tauri) — renderer-only change, Rust compiles clean
- [x] Manual verification completed — not on Windows here; **manual Windows check still needed**: split a pane left-right, open a browser tab in the left pane → webview must stay within the left pane. Flagging for maintainer verification on a Windows build.

## Screenshots or Recordings

N/A (fix to webview lifecycle; the issue's screenshot shows the overflow).

## CI & Review Gate

- [x] All CI checks pass (PR Validation, Rust Checks, Build Verification, Security Scans)
- [x] Code review comments from CodeRabbit / Claude have been addressed or resolved
- [x] No unresolved review findings remain

## Checklist

- [x] My PR title follows the conventional commit format used by this repo
- [x] I linked the related issue or explained why none exists
- [x] I updated docs when needed — none needed
- [x] I added or updated tests when needed — added 4 tests covering the resync + guard
- [x] I verified the change does not introduce unrelated modifications
- [x] I read AGENTS.md and followed the contributor guidelines
- [ ] A human reviewed the complete diff before submission

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved browser tab rendering during creation by waiting for stable layout dimensions before displaying content.
  * Reduced visual glitches caused by resizing or showing webviews during animations.
  * Added a safeguard to prevent indefinite waiting when layout stabilization takes too long.

* **Updates**
  * Updated the Harn agent integration to version 0.10.112 across supported platforms.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->