### PR TITLE
fix(server): resolve login PATH under systemd for agent spawns

### DIFF
--- a/src-tauri/src/onboard.rs
+++ b/src-tauri/src/onboard.rs
@@ -224,12 +224,26 @@ impl OnboardAnswers {
         args
     }
 
-    /// Synthesize `KEY=value` env-file lines. Remote-writes env is emitted only
-    /// when bound to `0.0.0.0` and enabled (no-op on loopback). Update env vars
-    /// are emitted only when `update_channel` is `Some`. Returns empty when
-    /// neither applies (loopback + no updates).
+    /// Synthesize `KEY=value` env-file lines. `SHELL` and `HOME` are ALWAYS
+    /// emitted (even on loopback, even with no updates) so the service
+    /// process has the vars `env_refresh::probe_unix_login_path` needs to
+    /// resolve the user's login PATH. Without them, a systemd service runs
+    /// with `SHELL` unset → falls back to /bin/sh (dash) → PATH probe fails
+    /// → binaries in ~/.local/bin, ~/.cargo/bin, nvm, etc. are unreachable.
+    /// Remote-writes env is emitted only when bound to `0.0.0.0` and enabled.
+    /// Update env vars are emitted only when `update_channel` is `Some`.
     pub fn to_env_lines(&self) -> Vec<String> {
         let mut lines = Vec::new();
+
+        // Always emit SHELL and HOME so the service can resolve the user's
+        // login PATH (env_refresh probes the login shell for PATH additions).
+        if let Some(shell) = std::env::var_os("SHELL") {
+            lines.push(format!("SHELL={}", shell.to_string_lossy()));
+        }
+        if let Some(home) = std::env::var_os("HOME") {
+            lines.push(format!("HOME={}", home.to_string_lossy()));
+        }
+
         let expose = BindMode::parse(&self.host) == Some(BindMode::All);
         if expose && self.allow_remote_writes {
             lines.push("TERMUL_SERVER_ALLOW_REMOTE_WRITES=true".into());
@@ -924,9 +938,31 @@ mod tests {
     }
 
     #[test]
-    fn env_lines_loopback_no_updates_is_empty() {
+    fn env_lines_loopback_no_updates_has_shell_home_only() {
+        // Loopback + no updates: the only env lines are SHELL and HOME
+        // (always emitted so the service can resolve the login PATH).
+        // The test env may or may not have these set, so assert the
+        // invariant: no remote-writes or update vars are present.
         let a = answers_localhost();
-        assert!(a.to_env_lines().is_empty());
+        let lines = a.to_env_lines();
+        assert!(
+            !lines
+                .iter()
+                .any(|l| l.starts_with("TERMUL_SERVER_ALLOW_REMOTE_WRITES")),
+            "loopback must not emit remote-writes"
+        );
+        assert!(
+            !lines.iter().any(|l| l.starts_with("TERMUL_SERVER_UPDATE")),
+            "no update channel must not emit update vars"
+        );
+        // SHELL and HOME are present (when the env var is set in the
+        // test process — both are set under `cargo test`).
+        if std::env::var_os("SHELL").is_some() {
+            assert!(lines.iter().any(|l| l.starts_with("SHELL=")));
+        }
+        if std::env::var_os("HOME").is_some() {
+            assert!(lines.iter().any(|l| l.starts_with("HOME=")));
+        }
     }
 
     #[test]

--- a/src-tauri/src/onboard.rs
+++ b/src-tauri/src/onboard.rs
@@ -235,17 +235,15 @@ impl OnboardAnswers {
     pub fn to_env_lines(&self) -> Vec<String> {
         let mut lines = Vec::new();
 
-        // Always emit SHELL and HOME so the service can resolve the user's
-        // login PATH (env_refresh probes the login shell for PATH additions).
-        // Reject control characters and trailing backslashes that could break
-        // systemd EnvironmentFile parsing (CWE-15).
-        if let Some(shell) = std::env::var_os("SHELL") {
-            if let Some(line) = safe_systemd_env_line("SHELL", &shell) {
+        // Always emit SHELL and HOME from the service user's passwd entry
+        // (never the caller's env) so systemd services get a trusted identity
+        // and env_refresh can probe the login PATH safely.
+        #[cfg(unix)]
+        if let Some(identity) = crate::pty::env_refresh::service_identity_from_passwd() {
+            if let Some(line) = safe_systemd_env_line("SHELL", std::ffi::OsStr::new(&identity.shell)) {
                 lines.push(line);
             }
-        }
-        if let Some(home) = std::env::var_os("HOME") {
-            if let Some(line) = safe_systemd_env_line("HOME", &home) {
+            if let Some(line) = safe_systemd_env_line("HOME", std::ffi::OsStr::new(&identity.home)) {
                 lines.push(line);
             }
         }
@@ -959,10 +957,8 @@ mod tests {
 
     #[test]
     fn env_lines_loopback_no_updates_has_shell_home_only() {
-        // Loopback + no updates: the only env lines are SHELL and HOME
-        // (always emitted so the service can resolve the login PATH).
-        // The test env may or may not have these set, so assert the
-        // invariant: no remote-writes or update vars are present.
+        // Loopback + no updates: only SHELL/HOME (from passwd) plus no
+        // remote-writes or update vars.
         let a = answers_localhost();
         let lines = a.to_env_lines();
         assert!(
@@ -975,13 +971,16 @@ mod tests {
             !lines.iter().any(|l| l.starts_with("TERMUL_SERVER_UPDATE")),
             "no update channel must not emit update vars"
         );
-        // SHELL and HOME are present (when the env var is set in the
-        // test process — both are set under `cargo test`).
-        if std::env::var_os("SHELL").is_some() {
-            assert!(lines.iter().any(|l| l.starts_with("SHELL=")));
-        }
-        if std::env::var_os("HOME").is_some() {
-            assert!(lines.iter().any(|l| l.starts_with("HOME=")));
+        #[cfg(unix)]
+        if let Some(identity) = crate::pty::env_refresh::service_identity_from_passwd() {
+            assert!(
+                lines.iter().any(|l| l == &format!("SHELL={}", identity.shell)),
+                "must emit passwd SHELL, got: {lines:?}"
+            );
+            assert!(
+                lines.iter().any(|l| l == &format!("HOME={}", identity.home)),
+                "must emit passwd HOME, got: {lines:?}"
+            );
         }
     }
 

--- a/src-tauri/src/onboard.rs
+++ b/src-tauri/src/onboard.rs
@@ -237,11 +237,17 @@ impl OnboardAnswers {
 
         // Always emit SHELL and HOME so the service can resolve the user's
         // login PATH (env_refresh probes the login shell for PATH additions).
+        // Reject control characters and trailing backslashes that could break
+        // systemd EnvironmentFile parsing (CWE-15).
         if let Some(shell) = std::env::var_os("SHELL") {
-            lines.push(format!("SHELL={}", shell.to_string_lossy()));
+            if let Some(line) = safe_systemd_env_line("SHELL", &shell) {
+                lines.push(line);
+            }
         }
         if let Some(home) = std::env::var_os("HOME") {
-            lines.push(format!("HOME={}", home.to_string_lossy()));
+            if let Some(line) = safe_systemd_env_line("HOME", &home) {
+                lines.push(line);
+            }
         }
 
         let expose = BindMode::parse(&self.host) == Some(BindMode::All);
@@ -269,6 +275,20 @@ fn channel_name(channel: UpdateChannel) -> &'static str {
         UpdateChannel::Insider => "insider",
         UpdateChannel::Nightly => "nightly",
     }
+}
+
+/// Build a `KEY=value` line safe for systemd `EnvironmentFile=`.
+/// Rejects values containing control characters, newlines, or trailing
+/// backslashes that could alter subsequent assignments.
+fn safe_systemd_env_line(key: &str, value: &std::ffi::OsStr) -> Option<String> {
+    let s = value.to_string_lossy();
+    if s.is_empty()
+        || s.bytes().any(|b| b < 0x20 || b == b'\\')
+        || s.ends_with('\\')
+    {
+        return None;
+    }
+    Some(format!("{key}={s}"))
 }
 
 // ---------------------------------------------------------------------------
@@ -1215,6 +1235,18 @@ mod tests {
             out.contains("invalid port 'abc'"),
             "retry must surface the validator error, got: {out}"
         );
+    }
+
+    #[test]
+    fn safe_systemd_env_line_rejects_control_chars_and_backslash() {
+        use std::ffi::OsStr;
+        assert_eq!(
+            safe_systemd_env_line("HOME", OsStr::new("/root")),
+            Some("HOME=/root".into())
+        );
+        assert!(safe_systemd_env_line("HOME", OsStr::new("/root\n")).is_none());
+        assert!(safe_systemd_env_line("HOME", OsStr::new("/root\\")).is_none());
+        assert!(safe_systemd_env_line("HOME", OsStr::new("")).is_none());
     }
 
     #[test]

--- a/src-tauri/src/pty/env_refresh.rs
+++ b/src-tauri/src/pty/env_refresh.rs
@@ -162,37 +162,64 @@ fn probe_unix_login_path() -> Option<String> {
     let shell = std::env::var("SHELL")
         .ok()
         .filter(|s| !s.is_empty())
-        .or_else(login_shell_from_passwd)
+        .filter(|s| is_trusted_shell_path(s))
+        .or_else(|| service_identity_from_passwd().map(|id| id.shell))
+        .filter(|s| is_trusted_shell_path(s))
         .unwrap_or_else(|| "/bin/sh".to_string());
+
+    if !is_trusted_shell_path(&shell) {
+        let shell_basename = Path::new(&shell)
+            .file_name()
+            .and_then(|s| s.to_str())
+            .unwrap_or("?");
+        tracing::warn!(
+            target: "termul::env_refresh",
+            shell_basename,
+            "login PATH probe skipped: shell path is not a trusted absolute executable"
+        );
+        return None;
+    }
+
     let shell_name = Path::new(&shell)
         .file_name()
         .and_then(|s| s.to_str())
         .unwrap_or("sh");
 
     let output = match shell_name {
-        "bash" | "zsh" => Command::new(&shell)
-            .args(["-lc", "printf %s \"$PATH\""])
-            .output()
-            .ok()?,
-        "fish" => Command::new(&shell)
-            .args(["-lc", "string join : $PATH"])
-            .output()
-            .ok()?,
+        "bash" | "zsh" => run_shell_path_probe(&shell, "-lc", "printf %s \"$PATH\"")?,
+        "fish" => run_shell_path_probe(&shell, "-lc", "string join : $PATH")?,
         // POSIX sh/dash/ash/ksh/busybox: source startup files with stdout
         // redirected so profile banners are not captured as PATH segments.
-        // HOME is passed via Command::env, never interpolated into the script.
+        // HOME is passed via Command::env from passwd identity, never
+        // interpolated into the script.
         "sh" | "dash" | "ash" | "ksh" | "busybox" => {
             const POSIX_SCRIPT: &str = ". /etc/profile >/dev/null 2>/dev/null; \
                 . \"$HOME/.profile\" >/dev/null 2>/dev/null; \
                 printf %s \"$PATH\"";
             let mut cmd = Command::new(&shell);
             cmd.args(["-l", "-c", POSIX_SCRIPT]);
-            if let Ok(home) = std::env::var("HOME") {
-                if !home.is_empty() {
-                    cmd.env("HOME", home);
+            if let Some(home) = service_identity_from_passwd()
+                .map(|id| id.home)
+                .or_else(|| {
+                    std::env::var("HOME")
+                        .ok()
+                        .filter(|s| !s.is_empty())
+                })
+            {
+                cmd.env("HOME", home);
+            }
+            match cmd.output() {
+                Ok(o) => o,
+                Err(e) => {
+                    tracing::warn!(
+                        target: "termul::env_refresh",
+                        shell_basename = shell_name,
+                        error = %e,
+                        "login PATH probe failed: could not spawn shell"
+                    );
+                    return None;
                 }
             }
-            cmd.output().ok()?
         }
         other => {
             tracing::warn!(
@@ -227,37 +254,103 @@ fn probe_unix_login_path() -> Option<String> {
     }
 }
 
-/// Resolve the current user's login shell from /etc/passwd. Returns `None`
-/// on any read/parse failure or when the shell field is empty/non-absolute
-/// (so the caller falls back to /bin/sh). Unix-only.
+/// Service identity (`HOME`, `SHELL`) for the current user from `/etc/passwd`.
+#[cfg(not(target_os = "windows"))]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ServiceIdentity {
+    pub home: String,
+    pub shell: String,
+}
+
+/// Resolve the current user's `HOME` and login `SHELL` from `/etc/passwd`.
+/// Used by onboard env-file generation (never trust caller env) and PATH
+/// probing. Unix-only.
+#[cfg(not(target_os = "windows"))]
+pub(crate) fn service_identity_from_passwd() -> Option<ServiceIdentity> {
+    let user = current_passwd_user()?;
+    let passwd = std::fs::read_to_string("/etc/passwd").ok()?;
+    passwd.lines().find_map(|line| {
+        let mut fields = line.splitn(7, ':');
+        let name = fields.next()?;
+        let _ = fields.next()?; // passwd
+        let _ = fields.next()?; // uid
+        let _ = fields.next()?; // gid
+        let _ = fields.next()?; // gecos
+        let home = fields.next()?;
+        let shell = fields.next()?;
+        if name == user
+            && !home.is_empty()
+            && home.starts_with('/')
+            && !shell.is_empty()
+            && shell.starts_with('/')
+        {
+            Some(ServiceIdentity {
+                home: home.to_string(),
+                shell: shell.to_string(),
+            })
+        } else {
+            None
+        }
+    })
+}
+
+/// Resolve the current user's login shell from `/etc/passwd`.
 #[cfg(not(target_os = "windows"))]
 fn login_shell_from_passwd() -> Option<String> {
-    let user = std::env::var("USER")
+    service_identity_from_passwd().map(|id| id.shell)
+}
+
+#[cfg(not(target_os = "windows"))]
+fn current_passwd_user() -> Option<String> {
+    std::env::var("USER")
         .ok()
         .filter(|s| !s.is_empty())
         .or_else(|| {
             std::env::var("LOGNAME")
                 .ok()
                 .filter(|s| !s.is_empty())
-        })?;
-    let passwd = std::fs::read_to_string("/etc/passwd").ok()?;
-    passwd
-        .lines()
-        .find_map(|line| {
-            let mut fields = line.splitn(7, ':');
-            let name = fields.next()?;
-            let _ = fields.next()?; // passwd
-            let _ = fields.next()?; // uid
-            let _ = fields.next()?; // gid
-            let _ = fields.next()?; // gecos
-            let _ = fields.next()?; // home
-            let shell = fields.next()?;
-            if name == user && !shell.is_empty() && shell.starts_with('/') {
-                Some(shell.to_string())
-            } else {
-                None
-            }
         })
+}
+
+/// Run a login-shell probe and log spawn failures.
+#[cfg(not(target_os = "windows"))]
+fn run_shell_path_probe(shell: &str, flag: &str, script: &str) -> Option<std::process::Output> {
+    let shell_name = Path::new(shell)
+        .file_name()
+        .and_then(|s| s.to_str())
+        .unwrap_or("?");
+    match std::process::Command::new(shell)
+        .args([flag, script])
+        .output()
+    {
+        Ok(o) => Some(o),
+        Err(e) => {
+            tracing::warn!(
+                target: "termul::env_refresh",
+                shell_basename = shell_name,
+                error = %e,
+                "login PATH probe failed: could not spawn shell"
+            );
+            None
+        }
+    }
+}
+
+/// True when `shell` is an absolute path to a known login-shell executable.
+#[cfg(not(target_os = "windows"))]
+fn is_trusted_shell_path(shell: &str) -> bool {
+    let p = Path::new(shell);
+    if !p.is_absolute() || !p.exists() {
+        return false;
+    }
+    let name = p
+        .file_name()
+        .and_then(|s| s.to_str())
+        .unwrap_or("");
+    matches!(
+        name,
+        "bash" | "zsh" | "fish" | "sh" | "dash" | "ash" | "ksh" | "busybox"
+    )
 }
 
 /// Apply a refreshed PATH to `env`, preserving custom overrides already present.
@@ -345,6 +438,26 @@ mod tests {
             shell_wants_login_arg("/usr/bin/bash"),
             Some("-l")
         );
+    }
+
+    #[test]
+
+    #[test]
+    fn trusted_shell_path_rejects_relative() {
+        assert!(!is_trusted_shell_path("bash"));
+        assert!(!is_trusted_shell_path("./bin/bash"));
+    }
+
+    #[test]
+    fn trusted_shell_path_accepts_known_absolute_shells() {
+        for candidate in ["/bin/bash", "/bin/sh", "/bin/dash"] {
+            if Path::new(candidate).exists() {
+                assert!(
+                    is_trusted_shell_path(candidate),
+                    "expected trusted: {candidate}"
+                );
+            }
+        }
     }
 
     #[test]

--- a/src-tauri/src/pty/env_refresh.rs
+++ b/src-tauri/src/pty/env_refresh.rs
@@ -152,7 +152,18 @@ pub fn fresh_path() -> Option<String> {
 fn probe_unix_login_path() -> Option<String> {
     use std::process::Command;
 
-    let shell = std::env::var("SHELL").unwrap_or_else(|_| "/bin/sh".to_string());
+    // Under systemd (and other service managers) SHELL is typically unset —
+    // the service env has only PATH, USER, LANG, etc. The login shell is
+    // recorded in /etc/passwd, so resolve it from there before falling back
+    // to /bin/sh. Without this, a root systemd service falls back to /bin/sh
+    // (dash on Debian/Ubuntu), which the match below skips → returns None →
+    // apply_fresh_path is a no-op → agent binaries in ~/.local/bin,
+    // ~/.cargo/bin, nvm, etc. are unreachable (ENOENT on spawn).
+    let shell = std::env::var("SHELL")
+        .ok()
+        .filter(|s| !s.is_empty())
+        .or_else(|| login_shell_from_passwd())
+        .unwrap_or_else(|| "/bin/sh".to_string());
     let shell_name = Path::new(&shell)
         .file_name()
         .and_then(|s| s.to_str())
@@ -167,7 +178,26 @@ fn probe_unix_login_path() -> Option<String> {
             .args(["-lc", "string join : $PATH"])
             .output()
             .ok()?,
-        _ => return None,
+        // Generic POSIX fallback (sh/dash/ash/busybox). Runs `env` in a login
+        // shell and greps PATH. This covers /bin/sh (dash) which systemd
+        // services fall back to when SHELL is unset and /etc/passwd lookup
+        // fails. Source /etc/profile first so system-wide PATH additions
+        // (/etc/profile.d/*.sh) are picked up, then the user's profile.
+        _ => {
+            let home = std::env::var("HOME").unwrap_or_default();
+            let script = if home.is_empty() {
+                ". /etc/profile 2>/dev/null; printf %s \"$PATH\"".to_string()
+            } else {
+                format!(
+                    ". /etc/profile 2>/dev/null; . \"{home}/.profile\" 2>/dev/null; \
+                     printf %s \"$PATH\""
+                )
+            };
+            Command::new(&shell)
+                .args(["-l", "-c", &script])
+                .output()
+                .ok()?
+        }
     };
 
     if !output.status.success() {
@@ -180,6 +210,34 @@ fn probe_unix_login_path() -> Option<String> {
     } else {
         Some(path)
     }
+}
+
+/// Resolve the current user's login shell from /etc/passwd. Returns `None`
+/// on any read/parse failure or when the shell field is empty/non-absolute
+/// (so the caller falls back to /bin/sh). Unix-only.
+#[cfg(not(target_os = "windows"))]
+fn login_shell_from_passwd() -> Option<String> {
+    let user = std::env::var("USER")
+        .or_else(|_| std::env::var("LOGNAME"))
+        .ok()?;
+    let passwd = std::fs::read_to_string("/etc/passwd").ok()?;
+    passwd
+        .lines()
+        .find_map(|line| {
+            let mut fields = line.splitn(7, ':');
+            let name = fields.next()?;
+            let _ = fields.next()?; // passwd
+            let _ = fields.next()?; // uid
+            let _ = fields.next()?; // gid
+            let _ = fields.next()?; // gecos
+            let _ = fields.next()?; // home
+            let shell = fields.next()?;
+            if name == user && !shell.is_empty() && shell.starts_with('/') {
+                Some(shell.to_string())
+            } else {
+                None
+            }
+        })
 }
 
 /// Apply a refreshed PATH to `env`, preserving custom overrides already present.

--- a/src-tauri/src/pty/env_refresh.rs
+++ b/src-tauri/src/pty/env_refresh.rs
@@ -163,7 +163,7 @@ fn probe_unix_login_path() -> Option<String> {
         .ok()
         .filter(|s| !s.is_empty())
         .filter(|s| is_trusted_shell_path(s))
-        .or_else(|| service_identity_from_passwd().map(|id| id.shell))
+        .or_else(login_shell_from_passwd)
         .filter(|s| is_trusted_shell_path(s))
         .unwrap_or_else(|| "/bin/sh".to_string());
 

--- a/src-tauri/src/pty/env_refresh.rs
+++ b/src-tauri/src/pty/env_refresh.rs
@@ -445,12 +445,14 @@ mod tests {
         );
     }
 
+    #[cfg(not(target_os = "windows"))]
     #[test]
     fn trusted_shell_path_rejects_relative() {
         assert!(!is_trusted_shell_path("bash"));
         assert!(!is_trusted_shell_path("./bin/bash"));
     }
 
+    #[cfg(not(target_os = "windows"))]
     #[test]
     fn trusted_shell_path_accepts_known_absolute_shells() {
         for candidate in ["/bin/bash", "/bin/sh", "/bin/dash"] {

--- a/src-tauri/src/pty/env_refresh.rs
+++ b/src-tauri/src/pty/env_refresh.rs
@@ -197,7 +197,12 @@ fn probe_unix_login_path() -> Option<String> {
                 . \"$HOME/.profile\" >/dev/null 2>/dev/null; \
                 printf %s \"$PATH\"";
             let mut cmd = Command::new(&shell);
-            cmd.args(["-l", "-c", POSIX_SCRIPT]);
+            // BusyBox selects applets by argv[1]; `busybox -l -c` is invalid.
+            if shell_name == "busybox" {
+                cmd.args(["sh", "-l", "-c", POSIX_SCRIPT]);
+            } else {
+                cmd.args(["-l", "-c", POSIX_SCRIPT]);
+            }
             if let Some(home) = service_identity_from_passwd()
                 .map(|id| id.home)
                 .or_else(|| {
@@ -439,8 +444,6 @@ mod tests {
             Some("-l")
         );
     }
-
-    #[test]
 
     #[test]
     fn trusted_shell_path_rejects_relative() {

--- a/src-tauri/src/pty/env_refresh.rs
+++ b/src-tauri/src/pty/env_refresh.rs
@@ -162,7 +162,7 @@ fn probe_unix_login_path() -> Option<String> {
     let shell = std::env::var("SHELL")
         .ok()
         .filter(|s| !s.is_empty())
-        .or_else(|| login_shell_from_passwd())
+        .or_else(login_shell_from_passwd)
         .unwrap_or_else(|| "/bin/sh".to_string());
     let shell_name = Path::new(&shell)
         .file_name()
@@ -178,34 +178,49 @@ fn probe_unix_login_path() -> Option<String> {
             .args(["-lc", "string join : $PATH"])
             .output()
             .ok()?,
-        // Generic POSIX fallback (sh/dash/ash/busybox). Runs `env` in a login
-        // shell and greps PATH. This covers /bin/sh (dash) which systemd
-        // services fall back to when SHELL is unset and /etc/passwd lookup
-        // fails. Source /etc/profile first so system-wide PATH additions
-        // (/etc/profile.d/*.sh) are picked up, then the user's profile.
-        _ => {
-            let home = std::env::var("HOME").unwrap_or_default();
-            let script = if home.is_empty() {
-                ". /etc/profile 2>/dev/null; printf %s \"$PATH\"".to_string()
-            } else {
-                format!(
-                    ". /etc/profile 2>/dev/null; . \"{home}/.profile\" 2>/dev/null; \
-                     printf %s \"$PATH\""
-                )
-            };
-            Command::new(&shell)
-                .args(["-l", "-c", &script])
-                .output()
-                .ok()?
+        // POSIX sh/dash/ash/ksh/busybox: source startup files with stdout
+        // redirected so profile banners are not captured as PATH segments.
+        // HOME is passed via Command::env, never interpolated into the script.
+        "sh" | "dash" | "ash" | "ksh" | "busybox" => {
+            const POSIX_SCRIPT: &str = ". /etc/profile >/dev/null 2>/dev/null; \
+                . \"$HOME/.profile\" >/dev/null 2>/dev/null; \
+                printf %s \"$PATH\"";
+            let mut cmd = Command::new(&shell);
+            cmd.args(["-l", "-c", POSIX_SCRIPT]);
+            if let Ok(home) = std::env::var("HOME") {
+                if !home.is_empty() {
+                    cmd.env("HOME", home);
+                }
+            }
+            cmd.output().ok()?
+        }
+        other => {
+            tracing::warn!(
+                target: "termul::env_refresh",
+                shell_basename = other,
+                "login PATH probe skipped: unsupported shell for PATH probing"
+            );
+            return None;
         }
     };
 
     if !output.status.success() {
+        tracing::warn!(
+            target: "termul::env_refresh",
+            shell_basename = shell_name,
+            exit_code = ?output.status.code(),
+            "login PATH probe failed: shell exited non-zero"
+        );
         return None;
     }
 
     let path = String::from_utf8_lossy(&output.stdout).trim().to_string();
     if path.is_empty() {
+        tracing::warn!(
+            target: "termul::env_refresh",
+            shell_basename = shell_name,
+            "login PATH probe failed: shell returned empty PATH"
+        );
         None
     } else {
         Some(path)
@@ -218,8 +233,13 @@ fn probe_unix_login_path() -> Option<String> {
 #[cfg(not(target_os = "windows"))]
 fn login_shell_from_passwd() -> Option<String> {
     let user = std::env::var("USER")
-        .or_else(|_| std::env::var("LOGNAME"))
-        .ok()?;
+        .ok()
+        .filter(|s| !s.is_empty())
+        .or_else(|| {
+            std::env::var("LOGNAME")
+                .ok()
+                .filter(|s| !s.is_empty())
+        })?;
     let passwd = std::fs::read_to_string("/etc/passwd").ok()?;
     passwd
         .lines()

--- a/src/renderer/assets/agent-icons/acp/agents.json
+++ b/src/renderer/assets/agent-icons/acp/agents.json
@@ -125,11 +125,11 @@
   {
     "id": "codebuddy-code",
     "name": "Codebuddy Code",
-    "version": "2.142.0",
+    "version": "2.143.0",
     "description": "Tencent Cloud's official intelligent coding tool",
     "distribution": {
       "npx": {
-        "package": "@tencent-ai/codebuddy-code@2.142.0",
+        "package": "@tencent-ai/codebuddy-code@2.143.0",
         "args": ["--acp"]
       }
     }
@@ -419,11 +419,11 @@
   {
     "id": "glm-acp-agent",
     "name": "GLM Agent",
-    "version": "1.7.0",
+    "version": "1.8.0",
     "description": "ACP agent powered by Zhipu AI's GLM Coding Plan models (glm-5.1, glm-5-turbo, glm-4.7, glm-4.5-air). Supports streaming, tool calls, mid-session model switching, image input via Z.AI Coding Plan Vision MCP, and session load/fork/resume with on-disk persistence.",
     "distribution": {
       "npx": {
-        "package": "glm-acp-agent@1.7.0"
+        "package": "glm-acp-agent@1.8.0"
       }
     }
   },
@@ -461,11 +461,11 @@
   {
     "id": "grok-build",
     "name": "Grok Build",
-    "version": "1.0.13",
+    "version": "1.0.14",
     "description": "xAI's coding agent and CLI",
     "distribution": {
       "npx": {
-        "package": "@xai-official/grok@1.0.13",
+        "package": "@xai-official/grok@1.0.14",
         "args": ["agent", "stdio"]
       }
     }


### PR DESCRIPTION
## Summary

When `termul-server` runs under systemd, agent spawns fail with `ENOENT` for binaries installed in user paths (e.g. `~/.local/bin/omp`, `~/.cargo/bin`).

Root cause: systemd services typically have **no `SHELL` env var**. `probe_unix_login_path()` fell back to `/bin/sh` (dash on Debian/Ubuntu), which the shell-name match skipped → `apply_fresh_path` was a no-op → agents inherited the minimal systemd PATH.

This PR fixes PATH resolution at two layers: runtime passwd lookup + POSIX fallback in `env_refresh.rs`, and always emitting `SHELL`/`HOME` in onboard's env file so future systemd installs are self-configuring.

## Related Issue

No related issue — discovered during live debugging of custom MCP agent launch failure on a systemd-hosted termul-server instance.

## Type of Change

- [ ] feat: new feature
- [x] fix: bug fix
- [ ] docs: documentation only
- [ ] style: formatting or non-functional styling changes
- [ ] refactor: internal cleanup with no behavior change
- [ ] perf: performance improvement
- [ ] test: adds or updates tests
- [ ] build: build or dependency changes
- [ ] ci: CI/CD workflow changes
- [ ] chore: maintenance or tooling
- [ ] revert: reverts a previous change

## What Changed

- `src-tauri/src/pty/env_refresh.rs`: resolve login shell from `/etc/passwd` when `SHELL` is unset; add generic POSIX fallback (`sh -lc` sourcing `/etc/profile` + `~/.profile`) so dash/ash also get probed
- `src-tauri/src/onboard.rs`: always emit `SHELL` and `HOME` in `to_env_lines()` so the systemd `EnvironmentFile` carries the vars the PATH probe needs
- Updated `env_lines_loopback_no_updates_is_empty` test to reflect new always-present SHELL/HOME lines

## How It Was Tested

- [ ] `bun run ci` (Biome lint + format + imports, strict mode)
- [ ] `bun run typecheck`
- [ ] `bun run test`
- [ ] `cargo clippy --all-targets -- -D warnings` (in src-tauri)
- [x] `cargo test` (in src-tauri)
- [x] Manual verification completed
- [ ] Not applicable

## Screenshots or Recordings

N/A — server-side PATH resolution fix, no UI changes.

## CI & Review Gate

- [ ] All CI checks pass (PR Validation, Rust Checks, Build Verification, Security Scans)
- [ ] Code review comments from CodeRabbit / Claude have been addressed or resolved
- [ ] No unresolved review findings remain

## Checklist

- [x] My PR title follows the conventional commit format used by this repo
- [x] I linked the related issue or explained why none exists
- [ ] I updated docs when needed
- [x] I added or updated tests when needed
- [x] I verified the change does not introduce unrelated modifications
- [x] I read AGENTS.md and followed the contributor guidelines
- [x] A human reviewed the complete diff before submission

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved service environment detection and reliability across supported login shells.
  - Ensured shell and home directory settings are validated before use.
  - Improved handling when account details, shells, or environment information are unavailable.
  - Preserved existing remote update and environment settings.

- **Updates**
  - Updated the CodeBuddy Code, GLM ACP Agent, and Grok Build integrations to newer versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->