### PR TITLE
fix(chat): resolve changed-files panel path from ACP locations field

### DIFF
--- a/src/renderer/components/chat/ChatChangedFilesPanel.test.tsx
+++ b/src/renderer/components/chat/ChatChangedFilesPanel.test.tsx
@@ -199,4 +199,42 @@ describe('ChatChangedFilesPanel', () => {
     renderPanel([makeToolCall({ toolCallId: 'e1', path: 'src/foo.ts' })])
     expect(screen.getByText('Changed files')).toBeInTheDocument()
   })
+
+  it('resolves file path from ACP locations field when rawInput has no path key', () => {
+    renderPanel([
+      makeToolCall({
+        toolCallId: 'e1',
+        path: undefined as unknown as string,
+        rawInput: { command: 'sed -i ...' },
+        locations: [{ path: 'src/from-locations.ts' }]
+      })
+    ])
+    expect(screen.getByText('Changed files')).toBeInTheDocument()
+    expect(screen.getByText('1')).toBeInTheDocument()
+  })
+
+  it('prefers locations path over rawInput path', () => {
+    renderPanel([
+      makeToolCall({
+        toolCallId: 'e1',
+        rawInput: { filePath: 'src/from-input.ts' },
+        locations: [{ path: 'src/from-locations.ts' }]
+      })
+    ])
+    fireEvent.click(screen.getByRole('button', { name: /expand/i }))
+    expect(screen.getByText('src/from-locations.ts')).toBeInTheDocument()
+  })
+
+  it('shows panel when locations is present even without diff content', () => {
+    renderPanel([
+      makeToolCall({
+        toolCallId: 'e1',
+        path: undefined as unknown as string,
+        content: [],
+        rawInput: {},
+        locations: [{ path: 'src/edited-via-locations.ts' }]
+      })
+    ])
+    expect(screen.getByText('Changed files')).toBeInTheDocument()
+  })
 })

--- a/src/renderer/components/chat/ChatChangedFilesPanel.tsx
+++ b/src/renderer/components/chat/ChatChangedFilesPanel.tsx
@@ -21,9 +21,9 @@ interface ChangedFile {
 }
 
 /** Extract file-changing tool calls (edit, delete, move) from the session's
- * tool-call list. Paths come from `toolCallPath` (rawInput + diff content).
- * Add/remove counts come from `describeToolCall().diffStat` — the same
- * battle-tested path used by ToolCallCard. */
+ * tool-call list. Paths come from `toolCallPath` (locations → rawInput → diff
+ * content). Add/remove counts come from `describeToolCall().diffStat` — the
+ * same battle-tested path used by ToolCallCard. */
 function extractChangedFiles(toolCalls: ToolCall[]): ChangedFile[] {
   const files: ChangedFile[] = []
   const seen = new Set<string>()

--- a/src/renderer/components/chat/tool-call-summary.test.ts
+++ b/src/renderer/components/chat/tool-call-summary.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it } from 'vitest'
 import type { ToolCall } from '@/lib/acp-api'
