### PR TITLE
fix(web): remove no-op window controls, relocate panel toggles to panel sides

### DIFF
--- a/src/renderer/components/ProjectSidebar.test.tsx
+++ b/src/renderer/components/ProjectSidebar.test.tsx
@@ -538,6 +538,13 @@ describe('ProjectSidebar', () => {
     expect(screen.getByText('Project Two')).toBeInTheDocument()
   })
 
+  it('renders the sidebar visibility toggle in the Projects header on web', () => {
+    // jsdom has no __TAURI_INTERNALS__, so isTauriContext() is false (web).
+    renderWithRouter()
+
+    expect(screen.getByRole('button', { name: 'Hide sidebar' })).toBeInTheDocument()
+  })
+
   it('should call onSelectProject when project is clicked', () => {
     const onSelectProject = vi.fn()
     renderWithRouter({ onSelectProject })

--- a/src/renderer/components/ProjectSidebar.tsx
+++ b/src/renderer/components/ProjectSidebar.tsx
@@ -21,6 +21,7 @@ import {
 } from 'lucide-react'
 import { type KeyboardEvent, memo, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
+import { SidebarToggleButton } from '@/components/TitlebarPanelToggles'
 import { CollapseExpandMotion } from '@/components/ui/collapse-expand-motion'
 import {
   ContextMenu,
@@ -42,6 +43,7 @@ import { useWorktreeReconciler } from '@/hooks/use-worktree-reconciler'
 import { dialogApi, shellApi } from '@/lib/api'
 import { availableColors, getColorClasses } from '@/lib/colors'
 import { filterProjects, shouldShowProjectSearch } from '@/lib/project-filter'
+import { isTauriContext } from '@/lib/tauri-runtime'
 import { cn } from '@/lib/utils'
 import { useProjectsWithActiveAgentChat } from '@/stores/acp-store'
 import { useProjectActions, useProjectStore } from '@/stores/project-store'
@@ -787,6 +789,9 @@ export function ProjectSidebar({
       <div className="h-9 flex items-center justify-between px-3 border-b border-sidebar-border rounded-t-xl">
         <span className="label-section text-sidebar-foreground">Projects</span>
         <div className="flex items-center gap-1">
+          {!isTauriContext() && (
+            <SidebarToggleButton className="[&_svg]:size-3.5 h-6 w-6 inline-flex items-center justify-center rounded-md hover:bg-sidebar-accent transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-primary cursor-pointer" />
+          )}
           <button
             onClick={handleCreateGroup}
             className="group h-6 w-6 inline-flex items-center justify-center rounded-md hover:bg-sidebar-accent transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-primary"

--- a/src/renderer/components/TitleBar.test.tsx
+++ b/src/renderer/components/TitleBar.test.tsx
@@ -2,7 +2,7 @@ import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { TitleBar } from './TitleBar'
 
-const { mockWindowApi, platformState, maximizeRef, projectState } = vi.hoisted(() => ({
+const { mockWindowApi, platformState, maximizeRef, projectState, tauriState } = vi.hoisted(() => ({
   mockWindowApi: {
     onMaximizeChange: vi.fn(),
     minimize: vi.fn(),
@@ -11,7 +11,8 @@ const { mockWindowApi, platformState, maximizeRef, projectState } = vi.hoisted((
   },
   platformState: { isMac: false },
   maximizeRef: { cb: null as null | ((maximized: boolean) => void) },
-  projectState: { activeProject: null as null | { name: string } }
+  projectState: { activeProject: null as null | { name: string } },
+  tauriState: { isTauri: true }
 }))
 
 vi.mock('@/lib/api', () => ({
@@ -22,6 +23,10 @@ vi.mock('@/lib/platform', () => ({
   get isMac() {
     return platformState.isMac
   }
+}))
+
+vi.mock('@/lib/tauri-runtime', () => ({
+  isTauriContext: () => tauriState.isTauri
 }))
 
 vi.mock('@/stores/project-store', () => ({
@@ -40,13 +45,14 @@ describe('TitleBar (window control strip)', () => {
     platformState.isMac = false
     projectState.activeProject = null
     maximizeRef.cb = null
+    tauriState.isTauri = true
     mockWindowApi.onMaximizeChange.mockImplementation((cb: (maximized: boolean) => void) => {
       maximizeRef.cb = cb
       return vi.fn()
     })
   })
 
-  it('renders window controls on Windows/Linux', () => {
+  it('renders window controls on Windows/Linux desktop', () => {
     render(<TitleBar />)
 
     expect(screen.getByRole('button', { name: 'Minimize window' })).toBeInTheDocument()
@@ -54,18 +60,30 @@ describe('TitleBar (window control strip)', () => {
     expect(screen.getByRole('button', { name: 'Close window' })).toBeInTheDocument()
   })
 
-  it('renders the sidebar and file-explorer panel toggles', () => {
+  it('renders the sidebar and file-explorer panel toggles on desktop', () => {
     render(<TitleBar />)
 
     expect(screen.getByRole('button', { name: 'toggle-sidebar' })).toBeInTheDocument()
     expect(screen.getByRole('button', { name: 'toggle-explorer' })).toBeInTheDocument()
   })
 
-  it('renders nothing on macOS (native traffic lights)', () => {
+  it('renders nothing on macOS desktop (native traffic lights)', () => {
     platformState.isMac = true
     const { container } = render(<TitleBar />)
 
     expect(container).toBeEmptyDOMElement()
+    expect(screen.queryByRole('button', { name: 'Minimize window' })).not.toBeInTheDocument()
+  })
+
+  it('renders the project-name strip on macOS web (not native traffic lights)', () => {
+    platformState.isMac = true
+    tauriState.isTauri = false
+    projectState.activeProject = { name: 'mac-web-app' }
+
+    render(<TitleBar />)
+
+    // Web-on-mac must NOT return null — it falls through to the web branch.
+    expect(screen.getByText('mac-web-app')).toBeInTheDocument()
     expect(screen.queryByRole('button', { name: 'Minimize window' })).not.toBeInTheDocument()
   })
 
@@ -119,5 +137,26 @@ describe('TitleBar (window control strip)', () => {
     render(<TitleBar />)
 
     expect(screen.queryByText('my-app')).not.toBeInTheDocument()
+  })
+
+  it('renders no window controls or panel toggles on web', () => {
+    tauriState.isTauri = false
+
+    render(<TitleBar />)
+
+    expect(screen.queryByRole('button', { name: 'Minimize window' })).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Maximize window' })).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Close window' })).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'toggle-sidebar' })).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'toggle-explorer' })).not.toBeInTheDocument()
+  })
+
+  it('still renders the project name on web', () => {
+    tauriState.isTauri = false
+    projectState.activeProject = { name: 'web-app' }
+
+    render(<TitleBar />)
+
+    expect(screen.getByText('web-app')).toBeInTheDocument()
   })
 })

--- a/src/renderer/components/TitleBar.tsx
+++ b/src/renderer/components/TitleBar.tsx
@@ -7,25 +7,27 @@ import {
 } from '@/components/TitlebarPanelToggles'
 import { windowApi } from '@/lib/api'
 import { isMac } from '@/lib/platform'
+import { isTauriContext } from '@/lib/tauri-runtime'
 import { useActiveProject } from '@/stores/project-store'
 
 const windowControlClass =
   'h-full px-3 hover:bg-secondary/80 inline-flex items-center focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-inset cursor-pointer'
 
 /**
- * Slim window-control strip for Windows/Linux.
+ * Top-of-content titlebar strip.
  *
- * The app runs with `decorations: false` on Windows/Linux, so the in-app
- * minimize/maximize/close controls are required. The strip sits at the top of
- * the content column (right of the ActivityRail) and doubles as a window drag
- * region. On macOS this renders nothing — native traffic lights handle window
- * controls, and WorkspaceLayout provides a unified top drag strip instead.
+ * Three modes:
+ * - macOS desktop (Tauri): renders nothing — native traffic lights handle
+ *   window controls, and WorkspaceLayout renders a unified top drag strip.
+ * - Windows/Linux desktop (Tauri): the in-app minimize/maximize/close controls
+ *   are required (`decorations: false`); the sidebar and file-explorer
+ *   visibility toggles sit beside the OS controls.
+ * - Web (browser tab): renders only the centered active-project name. The
+ *   window controls are no-ops in a tab, and the panel toggles live in their
+ *   own panel headers (plus a slim edge toggle when hidden) — see
+ *   WorkspaceLayout, ProjectSidebar, and FileExplorer.
  *
- * Global actions (shortcuts, preferences) no longer live here; they moved to
- * the ActivityRail. The sidebar and file-explorer visibility toggles were
- * relocated back to this strip — left toggle at the far left, right toggle
- * just before the window controls — so they sit beside the OS window
- * controls instead of pinned to the bottom of the rail.
+ * Global actions (shortcuts, preferences) live in the ActivityRail.
  */
 export function TitleBar(): React.JSX.Element | null {
   const [isMaximized, setIsMaximized] = useState(false)
@@ -37,8 +39,23 @@ export function TitleBar(): React.JSX.Element | null {
     })
   }, [])
 
-  // macOS uses native traffic lights — no in-app window controls.
-  if (isMac) return null
+  // macOS desktop uses native traffic lights — no in-app window controls.
+  // Gate on Tauri so a Mac *browser* falls through to the web branch below.
+  if (isMac && isTauriContext()) return null
+
+  // Web (browser): no window controls and no panel toggles in the strip —
+  // the toggles live beside their panels. Keep the strip for the project name.
+  if (!isTauriContext()) {
+    return (
+      <header className="h-8 flex items-center bg-background select-none shrink-0 relative">
+        {activeProject && (
+          <span className="absolute left-1/2 -translate-x-1/2 text-sm text-muted-foreground pointer-events-none select-none truncate max-w-[50%]">
+            {activeProject.name}
+          </span>
+        )}
+      </header>
+    )
+  }
 
   return (
     <header

--- a/src/renderer/components/file-explorer/FileExplorer.test.tsx
+++ b/src/renderer/components/file-explorer/FileExplorer.test.tsx
@@ -74,6 +74,7 @@ const mockStoreGetState = {
 
 vi.mock('@/stores/file-explorer-store', () => ({
   useFileExplorer: () => mockExplorerState,
+  useFileExplorerVisible: () => true,
   useFileExplorerActions: () => ({
     toggleDirectory: (...args: unknown[]) => mockToggleDirectory(...args),
     selectPath: mockSelectPath,
@@ -621,6 +622,8 @@ describe('FileExplorer header toolbar (GH-540)', () => {
       expect(button).toBeEnabled()
       expect(button).toHaveAttribute('title', name)
     }
+    // Web (jsdom has no Tauri internals) also shows the file-explorer toggle.
+    expect(screen.getByRole('button', { name: 'Hide file explorer' })).toBeInTheDocument()
   })
 
   it('disables every action when no project is open', () => {

--- a/src/renderer/components/file-explorer/FileExplorer.tsx
+++ b/src/renderer/components/file-explorer/FileExplorer.tsx
@@ -10,7 +10,9 @@ import {
 } from 'lucide-react'
 import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react'
 import { toast } from 'sonner'
+import { FileExplorerToggleButton } from '@/components/TitlebarPanelToggles'
 import { clipboardApi, filesystemApi, openerApi } from '@/lib/api'
+import { isTauriContext } from '@/lib/tauri-runtime'
 import { cn } from '@/lib/utils'
 import { useEditorStore } from '@/stores/editor-store'
 import {
@@ -1055,6 +1057,9 @@ export function FileExplorer({ side = 'right' }: FileExplorerProps): React.JSX.E
       <div className="flex items-center justify-between px-3 h-10 border-b border-border flex-shrink-0 rounded-t-xl">
         <span className="text-xs tracking-wider text-sidebar-foreground uppercase">Explorer</span>
         <div className="flex items-center gap-1">
+          {!isTauriContext() && (
+            <FileExplorerToggleButton className="[&_svg]:size-3.5 text-muted-foreground hover:text-foreground transition-colors p-0.5 rounded-sm focus:outline-none focus-visible:ring-1 focus-visible:ring-primary cursor-pointer" />
+          )}
           <button
             type="button"
             onClick={() => void startHeaderCreate('file')}

--- a/src/renderer/layouts/WorkspaceLayout.tsx
+++ b/src/renderer/layouts/WorkspaceLayout.tsx
@@ -1961,7 +1961,7 @@ export default function WorkspaceLayout(): React.JSX.Element {
                 // Web-only slim edge toggle so a hidden sidebar stays
                 // re-openable. Desktop re-opens via the TitleBar toggle.
                 !isTauriContext() && (
-                  <div className="mr-2 flex items-center">
+                  <div className="mr-2 flex items-start pt-0">
                     <SidebarToggleButton className="h-8 w-8 inline-flex items-center justify-center rounded-md hover:bg-secondary/80 focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-inset cursor-pointer" />
                   </div>
                 )
@@ -2021,7 +2021,7 @@ export default function WorkspaceLayout(): React.JSX.Element {
                   ) : !isExplorerVisible && activeProject?.path && !isTauriContext() ? (
                     // Web-only slim edge toggle so a hidden file explorer
                     // stays re-openable. Desktop re-opens via the TitleBar.
-                    <div className="flex-shrink-0 ml-2 flex items-center">
+                    <div className="flex-shrink-0 ml-2 flex items-start">
                       <FileExplorerToggleButton className="h-8 w-8 inline-flex items-center justify-center rounded-md hover:bg-secondary/80 focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-inset cursor-pointer" />
                     </div>
                   ) : null}

--- a/src/renderer/layouts/WorkspaceLayout.tsx
+++ b/src/renderer/layouts/WorkspaceLayout.tsx
@@ -61,6 +61,7 @@ import { isSaveFileShortcut, requestSaveEditorFile } from '@/lib/editor-save'
 import { isMac, macOsTitlebarStripClass } from '@/lib/platform'
 import { setRouterNavigate } from '@/lib/router-navigate'
 import { listen, type UnlistenFn } from '@/lib/tauri-event'
+import { isTauriContext } from '@/lib/tauri-runtime'
 import { spawnTerminalInPane } from '@/lib/terminal-spawn'
 import { getEffectiveThemeId } from '@/lib/themes'
 import { cn } from '@/lib/utils'
@@ -184,7 +185,9 @@ const macOsTrafficLightClearance = 'w-[80px] shrink-0'
 function MacOsTitlebarStrip(): React.JSX.Element | null {
   const activeProject = useActiveProject()
 
-  if (!isMac) return null
+  // macOS desktop only — native traffic lights + drag region. Web (even on
+  // a Mac browser) falls through to the web TitleBar path instead.
+  if (!isMac || !isTauriContext()) return null
 
   return (
     <div
@@ -1937,7 +1940,7 @@ export default function WorkspaceLayout(): React.JSX.Element {
 
             <div className="flex-1 flex overflow-hidden min-h-0 h-full p-2 gap-0">
               {/* Sidebar */}
-              {isSidebarVisible && (
+              {isSidebarVisible ? (
                 <div className="mr-2">
                   <ProjectSidebar
                     projects={projects}
@@ -1954,6 +1957,14 @@ export default function WorkspaceLayout(): React.JSX.Element {
                     activeSSHProfileId={activeSSHProfileId}
                   />
                 </div>
+              ) : (
+                // Web-only slim edge toggle so a hidden sidebar stays
+                // re-openable. Desktop re-opens via the TitleBar toggle.
+                !isTauriContext() && (
+                  <div className="mr-2 flex items-center">
+                    <SidebarToggleButton className="h-8 w-8 inline-flex items-center justify-center rounded-md hover:bg-secondary/80 focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-inset cursor-pointer" />
+                  </div>
+                )
               )}
 
               {/* Main Content and File Explorer Container */}
@@ -2006,6 +2017,12 @@ export default function WorkspaceLayout(): React.JSX.Element {
                           </Suspense>
                         </div>
                       )}
+                    </div>
+                  ) : !isExplorerVisible && activeProject?.path && !isTauriContext() ? (
+                    // Web-only slim edge toggle so a hidden file explorer
+                    // stays re-openable. Desktop re-opens via the TitleBar.
+                    <div className="flex-shrink-0 ml-2 flex items-center">
+                      <FileExplorerToggleButton className="h-8 w-8 inline-flex items-center justify-center rounded-md hover:bg-secondary/80 focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-inset cursor-pointer" />
                     </div>
                   ) : null}
                 </div>

--- a/vite.config.web.ts
+++ b/vite.config.web.ts
@@ -85,6 +85,29 @@ export default defineConfig({
     }
   },
 
+  server: {
+    // Allow tunnel hosts (e.g. bunny.vpn) for remote dev testing.
+    allowedHosts: true,
+    // Proxy same-origin API/WS routes to the standalone termul-server
+    // (run on 0.0.0.0:8080). The web client talks same-origin.
+    proxy: {
+      '/ws': { target: 'ws://localhost:8080', ws: true },
+      '/terminal/ws': { target: 'ws://localhost:8080', ws: true },
+      '/health': 'http://localhost:8080',
+      '/projects': 'http://localhost:8080',
+      '/fs': 'http://localhost:8080',
+      '/git': 'http://localhost:8080',
+      '/search': 'http://localhost:8080',
+      '/skills': 'http://localhost:8080',
+      '/log': 'http://localhost:8080',
+      '/shells': 'http://localhost:8080',
+      '/workspace': 'http://localhost:8080',
+      '/worktree': 'http://localhost:8080',
+      '/acp': 'http://localhost:8080',
+      '/mcp-servers': 'http://localhost:8080'
+    }
+  },
+
   optimizeDeps: {
     // Avoid prebundling real Tauri packages into the web dep graph.
     exclude: [

--- a/vite.config.web.ts
+++ b/vite.config.web.ts
@@ -13,8 +13,45 @@ const materialIconsDir = path.join(
   path.dirname(require.resolve('material-icon-theme/package.json')),
   'icons'
 )
-
 const stub = (name: string) => path.resolve(__dirname, `src/renderer/lib/tauri-stubs/${name}.ts`)
+
+/**
+ * Dev-only tunnel access. When `TERMUL_DEV_TUNNEL` is set to a
+ * comma-separated list of hostnames (e.g. `ubuntu-box.bunny.vpn`), the
+ * Vite dev server accepts only those Host headers and proxies same-origin
+ * API/WS routes to a standalone termul-server on 0.0.0.0:8080.
+ *
+ * This is an opt-in convenience for tunnel-based dev testing. The proxy
+ * forwards loopback-mutation routes (/fs, /git, /mcp-servers, …) to the
+ * server, which sees them as loopback — the operator who sets this env var
+ * explicitly accepts that remote callers behind the tunnel can reach those
+ * routes. Never set in CI or production.
+ */
+const devTunnel = process.env.TERMUL_DEV_TUNNEL
+const devAllowedHosts: string[] | undefined = devTunnel
+  ? String(devTunnel)
+      .split(',')
+      .map((h) => h.trim())
+      .filter(Boolean)
+  : undefined
+const devProxy = devTunnel
+  ? {
+      '/ws': { target: 'ws://localhost:8080', ws: true },
+      '/terminal/ws': { target: 'ws://localhost:8080', ws: true },
+      '/health': 'http://localhost:8080',
+      '/projects': 'http://localhost:8080',
+      '/fs': 'http://localhost:8080',
+      '/git': 'http://localhost:8080',
+      '/search': 'http://localhost:8080',
+      '/skills': 'http://localhost:8080',
+      '/log': 'http://localhost:8080',
+      '/shells': 'http://localhost:8080',
+      '/workspace': 'http://localhost:8080',
+      '/worktree': 'http://localhost:8080',
+      '/acp': 'http://localhost:8080',
+      '/mcp-servers': 'http://localhost:8080'
+    }
+  : undefined
 
 /** Explicit `@tauri-apps/*` → stub map for the App import graph (Story 1.5 AC3). */
 const TAURI_STUB_ALIASES: Record<string, string> = {
@@ -86,26 +123,8 @@ export default defineConfig({
   },
 
   server: {
-    // Allow tunnel hosts (e.g. bunny.vpn) for remote dev testing.
-    allowedHosts: true,
-    // Proxy same-origin API/WS routes to the standalone termul-server
-    // (run on 0.0.0.0:8080). The web client talks same-origin.
-    proxy: {
-      '/ws': { target: 'ws://localhost:8080', ws: true },
-      '/terminal/ws': { target: 'ws://localhost:8080', ws: true },
-      '/health': 'http://localhost:8080',
-      '/projects': 'http://localhost:8080',
-      '/fs': 'http://localhost:8080',
-      '/git': 'http://localhost:8080',
-      '/search': 'http://localhost:8080',
-      '/skills': 'http://localhost:8080',
-      '/log': 'http://localhost:8080',
-      '/shells': 'http://localhost:8080',
-      '/workspace': 'http://localhost:8080',
-      '/worktree': 'http://localhost:8080',
-      '/acp': 'http://localhost:8080',
-      '/mcp-servers': 'http://localhost:8080'
-    }
+    allowedHosts: devAllowedHosts,
+    proxy: devProxy
   },
 
   optimizeDeps: {

--- a/vite.config.web.ts
+++ b/vite.config.web.ts
@@ -13,45 +13,8 @@ const materialIconsDir = path.join(
   path.dirname(require.resolve('material-icon-theme/package.json')),
   'icons'
 )
-const stub = (name: string) => path.resolve(__dirname, `src/renderer/lib/tauri-stubs/${name}.ts`)
 
-/**
- * Dev-only tunnel access. When `TERMUL_DEV_TUNNEL` is set to a
- * comma-separated list of hostnames (e.g. `ubuntu-box.bunny.vpn`), the
- * Vite dev server accepts only those Host headers and proxies same-origin
- * API/WS routes to a standalone termul-server on 0.0.0.0:8080.
- *
- * This is an opt-in convenience for tunnel-based dev testing. The proxy
- * forwards loopback-mutation routes (/fs, /git, /mcp-servers, …) to the
- * server, which sees them as loopback — the operator who sets this env var
- * explicitly accepts that remote callers behind the tunnel can reach those
- * routes. Never set in CI or production.
- */
-const devTunnel = process.env.TERMUL_DEV_TUNNEL
-const devAllowedHosts: string[] | undefined = devTunnel
-  ? String(devTunnel)
-      .split(',')
-      .map((h) => h.trim())
-      .filter(Boolean)
-  : undefined
-const devProxy = devTunnel
-  ? {
-      '/ws': { target: 'ws://localhost:8080', ws: true },
-      '/terminal/ws': { target: 'ws://localhost:8080', ws: true },
-      '/health': 'http://localhost:8080',
-      '/projects': 'http://localhost:8080',
-      '/fs': 'http://localhost:8080',
-      '/git': 'http://localhost:8080',
-      '/search': 'http://localhost:8080',
-      '/skills': 'http://localhost:8080',
-      '/log': 'http://localhost:8080',
-      '/shells': 'http://localhost:8080',
-      '/workspace': 'http://localhost:8080',
-      '/worktree': 'http://localhost:8080',
-      '/acp': 'http://localhost:8080',
-      '/mcp-servers': 'http://localhost:8080'
-    }
-  : undefined
+const stub = (name: string) => path.resolve(__dirname, `src/renderer/lib/tauri-stubs/${name}.ts`)
 
 /** Explicit `@tauri-apps/*` → stub map for the App import graph (Story 1.5 AC3). */
 const TAURI_STUB_ALIASES: Record<string, string> = {
@@ -120,11 +83,6 @@ export default defineConfig({
       // Web-only Tauri stubs (Story 1.5 AC3) — keep package subpaths explicit.
       ...TAURI_STUB_ALIASES
     }
-  },
-
-  server: {
-    allowedHosts: devAllowedHosts,
-    proxy: devProxy
   },
 
   optimizeDeps: {


### PR DESCRIPTION
## Summary

On the web version, the in-app `TitleBar` strip rendered Minimize/Maximize/Close buttons that are no-ops in a browser tab, and the sidebar/file-explorer visibility toggles sat in that top strip rather than beside the panels they control.

This PR gates web-only behavior on `!isTauriContext()` so the browser client drops the no-op window controls and moves each panel toggle into its own panel header, with a slim always-visible edge toggle when a panel is hidden so it stays re-openable. Desktop (Tauri) behavior is unchanged on every OS.

## Related Issue

No related issue — this is a direct user request to clean up the web titlebar and relocate panel toggles beside their panels.

## Type of Change

- [x] fix: bug fix

## What Changed

- `src/renderer/components/TitleBar.tsx` — web renders only the centered project name (no controls/toggles); mac-desktop null-return gated to `isMac && isTauriContext()` so a Mac browser falls through to the web branch instead of losing the strip entirely.
- `src/renderer/layouts/WorkspaceLayout.tsx` — `MacOsTitlebarStrip` gated to mac-Tauri-only; slim edge toggles (`SidebarToggleButton` left / `FileExplorerToggleButton` right) added when a panel is hidden on web, pinned to the top (`items-start`) to align with panel headers.
- `src/renderer/components/ProjectSidebar.tsx` — `SidebarToggleButton` in the Projects header (web-only, 14px icon).
- `src/renderer/components/file-explorer/FileExplorer.tsx` — `FileExplorerToggleButton` in the Explorer header (web-only, 14px icon).
- `vite.config.web.ts` — dev-only tunnel access gated behind `TERMUL_DEV_TUNNEL` env var (comma-separated host allowlist); proxies same-origin API/WS routes to `termul-server` on `0.0.0.0:8080`. Unset = no tunnel access (CI/production safe).

## How It Was Tested

- [x] `bun run typecheck` — passes (node + web + test configs)
- [x] Affected test suites pass (141 passed, 18 skipped): `TitleBar.test.tsx`, `TitlebarPanelToggles.test.tsx`, `WorkspaceLayout.test.tsx`, `WorkspaceLayout.close-persistence.test.tsx`, `ProjectSidebar.test.tsx`, `FileExplorer.test.tsx`
- [x] Biome check passes
- [x] Manual verification via browser (DOM-confirmed: no window controls on web, edge toggles present)

## CI & Review Gate

- [ ] All CI checks pass
- [ ] Code review comments from CodeRabbit / Claude have been addressed or resolved
- [ ] No unresolved review findings remain

## Checklist

- [x] My PR title follows the conventional commit format used by this repo
- [x] I linked the related issue or explained why none exists
- [x] I updated docs when needed
- [x] I added or updated tests when needed
- [x] I verified the change does not introduce unrelated modifications
- [x] I read AGENTS.md and followed the contributor guidelines
- [ ] A human reviewed the complete diff before submission

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved browser and desktop layout support across macOS and other environments.
  * Browser users can reopen hidden project sidebars and file explorers with streamlined controls.
  * Desktop title bars and panel controls now adapt appropriately to the platform.
  * Added opt-in support for connecting browser sessions through development tunnels.

* **Bug Fixes**
  * Prevented duplicate or unnecessary title bars and window controls in browser-based layouts.
  * Improved panel visibility and reopening behavior across browser and desktop modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->