### PR TITLE
fix(desktop): re-grant fs scope for restored project roots after restart

### DIFF
--- a/docs/api-contracts.md
+++ b/docs/api-contracts.md
@@ -47,6 +47,26 @@ The Rust side implements this via `IpcResult<T>` and the renderer mirrors it in 
 
 **Purpose:** Return the current user's home directory with platform-aware fallback.
 
+## Filesystem Scope Commands
+
+### `fs_scope_grant`
+
+**Purpose:** Re-grant runtime filesystem scope for restored project roots and
+worktree paths. The dialog plugin extends the fs scope when a folder is picked,
+but that grant is in-memory and lost on restart, while the static `fs:scope`
+capability only allowlists specific drives — restored projects elsewhere fail
+with `forbidden path` after restart. The renderer (`useProjectsLoader`) calls
+this before hydrating the file explorer.
+
+**Input:**
+- `paths`: directory paths to allow recursively (project roots + worktrees)
+
+**Returns:** `{ granted: string[], failed: { path, error }[] }` — per-path
+failures (e.g. a detached external drive) do not fail the whole call.
+
+Web/remote mode is a no-op (`grantFsScope` returns success without invoking);
+browser fs access is enforced by the server's own permission model.
+
 ## Terminal Commands
 
 ### `terminal_spawn`

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -656,6 +656,81 @@ pub async fn agent_registry_fetch(
     }
 }
 
+// ==================== Filesystem Scope Commands ====================
+
+/// Per-path failure detail for [`fs_scope_grant`].
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FsScopeGrantFailure {
+    pub path: String,
+    pub error: String,
+}
+
+/// Summary of a [`fs_scope_grant`] call: granted paths and per-path failures.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FsScopeGrantSummary {
+    pub granted: Vec<String>,
+    pub failed: Vec<FsScopeGrantFailure>,
+}
+
+/// Re-grant runtime filesystem scope for restored project roots and worktrees.
+///
+/// The dialog plugin extends the fs scope at runtime when a folder is picked
+/// (that is why the first Add Project works), but the grant is in-memory and
+/// lost on restart, while the static `fs:scope` capability only allowlists
+/// specific drives. Restored projects on any other drive then fail every
+/// `readDir` with "forbidden path" after restart. The renderer calls this
+/// before hydrating the file explorer so restored roots are re-authorized.
+///
+/// Individual path failures (e.g. a detached external drive) are reported in
+/// the summary instead of failing the whole call, so one stale project cannot
+/// block the others from loading.
+#[tauri::command]
+pub async fn fs_scope_grant(
+    app: AppHandle,
+    paths: Vec<String>,
+) -> Result<IpcResult<FsScopeGrantSummary>, String> {
+    use tauri_plugin_fs::FsExt;
+
+    log::info!("[fs-scope] grant start count={}", paths.len());
+    let mut granted: Vec<String> = Vec::new();
+    let mut failed: Vec<FsScopeGrantFailure> = Vec::new();
+
+    for raw in paths {
+        if raw.trim().is_empty() {
+            continue;
+        }
+        match validate_project_path(&raw) {
+            Ok(path) => {
+                // Recursive so the file explorer can descend the whole tree,
+                // including `.termul/worktrees/*` created under the root.
+                match app.fs_scope().allow_directory(&path, true) {
+                    Ok(()) => granted.push(path.to_string_lossy().into_owned()),
+                    Err(e) => {
+                        log::warn!("[fs-scope] grant failed path={} error={}", raw, e);
+                        failed.push(FsScopeGrantFailure {
+                            path: raw,
+                            error: e.to_string(),
+                        });
+                    }
+                }
+            }
+            Err(e) => {
+                log::warn!("[fs-scope] grant validation failed path={} error={}", raw, e);
+                failed.push(FsScopeGrantFailure { path: raw, error: e });
+            }
+        }
+    }
+
+    log::info!(
+        "[fs-scope] grant done granted={} failed={}",
+        granted.len(),
+        failed.len()
+    );
+    Ok(IpcResult::success(FsScopeGrantSummary { granted, failed }))
+}
+
 // ==================== Worktree Commands ====================
 
 /// List all worktrees for a git repo at the given path.

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1608,6 +1608,8 @@ pub fn run() {
             commands::terminal_set_visibility,
             // Agent registry (ADR-004.6: identity/discovery, opt-in, read-only)
             commands::agent_registry_fetch,
+            // Filesystem scope restore (re-grant persisted project roots)
+            commands::fs_scope_grant,
             // Browser tab commands
             commands::browser_tab_create,
             commands::browser_tab_navigate,

--- a/src/renderer/hooks/use-projects-persistence.ts
+++ b/src/renderer/hooks/use-projects-persistence.ts
@@ -1,6 +1,13 @@
 import { useCallback, useEffect, useRef } from 'react'
 import { getAcpTransport } from '@/lib/acp-transport'
-import { persistenceApi, secureStorageApi, syncProjects, terminalApi, worktreeApi } from '@/lib/api'
+import {
+  filesystemApi,
+  persistenceApi,
+  secureStorageApi,
+  syncProjects,
+  terminalApi,
+  worktreeApi
+} from '@/lib/api'
 import { isTauriContext } from '@/lib/tauri-runtime'
 import { setTerminalProtected } from '@/lib/terminal-api'
 import { randomUUID } from '@/lib/uuid'
@@ -506,6 +513,22 @@ export function useProjectsLoader(): void {
       }
     }
 
