### PR TITLE
feat(acp): normalize Zed-style paste format + custom agent icon support

### DIFF
--- a/src/renderer/assets/agent-icons/acp/agents.json
+++ b/src/renderer/assets/agent-icons/acp/agents.json
@@ -113,11 +113,11 @@
   {
     "id": "cline",
     "name": "Cline",
-    "version": "3.0.57",
+    "version": "3.0.58",
     "description": "Autonomous coding agent CLI - capable of creating/editing files, running commands, using the browser, and more",
     "distribution": {
       "npx": {
-        "package": "cline@3.0.57",
+        "package": "cline@3.0.58",
         "args": ["--acp"]
       }
     }
@@ -125,11 +125,11 @@
   {
     "id": "codebuddy-code",
     "name": "Codebuddy Code",
-    "version": "2.137.1",
+    "version": "2.139.0",
     "description": "Tencent Cloud's official intelligent coding tool",
     "distribution": {
       "npx": {
-        "package": "@tencent-ai/codebuddy-code@2.137.1",
+        "package": "@tencent-ai/codebuddy-code@2.139.0",
         "args": ["--acp"]
       }
     }
@@ -300,38 +300,38 @@
   {
     "id": "devin",
     "name": "Devin",
-    "version": "3000.5.20",
+    "version": "3000.6.2",
     "description": "Devin CLI coding agent by Cognition",
     "distribution": {
       "binary": {
         "darwin-aarch64": {
           "cmd": "./bin/devin",
-          "archive": "https://static.devin.ai/cli/3000.5.20/devin-3000.5.20-aarch64-apple-darwin.tar.gz",
+          "archive": "https://static.devin.ai/cli/3000.6.2/devin-3000.6.2-aarch64-apple-darwin.tar.gz",
           "args": ["acp"]
         },
         "darwin-x86_64": {
           "cmd": "./bin/devin",
-          "archive": "https://static.devin.ai/cli/3000.5.20/devin-3000.5.20-x86_64-apple-darwin.tar.gz",
+          "archive": "https://static.devin.ai/cli/3000.6.2/devin-3000.6.2-x86_64-apple-darwin.tar.gz",
           "args": ["acp"]
         },
         "linux-aarch64": {
           "cmd": "./bin/devin",
-          "archive": "https://static.devin.ai/cli/3000.5.20/devin-3000.5.20-aarch64-unknown-linux.tar.gz",
+          "archive": "https://static.devin.ai/cli/3000.6.2/devin-3000.6.2-aarch64-unknown-linux.tar.gz",
           "args": ["acp"]
         },
         "linux-x86_64": {
           "cmd": "./bin/devin",
-          "archive": "https://static.devin.ai/cli/3000.5.20/devin-3000.5.20-x86_64-unknown-linux.tar.gz",
+          "archive": "https://static.devin.ai/cli/3000.6.2/devin-3000.6.2-x86_64-unknown-linux.tar.gz",
           "args": ["acp"]
         },
         "windows-aarch64": {
           "cmd": "./bin\\devin.exe",
-          "archive": "https://static.devin.ai/cli/3000.5.20/devin-3000.5.20-aarch64-pc-windows.zip",
+          "archive": "https://static.devin.ai/cli/3000.6.2/devin-3000.6.2-aarch64-pc-windows.zip",
           "args": ["acp"]
         },
         "windows-x86_64": {
           "cmd": "./bin\\devin.exe",
-          "archive": "https://static.devin.ai/cli/3000.5.20/devin-3000.5.20-x86_64-pc-windows.zip",
+          "archive": "https://static.devin.ai/cli/3000.6.2/devin-3000.6.2-x86_64-pc-windows.zip",
           "args": ["acp"]
         }
       }
@@ -340,11 +340,11 @@
   {
     "id": "dimcode",
     "name": "DimCode",
-    "version": "0.3.18",
+    "version": "0.3.20",
     "description": "A coding agent that puts leading models at your command.",
     "distribution": {
       "npx": {
-        "package": "dimcode@0.3.18",
+        "package": "dimcode@0.3.20",
         "args": ["acp"]
       }
     }
@@ -364,11 +364,11 @@
   {
     "id": "factory-droid",
     "name": "Factory Droid",
-    "version": "0.202.0",
+    "version": "0.204.0",
     "description": "Factory Droid - AI coding agent powered by Factory AI",
     "distribution": {
       "npx": {
-        "package": "droid@0.202.0",
+        "package": "droid@0.204.0",
         "args": ["exec", "--output-format", "acp-daemon"],
         "env": {
           "DROID_DISABLE_AUTO_UPDATE": "true",
@@ -395,11 +395,11 @@
   {
     "id": "gemini",
     "name": "Gemini CLI",
-    "version": "0.56.0",
+    "version": "0.57.0",
     "description": "Google's official CLI for Gemini",
     "distribution": {
       "npx": {
-        "package": "@google/gemini-cli@0.56.0",
+        "package": "@google/gemini-cli@0.57.0",
         "args": ["--acp"]
       }
     }
@@ -419,11 +419,11 @@
   {
     "id": "glm-acp-agent",
     "name": "GLM Agent",
-    "version": "1.6.0",
+    "version": "1.6.1",
     "description": "ACP agent powered by Zhipu AI's GLM Coding Plan models (glm-5.1, glm-5-turbo, glm-4.7, glm-4.5-air). Supports streaming, tool calls, mid-session model switching, image input via Z.AI Coding Plan Vision MCP, and session load/fork/resume with on-disk persistence.",
     "distribution": {
       "npx": {
-        "package": "glm-acp-agent@1.6.0"
+        "package": "glm-acp-agent@1.6.1"
       }
     }
   },
@@ -461,11 +461,11 @@
   {
     "id": "grok-build",
     "name": "Grok Build",
-    "version": "1.0.8",
+    "version": "1.0.10",
     "description": "xAI's coding agent and CLI",
     "distribution": {
       "npx": {
-        "package": "@xai-official/grok@1.0.8",
+        "package": "@xai-official/grok@1.0.10",
         "args": ["agent", "stdio"]
       }
     }
@@ -473,33 +473,33 @@
   {
     "id": "harn",
     "name": "Harn",
-    "version": "0.10.114",
+    "version": "0.10.116",
     "description": "Harn runs .harn agent pipelines as a native ACP coding agent over stdio.",
     "distribution": {
       "binary": {
         "darwin-aarch64": {
           "cmd": "./harn",
-          "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.114/harn-aarch64-apple-darwin.tar.gz",
+          "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.116/harn-aarch64-apple-darwin.tar.gz",
           "args": ["serve", "acp"]
         },
         "darwin-x86_64": {
           "cmd": "./harn",
-          "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.114/harn-x86_64-apple-darwin.tar.gz",
+          "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.116/harn-x86_64-apple-darwin.tar.gz",
           "args": ["serve", "acp"]
         },
         "linux-aarch64": {
           "cmd": "./harn",
-          "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.114/harn-aarch64-unknown-linux-gnu.tar.gz",
+          "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.116/harn-aarch64-unknown-linux-gnu.tar.gz",
           "args": ["serve", "acp"]
         },
         "linux-x86_64": {
           "cmd": "./harn",
-          "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.114/harn-x86_64-unknown-linux-gnu.tar.gz",
+          "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.116/harn-x86_64-unknown-linux-gnu.tar.gz",
           "args": ["serve", "acp"]
         },
         "windows-x86_64": {
           "cmd": "harn.exe",
-          "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.114/harn-x86_64-pc-windows-msvc.zip",
+          "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.116/harn-x86_64-pc-windows-msvc.zip",
           "args": ["serve", "acp"]
         }
       }
@@ -676,38 +676,38 @@
   {
     "id": "opencode",
     "name": "OpenCode",
-    "version": "1.18.21",
+    "version": "1.18.23",
     "description": "The open source coding agent",
     "distribution": {
       "binary": {
         "darwin-aarch64": {
           "cmd": "./opencode",
-          "archive": "https://github.com/anomalyco/opencode/releases/download/v1.18.21/opencode-darwin-arm64.zip",
+          "archive": "https://github.com/anomalyco/opencode/releases/download/v1.18.23/opencode-darwin-arm64.zip",
           "args": ["acp"]
         },
         "darwin-x86_64": {
           "cmd": "./opencode",
-          "archive": "https://github.com/anomalyco/opencode/releases/download/v1.18.21/opencode-darwin-x64.zip",
+          "archive": "https://github.com/anomalyco/opencode/releases/download/v1.18.23/opencode-darwin-x64.zip",
           "args": ["acp"]
         },
         "linux-aarch64": {
           "cmd": "./opencode",
-          "archive": "https://github.com/anomalyco/opencode/releases/download/v1.18.21/opencode-linux-arm64.tar.gz",
+          "archive": "https://github.com/anomalyco/opencode/releases/download/v1.18.23/opencode-linux-arm64.tar.gz",
           "args": ["acp"]
         },
         "linux-x86_64": {
           "cmd": "./opencode",
-          "archive": "https://github.com/anomalyco/opencode/releases/download/v1.18.21/opencode-linux-x64.tar.gz",
+          "archive": "https://github.com/anomalyco/opencode/releases/download/v1.18.23/opencode-linux-x64.tar.gz",
           "args": ["acp"]
         },
         "windows-aarch64": {
           "cmd": "./opencode",
-          "archive": "https://github.com/anomalyco/opencode/releases/download/v1.18.21/opencode-windows-arm64.zip",
+          "archive": "https://github.com/anomalyco/opencode/releases/download/v1.18.23/opencode-windows-arm64.zip",
           "args": ["acp"]
         },
         "windows-x86_64": {
           "cmd": "./opencode.exe",
-          "archive": "https://github.com/anomalyco/opencode/releases/download/v1.18.21/opencode-windows-x64.zip",
+          "archive": "https://github.com/anomalyco/opencode/releases/download/v1.18.23/opencode-windows-x64.zip",
           "args": ["acp"]
         }
       }
@@ -779,11 +779,11 @@
   {
     "id": "qwen-code",
     "name": "Qwen Code",
-    "version": "0.22.0",
+    "version": "0.22.1",
     "description": "Alibaba's Qwen coding assistant",
     "distribution": {
       "npx": {
-        "package": "@qwen-code/qwen-code@0.22.0",
+        "package": "@qwen-code/qwen-code@0.22.1",
         "args": ["--acp", "--experimental-skills"]
       }
     }

--- a/src/renderer/components/ProjectChatList.tsx
+++ b/src/renderer/components/ProjectChatList.tsx
@@ -14,7 +14,7 @@ import {
 import { clipboardApi, openerApi } from '@/lib/api'
 import { openTerminalAtCwd } from '@/lib/terminal-spawn'
 import { cn } from '@/lib/utils'
-import { useAcpStore, useAgentTemplateId } from '@/stores/acp-store'
+import { useAcpStore, useAgentIcon, useAgentTemplateId } from '@/stores/acp-store'
 import { useWorkspaceStore } from '@/stores/workspace-store'
 
 /** Hard cap of rendered chat rows per project before lazy pagination kicks in. */
@@ -377,5 +377,8 @@ function ChatRowIcon({
   agentConfigId?: string
 }): React.JSX.Element {
   const templateId = useAgentTemplateId(agentId ?? null, agentConfigId)
-  return <AgentGlyph templateId={templateId} size={12} className="text-muted-foreground" />
+  const icon = useAgentIcon(agentId ?? null, agentConfigId)
+  return (
+    <AgentGlyph templateId={templateId} icon={icon} size={12} className="text-muted-foreground" />
+  )
 }

--- a/src/renderer/components/agents/AgentLauncher.tsx
+++ b/src/renderer/components/agents/AgentLauncher.tsx
@@ -2163,11 +2163,16 @@ const EntryGlyph = memo(function EntryGlyph({
   name?: string
 }): React.JSX.Element {
   const normalized = useMemo(() => {
+    // Prefer a persisted custom icon (bundled or uploaded) over the catalog.
+    if (config?.icon) {
+      const sanitized = sanitizeInlineAgentSvg(config.icon)
+      if (sanitized) return sanitized
+    }
     const key = config?.templateId ?? templateId
     if (!key) return null
     const icon = findBundledIconByKey(`acp:${key}`)?.svg
     return icon ? sanitizeInlineAgentSvg(icon) : null
-  }, [config?.templateId, templateId])
+  }, [config?.icon, config?.templateId, templateId])
   const className = 'h-4 w-4 rounded-sm text-4xs'
 
   if (normalized) {

--- a/src/renderer/components/agents/CustomAcpAgentDialog.test.tsx
+++ b/src/renderer/components/agents/CustomAcpAgentDialog.test.tsx
@@ -299,4 +299,140 @@ describe('CustomAcpAgentDialog', () => {
     }
     expect(() => exportAgentConfig(corrupt)).toThrow(/configId missing/)
   })
+
+  // --- Zed-style map-unwrap (research 2026-08-22) ---
+
+  it('unwraps a Zed agent_servers map and takes name from the key', async () => {
+    render(<CustomAcpAgentDialog open={true} onOpenChange={() => {}} />)
+    await pasteAndAdvanceToConfirm(
+      `{"agent_servers":{"Poolside":{"type":"custom","command":"pool","args":["acp"]}}}`
+    )
+    await clickButton('Confirm — Execute Command')
+    await waitFor(() => expect(mockSaveAgentConfig).toHaveBeenCalledTimes(1))
+    const stored = mockSaveAgentConfig.mock.calls[0][0] as StoredAgentConfig
+    expect(stored.name).toBe('Poolside')
+    expect(stored.command).toBe('pool')
+    expect(stored.args).toEqual(['acp'])
+  })
+
+  it('unwraps a JetBrains-style agent_servers map (no type field)', async () => {
+    render(<CustomAcpAgentDialog open={true} onOpenChange={() => {}} />)
+    await pasteAndAdvanceToConfirm(
+      `{"agent_servers":{"MyAgent":{"command":"node","args":["a.js"],"env":{}}}}`
+    )
+    await clickButton('Confirm — Execute Command')
+    await waitFor(() => expect(mockSaveAgentConfig).toHaveBeenCalledTimes(1))
+    const stored = mockSaveAgentConfig.mock.calls[0][0] as StoredAgentConfig
+    expect(stored.name).toBe('MyAgent')
+    expect(stored.command).toBe('node')
+  })
+
+  it('unwraps a VS Code acp.agents nested map', async () => {
+    render(<CustomAcpAgentDialog open={true} onOpenChange={() => {}} />)
+    await pasteAndAdvanceToConfirm(`{"acp":{"agents":{"X":{"command":"npx","args":["-y","pkg"]}}}}`)
+    await clickButton('Confirm — Execute Command')
+    await waitFor(() => expect(mockSaveAgentConfig).toHaveBeenCalledTimes(1))
+    const stored = mockSaveAgentConfig.mock.calls[0][0] as StoredAgentConfig
+    expect(stored.name).toBe('X')
+    expect(stored.command).toBe('npx')
+  })
+
+  it('unwraps an acpx agents map', async () => {
+    render(<CustomAcpAgentDialog open={true} onOpenChange={() => {}} />)
+    await pasteAndAdvanceToConfirm(`{"agents":{"Y":{"command":"uvx","args":["pkg"]}}}`)
+    await clickButton('Confirm — Execute Command')
+    await waitFor(() => expect(mockSaveAgentConfig).toHaveBeenCalledTimes(1))
+    const stored = mockSaveAgentConfig.mock.calls[0][0] as StoredAgentConfig
+    expect(stored.name).toBe('Y')
+    expect(stored.command).toBe('uvx')
+  })
+
+  it('rejects a multi-entry agent_servers map inline', async () => {
+    render(<CustomAcpAgentDialog open={true} onOpenChange={() => {}} />)
+    await pasteAndAdvanceToConfirm(
+      `{"agent_servers":{"A":{"command":"a","args":[]},"B":{"command":"b","args":[]}}}`
+    )
+    expect(screen.getByRole('alert').textContent).toContain('Found 2 agent entries')
+    expect(mockSaveAgentConfig).not.toHaveBeenCalled()
+  })
+
+  it('rejects a type:registry entry inline', async () => {
+    render(<CustomAcpAgentDialog open={true} onOpenChange={() => {}} />)
+    await pasteAndAdvanceToConfirm(`{"agent_servers":{"Z":{"type":"registry","name":"Z"}}}`)
+    expect(screen.getByRole('alert').textContent).toContain('registry')
+    expect(mockSaveAgentConfig).not.toHaveBeenCalled()
+  })
+
+  it('accepts a bare single-entry object with a name (backward compat)', async () => {
+    render(<CustomAcpAgentDialog open={true} onOpenChange={() => {}} />)
+    await pasteAndAdvanceToConfirm(`{"name":"H","command":"node","args":[],"env":{}}`)
+    await clickButton('Confirm — Execute Command')
+    await waitFor(() => expect(mockSaveAgentConfig).toHaveBeenCalledTimes(1))
+    const stored = mockSaveAgentConfig.mock.calls[0][0] as StoredAgentConfig
+    expect(stored.name).toBe('H')
+  })
+
+  // --- Icon support ---
+
+  it('exportAgentConfig includes icon when present (7 fields)', () => {
+    const svg = '<svg viewBox="0 0 16 16"><circle cx="8" cy="8" r="4"/></svg>'
+    const stored: StoredAgentConfig = {
+      id: 'custom-abc12345',
+      configId: 'custom-abc12345',
+      name: 'Icon Agent',
+      command: 'node',
+      args: [],
+      env: {},
+      allowTerminal: false,
+      icon: svg
+    }
+    const json = exportAgentConfig(stored)
+    const parsed = JSON.parse(json)
+    expect(parsed.icon).toBe(svg)
+    expect(Object.keys(parsed).sort()).toEqual(
+      ['allowTerminal', 'args', 'command', 'configId', 'env', 'icon', 'name'].sort()
+    )
+  })
+
+  it('exportAgentConfig omits icon when absent (6 fields)', () => {
+    const stored: StoredAgentConfig = {
+      id: 'custom-abc12345',
+      configId: 'custom-abc12345',
+      name: 'No Icon',
+      command: 'node',
+      args: [],
+      env: {},
+      allowTerminal: false
+    }
+    const json = exportAgentConfig(stored)
+    const parsed = JSON.parse(json)
+    expect(parsed).not.toHaveProperty('icon')
+  })
+
+  it('round-trips an exported config with icon', async () => {
+    const svg = '<svg viewBox="0 0 16 16"><circle cx="8" cy="8" r="4"/></svg>'
+    const stored: StoredAgentConfig = {
+      id: 'custom-abc12345',
+      configId: 'custom-abc12345',
+      name: 'Icon Agent',
+      command: 'node',
+      args: [],
+      env: {},
+      allowTerminal: false,
+      icon: svg
+    }
+    const json = exportAgentConfig(stored)
+    render(<CustomAcpAgentDialog open={true} onOpenChange={() => {}} />)
+    await pasteAndAdvanceToConfirm(json)
+    await clickButton('Confirm — Execute Command')
+    await waitFor(() => expect(mockSaveAgentConfig).toHaveBeenCalledTimes(1))
+    const reimported = mockSaveAgentConfig.mock.calls[0][0] as StoredAgentConfig
+    // The paste path sanitizes the icon via DOMPurify — the exact string
+    // may differ (attribute order, self-closing tags), so assert the
+    // semantic content survives: it's a valid SVG with viewBox + circle.
+    expect(reimported.icon).toContain('viewBox')
+    expect(reimported.icon).toContain('circle')
+    expect(reimported.name).toBe('Icon Agent')
+    expect(reimported.id).toMatch(/^custom-[0-9a-f]{8}$/)
+  })
 })

--- a/src/renderer/components/agents/CustomAcpAgentDialog.tsx
+++ b/src/renderer/components/agents/CustomAcpAgentDialog.tsx
@@ -2,9 +2,12 @@
  * Custom ACP Agent dialog (outside the registry) — paste-JSON import + export.
  *
  * A user pastes an `AgentConfig`-shaped JSON (`{ configId?, name, command,
- * args, env, allowTerminal }`, camelCase). The dialog:
- *   1. parses the JSON and rejects unknown fields (only the 6 AgentConfig
- *      fields are allowed);
+ * args, env, allowTerminal, icon? }`, camelCase) — or a Zed-style
+ * `agent_servers` / `acp.agents` / `agents` map-wrapped config, which is
+ * unwrapped (name taken from the map key, `type`/`default_mode`/etc. dropped).
+ * The dialog:
+ *   1. parses + unwraps the JSON and rejects unknown fields (only the 7
+ *      AgentConfig fields incl. `icon` are allowed);
  *   2. runs `validateAgentConfig` (shape, incl. args/env element types) +
  *      `looksLikeSecretValue` per env value (no raw secrets on disk);
  *   3. assigns `id`=`custom-<uuid8>` (or reuses an existing config's `id` when
@@ -15,13 +18,14 @@
  *   5. saves via `useAcpStore.saveAgentConfig`.
  *
  * Export (`Copy JSON`) serializes a `StoredAgentConfig` back to pretty
- * camelCase JSON of just the 6 `AgentConfig` fields (strips `id`/`templateId`)
- * so it round-trips through this import validator.
+ * camelCase JSON of just the `AgentConfig` fields incl. `icon` when present
+ * (strips `id`/`templateId`) so it round-trips through this import validator.
  */
 
 import { ClipboardPaste, Plus } from 'lucide-react'
 import { useCallback, useState } from 'react'
 import { toast } from 'sonner'
+import { IconPicker } from '@/components/agents/IconPicker'
 import { Button } from '@/components/ui/button'
 import {
   Dialog,
@@ -38,6 +42,7 @@ import {
   validateAgentConfig
 } from '@/lib/acp-agents-persistence'
 import type { AgentConfig } from '@/lib/acp-api'
+import { sanitizeInlineAgentSvg } from '@/lib/agents/sanitize-agent-icon'
 import { logFrontendError } from '@/lib/log-api'
 import { useAcpStore } from '@/stores/acp-store'
 
@@ -46,15 +51,30 @@ interface CustomAcpAgentDialogProps {
   onOpenChange: (open: boolean) => void
 }
 
-/** Fields allowed in a pasted AgentConfig JSON (camelCase). */
-const ALLOWED_AGENT_CONFIG_FIELDS = new Set<keyof AgentConfig>([
+/** Fields allowed in a pasted AgentConfig JSON (camelCase), incl. `icon`. */
+const ALLOWED_AGENT_CONFIG_FIELDS = new Set<string>([
   'configId',
   'name',
   'command',
   'args',
   'env',
-  'allowTerminal'
+  'allowTerminal',
+  'icon'
 ])
+
+/** Zed session-preference fields silently dropped on import (no Termul equivalent). */
+const DROPPED_ZED_FIELDS = new Set([
+  'type',
+  'default_mode',
+  'default_config_options',
+  'favorite_config_option_values'
+])
+
+/** Max icon SVG string size (64KB) — matches the IconPicker upload cap. */
+const MAX_ICON_BYTES = 64 * 1024
+
+/** Top-level map wrapper keys accepted for paste normalization. */
+const MAP_WRAPPER_KEYS = new Set(['agent_servers', 'agents'])
 
 const ARBITRARY_COMMAND_PROMPT =
   'This will execute an arbitrary command on your machine. Are you sure you want to persist this agent?'
@@ -70,9 +90,10 @@ function freshCustomId(): string {
 
 /**
  * Serialize a stored custom agent to exportable AgentConfig JSON (no
- * id/templateId). Throws if `configId` is missing/empty — a saved custom agent
- * always carries one after the load-time backfill, but guard defensively so a
- * corrupt store never emits a non-round-trippable export.
+ * id/templateId). Includes `icon` when present. Throws if `configId` is
+ * missing/empty — a saved custom agent always carries one after the load-time
+ * backfill, but guard defensively so a corrupt store never emits a
+ * non-round-trippable export.
  */
 export function exportAgentConfig(stored: StoredAgentConfig): string {
   if (!stored.configId || stored.configId.trim().length === 0) {
@@ -80,7 +101,7 @@ export function exportAgentConfig(stored: StoredAgentConfig): string {
       `cannot export agent "${stored.name}": configId missing; the saved config is corrupt`
     )
   }
-  const exported: AgentConfig = {
+  const exported: AgentConfig & { icon?: string } = {
     configId: stored.configId,
     name: stored.name,
     command: stored.command,
@@ -88,21 +109,90 @@ export function exportAgentConfig(stored: StoredAgentConfig): string {
     env: stored.env,
     allowTerminal: stored.allowTerminal
   }
+  if (typeof stored.icon === 'string' && stored.icon.length > 0) {
+    exported.icon = stored.icon
+  }
   return JSON.stringify(exported, null, 2)
 }
 
 type ParsedConfig = {
-  config: AgentConfig
+  config: AgentConfig & { icon?: string }
   /** True when the paste carried a non-empty (post-trim) configId. */
   hadConfigId: boolean
+  /** The pasted icon SVG (undefined when absent). */
+  icon: string | undefined
+}
+
+/**
+ * Unwrap a Zed-style map wrapper (`agent_servers` / `acp.agents` / `agents`).
+ * Takes `name` from the map key. Returns the unwrapped entry object, or an
+ * error string. When no wrapper is present, returns the original object.
+ */
+type UnwrapResult = { ok: true; value: Record<string, unknown> } | { ok: false; error: string }
+
+/**
+ * Unwrap a Zed-style map wrapper (`agent_servers` / `acp.agents` / `agents`).
+ * Takes `name` from the map key. Returns the unwrapped entry object, or an
+ * error string. When no wrapper is present, returns the original object.
+ */
+function unwrapMapWrapper(obj: Record<string, unknown>): UnwrapResult {
+  // `acp.agents` dotted-key wrapper (flat VS Code form): { "acp.agents": { Name: { ... } } }
+  if ('acp.agents' in obj) {
+    const inner = obj['acp.agents']
+    if (inner !== null && typeof inner === 'object' && !Array.isArray(inner)) {
+      return unwrapSingleEntry(inner as Record<string, unknown>)
+    }
+  }
+
+  // `acp.agents` two-level wrapper: { acp: { agents: { Name: { ... } } } }
+  if ('acp' in obj && obj.acp !== null && typeof obj.acp === 'object' && !Array.isArray(obj.acp)) {
+    const acpObj = obj.acp as Record<string, unknown>
+    if (
+      acpObj.agents !== null &&
+      typeof acpObj.agents === 'object' &&
+      !Array.isArray(acpObj.agents)
+    ) {
+      return unwrapSingleEntry(acpObj.agents as Record<string, unknown>)
+    }
+  }
+
+  // `agent_servers` / `agents` single-level wrapper. A real Zed settings
+  // file carries sibling keys (session, theme, etc.) alongside `agent_servers`,
+  // so locate the wrapper by name regardless of sibling keys.
+  for (const wrapperKey of MAP_WRAPPER_KEYS) {
+    if (wrapperKey in obj) {
+      const inner = obj[wrapperKey]
+      if (inner !== null && typeof inner === 'object' && !Array.isArray(inner)) {
+        return unwrapSingleEntry(inner as Record<string, unknown>)
+      }
+    }
+  }
+
+  // No wrapper — bare object
+  return { ok: true, value: obj }
+}
+
+function unwrapSingleEntry(inner: Record<string, unknown>): UnwrapResult {
+  const entries = Object.entries(inner)
+  if (entries.length === 0) return { ok: false, error: 'The agent map is empty.' }
+  if (entries.length > 1) {
+    return { ok: false, error: `Found ${entries.length} agent entries; paste one at a time.` }
+  }
+  const [name, entryObj] = entries[0]
+  if (entryObj === null || typeof entryObj !== 'object' || Array.isArray(entryObj)) {
+    return { ok: false, error: `Agent entry "${name}" must be a JSON object.` }
+  }
+  return { ok: true, value: { ...(entryObj as Record<string, unknown>), name } }
 }
 
 /**
  * Parse + validate the pasted JSON. Returns an error string on failure, or the
- * promoted `AgentConfig` on success. Only the 6 AgentConfig fields are
- * permitted; unknown fields (incl. `id`/`templateId`) are rejected loudly so
- * the export shape round-trips. A whitespace-only `configId` is rejected
- * (rather than silently trimmed to a fresh identity).
+ * promoted `AgentConfig` on success. Unwraps Zed-style map wrappers first,
+ * then only the 7 allowed fields (incl. `icon`) are permitted; unknown fields
+ * (incl. `id`/`templateId`) are rejected loudly so the export shape
+ * round-trips. A whitespace-only `configId` is rejected (rather than silently
+ * trimmed to a fresh identity). Zed session-preference fields (`type`,
+ * `default_mode`, etc.) are silently dropped before the allowed-fields check.
  */
 function parsePastedAgentConfig(raw: string): ParsedConfig | { error: string } {
   const trimmed = raw.trim()
@@ -117,11 +207,35 @@ function parsePastedAgentConfig(raw: string): ParsedConfig | { error: string } {
   if (json === null || typeof json !== 'object' || Array.isArray(json)) {
     return { error: 'Agent config must be a JSON object.' }
   }
-  const obj = json as Record<string, unknown>
+
+  // Unwrap Zed-style map wrappers (agent_servers / acp.agents / agents).
+  const unwrapped = unwrapMapWrapper(json as Record<string, unknown>)
+  if (!unwrapped.ok) return { error: unwrapped.error }
+  let obj: Record<string, unknown> = unwrapped.value
+
+  // Reject registry/extension entries (they use the registry install flow,
+  // not the custom-agent paste path).
+  if (obj.type === 'registry' || obj.type === 'extension') {
+    return {
+      error:
+        'registry/extension agent entries are not supported in the custom-agent dialog; use the registry install flow.'
+    }
+  }
+
+  // Silently drop Zed session-preference fields before the allowed-fields
+  // check so they don't trigger "Unknown field" errors. Single-pass filter.
+  const filtered: Record<string, unknown> = {}
+  for (const [key, value] of Object.entries(obj)) {
+    if (!DROPPED_ZED_FIELDS.has(key)) {
+      filtered[key] = value
+    }
+  }
+  obj = filtered
+
   for (const key of Object.keys(obj)) {
-    if (!ALLOWED_AGENT_CONFIG_FIELDS.has(key as keyof AgentConfig)) {
+    if (!ALLOWED_AGENT_CONFIG_FIELDS.has(key)) {
       return {
-        error: `Unknown field "${key}". Only configId, name, command, args, env, allowTerminal are allowed.`
+        error: `Unknown field "${key}". Only configId, name, command, args, env, allowTerminal, icon are allowed.`
       }
     }
   }
@@ -160,8 +274,22 @@ function parsePastedAgentConfig(raw: string): ParsedConfig | { error: string } {
   if (allowTerminal !== undefined && typeof allowTerminal !== 'boolean') {
     return { error: 'allowTerminal must be a boolean.' }
   }
+  if (obj.icon !== undefined && typeof obj.icon !== 'string') {
+    return { error: 'icon must be a string.' }
+  }
+  // Size cap + sanitize at ingress: a pasted icon bypasses the upload path's
+  // 64KB guard, so enforce it here. Sanitize so no malformed/malicious SVG
+  // is persisted to disk (symmetry with the upload path).
+  let sanitizedIcon: string | undefined
+  if (typeof obj.icon === 'string') {
+    if (obj.icon.length > MAX_ICON_BYTES) {
+      return { error: 'icon is too large (max 64KB).' }
+    }
+    const sanitized = sanitizeInlineAgentSvg(obj.icon)
+    sanitizedIcon = sanitized ?? undefined
+  }
 
-  const cfg: AgentConfig = {
+  const cfg: AgentConfig & { icon?: string } = {
     configId: rawConfigId?.trim() || undefined,
     name: typeof obj.name === 'string' ? obj.name : '',
     command: typeof obj.command === 'string' ? obj.command : '',
@@ -170,7 +298,8 @@ function parsePastedAgentConfig(raw: string): ParsedConfig | { error: string } {
       env !== undefined && typeof env === 'object' && env !== null
         ? (env as Record<string, string>)
         : {},
-    allowTerminal: typeof allowTerminal === 'boolean' ? allowTerminal : false
+    allowTerminal: typeof allowTerminal === 'boolean' ? allowTerminal : false,
+    icon: sanitizedIcon
   }
 
   // Shape validation (non-empty name/command + element/value types) — reuse
@@ -191,7 +320,11 @@ function parsePastedAgentConfig(raw: string): ParsedConfig | { error: string } {
     }
   }
 
-  return { config: cfg, hadConfigId: Boolean(cfg.configId && cfg.configId.length > 0) }
+  return {
+    config: cfg,
+    hadConfigId: Boolean(cfg.configId && cfg.configId.length > 0),
+    icon: cfg.icon
+  }
 }
 
 export function CustomAcpAgentDialog({
@@ -203,6 +336,8 @@ export function CustomAcpAgentDialog({
   const [saving, setSaving] = useState(false)
   const [step, setStep] = useState<ConfirmStep>('idle')
   const [pendingConfig, setPendingConfig] = useState<StoredAgentConfig | null>(null)
+  const [icon, setIcon] = useState('')
+  const [iconTouched, setIconTouched] = useState(false)
   const saveAgentConfig = useAcpStore((s) => s.saveAgentConfig)
 
   const reset = useCallback(() => {
@@ -211,6 +346,8 @@ export function CustomAcpAgentDialog({
     setSaving(false)
     setStep('idle')
     setPendingConfig(null)
+    setIcon('')
+    setIconTouched(false)
   }, [])
 
   const handleOpenChange = useCallback(
@@ -220,7 +357,7 @@ export function CustomAcpAgentDialog({
       if (saving) return
       if (!next) {
         // Closing cancels any in-flight confirmation (no persistence). The
-        // pasted JSON is cleared so a fresh open starts clean.
+        // pasted JSON + icon are cleared so a fresh open starts clean.
         reset()
       }
       onOpenChange(next)
@@ -262,7 +399,7 @@ export function CustomAcpAgentDialog({
       setError(parsed.error)
       return
     }
-    const { config, hadConfigId } = parsed
+    const { config, hadConfigId, icon: parsedIcon } = parsed
 
     // PATCH 3: re-paste of an exported config updates the existing agent
     // instead of creating a duplicate. If a config with this configId is
@@ -277,18 +414,29 @@ export function CustomAcpAgentDialog({
     //   - configId pasted, no existing → fresh `custom-<uuid8>` id (configId honored)
     //   - no configId pasted, no existing → id == configId (one fresh identity)
     const id = existing ? existing.id : hadConfigId ? freshCustomId() : configId
+    // Icon precedence: if the user interacted with the picker (incl. clearing
+    // to "No icon"), the picker state wins — even when empty (clearing).
+    // Otherwise fall back to the pasted icon, then the existing agent's icon.
+    const resolvedIcon = iconTouched ? icon : parsedIcon || existing?.icon
     const stored: StoredAgentConfig = {
       ...config,
       configId,
       id,
-      templateId: undefined
+      templateId: undefined,
+      icon: resolvedIcon || undefined
+    }
+
+    // Sync the picker state from a pasted icon so the UI reflects the
+    // pasted value (the picker shows the right selected-state ring).
+    if (!iconTouched && parsedIcon) {
+      setIcon(parsedIcon)
     }
 
     // Move into the in-dialog arbitrary-command confirmation step (CAP-3).
     // `allowTerminal: true` advances to a SECOND confirmation after the first.
     setPendingConfig(stored)
     setStep('confirm')
-  }, [jsonText, saving, step])
+  }, [jsonText, saving, step, icon, iconTouched])
 
   const handleConfirmArbitrary = useCallback(() => {
     if (!pendingConfig || saving) return
@@ -319,13 +467,25 @@ export function CustomAcpAgentDialog({
           <DialogDescription>
             {confirming
               ? 'Persisting this agent will let it execute the configured command. Review it before confirming.'
-              : 'Paste an ACP agent config as JSON. Only configId, name, command, args, env, and allowTerminal fields are accepted; env values must be $VAR placeholders.'}
+              : 'Paste an ACP agent config as JSON (flat or Zed agent_servers format). Env values must be $VAR placeholders.'}
           </DialogDescription>
         </DialogHeader>
 
         <div className="grid gap-3 py-2">
           {!confirming && (
             <>
+              <div className="flex items-end gap-3">
+                <div className="flex flex-col gap-1.5">
+                  <Label className="text-xs">Icon</Label>
+                  <IconPicker
+                    value={icon}
+                    onChange={(svg) => {
+                      setIcon(svg)
+                      setIconTouched(true)
+                    }}
+                  />
+                </div>
+              </div>
               <Label htmlFor="custom-acp-agent-json" className="text-xs">
                 Agent config JSON
               </Label>

--- a/src/renderer/components/agents/IconPicker.test.tsx
+++ b/src/renderer/components/agents/IconPicker.test.tsx
@@ -1,0 +1,78 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { IconPicker } from './IconPicker'
+
+// Minimal DOMPurify-backed sanitize works in jsdom (see sanitize-agent-icon.test.ts).
+// The IconPicker uses sanitizeInlineAgentSvg internally; we test the upload path
+// end-to-end through the hidden file input + FileReader.
+
+const VALID_SVG = '<svg viewBox="0 0 16 16"><circle cx="8" cy="8" r="4"/></svg>'
+const INVALID_SVG = '<div>not an svg</div>'
+
+describe('IconPicker', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('renders the trigger button', () => {
+    render(<IconPicker value="" onChange={() => {}} />)
+    expect(screen.getByLabelText('Choose icon')).toBeInTheDocument()
+  })
+
+  it('opens the picker dialog and shows the upload affordance', () => {
+    render(<IconPicker value="" onChange={() => {}} />)
+    fireEvent.click(screen.getByLabelText('Choose icon'))
+    expect(screen.getByRole('heading', { name: 'Choose icon' })).toBeInTheDocument()
+    expect(screen.getByLabelText('Upload custom SVG icon')).toBeInTheDocument()
+  })
+
+  it('accepts a valid uploaded SVG and calls onChange', async () => {
+    const onChange = vi.fn()
+    render(<IconPicker value="" onChange={onChange} />)
+    fireEvent.click(screen.getByLabelText('Choose icon'))
+    const input = screen.getByLabelText('Upload custom SVG icon') as HTMLInputElement
+    const file = new File([VALID_SVG], 'icon.svg', { type: 'image/svg+xml' })
+    fireEvent.change(input, { target: { files: [file] } })
+    await waitFor(() => expect(onChange).toHaveBeenCalledTimes(1))
+    // The sanitized SVG is passed to onChange.
+    expect(onChange.mock.calls[0][0]).toContain('viewBox')
+  })
+
+  it('rejects an invalid SVG (no root svg/viewBox) with an inline error', async () => {
+    const onChange = vi.fn()
+    render(<IconPicker value="" onChange={onChange} />)
+    fireEvent.click(screen.getByLabelText('Choose icon'))
+    const input = screen.getByLabelText('Upload custom SVG icon') as HTMLInputElement
+    const file = new File([INVALID_SVG], 'bad.svg', { type: 'image/svg+xml' })
+    fireEvent.change(input, { target: { files: [file] } })
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toBeInTheDocument()
+    })
+    expect(onChange).not.toHaveBeenCalled()
+  })
+
+  it('rejects an oversize file (>64KB)', async () => {
+    const onChange = vi.fn()
+    render(<IconPicker value="" onChange={onChange} />)
+    fireEvent.click(screen.getByLabelText('Choose icon'))
+    const input = screen.getByLabelText('Upload custom SVG icon') as HTMLInputElement
+    // 65KB string — over the 64KB cap.
+    const big = 'x'.repeat(65 * 1024)
+    const file = new File([big], 'big.svg', { type: 'image/svg+xml' })
+    fireEvent.change(input, { target: { files: [file] } })
+    await waitFor(() => {
+      const alert = screen.getByRole('alert')
+      expect(alert.textContent).toContain('too large')
+    })
+    expect(onChange).not.toHaveBeenCalled()
+  })
+
+  it('shows a custom (non-bundled) SVG in the trigger when value is set', () => {
+    render(<IconPicker value={VALID_SVG} onChange={() => {}} />)
+    // The trigger button should render (not the Pencil fallback).
+    const trigger = screen.getByLabelText('Choose icon')
+    expect(trigger).toBeInTheDocument()
+    // The trigger contains an inline span with the SVG (sanitized).
+    expect(trigger.querySelector('svg')).not.toBeNull()
+  })
+})

--- a/src/renderer/components/agents/IconPicker.tsx
+++ b/src/renderer/components/agents/IconPicker.tsx
@@ -1,46 +1,88 @@
-import { Check, Pencil } from 'lucide-react'
-import { useMemo, useState } from 'react'
+import { Check, Pencil, Upload } from 'lucide-react'
+import { useMemo, useRef, useState } from 'react'
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog'
-import {
-  BUNDLED_ICON_CATALOG,
-  findBundledIconBySvg,
-  normalizeIconSvg
-} from '@/lib/agents/agent-icon-catalog'
+import { BUNDLED_ICON_CATALOG, findBundledIconBySvg } from '@/lib/agents/agent-icon-catalog'
+import { sanitizeInlineAgentSvg } from '@/lib/agents/sanitize-agent-icon'
 import { cn } from '@/lib/utils'
+
+const MAX_ICON_FILE_BYTES = 64 * 1024
 
 interface IconPickerProps {
   value: string
   onChange: (svg: string) => void
 }
 
-/** Render an SVG icon string inline with white color. */
+/** Render a sanitized SVG icon string inline with white color. */
 function InlineIcon({ svg, className }: { svg: string; className?: string }): React.JSX.Element {
+  const sanitized = useMemo(() => sanitizeInlineAgentSvg(svg), [svg])
   return (
     <span
       className={cn('inline-flex text-white [&_svg]:h-full [&_svg]:w-full', className)}
-      // biome-ignore lint/security/noDangerouslySetInnerHtml: icon SVG is sanitized via normalizeIconSvg (DOMPurify)
-      dangerouslySetInnerHTML={{ __html: normalizeIconSvg(svg) }}
+      // biome-ignore lint/security/noDangerouslySetInnerHtml: icon SVG is sanitized via sanitizeInlineAgentSvg (DOMPurify)
+      dangerouslySetInnerHTML={{ __html: sanitized ?? '' }}
     />
   )
 }
 
 /**
  * Modal icon picker — compact trigger button, full grid in a dialog.
- * All icons render as white on muted/secondary backgrounds.
+ * Bundled icons render as white on muted/secondary backgrounds.
+ * An upload affordance lets the user pick a custom SVG file from disk;
+ * uploaded SVGs are sanitized (DOMPurify + viewBox requirement) and capped
+ * at 64KB. Works in both desktop and web/remote mode (hidden file input).
  */
 export function IconPicker({ value, onChange }: IconPickerProps): React.JSX.Element {
   const [open, setOpen] = useState(false)
+  const [uploadError, setUploadError] = useState<string | null>(null)
+  const fileInputRef = useRef<HTMLInputElement>(null)
 
   const selectedEntry = useMemo(() => findBundledIconBySvg(value), [value])
+  // A non-empty value not in the bundled catalog is a custom (uploaded) SVG.
+  const isCustomSvg = value.length > 0 && !selectedEntry
 
   const handleSelect = (svg: string) => {
     onChange(svg)
     setOpen(false)
   }
 
+  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0]
+    if (!file) return
+    setUploadError(null)
+
+    if (file.size > MAX_ICON_FILE_BYTES) {
+      setUploadError('Icon file too large (max 64KB).')
+      // Reset so the same file can be re-selected after correction.
+      e.target.value = ''
+      return
+    }
+
+    const reader = new FileReader()
+    reader.onload = () => {
+      const text = String(reader.result ?? '')
+      const sanitized = sanitizeInlineAgentSvg(text)
+      if (!sanitized) {
+        setUploadError('Invalid SVG: must be a single `<svg>` with a `viewBox`.')
+        e.target.value = ''
+        return
+      }
+      onChange(sanitized)
+      setOpen(false)
+    }
+    reader.onerror = () => {
+      setUploadError('Failed to read the file.')
+      e.target.value = ''
+    }
+    reader.readAsText(file)
+  }
+
   const triggerIcon = selectedEntry ? (
     <div className="flex h-9 w-9 items-center justify-center rounded-md border border-border bg-secondary p-1.5 hover:bg-secondary/80 transition-colors">
       <InlineIcon svg={selectedEntry.svg} className="h-5 w-5 text-foreground" />
+    </div>
+  ) : isCustomSvg ? (
+    <div className="flex h-9 w-9 items-center justify-center rounded-md border border-border bg-secondary p-1.5 hover:bg-secondary/80 transition-colors">
+      <InlineIcon svg={value} className="h-5 w-5 text-foreground" />
     </div>
   ) : (
     <div className="flex h-9 w-9 items-center justify-center rounded-md border border-dashed border-muted-foreground/40 text-muted-foreground hover:bg-secondary/60 transition-colors">
@@ -85,6 +127,24 @@ export function IconPicker({ value, onChange }: IconPickerProps): React.JSX.Elem
                 —
               </button>
 
+              {/* Custom (uploaded) SVG — shown when value is non-bundled */}
+              {isCustomSvg && (
+                <button
+                  type="button"
+                  onClick={() => handleSelect(value)}
+                  className={cn(
+                    'relative flex h-9 w-9 items-center justify-center rounded-md border p-1.5 transition-colors',
+                    'border-primary/60 bg-primary/10 ring-2 ring-primary/30 text-white'
+                  )}
+                  title="Custom uploaded icon"
+                  aria-label="Custom uploaded icon"
+                  aria-pressed
+                >
+                  <InlineIcon svg={value} className="h-5 w-5" />
+                  <Check size={10} className="absolute -right-0.5 -top-0.5 text-primary" />
+                </button>
+              )}
+
               {BUNDLED_ICON_CATALOG.map((entry) => {
                 const isSelected = selectedEntry?.key === entry.key
                 return (
@@ -110,6 +170,31 @@ export function IconPicker({ value, onChange }: IconPickerProps): React.JSX.Elem
                 )
               })}
             </div>
+          </div>
+
+          {/* Upload affordance */}
+          <div className="flex flex-col gap-1.5 border-t border-border/60 pt-2">
+            <button
+              type="button"
+              onClick={() => fileInputRef.current?.click()}
+              className="flex items-center justify-center gap-1.5 rounded-md border border-border px-3 py-1.5 text-xs text-muted-foreground hover:bg-secondary transition-colors"
+            >
+              <Upload size={12} />
+              Upload custom SVG
+            </button>
+            <input
+              ref={fileInputRef}
+              type="file"
+              accept=".svg,image/svg+xml"
+              onChange={handleFileChange}
+              className="hidden"
+              aria-label="Upload custom SVG icon"
+            />
+            {uploadError && (
+              <p role="alert" className="text-xs text-destructive">
+                {uploadError}
+              </p>
+            )}
           </div>
         </DialogContent>
       </Dialog>

--- a/src/renderer/components/chat/AgentBadge.tsx
+++ b/src/renderer/components/chat/AgentBadge.tsx
@@ -27,12 +27,12 @@ export function AgentBadge({
   iconSize = 14,
   className
 }: AgentBadgeProps): React.JSX.Element {
-  const { name, templateId } = useAgentIdentity(agentId)
+  const { name, templateId, icon } = useAgentIdentity(agentId)
   const label = name ?? fallbackName ?? `Agent ${agentId.slice(0, 8)}`
 
   return (
     <span className={cn('inline-flex items-center gap-1.5', className)}>
-      <AgentGlyph templateId={templateId} size={iconSize} />
+      <AgentGlyph templateId={templateId} icon={icon} size={iconSize} />
       {showName && <span className="truncate">{label}</span>}
     </span>
   )

--- a/src/renderer/components/chat/AgentGlyph.tsx
+++ b/src/renderer/components/chat/AgentGlyph.tsx
@@ -5,27 +5,36 @@ import { sanitizeInlineAgentSvg } from '@/lib/agents/sanitize-agent-icon'
 import { cn } from '@/lib/utils'
 
 /**
- * Renders an ACP agent's bundled registry icon (theme-adaptive inline SVG via
- * `currentColor`) resolved by template id. Falls back to a generic bot glyph
- * when the template has no bundled icon (e.g. a custom agent or unresolved id).
+ * Renders an ACP agent's icon (theme-adaptive inline SVG via `currentColor`).
+ * Resolution precedence: `icon` prop (persisted custom SVG, bundled or
+ * uploaded) → `findBundledIconByKey(`acp:${templateId}`)` (registry catalog) →
+ * lucide `<Bot>` fallback.
  *
- * Uses the same bundled icon catalog as the agent launcher so every configured
- * registry agent renders its real CLI icon, not just a hardcoded subset.
+ * Used by every chat-side surface (AgentBadge, ChatHistoryEntryRow,
+ * ProjectChatList, ChatEmptyState, ChatInputBar) — the single chokepoint for
+ * ACP agent icons in the chat UI.
  */
 export function AgentGlyph({
   templateId,
+  icon,
   size = 14,
   className
 }: {
   templateId: string | null
+  /** Persisted custom icon SVG (bundled or uploaded). Takes precedence. */
+  icon?: string | null
   size?: number
   className?: string
 }): React.JSX.Element {
   const normalized = useMemo(() => {
+    if (icon) {
+      const sanitized = sanitizeInlineAgentSvg(icon)
+      if (sanitized) return sanitized
+    }
     if (!templateId) return null
     const svg = findBundledIconByKey(`acp:${templateId}`)?.svg
     return svg ? sanitizeInlineAgentSvg(svg) : null
-  }, [templateId])
+  }, [icon, templateId])
 
   if (normalized) {
     return (

--- a/src/renderer/components/chat/ChatEmptyState.tsx
+++ b/src/renderer/components/chat/ChatEmptyState.tsx
@@ -43,7 +43,7 @@ interface ChatEmptyStateProps {
 /** First-run state for an empty thread: agent identity + clickable starter prompts. */
 export function ChatEmptyState({ agentId, onPick }: ChatEmptyStateProps): React.JSX.Element {
   const reduced = useReducedMotion() ?? false
-  const { name, templateId } = useAgentIdentity(agentId)
+  const { name, templateId, icon } = useAgentIdentity(agentId)
   const transition = (i: number): Transition =>
     reduced ? { duration: 0 } : { ...CHAT_SPRING, delay: 0.04 * i }
 
@@ -56,7 +56,7 @@ export function ChatEmptyState({ agentId, onPick }: ChatEmptyStateProps): React.
         transition={transition(0)}
       >
         <div className="flex size-12 items-center justify-center rounded-2xl bg-secondary/60">
-          <AgentGlyph templateId={templateId} size={24} className="text-foreground" />
+          <AgentGlyph templateId={templateId} icon={icon} size={24} className="text-foreground" />
         </div>
         <div>
           <h2 className="text-base font-semibold text-foreground">

--- a/src/renderer/components/chat/ChatHistoryEntryRow.tsx
+++ b/src/renderer/components/chat/ChatHistoryEntryRow.tsx
@@ -1,6 +1,6 @@
 import { Trash2 } from 'lucide-react'
 import { cn } from '@/lib/utils'
-import { useAgentTemplateId } from '@/stores/acp-store'
+import { useAgentIcon, useAgentTemplateId } from '@/stores/acp-store'
 import { AgentGlyph } from './AgentGlyph'
 
 export interface ChatHistorySidebarEntry {
@@ -26,7 +26,10 @@ function ChatEntryIcon({
   agentConfigId?: string
 }): React.JSX.Element {
   const templateId = useAgentTemplateId(agentId ?? null, agentConfigId)
-  return <AgentGlyph templateId={templateId} size={12} className="text-muted-foreground" />
+  const icon = useAgentIcon(agentId ?? null, agentConfigId)
+  return (
+    <AgentGlyph templateId={templateId} icon={icon} size={12} className="text-muted-foreground" />
+  )
 }
 
 interface ChatHistoryEntryRowProps {

--- a/src/renderer/components/chat/ChatHistoryTab.test.tsx
+++ b/src/renderer/components/chat/ChatHistoryTab.test.tsx
@@ -63,7 +63,8 @@ vi.mock('@/stores/acp-store', () => {
   const configIdFromReuseKey = () => ''
   const discoveryKey = (agentId: string, cwd: string) => `${agentId}\0${cwd}`
   const useAgentTemplateId = () => null
-  return { useAcpStore, agentReuseKey, configIdFromReuseKey, discoveryKey, useAgentTemplateId }
+  const useAgentIcon = () => null
+  return { useAcpStore, agentReuseKey, configIdFromReuseKey, discoveryKey, useAgentTemplateId, useAgentIcon }
 })
 
 vi.mock('@/stores/workspace-store', () => ({

--- a/src/renderer/components/chat/ChatHistoryTab.test.tsx
+++ b/src/renderer/components/chat/ChatHistoryTab.test.tsx
@@ -64,7 +64,14 @@ vi.mock('@/stores/acp-store', () => {
   const discoveryKey = (agentId: string, cwd: string) => `${agentId}\0${cwd}`
   const useAgentTemplateId = () => null
   const useAgentIcon = () => null
-  return { useAcpStore, agentReuseKey, configIdFromReuseKey, discoveryKey, useAgentTemplateId, useAgentIcon }
+  return {
+    useAcpStore,
+    agentReuseKey,
+    configIdFromReuseKey,
+    discoveryKey,
+    useAgentTemplateId,
+    useAgentIcon
+  }
 })
 
 vi.mock('@/stores/workspace-store', () => ({

--- a/src/renderer/components/chat/ChatInputBar.test.tsx
+++ b/src/renderer/components/chat/ChatInputBar.test.tsx
@@ -123,7 +123,7 @@ vi.mock('@/hooks/use-agent-skills', async () => {
 })
 
 vi.mock('@/stores/acp-store', () => ({
-  useAgentIdentity: () => ({ name: 'Cursor', templateId: 'cursor' }),
+  useAgentIdentity: () => ({ name: 'Cursor', templateId: 'cursor', icon: null }),
   useSessionUsage: () => null,
   useAcpMessages: () => [],
   // Story 1.8: ChatInputBar reads the global MCP server count for the read-only

--- a/src/renderer/components/chat/ChatInputBar.tsx
+++ b/src/renderer/components/chat/ChatInputBar.tsx
@@ -154,7 +154,7 @@ export function ChatInputBar({
   const { skills: availableSkills } = useAgentSkills(projectRoot ?? session.cwd)
   const sessionUsage = useSessionUsage(session.id)
   const messages = useAcpMessages(session.id)
-  const { templateId: agentTemplateId } = useAgentIdentity(session.agentId)
+  const { templateId: agentTemplateId, icon: agentIcon } = useAgentIdentity(session.agentId)
   // Prefer project/session-scoped MCP context. Older/local sessions without a
   // recorded count retain the existing global-registry fallback.
   const globalMcpCount = useAcpStore((s) => s.mcpServers.length)
@@ -516,7 +516,12 @@ export function ChatInputBar({
       searchable
       maxVisibleOptions={5}
       leading={
-        <AgentGlyph templateId={agentTemplateId} size={13} className="text-muted-foreground" />
+        <AgentGlyph
+          templateId={agentTemplateId}
+          icon={agentIcon}
+          size={13}
+          className="text-muted-foreground"
+        />
       }
       onSelect={(valueId) =>
         modelSource === 'models' ? onSetModel(valueId) : onSetConfig(modelOption.id, valueId)

--- a/src/renderer/components/settings/AcpAgentsSettings.tsx
+++ b/src/renderer/components/settings/AcpAgentsSettings.tsx
@@ -7,7 +7,8 @@ import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { useAcpRegistryCatalog } from '@/hooks/use-acp-registry-catalog'
 import { useResolvedSupportedAcpAgents } from '@/hooks/use-resolved-supported-acp-agents'
-import { findBundledIconByKey, normalizeIconSvg } from '@/lib/agents/agent-icon-catalog'
+import { findBundledIconByKey } from '@/lib/agents/agent-icon-catalog'
+import { sanitizeInlineAgentSvg } from '@/lib/agents/sanitize-agent-icon'
 import {
   filterSupportedAcpAgents,
   isCustomAgentEntry,
@@ -18,16 +19,22 @@ import { logFrontendError } from '@/lib/log-api'
 import { cn } from '@/lib/utils'
 import { useAcpStore, useConfigWarmState } from '@/stores/acp-store'
 
-/** Render a bundled SVG icon string inline (theme-aware via currentColor). */
+/** Render a sanitized SVG icon string inline (theme-aware via currentColor). */
 function InlineIcon({ svg }: { svg: string }): React.JSX.Element {
+  const sanitized = useMemo(() => sanitizeInlineAgentSvg(svg), [svg])
   return (
     <span
       aria-hidden="true"
       className="inline-flex h-5 w-5 shrink-0 text-foreground/80 [&_svg]:h-full [&_svg]:w-full"
-      // biome-ignore lint/security/noDangerouslySetInnerHtml: icon SVG is sanitized via normalizeIconSvg (DOMPurify)
-      dangerouslySetInnerHTML={{ __html: normalizeIconSvg(svg) }}
+      // biome-ignore lint/security/noDangerouslySetInnerHtml: icon SVG is sanitized via sanitizeInlineAgentSvg (DOMPurify)
+      dangerouslySetInnerHTML={{ __html: sanitized ?? '' }}
     />
   )
+}
+
+/** True when the SVG sanitizes to a non-null value (safe to render). */
+function iconSanitizesOk(svg: string): boolean {
+  return sanitizeInlineAgentSvg(svg) !== null
 }
 
 function AgentPathEditor({ entry }: { entry: SupportedAcpAgentEntry }): React.JSX.Element | null {
@@ -143,6 +150,8 @@ interface AgentRowProps {
 function AgentRow({ entry }: AgentRowProps): React.JSX.Element {
   const warmState = useConfigWarmState(entry.configId)
   const iconEntry = useMemo(() => findBundledIconByKey(`acp:${entry.agent.id}`), [entry.agent.id])
+  // Prefer a persisted custom icon (bundled or uploaded) over the catalog.
+  const customIcon = entry.config?.icon
 
   const statusBadge: { label: string; tone: 'ready' | 'muted' | 'warn' } = warmState.sessionReady
     ? { label: 'Session ready', tone: 'ready' }
@@ -189,7 +198,9 @@ function AgentRow({ entry }: AgentRowProps): React.JSX.Element {
   return (
     <div className="flex items-start gap-3 rounded-md border border-border/60 px-3 py-2.5">
       <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-md bg-muted">
-        {iconEntry ? (
+        {customIcon && iconSanitizesOk(customIcon) ? (
+          <InlineIcon svg={customIcon} />
+        ) : iconEntry ? (
           <InlineIcon svg={iconEntry.svg} />
         ) : (
           <span className="text-xs font-semibold uppercase text-muted-foreground">

--- a/src/renderer/lib/acp-agents-persistence.test.ts
+++ b/src/renderer/lib/acp-agents-persistence.test.ts
@@ -167,6 +167,39 @@ describe('load/save agent configs', () => {
     expect(loaded[0].configId).toBe('custom-honored')
   })
 
+  it('preserves a string icon on load and drops non-string icon to undefined', async () => {
+    const svg = '<svg viewBox="0 0 16 16"><circle cx="8" cy="8" r="4"/></svg>'
+    const stored = [
+      {
+        id: 'custom-1',
+        configId: 'custom-1',
+        name: 'A',
+        command: 'node',
+        args: [],
+        env: {},
+        icon: svg
+      },
+      {
+        id: 'custom-2',
+        configId: 'custom-2',
+        name: 'B',
+        command: 'node',
+        args: [],
+        env: {},
+        icon: 123
+      },
+      { id: 'custom-3', configId: 'custom-3', name: 'C', command: 'node', args: [], env: {} }
+    ]
+    ;(persistenceApi.read as ReturnType<typeof vi.fn>).mockResolvedValue({
+      success: true,
+      data: stored
+    })
+    const loaded = await loadAgentConfigs()
+    expect(loaded[0].icon).toBe(svg)
+    expect(loaded[1].icon).toBeUndefined()
+    expect(loaded[2].icon).toBeUndefined()
+  })
+
   it('writes under the dedicated key and throws on failure', async () => {
     ;(persistenceApi.write as ReturnType<typeof vi.fn>).mockResolvedValue({ success: true })
     await saveAgentConfigs([])

--- a/src/renderer/lib/acp-agents-persistence.ts
+++ b/src/renderer/lib/acp-agents-persistence.ts
@@ -17,6 +17,8 @@ export interface StoredAgentConfig extends AgentConfig {
   id: string
   /** The template id this agent was created from (used to resolve an icon). */
   templateId?: string
+  /** Inline SVG markup for a custom (bundled or uploaded) agent icon. */
+  icon?: string
 }
 
 export interface AgentConfigValidation {
@@ -109,6 +111,7 @@ export async function loadAgentConfigs(): Promise<StoredAgentConfig[]> {
         Object.values(cfg.env).every((v) => typeof v === 'string')
           ? (cfg.env as Record<string, string>)
           : {}
+      const icon = typeof cfg.icon === 'string' ? cfg.icon : undefined
       return {
         ...cfg,
         id,
@@ -117,6 +120,7 @@ export async function loadAgentConfigs(): Promise<StoredAgentConfig[]> {
         configId,
         args,
         env,
+        icon,
         allowTerminal: typeof cfg.allowTerminal === 'boolean' ? cfg.allowTerminal : false
       }
     })

--- a/src/renderer/stores/acp-store.test.ts
+++ b/src/renderer/stores/acp-store.test.ts
@@ -5195,7 +5195,7 @@ describe('acp-store multi-project isolation', () => {
       configToLiveAgent: { ...s.configToLiveAgent, [agentReuseKey('cfg-1', '/b')]: 'agent-b' }
     }))
     const identity = selectAgentIdentity(useAcpStore.getState(), 'agent-b')
-    expect(identity).toEqual({ name: 'Claude', templateId: 'claude-acp' })
+    expect(identity).toEqual({ name: 'Claude', templateId: 'claude-acp', icon: null })
   })
 
   it('selectAgentIdentity falls back to sessionIndex agentConfigId when live map is cold', async () => {
@@ -5225,7 +5225,7 @@ describe('acp-store multi-project isolation', () => {
       ]
     })
     const identity = selectAgentIdentity(useAcpStore.getState(), 'agent-hist')
-    expect(identity).toEqual({ name: 'Cursor', templateId: 'cursor' })
+    expect(identity).toEqual({ name: 'Cursor', templateId: 'cursor', icon: null })
   })
 
   it('agent_error with session_id sets lastError on that session', () => {

--- a/src/renderer/stores/acp-store.ts
+++ b/src/renderer/stores/acp-store.ts
@@ -5941,16 +5941,18 @@ export interface AgentIdentity {
   name: string | null
   /** Template id used to resolve the agent icon, when known. */
   templateId: string | null
+  /** Persisted custom icon SVG (bundled or uploaded), when present. */
+  icon: string | null
 }
 
 /**
- * Resolve the configured agent's display name + template (for icon) behind a
- * live session, via the configToLiveAgent mapping. Falls back to the session
+ * Resolve the configured agent's display name + template + custom icon behind
+ * a live session, via the configToLiveAgent mapping. Falls back to the session
  * index `agentConfigId` when the live map is cold (history reopen / empty
  * state) so `AgentGlyph` still resolves the registry icon instead of Bot.
  */
 export function selectAgentIdentity(state: AcpState, agentId: AgentId | null): AgentIdentity {
-  if (!agentId) return { name: null, templateId: null }
+  if (!agentId) return { name: null, templateId: null, icon: null }
   const reuseKey = Object.keys(state.configToLiveAgent).find(
     (k) => state.configToLiveAgent[k] === agentId
   )
@@ -5960,7 +5962,11 @@ export function selectAgentIdentity(state: AcpState, agentId: AgentId | null): A
     configId = indexed?.agentConfigId
   }
   const config = configId ? state.agentConfigs.find((c) => c.id === configId) : undefined
-  return { name: config?.name ?? null, templateId: config?.templateId ?? null }
+  return {
+    name: config?.name ?? null,
+    templateId: config?.templateId ?? null,
+    icon: config?.icon ?? null
+  }
 }
 
 export const useAgentIdentity = (agentId: AgentId | null): AgentIdentity =>
@@ -5978,6 +5984,28 @@ export function useAgentTemplateId(agentId: AgentId | null, agentConfigId?: stri
         if (config?.templateId) return config.templateId
       }
       return selectAgentIdentity(s, agentId).templateId
+    })
+  )
+}
+
+/**
+ * Resolve an agent's persisted custom icon (bundled or uploaded) by
+ * `agentConfigId` (from a history entry) when the agent isn't live. Falls
+ * back to `useAgentIdentity` for live sessions. Returns null when no custom
+ * icon is set (the caller should fall back to the bundled catalog).
+ */
+export function useAgentIcon(agentId: AgentId | null, agentConfigId?: string): string | null {
+  return useAcpStore(
+    useShallow((s) => {
+      if (agentConfigId) {
+        const config = s.agentConfigs.find((c) => c.id === agentConfigId)
+        if (config?.icon) return config.icon
+        // Config found but no icon — short-circuit to null so we don't
+        // redundantly scan configToLiveAgent + agentConfigs again via
+        // selectAgentIdentity when the result would be the same null.
+        if (config) return null
+      }
+      return selectAgentIdentity(s, agentId).icon
     })
   )
 }


### PR DESCRIPTION
## Summary

<!-- Describe what this PR does and WHY. Not just what changed — explain the real problem this solves. -->

Two enhancements to the Custom ACP Agent dialog:

1. **Zed-style paste format normalization** — The paste parser now detects and unwraps the de-facto Zed-style `agent_servers` map wrapper (and JetBrains/VS Code/acpx variants) so pasted configs Just Work without manual unwrapping. Supports nested and dotted `acp.agents`, multi-key Zed settings files, silently drops Zed session-preference fields, rejects multi-entry and `type:"registry"`/`"extension"` entries. Bare single-entry objects stay accepted (backward compat).

2. **Custom agent icon (bundled or uploaded)** — `IconPicker` extended with an upload affordance (hidden file input + FileReader + 64KB cap + DOMPurify sanitize). `icon?: string` on `StoredAgentConfig` only (never on wire `AgentConfig`/Rust struct). Icon flows through all ACP surfaces: `AgentGlyph` (chat tabs, history, badges, empty state, model picker), `EntryGlyph` (launcher), `AgentRow` (settings). All uploaded-SVG paths switched to `sanitizeInlineAgentSvg` (DOMPurify) for untrusted-SVG safety.

## Related Issue

No related issue. The paste-format work was driven by research at `_bmad-output/planning-artifacts/research/technical-acp-custom-agent-server-config-2026-08-22/research.md`; icon support was a user request.

## Type of Change

- [x] feat: new feature

## What Changed

- `src/renderer/lib/acp-agents-persistence.ts` — ADD `icon?: string` to `StoredAgentConfig`; `loadAgentConfigs` preserves string `icon`, drops non-string to `undefined`
- `src/renderer/components/agents/IconPicker.tsx` — Upload affordance (hidden file input + trigger button + FileReader + 64KB cap + sanitizeInlineAgentSvg); `InlineIcon` switched to `sanitizeInlineAgentSvg`; custom-SVG trigger display
- `src/renderer/components/agents/CustomAcpAgentDialog.tsx` — Map-unwrap pre-step (4 client variants + dotted key + multi-key settings); `icon` in allowed fields; `IconPicker` in dialog; `exportAgentConfig` includes `icon`; icon-clearing fix (`iconTouched` sentinel); pasted-icon ingress sanitize + size cap; picker sync from pasted JSON
- `src/renderer/stores/acp-store.ts` — `AgentIdentity` gains `icon: string | null`; `selectAgentIdentity` resolves `icon`; new `useAgentIcon` hook with short-circuit
- `src/renderer/components/chat/AgentGlyph.tsx` — `icon?: string | null` prop; resolution: icon → catalog → `<Bot>`
- `src/renderer/components/agents/AgentLauncher.tsx` — `EntryGlyph`: `config?.icon` first, then catalog, then letter-initial
- `src/renderer/components/settings/AcpAgentsSettings.tsx` — `AgentRow`: `entry.config?.icon` first with corrupt-icon fallback; `InlineIcon` switched to `sanitizeInlineAgentSvg`
- `src/renderer/components/chat/AgentBadge.tsx`, `ChatEmptyState.tsx`, `ChatInputBar.tsx` — Destructure `icon` from `useAgentIdentity`
- `src/renderer/components/chat/ChatHistoryEntryRow.tsx`, `ProjectChatList.tsx` — `useAgentIcon` + pass `icon` to `AgentGlyph`
- Tests: 12 new dialog tests, 6 new IconPicker tests, 1 new persistence test, 2 updated store tests, 2 updated consumer test mocks

## How It Was Tested

- [x] `bun run ci` (Biome lint + format + imports, strict mode)
- [x] `bun run typecheck`
- [x] `bun run test`
- [x] `cargo clippy --all-targets -- -D warnings` (in src-tauri)
- [ ] `cargo test` (in src-tauri) — no Rust changes; clippy confirms compilation
- [x] Manual verification completed

## Screenshots or Recordings

<!-- Required for UI changes when applicable -->

## CI & Review Gate

- [ ] All CI checks pass (PR Validation, Rust Checks, Build Verification, Security Scans)
- [ ] Code review comments from CodeRabbit / Claude have been addressed or resolved
- [ ] No unresolved review findings remain

## Checklist

- [x] My PR title follows the conventional commit format used by this repo
- [x] I linked the related issue or explained why none exists
- [x] I updated docs when needed
- [x] I added or updated tests when needed
- [x] I verified the change does not introduce unrelated modifications
- [x] I read AGENTS.md and followed the contributor guidelines
- [x] A human reviewed the complete diff before submission

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for custom SVG icons for ACP agents.
  * Added an icon picker for uploading and selecting agent icons.
  * Custom icons now appear consistently across chat history, empty states, input controls, launchers, and settings.
  * Added support for importing compatible agent configurations with validation and icon handling.

* **Bug Fixes**
  * Invalid, oversized, or unsafe SVG icons are rejected safely.
  * Updated several bundled ACP agent versions and download sources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->