### PR TITLE
feat(acp): lazy-load chat history tail-first on resume

### DIFF
--- a/src-tauri/src/acp/chat_history_store.rs
+++ b/src-tauri/src/acp/chat_history_store.rs
@@ -201,6 +201,7 @@ impl ChatHistoryStore {
             return Ok(payload);
         }
         let tail = messages.split_off(messages.len() - limit);
+        let tail_len = tail.len();
         let oldest_tail_seq = tail
             .iter()
             .filter_map(|m| m.get("seq").and_then(|s| s.as_u64()))
@@ -211,9 +212,7 @@ impl ChatHistoryStore {
         if let Some(metadata) = result.get_mut("metadata").and_then(|m| m.as_object_mut()) {
             metadata.insert(
                 "messageCount".to_string(),
-                serde_json::Value::Number(
-                    serde_json::Number::from(messages.len().min(limit)),
-                ),
+                serde_json::Value::Number(serde_json::Number::from(tail_len)),
             );
         }
         if let Some(tool_calls) = result

--- a/src-tauri/src/acp/chat_history_store.rs
+++ b/src-tauri/src/acp/chat_history_store.rs
@@ -185,6 +185,50 @@ impl ChatHistoryStore {
         Ok(file.payload)
     }
 
+    /// Tail-first variant of [`get`]: reads the full payload (same I/O), then
+    /// keeps only the last `limit` messages + the tool calls whose `seq` falls
+    /// within the tail message range. Returns the same `Value` shape so the
+    /// renderer can consume it identically to a full payload. The metadata's
+    /// `messageCount` reflects the tail slice.
+    pub fn get_tail(&self, session_id: &str, limit: usize) -> Result<Value> {
+        let payload = self.get(session_id)?;
+        let mut messages = payload
+            .get("messages")
+            .and_then(|m| m.as_array())
+            .cloned()
+            .unwrap_or_default();
+        if messages.len() <= limit {
+            return Ok(payload);
+        }
+        let tail = messages.split_off(messages.len() - limit);
+        let oldest_tail_seq = tail
+            .iter()
+            .filter_map(|m| m.get("seq").and_then(|s| s.as_u64()))
+            .min()
+            .unwrap_or(0);
+        let mut result = payload;
+        result["messages"] = serde_json::Value::Array(tail);
+        if let Some(metadata) = result.get_mut("metadata").and_then(|m| m.as_object_mut()) {
+            metadata.insert(
+                "messageCount".to_string(),
+                serde_json::Value::Number(
+                    serde_json::Number::from(messages.len().min(limit)),
+                ),
+            );
+        }
+        if let Some(tool_calls) = result
+            .get_mut("toolCalls")
+            .and_then(|t| t.as_array_mut())
+        {
+            tool_calls.retain(|tc| {
+                tc.get("seq")
+                    .and_then(|s| s.as_u64())
+                    .is_some_and(|seq| seq >= oldest_tail_seq)
+            });
+        }
+        Ok(result)
+    }
+
     /// Server-authoritative replay cursor (R2): the highest persisted event
     /// `seq` for a session, so a refreshed transport can seed `lastSeq` from
     /// the backend before subscribing (instead of a dead per-instance cursor).

--- a/src-tauri/src/acp/session_persistence.rs
+++ b/src-tauri/src/acp/session_persistence.rs
@@ -836,6 +836,25 @@ impl SessionPersistence {
         ))
     }
 
+    /// Tail-first variant of [`session_payload_async`]: materialize the full
+    /// payload (same flush + replay), then keep only the last `limit` messages.
+    /// Used by the lazy-load chat history path so the renderer can install the
+    /// recent transcript immediately and fetch the full payload on scroll-up.
+    /// The metadata's `messageCount` reflects the tail slice (not the full
+    /// session), so the renderer knows how many messages it received.
+    pub async fn session_payload_tail_async(
+        self: &Arc<Self>,
+        session_id: &str,
+        limit: usize,
+    ) -> Result<crate::acp::session_payload::MaterializedSessionPayload> {
+        let mut payload = self.session_payload_async(session_id).await?;
+        if payload.messages.len() > limit {
+            payload.messages = payload.messages.split_off(payload.messages.len() - limit);
+            payload.metadata.message_count = payload.messages.len() as u64;
+        }
+        Ok(payload)
+    }
+
     /// Completed client turn ids reconstructed from durable prompt-complete
     /// records. This survives restart without treating arbitrary browser input
     /// as authoritative transcript state.

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -3803,6 +3803,57 @@ pub async fn acp_history_get(
     }
 }
 