+    /**
+     * Collect the filesystem paths that must be re-granted to the Tauri fs scope
+     * after a restart: every persisted project root plus its worktree paths.
+     * Deduplicated — a worktree nested under a root still costs one entry.
+     */
+    function collectProjectScopePaths(projects: Project[]): string[] {
+      const paths = new Set<string>()
+      for (const project of projects) {
+        if (project.path) paths.add(project.path)
+        for (const worktree of project.worktrees ?? []) {
+          if (worktree.path) paths.add(worktree.path)
+        }
+      }
+      return [...paths]
+    }
+
     async function load(): Promise<void> {
       const result = await persistenceApi.read<PersistedProjectData>(PersistenceKeys.projects)
       if (result.success && result.data) {
@@ -517,6 +540,18 @@ export function useProjectsLoader(): void {
           : projects.length > 0
             ? projects[0].id
             : ''
+        // Re-grant fs scope for restored roots BEFORE the explorer reads
+        // them: the dialog plugin's pick-time grant dies with the process,
+        // and the static capability only allowlists specific drives, so
+        // restored projects elsewhere fail with "forbidden path".
+        const scopePaths = collectProjectScopePaths(projects)
+        if (scopePaths.length > 0) {
+          const grant = await filesystemApi.grantFsScope(scopePaths)
+          if (!grant.success) {
+            console.debug('[projects] fs scope grant failed:', grant.error)
+          }
+        }
+
         setProjects(projects, validActiveId, result.data.groups as ProjectGroup[])
 
         // Reconcile all projects against git in parallel after loading

--- a/src/renderer/lib/__tests__/tauri-filesystem-api.test.ts
+++ b/src/renderer/lib/__tests__/tauri-filesystem-api.test.ts
@@ -21,6 +21,12 @@ vi.mock('../tauri-runtime', () => ({
   isTauriContext: mockIsTauriContext
 }))
 
+const { mockInvoke } = vi.hoisted(() => ({ mockInvoke: vi.fn(async () => undefined) }))
+
+vi.mock('@tauri-apps/api/core', () => ({
+  invoke: mockInvoke
+}))
+
 const defaultStat: FileInfo = {
   isFile: true,
   isDirectory: false,
@@ -107,6 +113,49 @@ describe('tauriFilesystemApi', () => {
 
   afterEach(() => {
     vi.clearAllMocks()
+  })
+
+  describe('grantFsScope', () => {
+    it('invokes fs_scope_grant with the given paths on desktop', async () => {
+      mockInvoke.mockResolvedValue({
+        success: true,
+        data: { granted: ['F:/simrs2/simrs'], failed: [] }
+      })
+
+      const result = await tauriFilesystemApi.grantFsScope(['F:/simrs2/simrs'])
+
+      expect(mockInvoke).toHaveBeenCalledWith('fs_scope_grant', {
+        paths: ['F:/simrs2/simrs']
+      })
+      expect(result.success).toBe(true)
+      if (result.success) {
+        expect(result.data?.granted).toEqual(['F:/simrs2/simrs'])
+      }
+    })
+
+    it('maps transport errors to FS_SCOPE_GRANT_ERROR', async () => {
+      mockInvoke.mockRejectedValue(new Error('forbidden path: F:/simrs2/simrs'))
+
+      const result = await tauriFilesystemApi.grantFsScope(['F:/simrs2/simrs'])
+
+      expect(result.success).toBe(false)
+      if (!result.success) {
+        expect(result.code).toBe('FS_SCOPE_GRANT_ERROR')
+        expect(result.error).toContain('forbidden path')
+      }
+    })
+
+    it('is a desktop-only no-op outside Tauri context', async () => {
+      mockIsTauriContext.mockReturnValue(false)
+      try {
+        const result = await tauriFilesystemApi.grantFsScope(['/srv/project'])
+
+        expect(mockInvoke).not.toHaveBeenCalled()
+        expect(result.success).toBe(true)
+      } finally {
+        mockIsTauriContext.mockReturnValue(true)
+      }
+    })
   })
 
   describe('readDirectory', () => {

--- a/src/renderer/lib/tauri-filesystem-api.ts
+++ b/src/renderer/lib/tauri-filesystem-api.ts
@@ -5,6 +5,7 @@ import type {
   FileContent,
   FileInfo,
   FilesystemApi,
+  FsScopeGrantSummary,
   IpcResult,
   SearchFileHit
 } from '@shared/types/ipc.types'
@@ -218,6 +219,20 @@ async function _collectFilesRecursively(rootPath: string): Promise<string[]> {
  */
 export function createTauriFilesystemApi(): FilesystemApi {
   return {
+    async grantFsScope(paths: string[]): Promise<IpcResult<FsScopeGrantSummary>> {
+      // Web/remote mode: the browser never talks to tauri-plugin-fs — fs
+      // access is enforced by the server's own permission model — so the
+      // scope grant is a desktop-only no-op.
+      if (!isTauriContext()) {
+        return { success: true, data: { granted: [], failed: [] } }
+      }
+      try {
+        return await invoke<IpcResult<FsScopeGrantSummary>>('fs_scope_grant', { paths })
+      } catch (err) {
+        return { success: false, error: String(err), code: 'FS_SCOPE_GRANT_ERROR' }
+      }
+    },
+
     async readDirectory(dirPath: string): Promise<IpcResult<DirectoryEntry[]>> {
       // Web/remote mode: route through the same-origin server (Story: Web/
       // remote project creation). Desktop stays on @tauri-apps/plugin-fs.

--- a/src/shared/types/ipc.types.ts
+++ b/src/shared/types/ipc.types.ts
@@ -498,7 +498,26 @@ export type SearchStreamErrorCode =
   | 'RG_STREAM_FAILED'
   | (string & {})
 
+/** Per-path failure detail for `grantFsScope`. */
+export interface FsScopeGrantFailure {
+  path: string
+  error: string
+}
+
+/** Summary of a `grantFsScope` call: granted paths and per-path failures. */
+export interface FsScopeGrantSummary {
+  granted: string[]
+  failed: FsScopeGrantFailure[]
+}
+
 export interface FilesystemApi {
+  /**
+   * Re-grant runtime fs scope for restored project roots/worktrees. The
+   * dialog plugin's pick-time grant is lost on restart; restored roots on
+   * non-allowlisted drives fail with "forbidden path" without this. Web mode
+   * is a no-op (fs goes through the server's own permission model).
+   */
+  grantFsScope: (paths: string[]) => Promise<IpcResult<FsScopeGrantSummary>>
   readDirectory: (dirPath: string) => Promise<IpcResult<DirectoryEntry[]>>
   readFile: (filePath: string) => Promise<IpcResult<FileContent>>
   getFileInfo: (filePath: string) => Promise<IpcResult<FileInfo>>


### PR DESCRIPTION
## Summary

Restored projects on drives not covered by the static `fs:scope` capability (only `C:`, `D:`, `E:` are allowlisted) fail with `forbidden path` after every app restart, forcing a manual remove + re-add of the project. The root cause: `tauri-plugin-dialog` extends the fs scope at runtime when a folder is picked (which is why the first Add Project works), but that grant is in-memory and dies with the process. Nothing re-authorizes the persisted roots on startup.

Reproduced on Windows with a project on `F:\simrs2\simrs` (Termul v0.4.10): loads fine right after Add Project; after a full app restart the file explorer shows "Failed to load project files." with `forbidden path: F:/simrs2/simrs`. Remove + Add again works — until the next restart. Projects on `C:`/`D:`/`E:` are unaffected, which is why this went unnoticed.

## Related Issue

No related issue exists. Searched open + closed PRs and issues before opening this: the fs-scope-related PRs found (#468 web path jail, #450 web project-root boundary, #652 server-side writes) all address the **web/server** fs boundary, not the desktop `tauri-plugin-fs` scope restore. Happy to file a matching bug report if maintainers prefer issue-first.

## Type of Change

- [ ] feat: new feature
- [x] fix: bug fix
- [ ] docs: documentation only
- [ ] style: formatting or non-functional styling changes
- [ ] refactor: internal cleanup with no behavior change
- [ ] perf: performance improvement
- [ ] test: adds or updates tests
- [ ] build: build or dependency changes
- [ ] ci: CI/CD workflow changes
- [ ] chore: maintenance or tooling
- [ ] revert: reverts a previous change

## What Changed

- New `fs_scope_grant` Tauri command (`src-tauri/src/commands.rs`): canonicalizes each path via the existing `validate_project_path` (verbatim-prefix stripped) and re-allows it recursively on the app fs scope. Per-path failures (e.g. a detached external drive) are reported in the summary (`{ granted, failed }`) instead of failing the whole call, so one stale project cannot block the rest from loading. Structured logs at boundaries (`[fs-scope] grant start/done/failed`).
- `useProjectsLoader` (`src/renderer/hooks/use-projects-persistence.ts`) collects every persisted project root + worktree path and awaits `grantFsScope` **before** `setProjects`, so the file explorer only reads after scope is restored.
- `grantFsScope` facade (`src/renderer/lib/tauri-filesystem-api.ts`) + shared contract types (`FsScopeGrantSummary`/`FsScopeGrantFailure` in `src/shared/types/ipc.types.ts`). Web/remote mode is an explicit desktop-only no-op (browser fs is enforced by the server's own permission model), documented in `docs/api-contracts.md`.
- Worktrees are included because git-reconciled worktrees can live outside the project root; Termul-created ones (`.termul/worktrees/*`) are covered by the recursive root grant either way.

## How It Was Tested

- [ ] `bun run ci` (Biome lint + format + imports, strict mode)
- [x] `bun run typecheck`
- [x] `bun run test`
- [x] `cargo clippy --all-targets -- -D warnings` (in src-tauri)
- [ ] `cargo test` (in src-tauri)
- [x] Manual verification completed
- [ ] Not applicable

Notes:
- Full vitest suite green (3795 passed / 282 files), including 3 new facade contract tests for `grantFsScope` (invoke shape, `FS_SCOPE_GRANT_ERROR` mapping, web no-op).
- `cargo test` could not run on the contributor's Windows machine due to a pre-existing test-binary loader failure (`STATUS_ENTRYPOINT_NOT_FOUND`) that reproduces identically on a clean `origin/dev` checkout — environment issue, not introduced by this PR. Relying on CI for the Rust suite.
- Repo-wide `bun run ci` on the contributor's Windows checkout reports pre-existing format diffs on ~17 untouched files (verified via stash on clean `origin/dev`; line-ending related). The four files touched by this PR pass Biome cleanly.
- Manual verification (dev build, isolated `.dev` identifier): PASSED — Add Project on `F:\simrs2\simrs` → loads; full app restart → project loads again without remove + re-add; `termul.log` shows `[fs-scope] grant start count=1` / `grant done granted=1 failed=0`. Before the fix the same steps reproduce `forbidden path` (observed on v0.4.10 by the reporter).

## Screenshots or Recordings

No UI change — the fix removes an error state. Log evidence included in the testing notes above.

## CI & Review Gate

- [ ] All CI checks pass (PR Validation, Rust Checks, Build Verification, Security Scans)
- [ ] Code review comments from CodeRabbit / Claude have been addressed or resolved
- [ ] No unresolved review findings remain

## Checklist

- [x] My PR title follows the conventional commit format used by this repo
- [x] I linked the related issue or explained why none exists
- [x] I updated docs when needed
- [x] I added or updated tests when needed
- [x] I verified the change does not introduce unrelated modifications
- [x] I read AGENTS.md and followed the contributor guidelines
- [x] A human reviewed the complete diff before submission
