### PR TITLE
feat(acp): show relative last-activity time on chat history rows

### DIFF
--- a/src/renderer/components/ProjectChatList.tsx
+++ b/src/renderer/components/ProjectChatList.tsx
@@ -12,6 +12,7 @@ import {
   ContextMenuTrigger
 } from '@/components/ui/context-menu'
 import { clipboardApi, openerApi } from '@/lib/api'
+import { formatRelativeTimeFromMs } from '@/lib/git-time'
 import { openTerminalAtCwd } from '@/lib/terminal-spawn'
 import { cn } from '@/lib/utils'
 import { useAcpStore, useAgentIcon, useAgentTemplateId } from '@/stores/acp-store'
@@ -315,7 +316,9 @@ function ProjectChatRow({
           >
             <ChatRowIcon agentId={entry.agentId} agentConfigId={entry.agentConfigId} />
             <span className="truncate flex-1 text-sidebar-foreground">{entry.title}</span>
-            <span className="text-3xs text-muted-foreground">{entry.messageCount}</span>
+            <span className="text-3xs text-muted-foreground">
+              {formatRelativeTimeFromMs(entry.lastActivityAt)}
+            </span>
           </button>
           <button
             type="button"

--- a/src/renderer/components/ProjectChatList.tsx
+++ b/src/renderer/components/ProjectChatList.tsx
@@ -289,7 +289,10 @@ interface ProjectChatRowProps {
   onCopyPath: (cwd: string) => void
   onDelete: (entry: ProjectChatEntry) => void
 }
-
+/**
+ * A single per-project chat row: title + relative last-activity time, with a
+ * context menu (open terminal / file explorer / copy path / delete).
+ */
 function ProjectChatRow({
   entry,
   onOpen,

--- a/src/renderer/components/chat/ChatHistoryEntryRow.tsx
+++ b/src/renderer/components/chat/ChatHistoryEntryRow.tsx
@@ -38,7 +38,10 @@ interface ChatHistoryEntryRowProps {
   onOpen: (entry: ChatHistorySidebarEntry) => void
   onDelete: (id: string) => void
 }
-
+/**
+ * A single chat-history row for the sidebar `ChatHistoryTab`: agent icon, title,
+ * and a compact relative last-activity time (replacing the old message count).
+ */
 export function ChatHistoryEntryRow({
   entry,
   onOpen,

--- a/src/renderer/components/chat/ChatHistoryEntryRow.tsx
+++ b/src/renderer/components/chat/ChatHistoryEntryRow.tsx
@@ -1,4 +1,5 @@
 import { Trash2 } from 'lucide-react'
+import { formatRelativeTimeFromMs } from '@/lib/git-time'
 import { cn } from '@/lib/utils'
 import { useAgentIcon, useAgentTemplateId } from '@/stores/acp-store'
 import { AgentGlyph } from './AgentGlyph'
@@ -71,7 +72,9 @@ export function ChatHistoryEntryRow({
             <span className="text-3xs text-muted-foreground/70 shrink-0">{entry.agentName}</span>
           ) : null
         ) : (
-          <span className="text-3xs text-muted-foreground">{entry.messageCount}</span>
+          <span className="text-3xs text-muted-foreground">
+            {formatRelativeTimeFromMs(entry.lastActivityAt)}
+          </span>
         )}
       </button>
       {!entry.discovered && (

--- a/src/renderer/lib/git-time.test.ts
+++ b/src/renderer/lib/git-time.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { formatRelativeTime } from './git-time'
+import { formatRelativeTime, formatRelativeTimeFromMs } from './git-time'
 
 describe('formatRelativeTime', () => {
   const now = Date.parse('2026-05-30T12:00:00Z')
@@ -29,5 +29,31 @@ describe('formatRelativeTime', () => {
     const result = formatRelativeTime('2026-03-01T12:00:00Z', now)
     expect(result).not.toBe('')
     expect(result).not.toMatch(/^\d+[mhdw]$/)
+  })
+})
+
+describe('formatRelativeTimeFromMs', () => {
+  const now = Date.parse('2026-05-30T12:00:00Z')
+
+  it('returns empty string for non-finite input (NaN/Infinity)', () => {
+    expect(formatRelativeTimeFromMs(Number.NaN, now)).toBe('')
+    expect(formatRelativeTimeFromMs(Number.POSITIVE_INFINITY, now)).toBe('')
+  })
+
+  it('matches formatRelativeTime for the same instant', () => {
+    const iso = '2026-05-30T09:00:00Z'
+    expect(formatRelativeTimeFromMs(Date.parse(iso), now)).toBe(formatRelativeTime(iso, now))
+  })
+
+  it("formats sub-minute as 'now' and clamps future timestamps to 'now'", () => {
+    expect(formatRelativeTimeFromMs(now - 30_000, now)).toBe('now')
+    expect(formatRelativeTimeFromMs(now + 60_000, now)).toBe('now')
+  })
+
+  it('formats minutes, hours, days, and weeks', () => {
+    expect(formatRelativeTimeFromMs(now - 5 * 60_000, now)).toBe('5m')
+    expect(formatRelativeTimeFromMs(now - 3 * 3_600_000, now)).toBe('3h')
+    expect(formatRelativeTimeFromMs(now - 2 * 86_400_000, now)).toBe('2d')
+    expect(formatRelativeTimeFromMs(now - 14 * 86_400_000, now)).toBe('2w')
   })
 })

--- a/src/renderer/lib/git-time.ts
+++ b/src/renderer/lib/git-time.ts
@@ -1,16 +1,17 @@
 /**
- * Format an ISO 8601 timestamp as a compact relative time for commit rows,
- * e.g. "now", "5m", "3h", "2d", "5w". Falls back to a short localized date for
- * anything older than ~8 weeks. Invalid input yields an empty string so the UI
- * can render nothing rather than "Invalid Date".
+ * Format an epoch-millisecond timestamp as a compact relative time, e.g.
+ * "now", "5m", "3h", "2d", "5w". Falls back to a short localized date for
+ * anything older than ~8 weeks. A non-finite timestamp yields an empty string
+ * so the UI can render nothing rather than "Invalid Date".
  *
- * `now` is injectable for deterministic tests.
+ * `now` is injectable for deterministic tests. This is the number-based core
+ * shared by commit rows (ISO via `formatRelativeTime`) and chat-history rows
+ * (epoch-ms `lastActivityAt`).
  */
-export function formatRelativeTime(iso: string, now: number = Date.now()): string {
-  const then = Date.parse(iso)
-  if (Number.isNaN(then)) return ''
+export function formatRelativeTimeFromMs(ms: number, now: number = Date.now()): string {
+  if (!Number.isFinite(ms)) return ''
 
-  const diffMs = now - then
+  const diffMs = now - ms
   // Future timestamps (clock skew) clamp to "now" rather than negative values.
   const seconds = Math.max(0, Math.floor(diffMs / 1000))
 
@@ -24,9 +25,20 @@ export function formatRelativeTime(iso: string, now: number = Date.now()): strin
   const weeks = Math.floor(days / 7)
   if (weeks < 8) return `${weeks}w`
 
-  return new Date(then).toLocaleDateString(undefined, {
+  return new Date(ms).toLocaleDateString(undefined, {
     year: 'numeric',
     month: 'short',
     day: 'numeric'
   })
+}
+
+/**
+ * Format an ISO 8601 timestamp as a compact relative time for commit rows.
+ * Delegates to `formatRelativeTimeFromMs` after parsing; invalid input yields
+ * an empty string. `now` is injectable for deterministic tests.
+ */
+export function formatRelativeTime(iso: string, now: number = Date.now()): string {
+  const then = Date.parse(iso)
+  if (Number.isNaN(then)) return ''
+  return formatRelativeTimeFromMs(then, now)
 }


### PR DESCRIPTION
## Summary

ACP chat-history rows showed a bare **message count** number. That number is a poor recency signal — users want to find recent chats, not count messages. Both chat-history surfaces (the sidebar `ChatHistoryTab` and the per-project `ProjectChatList`) already sorted newest-first by `lastActivityAt`, but the display did not reflect that.

This replaces the count with a compact relative-time string (`1h`, `2d`, `5w`) derived from the `lastActivityAt` timestamp every row already carries. No data-model or sort change — only the display. Reuses the existing `git-time.ts` formatter by adding a number-based core (`formatRelativeTimeFromMs`) that the ISO-string `formatRelativeTime` (used by the git panel) now delegates to, preserving that API and its tests exactly.

## Related Issue

No related issue — direct user request: the session chat-histories list showed a number; show last activity instead, sorted by latest activity first. Sorting was already in place; only the display changed.

## Type of Change

- [x] feat: new feature

## What Changed

- **`src/renderer/lib/git-time.ts`** — added `formatRelativeTimeFromMs(ms, now?)` as the shared number-based core; refactored the existing ISO-string `formatRelativeTime` to delegate to it. The git panel's API and behavior are unchanged.
- **`src/renderer/components/chat/ChatHistoryEntryRow.tsx`** — sidebar row (used by `ChatHistoryTab`): renders `formatRelativeTimeFromMs(entry.lastActivityAt)` instead of `entry.messageCount`.
- **`src/renderer/components/ProjectChatList.tsx`** — per-project chat row (`ProjectChatRow`): same swap, for parity with the sidebar.
- **`src/renderer/lib/git-time.test.ts`** — added a `formatRelativeTimeFromMs` describe block covering non-finite input, ISO/number parity, sub-minute + future-clamp, and the minute/hour/day/week tiers.

## How It Was Tested

- [x] `bun run typecheck` — clean (node + web + test configs; also enforced by pre-commit hook).
- [x] `bun run test` — `git-time.test.ts`, `ChatHistoryTab.test.tsx`, `ProjectChatList.test.tsx`: 41/41 pass.
- [x] Manual verification completed — Tauri dev (`tauri dev`) launched; the desktop app rendered with chat-history rows showing relative time.
- [ ] `cargo clippy --all-targets -- -D warnings` (in src-tauri) — N/A (renderer-only change, no Rust touched).
- [ ] `cargo test` (in src-tauri) — N/A (renderer-only change).

## Screenshots or Recordings

UI change: chat-history rows now show `3h` / `2d` / `5w` in the existing `text-3xs text-muted-foreground` slot where the message count used to be.

## CI & Review Gate

- [ ] All CI checks pass (PR Validation, Rust Checks, Build Verification, Security Scans)
- [ ] Code review comments from CodeRabbit / Claude have been addressed or resolved
- [ ] No unresolved review findings remain

## Checklist

- [x] My PR title follows the conventional commit format used by this repo
- [x] I linked the related issue or explained why none exists
- [x] I updated docs when needed — N/A (no user-facing docs for this slot)
- [x] I added or updated tests when needed — added `formatRelativeTimeFromMs` coverage
- [x] I verified the change does not introduce unrelated modifications
- [x] I read AGENTS.md and followed the contributor guidelines

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Project chat lists now show each chat’s relative last-activity time instead of message counts.
  * Chat history entries now display when each session was last active.
  * Relative-time displays are more reliable, with graceful handling for invalid timestamps and localized date fallbacks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->