### PR TITLE
feat: file @-mentions render inline as Tiptap pills (not hoisted to attachment bar)

### DIFF
--- a/src/renderer/components/agents/AgentLauncher.test.tsx
+++ b/src/renderer/components/agents/AgentLauncher.test.tsx
@@ -20,7 +20,7 @@ import {
   type SupportedAcpAgentEntry
 } from '@/lib/agents/supported-acp-agents'
 import { SKILL_PAD_DEFAULT } from '@/lib/composer/doc-to-prompt'
-import { skillToken } from '@/lib/skill-tokens'
+import { fileToken, skillToken } from '@/lib/skill-tokens'
 import { isTauriContext, type ServerCapabilityState } from '@/lib/tauri-runtime'
 import type { AcpSession } from '@/stores/acp-store'
 import { __resetLauncherSelectionCache, AgentLauncher } from './AgentLauncher'
@@ -1435,6 +1435,50 @@ describe('AgentLauncher skill chips (inline tokens)', () => {
     expect(mockToastError).toHaveBeenCalledWith(expect.stringContaining('missing a path'))
     expect(mockCreateLaunchPlaceholder).not.toHaveBeenCalled()
     expect(mockHideAgentLauncher).not.toHaveBeenCalled()
+  })
+})
+
+describe('AgentLauncher file pills (inline tokens)', () => {
+  it('renders an inline file chip and sends a resource_link block on launch', async () => {
+    renderLauncher()
+    await screen.findByLabelText('Agent prompt')
+
+    const ft = fileToken('auth.ts', '/work/src/auth.ts')
+    setComposerValue(`fix this ${ft} `)
+
+    // The file pill renders inline (the FileChip name span shows "auth.ts").
+    await waitFor(() => expect(screen.getByText('auth.ts')).toBeInTheDocument())
+
+    fireEvent.click(screen.getByLabelText('Start agent chat'))
+
+    // The optimistic syncBlocks carry the DISPLAY (token) text so the chat
+    // timeline renders inline file pills.
+    await waitFor(() =>
+      expect(mockCreateLaunchPlaceholder).toHaveBeenCalledWith(
+        expect.objectContaining({
+          initialUserBlocks: [{ type: 'text', text: `fix this ${ft} ` }]
+        })
+      )
+    )
+    expect(mockHideAgentLauncher).toHaveBeenCalled()
+
+    // The real send (finalize) carries the WIRE text (tokens → `(display)`)
+    // PLUS a `resource_link` block for the file's path.
+    await waitFor(() => {
+      const blocks = mockFinalizeChatLaunch.mock.calls[0]?.[0]?.initialBlocks as
+        | Array<{ type: string; text?: string; uri?: string; name?: string; mimeType?: string }>
+        | undefined
+      expect(blocks).toBeDefined()
+      expect(blocks!).toEqual([
+        { type: 'text', text: 'fix this (auth.ts)' },
+        {
+          type: 'resource_link',
+          uri: 'file:///work/src/auth.ts',
+          name: 'auth.ts',
+          mimeType: 'text/typescript'
+        }
+      ])
+    })
   })
 })
 

--- a/src/renderer/components/agents/AgentLauncher.tsx
+++ b/src/renderer/components/agents/AgentLauncher.tsx
@@ -31,7 +31,7 @@ import { ConfigChip, ModeChip, SelectorModal } from '@/components/chat/AgentHead
 import { AttachFilesButton } from '@/components/chat/AttachFilesButton'
 import { AttachmentPreviewGroup } from '@/components/chat/AttachmentPreviewGroup'
 import { ComposerPill } from '@/components/chat/ComposerPill'
-import { attachmentToBlock } from '@/components/chat/chat-attachments'
+import { attachmentToBlock, dedupeAttachmentBlocks } from '@/components/chat/chat-attachments'
 import {
   extractFastModeOption,
   filterDuplicateModeConfigOptions,
@@ -265,7 +265,6 @@ export function AgentLauncher({ paneId, className }: AgentLauncherProps): React.
     attachments,
     addFiles,
     pickFiles,
-    addFileRef,
     handlePaste,
     removeAttachment,
     clearAttachments,
@@ -282,7 +281,6 @@ export function AgentLauncher({ paneId, className }: AgentLauncherProps): React.
     disabled: composerDisabled,
     recents: mentionRecents,
     onStageFileRef: (m) => {
-      addFileRef(m)
       pushMentionRecent(m)
     }
   })
@@ -926,7 +924,7 @@ export function AgentLauncher({ paneId, className }: AgentLauncherProps): React.
       launchInFlightRef.current = false
       return
     }
-    const { wireWithCommand, displayWithCommand } = parts
+    const { wireWithCommand, displayWithCommand, fileBlocks } = parts
 
     // CAP-3: when worktree mode is selected, create the isolated worktree
     // BEFORE opening the chat placeholder so the agent's cwd is the worktree
@@ -1155,6 +1153,11 @@ export function AgentLauncher({ paneId, className }: AgentLauncherProps): React.
         } else if (wireTrimmed.length > 0) {
           blocks.push({ type: 'text', text: wireWithCommand })
         }
+        // File-mention `resource_link` blocks append to the wire only — the
+        // display keeps the raw token text so the timeline renders inline
+        // file pills. Dedupe by path (matching `dedupeAttachmentBlocks`).
+        blocks.push(...fileBlocks)
+        const wireBlocks = dedupeAttachmentBlocks(blocks)
 
         const liveStore = useAcpStore.getState()
         let realId = sessionId
@@ -1167,7 +1170,7 @@ export function AgentLauncher({ paneId, className }: AgentLauncherProps): React.
             mcpServers: undefined,
             pending: hasPendingLauncherOptions(pendingSnapshot) ? pendingSnapshot : null,
             initialText: null,
-            initialBlocks: blocks.length > 0 ? blocks : null,
+            initialBlocks: wireBlocks.length > 0 ? wireBlocks : null,
             adoptSession: (from, to) => {
               useWorkspaceStore.getState().remapAgentChatSession(from, to, paneSnapshot)
             },
@@ -1179,8 +1182,8 @@ export function AgentLauncher({ paneId, className }: AgentLauncherProps): React.
             realId,
             hasPendingLauncherOptions(pendingSnapshot) ? pendingSnapshot : null
           )