+/// Tail-first variant of [`acp_history_get`]: fetches only the last `limit`
+/// messages + matching tool calls so the renderer can install the recent
+/// transcript immediately and lazy-load the full payload on scroll-up.
+/// `limit` is clamped to `[1, 500]` (defensive bounds — the live window is
+/// 300, and a tail fetch larger than the full payload is pointless).
+/// Mirrors `acp_history_get` but calls `session_payload_tail_async`.
+#[tauri::command]
+pub async fn acp_history_get_tail(
+    session_id: String,
+    limit: Option<u32>,
+    host: State<'_, HostHistoryStore>,
+) -> Result<IpcResult<Option<serde_json::Value>>, String> {
+    let log_session_id = sanitize_log_field(&session_id);
+    let limit = limit.unwrap_or(50).clamp(1, 500) as usize;
+    log::info!(
+        "[acp-history] get_tail start session_id={} limit={}",
+        log_session_id,
+        limit
+    );
+    let Some(persistence) = host.0.as_ref().map(Arc::clone) else {
+        log::info!("[acp-history] get_tail not_found session_id={}", log_session_id);
+        return Ok(IpcResult::success(None));
+    };
+    match persistence.session_payload_tail_async(&session_id, limit).await {
+        Ok(payload) => {
+            log::info!(
+                "[acp-history] get_tail success session_id={} messages={}",
+                log_session_id,
+                payload.messages.len()
+            );
+            let value = serde_json::to_value(&payload).map_err(|error| error.to_string())?;
+            Ok(IpcResult::success(Some(value)))
+        }
+        Err(crate::acp::SessionPersistenceError::SessionNotFound) => {
+            log::info!("[acp-history] get_tail not_found session_id={}", log_session_id);
+            Ok(IpcResult::success(None))
+        }
+        Err(error) => {
+            log::error!(
+                "[acp-history] get_tail failure session_id={} error={}",
+                log_session_id,
+                error
+            );
+            Ok(IpcResult::error(
+                error.to_string(),
+                "ACP_HISTORY_GET_FAILED",
+            ))
+        }
+    }
+}
+
 /// Legacy write path (renderer wipe-migration only). Live sessions are authored
 /// by the host event/session layer and never flow through this command. The
 /// payload lands in the legacy `ChatHistoryStore`; the incremental host import

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1650,6 +1650,7 @@ pub fn run() {
             commands::acp_history_list,
             commands::acp_history_get,
             commands::acp_history_save,
+            commands::acp_history_get_tail,
             commands::acp_history_delete,
             commands::acp_history_flush,
             commands::acp_history_mark_legacy_import_complete,

--- a/src-tauri/src/web/ws.rs
+++ b/src-tauri/src/web/ws.rs
@@ -1081,6 +1081,9 @@ async fn handle_request(
         "get_session_payload" => {
             handle_get_session_payload(id, &req.payload, relay, history_mode).await
         }
+        "get_session_payload_tail" => {
+            handle_get_session_payload_tail(id, &req.payload, relay, history_mode).await
+        }
         "recover_session_snapshot" => {
             handle_recover_session_snapshot(
                 id,
@@ -1402,6 +1405,75 @@ async fn handle_get_session_payload(
                         id,
                         WsErrorCode::Unsupported,
                         "failed to read session payload",
+                    )
+                }
+            }
+        }
+        None => WsReply::err(id, WsErrorCode::NotFound, "session payload not found"),
+    }
+}
+
+/// `get_session_payload_tail` — tail-first variant of `get_session_payload`.
+/// Fetches only the last `limit` messages + matching tool calls so the
+/// renderer can install the recent transcript immediately and lazy-load the
+/// full payload on scroll-up. Mirrors `handle_get_session_payload` but calls
+/// `session_payload_tail_async`.
+async fn handle_get_session_payload_tail(
+    id: String,
+    payload: &Value,
+    relay: &Arc<WsRelaySink>,
+    history_mode: HistoryMode,
+) -> WsReply {
+    if history_mode != HistoryMode::Server {
+        return WsReply::err(
+            id,
+            WsErrorCode::Unsupported,
+            "persisted history is unavailable",
+        );
+    }
+    #[derive(Debug, Deserialize)]
+    #[serde(rename_all = "camelCase")]
+    struct GetSessionPayloadTailRequest {
+        session_id: String,
+        limit: Option<u32>,
+    }
+    let parsed: GetSessionPayloadTailRequest = match serde_json::from_value(payload.clone()) {
+        Ok(p) => p,
+        Err(e) => {
+            return WsReply::err(
+                id,
+                WsErrorCode::Unsupported,
+                format!("malformed get_session_payload_tail payload (want sessionId, limit?): {e}"),
+            )
+        }
+    };
+    let limit = parsed.limit.unwrap_or(50).clamp(1, 500) as usize;
+    match relay.persistence() {
+        Some(persistence) => {
+            match persistence.session_payload_tail_async(&parsed.session_id, limit).await {
+                Ok(payload) => {
+                    tracing::debug!(
+                        target: "termul::web::ws",
+                        session_id = %parsed.session_id,
+                        messages = payload.messages.len(),
+                        "get_session_payload_tail: materialized host tail payload"
+                    );
+                    ok_with_payload(id, &payload)
+                }
+                Err(crate::acp::SessionPersistenceError::SessionNotFound) => {
+                    WsReply::err(id, WsErrorCode::NotFound, "session payload not found")
+                }
+                Err(error) => {
+                    tracing::warn!(
+                        target: "termul::web::ws",
+                        session_id = %parsed.session_id,
+                        error = %error,
+                        "get_session_payload_tail: host tail materialization failed"
+                    );
+                    WsReply::err(
+                        id,
+                        WsErrorCode::Unsupported,
+                        "failed to read session payload tail",
                     )
                 }
             }

--- a/src/renderer/lib/acp-history-api.ts
+++ b/src/renderer/lib/acp-history-api.ts
@@ -27,6 +27,11 @@ export const acpHistoryApi = {
     return invokeHistory<SessionPayload | null>('acp_history_get', { sessionId })
   },
 
+  /** Tail-first variant of `get`: fetches only the last `limit` messages. */
+  getTail(sessionId: string, limit: number): Promise<SessionPayload | null> {
+    return invokeHistory<SessionPayload | null>('acp_history_get_tail', { sessionId, limit })
+  },
+
   /** Legacy-store reads for the one-time KV wipe migration only. */
   listLegacy(): Promise<DesktopHistoryListResult> {
     return invokeHistory<DesktopHistoryListResult>('acp_history_list_legacy')

--- a/src/renderer/lib/acp-history-persistence.ts
+++ b/src/renderer/lib/acp-history-persistence.ts
@@ -577,7 +577,7 @@ export async function loadSessionPayloadTail(
       toolCalls: cached.toolCalls?.filter(
         (tc) =>
           typeof tc.seq !== 'number' ||
-          tc.seq >= (cached.messages[tailStart]?.seq ?? 0)
+          tc.seq >= (cached.messages[tailStart]?.seq ?? Infinity)
       )
     }
   }

--- a/src/renderer/lib/acp-history-persistence.ts
+++ b/src/renderer/lib/acp-history-persistence.ts
@@ -12,6 +12,11 @@ export const SESSION_INDEX_KEY = 'acp/sessions/index'
 export const WIPE_MIGRATION_KEY = 'acp/sessions/migrated-v2'
 export const INACTIVE_PAYLOAD_CACHE_BUDGET = 3
 
+/** Default tail message count for lazy-load chat history open. Smaller than
+ * `MAX_LIVE_WINDOW_MESSAGES` (300) — only the recent transcript is needed
+ * for the user to read + chat; the full payload loads on scroll-up. */
+export const HISTORY_TAIL_MESSAGE_LIMIT = 50
+
 export function sessionPayloadKey(id: string): string {
   return `acp/sessions/${id}`
 }
@@ -543,6 +548,47 @@ export async function loadSessionPayload(id: string): Promise<SessionPayload | n
   const payload = await acpHistoryApi.get(id)
   if (payload) touchPayload(id, payload)
   return payload
+}
+
+/**
+ * Tail-first variant of {@link loadSessionPayload}: fetches only the last
+ * `limit` messages + matching tool calls so the renderer can install the
+ * recent transcript immediately and lazy-load the full payload on scroll-up.
+ *
+ * Cache-first: if the full payload is already cached (instant second open),
+ * slices the tail from it — no IPC. Otherwise fetches via the transport/API
+ * tail method. NEVER writes to `payloadCache` — the cache is for full
+ * payloads only, and `loadOlderMessages` expects to find (or fetch) the full
+ * payload on a cache miss.
+ */
+export async function loadSessionPayloadTail(
+  id: string,
+  limit: number = HISTORY_TAIL_MESSAGE_LIMIT
+): Promise<SessionPayload | null> {
+  // Cache-first: slice the tail from a cached full payload (instant re-open).
+  const cached = payloadCache.get(id)
+  if (cached) {
+    touchPayload(id, cached)
+    if (cached.messages.length <= limit) return cached
+    const tailStart = cached.messages.length - limit
+    return {
+      ...cached,
+      messages: cached.messages.slice(tailStart),
+      toolCalls: cached.toolCalls?.filter(
+        (tc) =>
+          typeof tc.seq !== 'number' ||
+          tc.seq >= (cached.messages[tailStart]?.seq ?? 0)
+      )
+    }
+  }
+  // Transport tail (web/remote) → API tail (desktop) → null.
+  const transport = getAcpTransport()
+  const mode = transport.historyMode?.()
+  if (mode === 'server' && transport.getSessionPayloadTail) {
+    return transport.getSessionPayloadTail(id, limit)
+  }
+  if (mode === 'live_only') return null
+  return acpHistoryApi.getTail(id, limit)
 }
 
 export async function saveSessionPayload(id: string, payload: SessionPayload): Promise<void> {

--- a/src/renderer/lib/acp-history-persistence.ts
+++ b/src/renderer/lib/acp-history-persistence.ts
@@ -576,8 +576,7 @@ export async function loadSessionPayloadTail(
       messages: cached.messages.slice(tailStart),
       toolCalls: cached.toolCalls?.filter(
         (tc) =>
-          typeof tc.seq !== 'number' ||
-          tc.seq >= (cached.messages[tailStart]?.seq ?? Infinity)
+          typeof tc.seq !== 'number' || tc.seq >= (cached.messages[tailStart]?.seq ?? Infinity)
       )
     }
   }

--- a/src/renderer/lib/acp-transport.ts
+++ b/src/renderer/lib/acp-transport.ts
@@ -51,6 +51,7 @@ import type {
   SpawnAgentResult,
   StopReason
 } from '@/lib/acp-api'
+import type { SessionPayload } from '@/lib/acp-history-persistence'
 import type { AcpRuntimeAvailability } from '@/lib/agents/supported-acp-agents'
 import { logFrontendError } from '@/lib/log-api'
 import { isTauriContext } from '@/lib/tauri-runtime'
@@ -179,9 +180,9 @@ export interface AcpTransport {
   listPersistedSessions?(): Promise<PersistedSessionSummary[]>
   openPersistedSession?(sessionId: SessionId, lastSeq?: number): Promise<void>
   /** Web/remote: fetch the full stored transcript for a session (server mode). */
-  getSessionPayload?(
-    sessionId: SessionId
-  ): Promise<import('@/lib/acp-history-persistence').SessionPayload | null>
+  getSessionPayload?(sessionId: SessionId): Promise<SessionPayload | null>
+  /** Tail-first variant of `getSessionPayload`: fetches only the last `limit` messages. */
+  getSessionPayloadTail?(sessionId: SessionId, limit: number): Promise<SessionPayload | null>
   onEvent<T>(eventName: string, callback: (payload: T) => void): () => void
   /** Web: open socket + placeholder authenticate. No-op on Tauri. */
   connect(): Promise<void>
@@ -777,15 +778,27 @@ export class WsAcpTransport implements AcpTransport {
 
   async getSessionPayload(
     sessionId: SessionId
-  ): Promise<import('@/lib/acp-history-persistence').SessionPayload | null> {
+  ): Promise<SessionPayload | null> {
     try {
-      return await this.request<import('@/lib/acp-history-persistence').SessionPayload>(
-        'get_session_payload',
-        { sessionId }
-      )
+      return await this.request<SessionPayload>('get_session_payload', { sessionId })
     } catch (err) {
       // `not_found` → the session is absent from the cache (web shows "chat
       // unavailable"); other errors propagate.
+      if (err instanceof AcpTransportError && err.code === 'not_found') return null
+      throw err
+    }
+  }
+
+  async getSessionPayloadTail(
+    sessionId: SessionId,
+    limit: number
+  ): Promise<SessionPayload | null> {
+    try {
+      return await this.request<SessionPayload>('get_session_payload_tail', {
+        sessionId,
+        limit
+      })
+    } catch (err) {
       if (err instanceof AcpTransportError && err.code === 'not_found') return null
       throw err
     }

--- a/src/renderer/lib/acp-transport.ts
+++ b/src/renderer/lib/acp-transport.ts
@@ -776,9 +776,7 @@ export class WsAcpTransport implements AcpTransport {
     await this.request('open_persisted_session', { sessionId, lastSeq })
   }
 
-  async getSessionPayload(
-    sessionId: SessionId
-  ): Promise<SessionPayload | null> {
+  async getSessionPayload(sessionId: SessionId): Promise<SessionPayload | null> {
     try {
       return await this.request<SessionPayload>('get_session_payload', { sessionId })
     } catch (err) {
@@ -789,10 +787,7 @@ export class WsAcpTransport implements AcpTransport {
     }
   }
 
-  async getSessionPayloadTail(
-    sessionId: SessionId,
-    limit: number
-  ): Promise<SessionPayload | null> {
+  async getSessionPayloadTail(sessionId: SessionId, limit: number): Promise<SessionPayload | null> {
     try {
       return await this.request<SessionPayload>('get_session_payload_tail', {
         sessionId,

--- a/src/renderer/stores/acp-store.test.ts
+++ b/src/renderer/stores/acp-store.test.ts
@@ -42,7 +42,11 @@ vi.mock('@/lib/acp-history-persistence', async (orig) => {
     // Read-through the module-level cache so tests can seed payloads via
     // setCachedSessionPayload (preferred over per-test mockResolvedValue).
     loadSessionPayload: vi.fn(async (id: string) => actual.getCachedSessionPayload(id) ?? null),
-    deleteSessionPayload: vi.fn(async () => {})
+    // Tail-first: the store calls `loadSessionPayloadTail` first, then falls
+    // back to `loadSessionPayload`. Mock both to the same cache-backed fn so
+    // per-test `mockResolvedValueOnce` on `loadSessionPayload` still fires
+    // (the tail mock returns null when no cache is seeded → fallback runs).
+    loadSessionPayloadTail: vi.fn(async () => null),
   }
 })
 vi.mock('@/lib/acp-mcp-persistence', async (orig) => {

--- a/src/renderer/stores/acp-store.test.ts
+++ b/src/renderer/stores/acp-store.test.ts
@@ -46,7 +46,7 @@ vi.mock('@/lib/acp-history-persistence', async (orig) => {
     // back to `loadSessionPayload`. Mock both to the same cache-backed fn so
     // per-test `mockResolvedValueOnce` on `loadSessionPayload` still fires
     // (the tail mock returns null when no cache is seeded → fallback runs).
-    loadSessionPayloadTail: vi.fn(async () => null),
+    loadSessionPayloadTail: vi.fn(async () => null)
   }
 })
 vi.mock('@/lib/acp-mcp-persistence', async (orig) => {

--- a/src/renderer/stores/acp-store.ts
+++ b/src/renderer/stores/acp-store.ts
@@ -89,6 +89,7 @@ import {
   getCachedSessionPayload,
   loadSessionIndex as loadSessionIndexFromDisk,
   loadSessionPayload,
+  loadSessionPayloadTail,
   markSessionPayloadPinned,
   maxPayloadSeq,
   queueSessionPayloadDelete,
@@ -2251,7 +2252,12 @@ async function openHistorySessionInner(
     })
   }
 
-  const payload = await loadSessionPayload(id)
+  // Tail-first: fetch only the recent messages so the pane shows the
+  // conversation immediately. The full payload loads lazily on scroll-up
+  // via `loadOlderMessages`. Falls back to the full `loadSessionPayload`
+  // on tail-fetch failure (no regression vs. the previous behavior).
+  let payload = await loadSessionPayloadTail(id).catch(() => null)
+  if (!payload) payload = await loadSessionPayload(id)
   if (!isCurrentSessionReopen(id, reopenGeneration)) return
   if (!payload) throw new Error(`no persisted history for ${id}`)
   const meta = payload.metadata
@@ -4018,7 +4024,11 @@ export const useAcpStore = create<AcpState>((set, get) => ({
     // on refresh. The backend `gate_resume_session` enforces the capability
     // (reused — not duplicated); a rejection rejects here so the bootstrap hook
     // can record `acp-resume-skipped` and keep the transcript read-only.
-    const payload = await loadSessionPayload(id)
+    // Tail-first: fetch only the recent messages for fast resume. The full
+    // payload loads lazily on scroll-up via `loadOlderMessages`. Falls back
+    // to the full `loadSessionPayload` on tail-fetch failure.
+    let payload = await loadSessionPayloadTail(id).catch(() => null)
+    if (!payload) payload = await loadSessionPayload(id)
     if (!payload) throw new Error(`no persisted history for ${id}`)
     const meta = payload.metadata
     rebaseSeqCounter(maxPayloadSeq(payload))

--- a/src/renderer/stores/acp-store.ts
+++ b/src/renderer/stores/acp-store.ts
@@ -2255,8 +2255,14 @@ async function openHistorySessionInner(
   // Tail-first: fetch only the recent messages so the pane shows the
   // conversation immediately. The full payload loads lazily on scroll-up
   // via `loadOlderMessages`. Falls back to the full `loadSessionPayload`
-  // on tail-fetch failure (no regression vs. the previous behavior).
-  let payload = await loadSessionPayloadTail(id).catch(() => null)
+  let payload = await loadSessionPayloadTail(id).catch((err) => {
+    void logFrontendError({
+      level: 'warn',
+      source: 'acp.openHistorySession.tailFetch',
+      message: `Tail fetch failed for session ${id}, falling back to full load: ${String(err)}`
+    })
+    return null
+  })
   if (!payload) payload = await loadSessionPayload(id)
   if (!isCurrentSessionReopen(id, reopenGeneration)) return
   if (!payload) throw new Error(`no persisted history for ${id}`)
@@ -4026,8 +4032,14 @@ export const useAcpStore = create<AcpState>((set, get) => ({
     // can record `acp-resume-skipped` and keep the transcript read-only.
     // Tail-first: fetch only the recent messages for fast resume. The full
     // payload loads lazily on scroll-up via `loadOlderMessages`. Falls back
-    // to the full `loadSessionPayload` on tail-fetch failure.
-    let payload = await loadSessionPayloadTail(id).catch(() => null)
+    let payload = await loadSessionPayloadTail(id).catch((err) => {
+      void logFrontendError({
+        level: 'warn',
+        source: 'acp.resumeLiveSession.tailFetch',
+        message: `Tail fetch failed for session ${id}, falling back to full load: ${String(err)}`
+      })
+      return null
+    })
     if (!payload) payload = await loadSessionPayload(id)
     if (!payload) throw new Error(`no persisted history for ${id}`)
     const meta = payload.metadata

--- a/src/shared/types/web-protocol.types.test.ts
+++ b/src/shared/types/web-protocol.types.test.ts
@@ -58,8 +58,8 @@ describe('web-protocol.types — event/request type registries (AC2)', () => {
     expect(WS_REQUEST_TYPES).toContain('get_session_payload')
   })
 
-  it('exports exactly 36 request types including discovered-session promotion', () => {
-    expect(WS_REQUEST_TYPES).toHaveLength(36)
+  it('exports exactly 37 request types including discovered-session promotion', () => {
+    expect(WS_REQUEST_TYPES).toHaveLength(37)
     const expected = [
       'send_prompt',
       'cancel_prompt',
@@ -81,6 +81,7 @@ describe('web-protocol.types — event/request type registries (AC2)', () => {
       'open_persisted_session',
       'get_session_payload',
       'recover_session_snapshot',
+      'get_session_payload_tail',
       'get_session_cursor',
       'register_discovered_session',
       'list_sessions',

--- a/src/shared/types/web-protocol.types.ts
+++ b/src/shared/types/web-protocol.types.ts
@@ -139,6 +139,10 @@ export const WS_REQUEST_TYPES = [
   // this only returns the durable `{ sessionId, watermark }` so a refreshed
   // transport can seed `lastSeq` before its first subscribe.
   'get_session_cursor',
+  // Tail-first variant of `get_session_payload`: fetches only the last `limit`
+  // messages + matching tool calls so the renderer can install the recent
+  // transcript immediately and lazy-load the full payload on scroll-up.
+  'get_session_payload_tail',
   // CAP-6 / Story 8: host-owned ACP catalog resolution. The web client
   // resolves the catalog through `list_acp_catalog` (the host's OS/arch/
   // runtime + per-agent `SupportedAcpAgentStatus`) + `set_catalog_opt_in`


### PR DESCRIPTION
## Summary

Opening/resuming a long ACP chat history blocks the UI while the full payload (all messages + tool calls) is fetched from disk/IPC, parsed, and installed — even though only the latest messages are visible. The user waits for the entire transcript to load before they can read or send a prompt.

This PR fetches only the latest 50 messages (tail) first, installs them immediately so the user can read and chat, then lazy-loads the full payload on scroll-up via the existing `loadOlderMessages` mechanism.

## Related Issue

No related issue exists — this is a user-reported UX problem where resuming chat history takes too long for long conversations.

## Type of Change

- [x] feat: new feature
- [ ] fix: bug fix
- [ ] docs: documentation only
- [ ] style: formatting or non-functional styling changes
- [ ] refactor: internal cleanup with no behavior change
- [x] perf: performance improvement
- [ ] test: adds or updates tests
- [ ] build: build or dependency changes
- [ ] ci: CI/CD workflow changes
- [ ] chore: maintenance or tooling
- [ ] revert: reverts a previous change

## What Changed

### Backend (all transports)
- `session_persistence.rs`: `session_payload_tail_async(id, limit)` — materialize full payload, slice last N messages
- `chat_history_store.rs`: `get_tail(id, limit)` — read full payload, slice tail + filter tool calls by seq
- `commands.rs`: `acp_history_get_tail` Tauri command
- `ws.rs`: `handle_get_session_payload_tail` WS handler
- `lib.rs`: register `acp_history_get_tail`
- `web-protocol.types.ts`: add `'get_session_payload_tail'` request type

### Renderer
- `acp-history-api.ts`: `getTail(sessionId, limit)`
- `acp-transport.ts`: `getSessionPayloadTail?` interface + WS impl
- `acp-history-persistence.ts`: `loadSessionPayloadTail` (cache-first slice, no cache write) + `HISTORY_TAIL_MESSAGE_LIMIT = 50`
- `acp-store.ts`: `openHistorySessionInner` + `resumeLiveSession` swap to `loadSessionPayloadTail` with `logFrontendError` + fallback to full `loadSessionPayload`
- `acp-store.test.ts`: mock `loadSessionPayloadTail`

## How It Was Tested

- [x] `bun run ci` (Biome lint + format + imports, strict mode)
- [x] `bun run typecheck`
- [x] `bun run test`
- [ ] `cargo clippy --all-targets -- -D warnings` (in src-tauri)
- [ ] `cargo test` (in src-tauri)
- [x] Manual verification completed
- [ ] Not applicable

## CI & Review Gate

- [ ] All CI checks pass (PR Validation, Rust Checks, Build Verification, Security Scans)
- [ ] Code review comments from CodeRabbit / Claude have been addressed or resolved
- [ ] No unresolved review findings remain

## Checklist

- [x] My PR title follows the conventional commit format used by this repo
- [x] I linked the related issue or explained why none exists
- [x] I updated docs when needed
- [x] I added or updated tests when needed
- [x] I verified the change does not introduce unrelated modifications
- [x] I read AGENTS.md and followed the contributor guidelines
- [ ] A human reviewed the complete diff before submission