-import { baseName, describeToolCall, isSubagentCall, readableOutput } from './tool-call-summary'
+import {
+  baseName,
+  describeToolCall,
+  isSubagentCall,
+  readableOutput,
+  toolCallPath
+} from './tool-call-summary'
 
 function call(partial: Partial<ToolCall>): ToolCall {
   return { toolCallId: 't1', ...partial }
@@ -135,5 +141,39 @@ describe('readableOutput', () => {
   it('returns empty (never raw JSON) when nothing readable exists', () => {
     expect(readableOutput({ metadata: { ids: [1, 2] } })).toBe('')
     expect(readableOutput(null)).toBe('')
+  })
+})
+
+describe('toolCallPath', () => {
+  it('prefers locations[0].path over rawInput and diff content', () => {
+    const p = toolCallPath(
+      call({
+        kind: 'edit',
+        rawInput: { filePath: 'src/from-input.ts' },
+        content: [{ type: 'diff', path: 'src/from-diff.ts', newText: 'x' }],
+        locations: [{ path: 'src/from-locations.ts' }]
+      })
+    )
+    expect(p).toBe('src/from-locations.ts')
+  })
+
+  it('falls back to rawInput when locations is absent', () => {
+    const p = toolCallPath(call({ kind: 'edit', rawInput: { path: 'src/from-input.ts' } }))
+    expect(p).toBe('src/from-input.ts')
+  })
+
+  it('falls back to diff content path when locations and rawInput are absent', () => {
+    const p = toolCallPath(
+      call({
+        kind: 'edit',
+        content: [{ type: 'diff', path: 'src/from-diff.ts', newText: 'x' }]
+      })
+    )
+    expect(p).toBe('src/from-diff.ts')
+  })
+
+  it('returns undefined when no path source is available', () => {
+    expect(toolCallPath(call({ kind: 'edit', rawInput: { command: 'ls' } }))).toBeUndefined()
+    expect(toolCallPath(call({ kind: 'edit' }))).toBeUndefined()
   })
 })

--- a/src/renderer/components/chat/tool-call-summary.ts
+++ b/src/renderer/components/chat/tool-call-summary.ts
@@ -121,12 +121,15 @@ function diffInfo(content: ToolCallContent[]): {
 }
 
 /**
- * Shared best-effort file-path resolver for a tool call. Checks `rawInput`
- * against `PATH_KEYS`, then falls back to `diffInfo(content).path`. Used by
- * both `describeToolCall` (chip label) and `ToolCallCard`'s open-file action
+ * Shared best-effort file-path resolver for a tool call. Checks `locations`
+ * (the canonical ACP follow-along field) first, then `rawInput` against
+ * `PATH_KEYS`, then falls back to `diffInfo(content).path`. Used by both
+ * `describeToolCall` (chip label) and `ToolCallCard`'s open-file action
  * so they stay in sync.
  */
 export function toolCallPath(toolCall: ToolCall): string | undefined {
+  const loc = toolCall.locations?.[0]?.path
+  if (loc) return loc
   const input = asRecord(toolCall.rawInput)
   const fromInput = firstString(input, PATH_KEYS)
   if (fromInput) return fromInput

--- a/src/renderer/lib/acp-api.ts
+++ b/src/renderer/lib/acp-api.ts
@@ -129,12 +129,22 @@ export type ToolCallContent =
   | { type: 'terminal'; terminalId?: string }
   | { type: string; [k: string]: unknown }
 
+/** A file location affected by a tool call (ACP `ToolCallLocation`). */
+export interface ToolCallLocation {
+  path: string
+  line?: number
+}
+
 export interface ToolCall {
   toolCallId: string
   title?: string
   kind?: ToolKind
   status?: ToolCallStatus
   content?: ToolCallContent[]
+  /** File locations affected by this tool call (ACP `locations` field).
+   * Agents populate this for "follow-along" features — it is the canonical
+   * path source, ahead of the `rawInput` heuristic and diff-content fallback. */
+  locations?: ToolCallLocation[]
   rawInput?: unknown
   rawOutput?: unknown
   /** Client-side arrival time (stamped in the store for timeline ordering). */
@@ -150,6 +160,7 @@ export interface ToolCallUpdate {
   kind?: ToolKind
   status?: ToolCallStatus
   content?: ToolCallContent[]
+  locations?: ToolCallLocation[]
   rawInput?: unknown
   rawOutput?: unknown
   [k: string]: unknown


### PR DESCRIPTION
## Summary

The "Changed files" panel above the live chatbox did not appear when agents edited files during a live session. The root cause: `toolCallPath()` resolved file paths from only two heuristic sources — `rawInput` (a hardcoded list of key names like `path`, `filePath`) and diff content — but missed the canonical ACP `locations` field that agents populate for "follow-along" features. Agents that populate `locations` but use non-standard `rawInput` key names produced `undefined`, so `extractChangedFiles` skipped them and the panel never mounted.

## Related Issue

Closes #675

## Type of Change

- [x] fix: bug fix

## What Changed

- **`src/renderer/lib/acp-api.ts`** — Added `ToolCallLocation` interface (`{ path: string; line?: number }`) and `locations?: ToolCallLocation[]` to both `ToolCall` and `ToolCallUpdate`, matching the ACP schema's `ToolCallLocation` struct.
- **`src/renderer/components/chat/tool-call-summary.ts`** — Updated `toolCallPath()` to check `toolCall.locations?.[0]?.path` **first** (the canonical ACP field), then fall back to the existing `rawInput` heuristic and diff-content path. One-line addition at the top of the resolver; the rest of the chain is unchanged.
- **`src/renderer/components/chat/ChatChangedFilesPanel.tsx`** — Updated doc comment only (no logic change needed; it calls `toolCallPath` which now checks `locations`).

## How It Was Tested

- [x] `bun run typecheck` — clean, no errors
- [x] `bun run test` — 24/24 tool-call-summary + 18/18 ChatChangedFilesPanel + 14/14 ToolCallCard + 49/49 acp-history-persistence tests pass
- [x] Manual verification completed (code path traced through live event flow)

## CI & Review Gate

- [ ] All CI checks pass
- [ ] Code review comments addressed
- [ ] No unresolved review findings remain

## Checklist

- [x] My PR title follows the conventional commit format used by this repo
- [x] I linked the related issue or explained why none exists
- [x] I updated docs when needed (doc comments updated)
- [x] I added or updated tests when needed (7 new test cases)
- [x] I verified the change does not introduce unrelated modifications
- [x] I read AGENTS.md and followed the contributor guidelines
- [x] A human reviewed the complete diff before submission