### PR TITLE
feat(git): per-line stage/unstage within a hunk

### DIFF
--- a/src/renderer/assets/agent-icons/acp/agents.json
+++ b/src/renderer/assets/agent-icons/acp/agents.json
@@ -300,38 +300,38 @@
   {
     "id": "devin",
     "name": "Devin",
-    "version": "3000.6.2",
+    "version": "3000.6.7",
     "description": "Devin CLI coding agent by Cognition",
     "distribution": {
       "binary": {
         "darwin-aarch64": {
           "cmd": "./bin/devin",
-          "archive": "https://static.devin.ai/cli/3000.6.2/devin-3000.6.2-aarch64-apple-darwin.tar.gz",
+          "archive": "https://static.devin.ai/cli/3000.6.7/devin-3000.6.7-aarch64-apple-darwin.tar.gz",
           "args": ["acp"]
         },
         "darwin-x86_64": {
           "cmd": "./bin/devin",
-          "archive": "https://static.devin.ai/cli/3000.6.2/devin-3000.6.2-x86_64-apple-darwin.tar.gz",
+          "archive": "https://static.devin.ai/cli/3000.6.7/devin-3000.6.7-x86_64-apple-darwin.tar.gz",
           "args": ["acp"]
         },
         "linux-aarch64": {
           "cmd": "./bin/devin",
-          "archive": "https://static.devin.ai/cli/3000.6.2/devin-3000.6.2-aarch64-unknown-linux.tar.gz",
+          "archive": "https://static.devin.ai/cli/3000.6.7/devin-3000.6.7-aarch64-unknown-linux.tar.gz",
           "args": ["acp"]
         },
         "linux-x86_64": {
           "cmd": "./bin/devin",
-          "archive": "https://static.devin.ai/cli/3000.6.2/devin-3000.6.2-x86_64-unknown-linux.tar.gz",
+          "archive": "https://static.devin.ai/cli/3000.6.7/devin-3000.6.7-x86_64-unknown-linux.tar.gz",
           "args": ["acp"]
         },
         "windows-aarch64": {
           "cmd": "./bin\\devin.exe",
-          "archive": "https://static.devin.ai/cli/3000.6.2/devin-3000.6.2-aarch64-pc-windows.zip",
+          "archive": "https://static.devin.ai/cli/3000.6.7/devin-3000.6.7-aarch64-pc-windows.zip",
           "args": ["acp"]
         },
         "windows-x86_64": {
           "cmd": "./bin\\devin.exe",
-          "archive": "https://static.devin.ai/cli/3000.6.2/devin-3000.6.2-x86_64-pc-windows.zip",
+          "archive": "https://static.devin.ai/cli/3000.6.7/devin-3000.6.7-x86_64-pc-windows.zip",
           "args": ["acp"]
         }
       }
@@ -364,11 +364,11 @@
   {
     "id": "factory-droid",
     "name": "Factory Droid",
-    "version": "0.206.0",
+    "version": "0.208.0",
     "description": "Factory Droid - AI coding agent powered by Factory AI",
     "distribution": {
       "npx": {
-        "package": "droid@0.206.0",
+        "package": "droid@0.208.0",
         "args": ["exec", "--output-format", "acp-daemon"],
         "env": {
           "DROID_DISABLE_AUTO_UPDATE": "true",
@@ -419,11 +419,11 @@
   {
     "id": "glm-acp-agent",
     "name": "GLM Agent",
-    "version": "1.6.1",
+    "version": "1.7.0",
     "description": "ACP agent powered by Zhipu AI's GLM Coding Plan models (glm-5.1, glm-5-turbo, glm-4.7, glm-4.5-air). Supports streaming, tool calls, mid-session model switching, image input via Z.AI Coding Plan Vision MCP, and session load/fork/resume with on-disk persistence.",
     "distribution": {
       "npx": {
-        "package": "glm-acp-agent@1.6.1"
+        "package": "glm-acp-agent@1.7.0"
       }
     }
   },
@@ -461,11 +461,11 @@
   {
     "id": "grok-build",
     "name": "Grok Build",
-    "version": "1.0.12",
+    "version": "1.0.13",
     "description": "xAI's coding agent and CLI",
     "distribution": {
       "npx": {
-        "package": "@xai-official/grok@1.0.12",
+        "package": "@xai-official/grok@1.0.13",
         "args": ["agent", "stdio"]
       }
     }
@@ -548,37 +548,37 @@
   {
     "id": "kilo",
     "name": "Kilo",
-    "version": "7.5.5",
+    "version": "7.5.6",
     "description": "The open source coding agent",
     "distribution": {
       "npx": {
-        "package": "@kilocode/cli@7.5.5",
+        "package": "@kilocode/cli@7.5.6",
         "args": ["acp"]
       },
       "binary": {
         "darwin-aarch64": {
           "cmd": "./kilo",
-          "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.5.5/kilo-darwin-arm64.zip",
+          "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.5.6/kilo-darwin-arm64.zip",
           "args": ["acp"]
         },
         "darwin-x86_64": {
           "cmd": "./kilo",
-          "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.5.5/kilo-darwin-x64.zip",
+          "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.5.6/kilo-darwin-x64.zip",
           "args": ["acp"]
         },
         "linux-aarch64": {
           "cmd": "./kilo",
-          "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.5.5/kilo-linux-arm64.tar.gz",
+          "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.5.6/kilo-linux-arm64.tar.gz",
           "args": ["acp"]
         },
         "linux-x86_64": {
           "cmd": "./kilo",
-          "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.5.5/kilo-linux-x64.tar.gz",
+          "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.5.6/kilo-linux-x64.tar.gz",
           "args": ["acp"]
         },
         "windows-x86_64": {
           "cmd": "./kilo.exe",
-          "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.5.5/kilo-windows-x64.zip",
+          "archive": "https://github.com/Kilo-Org/kilocode/releases/download/v7.5.6/kilo-windows-x64.zip",
           "args": ["acp"]
         }
       }
@@ -779,11 +779,11 @@
   {
     "id": "qwen-code",
     "name": "Qwen Code",
-    "version": "0.22.2",
+    "version": "0.22.3",
     "description": "Alibaba's Qwen coding assistant",
     "distribution": {
       "npx": {
-        "package": "@qwen-code/qwen-code@0.22.2",
+        "package": "@qwen-code/qwen-code@0.22.3",
         "args": ["--acp", "--experimental-skills"]
       }
     }

--- a/src/renderer/assets/agent-icons/acp/agents.json
+++ b/src/renderer/assets/agent-icons/acp/agents.json
@@ -125,11 +125,11 @@
   {
     "id": "codebuddy-code",
     "name": "Codebuddy Code",
-    "version": "2.140.0",
+    "version": "2.141.0",
     "description": "Tencent Cloud's official intelligent coding tool",
     "distribution": {
       "npx": {
-        "package": "@tencent-ai/codebuddy-code@2.140.0",
+        "package": "@tencent-ai/codebuddy-code@2.141.0",
         "args": ["--acp"]
       }
     }
@@ -137,11 +137,11 @@
   {
     "id": "codex-acp",
     "name": "Codex",
-    "version": "1.6.2",
+    "version": "1.7.0",
     "description": "ACP adapter for OpenAI's coding assistant",
     "distribution": {
       "npx": {
-        "package": "@agentclientprotocol/codex-acp@1.6.2"
+        "package": "@agentclientprotocol/codex-acp@1.7.0"
       }
     }
   },
@@ -340,11 +340,11 @@
   {
     "id": "dimcode",
     "name": "DimCode",
-    "version": "0.3.21",
+    "version": "0.3.22",
     "description": "A coding agent that puts leading models at your command.",
     "distribution": {
       "npx": {
-        "package": "dimcode@0.3.21",
+        "package": "dimcode@0.3.22",
         "args": ["acp"]
       }
     }
@@ -352,11 +352,11 @@
   {
     "id": "dirac",
     "name": "Dirac",
-    "version": "0.5.0",
+    "version": "0.5.1",
     "description": "Reduces API costs by more than 50%, produces better and faster work. Uses Hash anchored parallel edits, AST manipulation and a whole lot of neat optimizations. Fully Open Source.",
     "distribution": {
       "npx": {
-        "package": "dirac-cli@0.5.0",
+        "package": "dirac-cli@0.5.1",
         "args": ["--acp"]
       }
     }
@@ -364,11 +364,11 @@
   {
     "id": "factory-droid",
     "name": "Factory Droid",
-    "version": "0.205.0",
+    "version": "0.206.0",
     "description": "Factory Droid - AI coding agent powered by Factory AI",
     "distribution": {
       "npx": {
-        "package": "droid@0.205.0",
+        "package": "droid@0.206.0",
         "args": ["exec", "--output-format", "acp-daemon"],
         "env": {
           "DROID_DISABLE_AUTO_UPDATE": "true",
@@ -407,11 +407,11 @@
   {
     "id": "github-copilot-cli",
     "name": "GitHub Copilot",
-    "version": "1.0.80",
+    "version": "1.0.81",
     "description": "GitHub's AI pair programmer",
     "distribution": {
       "npx": {
-        "package": "@github/copilot@1.0.80",
+        "package": "@github/copilot@1.0.81",
         "args": ["--acp"]
       }
     }
@@ -430,7 +430,7 @@
   {
     "id": "goose",
     "name": "goose",
-    "version": "1.47.0",
+    "version": "1.48.0",
     "description": "A local, extensible, open source AI agent that automates engineering tasks",
     "distribution": {
       "binary": {
@@ -452,7 +452,7 @@
         },
         "windows-x86_64": {
           "cmd": "./goose-package\\goose.exe",
-          "archive": "https://github.com/block/goose/releases/download/v1.47.0/goose-x86_64-pc-windows-msvc.zip",
+          "archive": "https://github.com/block/goose/releases/download/v1.48.0/goose-x86_64-pc-windows-msvc.zip",
           "args": ["acp"]
         }
       }
@@ -461,11 +461,11 @@
   {
     "id": "grok-build",
     "name": "Grok Build",
-    "version": "1.0.11",
+    "version": "1.0.12",
     "description": "xAI's coding agent and CLI",
     "distribution": {
       "npx": {
-        "package": "@xai-official/grok@1.0.11",
+        "package": "@xai-official/grok@1.0.12",
         "args": ["agent", "stdio"]
       }
     }
@@ -473,33 +473,33 @@
   {
     "id": "harn",
     "name": "Harn",
-    "version": "0.10.118",
+    "version": "0.10.119",
     "description": "Harn runs .harn agent pipelines as a native ACP coding agent over stdio.",
     "distribution": {
       "binary": {
         "darwin-aarch64": {
           "cmd": "./harn",
-          "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.118/harn-aarch64-apple-darwin.tar.gz",
+          "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.119/harn-aarch64-apple-darwin.tar.gz",
           "args": ["serve", "acp"]
         },
         "darwin-x86_64": {
           "cmd": "./harn",
-          "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.118/harn-x86_64-apple-darwin.tar.gz",
+          "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.119/harn-x86_64-apple-darwin.tar.gz",
           "args": ["serve", "acp"]
         },
         "linux-aarch64": {
           "cmd": "./harn",
-          "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.118/harn-aarch64-unknown-linux-gnu.tar.gz",
+          "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.119/harn-aarch64-unknown-linux-gnu.tar.gz",
           "args": ["serve", "acp"]
         },
         "linux-x86_64": {
           "cmd": "./harn",
-          "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.118/harn-x86_64-unknown-linux-gnu.tar.gz",
+          "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.119/harn-x86_64-unknown-linux-gnu.tar.gz",
           "args": ["serve", "acp"]
         },
         "windows-x86_64": {
           "cmd": "harn.exe",
-          "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.118/harn-x86_64-pc-windows-msvc.zip",
+          "archive": "https://github.com/burin-labs/harn/releases/download/v0.10.119/harn-x86_64-pc-windows-msvc.zip",
           "args": ["serve", "acp"]
         }
       }
@@ -676,38 +676,38 @@
   {
     "id": "opencode",
     "name": "OpenCode",
-    "version": "1.18.23",
+    "version": "1.18.25",
     "description": "The open source coding agent",
     "distribution": {
       "binary": {
         "darwin-aarch64": {
           "cmd": "./opencode",
-          "archive": "https://github.com/anomalyco/opencode/releases/download/v1.18.23/opencode-darwin-arm64.zip",
+          "archive": "https://github.com/anomalyco/opencode/releases/download/v1.18.25/opencode-darwin-arm64.zip",
           "args": ["acp"]
         },
         "darwin-x86_64": {
           "cmd": "./opencode",
-          "archive": "https://github.com/anomalyco/opencode/releases/download/v1.18.23/opencode-darwin-x64.zip",
+          "archive": "https://github.com/anomalyco/opencode/releases/download/v1.18.25/opencode-darwin-x64.zip",
           "args": ["acp"]
         },
         "linux-aarch64": {
           "cmd": "./opencode",
-          "archive": "https://github.com/anomalyco/opencode/releases/download/v1.18.23/opencode-linux-arm64.tar.gz",
+          "archive": "https://github.com/anomalyco/opencode/releases/download/v1.18.25/opencode-linux-arm64.tar.gz",
           "args": ["acp"]
         },
         "linux-x86_64": {
           "cmd": "./opencode",
-          "archive": "https://github.com/anomalyco/opencode/releases/download/v1.18.23/opencode-linux-x64.tar.gz",
+          "archive": "https://github.com/anomalyco/opencode/releases/download/v1.18.25/opencode-linux-x64.tar.gz",
           "args": ["acp"]
         },
         "windows-aarch64": {
           "cmd": "./opencode",
-          "archive": "https://github.com/anomalyco/opencode/releases/download/v1.18.23/opencode-windows-arm64.zip",
+          "archive": "https://github.com/anomalyco/opencode/releases/download/v1.18.25/opencode-windows-arm64.zip",
           "args": ["acp"]
         },
         "windows-x86_64": {
           "cmd": "./opencode.exe",
-          "archive": "https://github.com/anomalyco/opencode/releases/download/v1.18.23/opencode-windows-x64.zip",
+          "archive": "https://github.com/anomalyco/opencode/releases/download/v1.18.25/opencode-windows-x64.zip",
           "args": ["acp"]
         }
       }

--- a/src/renderer/components/git/GitDiffView.test.tsx
+++ b/src/renderer/components/git/GitDiffView.test.tsx
@@ -134,3 +134,28 @@ index 1234567..abcdefg 100644
     expect(button.textContent).toContain('(1)')
   })
 })
+
+describe('GitDiffView line-selection gating', () => {
+  const MULTI_LINE_DIFF = `diff --git a/foo.ts b/foo.ts
+index 1234567..abcdefg 100644
+--- a/foo.ts
++++ b/foo.ts
+@@ -1,4 +1,4 @@
+ const x = 1
+-oldLine
+-oldLine2
++newLine
++newLine2
+ const y = 2
+`
+
+  it('renders no selection toggles when the mutation callback is absent (mobile path)', () => {
+    render(
+      <GitDiffView diff={MULTI_LINE_DIFF} mode="inline" filePath="foo.ts" diffSide="unstaged" />
+    )
+    expect(screen.queryAllByRole('button', { name: /line for partial staging/i })).toHaveLength(0)
+    expect(screen.queryByRole('button', { name: 'Stage selected lines' })).not.toBeInTheDocument()
+    // The hunk-level button is gated as well (no callback wired).
+    expect(screen.queryByRole('button', { name: 'Stage hunk' })).not.toBeInTheDocument()
+  })
+})

--- a/src/renderer/components/git/GitDiffView.test.tsx
+++ b/src/renderer/components/git/GitDiffView.test.tsx
@@ -1,4 +1,4 @@
-import { render } from '@testing-library/react'
+import { fireEvent, render, screen } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { GitDiffView } from './GitDiffView'
 
@@ -60,5 +60,77 @@ describe('GitDiffView', () => {
     const text = container.textContent ?? ''
     expect(text).toContain('oldLine')
     expect(text).toContain('newLine')
+  })
+})
+
+describe('GitDiffView per-line staging (Phase 2, #257)', () => {
+  const MULTI_LINE_DIFF = `diff --git a/foo.ts b/foo.ts
+index 1234567..abcdefg 100644
+--- a/foo.ts
++++ b/foo.ts
+@@ -1,4 +1,4 @@
+ const x = 1
+-oldLine
+-oldLine2
++newLine
++newLine2
+ const y = 2
+`
+
+  it('toggles line selection via the gutter and stages only the selected lines', () => {
+    const onStageHunk = vi.fn()
+    render(
+      <GitDiffView
+        diff={MULTI_LINE_DIFF}
+        mode="inline"
+        filePath="foo.ts"
+        diffSide="unstaged"
+        onStageHunk={onStageHunk}
+      />
+    )
+
+    // No partial action before any selection.
+    expect(screen.queryByRole('button', { name: 'Stage selected lines' })).not.toBeInTheDocument()
+
+    // Toggle gutter renders one control per +/- line, in diff order:
+    // -oldLine, -oldLine2, +newLine, +newLine2.
+    const toggles = screen.getAllByRole('button', { name: /line for partial staging/i })
+    expect(toggles).toHaveLength(4)
+    const [oldLineToggle, , , newLine2Toggle] = toggles
+
+    fireEvent.click(oldLineToggle)
+    fireEvent.click(newLine2Toggle)
+
+    const selected = screen.getByRole('button', { name: 'Stage selected lines' })
+    expect(selected.textContent).toContain('(2)')
+    fireEvent.click(selected)
+
+    expect(onStageHunk).toHaveBeenCalledTimes(1)
+    const patch = onStageHunk.mock.calls[0][0] as string
+    expect(patch).toContain('-oldLine\n')
+    expect(patch).toContain('+newLine2\n')
+    // Unselected deletion stays in the patch as context; unselected addition
+    // is dropped entirely.
+    expect(patch).toContain(' oldLine2\n')
+    expect(patch).not.toContain('+newLine\n')
+    expect(patch).not.toContain('-oldLine2\n')
+    // Recomputed header counts: ctx(x,y,oldLine2)=3 + del 1 = old 4; 3 + add 1 = 4.
+    expect(patch).toContain('@@ -1,4 +1,4 @@')
+  })
+
+  it('labels the partial action Unstage on the staged side', () => {
+    render(
+      <GitDiffView
+        diff={MULTI_LINE_DIFF}
+        mode="inline"
+        filePath="foo.ts"
+        diffSide="staged"
+        onUnstageHunk={vi.fn()}
+      />
+    )
+    const toggle = screen.getAllByRole('button', { name: /line for partial staging/i })[0]
+    fireEvent.click(toggle)
+    const button = screen.getByRole('button', { name: 'Unstage selected lines' })
+    expect(button.textContent).toContain('(1)')
   })
 })

--- a/src/renderer/components/git/GitDiffView.tsx
+++ b/src/renderer/components/git/GitDiffView.tsx
@@ -263,7 +263,8 @@ function InlineDiff({
   action,
   onAction,
   selectedLines,
-  onToggleLine
+  onToggleLine,
+  selectionEnabled
 }: {
   diff: string
   filePath: string
@@ -273,6 +274,7 @@ function InlineDiff({
   onAction?: (patch: string) => void
   selectedLines: ReadonlySet<number>
   onToggleLine: (index: number) => void
+  selectionEnabled: boolean
 }): React.JSX.Element {
   const lines = useMemo(() => parseUnifiedDiffInline(diff), [diff])
   const wordDiffRanges = useMemo(() => computeInlineWordDiffRanges(lines), [lines])
@@ -300,7 +302,8 @@ function InlineDiff({
           text selection (copy) is not hijacked. */}
       <div className="flex-shrink-0 select-none">
         {lines.map((line, i) => {
-          const selectable = line.kind === 'deletion' || line.kind === 'addition'
+          const selectable =
+            selectionEnabled && (line.kind === 'deletion' || line.kind === 'addition')
           if (!selectable) {
             return <div key={`tog-${i}`} className="w-4 py-0.5 min-h-[1.25rem]" />
           }
@@ -653,6 +656,10 @@ export function GitDiffView({
       onAction={onAction}
       selectedLines={selectedLines}
       onToggleLine={toggleLine}
+      // Line selection is only meaningful when an apply callback exists
+      // (the mobile GitPanel path omits the stage/unstage handlers, so its
+      // diff view must not offer selections that nothing can consume).
+      selectionEnabled={rawAction !== undefined}
     />
   )
 }

--- a/src/renderer/components/git/GitDiffView.tsx
+++ b/src/renderer/components/git/GitDiffView.tsx
@@ -1,6 +1,6 @@
 import type React from 'react'
-import { useEffect, useMemo, useState } from 'react'
-import { buildHunkPatches, type HunkPatch } from '@/lib/build-hunk-patch'
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { buildHunkPatches, buildLinePatch, type HunkPatch } from '@/lib/build-hunk-patch'
 import {
   getLanguageForFile,
   isParserReady,
@@ -214,44 +214,116 @@ function computeInlineWordDiffRanges(
 
 function HunkActionBar({
   action,
-  onAction
+  onAction,
+  selectedCount,
+  onSelectedAction
 }: {
   action: HunkAction
   onAction?: () => void
+  selectedCount?: number
+  onSelectedAction?: () => void
 }): React.JSX.Element | null {
-  if (!onAction) return null
-  const label = action === 'stage' ? 'Stage hunk' : 'Unstage hunk'
+  if (!onAction && !onSelectedAction) return null
+  const verb = action === 'stage' ? 'Stage' : 'Unstage'
+  const buttonClass =
+    'ml-2 inline-flex items-center rounded border border-border/60 bg-background/80 px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide text-muted-foreground hover:bg-accent hover:text-accent-foreground'
   return (
-    <button
-      type="button"
-      onClick={onAction}
-      className="ml-2 inline-flex items-center rounded border border-border/60 bg-background/80 px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide text-muted-foreground hover:bg-accent hover:text-accent-foreground"
-      title={label}
-      aria-label={label}
-    >
-      {label}
-    </button>
+    <>
+      {onAction ? (
+        <button
+          type="button"
+          onClick={onAction}
+          className={buttonClass}
+          title={`${verb} hunk`}
+          aria-label={`${verb} hunk`}
+        >
+          {verb} hunk
+        </button>
+      ) : null}
+      {onSelectedAction && selectedCount && selectedCount > 0 ? (
+        <button
+          type="button"
+          onClick={onSelectedAction}
+          className={buttonClass}
+          title={`${verb} selected lines`}
+          aria-label={`${verb} selected lines`}
+        >
+          {verb} selected ({selectedCount})
+        </button>
+      ) : null}
+    </>
   )
 }
 
 function InlineDiff({
   diff,
+  filePath,
   language,
   hunkByIndex,
   action,
-  onAction
+  onAction,
+  selectedLines,
+  onToggleLine
 }: {
   diff: string
+  filePath: string
   language: string
   hunkByIndex: Map<number, HunkPatch>
   action?: HunkAction
   onAction?: (patch: string) => void
+  selectedLines: ReadonlySet<number>
+  onToggleLine: (index: number) => void
 }): React.JSX.Element {
   const lines = useMemo(() => parseUnifiedDiffInline(diff), [diff])
   const wordDiffRanges = useMemo(() => computeInlineWordDiffRanges(lines), [lines])
 
+  // Per-hunk count of selected +/- lines (context lines are not selectable).
+  const selectedCountByHunk = useMemo(() => {
+    const counts = new Map<number, number>()
+    for (const hunk of hunkByIndex.values()) {
+      let count = 0
+      for (const index of hunk.bodyLineIndices) {
+        const raw = lines[index]?.raw ?? ''
+        if (selectedLines.has(index) && (raw.startsWith('+') || raw.startsWith('-'))) {
+          count += 1
+        }
+      }
+      if (count > 0) counts.set(hunk.headerIndex, count)
+    }
+    return counts
+  }, [hunkByIndex, lines, selectedLines])
+
   return (
     <div className="flex p-4 font-mono text-xs min-w-full" style={{ tabSize: 4, MozTabSize: 4 }}>
+      {/* Phase 2 (#257): line-selection toggle gutter. Only +/- lines are
+          selectable; the strip is separate from the line numbers so plain
+          text selection (copy) is not hijacked. */}
+      <div className="flex-shrink-0 select-none">
+        {lines.map((line, i) => {
+          const selectable = line.kind === 'deletion' || line.kind === 'addition'
+          if (!selectable) {
+            return <div key={`tog-${i}`} className="w-4 py-0.5 min-h-[1.25rem]" />
+          }
+          const selected = selectedLines.has(i)
+          return (
+            <button
+              key={`tog-${i}`}
+              type="button"
+              onClick={() => onToggleLine(i)}
+              aria-pressed={selected}
+              aria-label={`${selected ? 'Clear' : 'Select'} line for partial staging`}
+              className={cn(
+                'w-4 py-0.5 min-h-[1.25rem] flex items-center justify-center text-[9px] leading-none cursor-pointer',
+                selected
+                  ? 'text-primary font-bold'
+                  : 'text-transparent hover:text-muted-foreground/50'
+              )}
+            >
+              {selected ? '●' : '·'}
+            </button>
+          )
+        })}
+      </div>
       {/* Line number gutters */}
       <div className="flex-shrink-0 select-none border-r border-border/40">
         {lines.map((line, i) => (
@@ -286,6 +358,7 @@ function InlineDiff({
               : line.kind === 'addition'
                 ? (diffRanges?.added ?? [])
                 : []
+          const isSelected = selectedLines.has(i)
 
           return (
             <div
@@ -293,7 +366,8 @@ function InlineDiff({
               className={cn(
                 lineClass(line.kind),
                 line.kind === 'deletion' && changedRanges.length > 0 && 'bg-red-500/15',
-                line.kind === 'addition' && changedRanges.length > 0 && 'bg-green-500/15'
+                line.kind === 'addition' && changedRanges.length > 0 && 'bg-green-500/15',
+                isSelected && 'bg-primary/15 outline outline-1 outline-primary/40'
               )}
             >
               {isHunkBody ? (
@@ -312,6 +386,15 @@ function InlineDiff({
                       onAction={
                         hunkByIndex.has(i) && onAction
                           ? () => onAction(hunkByIndex.get(i)!.patch)
+                          : undefined
+                      }
+                      selectedCount={selectedCountByHunk.get(i) ?? 0}
+                      onSelectedAction={
+                        hunkByIndex.has(i) && onAction
+                          ? () => {
+                              const partial = buildLinePatch(diff, filePath, i, selectedLines)
+                              if (partial) onAction(partial)
+                            }
                           : undefined
                       }
                     />
@@ -512,8 +595,36 @@ export function GitDiffView({
   // The displayed side decides whether a hunk action stages or unstages.
   const action: HunkAction | undefined =
     diffSide === 'unstaged' ? 'stage' : diffSide === 'staged' ? 'unstage' : undefined
-  const onAction =
+  const rawAction =
     action === 'stage' ? onStageHunk : action === 'unstage' ? onUnstageHunk : undefined
+
+  // Phase 2 (#257): per-line selection for partial staging. Indices are
+  // positions in the raw diff string — the same key `buildLinePatch` uses.
+  // Selection resets whenever the diff changes (post-stage refetch) and is
+  // cleared after any apply so stale toggles never linger.
+  const [selectedLines, setSelectedLines] = useState<Set<number>>(new Set())
+  // biome-ignore lint/correctness/useExhaustiveDependencies: deliberate reset-on-diff — selection must not survive a refetch
+  useEffect(() => {
+    setSelectedLines(new Set())
+  }, [diff])
+  const toggleLine = useCallback((index: number) => {
+    setSelectedLines((prev) => {
+      const next = new Set(prev)
+      if (next.has(index)) {
+        next.delete(index)
+      } else {
+        next.add(index)
+      }
+      return next
+    })
+  }, [])
+  const onAction = useCallback(
+    (patch: string) => {
+      setSelectedLines(new Set())
+      rawAction?.(patch)
+    },
+    [rawAction]
+  )
 
   if (mode === 'split') {
     return (
@@ -529,10 +640,13 @@ export function GitDiffView({
   return (
     <InlineDiff
       diff={diff}
+      filePath={filePath ?? ''}
       language={language}
       hunkByIndex={hunkByInlineIndex}
       action={action}
       onAction={onAction}
+      selectedLines={selectedLines}
+      onToggleLine={toggleLine}
     />
   )
 }

--- a/src/renderer/components/git/GitDiffView.tsx
+++ b/src/renderer/components/git/GitDiffView.tsx
@@ -601,6 +601,7 @@ export function GitDiffView({
   // anything (review feedback).
   const rawAction =
     diffSide === 'unstaged' ? onStageHunk : diffSide === 'staged' ? onUnstageHunk : undefined
+  const selectionEnabled = rawAction !== undefined
   const action: HunkAction | undefined = rawAction
     ? diffSide === 'unstaged'
       ? 'stage'
@@ -612,10 +613,10 @@ export function GitDiffView({
   // Selection resets whenever the diff changes (post-stage refetch) and is
   // cleared after any apply so stale toggles never linger.
   const [selectedLines, setSelectedLines] = useState<Set<number>>(new Set())
-  // biome-ignore lint/correctness/useExhaustiveDependencies: deliberate reset-on-diff — selection must not survive a refetch
+  // biome-ignore lint/correctness/useExhaustiveDependencies: deliberate reset-on-diff and on apply-availability — selection must not survive a refetch or a callback unmount (review: stale selections could reactivate if the callback returns for the same diff)
   useEffect(() => {
     setSelectedLines(new Set())
-  }, [diff])
+  }, [diff, selectionEnabled])
   const toggleLine = useCallback((index: number) => {
     setSelectedLines((prev) => {
       const next = new Set(prev)
@@ -659,7 +660,7 @@ export function GitDiffView({
       // Line selection is only meaningful when an apply callback exists
       // (the mobile GitPanel path omits the stage/unstage handlers, so its
       // diff view must not offer selections that nothing can consume).
-      selectionEnabled={rawAction !== undefined}
+      selectionEnabled={selectionEnabled}
     />
   )
 }

--- a/src/renderer/components/git/GitDiffView.tsx
+++ b/src/renderer/components/git/GitDiffView.tsx
@@ -616,7 +616,7 @@ export function GitDiffView({
   // biome-ignore lint/correctness/useExhaustiveDependencies: deliberate reset-on-diff and on apply-availability — selection must not survive a refetch or a callback unmount (review: stale selections could reactivate if the callback returns for the same diff)
   useEffect(() => {
     setSelectedLines(new Set())
-  }, [diff, selectionEnabled])
+  }, [diff, filePath, mode, action, selectionEnabled])
   const toggleLine = useCallback((index: number) => {
     setSelectedLines((prev) => {
       const next = new Set(prev)

--- a/src/renderer/components/git/GitDiffView.tsx
+++ b/src/renderer/components/git/GitDiffView.tsx
@@ -593,10 +593,16 @@ export function GitDiffView({
   }, [diff, hunks])
 
   // The displayed side decides whether a hunk action stages or unstages.
-  const action: HunkAction | undefined =
-    diffSide === 'unstaged' ? 'stage' : diffSide === 'staged' ? 'unstage' : undefined
+  // Actions are only exposed when the matching callback is wired — a rendered
+  // button without a callback would clear the selection without applying
+  // anything (review feedback).
   const rawAction =
-    action === 'stage' ? onStageHunk : action === 'unstage' ? onUnstageHunk : undefined
+    diffSide === 'unstaged' ? onStageHunk : diffSide === 'staged' ? onUnstageHunk : undefined
+  const action: HunkAction | undefined = rawAction
+    ? diffSide === 'unstaged'
+      ? 'stage'
+      : 'unstage'
+    : undefined
 
   // Phase 2 (#257): per-line selection for partial staging. Indices are
   // positions in the raw diff string — the same key `buildLinePatch` uses.

--- a/src/renderer/components/git/GitPanel.tsx
+++ b/src/renderer/components/git/GitPanel.tsx
@@ -44,6 +44,7 @@ import {
 import { ScrollArea } from '@/components/ui/scroll-area'
 import { useMobileWebShell } from '@/hooks/use-mobile-web-shell'
 import { gitApi } from '@/lib/git-api'
+import { logFrontendError } from '@/lib/log-api'
 import {
   type GitDiffViewMode,
   loadGitDiffViewMode,
@@ -315,16 +316,28 @@ export function GitPanel({ cwd, isVisible }: GitPanelProps) {
   // Per-hunk stage/unstage (#257). The patch is built by GitDiffView from
   // the displayed diff and applied to the index without touching the rest
   // of the file. After mutation, fetchDiff re-loads the (now smaller) diff
-  // so the panel reflects the partial stage.
+  // so the panel reflects the partial stage. The same handlers serve both
+  // the hunk-level and the per-line (Phase 2) actions; boundary + failure
+  // logs carry non-sensitive metadata only (operation, patch size).
   const runStageHunk = useCallback(
     async (patch: string) => {
       if (!selectedFile || generationInFlight.current || hunkInFlight.current) return
       hunkInFlight.current = true
       setIsMutating(true)
+      void logFrontendError({
+        level: 'info',
+        source: 'GitPanel.runStageHunk',
+        message: `dispatch: stage patch (${patch.split('\n').length} lines)`
+      })
       try {
         await stageHunk(cwd, selectedFile, patch)
         await fetchDiff(cwd, selectedFile, false)
       } catch (error) {
+        void logFrontendError({
+          level: 'warn',
+          source: 'GitPanel.runStageHunk',
+          message: `failed: ${String(error)}`
+        })
         toast.error(`Failed to stage hunk: ${String(error)}`)
       } finally {
         setIsMutating(false)
@@ -339,10 +352,20 @@ export function GitPanel({ cwd, isVisible }: GitPanelProps) {
       if (!selectedFile || generationInFlight.current || hunkInFlight.current) return
       hunkInFlight.current = true
       setIsMutating(true)
+      void logFrontendError({
+        level: 'info',
+        source: 'GitPanel.runUnstageHunk',
+        message: `dispatch: unstage patch (${patch.split('\n').length} lines)`
+      })
       try {
         await unstageHunk(cwd, selectedFile, patch)
         await fetchDiff(cwd, selectedFile, true)
       } catch (error) {
+        void logFrontendError({
+          level: 'warn',
+          source: 'GitPanel.runUnstageHunk',
+          message: `failed: ${String(error)}`
+        })
         toast.error(`Failed to unstage hunk: ${String(error)}`)
       } finally {
         setIsMutating(false)

--- a/src/renderer/components/git/GitPanel.tsx
+++ b/src/renderer/components/git/GitPanel.tsx
@@ -325,7 +325,7 @@ export function GitPanel({ cwd, isVisible }: GitPanelProps) {
       hunkInFlight.current = true
       setIsMutating(true)
       void logFrontendError({
-        level: 'info',
+        level: 'warn',
         source: 'GitPanel.runStageHunk',
         message: `dispatch: stage patch (${patch.split('\n').length} lines)`
       })
@@ -353,7 +353,7 @@ export function GitPanel({ cwd, isVisible }: GitPanelProps) {
       hunkInFlight.current = true
       setIsMutating(true)
       void logFrontendError({
-        level: 'info',
+        level: 'warn',
         source: 'GitPanel.runUnstageHunk',
         message: `dispatch: unstage patch (${patch.split('\n').length} lines)`
       })

--- a/src/renderer/components/git/GitPanel.tsx
+++ b/src/renderer/components/git/GitPanel.tsx
@@ -336,7 +336,7 @@ export function GitPanel({ cwd, isVisible }: GitPanelProps) {
         void logFrontendError({
           level: 'warn',
           source: 'GitPanel.runStageHunk',
-          message: `failed: ${String(error)}`
+          message: 'failed: git apply rejected the patch (details surfaced via UI toast only)'
         })
         toast.error(`Failed to stage hunk: ${String(error)}`)
       } finally {
@@ -364,7 +364,7 @@ export function GitPanel({ cwd, isVisible }: GitPanelProps) {
         void logFrontendError({
           level: 'warn',
           source: 'GitPanel.runUnstageHunk',
-          message: `failed: ${String(error)}`
+          message: 'failed: git apply rejected the patch (details surfaced via UI toast only)'
         })
         toast.error(`Failed to unstage hunk: ${String(error)}`)
       } finally {

--- a/src/renderer/lib/build-hunk-patch.test.ts
+++ b/src/renderer/lib/build-hunk-patch.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { buildHunkPatches } from './build-hunk-patch'
+import { buildHunkPatches, buildLinePatch } from './build-hunk-patch'
 
 const SINGLE_HUNK_DIFF = [
   'diff --git a/foo.txt b/foo.txt',
@@ -118,5 +118,79 @@ describe('buildHunkPatches', () => {
     // hunk belongs to a different path (which the backend would reject).
     expect(hunks).toHaveLength(1)
     expect(hunks[0].patch).toContain('-a\n+A')
+  })
+})
+
+describe('buildLinePatch (Phase 2, #257)', () => {
+  const DIFF = [
+    '--- a/foo.txt',
+    '+++ b/foo.txt',
+    '@@ -1,4 +1,4 @@',
+    ' keep me',
+    '-drop del',
+    '-keep del',
+    '+drop add',
+    '+keep add',
+    ' tail'
+  ].join('\n')
+
+  it('keeps selected +/- lines, converts unselected deletions to context, drops unselected additions', () => {
+    // Selected: "-keep del" (index 5) and "+keep add" (index 7). "-drop del"
+    // becomes context (index keeps old text); "+drop add" is dropped.
+    const selected = new Set([5, 7])
+    const patch = buildLinePatch(DIFF, 'foo.txt', 2, selected)
+    expect(patch).toBe(
+      [
+        '--- a/foo.txt',
+        '+++ b/foo.txt',
+        '@@ -1,4 +1,4 @@',
+        ' keep me',
+        ' drop del',
+        '-keep del',
+        '+keep add',
+        ' tail'
+      ].join('\n') + '\n'
+    )
+  })
+
+  it('recomputes the header counts from the transformed body', () => {
+    const selected = new Set([5, 7]) // one deletion + one addition kept
+    const patch = buildLinePatch(DIFF, 'foo.txt', 2, selected)!
+    // Body after transform: " keep me", " drop del"(ctx), "-keep del",
+    // "+keep add", " tail" → old = 4 ctx-ish? ctx lines: keep me, drop del,
+    // tail = 3; del = 1 → old 4. new = 3 ctx + 1 add = 4.
+    expect(patch).toContain('@@ -1,4 +1,4 @@')
+  })
+
+  it('returns null when nothing +/- is selected', () => {
+    // Only a context line index (3 = " keep me").
+    expect(buildLinePatch(DIFF, 'foo.txt', 2, new Set([3]))).toBeNull()
+    expect(buildLinePatch(DIFF, 'foo.txt', 2, new Set())).toBeNull()
+  })
+
+  it('returns null for an unknown hunk header index', () => {
+    expect(buildLinePatch(DIFF, 'foo.txt', 99, new Set([5]))).toBeNull()
+  })
+
+  it('keeps a no-newline marker after a kept line and drops it after a dropped addition', () => {
+    const diff = [
+      '--- a/foo.txt',
+      '+++ b/foo.txt',
+      '@@ -1,2 +1,3 @@',
+      ' ctx',
+      '-gone',
+      '+kept',
+      '\\ No newline at end of file',
+      '+dropped',
+      '\\ No newline at end of file'
+    ].join('\n')
+    // Select only "+kept" (index 5). "-gone" becomes context; the first
+    // marker follows a kept line and stays; "+dropped" and its marker go.
+    const patch = buildLinePatch(diff, 'foo.txt', 2, new Set([5]))!
+    expect(patch).toContain('+kept')
+    expect(patch).toContain(' ctx')
+    expect(patch).toContain(' gone')
+    expect(patch).not.toContain('+dropped')
+    expect(patch.match(/\\ No newline/g)?.length).toBe(1)
   })
 })

--- a/src/renderer/lib/build-hunk-patch.ts
+++ b/src/renderer/lib/build-hunk-patch.ts
@@ -15,6 +15,12 @@
  * rather than by prefix sniffing, so a body line that happens to look like a
  * file header (e.g. deleting a line whose text is `-- comment` produces the
  * diff line `--- comment`) is not mistaken for a structural header.
+ *
+ * Phase 2 (#257): `buildLinePatch` builds a partial patch from a subset of a
+ * hunk's +/- lines for per-line stage/unstage. Selection semantics mirror
+ * `git add -p`'s manual edit: selected additions/deletions are kept; an
+ * UNSELECTED DELETION becomes a context line (the index keeps the old text);
+ * an UNSELECTED ADDITION is dropped (the new text is left unstaged).
  */
 export interface HunkPatch {
   /** Index of the hunk header line in the diff (for keying UI rows). */
@@ -23,12 +29,15 @@ export interface HunkPatch {
   headerLine: string
   /** Full patch text ready for `git apply`. */
   patch: string
+  /** Diff line indices of the hunk body, in order (context/+/-/\\ meta). */
+  bodyLineIndices: number[]
 }
 
-interface ActiveHunk {
+interface RichHunk {
   headerIndex: number
   headerLine: string
   bodyLines: string[]
+  bodyLineIndices: number[]
   oldLeft: number
   newLeft: number
 }
@@ -50,11 +59,26 @@ function hunkBodyBudget(header: string): { old: number; new: number } | null {
   }
 }
 
-export function buildHunkPatches(diff: string, filePath: string): HunkPatch[] {
-  if (!diff || !filePath) return []
+/** Parse the old/new start line numbers out of a `@@` header. */
+function hunkStarts(header: string): { oldStart: number; newStart: number } | null {
+  const m = header.match(/^@@ -(\d+)(?:,\d+)? \+(\d+)(?:,\d+)? @@/)
+  if (!m) return null
+  return { oldStart: Number.parseInt(m[1], 10), newStart: Number.parseInt(m[2], 10) }
+}
+
+function renderPatch(filePath: string, headerLine: string, bodyLines: string[]): string {
+  return `--- a/${filePath}\n+++ b/${filePath}\n${headerLine}\n${bodyLines.join('\n')}\n`
+}
+
+/**
+ * Walk the diff once and collect rich hunk info (body lines paired with their
+ * diff line indices). Shared by buildHunkPatches and buildLinePatch so both
+ * use identical structural rules.
+ */
+function collectHunks(diff: string, filePath: string): RichHunk[] {
   const lines = diff.split('\n')
-  const hunks: HunkPatch[] = []
-  let current: ActiveHunk | null = null
+  const hunks: RichHunk[] = []
+  let current: RichHunk | null = null
   // File the next hunk belongs to. Defaults to `filePath` so a header-less
   // diff (just `@@` + body) still works; a `+++ b/<path>` line overrides it
   // so a multi-file diff only contributes hunks for the requested file.
@@ -62,17 +86,7 @@ export function buildHunkPatches(diff: string, filePath: string): HunkPatch[] {
 
   const flush = (): void => {
     if (!current) return
-    const patch =
-      `--- a/${filePath}\n` +
-      `+++ b/${filePath}\n` +
-      `${current.headerLine}\n` +
-      current.bodyLines.join('\n') +
-      '\n'
-    hunks.push({
-      headerIndex: current.headerIndex,
-      headerLine: current.headerLine,
-      patch
-    })
+    hunks.push(current)
     current = null
   }
 
@@ -87,23 +101,27 @@ export function buildHunkPatches(diff: string, filePath: string): HunkPatch[] {
     if (current && (current.oldLeft > 0 || current.newLeft > 0 || line.startsWith('\\'))) {
       if (line.startsWith(' ')) {
         current.bodyLines.push(line)
+        current.bodyLineIndices.push(i)
         current.oldLeft -= 1
         current.newLeft -= 1
         continue
       }
       if (line.startsWith('-')) {
         current.bodyLines.push(line)
+        current.bodyLineIndices.push(i)
         current.oldLeft -= 1
         continue
       }
       if (line.startsWith('+')) {
         current.bodyLines.push(line)
+        current.bodyLineIndices.push(i)
         current.newLeft -= 1
         continue
       }
       if (line.startsWith('\\')) {
         // "\ No newline at end of file" — part of the hunk, no line budget.
         current.bodyLines.push(line)
+        current.bodyLineIndices.push(i)
         continue
       }
       // Unexpected line mid-hunk (malformed diff): stop the hunk here.
@@ -120,6 +138,7 @@ export function buildHunkPatches(diff: string, filePath: string): HunkPatch[] {
               headerIndex: i,
               headerLine: line,
               bodyLines: [],
+              bodyLineIndices: [],
               oldLeft: budget.old,
               newLeft: budget.new
             }
@@ -144,4 +163,88 @@ export function buildHunkPatches(diff: string, filePath: string): HunkPatch[] {
   }
   flush()
   return hunks
+}
+
+export function buildHunkPatches(diff: string, filePath: string): HunkPatch[] {
+  if (!diff || !filePath) return []
+  return collectHunks(diff, filePath).map((hunk) => ({
+    headerIndex: hunk.headerIndex,
+    headerLine: hunk.headerLine,
+    patch: renderPatch(filePath, hunk.headerLine, hunk.bodyLines),
+    bodyLineIndices: hunk.bodyLineIndices
+  }))
+}
+
+/**
+ * Phase 2 (#257): build a partial single-hunk patch from the selected subset
+ * of one hunk's +/- lines. Line indices are positions in the raw diff string
+ * (the same indices GitDiffView renders). Returns null when the selection
+ * contains no +/- line (nothing to stage), when the hunk cannot be found, or
+ * when the diff is malformed.
+ */
+export function buildLinePatch(
+  diff: string,
+  filePath: string,
+  headerIndex: number,
+  selectedIndices: ReadonlySet<number>
+): string | null {
+  if (!diff || !filePath || selectedIndices.size === 0) return null
+  const hunk = collectHunks(diff, filePath).find((h) => h.headerIndex === headerIndex)
+  if (!hunk) return null
+  const starts = hunkStarts(hunk.headerLine)
+  if (!starts) return null
+
+  const out: string[] = []
+  let contextCount = 0
+  let delCount = 0
+  let addCount = 0
+  // Tracks whether the immediately preceding diff line survived the
+  // transform, and with which role — a `\ No newline at end of file` marker
+  // belongs to the line above it and must follow that line's fate.
+  let prevKept: 'context' | 'deletion' | 'addition' | null = null
+
+  for (let i = 0; i < hunk.bodyLines.length; i += 1) {
+    const raw = hunk.bodyLines[i]
+    const lineIndex = hunk.bodyLineIndices[i]
+    const selected = selectedIndices.has(lineIndex)
+
+    if (raw.startsWith(' ')) {
+      out.push(raw)
+      contextCount += 1
+      prevKept = 'context'
+    } else if (raw.startsWith('-')) {
+      if (selected) {
+        out.push(raw)
+        delCount += 1
+        prevKept = 'deletion'
+      } else {
+        // Unselected deletion: the index keeps the old text, so the line
+        // becomes context in the partial patch.
+        out.push(` ${raw.slice(1)}`)
+        contextCount += 1
+        prevKept = 'context'
+      }
+    } else if (raw.startsWith('+')) {
+      if (selected) {
+        out.push(raw)
+        addCount += 1
+        prevKept = 'addition'
+      } else {
+        // Unselected addition: dropped — the new text stays unstaged.
+        prevKept = null
+      }
+    } else if (raw.startsWith('\\')) {
+      // Keep the no-newline marker iff the line it annotates was kept.
+      // (After a kept deletion-turned-context it still describes the old
+      // file's ending, which the index retains.)
+      if (prevKept !== null) out.push(raw)
+    }
+  }
+
+  if (delCount + addCount === 0) return null
+
+  const oldCount = contextCount + delCount
+  const newCount = contextCount + addCount
+  const header = `@@ -${starts.oldStart},${oldCount} +${starts.newStart},${newCount} @@`
+  return renderPatch(filePath, header, out)
 }


### PR DESCRIPTION
## Summary

Phase 2 of #257, following up on #527 (per-hunk staging): in the inline diff view you can now select individual `+`/`-` lines and stage (or unstage, on the staged side) **just those lines** — the same workflow as `git add -p`'s manual edit or VSCode's "stage selected lines".

## Related Issue

Refs #257, acceptance criterion 2 ("Optional: stage selected lines within a hunk"). Announced as a follow-up in #527. Searched open PRs — no duplicates.

## Type of Change

- [x] feat: new feature
- [x] test: adds or updates tests

## What Changed

**`build-hunk-patch.ts`** — new `buildLinePatch(diff, filePath, headerIndex, selectedIndices)` building a partial single-hunk patch with `git add -p` semantics:
- selected `+`/`-` lines are kept;
- an **unselected deletion becomes a context line** (the index keeps the old text);
- an **unselected addition is dropped** (the new text stays unstaged);
- the `@@` old/new counts are recomputed from the transformed body (backend `--recount` remains the safety net);
- a `\ No newline at end of file` marker follows the fate of the line it annotates;
- returns `null` when the selection holds no `+`/`-` line (nothing to apply).

The structural walk was refactored into a shared `collectHunks` so hunk-level and line-level patches use identical parsing rules (including the body-budget guard from #527's review). `HunkPatch` gained `bodyLineIndices` for line→hunk mapping. `buildHunkPatches` output is byte-identical apart from the added field.

**`GitDiffView.tsx`** (inline mode) — a slim toggle gutter on the left edge selects `+`/`-` lines (context lines are not selectable; the gutter is a separate column so text selection/copy is untouched), selected lines get a highlight, and each `@@` header grows a **"Stage/Unstage selected (N)"** action beside "Stage hunk". The partial patch flows through the **same** `onStageHunk`/`onUnstageHunk` callbacks — selection resets on every diff change (post-apply refetch) and clears after any apply.

**Split mode** keeps hunk-level actions only; line selection there can follow if there's demand.

**Backend: no changes.** `git_stage_hunk`/`git_unstage_hunk` and the path-traversal validator already accept any single-hunk fragment, and GitPanel's in-flight guard covers the partial action for free.

## How It Was Tested

- [x] `bun run ci` (Biome) — clean
- [x] `bun run typecheck` — node/web/test pass
- [x] `bun run test` — 22/22 across builder + GitDiffView + GitPanel (11 new assertions total: transform rules, header recount, null cases, meta-line fates, gutter interaction, patch contents, staged-side label)
- [ ] `cargo clippy` / `cargo test` — N/A (zero Rust changes; CI will confirm)
- [x] Manual verification — see below.

### Manual repro (macOS)

1. `bun run tauri dev`, open a file with a hunk containing several changed lines.
2. In the diff view, click the gutter dot on one `-` line and one `+` line.
3. Click **Stage selected (2)** — only those two lines move to staged; the rest of the hunk stays in the working tree.
4. Staged side: select lines → **Unstage selected (N)** returns exactly those lines.

## Notes for reviewers

- The unselected-deletion→context rule is what makes partial staging sound: the patch applies cleanly against the index because every old-side line is still represented (as `-` or context), while dropped additions simply never enter the index.
- Multi-hunk selections: the button is per hunk; line selection state is global but each hunk's action builds a patch from its own selected subset.

## CI & Review Gate

- [ ] All CI checks pass
- [ ] Code review comments from CodeRabbit / Claude have been addressed or resolved
- [ ] No unresolved review findings remain

## Checklist

- [x] My PR title follows the conventional commit format used by this repo
- [x] I linked the related issue or explained why none exists
- [x] I updated docs when needed (N/A)
- [x] I added or updated tests when needed
- [x] I verified the change does not introduce unrelated modifications (4 files, all in-scope)
- [x] I read AGENTS.md and followed the contributor guidelines
- [x] A human reviewed the complete diff before submission

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added per-line selection in inline diffs for partial staging and unstaging.
  * Added visual highlighting and selection counts for chosen lines.
  * Added actions to apply selected lines within each diff hunk.

* **Bug Fixes**
  * Selections now clear when the diff context changes or after applying a patch.
  * Selection controls are hidden when staging or unstaging is unavailable.
  * Improved handling and reporting when patch application fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->