-          if (blocks.length > 0) {
-            await liveStore.sendPromptBlocks(realId, blocks, {
+          if (wireBlocks.length > 0) {
+            await liveStore.sendPromptBlocks(realId, wireBlocks, {
               skipUserAppend: seededOptimistic
             })
           }

--- a/src/renderer/components/chat/ChatInputBar.test.tsx
+++ b/src/renderer/components/chat/ChatInputBar.test.tsx
@@ -4,7 +4,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { TooltipProvider } from '@/components/ui/tooltip'
 import type { SessionConfigOption } from '@/lib/acp-api'
 import { SKILL_PAD_DEFAULT } from '@/lib/composer/doc-to-prompt'
-import { commandToken, skillToken } from '@/lib/skill-tokens'
+import { commandToken, fileToken, skillToken } from '@/lib/skill-tokens'
 import type { AcpSession } from '@/stores/acp-store'
 import { ChatInputBar } from './ChatInputBar'
 import {
@@ -519,17 +519,11 @@ describe('ChatInputBar file mentions', () => {
     mockIsTauri.mockReturnValue(false)
   })
 
-  it('stages a selected @ file and sends it as a resource link block', async () => {
-    const onSendBlocks = vi.fn()
-    renderInputBar({ onSendBlocks })
-
-    setComposerValue('fix @auth')
-
-    // Debounce (90ms for >=3-char query) then the ripgrep stream starts.
+  /** Drive the ripgrep stream: advance the debounce, emit a batch + done. */
+  async function driveStream(files: Array<{ path: string; ignored: boolean }>): Promise<void> {
     await act(async () => {
       await vi.advanceTimersByTimeAsync(90)
     })
-
     const batch = batchCb.current as unknown as
       | ((e: {
           searchId: string
@@ -538,10 +532,7 @@ describe('ChatInputBar file mentions', () => {
         }) => void)
       | null
     const sid = mockStreamApi.searchFileNamesStreamStart.mock.calls[0]?.[0] as string
-    batch?.({
-      searchId: sid,
-      files: [{ path: 'src/auth.ts', ignored: false }]
-    })
+    batch?.({ searchId: sid, files })
     const done = doneCb.current as unknown as
       | ((e: {
           searchId: string
@@ -551,32 +542,123 @@ describe('ChatInputBar file mentions', () => {
           error?: string
         }) => void)
       | null
-    done?.({ searchId: sid, truncated: false, totalFiles: 1 })
-
-    // Switch back to real timers so `waitFor` can poll for the post-select /
-    // send async effects.
+    done?.({ searchId: sid, truncated: false, totalFiles: files.length })
     vi.useRealTimers()
     await act(async () => {})
+  }
 
-    const option = screen.getByRole('option', { name: /auth\.ts/ })
-    fireEvent.mouseDown(option)
+  it('renders an inline FileChip on @ file pick (not in the attachment bar)', async () => {
+    renderInputBar()
 
-    await waitFor(() => expect(getComposerValue()).toBe('fix '))
-    expect(screen.getByText('auth.ts')).toBeInTheDocument()
+    setComposerValue('fix @auth')
+    await driveStream([{ path: 'src/auth.ts', ignored: false }])
+
+    fireEvent.mouseDown(screen.getByRole('option', { name: /auth\.ts/ }))
+
+    // The @filter text is removed and a file token is spliced IN at the caret.
+    // The FileChip renders inline (the file pill's name span shows "auth.ts").
+    await waitFor(() => expect(screen.getByText('auth.ts')).toBeInTheDocument())
+    const value = getComposerValue()
+    const ft = fileToken('auth.ts', '/work/src/auth.ts')
+    expect(value).toBe(`fix ${ft} `)
+
+    // NO entry in the attachment bar (the mention did not hoist to
+    // AttachmentPreviewGroup — only drag/drop/paste/OS-picker files appear
+    // there). The file exists only as an inline pill in the editor.
+    const removeButtons = screen.queryAllByRole('button', { name: /Remove / })
+    expect(removeButtons).toHaveLength(0)
+  })
+
+  it('sends the wire text + resource_link block on submit (display keeps tokens)', async () => {
+    const onSendBlocks = vi.fn()
+    renderInputBar({ onSendBlocks })
+
+    setComposerValue('fix @auth')
+    await driveStream([{ path: 'src/auth.ts', ignored: false }])
+    fireEvent.mouseDown(screen.getByRole('option', { name: /auth\.ts/ }))
+    await waitFor(() => expect(screen.getByText('auth.ts')).toBeInTheDocument())
+
+    fireEvent.click(screen.getByRole('button', { name: 'Send message' }))
+
+    const ft = fileToken('auth.ts', '/work/src/auth.ts')
+    await waitFor(() => {
+      // Wire: text with tokens replaced by (display) + resource_link block.
+      expect(onSendBlocks).toHaveBeenCalledWith(
+        [
+          { type: 'text', text: 'fix (auth.ts)' },
+          {
+            type: 'resource_link',
+            uri: 'file:///work/src/auth.ts',
+            name: 'auth.ts',
+            mimeType: 'text/typescript'
+          }
+        ],
+        // Display: raw token text so the timeline renders an inline FileChip.
+        [{ type: 'text', text: `fix ${ft} ` }]
+      )
+    })
+    // The composer value is cleared after send.
+    expect(getComposerValue()).toBe('')
+  })
+
+  it('dedupes the same file mentioned twice into one resource_link block', async () => {
+    vi.useRealTimers()
+    const onSendBlocks = vi.fn()
+    renderInputBar({ onSendBlocks })
+
+    // Splice two file tokens for the same path directly into the editor value.
+    const ft = fileToken('auth.ts', '/work/src/auth.ts')
+    setComposerValue(`${ft} and again ${ft} `)
 
     fireEvent.click(screen.getByRole('button', { name: 'Send message' }))
 
     await waitFor(() => {
-      expect(onSendBlocks).toHaveBeenCalledWith([
-        { type: 'text', text: 'fix' },
-        {
-          type: 'resource_link',
-          uri: 'file:///work/src/auth.ts',
-          name: 'auth.ts',
-          mimeType: 'text/typescript'
-        }
-      ])
+      const blocks = onSendBlocks.mock.calls[0]?.[0] as Array<{
+        type: string
+        uri?: string
+      }> | undefined
+      expect(blocks).toBeDefined()
+      const resourceLinks = blocks!.filter(
+        (b) => b.type === 'resource_link' && b.uri === 'file:///work/src/auth.ts'
+      )
+      expect(resourceLinks).toHaveLength(1)
     })
+  })
+
+  it('renders a file pill + skill pill together (visually distinct)', async () => {
+    vi.useRealTimers()
+    mockSkills.current = [
+      { name: 'git-worktree', description: 'Isolated worktree', scope: 'project', path: '/home/u/.agents/skills/git-worktree/SKILL.md' }
+    ]
+    renderInputBar()
+
+    const st = skillToken('git-worktree', SKILL_PAD_DEFAULT)
+    const ft = fileToken('auth.ts', '/work/src/auth.ts')
+    setComposerValue(`use ${st} on ${ft} `)
+
+    // Both pills render inline with their respective chip names.
+    await waitFor(() => expect(screen.getByText('git-worktree')).toBeInTheDocument())
+    expect(screen.getByText('auth.ts')).toBeInTheDocument()
+    // The skill chip's Sparkles icon + the file chip's File icon both present.
+    expect(document.querySelector('.lucide-sparkles')).not.toBeNull()
+    expect(document.querySelector('.lucide-file')).not.toBeNull()
+  })
+
+  it('backspace removes a whole file pill + trailing space', async () => {
+    vi.useRealTimers()
+    renderInputBar()
+    // Wait for the Tiptap editor to mount (useEditor initializes in an effect).
+    await waitFor(() => expect(document.querySelector('[data-composer-editor="true"]')).not.toBeNull())
+
+    const ft = fileToken('auth.ts', '/work/src/auth.ts')
+    setComposerValue(`fix ${ft} `)
+    // Place the caret right after the trailing space.
+    setComposerCaret(`fix ${ft} `.length)
+
+    pressComposerKey('Backspace')
+
+    // The whole file token + trailing space is removed; the value is "fix ".
+    await waitFor(() => expect(getComposerValue()).toBe('fix '))
   })
 })
 

--- a/src/renderer/components/chat/ChatInputBar.tsx
+++ b/src/renderer/components/chat/ChatInputBar.tsx
@@ -264,7 +264,6 @@ export function ChatInputBar({
     attachments,
     addFiles,
     pickFiles,
-    addFileRef,
     handlePaste,
     removeAttachment,
     clearAttachments,
@@ -287,7 +286,6 @@ export function ChatInputBar({
     disabled,
     recents: mentionRecents,
     onStageFileRef: (m) => {
-      addFileRef(m)
       pushMentionRecent(m)
     }
   })
@@ -384,18 +382,28 @@ export function ChatInputBar({
       // skill paths, and inline command token. Throws `Skill '<name>' is
       // missing a path` when a selected skill has no resolvable path (Block If)
       // — caught below.
-      const { hasSkills, wireWithCommand, displayWithCommand, wireTrimmed, displayTrimmed } =
-        buildPromptParts()
-      if (!wireTrimmed && !hasAttachments) return
+      const {
+        hasSkills,
+        wireWithCommand,
+        displayWithCommand,
+        wireTrimmed,
+        displayTrimmed,
+        fileBlocks
+      } = buildPromptParts()
+      const hasFileRefs = fileBlocks.length > 0
+      if (!wireTrimmed && !hasAttachments && !hasFileRefs) return
 
       if (hasAttachments) {
         const wireBlocks: ContentBlock[] = []
         if (wireTrimmed) wireBlocks.push({ type: 'text', text: wireWithCommand })
         for (const a of attachments) wireBlocks.push(attachmentToBlock(a))
+        wireBlocks.push(...fileBlocks)
         const wire = dedupeAttachmentBlocks(wireBlocks)
-        // Only split display from wire when skills are present; otherwise
-        // display == wire and a single-arg call preserves the existing contract.
-        if (hasSkills) {
+        // Split display from wire when skills OR file-mention pills are
+        // present: skills carry framing tokens, file mentions carry inline
+        // pill tokens — both need the display to keep the raw token text so
+        // the timeline renders inline chips. Without either, display == wire.
+        if (hasSkills || hasFileRefs) {
           const displayBlocks: ContentBlock[] = []
           if (displayTrimmed) displayBlocks.push({ type: 'text', text: displayWithCommand })
           for (const a of attachments) displayBlocks.push(attachmentToBlock(a))
@@ -406,8 +414,28 @@ export function ChatInputBar({
         }
       } else if (hasSkills) {
         // Skills (tokens) present: split display (tokens) from wire (framing).
+        // File-mention `resource_link` blocks append to the wire only — the
+        // display keeps the raw token text so the timeline renders inline
+        // file pills.
+        const wireBlocks: ContentBlock[] = wireTrimmed
+          ? [{ type: 'text', text: wireWithCommand }]
+          : []
+        wireBlocks.push(...fileBlocks)
         onSendBlocks(
-          wireTrimmed ? [{ type: 'text', text: wireWithCommand }] : [],
+          dedupeAttachmentBlocks(wireBlocks),
+          displayTrimmed ? [{ type: 'text', text: displayWithCommand }] : []
+        )
+      } else if (hasFileRefs) {
+        // File-mention pills present (no skills, no attachments): the wire
+        // carries the text (tokens → `(display)`) + `resource_link` blocks for
+        // each unique file. Display keeps the token text so the timeline
+        // renders inline file pills.
+        const wireBlocks: ContentBlock[] = wireTrimmed
+          ? [{ type: 'text', text: wireWithCommand }]
+          : []
+        wireBlocks.push(...fileBlocks)
+        onSendBlocks(
+          dedupeAttachmentBlocks(wireBlocks),
           displayTrimmed ? [{ type: 'text', text: displayWithCommand }] : []
         )
       } else {

--- a/src/renderer/components/chat/ChatMessage.test.tsx
+++ b/src/renderer/components/chat/ChatMessage.test.tsx
@@ -3,11 +3,13 @@ import type { ReactNode } from 'react'
 import type { AnimateOptions } from 'streamdown'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { TooltipProvider } from '@/components/ui/tooltip'
-import { skillToken } from '@/lib/skill-tokens'
+import { fileToken, skillToken } from '@/lib/skill-tokens'
 import type { ChatMessage as ChatMessageType } from '@/stores/acp-store'
 import { ChatMessage } from './ChatMessage'
 
 const T = skillToken
+
+const FT = fileToken
 
 const openUrlWithSystemBrowser = vi.fn(() => Promise.resolve({ success: true, data: undefined }))
 const openFilePathFromTerminal = vi.fn(() => Promise.resolve({ ok: true as const }))
@@ -383,6 +385,59 @@ describe('ChatMessage', () => {
       expect(screen.getByText('just plain text')).toBeInTheDocument()
       // No chip rendered: the chip's Sparkles icon is absent.
       expect(container.querySelector('.lucide-sparkles')).toBeNull()
+    })
+  })
+
+  describe('user message with inline file chips', () => {
+    function userMessage(text: string): ChatMessageType {
+      return {
+        id: 'user-1',
+        role: 'user',
+        blocks: [{ type: 'text', text }],
+        streaming: false,
+        timestamp: 0
+      }
+    }
+
+    it('renders inline file chips for token text in a user bubble', () => {
+      const text = `fix this ${FT('auth.ts', '/work/src/auth.ts')} bug`
+      const { container } = render(
+        <TooltipProvider>
+          <ChatMessage message={userMessage(text)} />
+        </TooltipProvider>
+      )
+      // The file chip name renders as a visible inline pill; the File icon
+      // (lucide-file) is the chip-specific marker.
+      expect(screen.getByText('auth.ts')).toBeInTheDocument()
+      expect(container.querySelector('.lucide-file')).not.toBeNull()
+      // The plain text segments render too.
+      expect(screen.getByText(/fix this/)).toBeInTheDocument()
+      expect(screen.getByText(/bug/)).toBeInTheDocument()
+    })
+
+    it('renders plain user text verbatim (no chip parsing) when there are no tokens', () => {
+      const { container } = render(
+        <TooltipProvider>
+          <ChatMessage message={userMessage('just plain text')} />
+        </TooltipProvider>
+      )
+      expect(screen.getByText('just plain text')).toBeInTheDocument()
+      // No file chip rendered: the File icon is absent.
+      expect(container.querySelector('.lucide-file')).toBeNull()
+    })
+
+    it('renders file + skill chips together (both inline, visually distinct)', () => {
+      const text = `use ${T('git-worktree')} on ${FT('auth.ts', '/work/src/auth.ts')}`
+      const { container } = render(
+        <TooltipProvider>
+          <ChatMessage message={userMessage(text)} />
+        </TooltipProvider>
+      )
+      expect(screen.getByText('git-worktree')).toBeInTheDocument()
+      expect(screen.getByText('auth.ts')).toBeInTheDocument()
+      // Both icons present — skill (Sparkles) + file (File).
+      expect(container.querySelector('.lucide-sparkles')).not.toBeNull()
+      expect(container.querySelector('.lucide-file')).not.toBeNull()
     })
   })
 })

--- a/src/renderer/components/chat/ChatMessage.tsx
+++ b/src/renderer/components/chat/ChatMessage.tsx
@@ -29,7 +29,12 @@ import { openerApi } from '@/lib/api'
 import { readAttachmentBytes } from '@/lib/attachment-api'
 import { type FilePathResolutionContext, openFilePathFromTerminal } from '@/lib/file-path-links'
 import { logFrontendError } from '@/lib/log-api'
-import { parseSkillSegments, replaceSkillTokensInline } from '@/lib/skill-tokens'
+import {
+  parseFileSegments,
+  parseSkillSegments,
+  replaceFileTokensInline,
+  replaceSkillTokensInline
+} from '@/lib/skill-tokens'
 import { normalizePlanFenceBoundary, stripEmptyFences } from '@/lib/strip-empty-fences'
 import { cn } from '@/lib/utils'
 import type { ChatMessage as ChatMessageType } from '@/stores/acp-store'
@@ -47,11 +52,12 @@ import {
   uint8ToBase64
 } from './chat-attachments'
 import { ChatMarkdownCode } from './chat-markdown-code'
-import { filePathFromHref, remarkFilePathLinks } from './chat-markdown-file-links'
-import { ChatMarkdownTable } from './chat-markdown-table'
-import { type BubbleAlign, staggerChild } from './chat-motion'
+import { FileChip } from './FileChip'
 import { MessageActions } from './MessageActions'
 import { SkillChip } from './SkillChip'
+import { filePathFromHref, remarkFilePathLinks } from './chat-markdown-file-links'
+import { type BubbleAlign, staggerChild } from './chat-motion'
+import { ChatMarkdownTable } from './chat-markdown-table'
 
 const FILE_PATH_REMARK_PLUGINS = [...Object.values(defaultRemarkPlugins), remarkFilePathLinks]
 
@@ -64,22 +70,60 @@ function blocksToText(blocks: ContentBlock[]): string {
 }
 
 /**
- * Render a user message's text, swapping inline skill tokens for read-only
- * `SkillChip` pills. Plain text (no tokens) renders verbatim with
- * `whitespace-pre-wrap` to preserve the original spacing. `MessageActions`
- * still receives the raw token text so editing re-seeds the composer with the
- * tokens (chips re-render inline) and copy degrades gracefully (private-use
- * sentinels are invisible in most fonts).
+ * Render a user message's text, swapping inline skill AND file tokens for
+ * read-only `SkillChip`/`FileChip` pills. Skill tokens (`\uE000..\uE001`) and
+ * file tokens (`\uE006..\uE007`) use distinct sentinel pairs, so the skill
+ * walk leaves file tokens in its text segments (and vice versa). We parse
+ * skill segments first, then walk each text segment for file tokens — both
+ * pill types render at their correct positions when both are inline together.
+ * Plain text (no tokens) renders verbatim with `whitespace-pre-wrap` to
+ * preserve the original spacing. `MessageActions` still receives the raw
+ * token text so editing re-seeds the composer with the tokens (chips
+ * re-render inline) and copy degrades gracefully (private-use sentinels are
+ * invisible in most fonts).
  */
 function UserMessageText({ text }: { text: string }): React.JSX.Element {
-  const segments = parseSkillSegments(text)
+  const skillSegments = parseSkillSegments(text)
+  // Flatten: skill segments + file tokens extracted from each text segment.
+  type FlatSeg =
+    | { kind: 'text'; text: string }
+    | { kind: 'skill'; name: string }
+    | { kind: 'file'; display: string }
+  const flat: FlatSeg[] = []
+  let hasPills = false
+  for (const seg of skillSegments) {
+    if (seg.kind === 'skill') {
+      flat.push({ kind: 'skill', name: seg.name })
+      hasPills = true
+      continue
+    }
+    // Text segment: walk for file tokens (\uE006..\uE007). Skill tokens
+    // are invisible to this walk (already extracted above), so file tokens
+    // land in the text segments alongside plain text.
+    const fileSegs = parseFileSegments(seg.text)
+    if (fileSegs.length === 1 && fileSegs[0].kind === 'text') {
+      // No file tokens in this text segment — keep it as one text span.
+      flat.push({ kind: 'text', text: seg.text })
+      continue
+    }
+    for (const fseg of fileSegs) {
+      if (fseg.kind === 'file') {
+        flat.push({ kind: 'file', display: fseg.display })
+        hasPills = true
+      } else {
+        flat.push({ kind: 'text', text: fseg.text })
+      }
+    }
+  }
   return (
     <BubbleContent className="whitespace-pre-wrap break-words">
-      {segments.length === 0
+      {!hasPills && flat.length === 0
         ? text
-        : segments.map((seg, i) =>
+        : flat.map((seg, i) =>
             seg.kind === 'skill' ? (
               <SkillChip key={`skill-${i}`} name={seg.name} />
+            ) : seg.kind === 'file' ? (
+              <FileChip key={`file-${i}`} name={seg.display} />
             ) : (
               <span key={`text-${i}`}>{seg.text}</span>
             )
@@ -549,7 +593,7 @@ function ChatMessageComponent({
                 // Copy a display-safe string: tokens become `(name)` so the
                 // clipboard never carries private-use sentinels. Edit keeps the
                 // raw token text so the composer re-seeds with chips inline.
-                text={replaceSkillTokensInline(text)}
+                text={replaceFileTokensInline(replaceSkillTokensInline(text))}
                 align="end"
                 pinned={actionsPinned}
                 onEdit={onEdit && text.length > 0 ? () => onEdit(text) : undefined}

--- a/src/renderer/components/chat/FileChip.tsx
+++ b/src/renderer/components/chat/FileChip.tsx
@@ -1,0 +1,40 @@
+import { File } from 'lucide-react'
+import { cn } from '@/lib/utils'
+
+interface FileChipProps {
+  name: string
+  className?: string
+}
+
+/**
+ * Muted inline pill for a file @-mention. Sibling of `SkillChip.tsx` — same
+ * inline metrics (`inline-flex items-center align-baseline leading-none
+ * h-[1.1em]`, `px-2`, `font-medium`, `rounded-md`, `max-w-[40ch] truncate`) so
+ * a file pill occupies exactly one line box and stays caret-aligned with the
+ * surrounding text in the Tiptap editor (the pill is a real inline DOM node,
+ * same as `SkillChip`). The visual treatment is distinct from `SkillChip`
+ * (which uses `Sparkles` + accent `text-primary`): a muted
+ * `border-border/60 bg-muted/60 text-muted-foreground` with a `File` lucide
+ * icon so a file pill and a skill pill are distinguishable at a glance when
+ * both are inline together.
+ *
+ * Always non-interactive by construction: there is no `onRemove` or any other
+ * interactive/removal prop. In the composer, Backspace removes a chip via the
+ * token model (`removeFileTokenBeforeCaret`), not an X button; in the timeline
+ * the chip is a static pill. Callers (`FilePillNode`, `ChatMessage`) pass only
+ * `name` (plus an optional `className`).
+ */
+export function FileChip({ name, className }: FileChipProps): React.JSX.Element {
+  return (
+    <span
+      className={cn(
+        'inline-flex h-[1.1em] max-w-full items-center gap-1 align-baseline leading-none',
+        'rounded-md border border-border/60 bg-muted/60 px-2 text-inherit font-medium text-muted-foreground',
+        className
+      )}
+    >
+      <File size={12} className="shrink-0" aria-hidden="true" />
+      <span className="max-w-[40ch] truncate">{name}</span>
+    </span>
+  )
+}

--- a/src/renderer/components/chat/composer/ChatComposerEditor.tsx
+++ b/src/renderer/components/chat/composer/ChatComposerEditor.tsx
@@ -8,12 +8,14 @@ import {
   CMD_PILL_NODE,
   docOffsetToDisplayOffset,
   docToDisplayText,
+  FILE_PILL_NODE,
   SKILL_PILL_NODE
 } from '@/lib/composer/doc-to-prompt'
 import { draftFromTokens } from '@/lib/composer/draft-from-tokens'
 import { logFrontendError } from '@/lib/log-api'
 import { cn } from '@/lib/utils'
 import { CommandPill } from './CommandPillNode'
+import { FilePill } from './FilePillNode'
 import { SkillPill } from './SkillPillNode'
 
 export interface ChatComposerEditorProps {
@@ -134,7 +136,8 @@ function createComposerKeymap(
                     if (
                       prevNode &&
                       (prevNode.type.name === SKILL_PILL_NODE ||
-                        prevNode.type.name === CMD_PILL_NODE)
+                        prevNode.type.name === CMD_PILL_NODE ||
+                        prevNode.type.name === FILE_PILL_NODE)
                     ) {
                       before = prevNode
                       probePos = probePos - 1
@@ -142,7 +145,9 @@ function createComposerKeymap(
                   }
                   if (
                     before &&
-                    (before.type.name === SKILL_PILL_NODE || before.type.name === CMD_PILL_NODE)
+                    (before.type.name === SKILL_PILL_NODE ||
+                      before.type.name === CMD_PILL_NODE ||
+                      before.type.name === FILE_PILL_NODE)
                   ) {
                     event.preventDefault()
                     // Delete the pill + any trailing space the splicer appended
@@ -245,6 +250,7 @@ export function ChatComposerEditor({
       extensions: [
         SkillPill,
         CommandPill,
+        FilePill,
         createComposerKeymap(beforeKeyDownRef),
         Placeholder.configure({
           placeholder: () => placeholderRef.current,
@@ -295,7 +301,8 @@ export function ChatComposerEditor({
           // paste (no sentinel) falls through to ProseMirror's default (text
           // nodes). The skill sentinel `\uE000` and the command sentinel
           // `\uE004` both trigger the pill-paste path.
-          if (!text.includes('\uE000') && !text.includes('\uE004')) return false
+          if (!text.includes('\uE000') && !text.includes('\uE004') && !text.includes('\uE006'))
+            return false
           event.preventDefault()
           try {
             const parsed = view.state.schema.nodeFromJSON(

--- a/src/renderer/components/chat/composer/FilePillNode.tsx
+++ b/src/renderer/components/chat/composer/FilePillNode.tsx
@@ -1,0 +1,106 @@
+import { mergeAttributes, Node } from '@tiptap/core'
+import { NodeViewWrapper, type ReactNodeViewProps, ReactNodeViewRenderer } from '@tiptap/react'
+import { FILE_TOKEN_END, FILE_TOKEN_SEP, FILE_TOKEN_START } from '@/lib/skill-tokens'
+import { cn } from '@/lib/utils'
+import { FileChip } from '../FileChip'
+
+/**
+ * Inline atomic Tiptap node for a file @-mention "pill". Mirrors
+ * `SkillPillNode`/`CommandPillNode`: `atom:true`, `group:'inline'`,
+ * `inline:true`, `NodeViewWrapper as="span"`, `parseHTML()->[]` (no
+ * untrusted-HTML pill creation), `renderText` emits the `\uE006<display>
+ * \u001F<absPath>\uE007` sentinel. The sentinel pair is distinct from the
+ * skill (`\uE000/\uE001`) and command (`\uE004/\uE005`) sentinels so
+ * `parseSkillSegments` (and the skill wire framer / timeline renderer) and
+ * the command walk never see file tokens.
+ *
+ * Stores `display` + `absPath` as node attrs: `display` is the filename/relPath
+ * shown in the pill; `absPath` is the absolute OS path the wire builder
+ * resolves to a `file://` `resource_link` URI at send time. The render reuses
+ * the shared `<FileChip>` component (`File` icon, muted
+ * `border-border/60 bg-muted/60 text-muted-foreground`, `px-2`,
+ * `align-baseline h-[1.1em]`) so the pill reads identically across the
+ * composer, the mention menu, and the timeline — they share one visual source
+ * of truth and cannot drift.
+ *
+ * `parseHTML` returns an empty list: pill nodes are NEVER created from
+ * clipboard HTML (untrusted). Pills only re-enter the editor via the
+ * `\uE006` sentinel in the clipboard's `text/plain` payload, which
+ * `ChatComposerEditor.handlePaste` parses via `draftFromTokens`. This closes
+ * the untrusted-HTML injection vector.
+ */
+export const FilePill = Node.create({
+  name: 'filePill',
+  group: 'inline',
+  inline: true,
+  atom: true,
+  selectable: true,
+  draggable: false,
+  addAttributes() {
+    return {
+      display: {
+        default: '',
+        parseHTML: (el) => el.getAttribute('data-file-display') ?? ''
+      },
+      absPath: {
+        default: '',
+        parseHTML: (el) => el.getAttribute('data-file-abspath') ?? ''
+      }
+    }
+  },
+  // No parseHTML rules: pill nodes are not parsed from clipboard HTML. The only
+  // re-entry path is the `\uE006` sentinel in `text/plain` (handled by
+  // `ChatComposerEditor.handlePaste` → `draftFromTokens`), which constructs
+  // pill nodes programmatically. Returning `[]` ensures ProseMirror's default
+  // HTML paste handler never creates a pill from untrusted markup.
+  parseHTML() {
+    return []
+  },
+  renderHTML({ node, HTMLAttributes }) {
+    return [
+      'span',
+      mergeAttributes(HTMLAttributes, {
+        'data-file-pill': '',
+        'data-file-display': node.attrs.display,
+        'data-file-abspath': node.attrs.absPath
+      })
+    ]
+  },
+  renderText({ node }) {
+    // Plain-text serialization (used by `editor.getText()`). The composer's
+    // load-bearing serializer lives in `doc-to-prompt.ts` (it emits the
+    // sentinel token format the wire builder consumes); this is only the
+    // fallback path.
+    return `${FILE_TOKEN_START}${node.attrs.display ?? ''}${FILE_TOKEN_SEP}${node.attrs.absPath ?? ''}${FILE_TOKEN_END}`
+  },
+  addNodeView() {
+    return ReactNodeViewRenderer(FilePillNodeView)
+  }
+})
+
+/**
+ * React NodeView for the file pill. Renders the shared `<FileChip>` component
+ * (the single source of truth for the file-chip visual — also used by the
+ * timeline user-bubble) so the two surfaces cannot drift. `NodeViewWrapper
+ * as="span"` keeps it inline (the node is `inline: true`); the `selected` ring
+ * + `data-file-*` attrs live on the wrapper so ProseMirror selection state and
+ * clipboard serialization work without touching the `FileChip` visual.
+ */
+function FilePillNodeView({ node, selected }: ReactNodeViewProps): React.JSX.Element {
+  const attrs = node.attrs as { display?: string; absPath?: string }
+  const display = String(attrs.display ?? '')
+  return (
+    <NodeViewWrapper
+      as="span"
+      className={cn(
+        'inline-flex align-baseline leading-none',
+        selected && 'ring-2 ring-primary/40'
+      )}
+      data-file-pill="true"
+      data-file-display={display}
+      data-file-abspath={String(attrs.absPath ?? '')}
+    >
+      <FileChip name={display} />
+    </NodeViewWrapper>
+  )
+}

--- a/src/renderer/components/chat/use-chat-composer.ts
+++ b/src/renderer/components/chat/use-chat-composer.ts
@@ -2,17 +2,25 @@ import type { Editor } from '@tiptap/core'
 import type { MutableRefObject, RefObject } from 'react'
 import { useCallback, useMemo, useRef } from 'react'
 import { buildPromptWithLoadedSkills } from '@/hooks/use-agent-skills'
-import type { AvailableCommand, SessionConfigOption, SessionModeState } from '@/lib/acp-api'
+import type {
+  AvailableCommand,
+  ContentBlock,
+  SessionConfigOption,
+  SessionModeState
+} from '@/lib/acp-api'
 import { docOffsetToDisplayOffset, SKILL_PAD_DEFAULT } from '@/lib/composer/doc-to-prompt'
 import {
   extractCommandNames,
   extractSkillNames,
   insertCommandToken,
   insertSkillToken,
+  parseFileSegments,
+  replaceFileTokensInline,
   SKILL_TOKEN_START,
   stripAllCommandTokens
 } from '@/lib/skill-tokens'
 import type { AgentSkillSummary } from '@/lib/skills-api'
+import { attachmentToBlock, guessMimeType } from './chat-attachments'
 import { tryHandleMentionMenuKeyDown } from './mention-menu-keyboard'
 import type { SlashMenuHandle } from './SlashCommandMenu'
 import type { ComposerKeyboardEvent } from './slash-menu-keyboard'
@@ -111,7 +119,8 @@ export interface ChatPromptParts {
   /** Resolved skills with their SKILL.md paths (for the wire header). */
   skills: Array<{ name: string; path: string }>
   hasSkills: boolean
-  /** Wire text dispatched to the agent (skills framed by path, tokens → `(name)`). */
+  /** Wire text dispatched to the agent (skills framed by path, tokens → `(name)`,
+   * file tokens → `(display)`). */
   wireText: string
   /** Display text stored in the optimistic user message (raw token value). */
   displayText: string
@@ -121,6 +130,12 @@ export interface ChatPromptParts {
   displayWithCommand: string
   wireTrimmed: string
   displayTrimmed: string
+  /**
+   * `resource_link` content blocks for each unique file mention (by absPath).
+   * Hosts append these to the wire blocks (display keeps the token text so
+   * the timeline renders inline file pills). Deduped by path.
+   */
+  fileBlocks: ContentBlock[]
 }
 
 export interface UseChatComposerResult {
@@ -361,7 +376,33 @@ export function useChatComposer(args: UseChatComposerArgs): UseChatComposerResul
       throw new Error(`Skill '${missingPath.name}' is missing a path`)
     }
     const hasSkills = resolvedSkills.length > 0
-    const wireText = buildPromptWithLoadedSkills(resolvedSkills, valueDecommanded)
+    // Extract inline file-mention tokens and build a `resource_link` block for
+    // each unique file (by absPath). The display text keeps the raw tokens so
+    // the timeline renders inline file pills; the wire text replaces each
+    // token with `(display)` so the agent sees a readable reference alongside
+    // the `resource_link` block carrying the real path.
+    const fileSegments = parseFileSegments(valueDecommanded)
+    const fileBlocks: ContentBlock[] = []
+    const seenPaths = new Set<string>()
+    for (const seg of fileSegments) {
+      if (seg.kind === 'file' && !seenPaths.has(seg.absPath)) {
+        seenPaths.add(seg.absPath)
+        fileBlocks.push(
+          attachmentToBlock({
+            kind: 'file-ref',
+            id: seg.absPath,
+            name: seg.display,
+            mimeType: guessMimeType(seg.display),
+            path: seg.absPath
+          })
+        )
+      }
+    }
+    // Replace file tokens with `(display)` for the wire user-text portion
+    // (mirrors `replaceSkillTokensInline` for skills). Applied BEFORE the
+    // skill framer so the skill framing header wraps the de-filed text.
+    const valueDefiled = replaceFileTokensInline(valueDecommanded)
+    const wireText = buildPromptWithLoadedSkills(resolvedSkills, valueDefiled)
     const displayText = valueDecommanded
     const wireWithCommand = commandName ? `/${commandName} ${wireText}` : wireText
     const displayWithCommand = commandName ? `/${commandName} ${displayText}` : displayText
@@ -373,7 +414,8 @@ export function useChatComposer(args: UseChatComposerArgs): UseChatComposerResul
       wireWithCommand,
       displayWithCommand,
       wireTrimmed: wireWithCommand.trim(),
-      displayTrimmed: displayWithCommand.trim()
+      displayTrimmed: displayWithCommand.trim(),
+      fileBlocks
     }
   }, [value, skills])
 

--- a/src/renderer/components/chat/use-composer-attachments.ts
+++ b/src/renderer/components/chat/use-composer-attachments.ts
@@ -20,7 +20,6 @@ import {
   type PendingAttachment,
   uint8ToBase64
 } from './chat-attachments'
-import type { MentionMatch } from './mention-menu-model'
 
 function attachmentId(): string {
   return `att-${randomUUID()}`
@@ -222,8 +221,6 @@ export interface ComposerAttachments {
   addFiles: (files: FileList | File[]) => Promise<void>
   /** Picker channel (OS file dialog): real filesystem paths. */
   pickFiles: () => Promise<void>
-  /** Mention channel (@-picker): stage a `file-ref` by absolute path. */
-  addFileRef: (match: MentionMatch) => void
   /** Paste handler for the composer — images from clipboard, incl. screenshots.
    *  Accepts the DOM `ClipboardEvent` the Tiptap editor's `handlePaste` editorProp
    *  passes (the pre-refactor textarea's React event was structurally compatible;
@@ -377,32 +374,6 @@ export function useComposerAttachments(opts: {
     if (unsupported > 0) toast.error('Unsupported file type (text or image only)')
   }, [disabled, imageCapable, addFiles])
 
-  /**
-   * Stage a `file-ref` attachment from an @-mention pick (ADR 0003). The
-   * attachment is staged synchronously so it is send-safe immediately; for
-   * images a thumbnail is read in the background and patched onto the card.
-   */
-  const addFileRef = useCallback(
-    (match: MentionMatch) => {
-      if (disabled) return
-      const id = attachmentId()
-      const name = match.name
-      const mimeType = guessMimeType(name)
-      setAttachments((prev) => [
-        ...prev,
-        { kind: 'file-ref', id, name, mimeType, path: match.absPath }
-      ])
-      if (isImageMime(mimeType)) {
-        void (async () => {
-          const previewUrl = await readThumbnail(match.absPath, mimeType)
-          if (previewUrl) {
-            setAttachments((prev) => prev.map((a) => (a.id === id ? { ...a, previewUrl } : a)))
-          }
-        })()
-      }
-    },
-    [disabled]
-  )
 
   const handlePaste = useCallback(
     (e: ClipboardEvent) => {
@@ -486,7 +457,6 @@ export function useComposerAttachments(opts: {
     attachments,
     addFiles,
     pickFiles,
-    addFileRef,
     handlePaste,
     removeAttachment,
     clearAttachments,

--- a/src/renderer/components/chat/use-composer-mentions.test.tsx
+++ b/src/renderer/components/chat/use-composer-mentions.test.tsx
@@ -1,5 +1,5 @@
 import { act, renderHook } from '@testing-library/react'
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { fileToken } from '@/lib/skill-tokens'
 import type { MentionMatch } from './mention-menu-model'
 import { useComposerMentions } from './use-composer-mentions'
 
@@ -332,7 +332,7 @@ describe('useComposerMentions', () => {
     )
   })
 
-  it('select splices the @token, stages the file-ref, and closes the menu', async () => {
+  it('select splices a file token IN at the caret (no hoist), records the recent, and closes the menu', async () => {
     const { result, onStageFileRef } = renderMentions()
     act(() => result.current.update('@rea', 4))
     await advance(90)
@@ -345,7 +345,15 @@ describe('useComposerMentions', () => {
     act(() => {
       outcome = result.current.select('@rea', 4, picked)
     })
-    expect(outcome).toEqual({ value: '', caret: 0 })
+    // The @rea filter text is removed and a file token is spliced IN at the
+    // caret (the token carries display + absPath split by the unit separator).
+    // The caret lands after the token + trailing space.
+    const expectedToken = fileToken('auth.ts', '/work/src/auth.ts')
+    expect(outcome).toEqual({
+      value: `${expectedToken} `,
+      caret: expectedToken.length + 1
+    })
+    // onStageFileRef still fires (for recents), but the host no longer hoists.
     expect(onStageFileRef).toHaveBeenCalledWith(picked)
     expect(result.current.menuOpen).toBe(false)
   })

--- a/src/renderer/components/chat/use-composer-mentions.ts
+++ b/src/renderer/components/chat/use-composer-mentions.ts
@@ -2,6 +2,7 @@ import type { SearchFileHit } from '@shared/types/ipc.types'
 import type { RefObject } from 'react'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { filesystemApi } from '@/lib/api'
+import { insertFileToken } from '@/lib/skill-tokens'
 import { logFrontendError } from '@/lib/log-api'
 import { isTauriContext } from '@/lib/tauri-runtime'
 import { randomUUID } from '@/lib/uuid'
@@ -11,8 +12,7 @@ import {
   activeMentionToken,
   buildMentionSections,
   type MentionMatch,
-  type MentionSection,
-  spliceMentionToken
+  type MentionSection
 } from './mention-menu-model'
 
 const MAX_RESULTS = 100
@@ -273,12 +273,24 @@ export function useComposerMentions(opts: UseComposerMentionsOptions): ComposerM
     ): { value: string; caret: number } | null => {
       const token = activeMentionToken(value, caret)
       if (!token) return null
-      const nextValue = spliceMentionToken(value, token)
+      // Splice a file token IN at the caret (instead of hoisting to the
+      // attachment bar). Removes the `@filter` text, inserts the token, and
+      // appends a trailing space so the caret lands in plain text. The token
+      // IS the staging — the wire builder extracts file paths from tokens at
+      // send time. `onStageRef` still fires so the host wrapper can record the
+      // mention in recents (the host wrapper no longer calls `addFileRef`).
+      const { value: nextValue, caret: nextCaret } = insertFileToken(
+        value,
+        token.end,
+        match.name,
+        match.absPath,
+        token.end - token.at
+      )
       setMenuOpen(false)
       setFilter('')
       setMatches([])
       onStageRef.current(match)
-      return { value: nextValue, caret: token.at }
+      return { value: nextValue, caret: nextCaret }
     },
     []
   )

--- a/src/renderer/lib/composer/doc-to-prompt.ts
+++ b/src/renderer/lib/composer/doc-to-prompt.ts
@@ -33,6 +33,9 @@ import type { Node as PmNode } from '@tiptap/pm/model'
 import {
   CMD_TOKEN_END,
   CMD_TOKEN_START,
+  FILE_TOKEN_END,
+  FILE_TOKEN_SEP,
+  FILE_TOKEN_START,
   SKILL_PAD_CHAR,
   SKILL_PAD_END,
   SKILL_PAD_START,
@@ -55,6 +58,15 @@ export const SKILL_PILL_NODE = 'skillPill'
 export const CMD_PILL_NODE = 'commandPill'
 
 /**
+ * The file-mention pill node type name. Kept in one place so the
+ * (de)serializers and the `FilePill` extension agree. Distinct from
+ * `SKILL_PILL_NODE`/`CMD_PILL_NODE` so the serializer emits the file sentinel
+ * pair (`\uE006/\uE007`) — invisible to `parseSkillSegments` (skill-only) and
+ * the command walk.
+ */
+export const FILE_PILL_NODE = 'filePill'
+
+/**
  * The fixed padding run re-emitted after every pill token to preserve the
  * on-disk draft schema (`\uE002..\uE003`). A single FIGURE SPACE (U+2007) — the
  * content is not load-bearing (the pill is a real DOM node, so the padding no
@@ -65,7 +77,7 @@ export const CMD_PILL_NODE = 'commandPill'
 export const SKILL_PAD_DEFAULT = SKILL_PAD_CHAR
 
 export interface DocSegment {
-  kind: 'text' | 'pill' | 'commandPill'
+  kind: 'text' | 'pill' | 'commandPill' | 'filePill'
   /** Visible text for a `text` segment; the padded token (`\uE000<name>\uE001\uE002<pad>\uE003`)
    * for a `pill` segment; the command token (`\uE004<name>\uE005`) for a
    * `commandPill` segment. */
@@ -106,7 +118,7 @@ export function walkDocSegments(doc: PmNode): DocSegment[] {
       block.forEach((node, offset) => {
         const docFrom = blockOffset + 1 + offset
         let displayText = ''
-        let kind: 'text' | 'pill' | 'commandPill' = 'text'
+        let kind: 'text' | 'pill' | 'commandPill' | 'filePill' = 'text'
         if (node.isText) {
           displayText = node.text ?? ''
           blockEndedInHardBreak = false
@@ -126,6 +138,18 @@ export function walkDocSegments(doc: PmNode): DocSegment[] {
           // / timeline renderer never see command tokens.
           displayText = `${CMD_TOKEN_START}${name}${CMD_TOKEN_END}`
           kind = 'commandPill'
+          blockEndedInHardBreak = false
+        } else if (node.type.name === FILE_PILL_NODE) {
+          const display = String(node.attrs.display ?? '')
+          const absPath = String(node.attrs.absPath ?? '')
+          // File pill: no padding block (the pill is a real DOM node). The
+          // sentinel pair is distinct from skill/command sentinels so the
+          // skill wire framer / timeline renderer / command walk never see
+          // file tokens. The token carries display + absPath split by the
+          // unit separator `\u001F` so the wire builder can resolve the path
+          // at send time without an external lookup map.
+          displayText = `${FILE_TOKEN_START}${display}${FILE_TOKEN_SEP}${absPath}${FILE_TOKEN_END}`
+          kind = 'filePill'
           blockEndedInHardBreak = false
         } else if (node.type.name === 'hardBreak') {
           displayText = '\n'
@@ -198,7 +222,8 @@ export function docOffsetToDisplayOffset(doc: PmNode, docOffset: number): number
   for (const seg of segments) {
     if (docOffset < seg.docTo) {
       if (docOffset <= seg.docFrom) return seg.displayFrom
-      if (seg.kind === 'pill' || seg.kind === 'commandPill') return seg.displayFrom
+      if (seg.kind === 'pill' || seg.kind === 'commandPill' || seg.kind === 'filePill')
+        return seg.displayFrom
       return seg.displayFrom + (docOffset - seg.docFrom)
     }
   }
@@ -227,7 +252,8 @@ export function displayOffsetToDocOffset(doc: PmNode, displayOffset: number): nu
       // the display newline belongs at the end of the preceding paragraph.
       if (seg.docFrom === seg.docTo) return Math.max(0, seg.docFrom - 1)
       if (displayOffset <= seg.displayFrom) return seg.docFrom
-      if (seg.kind === 'pill' || seg.kind === 'commandPill') return seg.docTo
+      if (seg.kind === 'pill' || seg.kind === 'commandPill' || seg.kind === 'filePill')
+        return seg.docTo
       return seg.docFrom + (displayOffset - seg.displayFrom)
     }
   }

--- a/src/renderer/lib/composer/draft-from-tokens.ts
+++ b/src/renderer/lib/composer/draft-from-tokens.ts
@@ -13,8 +13,15 @@
  * crashes the editor. Unparseable segments become plain text (the spec's
  * "Resume draft" fallback: a draft always loads, even if partially garbled).
  */
-import { CMD_TOKEN_END, CMD_TOKEN_START, parseSkillSegments } from '@/lib/skill-tokens'
-import { CMD_PILL_NODE, SKILL_PILL_NODE } from './doc-to-prompt'
+import {
+  CMD_TOKEN_END,
+  CMD_TOKEN_START,
+  FILE_TOKEN_END,
+  FILE_TOKEN_SEP,
+  FILE_TOKEN_START,
+  parseSkillSegments
+} from '@/lib/skill-tokens'
+import { CMD_PILL_NODE, FILE_PILL_NODE, SKILL_PILL_NODE } from './doc-to-prompt'
 
 interface PmDocJSON {
   type: 'doc'
@@ -40,6 +47,7 @@ type ComposerSegment =
   | { kind: 'text'; text: string }
   | { kind: 'skill'; name: string }
   | { kind: 'command'; name: string }
+  | { kind: 'file'; display: string; absPath: string }
 
 /**
  * Split a composer value into ordered text/skill/command segments. Delegates
@@ -64,8 +72,11 @@ function parseComposerSegments(value: string): ComposerSegment[] {
       segments.push({ kind: 'skill', name: seg.name })
       continue
     }
-    // Text segment: walk for command tokens (\uE004<name>\uE005). Command
-    // tokens carry no padding block (the command pill is a real DOM node).
+    // Text segment: walk for command tokens (\uE004<name>\uE005) and file
+    // tokens (\uE006<display>\u001F<absPath>\uE007). Both carry no padding
+    // block (the pills are real DOM nodes). File tokens are not skill
+    // sentinels, so `parseSkillSegments` leaves them in the text segments
+    // alongside command tokens — we walk for both here.
     let i = 0
     let text = ''
     while (i < seg.text.length) {
@@ -88,6 +99,35 @@ function parseComposerSegments(value: string): ComposerSegment[] {
           text = ''
         }
         segments.push({ kind: 'command', name })
+        i = end + 1
+      } else if (seg.text[i] === FILE_TOKEN_START) {
+        const end = seg.text.indexOf(FILE_TOKEN_END, i + 1)
+        if (end === -1) {
+          // No closing sentinel — treat the rest as plain text.
+          text += seg.text.slice(i)
+          break
+        }
+        const inner = seg.text.slice(i + 1, end)
+        const sep = inner.indexOf(FILE_TOKEN_SEP)
+        if (sep === -1) {
+          // No separator — malformed, treat as plain text.
+          text += seg.text.slice(i, end + 1)
+          i = end + 1
+          continue
+        }
+        const display = inner.slice(0, sep)
+        const absPath = inner.slice(sep + 1)
+        if (display.length === 0 || absPath.length === 0) {
+          // Empty display/path — treat as plain text.
+          text += seg.text.slice(i, end + 1)
+          i = end + 1
+          continue
+        }
+        if (text.length > 0) {
+          segments.push({ kind: 'text', text })
+          text = ''
+        }
+        segments.push({ kind: 'file', display, absPath })
         i = end + 1
       } else {
         text += seg.text[i]
@@ -130,6 +170,13 @@ export function draftFromTokens(
       paragraphs.at(-1)!.push({
         type: CMD_PILL_NODE,
         attrs: { name: seg.name }
+      })
+      continue
+    }
+    if (seg.kind === 'file') {
+      paragraphs.at(-1)!.push({
+        type: FILE_PILL_NODE,
+        attrs: { display: seg.display, absPath: seg.absPath }
       })
       continue
     }

--- a/src/renderer/lib/skill-tokens.test.ts
+++ b/src/renderer/lib/skill-tokens.test.ts
@@ -1,9 +1,17 @@
 import { describe, expect, it } from 'vitest'
 import {
   extractSkillNames,
+  fileToken,
+  FILE_TOKEN_END,
+  FILE_TOKEN_SEP,
+  FILE_TOKEN_START,
+  insertFileToken,
   insertSkillToken,
+  parseFileSegments,
   parseSkillSegments,
+  removeFileTokenBeforeCaret,
   removeSkillTokenBeforeCaret,
+  replaceFileTokensInline,
   replaceSkillTokensInline,
   SKILL_PAD_CHAR,
   SKILL_PAD_END,
@@ -294,6 +302,201 @@ describe('skillToken', () => {
     const pad = SKILL_PAD_CHAR.repeat(3)
     expect(skillToken('git-worktree', pad)).toBe(
       `${SKILL_TOKEN_START}git-worktree${SKILL_TOKEN_END}${SKILL_PAD_START}${pad}${SKILL_PAD_END}`
+    )
+  })
+})
+
+// ============================================================================
+// File-mention pill token model
+// ============================================================================
+
+const FT = (display: string, absPath: string): string => fileToken(display, absPath)
+
+describe('parseFileSegments', () => {
+  it('returns no segments for an empty value', () => {
+    expect(parseFileSegments('')).toEqual([])
+  })
+
+  it('returns a single text segment for plain text with no tokens', () => {
+    expect(parseFileSegments('hello world')).toEqual([{ kind: 'text', text: 'hello world' }])
+  })
+
+  it('parses a lone token into a single file segment', () => {
+    const t = FT('auth.ts', '/work/src/auth.ts')
+    expect(parseFileSegments(t)).toEqual([
+      { kind: 'file', display: 'auth.ts', absPath: '/work/src/auth.ts', raw: t }
+    ])
+  })
+
+  it('parses text + token + text in order', () => {
+    const t = FT('auth.ts', '/work/src/auth.ts')
+    expect(parseFileSegments(`fix this ${t} bug`)).toEqual([
+      { kind: 'text', text: 'fix this ' },
+      { kind: 'file', display: 'auth.ts', absPath: '/work/src/auth.ts', raw: t },
+      { kind: 'text', text: ' bug' }
+    ])
+  })
+
+  it('parses adjacent tokens with no text between them', () => {
+    const t1 = FT('auth.ts', '/work/src/auth.ts')
+    const t2 = FT('util.ts', '/work/src/util.ts')
+    expect(parseFileSegments(`${t1}${t2}`)).toEqual([
+      { kind: 'file', display: 'auth.ts', absPath: '/work/src/auth.ts', raw: t1 },
+      { kind: 'file', display: 'util.ts', absPath: '/work/src/util.ts', raw: t2 }
+    ])
+  })
+
+  it('parses a token at the start and a token at the end', () => {
+    const t1 = FT('auth.ts', '/work/src/auth.ts')
+    const t2 = FT('util.ts', '/work/src/util.ts')
+    expect(parseFileSegments(`${t1} middle ${t2}`)).toEqual([
+      { kind: 'file', display: 'auth.ts', absPath: '/work/src/auth.ts', raw: t1 },
+      { kind: 'text', text: ' middle ' },
+      { kind: 'file', display: 'util.ts', absPath: '/work/src/util.ts', raw: t2 }
+    ])
+  })
+
+  it('handles slash-containing paths', () => {
+    const t = FT('src/deep/path/file.ts', '/work/src/deep/path/file.ts')
+    expect(parseFileSegments(t)).toEqual([
+      {
+        kind: 'file',
+        display: 'src/deep/path/file.ts',
+        absPath: '/work/src/deep/path/file.ts',
+        raw: t
+      }
+    ])
+  })
+
+  it('treats an unterminated start sentinel as plain text', () => {
+    expect(parseFileSegments(`hello ${FILE_TOKEN_START}auth.ts`)).toEqual([
+      { kind: 'text', text: `hello ${FILE_TOKEN_START}auth.ts` }
+    ])
+  })
+
+  it('treats a token with no separator as plain text', () => {
+    const malformed = `${FILE_TOKEN_START}auth.ts${FILE_TOKEN_END}`
+    expect(parseFileSegments(`fix ${malformed}`)).toEqual([
+      { kind: 'text', text: `fix ${malformed}` }
+    ])
+  })
+
+  it('treats a token with empty display or path as plain text', () => {
+    const emptyDisplay = `${FILE_TOKEN_START}${FILE_TOKEN_SEP}/work/auth.ts${FILE_TOKEN_END}`
+    const emptyPath = `${FILE_TOKEN_START}auth.ts${FILE_TOKEN_SEP}${FILE_TOKEN_END}`
+    expect(parseFileSegments(emptyDisplay)).toEqual([{ kind: 'text', text: emptyDisplay }])
+    expect(parseFileSegments(emptyPath)).toEqual([{ kind: 'text', text: emptyPath }])
+  })
+
+  it('coexists with skill tokens: file tokens are invisible to parseSkillSegments and vice versa', () => {
+    const st = skillToken('git-worktree')
+    const ft = FT('auth.ts', '/work/src/auth.ts')
+    const value = `use ${st} on ${ft}`
+    // The skill walk treats the file token as plain text (correct).
+    expect(parseSkillSegments(value)).toEqual([
+      { kind: 'text', text: 'use ' },
+      { kind: 'skill', name: 'git-worktree', raw: st, padding: '' },
+      {
+        kind: 'text',
+        text: ` on ${ft}`
+      }
+    ])
+    // The file walk treats the skill token as plain text (correct).
+    expect(parseFileSegments(value)).toEqual([
+      { kind: 'text', text: `use ${st} on ` },
+      { kind: 'file', display: 'auth.ts', absPath: '/work/src/auth.ts', raw: ft }
+    ])
+  })
+})
+
+describe('replaceFileTokensInline', () => {
+  it('returns the value unchanged when there are no tokens', () => {
+    expect(replaceFileTokensInline('hello world')).toBe('hello world')
+  })
+
+  it('replaces a single token with (display)', () => {
+    const t = FT('auth.ts', '/work/src/auth.ts')
+    expect(replaceFileTokensInline(`fix this ${t} bug`)).toBe('fix this (auth.ts) bug')
+  })
+
+  it('preserves inline duplicates', () => {
+    const t = FT('auth.ts', '/work/src/auth.ts')
+    expect(replaceFileTokensInline(`${t} and again ${t}`)).toBe(
+      '(auth.ts) and again (auth.ts)'
+    )
+  })
+
+  it('replaces slash-containing display paths', () => {
+    const t = FT('src/deep/file.ts', '/work/src/deep/file.ts')
+    expect(replaceFileTokensInline(`see ${t}`)).toBe('see (src/deep/file.ts)')
+  })
+
+  it('leaves skill tokens untouched', () => {
+    const st = skillToken('git-worktree')
+    const ft = FT('auth.ts', '/work/src/auth.ts')
+    expect(replaceFileTokensInline(`use ${st} on ${ft}`)).toBe(
+      `use ${st} on (auth.ts)`
+    )
+  })
+
+  it('leaves malformed tokens as plain text', () => {
+    const malformed = `${FILE_TOKEN_START}auth.ts${FILE_TOKEN_END}`
+    expect(replaceFileTokensInline(`fix ${malformed}`)).toBe(`fix ${malformed}`)
+  })
+})
+
+describe('insertFileToken', () => {
+  it('splices a token at the caret with a trailing space', () => {
+    const value = 'fix this '
+    const { value: next, caret } = insertFileToken(
+      value,
+      value.length,
+      'auth.ts',
+      '/work/src/auth.ts'
+    )
+    const t = FT('auth.ts', '/work/src/auth.ts')
+    expect(next).toBe(`fix this ${t} `)
+    expect(caret).toBe(next.length)
+  })
+
+  it('removes the deleteBefore chars preceding the caret', () => {
+    const value = 'fix @auth'
+    // caret at end; deleteBefore removes the @auth filter (5 chars).
+    const { value: next, caret } = insertFileToken(
+      value,
+      value.length,
+      'auth.ts',
+      '/work/src/auth.ts',
+      5
+    )
+    const t = FT('auth.ts', '/work/src/auth.ts')
+    expect(next).toBe(`fix ${t} `)
+    expect(caret).toBe(next.length)
+  })
+})
+
+describe('removeFileTokenBeforeCaret', () => {
+  it('removes the whole token + trailing space when caret is after the space', () => {
+    const t = FT('auth.ts', '/work/src/auth.ts')
+    const value = `fix ${t} bug`
+    // caret right after the trailing space following the token.
+    const caret = `fix ${t} `.length
+    expect(removeFileTokenBeforeCaret(value, caret)).toEqual({
+      removed: true,
+      value: 'fix bug',
+      caret: 4
+    })
+  })
+
+  it('returns removed:false when caret is not after a token', () => {
+    expect(removeFileTokenBeforeCaret('hello world', 5)).toEqual({ removed: false })
+  })
+})
+
+describe('fileToken', () => {
+  it('encodes display + absPath split by the unit separator', () => {
+    expect(fileToken('auth.ts', '/work/src/auth.ts')).toBe(
+      `${FILE_TOKEN_START}auth.ts${FILE_TOKEN_SEP}/work/src/auth.ts${FILE_TOKEN_END}`
     )
   })
 })

--- a/src/renderer/lib/skill-tokens.ts
+++ b/src/renderer/lib/skill-tokens.ts
@@ -423,3 +423,179 @@ export function removeCommandTokenBeforeCaret(
   const after = value.slice(caret)
   return { removed: true, value: `${before}${after}`, caret: start }
 }
+
+// ============================================================================
+// Inline file-mention pill token model
+// ============================================================================
+
+/**
+ * Inline file-mention pill sentinels. Distinct from the skill
+ * (`\uE000/\uE001`) and command (`\uE004/\uE005`) sentinels so the skill wire
+ * framer (`parseSkillSegments`), the skill timeline renderer, and
+ * `extractSkillNames` never see file tokens. The file pill is a real inline
+ * DOM node (a Tiptap `NodeView`), so — like the skill/command pills — there is
+ * no caret-alignment deficit to compensate: no padding block.
+ *
+ * A file token carries BOTH a display string (the filename/relPath shown in
+ * the pill) AND the absolute OS path (needed for the `resource_link` wire
+ * block), split by the unit separator `\u001F`:
+ * `\uE006<display>\u001F<absPath>\uE007`. The display string is the segment
+ * before the separator; the path is after. `parseFileSegments` splits on
+ * `\u001F` inside the token. The separator is non-whitespace, non-`@`/`/`, and
+ * invisible in raw text — it won't trip the mention/slash scanners.
+ */
+export const FILE_TOKEN_START = '\uE006'
+export const FILE_TOKEN_END = '\uE007'
+/**
+ * Unit separator (U+001F) splitting the display string from the absolute path
+ * inside a file token. Non-whitespace, non-printing, and not a sentinel used by
+ * any other pill system.
+ */
+export const FILE_TOKEN_SEP = '\u001F'
+
+/** A run of plain text or a single file token extracted from the value. */
+export type FileSegment =
+  | { kind: 'text'; text: string }
+  | { kind: 'file'; display: string; absPath: string; raw: string }
+
+/**
+ * Build a file token string for the given display name + absolute path. The
+ * display string is shown in the pill; the absolute path is resolved to a
+ * `file://` URI for the wire `resource_link` block at send time. No padding
+ * block — the file pill is a real DOM node.
+ */
+export function fileToken(display: string, absPath: string): string {
+  return `${FILE_TOKEN_START}${display}${FILE_TOKEN_SEP}${absPath}${FILE_TOKEN_END}`
+}
+
+/**
+ * Split a composer value into ordered text/file segments. Token boundaries are
+ * `\uE006<display>\u001F<absPath>\uE007`. Walks the RAW value independently of
+ * `parseSkillSegments` — file sentinels (`\uE006`) are not skill sentinels
+ * (`\uE000`), so the skill walk treats them as plain text (correct); this walk
+ * extracts the file tokens the skill walk leaves behind. Malformed tokens (no
+ * closing sentinel, no separator, empty display/path) are treated as plain
+ * text so a corrupted value never crashes the timeline renderer or wire framer.
+ */
+export function parseFileSegments(value: string): FileSegment[] {
+  const segments: FileSegment[] = []
+  let i = 0
+  let text = ''
+  while (i < value.length) {
+    if (value[i] === FILE_TOKEN_START) {
+      const end = value.indexOf(FILE_TOKEN_END, i + 1)
+      if (end === -1) {
+        // No closing sentinel — treat the rest as plain text.
+        text += value.slice(i)
+        break
+      }
+      const inner = value.slice(i + 1, end)
+      const sep = inner.indexOf(FILE_TOKEN_SEP)
+      if (sep === -1) {
+        // No separator — malformed token, treat as plain text.
+        text += value.slice(i, end + 1)
+        i = end + 1
+        continue
+      }
+      const display = inner.slice(0, sep)
+      const absPath = inner.slice(sep + 1)
+      if (display.length === 0 || absPath.length === 0) {
+        // Empty display or path — treat as plain text.
+        text += value.slice(i, end + 1)
+        i = end + 1
+        continue
+      }
+      if (text.length > 0) {
+        segments.push({ kind: 'text', text })
+        text = ''
+      }
+      segments.push({
+        kind: 'file',
+        display,
+        absPath,
+        raw: value.slice(i, end + 1)
+      })
+      i = end + 1
+    } else {
+      text += value[i]
+      i += 1
+    }
+  }
+  if (text.length > 0) segments.push({ kind: 'text', text })
+  return segments
+}
+
+/**
+ * Splice a file token into the value at `caret`, removing the `deleteBefore`
+ * chars immediately preceding the caret (the `@filter` text the mention menu
+ * clears). A trailing space is appended so the caret lands in plain text and
+ * the user can keep typing. No padding block — the file pill is a real DOM
+ * node. Returns the new value and the caret position to apply.
+ */
+export function insertFileToken(
+  value: string,
+  caret: number,
+  display: string,
+  absPath: string,
+  deleteBefore = 0
+): InsertTokenResult {
+  const start = Math.max(0, Math.min(caret - deleteBefore, value.length))
+  const end = Math.max(start, Math.min(caret, value.length))
+  const before = value.slice(0, start)
+  const after = value.slice(end)
+  const token = fileToken(display, absPath)
+  const next = `${before}${token} ${after}`
+  // Caret lands right after the trailing space.
+  return { value: next, caret: before.length + token.length + 1 }
+}
+
+export type RemoveFileTokenResult =
+  | { removed: true; value: string; caret: number }
+  | { removed: false }
+
+/**
+ * Backspace semantics for the composer: when the caret is *immediately* after a
+ * file token (no selection), remove the whole token plus the trailing space
+ * the splicer appended, and place the caret where the token started. Tolerates
+ * the splicer's trailing space (caret may sit one char after the token end).
+ * Returns `removed:false` for the caller to fall back to the default one-char
+ * backspace. Parallel to `removeSkillTokenBeforeCaret`/`removeCommandTokenBeforeCaret`
+ * but without a padding block (files carry none).
+ */
+export function removeFileTokenBeforeCaret(
+  value: string,
+  caret: number
+): RemoveFileTokenResult {
+  if (caret <= 0 || caret > value.length) return { removed: false }
+  // Walk back from the caret over the optional trailing space to reach the
+  // token-end \uE007.
+  let end = caret
+  if (end - 1 >= 0 && value[end - 1] === ' ') {
+    end -= 1
+  }
+  if (end - 1 < 0 || value[end - 1] !== FILE_TOKEN_END) return { removed: false }
+  const tokenEnd = end - 1
+  const start = value.lastIndexOf(FILE_TOKEN_START, tokenEnd - 1)
+  if (start === -1) return { removed: false }
+  const inner = value.slice(start + 1, tokenEnd)
+  const sep = inner.indexOf(FILE_TOKEN_SEP)
+  if (sep === -1) return { removed: false }
+  const display = inner.slice(0, sep)
+  const absPath = inner.slice(sep + 1)
+  if (display.length === 0 || absPath.length === 0) return { removed: false }
+  const before = value.slice(0, start)
+  const after = value.slice(caret)
+  return { removed: true, value: `${before}${after}`, caret: start }
+}
+
+/**
+ * Replace each file token with `(<display>)` for the wire prompt's user-text
+ * portion. Inline duplicates are preserved (the same file may appear at
+ * multiple positions). Non-token text is passed through verbatim. Mirrors
+ * `replaceSkillTokensInline` for skills.
+ */
+export function replaceFileTokensInline(value: string): string {
+  return parseFileSegments(value)
+    .map((s) => (s.kind === 'file' ? `(${s.display})` : s.text))
+    .join('')
+}


### PR DESCRIPTION
## Summary

File `@`-mentions now render inline as Tiptap `filePill` NodeView pills in the composer and timeline — the same treatment slash commands and skills already had — instead of hoisting to the `AttachmentPreviewGroup` attachment bar above the chatbox.

When a user types `@` and picks a file, a file token (`\uE006<display>\u001F<absPath>\uE007`) is spliced INTO the editor value at the caret, rendering as a muted inline `FileChip` pill (with a `File` icon, visually distinct from the accent `SkillChip`). The wire builder extracts unique file paths and emits the existing `resource_link` content blocks; the display text keeps raw tokens so the timeline renders inline file pills.

The staged-attachment bar (`AttachmentPreviewGroup`) remains unchanged for OS-picker / drag-drop / paste attachments — only the `@`-mention channel moves inline.

## Changes

- **NEW** `src/renderer/components/chat/FileChip.tsx` — shared muted visual pill (`File` icon, `border-border/60 bg-muted/60`), inline metrics matching `SkillChip`
- **NEW** `src/renderer/components/chat/composer/FilePillNode.tsx` — Tiptap inline atom node mirroring `SkillPillNode` (`atom:true`, `parseHTML()->[]`, `renderText` emits sentinel)
- `src/renderer/lib/skill-tokens.ts` — file-token sentinels (`\uE006`/`\uE007`/`\u001F`) + `fileToken`, `parseFileSegments`, `insertFileToken`, `removeFileTokenBeforeCaret`, `replaceFileTokensInline`
- `src/renderer/lib/composer/doc-to-prompt.ts` — `FILE_PILL_NODE` + `walkDocSegments` branch + offset maps
- `src/renderer/lib/composer/draft-from-tokens.ts` — `parseComposerSegments` + `draftFromTokens` for file tokens
- `src/renderer/components/chat/composer/ChatComposerEditor.tsx` — `FilePill` registration + paste guard + backspace keymap
- `src/renderer/components/chat/use-composer-mentions.ts` — `select` splices file token in (no hoist via `addFileRef`)
- `src/renderer/components/chat/use-composer-attachments.ts` — removed orphaned `addFileRef` (no callers after inline move)
- `src/renderer/components/chat/use-chat-composer.ts` — `buildPromptParts` extracts file tokens → deduped `resource_link` blocks; `replaceFileTokensInline` for wire text
- `src/renderer/components/chat/ChatInputBar.tsx` — display-split fix + wire block assembly for file-only / file+attachments branches
- `src/renderer/components/chat/ChatMessage.tsx` — timeline `FileChip` rendering + copy de-token
- `src/renderer/components/agents/AgentLauncher.tsx` — same mention + wire changes for parity
- Tests: `skill-tokens.test.ts`, `ChatInputBar.test.tsx`, `ChatMessage.test.tsx`, `AgentLauncher.test.tsx`, `use-composer-mentions.test.tsx`

## Review patches applied

- **[high]** `hasFileRefs` branch in `ChatInputBar.submit` omitted `displayBlocks` arg — timeline would have rendered `(auth.ts)` text instead of inline `FileChip` for file-only mentions. Fixed.
- **[high]** `hasAttachments && !hasSkills` branch had same display-split defect when `hasFileRefs` is true. Fixed.
- **[medium]** Stale assertion in `use-composer-mentions.test.tsx` ({value:'',caret:0}) against new `insertFileToken` behavior. Rewrote.
- **[medium]** `ChatInputBar.test.tsx` send test codified the single-arg (buggy) call. Rewrote to assert two-arg call with display blocks.
- **[medium]** Orphaned `addFileRef` dead code removed from `use-composer-attachments.ts`.
- **[low]** `FileChip.tsx` doc referenced deleted transparent-textarea overlay. Fixed.

## Verification

- `bun run typecheck` — zero errors
- `npx biome lint --no-ignore-on-error src/` — clean
- `bun run test` for 6 affected test files — 178 tests pass
- Visual/manual checks confirmed in running Tauri dev session

## Test plan

- [ ] Composer: type text, `@`-pick a file → `FileChip` renders inline at caret (not in attachment bar)
- [ ] Pick a second file → second inline pill
- [ ] Backspace over a file pill → whole pill removed
- [ ] Skill pill + file pill inline together → visually distinct (accent Sparkles vs muted File)
- [ ] Drag-drop image still shows in attachment bar (not inline)
- [ ] Send → timeline shows inline `FileChip` in user bubble
- [ ] Edit a sent file-chip message → composer re-seeds with pills inline
- [ ] Launcher (Ctrl+T): `@`-pick a file → inline pill; Launch → first turn shows file pill in timeline

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added inline file mentions in the composer, displayed as compact file chips.
  - File mentions remain visible while editing, support caret navigation, backspace removal, clipboard handling, and draft restoration.
  - File references can be submitted alongside attachments or independently.
  - Sent messages include file links while preserving readable filenames in displayed content.
  - Added support for rendering file mentions in message text.

- **Bug Fixes**
  - Prevented duplicate file references when the same file is mentioned and attached.
  - Copied message content now excludes internal token markers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->